### PR TITLE
Clippy warnings

### DIFF
--- a/beacon_chain/utils/ssz/src/decode.rs
+++ b/beacon_chain/utils/ssz/src/decode.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "clippy"), allow(needless_range_loop))]
+
 use super::{
     LENGTH_BYTES,
 };
@@ -79,7 +81,7 @@ pub fn decode_length(bytes: &[u8], index: usize, length_bytes: usize)
     let mut len: usize = 0;
     for i in index..index+length_bytes {
         let offset = (index+length_bytes - i - 1) * 8;
-        len = ((bytes[i] as usize) << offset) | len;
+        len |= (bytes[i] as usize) << offset;
     };
     Ok(len)
 }

--- a/beacon_chain/utils/ssz/src/decode.rs
+++ b/beacon_chain/utils/ssz/src/decode.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "clippy"), allow(needless_range_loop))]
-
 use super::{
     LENGTH_BYTES,
 };
@@ -79,10 +77,10 @@ pub fn decode_length(bytes: &[u8], index: usize, length_bytes: usize)
         return Err(DecodeError::TooShort);
     };
     let mut len: usize = 0;
-    for i in index..index+length_bytes {
+    for (i, byte) in bytes.iter().enumerate().take(index+length_bytes).skip(index) {
         let offset = (index+length_bytes - i - 1) * 8;
-        len |= (bytes[i] as usize) << offset;
-    };
+        len |= (*byte as usize) << offset;
+    }
     Ok(len)
 }
 

--- a/beacon_chain/utils/ssz/src/encode.rs
+++ b/beacon_chain/utils/ssz/src/encode.rs
@@ -41,7 +41,7 @@ impl SszStream {
     ///
     /// The length of the supplied bytes will be concatenated
     /// to the stream before the supplied bytes.
-    pub fn append_encoded_val(&mut self, vec: &Vec<u8>) {
+    pub fn append_encoded_val(&mut self, vec: &[u8]) {
         self.buffer.extend_from_slice(
             &encode_length(vec.len(),
             LENGTH_BYTES));
@@ -51,7 +51,7 @@ impl SszStream {
     /// Append some ssz encoded bytes to the stream without calculating length
     ///
     /// The raw bytes will be concatenated to the stream.
-    pub fn append_encoded_raw(&mut self, vec: &Vec<u8>) {
+    pub fn append_encoded_raw(&mut self, vec: &[u8]) {
         self.buffer.extend_from_slice(&vec);
     }
 
@@ -59,7 +59,7 @@ impl SszStream {
     ///
     /// The length of the list will be concatenated to the stream, then
     /// each item in the vector will be encoded and concatenated.
-    pub fn append_vec<E>(&mut self, vec: &Vec<E>)
+    pub fn append_vec<E>(&mut self, vec: &[E])
         where E: Encodable
     {
         let mut list_stream = SszStream::new();

--- a/beacon_chain/utils/ssz/src/encode.rs
+++ b/beacon_chain/utils/ssz/src/encode.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "clippy"), allow(needless_range_loop))]
+
 use super::{
     LENGTH_BYTES,
     MAX_LIST_SIZE,
@@ -17,6 +19,7 @@ pub trait Encodable {
 /// Use the `append()` fn to add a value to a list, then use
 /// the `drain()` method to consume the struct and return the
 /// ssz encoded bytes.
+#[derive(Default)]
 pub struct SszStream {
     buffer: Vec<u8>
 }

--- a/beacon_chain/utils/ssz/src/encode.rs
+++ b/beacon_chain/utils/ssz/src/encode.rs
@@ -1,14 +1,8 @@
 #![cfg_attr(not(feature = "clippy"), allow(needless_range_loop))]
 
 use super::{
-    LENGTH_BYTES,
-    MAX_LIST_SIZE,
+    LENGTH_BYTES
 };
-
-#[derive(Debug)]
-pub enum EncodeError {
-    ListTooLong,
-}
 
 pub trait Encodable {
     fn ssz_append(&self, s: &mut SszStream);

--- a/beacon_chain/utils/ssz/src/encode.rs
+++ b/beacon_chain/utils/ssz/src/encode.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "clippy"), allow(needless_range_loop))]
-
 use super::{
     LENGTH_BYTES
 };
@@ -80,6 +78,7 @@ pub fn encode_length(len: usize, length_bytes: usize) -> Vec<u8> {
     assert!(length_bytes > 0);  // For sanity
     assert!((len as usize) < 2usize.pow(length_bytes as u32 * 8));
     let mut header: Vec<u8> = vec![0; length_bytes];
+    #[allow(needless_range_loop)]
     for i in 0..length_bytes {
         let offset = (length_bytes - i - 1) * 8;
         header[i] = ((len >> offset) & 0xff) as u8;

--- a/beacon_chain/utils/ssz/src/impl_decode.rs
+++ b/beacon_chain/utils/ssz/src/impl_decode.rs
@@ -8,20 +8,20 @@ use super::{
 macro_rules! impl_decodable_for_uint {
     ($type: ident, $bit_size: expr) => {
         impl Decodable for $type {
-            fn ssz_decode(bytes: &[u8], index: usize)
+            fn ssz_decode(bytes: &[u8], start_bytes: usize)
                 -> Result<(Self, usize), DecodeError>
             {
                 assert!((0 < $bit_size) &
                         ($bit_size <= 64) &
                         ($bit_size % 8 == 0));
                 let max_bytes = $bit_size / 8;
-                if bytes.len() >= (index + max_bytes) {
-                    let end_bytes = index + max_bytes;
+                if bytes.len() >= (start_bytes + max_bytes) {
+                    let end_bytes = start_bytes + max_bytes;
                     let mut result: $type = 0;
-                    for i in index..end_bytes {
-                        let offset = ((index + max_bytes) - i - 1) * 8;
-                        result |= ($type::from(bytes[i])) << offset;
-                    };
+                    for (index, byte) in bytes.iter().enumerate().take(end_bytes).skip(start_bytes) {
+                        let offset = (end_bytes - index - 1) * 8;
+                        result |= ($type::from(*byte)) << offset;
+                    }
                     Ok((result, end_bytes))
                 } else {
                     Err(DecodeError::TooShort)

--- a/beacon_chain/utils/ssz/src/impl_decode.rs
+++ b/beacon_chain/utils/ssz/src/impl_decode.rs
@@ -20,7 +20,7 @@ macro_rules! impl_decodable_for_uint {
                     let mut result: $type = 0;
                     for i in index..end_bytes {
                         let offset = ((index + max_bytes) - i - 1) * 8;
-                        result = ((bytes[i] as $type) << offset) | result;
+                        result |= ($type::from(bytes[i])) << offset;
                     };
                     Ok((result, end_bytes))
                 } else {
@@ -52,10 +52,7 @@ impl Decodable for H256 {
     fn ssz_decode(bytes: &[u8], index: usize)
         -> Result<(Self, usize), DecodeError>
     {
-        if bytes.len() < 32 {
-            return Err(DecodeError::TooShort)
-        }
-        else if bytes.len() - 32 < index {
+        if bytes.len() < 32 || bytes.len() - 32 < index {
             return Err(DecodeError::TooShort)
         }
         else {

--- a/beacon_chain/utils/ssz/src/impl_decode.rs
+++ b/beacon_chain/utils/ssz/src/impl_decode.rs
@@ -53,11 +53,10 @@ impl Decodable for H256 {
         -> Result<(Self, usize), DecodeError>
     {
         if bytes.len() < 32 || bytes.len() - 32 < index {
-            return Err(DecodeError::TooShort)
+            Err(DecodeError::TooShort)
         }
         else {
-            return Ok((H256::from(&bytes[index..(index + 32)]),
-                       index + 32));
+            Ok((H256::from(&bytes[index..(index + 32)]), index + 32))
         }
     }
 }

--- a/beacon_chain/utils/ssz/src/impl_encode.rs
+++ b/beacon_chain/utils/ssz/src/impl_encode.rs
@@ -35,7 +35,7 @@ macro_rules! impl_encodable_for_uint {
                 }
 
                 // Append bytes to the SszStream
-                s.append_encoded_raw(&mut buf.to_vec());
+                s.append_encoded_raw(&buf.to_vec());
             }
         }
     }

--- a/beacon_chain/utils/ssz/src/impl_encode.rs
+++ b/beacon_chain/utils/ssz/src/impl_encode.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "clippy"), allow(cast_lossless))]
+
 extern crate bytes;
 
 use super::{

--- a/beacon_chain/utils/ssz/src/impl_encode.rs
+++ b/beacon_chain/utils/ssz/src/impl_encode.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(not(feature = "clippy"), allow(cast_lossless))]
-
 extern crate bytes;
 
 use super::{
@@ -17,8 +15,8 @@ use self::bytes::{ BytesMut, BufMut };
 macro_rules! impl_encodable_for_uint {
     ($type: ident, $bit_size: expr) => {
         impl Encodable for $type {
-            fn ssz_append(&self, s: &mut SszStream)
-            {
+            #[allow(cast_lossless)]
+            fn ssz_append(&self, s: &mut SszStream) {
                 // Ensure bit size is valid
                 assert!((0 < $bit_size) &&
                         ($bit_size % 8 == 0) &&


### PR DESCRIPTION
## Issue Addressed

Addresses issue #52 

## Proposed Changes

Refactored ssz module to pass clippy lint.

## Additional Info

There are a couple places where I added tags to suppress warnings. 

In `impl_encodable_for_uint` there were warnings around data loss in integer casting, but from what I can tell it's not a valid concern. 

In `encode.encode_length` a vector is being assigned values within a loop, clippy seems to think that using an iterator would be better here since the vector is being indexed. I'm not sure if there's a way to assign values within in an iterator, and even if there were, I don't see how that would prevent issues down the road or make it more readable.

This is my first time using Rust, so don't be surprised if I missed something obvious on these two warnings or did something silly in one of the other refactors. Also, if I get the go ahead for this bounty, I would not mind spending some more time digging in deeper and trying to find some other improvements within this module.
