### PR TITLE
removed unnecessary call to saturated_sub() in vec_shuffle

### DIFF
--- a/beacon_chain/utils/vec_shuffle/src/lib.rs
+++ b/beacon_chain/utils/vec_shuffle/src/lib.rs
@@ -29,7 +29,7 @@ pub fn shuffle<T>(seed: &[u8], mut list: Vec<T>) -> Result<Vec<T>, ShuffleErr> {
         return Ok(list);
     }
 
-    for i in 0..(list.len().saturating_sub(1)) {
+    for i in 0..(list.len() - 1) {
         let n = list.len() - i;
         let j = rng.rand_range(n as u32) as usize + i;
         list.swap(i, j);


### PR DESCRIPTION
## Issue Addressed

Unnecessary saturating_sub in shuffler #59
