### PR TITLE
Add new `State` type and dependant types

### DIFF
--- a/beacon_chain/types/src/candidate_pow_receipt_root_record.rs
+++ b/beacon_chain/types/src/candidate_pow_receipt_root_record.rs
@@ -1,0 +1,7 @@
+use super::Hash256;
+
+#[derive(Debug, PartialEq)]
+pub struct CandidatePoWReceiptRootRecord {
+    pub candidate_pow_receipt_root: Hash256,
+    pub votes: u64,
+}

--- a/beacon_chain/types/src/lib.rs
+++ b/beacon_chain/types/src/lib.rs
@@ -6,11 +6,14 @@ extern crate ssz;
 pub mod active_state;
 pub mod attestation_record;
 pub mod beacon_block;
+pub mod candidate_pow_receipt_root_record;
 pub mod chain_config;
 pub mod crosslink_record;
 pub mod crystallized_state;
 pub mod shard_and_committee;
+pub mod shard_reassignment_record;
 pub mod special_record;
+pub mod state;
 pub mod validator_record;
 pub mod validator_registration;
 

--- a/beacon_chain/types/src/shard_reassignment_record.rs
+++ b/beacon_chain/types/src/shard_reassignment_record.rs
@@ -1,0 +1,6 @@
+#[derive(Debug, PartialEq)]
+pub struct ShardReassignmentRecord {
+    pub validator_index: u64,
+    pub shard: u64,
+    pub slot: u64,
+}

--- a/beacon_chain/types/src/state.rs
+++ b/beacon_chain/types/src/state.rs
@@ -1,0 +1,54 @@
+use super::attestation_record::AttestationRecord;
+use super::candidate_pow_receipt_root_record::CandidatePoWReceiptRootRecord;
+use super::crosslink_record::CrosslinkRecord;
+use super::shard_and_committee::ShardAndCommittee;
+use super::shard_reassignment_record::ShardReassignmentRecord;
+use super::validator_record::ValidatorRecord;
+use super::Hash256;
+
+#[derive(Debug, PartialEq)]
+pub struct BeaconState {
+    // Slot of last validator set change
+    validator_set_change_slot: u64,
+    // List of validators
+    validators: Vec<ValidatorRecord>,
+    // Most recent crosslink for each shard
+    crosslinks: Vec<CrosslinkRecord>,
+    // Last cycle-boundary state recalculation
+    last_state_recalculation_slot: u64,
+    // Last finalized slot
+    last_finalized_slot: u64,
+    // Last justified slot
+    last_justified_slot: u64,
+    // Number of consecutive justified slots
+    justified_streak: u64,
+    // Committee members and their assigned shard, per slot
+    shard_and_committee_for_slots: Vec<Vec<ShardAndCommittee>>,
+    // Persistent shard committees
+    persistent_committees: Vec<Vec<u32>>,
+    persistent_committee_reassignments: Vec<ShardReassignmentRecord>,
+    // Randao seed used for next shuffling
+    next_shuffling_seed: Hash256,
+    // Total deposits penalized in the given withdrawal period
+    deposits_penalized_in_period: Vec<u64>,
+    // Hash chain of validator set changes (for light clients to easily track deltas)
+    validator_set_delta_hash_chain: Hash256,
+    // Current sequence number for withdrawals
+    current_exit_seq: u64,
+    // Genesis time
+    genesis_time: u64,
+    // PoW receipt root
+    processed_pow_receipt_root: Hash256,
+    candidate_pow_receipt_roots: Vec<CandidatePoWReceiptRootRecord>,
+    // Parameters relevant to hard forks / versioning.
+    // Should be updated only by hard forks.
+    pre_fork_version: u64,
+    post_fork_version: u64,
+    fork_slot_number: u64,
+    // Attestations not yet processed
+    pending_attestations: Vec<AttestationRecord>,
+    // recent beacon block hashes needed to process attestations, older to newer
+    recent_block_hashes: Vec<Hash256>,
+    // RANDAO state
+    randao_mix: Hash256,
+}


### PR DESCRIPTION
## Issue Addressed

#73

## Proposed Changes

This PR introduces the following types:

- `BeaconState`
- `ShardReassignmentRecord`
- `CandidatePoWReceiptRootRecord`

It does _not_ remove the existing `CrystallizedState` and `ActiveState` objects. These can be removed once the rest of the code base has been updated to use `BeaconState`. 

## Additional Info

Rust doesn't have a built-in u24, so u32 is used in its place. This is consistent with the rest of the code base.
