### PR TITLE
Adds ForkData container type from the spec

### DIFF
--- a/beacon_chain/types/src/fork_data.rs
+++ b/beacon_chain/types/src/fork_data.rs
@@ -1,0 +1,7 @@
+/// ForkData helps track which fork the current beacon chain is currently on in the case of planned hard forks (e.g. to upgrade the beacon chain).
+#[derive(Debug, PartialEq)]
+pub struct ForkData {
+    pub pre_fork_version: u64,
+    pub post_fork_version: u64,
+    pub fork_slot_number: u64,
+}

--- a/beacon_chain/types/src/lib.rs
+++ b/beacon_chain/types/src/lib.rs
@@ -10,6 +10,7 @@ pub mod candidate_pow_receipt_root_record;
 pub mod chain_config;
 pub mod crosslink_record;
 pub mod crystallized_state;
+pub mod fork_data;
 pub mod shard_and_committee;
 pub mod shard_reassignment_record;
 pub mod special_record;

--- a/beacon_chain/types/src/state.rs
+++ b/beacon_chain/types/src/state.rs
@@ -1,6 +1,7 @@
 use super::attestation_record::AttestationRecord;
 use super::candidate_pow_receipt_root_record::CandidatePoWReceiptRootRecord;
 use super::crosslink_record::CrosslinkRecord;
+use super::fork_data::ForkData;
 use super::shard_and_committee::ShardAndCommittee;
 use super::shard_reassignment_record::ShardReassignmentRecord;
 use super::validator_record::ValidatorRecord;
@@ -42,9 +43,7 @@ pub struct BeaconState {
     candidate_pow_receipt_roots: Vec<CandidatePoWReceiptRootRecord>,
     // Parameters relevant to hard forks / versioning.
     // Should be updated only by hard forks.
-    pre_fork_version: u64,
-    post_fork_version: u64,
-    fork_slot_number: u64,
+    fork_data: ForkData,
     // Attestations not yet processed
     pending_attestations: Vec<AttestationRecord>,
     // recent beacon block hashes needed to process attestations, older to newer


### PR DESCRIPTION
## Issue Addressed

No issue for this.

## Proposed Changes

Remains consistent with the spec and this implementation's usage of container types.

Adds `ForkData` as a container type for the forking data.
