### PR TITLE
Rename `AttestationRecord` -> `Attestation`

### DIFF
--- a/beacon_chain/types/src/active_state.rs
+++ b/beacon_chain/types/src/active_state.rs
@@ -1,9 +1,9 @@
 use super::Hash256;
-use super::{AttestationRecord, SpecialRecord};
+use super::{Attestation, SpecialRecord};
 
 #[derive(Debug, PartialEq)]
 pub struct ActiveState {
-    pub pending_attestations: Vec<AttestationRecord>,
+    pub pending_attestations: Vec<Attestation>,
     pub pending_specials: Vec<SpecialRecord>,
     pub recent_block_hashes: Vec<Hash256>,
     pub randao_mix: Hash256,

--- a/beacon_chain/types/src/attestation.rs
+++ b/beacon_chain/types/src/attestation.rs
@@ -11,14 +11,14 @@ pub const MIN_SSZ_ATTESTION_RECORD_LENGTH: usize = {
 };
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct AttestationRecord {
+pub struct Attestation {
     pub data: AttestationData,
     pub participation_bitfield: Bitfield,
     pub custody_bitfield: Bitfield,
     pub aggregate_sig: AggregateSignature,
 }
 
-impl Encodable for AttestationRecord {
+impl Encodable for Attestation {
     fn ssz_append(&self, s: &mut SszStream) {
         s.append(&self.data);
         s.append(&self.participation_bitfield);
@@ -27,7 +27,7 @@ impl Encodable for AttestationRecord {
     }
 }
 
-impl Decodable for AttestationRecord {
+impl Decodable for Attestation {
     fn ssz_decode(bytes: &[u8], i: usize) -> Result<(Self, usize), DecodeError> {
         let (data, i) = AttestationData::ssz_decode(bytes, i)?;
         let (participation_bitfield, i) = Bitfield::ssz_decode(bytes, i)?;
@@ -46,7 +46,7 @@ impl Decodable for AttestationRecord {
     }
 }
 
-impl AttestationRecord {
+impl Attestation {
     pub fn zero() -> Self {
         Self {
             data: AttestationData::zero(),
@@ -64,7 +64,7 @@ mod tests {
 
     #[test]
     pub fn test_attestation_record_min_ssz_length() {
-        let ar = AttestationRecord::zero();
+        let ar = Attestation::zero();
         let ssz = ssz_encode(&ar);
 
         assert_eq!(ssz.len(), MIN_SSZ_ATTESTION_RECORD_LENGTH);
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     pub fn test_attestation_record_ssz_round_trip() {
-        let original = AttestationRecord {
+        let original = Attestation {
             data: AttestationData::zero(),
             participation_bitfield: Bitfield::from_bytes(&vec![17; 42][..]),
             custody_bitfield: Bitfield::from_bytes(&vec![18; 12][..]),
@@ -80,7 +80,7 @@ mod tests {
         };
 
         let ssz = ssz_encode(&original);
-        let (decoded, _) = AttestationRecord::ssz_decode(&ssz, 0).unwrap();
+        let (decoded, _) = Attestation::ssz_decode(&ssz, 0).unwrap();
 
         assert_eq!(original, decoded);
     }

--- a/beacon_chain/types/src/beacon_block.rs
+++ b/beacon_chain/types/src/beacon_block.rs
@@ -1,4 +1,4 @@
-use super::attestation_record::AttestationRecord;
+use super::attestation::Attestation;
 use super::special_record::SpecialRecord;
 use super::ssz::{Decodable, DecodeError, Encodable, SszStream};
 use super::Hash256;
@@ -23,7 +23,7 @@ pub struct BeaconBlock {
     pub ancestor_hashes: Vec<Hash256>,
     pub active_state_root: Hash256,
     pub crystallized_state_root: Hash256,
-    pub attestations: Vec<AttestationRecord>,
+    pub attestations: Vec<Attestation>,
     pub specials: Vec<SpecialRecord>,
 }
 

--- a/beacon_chain/types/src/lib.rs
+++ b/beacon_chain/types/src/lib.rs
@@ -5,7 +5,7 @@ extern crate ssz;
 
 pub mod active_state;
 pub mod attestation_data;
-pub mod attestation_record;
+pub mod attestation;
 pub mod beacon_block;
 pub mod beacon_state;
 pub mod candidate_pow_receipt_root_record;
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 pub use active_state::ActiveState;
 pub use attestation_data::AttestationData;
-pub use attestation_record::AttestationRecord;
+pub use attestation::Attestation;
 pub use beacon_block::BeaconBlock;
 pub use beacon_state::BeaconState;
 pub use chain_config::ChainConfig;

--- a/beacon_chain/utils/ssz_helpers/src/ssz_beacon_block.rs
+++ b/beacon_chain/utils/ssz_helpers/src/ssz_beacon_block.rs
@@ -217,7 +217,7 @@ mod tests {
     use super::super::ssz::encode::encode_length;
     use super::super::ssz::SszStream;
     use super::super::types::Hash256;
-    use super::super::types::{AttestationRecord, BeaconBlock, SpecialRecord};
+    use super::super::types::{Attestation, BeaconBlock, SpecialRecord};
     use super::*;
 
     fn get_block_ssz(b: &BeaconBlock) -> Vec<u8> {
@@ -232,7 +232,7 @@ mod tests {
         ssz_stream.drain()
     }
 
-    fn get_attestation_record_ssz(ar: &AttestationRecord) -> Vec<u8> {
+    fn get_attestation_record_ssz(ar: &Attestation) -> Vec<u8> {
         let mut ssz_stream = SszStream::new();
         ssz_stream.append(ar);
         ssz_stream.drain()
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_ssz_block_single_attestation_record_one_byte_short() {
         let mut b = BeaconBlock::zero();
-        b.attestations = vec![AttestationRecord::zero()];
+        b.attestations = vec![Attestation::zero()];
         let ssz = get_block_ssz(&b);
 
         assert_eq!(
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn test_ssz_block_single_attestation_record_one_byte_long() {
         let mut b = BeaconBlock::zero();
-        b.attestations = vec![AttestationRecord::zero()];
+        b.attestations = vec![Attestation::zero()];
         let mut ssz = get_block_ssz(&b);
         let original_len = ssz.len();
         ssz.push(42);
@@ -275,7 +275,7 @@ mod tests {
     #[test]
     fn test_ssz_block_single_attestation_record() {
         let mut b = BeaconBlock::zero();
-        b.attestations = vec![AttestationRecord::zero()];
+        b.attestations = vec![Attestation::zero()];
         let ssz = get_block_ssz(&b);
 
         assert!(SszBeaconBlock::from_slice(&ssz[..]).is_ok());
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     fn test_ssz_block_block_hash() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         let serialized = get_block_ssz(&block);
         let ssz_block = SszBeaconBlock::from_slice(&serialized).unwrap();
         let hash = ssz_block.block_hash();
@@ -311,7 +311,7 @@ mod tests {
     #[test]
     fn test_ssz_block_slot() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         block.slot = 42;
 
         let serialized = get_block_ssz(&block);
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn test_ssz_block_randao_reveal() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         let reference_hash = Hash256::from([42_u8; 32]);
         block.randao_reveal = reference_hash.clone();
 
@@ -404,14 +404,14 @@ mod tests {
     #[test]
     fn test_ssz_block_attestations() {
         /*
-         * Single AttestationRecord
+         * Single Attestation
          */
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
 
         let serialized = get_block_ssz(&block);
         let ssz_block = SszBeaconBlock::from_slice(&serialized).unwrap();
-        let ssz_ar = get_attestation_record_ssz(&AttestationRecord::zero());
+        let ssz_ar = get_attestation_record_ssz(&Attestation::zero());
 
         let mut expected = encode_length(ssz_ar.len(), LENGTH_PREFIX_BYTES);
         expected.append(&mut ssz_ar.to_vec());
@@ -419,16 +419,16 @@ mod tests {
         assert_eq!(ssz_block.attestations(), &expected[..]);
 
         /*
-         * Multiple AttestationRecords
+         * Multiple Attestations
          */
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
+        block.attestations.push(Attestation::zero());
 
         let serialized = get_block_ssz(&block);
         let ssz_block = SszBeaconBlock::from_slice(&serialized).unwrap();
-        let mut ssz_ar = get_attestation_record_ssz(&AttestationRecord::zero());
-        ssz_ar.append(&mut get_attestation_record_ssz(&AttestationRecord::zero()));
+        let mut ssz_ar = get_attestation_record_ssz(&Attestation::zero());
+        ssz_ar.append(&mut get_attestation_record_ssz(&Attestation::zero()));
 
         let mut expected = encode_length(ssz_ar.len(), LENGTH_PREFIX_BYTES);
         expected.append(&mut ssz_ar.to_vec());
@@ -439,7 +439,7 @@ mod tests {
     #[test]
     fn test_ssz_block_pow_chain_reference() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         let reference_hash = Hash256::from([42_u8; 32]);
         block.pow_chain_reference = reference_hash.clone();
 
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn test_ssz_block_act_state_root() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         let reference_hash = Hash256::from([42_u8; 32]);
         block.active_state_root = reference_hash.clone();
 
@@ -468,7 +468,7 @@ mod tests {
     #[test]
     fn test_ssz_block_cry_state_root() {
         let mut block = BeaconBlock::zero();
-        block.attestations.push(AttestationRecord::zero());
+        block.attestations.push(Attestation::zero());
         let reference_hash = Hash256::from([42_u8; 32]);
         block.crystallized_state_root = reference_hash.clone();
 

--- a/lighthouse/db/src/stores/beacon_block_store.rs
+++ b/lighthouse/db/src/stores/beacon_block_store.rs
@@ -87,7 +87,7 @@ mod tests {
     extern crate types;
 
     use self::ssz::SszStream;
-    use self::types::attestation_record::AttestationRecord;
+    use self::types::attestation::Attestation;
     use self::types::beacon_block::BeaconBlock;
     use self::types::Hash256;
 
@@ -182,7 +182,10 @@ mod tests {
         let hash = &Hash256::from("some hash".as_bytes()).to_vec();
 
         db.put(DB_COLUMN, hash, ssz).unwrap();
-        assert_eq!(store.block_at_slot(hash, 42), Err(BeaconBlockAtSlotError::InvalidBeaconBlock));
+        assert_eq!(
+            store.block_at_slot(hash, 42),
+            Err(BeaconBlockAtSlotError::InvalidBeaconBlock)
+        );
     }
 
     #[test]
@@ -195,7 +198,10 @@ mod tests {
         let other_hash = &Hash256::from("another hash".as_bytes()).to_vec();
 
         db.put(DB_COLUMN, hash, ssz).unwrap();
-        assert_eq!(store.block_at_slot(other_hash, 42), Err(BeaconBlockAtSlotError::UnknownBeaconBlock));
+        assert_eq!(
+            store.block_at_slot(other_hash, 42),
+            Err(BeaconBlockAtSlotError::UnknownBeaconBlock)
+        );
     }
 
     #[test]
@@ -244,7 +250,7 @@ mod tests {
 
         let blocks = (0..5).into_iter().map(|_| {
             let mut block = BeaconBlock::zero();
-            let ar = AttestationRecord::zero();
+            let ar = Attestation::zero();
             block.attestations.push(ar);
             block
         });


### PR DESCRIPTION
## Issue Addressed

Addresses #82

## Proposed Changes

Rename `AttestationRecord` -> `Attestation` globally.

## Additional Info

Simple change.