### PR TITLE
Add `ChainSpec` structure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
 	"beacon_chain/attestation_validation",
 	"beacon_chain/chain",
 	"beacon_chain/naive_fork_choice",
+	"beacon_chain/spec",
 	"beacon_chain/state-transition",
 	"beacon_chain/types",
 	"beacon_chain/utils/active-validators",

--- a/beacon_chain/spec/Cargo.toml
+++ b/beacon_chain/spec/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "spec"
+version = "0.1.0"
+authors = ["Paul Hauner <paul@paulhauner.com>"]
+
+[dependencies]
+types = { path = "../types" }

--- a/beacon_chain/spec/src/foundation.rs
+++ b/beacon_chain/spec/src/foundation.rs
@@ -1,0 +1,61 @@
+use super::ChainSpec;
+
+use types::{Address, Hash256};
+
+impl ChainSpec {
+    /// Returns a `ChainSpec` compatible with the specification from Ethereum Foundation.
+    pub fn foundation() -> Self {
+        Self {
+            /*
+             * Misc
+             */
+            shard_count: 1_024,
+            target_committee_size: 256,
+            ejection_balance: 16,
+            max_balance_churn_quotient: 32,
+            gwei_per_eth: u64::pow(10, 9),
+            beacon_chain_shard_number: u64::max_value(),
+            bls_withdrawal_prefix_byte: 0x00,
+            max_casper_votes: 1_024,
+            /*
+             *  Deposit contract
+             */
+            deposit_contract_address: Address::from("TBD".as_bytes()),
+            deposit_contract_tree_depth: 32,
+            min_deposit: 1,
+            max_deposit: 32,
+            /*
+             * Initial Values
+             */
+            initial_fork_version: 0,
+            initial_slot_number: 0,
+            zero_hash: Hash256::zero(),
+            /*
+             * Time parameters
+             */
+            slot_duration: 6,
+            min_attestation_inclusion_delay: 4,
+            epoch_length: 64,
+            min_validator_registry_change_interval: 256,
+            pow_receipt_root_voting_period: 1_024,
+            shard_persistent_committee_change_period: u64::pow(2, 17),
+            collective_penalty_calculation_period: u64::pow(2, 20),
+            zero_balance_validator_ttl: u64::pow(2, 22),
+            /*
+             * Reward and penalty quotients
+             */
+            base_reward_quotient: 2_048,
+            whistleblower_reward_quotient: 512,
+            includer_reward_quotient: 8,
+            inactivity_penalty_quotient: u64::pow(2, 34),
+            /*
+             * Max operations per block
+             */
+            max_proposer_slashings: 16,
+            max_casper_slashings: 15,
+            max_attestations: 128,
+            max_deposits: 16,
+            max_exits: 16,
+        }
+    }
+}

--- a/beacon_chain/spec/src/lib.rs
+++ b/beacon_chain/spec/src/lib.rs
@@ -1,0 +1,58 @@
+extern crate types;
+
+mod foundation;
+
+use types::{Address, Hash256};
+
+pub struct ChainSpec {
+    /*
+     * Misc
+     */
+    pub shard_count: u64,
+    pub target_committee_size: u64,
+    pub ejection_balance: u64,
+    pub max_balance_churn_quotient: u64,
+    pub gwei_per_eth: u64,
+    pub beacon_chain_shard_number: u64,
+    pub bls_withdrawal_prefix_byte: u8,
+    pub max_casper_votes: u64,
+    /*
+     *  Deposit contract
+     */
+    pub deposit_contract_address: Address,
+    pub deposit_contract_tree_depth: u64,
+    pub min_deposit: u64,
+    pub max_deposit: u64,
+    /*
+     * Initial Values
+     */
+    pub initial_fork_version: u64,
+    pub initial_slot_number: u64,
+    pub zero_hash: Hash256,
+    /*
+     * Time parameters
+     */
+    pub slot_duration: u64,
+    pub min_attestation_inclusion_delay: u64,
+    pub epoch_length: u64,
+    pub min_validator_registry_change_interval: u64,
+    pub pow_receipt_root_voting_period: u64,
+    pub shard_persistent_committee_change_period: u64,
+    pub collective_penalty_calculation_period: u64,
+    pub zero_balance_validator_ttl: u64,
+    /*
+     * Reward and penalty quotients
+     */
+    pub base_reward_quotient: u64,
+    pub whistleblower_reward_quotient: u64,
+    pub includer_reward_quotient: u64,
+    pub inactivity_penalty_quotient: u64,
+    /*
+     * Max operations per block
+     */
+    pub max_proposer_slashings: u64,
+    pub max_casper_slashings: u64,
+    pub max_attestations: u64,
+    pub max_deposits: u64,
+    pub max_exits: u64,
+}


### PR DESCRIPTION
## Issue Addressed

Resolves #101

## Proposed Changes

It includes all constants from the [Constants](https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#attestation) section in the spec, except for things that are clearly enums.

My reasoning is that this struct should be reserved for items that "configure" the chain and these enums are much more static and are strongly tied to the structs they will inhabit (e.g., `ValidatorRecord`).
