### PR TITLE
Validator status typing

### DIFF
--- a/beacon_chain/types/src/validator_record.rs
+++ b/beacon_chain/types/src/validator_record.rs
@@ -42,6 +42,10 @@ impl ValidatorRecord {
         };
         (s, keypair)
     }
+
+    pub fn status_is(&self, status: ValidatorStatus) -> bool {
+        self.status == status as u8
+    }
 }
 
 #[cfg(test)]

--- a/beacon_chain/types/src/validator_record.rs
+++ b/beacon_chain/types/src/validator_record.rs
@@ -2,14 +2,14 @@ use super::bls::{Keypair, PublicKey};
 use super::{Address, Hash256};
 use std::convert;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ValidatorStatus {
-    PendingActivation = 0,
-    Active = 1,
-    PendingExit = 2,
-    PendingWithdraw = 3,
-    Withdrawn = 5,
-    Penalized = 127,
+    PendingActivation,
+    Active,
+    PendingExit,
+    PendingWithdraw,
+    Withdrawn,
+    Penalized,
 }
 
 impl convert::From<u8> for ValidatorStatus {
@@ -59,7 +59,7 @@ impl ValidatorRecord {
     }
 
     pub fn status_is(&self, status: ValidatorStatus) -> bool {
-        self.status == status as u8
+        self.status == status
     }
 }
 

--- a/beacon_chain/types/src/validator_record.rs
+++ b/beacon_chain/types/src/validator_record.rs
@@ -1,5 +1,6 @@
 use super::bls::{Keypair, PublicKey};
 use super::{Address, Hash256};
+use std::convert;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ValidatorStatus {
@@ -11,6 +12,20 @@ pub enum ValidatorStatus {
     Penalized = 127,
 }
 
+impl convert::From<u8> for ValidatorStatus {
+    fn from(status: u8) -> Self {
+        match status {
+            0 => ValidatorStatus::PendingActivation,
+            1 => ValidatorStatus::Active,
+            2 => ValidatorStatus::PendingExit,
+            3 => ValidatorStatus::PendingWithdraw,
+            5 => ValidatorStatus::Withdrawn,
+            127 => ValidatorStatus::Penalized,
+            _ => unreachable!(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidatorRecord {
     pub pubkey: PublicKey,
@@ -19,7 +34,7 @@ pub struct ValidatorRecord {
     pub randao_commitment: Hash256,
     pub randao_last_change: u64,
     pub balance: u64,
-    pub status: u8,
+    pub status: ValidatorStatus,
     pub exit_slot: u64,
 }
 
@@ -37,7 +52,7 @@ impl ValidatorRecord {
             randao_commitment: Hash256::zero(),
             randao_last_change: 0,
             balance: 0,
-            status: 0,
+            status: From::from(0),
             exit_slot: 0,
         };
         (s, keypair)
@@ -60,7 +75,7 @@ mod tests {
         assert!(v.randao_commitment.is_zero());
         assert_eq!(v.randao_last_change, 0);
         assert_eq!(v.balance, 0);
-        assert_eq!(v.status, 0);
+        assert_eq!(v.status, From::from(0));
         assert_eq!(v.exit_slot, 0);
     }
 }

--- a/beacon_chain/utils/active-validators/src/lib.rs
+++ b/beacon_chain/utils/active-validators/src/lib.rs
@@ -30,32 +30,32 @@ mod tests {
         let mut validators = vec![];
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::Active as u8;
+        v.status = ValidatorStatus::Active;
         assert!(validator_is_active(&v));
         validators.push(v);
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::PendingActivation as u8;
+        v.status = ValidatorStatus::PendingActivation;
         assert!(!validator_is_active(&v));
         validators.push(v);
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::PendingExit as u8;
+        v.status = ValidatorStatus::PendingExit;
         assert!(!validator_is_active(&v));
         validators.push(v);
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::PendingWithdraw as u8;
+        v.status = ValidatorStatus::PendingWithdraw;
         assert!(!validator_is_active(&v));
         validators.push(v);
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::Withdrawn as u8;
+        v.status = ValidatorStatus::Withdrawn;
         assert!(!validator_is_active(&v));
         validators.push(v);
 
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::Penalized as u8;
+        v.status = ValidatorStatus::Penalized;
         assert!(!validator_is_active(&v));
         validators.push(v);
 

--- a/beacon_chain/utils/active-validators/src/lib.rs
+++ b/beacon_chain/utils/active-validators/src/lib.rs
@@ -2,27 +2,28 @@ extern crate types;
 
 use types::{ValidatorRecord, ValidatorStatus};
 
-pub fn validator_is_active(v: &ValidatorRecord) -> bool {
-    v.status == ValidatorStatus::Active as u8
-}
-
 /// Returns the indicies of each active validator in a given vec of validators.
 pub fn active_validator_indices(validators: &[ValidatorRecord]) -> Vec<usize> {
     validators
         .iter()
         .enumerate()
         .filter_map(|(i, validator)| {
-            if validator_is_active(&validator) {
+            if validator.status_is(ValidatorStatus::Active) {
                 Some(i)
             } else {
                 None
             }
-        }).collect()
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    pub fn validator_is_active(v: &ValidatorRecord) -> bool {
+        v.status_is(ValidatorStatus::Active)
+    }
 
     #[test]
     fn test_active_validator() {

--- a/beacon_chain/validator_change/src/lib.rs
+++ b/beacon_chain/validator_change/src/lib.rs
@@ -3,7 +3,6 @@ extern crate bytes;
 extern crate hashing;
 extern crate types;
 
-use active_validators::validator_is_active;
 use bytes::{BufMut, BytesMut};
 use hashing::canonical_hash;
 use std::cmp::max;
@@ -31,7 +30,7 @@ pub fn update_validator_set(
     let total_balance = {
         let mut bal: u64 = 0;
         for v in validators.iter() {
-            if validator_is_active(&v) {
+            if v.status_is(ValidatorStatus::Active) {
                 bal = bal
                     .checked_add(v.balance)
                     .ok_or(UpdateValidatorSetError::ArithmeticOverflow)?;

--- a/beacon_chain/validator_change/src/lib.rs
+++ b/beacon_chain/validator_change/src/lib.rs
@@ -62,7 +62,7 @@ pub fn update_validator_set(
             /*
              * Validator is pending activiation.
              */
-            x if x == ValidatorStatus::PendingActivation => {
+            ValidatorStatus::PendingActivation => {
                 let new_total_changed = total_changed
                     .checked_add(deposit_size_gwei)
                     .ok_or(UpdateValidatorSetError::ArithmeticOverflow)?;
@@ -82,7 +82,7 @@ pub fn update_validator_set(
             /*
              * Validator is pending exit.
              */
-            x if x == ValidatorStatus::PendingExit => {
+            ValidatorStatus::PendingExit => {
                 let new_total_changed = total_changed
                     .checked_add(v.balance)
                     .ok_or(UpdateValidatorSetError::ArithmeticOverflow)?;

--- a/beacon_chain/validator_change/src/lib.rs
+++ b/beacon_chain/validator_change/src/lib.rs
@@ -62,7 +62,7 @@ pub fn update_validator_set(
             /*
              * Validator is pending activiation.
              */
-            x if x == ValidatorStatus::PendingActivation as u8 => {
+            x if x == ValidatorStatus::PendingActivation => {
                 let new_total_changed = total_changed
                     .checked_add(deposit_size_gwei)
                     .ok_or(UpdateValidatorSetError::ArithmeticOverflow)?;
@@ -71,7 +71,7 @@ pub fn update_validator_set(
                  * activate the validator.
                  */
                 if new_total_changed <= max_allowable_change {
-                    v.status = ValidatorStatus::Active as u8;
+                    v.status = ValidatorStatus::Active;
                     hasher.extend(i, &v.pubkey.as_bytes(), VALIDATOR_FLAG_ENTRY);
                     total_changed = new_total_changed;
                 } else {
@@ -82,7 +82,7 @@ pub fn update_validator_set(
             /*
              * Validator is pending exit.
              */
-            x if x == ValidatorStatus::PendingExit as u8 => {
+            x if x == ValidatorStatus::PendingExit => {
                 let new_total_changed = total_changed
                     .checked_add(v.balance)
                     .ok_or(UpdateValidatorSetError::ArithmeticOverflow)?;
@@ -91,7 +91,7 @@ pub fn update_validator_set(
                  * exit the validator
                  */
                 if new_total_changed <= max_allowable_change {
-                    v.status = ValidatorStatus::PendingWithdraw as u8;
+                    v.status = ValidatorStatus::PendingWithdraw;
                     v.exit_slot = present_slot;
                     hasher.extend(i, &v.pubkey.as_bytes(), VALIDATOR_FLAG_EXIT);
                     total_changed = new_total_changed;

--- a/beacon_chain/validator_induction/src/inductor.rs
+++ b/beacon_chain/validator_induction/src/inductor.rs
@@ -68,7 +68,7 @@ impl ValidatorInductor {
             randao_commitment: r.randao_commitment,
             randao_last_change: self.current_slot,
             balance: DEPOSIT_GWEI,
-            status: status as u8,
+            status: status,
             exit_slot: 0,
         })
     }
@@ -77,7 +77,7 @@ impl ValidatorInductor {
     /// `validator.status == Withdrawn`. If no such record exists, `None` is returned.
     fn first_withdrawn_validator(&mut self) -> Option<usize> {
         for i in self.empty_validator_start..self.validators.len() {
-            if self.validators[i].status == ValidatorStatus::Withdrawn as u8 {
+            if self.validators[i].status == ValidatorStatus::Withdrawn {
                 self.empty_validator_start = i + 1;
                 return Some(i);
             }
@@ -166,8 +166,8 @@ mod tests {
         let _ = inductor.induct(&r, ValidatorStatus::Active);
         let validators = inductor.to_vec();
 
-        assert!(validators[0].status == ValidatorStatus::PendingActivation as u8);
-        assert!(validators[1].status == ValidatorStatus::Active as u8);
+        assert!(validators[0].status == ValidatorStatus::PendingActivation);
+        assert!(validators[1].status == ValidatorStatus::Active);
         assert_eq!(validators.len(), 2);
     }
 
@@ -176,7 +176,7 @@ mod tests {
         let mut validators = vec![];
         for _ in 0..5 {
             let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-            v.status = ValidatorStatus::Active as u8;
+            v.status = ValidatorStatus::Active;
             validators.push(v);
         }
 
@@ -195,11 +195,11 @@ mod tests {
     fn test_validator_inductor_valid_all_second_validator_withdrawn() {
         let mut validators = vec![];
         let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-        v.status = ValidatorStatus::Active as u8;
+        v.status = ValidatorStatus::Active;
         validators.push(v);
         for _ in 0..4 {
             let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-            v.status = ValidatorStatus::Withdrawn as u8;
+            v.status = ValidatorStatus::Withdrawn;
             validators.push(v);
         }
 
@@ -219,7 +219,7 @@ mod tests {
         let mut validators = vec![];
         for _ in 0..5 {
             let (mut v, _) = ValidatorRecord::zero_with_thread_rand_keypair();
-            v.status = ValidatorStatus::Withdrawn as u8;
+            v.status = ValidatorStatus::Withdrawn;
             validators.push(v);
         }
 


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

Use stronger typing for the `ValidatorStatus`.

## Additional Info

Idea is to convert to opaque rust types as quickly as possible (wrt IO on the edges of the node). The general idea is that we won't accidentally be comparing some arbitrary bytes in the hope that we are correctly identifying validators.