### PR TITLE
vec_shuffle: Add a keccak testsuite

### DIFF
--- a/beacon_chain/utils/vec_shuffle/src/specs/shuffle_test_vectors.yaml
+++ b/beacon_chain/utils/vec_shuffle/src/specs/shuffle_test_vectors.yaml
@@ -1,5 +1,3 @@
-# This file was generated with sigp/shuffling_sandbox
-# python3 sandbox.py test_vectors
 title: Shuffling Algorithm Tests
 summary: Test vectors for shuffling a list based upon a seed.
 test_suite: Shuffling
@@ -15,13 +13,13 @@ test_cases:
   output: [255]
   seed: ''
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [1, 6, 4, 1, 6, 6, 2, 2, 4, 5]
+  output: [2, 1, 1, 5, 6, 6, 6, 2, 4, 4]
   seed: ''
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [4, 7, 10, 13, 3, 1, 2, 9, 12, 6, 11, 8, 5]
+  output: [4, 9, 6, 8, 13, 3, 2, 11, 5, 1, 12, 7, 10]
   seed: ''
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [1, 6, 65, 1, 6, 6, 2, 2, 4, 5]
+  output: [2, 1, 1, 5, 6, 6, 6, 2, 4, 65]
   seed: ''
 - input: []
   output: []
@@ -33,13 +31,13 @@ test_cases:
   output: [255]
   seed: 4kn4driuctg8
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 4, 2, 5, 4, 2, 6, 6, 1, 1]
+  output: [2, 4, 4, 2, 1, 1, 6, 5, 6, 6]
   seed: 4kn4driuctg8
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [13, 1, 9, 8, 3, 10, 6, 2, 5, 12, 11, 4, 7]
+  output: [7, 6, 3, 12, 11, 1, 8, 13, 10, 5, 9, 4, 2]
   seed: 4kn4driuctg8
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 65, 2, 5, 4, 2, 6, 6, 1, 1]
+  output: [2, 4, 65, 2, 1, 1, 6, 5, 6, 6]
   seed: 4kn4driuctg8
 - input: []
   output: []
@@ -51,13 +49,13 @@ test_cases:
   output: [255]
   seed: ytre1p
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 5, 1, 6, 4, 1, 2, 4, 6]
+  output: [6, 1, 1, 5, 6, 2, 6, 2, 4, 4]
   seed: ytre1p
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [3, 8, 10, 4, 7, 11, 6, 1, 2, 5, 13, 9, 12]
+  output: [6, 2, 3, 4, 8, 5, 12, 9, 7, 11, 10, 1, 13]
   seed: ytre1p
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 5, 1, 6, 4, 1, 2, 65, 6]
+  output: [6, 1, 1, 5, 6, 2, 6, 2, 4, 65]
   seed: ytre1p
 - input: []
   output: []
@@ -69,13 +67,13 @@ test_cases:
   output: [255]
   seed: mytobcffnkvj
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [5, 6, 2, 1, 6, 4, 6, 4, 1, 2]
+  output: [2, 4, 1, 1, 6, 4, 6, 5, 6, 2]
   seed: mytobcffnkvj
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [12, 4, 11, 6, 13, 10, 9, 2, 3, 7, 8, 1, 5]
+  output: [11, 5, 9, 7, 2, 4, 12, 10, 8, 1, 6, 3, 13]
   seed: mytobcffnkvj
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [5, 6, 2, 1, 6, 65, 6, 4, 1, 2]
+  output: [2, 65, 1, 1, 6, 4, 6, 5, 6, 2]
   seed: mytobcffnkvj
 - input: []
   output: []
@@ -87,13 +85,13 @@ test_cases:
   output: [255]
   seed: myzu3g7evxp5nkvj
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 6, 5, 4, 4, 1, 6, 2, 1]
+  output: [6, 2, 1, 4, 2, 6, 5, 6, 4, 1]
   seed: myzu3g7evxp5nkvj
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [10, 12, 13, 3, 7, 11, 2, 4, 9, 8, 6, 5, 1]
+  output: [2, 1, 11, 3, 9, 7, 8, 13, 4, 10, 5, 6, 12]
   seed: myzu3g7evxp5nkvj
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 6, 5, 65, 4, 1, 6, 2, 1]
+  output: [6, 2, 1, 4, 2, 6, 5, 6, 65, 1]
   seed: myzu3g7evxp5nkvj
 - input: []
   output: []
@@ -105,13 +103,13 @@ test_cases:
   output: [255]
   seed: xdpli1jsx5xb
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 4, 1, 2, 6, 5, 1, 6, 4]
+  output: [2, 1, 2, 4, 6, 6, 5, 6, 1, 4]
   seed: xdpli1jsx5xb
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [11, 8, 12, 9, 2, 1, 10, 4, 13, 5, 7, 3, 6]
+  output: [5, 8, 12, 9, 11, 4, 7, 13, 1, 3, 2, 10, 6]
   seed: xdpli1jsx5xb
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [6, 2, 65, 1, 2, 6, 5, 1, 6, 4]
+  output: [2, 1, 2, 65, 6, 6, 5, 6, 1, 4]
   seed: xdpli1jsx5xb
 - input: []
   output: []
@@ -123,11 +121,11 @@ test_cases:
   output: [255]
   seed: oab3mbb3xe8qsx5xb
 - input: [4, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [2, 5, 1, 6, 1, 2, 6, 6, 4, 4]
+  output: [6, 2, 1, 1, 6, 2, 4, 4, 6, 5]
   seed: oab3mbb3xe8qsx5xb
 - input: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-  output: [5, 13, 9, 7, 11, 10, 12, 2, 6, 8, 3, 1, 4]
+  output: [1, 8, 5, 13, 2, 10, 7, 11, 12, 6, 3, 4, 9]
   seed: oab3mbb3xe8qsx5xb
 - input: [65, 6, 2, 6, 1, 4, 6, 2, 1, 5]
-  output: [2, 5, 1, 6, 1, 2, 6, 6, 65, 4]
+  output: [6, 2, 1, 1, 6, 2, 4, 65, 6, 5]
   seed: oab3mbb3xe8qsx5xb


### PR DESCRIPTION
## Issue Addressed
Closes #121.

## Proposed Changes
I asked on `ethereum/sharding` and Mamy recommended
https://github.com/status-im/eth2-testgen/, so I just grabbed the yaml file from [here](https://github.com/status-im/eth2-testgen/blob/master/test_vectors/test_vector_shuffling.yml)

## Additional Info
The file is CC0-licensed. I believe this is blocked by #109  before I even know how to hook this up to the unit test.