### PR TITLE
Wrap Signature and AggregateSignature in a newtype 

### DIFF
--- a/beacon_chain/types/src/attestation.rs
+++ b/beacon_chain/types/src/attestation.rs
@@ -1,6 +1,6 @@
 use super::attestation_data::SSZ_ATTESTION_DATA_LENGTH;
 use super::bls::{AggregateSignature, BLS_AGG_SIG_BYTE_SIZE};
-use super::ssz::{decode_ssz_list, Decodable, DecodeError, Encodable, SszStream, LENGTH_BYTES};
+use super::ssz::{Decodable, DecodeError, Encodable, SszStream, LENGTH_BYTES};
 use super::{AttestationData, Bitfield};
 
 pub const MIN_SSZ_ATTESTION_RECORD_LENGTH: usize = {
@@ -23,7 +23,7 @@ impl Encodable for Attestation {
         s.append(&self.data);
         s.append(&self.participation_bitfield);
         s.append(&self.custody_bitfield);
-        s.append_vec(&self.aggregate_sig.as_bytes());
+        s.append(&self.aggregate_sig);
     }
 }
 
@@ -32,9 +32,7 @@ impl Decodable for Attestation {
         let (data, i) = AttestationData::ssz_decode(bytes, i)?;
         let (participation_bitfield, i) = Bitfield::ssz_decode(bytes, i)?;
         let (custody_bitfield, i) = Bitfield::ssz_decode(bytes, i)?;
-        let (agg_sig_bytes, i) = decode_ssz_list(bytes, i)?;
-        let aggregate_sig =
-            AggregateSignature::from_bytes(&agg_sig_bytes).map_err(|_| DecodeError::TooShort)?; // also could be TooLong
+        let (aggregate_sig, i) = AggregateSignature::ssz_decode(bytes, i)?;
 
         let attestation_record = Self {
             data,

--- a/beacon_chain/utils/bls/Cargo.toml
+++ b/beacon_chain/utils/bls/Cargo.toml
@@ -6,3 +6,4 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 [dependencies]
 bls-aggregates = { git = "https://github.com/sigp/signature-schemes" }
 hashing = { path = "../hashing" }
+ssz = { path = "../ssz" }

--- a/beacon_chain/utils/bls/src/aggregate_signature.rs
+++ b/beacon_chain/utils/bls/src/aggregate_signature.rs
@@ -1,0 +1,72 @@
+use super::ssz::{decode_ssz_list, Decodable, DecodeError, Encodable, SszStream};
+use super::{AggregatePublicKey, Signature};
+use bls_aggregates::AggregateSignature as RawAggregateSignature;
+
+/// A BLS aggregate signature.
+///
+/// This struct is a wrapper upon a base type and provides helper functions (e.g., SSZ
+/// serialization).
+#[derive(Debug, PartialEq, Clone)]
+pub struct AggregateSignature(RawAggregateSignature);
+
+impl AggregateSignature {
+    /// Instantiate a new AggregateSignature.
+    pub fn new() -> Self {
+        AggregateSignature(RawAggregateSignature::new())
+    }
+
+    /// Add (aggregate) a signature to the `AggregateSignature`.
+    pub fn add(&mut self, signature: &Signature) {
+        self.0.add(signature.as_raw())
+    }
+
+    /// Verify the `AggregateSignature` against an `AggregatePublicKey`.
+    ///
+    /// Only returns `true` if the set of keys in the `AggregatePublicKey` match the set of keys
+    /// that signed the `AggregateSignature`.
+    pub fn verify(&mut self, msg: &[u8], avk: &AggregatePublicKey) -> bool {
+        self.0.verify(msg, avk)
+    }
+}
+
+impl Default for AggregateSignature {
+    /// A "default" signature is a signature across an empty message by a secret key of 48 zeros.
+    fn default() -> Self {
+        AggregateSignature::new()
+    }
+}
+
+impl Encodable for AggregateSignature {
+    fn ssz_append(&self, s: &mut SszStream) {
+        s.append_vec(&self.0.as_bytes());
+    }
+}
+
+impl Decodable for AggregateSignature {
+    fn ssz_decode(bytes: &[u8], i: usize) -> Result<(Self, usize), DecodeError> {
+        let (sig_bytes, i) = decode_ssz_list(bytes, i)?;
+        let raw_sig =
+            RawAggregateSignature::from_bytes(&sig_bytes).map_err(|_| DecodeError::TooShort)?;
+        Ok((AggregateSignature(raw_sig), i))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::ssz::ssz_encode;
+    use super::super::{Keypair, Signature};
+    use super::*;
+
+    #[test]
+    pub fn test_ssz_round_trip() {
+        let keypair = Keypair::random();
+
+        let mut original = AggregateSignature::new();
+        original.add(&Signature::new(&[42, 42], &keypair.sk));
+
+        let bytes = ssz_encode(&original);
+        let (decoded, _) = AggregateSignature::ssz_decode(&bytes, 0).unwrap();
+
+        assert_eq!(original, decoded);
+    }
+}

--- a/beacon_chain/utils/bls/src/aggregate_signature.rs
+++ b/beacon_chain/utils/bls/src/aggregate_signature.rs
@@ -24,8 +24,8 @@ impl AggregateSignature {
     ///
     /// Only returns `true` if the set of keys in the `AggregatePublicKey` match the set of keys
     /// that signed the `AggregateSignature`.
-    pub fn verify(&self, msg: &[u8], avk: &AggregatePublicKey) -> bool {
-        self.0.verify(msg, avk)
+    pub fn verify(&self, msg: &[u8], aggregate_public_key: &AggregatePublicKey) -> bool {
+        self.0.verify(msg, aggregate_public_key)
     }
 }
 

--- a/beacon_chain/utils/bls/src/aggregate_signature.rs
+++ b/beacon_chain/utils/bls/src/aggregate_signature.rs
@@ -29,13 +29,6 @@ impl AggregateSignature {
     }
 }
 
-impl Default for AggregateSignature {
-    /// A "default" signature is a signature across an empty message by a secret key of 48 zeros.
-    fn default() -> Self {
-        AggregateSignature::new()
-    }
-}
-
 impl Encodable for AggregateSignature {
     fn ssz_append(&self, s: &mut SszStream) {
         s.append_vec(&self.0.as_bytes());

--- a/beacon_chain/utils/bls/src/aggregate_signature.rs
+++ b/beacon_chain/utils/bls/src/aggregate_signature.rs
@@ -24,7 +24,7 @@ impl AggregateSignature {
     ///
     /// Only returns `true` if the set of keys in the `AggregatePublicKey` match the set of keys
     /// that signed the `AggregateSignature`.
-    pub fn verify(&mut self, msg: &[u8], avk: &AggregatePublicKey) -> bool {
+    pub fn verify(&self, msg: &[u8], avk: &AggregatePublicKey) -> bool {
         self.0.verify(msg, avk)
     }
 }

--- a/beacon_chain/utils/bls/src/lib.rs
+++ b/beacon_chain/utils/bls/src/lib.rs
@@ -1,12 +1,17 @@
 extern crate bls_aggregates;
 extern crate hashing;
+extern crate ssz;
+
+mod aggregate_signature;
+mod signature;
+
+pub use aggregate_signature::AggregateSignature;
+pub use signature::Signature;
 
 pub use self::bls_aggregates::AggregatePublicKey;
-pub use self::bls_aggregates::AggregateSignature;
 pub use self::bls_aggregates::Keypair;
 pub use self::bls_aggregates::PublicKey;
 pub use self::bls_aggregates::SecretKey;
-pub use self::bls_aggregates::Signature;
 
 pub const BLS_AGG_SIG_BYTE_SIZE: usize = 97;
 

--- a/beacon_chain/utils/bls/src/signature.rs
+++ b/beacon_chain/utils/bls/src/signature.rs
@@ -36,17 +36,6 @@ impl Signature {
     }
 }
 
-impl Default for Signature {
-    /// A "default" signature is a signature across an empty message by a secret key of 48 zeros.
-    fn default() -> Self {
-        let sk = match SecretKey::from_bytes(&[0; 48]) {
-            Ok(key) => key,
-            _ => unreachable!(), // Key is static, should not fail.
-        };
-        Signature(RawSignature::new(&[], &sk))
-    }
-}
-
 impl Encodable for Signature {
     fn ssz_append(&self, s: &mut SszStream) {
         s.append_vec(&self.0.as_bytes());


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

Wrap the `Signature` and `AggregateSignature` BLS structs in a newtype struct. This provides the following:

- Simpler, cleaner SSZ serialization.
- Ability to swap out BLS libraries with more ease.
- Finer control over which crypto functions are made available to the rest of the program.

## Additional Info

I considered using a `Deref` pattern but [this post](https://stackoverflow.com/a/45086999) put me off that method. I think cryptography is a good place to have absolute control over the methods that are available on a struct. This allows lighthouse to guide the usage of the underlying crypto by making "good" methods available and "bad" methods hidden.

It would be consistent to wrap all the BLS structs in newtypes. I leave this for a later time because:

1. I'd like feedback on the concept before going too far with it.
2. it's not imminently important; the new spec requires serialization of signatures and agg. signatures in several places and these newtypes make the code much cleaner.
3. It would make for a great "good-first-issue".

Keen to hear your thoughts @ralexstokes 
