### PR TITLE
Add rustfmt to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
+cache: cargo
 script:
+  - cargo fmt --all -- --check
   - cargo build --verbose --all
   - cargo test --verbose --all
 rust:
@@ -10,3 +12,6 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+install:
+  - (cargo install rustfmt || true)
+  - PATH=$PATH:/home/travis/.cargo/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-cache: cargo
 script:
   - cargo fmt --all -- --check
   - cargo build --verbose --all
@@ -13,5 +12,4 @@ matrix:
     - rust: nightly
   fast_finish: true
 install:
-  - (cargo install rustfmt || true)
-  - PATH=$PATH:/home/travis/.cargo/bin
+  - rustup component add rustfmt

--- a/beacon_chain/attestation_validation/src/lib.rs
+++ b/beacon_chain/attestation_validation/src/lib.rs
@@ -14,9 +14,9 @@ mod justified_slot;
 mod shard_block;
 mod signature;
 
-pub use crate::enums::{Invalid, Outcome, Error};
 pub use crate::block_inclusion::validate_attestation_for_block;
-pub use crate::justified_slot::validate_attestation_justified_slot;
+pub use crate::enums::{Error, Invalid, Outcome};
 pub use crate::justified_block::validate_attestation_justified_block_hash;
-pub use crate::signature::validate_attestation_signature;
+pub use crate::justified_slot::validate_attestation_justified_slot;
 pub use crate::shard_block::validate_attestation_data_shard_block_hash;
+pub use crate::signature::validate_attestation_signature;

--- a/beacon_chain/genesis/src/lib.rs
+++ b/beacon_chain/genesis/src/lib.rs
@@ -3,8 +3,8 @@ extern crate types;
 extern crate validator_induction;
 extern crate validator_shuffling;
 
-mod beacon_state;
 mod beacon_block;
+mod beacon_state;
 
 pub use crate::beacon_block::genesis_beacon_block;
 pub use crate::beacon_state::{genesis_beacon_state, Error as GenesisError};

--- a/beacon_chain/types/src/test_utils/mod.rs
+++ b/beacon_chain/types/src/test_utils/mod.rs
@@ -6,12 +6,13 @@ pub mod address;
 pub mod aggregate_signature;
 pub mod bitfield;
 pub mod hash256;
-pub mod signature;
-pub mod secret_key;
 pub mod public_key;
+pub mod secret_key;
+pub mod signature;
 
 pub trait TestRandom<T>
-where T: RngCore
+where
+    T: RngCore,
 {
     fn random_for_test(rng: &mut T) -> Self;
 }
@@ -35,7 +36,8 @@ impl<T: RngCore> TestRandom<T> for usize {
 }
 
 impl<T: RngCore, U> TestRandom<T> for Vec<U>
-where U: TestRandom<T>
+where
+    U: TestRandom<T>,
 {
     fn random_for_test(rng: &mut T) -> Self {
         vec![

--- a/beacon_chain/types/src/validator_record.rs
+++ b/beacon_chain/types/src/validator_record.rs
@@ -1,5 +1,5 @@
 use super::bls::PublicKey;
-use super::{Hash256};
+use super::Hash256;
 use crate::test_utils::TestRandom;
 use rand::RngCore;
 use ssz::{Decodable, DecodeError, Encodable, SszStream};
@@ -40,7 +40,7 @@ pub struct ValidatorRecord {
     pub exit_count: u64,
     pub custody_commitment: Hash256,
     pub latest_custody_reseed_slot: u64,
-    pub penultimate_custody_reseed_slot: u64
+    pub penultimate_custody_reseed_slot: u64,
 }
 
 impl ValidatorRecord {
@@ -132,7 +132,7 @@ impl Decodable for ValidatorRecord {
                 exit_count,
                 custody_commitment,
                 latest_custody_reseed_slot,
-                penultimate_custody_reseed_slot
+                penultimate_custody_reseed_slot,
             },
             i,
         ))

--- a/beacon_chain/utils/bls/src/lib.rs
+++ b/beacon_chain/utils/bls/src/lib.rs
@@ -19,8 +19,8 @@ pub use self::bls_aggregates::AggregatePublicKey;
 pub const BLS_AGG_SIG_BYTE_SIZE: usize = 97;
 
 use hashing::canonical_hash;
-use std::default::Default;
 use ssz::ssz_encode;
+use std::default::Default;
 
 fn extend_if_needed(hash: &mut Vec<u8>) {
     // NOTE: bls_aggregates crate demands 48 bytes, this may be removed as we get closer to production

--- a/beacon_chain/validator_induction/src/lib.rs
+++ b/beacon_chain/validator_induction/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate bls;
 extern crate hashing;
-extern crate types;
 extern crate spec;
+extern crate types;
 
 mod inductor;
 
-pub use crate::inductor::{ValidatorInductionError, process_deposit};
+pub use crate::inductor::{process_deposit, ValidatorInductionError};

--- a/lighthouse/beacon_chain/tests/chain_test.rs
+++ b/lighthouse/beacon_chain/tests/chain_test.rs
@@ -1,4 +1,4 @@
-use chain::{BlockProcessingOutcome, BeaconChain};
+use chain::{BeaconChain, BlockProcessingOutcome};
 use db::{
     stores::{BeaconBlockStore, BeaconStateStore},
     MemoryDB,

--- a/lighthouse/db/src/disk_db.rs
+++ b/lighthouse/db/src/disk_db.rs
@@ -44,7 +44,8 @@ impl DiskDB {
         let db = match columns {
             None => DB::open(&options, db_path),
             Some(columns) => DB::open_cf(&options, db_path, columns),
-        }.expect("Unable to open local database");;
+        }
+        .expect("Unable to open local database");;
 
         Self { db }
     }

--- a/lighthouse/db/src/stores/beacon_state_store.rs
+++ b/lighthouse/db/src/stores/beacon_state_store.rs
@@ -42,10 +42,10 @@ mod tests {
     use super::super::super::MemoryDB;
     use super::*;
 
-    use std::sync::Arc;
     use ssz::ssz_encode;
-    use types::Hash256;
+    use std::sync::Arc;
     use types::test_utils::{SeedableRng, TestRandom, XorShiftRng};
+    use types::Hash256;
 
     test_crud_for_store!(BeaconStateStore, DB_COLUMN);
 

--- a/lighthouse/main.rs
+++ b/lighthouse/main.rs
@@ -12,8 +12,8 @@ mod config;
 
 use std::path::PathBuf;
 
-use clap::{App, Arg};
 use crate::config::LighthouseConfig;
+use clap::{App, Arg};
 use slog::Drain;
 
 fn main() {
@@ -32,13 +32,15 @@ fn main() {
                 .value_name("DIR")
                 .help("Data directory for keys and databases.")
                 .takes_value(true),
-        ).arg(
+        )
+        .arg(
             Arg::with_name("port")
                 .long("port")
                 .value_name("PORT")
                 .help("Network listen port for p2p connections.")
                 .takes_value(true),
-        ).get_matches();
+        )
+        .get_matches();
 
     let mut config = LighthouseConfig::default();
 


### PR DESCRIPTION
## Issue Addressed

Closes #143.

## Proposed Changes

Adds `cargo fmt` to the CI process so that any commit that returns a non-empty diff will fail the pipeline.
