### PR TITLE
[WIP] Implement get_attestation_participants

### DIFF
--- a/eth2/attestation_validation/Cargo.toml
+++ b/eth2/attestation_validation/Cargo.toml
@@ -10,3 +10,4 @@ db = { path = "../../beacon_node/db" }
 hashing = { path = "../utils/hashing" }
 ssz = { path = "../utils/ssz" }
 types = { path = "../types" }
+failure = "0.1.5"

--- a/eth2/attestation_validation/src/get_attestation_participants.rs
+++ b/eth2/attestation_validation/src/get_attestation_participants.rs
@@ -1,0 +1,74 @@
+//! This implements [`get_attestation_participants`]
+//! (https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#get_attestation_participants)
+
+use failure::{Error, Fail};
+use types::{AttestationData, BeaconState, Bitfield, ShardCommittee};
+
+#[derive(Debug, Fail)]
+/// An error type for `get_attestation_participants()` problems
+pub enum AttestationParticipantError {
+    #[fail(
+        display = "Invalid aggregation_bitfield size: {}, expected {}",
+        got, expected
+    )]
+    /// The participation bitfield was the wrong size
+    InvalidBitfieldSize { expected: usize, got: usize },
+    #[fail(
+        display = "No crosslink committee found in attestation data shart {}",
+        _0
+    )]
+    /// The attestation data shard doesn't match any committee's shard
+    NoMatchingShard(u64),
+}
+
+use self::AttestationParticipantError::*;
+
+fn dummy_get_crosslink_committees_at_slot(
+    state: &BeaconState,
+    slot: u64,
+) -> Result<Vec<ShardCommittee>, Error> {
+    Ok(vec![])
+}
+
+/// Get validator indices partaking in the attestation described by `attestation_data` and
+/// `aggregation_bitfield`.
+pub fn get_attestation_participants(
+    state: &BeaconState,
+    attestation_data: &AttestationData,
+    aggregation_bitfield: &Bitfield,
+) -> Result<Vec<usize>, Error> {
+    // Find the committee in the list with the desired shard
+    let crosslink_committees =
+        dummy_get_crosslink_committees_at_slot(state, attestation_data.slot)?;
+    let crosslink_committee = match crosslink_committees
+        .iter()
+        .filter(|committee| committee.shard == attestation_data.shard)
+        .nth(0)
+    {
+        Some(committee) => committee,
+        None => return Err(NoMatchingShard(attestation_data.shard).into()),
+    };
+
+    let desired_bitfield_len = (crosslink_committee.len() + 7) / 8;
+    // The Bitfield type is bit-indexed while the spec assumes the byte-indexed Python bytes()
+    if aggregation_bitfield.num_bytes() != desired_bitfield_len {
+        return Err(InvalidBitfieldSize {
+            expected: aggregation_bitfield.num_bytes(),
+            got: desired_bitfield_len,
+        }
+        .into());
+    }
+
+    // Find the participating attesters in the committee
+    let mut participants = vec![];
+    for (i, validator_index) in crosslink_committee.committee.iter().enumerate() {
+        // Again, we need `to_bytes()` because the spec assumes a byte-indexed vec
+        let aggregation_bit = (aggregation_bitfield.to_bytes()[i / 8] >> (7 - (i % 8))) % 2;
+
+        if aggregation_bit == 1 {
+            participants.push(*validator_index);
+        }
+    }
+
+    Ok(participants)
+}

--- a/eth2/attestation_validation/src/lib.rs
+++ b/eth2/attestation_validation/src/lib.rs
@@ -9,6 +9,7 @@ mod macros;
 
 mod block_inclusion;
 mod enums;
+mod get_attestation_participants;
 mod justified_block;
 mod justified_slot;
 mod shard_block;
@@ -16,6 +17,7 @@ mod signature;
 
 pub use crate::block_inclusion::validate_attestation_for_block;
 pub use crate::enums::{Error, Invalid, Outcome};
+pub use crate::get_attestation_participants::get_attestation_participants;
 pub use crate::justified_block::validate_attestation_justified_block_hash;
 pub use crate::justified_slot::validate_attestation_justified_slot;
 pub use crate::shard_block::validate_attestation_data_shard_block_hash;

--- a/eth2/types/src/shard_committee.rs
+++ b/eth2/types/src/shard_committee.rs
@@ -8,6 +8,12 @@ pub struct ShardCommittee {
     pub committee: Vec<usize>,
 }
 
+impl ShardCommittee {
+    pub fn len(&self) -> usize {
+        self.committee.len()
+    }
+}
+
 impl Encodable for ShardCommittee {
     fn ssz_append(&self, s: &mut SszStream) {
         s.append(&self.shard);

--- a/eth2/utils/boolean-bitfield/src/lib.rs
+++ b/eth2/utils/boolean-bitfield/src/lib.rs
@@ -3,9 +3,6 @@ extern crate ssz;
 
 use bit_vec::BitVec;
 
-use std::cmp;
-use std::default;
-
 /// A BooleanBitfield represents a set of booleans compactly stored as a vector of bits.
 /// The BooleanBitfield is given a fixed size during construction. Reads outside of the current size return an out-of-bounds error. Writes outside of the current size expand the size of the set.
 #[derive(Debug, Clone)]
@@ -97,7 +94,7 @@ impl BooleanBitfield {
     }
 }
 
-impl default::Default for BooleanBitfield {
+impl Default for BooleanBitfield {
     /// default provides the "empty" bitfield
     /// Note: the empty bitfield is set to the `0` byte.
     fn default() -> Self {
@@ -105,7 +102,7 @@ impl default::Default for BooleanBitfield {
     }
 }
 
-impl cmp::PartialEq for BooleanBitfield {
+impl PartialEq for BooleanBitfield {
     /// Determines equality by comparing the `ssz` encoding of the two candidates.
     /// This method ensures that the presence of high-order (empty) bits in the highest byte do not exclude equality when they are in fact representing the same information.
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
## Issue Addressed
Closes #145.

## Proposed Changes
* Implement the function
* Add len() to ShardCommittee
* Remove unneeded imports from BooleanBitfield

## Additional Info
This introduces the `failure` crate to `attestation_validation`. I personally
find it to be very ergonomic, well-organized and self-documenting (see
`AttestationParticipantError` in this PR diff). Also, it is backed by the Rust
language nursery. This is good because good maintenance of the package can be
ensured that way.

## TODO
* [ ] Hook up `get_committee_at_slot()` once it's done
* [ ] Unit tests