### PR TITLE
Fix hardcoded string to use system constant for directory separator

### DIFF
--- a/protos/build.rs
+++ b/protos/build.rs
@@ -1,7 +1,7 @@
 extern crate protoc_grpcio;
 
 fn main() {
-    let proto_root = "src/";
+    let proto_root = &format!("{}{}", "src", std::path::MAIN_SEPARATOR);
     println!("cargo:rerun-if-changed={}", proto_root);
     protoc_grpcio::compile_grpc_protos(&["services.proto"], &[proto_root], &proto_root)
         .expect("Failed to compile gRPC definitions!");


### PR DESCRIPTION
## Issue Addressed

protos build fails on Windows due to incorrect directory separator character #165

## Proposed Changes

Modified protos build file to use system line separator constant.

## Additional Info

n/a
