### PR TITLE
added version to signature-schemes dependency

### DIFF
--- a/eth2/utils/bls/Cargo.toml
+++ b/eth2/utils/bls/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-bls-aggregates = { git = "https://github.com/sigp/signature-schemes" }
+bls-aggregates = { git = "https://github.com/sigp/signature-schemes", tag = "v0.3.0" }
 hashing = { path = "../hashing" }
 hex = "0.3"
 ssz = { path = "../ssz" }


### PR DESCRIPTION
## Issue Addressed

Partially address #91

## Proposed Changes

This change is mentioned [here](https://github.com/sigp/signature-schemes/pull/2#issue-246077474). 

It would be helpful in this case and probably in the future to cut version branches off of master in the [signature-schemes](https://github.com/sigp/signature-schemes) repository whenever breaking changes are introduced. This way we can more easily coordinate updates to the BLS library spec.

## Additional Info

If this gets merged, I can update the version in this [PR](https://github.com/sigp/signature-schemes/pull/2) to `0.2.0`, then make use of the `domain` parameter in a PR to lighthouse by changing the branch back to `master`.

This is the best solution I can think of at the moment to avoid breaking everyone's builds, but it could be more ideal, since this approach would always require preemptive version cuts and PRs like this :) 
