### PR TITLE
Merkle hashing chunk size fix

### DIFF
--- a/eth2/utils/ssz/src/tree_hash.rs
+++ b/eth2/utils/ssz/src/tree_hash.rs
@@ -30,8 +30,9 @@ pub fn merkle_hash(list: &mut Vec<Vec<u8>>) -> Vec<u8> {
                 // Hash two chuncks together
                 new_chunkz.append(&mut hash(two_chunks));
             }
-            chunk_size = HASHSIZE;
         }
+
+        chunk_size = HASHSIZE;
         chunkz = new_chunkz;
     }
 


### PR DESCRIPTION
## Issue Addressed

N/a

## Proposed Changes

Modify when the chunk size is updated such that after the first round of merklizing the chunk size will be set to hashsize (and not before).
