### PR TITLE
Add benchmarks to shuffling crates

### DIFF
--- a/eth2/utils/fisher_yates_shuffle/Cargo.toml
+++ b/eth2/utils/fisher_yates_shuffle/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
-[dependencies]
-hashing = { path = "../hashing" }
+[[bench]]
+name = "benches"
+harness = false
 
 [dev-dependencies]
+criterion = "0.2"
 yaml-rust = "0.4.2"
+
+[dependencies]
+hashing = { path = "../hashing" }

--- a/eth2/utils/fisher_yates_shuffle/benches/benches.rs
+++ b/eth2/utils/fisher_yates_shuffle/benches/benches.rs
@@ -1,0 +1,55 @@
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use fisher_yates_shuffle::shuffle;
+
+fn get_list(n: usize) -> Vec<usize> {
+    let mut list = Vec::with_capacity(n);
+    for i in 0..n {
+        list.push(i)
+    }
+    assert_eq!(list.len(), n);
+    list
+}
+
+fn shuffles(c: &mut Criterion) {
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("8 elements", move |b| {
+            let seed = vec![42; 32];
+            let list = get_list(8);
+            b.iter_with_setup(|| list.clone(), |list| black_box(shuffle(&seed, list)))
+        }),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("16 elements", move |b| {
+            let seed = vec![42; 32];
+            let list = get_list(16);
+            b.iter_with_setup(|| list.clone(), |list| black_box(shuffle(&seed, list)))
+        }),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("512 elements", move |b| {
+            let seed = vec![42; 32];
+            let list = get_list(512);
+            b.iter_with_setup(|| list.clone(), |list| black_box(shuffle(&seed, list)))
+        })
+        .sample_size(10),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("16384 elements", move |b| {
+            let seed = vec![42; 32];
+            let list = get_list(16_384);
+            b.iter_with_setup(|| list.clone(), |list| black_box(shuffle(&seed, list)))
+        })
+        .sample_size(10),
+    );
+}
+
+criterion_group!(benches, shuffles);
+criterion_main!(benches);

--- a/eth2/utils/swap_or_not_shuffle/Cargo.toml
+++ b/eth2/utils/swap_or_not_shuffle/Cargo.toml
@@ -4,12 +4,17 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
+[[bench]]
+name = "benches"
+harness = false
+
+[dev-dependencies]
+criterion = "0.2"
+yaml-rust = "0.4.2"
+hex = "0.3"
+ethereum-types = "0.5"
+
 [dependencies]
 bytes = "0.4"
 hashing = { path = "../hashing" }
 int_to_bytes = { path = "../int_to_bytes" }
-
-[dev-dependencies]
-yaml-rust = "0.4.2"
-hex = "0.3"
-ethereum-types = "0.5"

--- a/eth2/utils/swap_or_not_shuffle/benches/benches.rs
+++ b/eth2/utils/swap_or_not_shuffle/benches/benches.rs
@@ -1,0 +1,62 @@
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use swap_or_not_shuffle::get_permutated_index;
+
+const SHUFFLE_ROUND_COUNT: u8 = 90;
+
+fn shuffle_list(seed: &[u8], list_size: usize) -> Vec<usize> {
+    let mut output = Vec::with_capacity(list_size);
+    for i in 0..list_size {
+        output.push(get_permutated_index(i, list_size, seed, SHUFFLE_ROUND_COUNT).unwrap());
+    }
+    output
+}
+
+fn shuffles(c: &mut Criterion) {
+    c.bench_function("single swap", move |b| {
+        let seed = vec![42; 32];
+        b.iter(|| black_box(get_permutated_index(0, 10, &seed, SHUFFLE_ROUND_COUNT)))
+    });
+
+    c.bench_function("whole list of size 8", move |b| {
+        let seed = vec![42; 32];
+        b.iter(|| black_box(shuffle_list(&seed, 8)))
+    });
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("8 elements", move |b| {
+            let seed = vec![42; 32];
+            b.iter(|| black_box(shuffle_list(&seed, 8)))
+        }),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("16 elements", move |b| {
+            let seed = vec![42; 32];
+            b.iter(|| black_box(shuffle_list(&seed, 16)))
+        }),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("512 elements", move |b| {
+            let seed = vec![42; 32];
+            b.iter(|| black_box(shuffle_list(&seed, 512)))
+        })
+        .sample_size(10),
+    );
+
+    c.bench(
+        "whole list shuffle",
+        Benchmark::new("16384 elements", move |b| {
+            let seed = vec![42; 32];
+            b.iter(|| black_box(shuffle_list(&seed, 16_384)))
+        })
+        .sample_size(10),
+    );
+}
+
+criterion_group!(benches, shuffles,);
+criterion_main!(benches);


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Adds benchmarks to `swap_or_not_shuffle`
- Adds benchmakrs to `fisher_yates_shuffle`

## Additional Info

Times for shuffling a list of 16,384 items:

- swap or not: **2.1307 s**
- fisher yates: **1.0636 ms** 