### PR TITLE
Move epoch benches to 16k validators

### DIFF
--- a/beacon_node/beacon_chain/test_harness/Cargo.toml
+++ b/beacon_node/beacon_chain/test_harness/Cargo.toml
@@ -10,6 +10,7 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.2"
+state_processing = { path = "../../../eth2/state_processing" }
 
 [dependencies]
 attester = { path = "../../../eth2/attester" }

--- a/beacon_node/beacon_chain/test_harness/benches/state_transition.rs
+++ b/beacon_node/beacon_chain/test_harness/benches/state_transition.rs
@@ -1,6 +1,7 @@
 use criterion::Criterion;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark};
 // use env_logger::{Builder, Env};
+use state_processing::SlotProcessable;
 use test_harness::BeaconChainHarness;
 use types::{ChainSpec, Hash256};
 

--- a/eth2/state_processing/benches/benches.rs
+++ b/eth2/state_processing/benches/benches.rs
@@ -2,24 +2,30 @@ use criterion::Criterion;
 use criterion::{black_box, criterion_group, criterion_main};
 // use env_logger::{Builder, Env};
 use state_processing::SlotProcessable;
-use types::*;
 use types::beacon_state::BeaconStateBuilder;
+use types::*;
 
 fn epoch_processing(c: &mut Criterion) {
     // Builder::from_env(Env::default().default_filter_or("debug")).init();
 
-    let mut builder = BeaconStateBuilder::with_random_validators(8);
+    let mut builder = BeaconStateBuilder::new(8);
     builder.spec = ChainSpec::few_validators();
 
-    builder.genesis().unwrap();
+    builder.build().unwrap();
     builder.teleport_to_end_of_epoch(builder.spec.genesis_epoch + 4);
 
-    let mut state = builder.build().unwrap();
+    let mut state = builder.cloned_state();
 
     // Build all the caches so the following state does _not_ include the cache-building time.
-    state.build_epoch_cache(RelativeEpoch::Previous, &builder.spec).unwrap();
-    state.build_epoch_cache(RelativeEpoch::Current, &builder.spec).unwrap();
-    state.build_epoch_cache(RelativeEpoch::Next, &builder.spec).unwrap();
+    state
+        .build_epoch_cache(RelativeEpoch::Previous, &builder.spec)
+        .unwrap();
+    state
+        .build_epoch_cache(RelativeEpoch::Current, &builder.spec)
+        .unwrap();
+    state
+        .build_epoch_cache(RelativeEpoch::Next, &builder.spec)
+        .unwrap();
 
     let cached_state = state.clone();
 

--- a/eth2/state_processing/benches/benches.rs
+++ b/eth2/state_processing/benches/benches.rs
@@ -2,7 +2,8 @@ use criterion::Criterion;
 use criterion::{black_box, criterion_group, criterion_main};
 // use env_logger::{Builder, Env};
 use state_processing::SlotProcessable;
-use types::{beacon_state::BeaconStateBuilder, ChainSpec, Hash256};
+use types::*;
+use types::beacon_state::BeaconStateBuilder;
 
 fn epoch_processing(c: &mut Criterion) {
     // Builder::from_env(Env::default().default_filter_or("debug")).init();
@@ -13,13 +14,36 @@ fn epoch_processing(c: &mut Criterion) {
     builder.genesis().unwrap();
     builder.teleport_to_end_of_epoch(builder.spec.genesis_epoch + 4);
 
-    let state = builder.build().unwrap();
+    let mut state = builder.build().unwrap();
 
-    c.bench_function("epoch processing", move |b| {
-        let spec = &builder.spec;
+    // Build all the caches so the following state does _not_ include the cache-building time.
+    state.build_epoch_cache(RelativeEpoch::Previous, &builder.spec).unwrap();
+    state.build_epoch_cache(RelativeEpoch::Current, &builder.spec).unwrap();
+    state.build_epoch_cache(RelativeEpoch::Next, &builder.spec).unwrap();
+
+    let cached_state = state.clone();
+
+    // Drop all the caches so the following state includes the cache-building time.
+    state.drop_cache(RelativeEpoch::Previous);
+    state.drop_cache(RelativeEpoch::Current);
+    state.drop_cache(RelativeEpoch::Next);
+
+    let cacheless_state = state;
+
+    let spec_a = builder.spec.clone();
+    let spec_b = builder.spec.clone();
+
+    c.bench_function("epoch processing with pre-built caches", move |b| {
         b.iter_with_setup(
-            || state.clone(),
-            |mut state| black_box(state.per_slot_processing(Hash256::zero(), spec).unwrap()),
+            || cached_state.clone(),
+            |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_a).unwrap()),
+        )
+    });
+
+    c.bench_function("epoch processing without pre-built caches", move |b| {
+        b.iter_with_setup(
+            || cacheless_state.clone(),
+            |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_b).unwrap()),
         )
     });
 }

--- a/eth2/state_processing/benches/benches.rs
+++ b/eth2/state_processing/benches/benches.rs
@@ -1,5 +1,5 @@
 use criterion::Criterion;
-use criterion::{black_box, criterion_group, criterion_main};
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
 // use env_logger::{Builder, Env};
 use state_processing::SlotProcessable;
 use types::beacon_state::BeaconStateBuilder;
@@ -8,10 +8,9 @@ use types::*;
 fn epoch_processing(c: &mut Criterion) {
     // Builder::from_env(Env::default().default_filter_or("debug")).init();
 
-    let mut builder = BeaconStateBuilder::new(8);
-    builder.spec = ChainSpec::few_validators();
+    let mut builder = BeaconStateBuilder::new(16_384);
 
-    builder.build().unwrap();
+    builder.build_fast().unwrap();
     builder.teleport_to_end_of_epoch(builder.spec.genesis_epoch + 4);
 
     let mut state = builder.cloned_state();
@@ -39,19 +38,27 @@ fn epoch_processing(c: &mut Criterion) {
     let spec_a = builder.spec.clone();
     let spec_b = builder.spec.clone();
 
-    c.bench_function("epoch processing with pre-built caches", move |b| {
-        b.iter_with_setup(
-            || cached_state.clone(),
-            |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_a).unwrap()),
-        )
-    });
+    c.bench(
+        "epoch processing",
+        Benchmark::new("with pre-built caches", move |b| {
+            b.iter_with_setup(
+                || cached_state.clone(),
+                |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_a).unwrap()),
+            )
+        })
+        .sample_size(10),
+    );
 
-    c.bench_function("epoch processing without pre-built caches", move |b| {
-        b.iter_with_setup(
-            || cacheless_state.clone(),
-            |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_b).unwrap()),
-        )
-    });
+    c.bench(
+        "epoch processing",
+        Benchmark::new("without pre-built caches", move |b| {
+            b.iter_with_setup(
+                || cacheless_state.clone(),
+                |mut state| black_box(state.per_slot_processing(Hash256::zero(), &spec_b).unwrap()),
+            )
+        })
+        .sample_size(10),
+    );
 }
 
 criterion_group!(benches, epoch_processing,);

--- a/eth2/state_processing/src/epoch_processable/tests.rs
+++ b/eth2/state_processing/src/epoch_processable/tests.rs
@@ -8,13 +8,13 @@ use types::*;
 fn runs_without_error() {
     Builder::from_env(Env::default().default_filter_or("error")).init();
 
-    let mut builder = BeaconStateBuilder::with_random_validators(8);
+    let mut builder = BeaconStateBuilder::new(8);
     builder.spec = ChainSpec::few_validators();
 
-    builder.genesis().unwrap();
+    builder.build().unwrap();
     builder.teleport_to_end_of_epoch(builder.spec.genesis_epoch + 4);
 
-    let mut state = builder.build().unwrap();
+    let mut state = builder.cloned_state();
 
     let spec = &builder.spec;
     state.per_epoch_processing(spec).unwrap();

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -290,12 +290,16 @@ impl BeaconState {
     /// -- `Next` epoch is always _without_ a registry change. If you perform a registry update,
     /// you should rebuild the `Current` cache so it uses the new seed.
     pub fn advance_caches(&mut self) {
-        let previous_cache_index = self.cache_index(RelativeEpoch::Previous);
-
-        self.caches[previous_cache_index] = EpochCache::empty();
+        self.drop_cache(RelativeEpoch::Previous);
 
         self.cache_index_offset += 1;
         self.cache_index_offset %= CACHED_EPOCHS;
+    }
+
+    /// Removes the specified cache and sets it to uninitialized.
+    pub fn drop_cache(&mut self, relative_epoch: RelativeEpoch) {
+        let previous_cache_index = self.cache_index(relative_epoch);
+        self.caches[previous_cache_index] = EpochCache::empty();
     }
 
     /// Returns the index of `self.caches` for some `RelativeEpoch`.

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -117,19 +117,18 @@ pub struct BeaconState {
 
 impl BeaconState {
     /// Produce the first state of the Beacon Chain.
-    pub fn genesis(
+    pub fn genesis_without_validators(
         genesis_time: u64,
-        initial_validator_deposits: Vec<Deposit>,
         latest_eth1_data: Eth1Data,
         spec: &ChainSpec,
     ) -> Result<BeaconState, Error> {
-        debug!("Creating genesis state.");
+        debug!("Creating genesis state (without validator processing).");
         let initial_crosslink = Crosslink {
             epoch: spec.genesis_epoch,
             shard_block_root: spec.zero_hash,
         };
 
-        let mut genesis_state = BeaconState {
+        Ok(BeaconState {
             /*
              * Misc
              */
@@ -188,7 +187,19 @@ impl BeaconState {
              */
             cache_index_offset: 0,
             caches: vec![EpochCache::empty(); CACHED_EPOCHS],
-        };
+        })
+    }
+    /// Produce the first state of the Beacon Chain.
+    pub fn genesis(
+        genesis_time: u64,
+        initial_validator_deposits: Vec<Deposit>,
+        latest_eth1_data: Eth1Data,
+        spec: &ChainSpec,
+    ) -> Result<BeaconState, Error> {
+        let mut genesis_state =
+            BeaconState::genesis_without_validators(genesis_time, latest_eth1_data, spec)?;
+
+        trace!("Processing genesis deposits...");
 
         let deposit_data = initial_validator_deposits
             .iter()

--- a/eth2/types/src/beacon_state/builder.rs
+++ b/eth2/types/src/beacon_state/builder.rs
@@ -46,6 +46,10 @@ impl BeaconStateBuilder {
         }
     }
 
+    /// Builds a `BeaconState` using the `BeaconState::genesis(..)` function.
+    ///
+    /// Each validator is assigned a unique, randomly-generated keypair and all
+    /// proof-of-possessions are verified during genesis.
     pub fn build(&mut self) -> Result<(), BeaconStateError> {
         self.keypairs = (0..self.validator_count)
             .collect::<Vec<usize>>()
@@ -53,7 +57,8 @@ impl BeaconStateBuilder {
             .map(|_| Keypair::random())
             .collect();
 
-        let initial_validator_deposits = self.keypairs
+        let initial_validator_deposits = self
+            .keypairs
             .iter()
             .map(|keypair| Deposit {
                 branch: vec![], // branch verification is not specified.
@@ -82,6 +87,16 @@ impl BeaconStateBuilder {
         Ok(())
     }
 
+    /// Builds a `BeaconState` using the `BeaconState::genesis(..)` function, without supplying any
+    /// validators. Instead validators are added to the state post-genesis.
+    ///
+    /// One keypair is randomly generated and all validators are assigned this same keypair.
+    /// Proof-of-possessions are not created (or validated).
+    ///
+    /// This function runs orders of magnitude faster than `Self::build()`, however it will be
+    /// erroneous for functions which use a validators public key as an identifier (e.g.,
+    /// deposits).
+    /// proof-of-possessions are verified during genesis.
     pub fn build_fast(&mut self) -> Result<(), BeaconStateError> {
         let common_keypair = Keypair::random();
 

--- a/eth2/types/src/beacon_state/builder.rs
+++ b/eth2/types/src/beacon_state/builder.rs
@@ -96,7 +96,6 @@ impl BeaconStateBuilder {
     /// This function runs orders of magnitude faster than `Self::build()`, however it will be
     /// erroneous for functions which use a validators public key as an identifier (e.g.,
     /// deposits).
-    /// proof-of-possessions are verified during genesis.
     pub fn build_fast(&mut self) -> Result<(), BeaconStateError> {
         let common_keypair = Keypair::random();
 

--- a/eth2/types/src/beacon_state/tests.rs
+++ b/eth2/types/src/beacon_state/tests.rs
@@ -7,9 +7,7 @@ use ssz::{ssz_encode, Decodable};
 
 #[test]
 pub fn can_produce_genesis_block() {
-    let mut builder = BeaconStateBuilder::with_random_validators(2);
-    builder.genesis().unwrap();
-
+    let mut builder = BeaconStateBuilder::new(2);
     builder.build().unwrap();
 }
 
@@ -19,12 +17,12 @@ pub fn can_produce_genesis_block() {
 pub fn get_attestation_participants_consistency() {
     let mut rng = XorShiftRng::from_seed([42; 16]);
 
-    let mut builder = BeaconStateBuilder::with_random_validators(8);
+    let mut builder = BeaconStateBuilder::new(8);
     builder.spec = ChainSpec::few_validators();
 
-    builder.genesis().unwrap();
+    builder.build().unwrap();
 
-    let mut state = builder.build().unwrap();
+    let mut state = builder.cloned_state();
     let spec = builder.spec.clone();
 
     state


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Changes `BeaconState::per_epoch_processing(..)` to use 16k validators instead of 8.
- Adds the `BeaconStateBuilder::build_fast()` method to allow generating a `BeaconState` without generating keypairs and proof-of-possessions for each validator. This reduces the setup time for benchmarks by orders of magnitude.

## Additional Info

Bench results:

```
epoch processing/pre-built caches
                        time:   [2.0584 s 2.0917 s 2.1076 s]

epoch processing/without pre-built caches
                        time:   [8.4381 s 8.4747 s 8.5258 s]

Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low severe
```
