### PR TITLE
Remove cache operations from epoch processing

### DIFF
--- a/eth2/state_processing/src/epoch_processable.rs
+++ b/eth2/state_processing/src/epoch_processable.rs
@@ -619,12 +619,6 @@ impl EpochProcessable for BeaconState {
             .cloned()
             .collect();
 
-        /*
-         * Manage the beacon state caches
-         */
-        self.advance_caches();
-        self.build_epoch_cache(RelativeEpoch::Next, spec)?;
-
         debug!("Epoch transition complete.");
 
         Ok(())

--- a/eth2/state_processing/src/slot_processable.rs
+++ b/eth2/state_processing/src/slot_processable.rs
@@ -26,6 +26,7 @@ where
     ) -> Result<(), Error> {
         if (self.slot + 1) % spec.epoch_length == 0 {
             self.per_epoch_processing(spec)?;
+            self.advance_caches();
         }
 
         self.slot += 1;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Don't build the next cache at all.
- Call `advance_caches()` in per-slot processing.

## Additional Info

Very small change. Building the cache inside the epoch is unnecessary and it slowed our benches down massively.
