### PR TITLE
Correct bitwise fork-choice rule.

### DIFF
--- a/eth2/fork_choice/src/bitwise_lmd_ghost.rs
+++ b/eth2/fork_choice/src/bitwise_lmd_ghost.rs
@@ -192,7 +192,7 @@ where
         }
         // Check if there is a clear block winner at this height. If so return it.
         for (hash, votes) in current_votes.iter() {
-            if *votes >= total_vote_count / 2 {
+            if *votes > total_vote_count / 2 {
                 // we have a clear winner, return it
                 return Some(*hash);
             }
@@ -371,7 +371,10 @@ impl<T: ClientDB + Sized> ForkChoice for BitwiseLMDGhost<T> {
             // if there are no children, we are done, return the current_head
             let children = match self.children.get(&current_head) {
                 Some(children) => children.clone(),
-                None => return Ok(current_head),
+                None => {
+                    debug!("Head found: {}", current_head);
+                    return Ok(current_head);
+                }
             };
 
             // logarithmic lookup blocks to see if there are obvious winners, if so,
@@ -391,7 +394,7 @@ impl<T: ClientDB + Sized> ForkChoice for BitwiseLMDGhost<T> {
                 step /= 2;
             }
             if step > 0 {
-                trace!("Found clear winner in log lookup");
+                trace!("Found clear winner: {}", current_head);
             }
             // if our skip lookup failed and we only have one child, progress to that child
             else if children.len() == 1 {

--- a/eth2/fork_choice/tests/bitwise_lmd_ghost_test_vectors.yaml
+++ b/eth2/fork_choice/tests/bitwise_lmd_ghost_test_vectors.yaml
@@ -35,3 +35,31 @@ test_cases:
     - b3: 3
   heads:
     - id: 'b2'
+- blocks:
+    - id: 'b0'
+      parent: 'b0'
+    - id: 'b1'
+      parent: 'b0'
+    - id: 'b2'
+      parent: 'b0'
+    - id: 'b3'
+      parent: 'b1'
+    - id: 'b4'
+      parent: 'b1'
+    - id: 'b5'
+      parent: 'b1'
+    - id: 'b6'
+      parent: 'b2'
+    - id: 'b7'
+      parent: 'b6'
+  weights:
+    - b0: 0
+    - b1: 3
+    - b2: 2
+    - b3: 1
+    - b4: 1
+    - b5: 1
+    - b6: 2
+    - b7: 2
+  heads:
+    - id: 'b4'


### PR DESCRIPTION
Correct inconsistency in choosing equally weighted children using the `get_clear_winner` optimisation, present in Vitalik's optimisation implementation (pointed out by @pawanjay176). 