### PR TITLE
Fix log_int implementation, removing floats

### DIFF
--- a/eth2/fork_choice/Cargo.toml
+++ b/eth2/fork_choice/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 db = { path = "../../beacon_node/db" }
 ssz = { path = "../utils/ssz" }
 types = { path = "../types" }
-fast-math = "0.1.1"
 log = "0.4.6"
 bit-vec = "0.5.0"
 


### PR DESCRIPTION
## Proposed Changes

Remove floating point logarithms from the implementation of `log_int` so that it always computes the correct result.

## Additional Info

The `test_power_of_2_below` test was failing on my machine, and I was super confused because I could see it was succeeding on CI. The assert `x <= std::f32::MAX as u32` was failing, and I eventually tracked this down as [undefined behaviour](https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics) (because the largest `f32` value doesn't fit in a `u32`). Removing the assert made the test pass, but then that got me thinking about whether there was a different assert I should add in its place...

In the end, I found that there were some inputs (close to powers of 2), for which the function would compute the incorrect result because of float rounding. [Here's an example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d679d95d80fc512e1848ab2eea02908b). To remedy this I've rewritten the function to use integer arithmetic.
