### PR TITLE
Update ethereum-types to 0.5

### DIFF
--- a/beacon_node/db/src/stores/macros.rs
+++ b/beacon_node/db/src/stores/macros.rs
@@ -2,19 +2,19 @@ macro_rules! impl_crud_for_store {
     ($store: ident, $db_column: expr) => {
         impl<T: ClientDB> $store<T> {
             pub fn put(&self, hash: &Hash256, ssz: &[u8]) -> Result<(), DBError> {
-                self.db.put($db_column, hash, ssz)
+                self.db.put($db_column, hash.as_bytes(), ssz)
             }
 
             pub fn get(&self, hash: &Hash256) -> Result<Option<Vec<u8>>, DBError> {
-                self.db.get($db_column, hash)
+                self.db.get($db_column, hash.as_bytes())
             }
 
             pub fn exists(&self, hash: &Hash256) -> Result<bool, DBError> {
-                self.db.exists($db_column, hash)
+                self.db.exists($db_column, hash.as_bytes())
             }
 
             pub fn delete(&self, hash: &Hash256) -> Result<(), DBError> {
-                self.db.delete($db_column, hash)
+                self.db.delete($db_column, hash.as_bytes())
             }
         }
     };
@@ -29,10 +29,10 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
 
             store.put(hash, ssz).unwrap();
-            assert_eq!(db.get(DB_COLUMN, hash).unwrap().unwrap(), ssz);
+            assert_eq!(db.get(DB_COLUMN, hash.as_bytes()).unwrap().unwrap(), ssz);
         }
 
         #[test]
@@ -41,9 +41,9 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
 
-            db.put(DB_COLUMN, hash, ssz).unwrap();
+            db.put(DB_COLUMN, hash.as_bytes(), ssz).unwrap();
             assert_eq!(store.get(hash).unwrap().unwrap(), ssz);
         }
 
@@ -53,10 +53,10 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
-            let other_hash = &Hash256::from("another hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
+            let other_hash = &Hash256::from([0xBB; 32]);
 
-            db.put(DB_COLUMN, other_hash, ssz).unwrap();
+            db.put(DB_COLUMN, other_hash.as_bytes(), ssz).unwrap();
             assert_eq!(store.get(hash).unwrap(), None);
         }
 
@@ -66,9 +66,9 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
 
-            db.put(DB_COLUMN, hash, ssz).unwrap();
+            db.put(DB_COLUMN, hash.as_bytes(), ssz).unwrap();
             assert!(store.exists(hash).unwrap());
         }
 
@@ -78,10 +78,10 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
-            let other_hash = &Hash256::from("another hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
+            let other_hash = &Hash256::from([0xBB; 32]);
 
-            db.put(DB_COLUMN, hash, ssz).unwrap();
+            db.put(DB_COLUMN, hash.as_bytes(), ssz).unwrap();
             assert!(!store.exists(other_hash).unwrap());
         }
 
@@ -91,13 +91,13 @@ macro_rules! test_crud_for_store {
             let store = $store::new(db.clone());
 
             let ssz = "some bytes".as_bytes();
-            let hash = &Hash256::from("some hash".as_bytes());
+            let hash = &Hash256::from([0xAA; 32]);
 
-            db.put(DB_COLUMN, hash, ssz).unwrap();
-            assert!(db.exists(DB_COLUMN, hash).unwrap());
+            db.put(DB_COLUMN, hash.as_bytes(), ssz).unwrap();
+            assert!(db.exists(DB_COLUMN, hash.as_bytes()).unwrap());
 
             store.delete(hash).unwrap();
-            assert!(!db.exists(DB_COLUMN, hash).unwrap());
+            assert!(!db.exists(DB_COLUMN, hash.as_bytes()).unwrap());
         }
     };
 }

--- a/beacon_node/db/src/stores/pow_chain_store.rs
+++ b/beacon_node/db/src/stores/pow_chain_store.rs
@@ -37,7 +37,7 @@ mod tests {
         let db = Arc::new(MemoryDB::open());
         let store = PoWChainStore::new(db.clone());
 
-        let hash = &Hash256::from("some hash".as_bytes()).to_vec();
+        let hash = &Hash256::from([0xAA; 32]).as_bytes().to_vec();
         store.put_block_hash(hash).unwrap();
 
         assert!(db.exists(DB_COLUMN, hash).unwrap());
@@ -48,7 +48,7 @@ mod tests {
         let db = Arc::new(MemoryDB::open());
         let store = PoWChainStore::new(db.clone());
 
-        let hash = &Hash256::from("some hash".as_bytes()).to_vec();
+        let hash = &Hash256::from([0xAA; 32]).as_bytes().to_vec();
         db.put(DB_COLUMN, hash, &[0]).unwrap();
 
         assert!(store.block_hash_exists(hash).unwrap());
@@ -59,8 +59,8 @@ mod tests {
         let db = Arc::new(MemoryDB::open());
         let store = PoWChainStore::new(db.clone());
 
-        let hash = &Hash256::from("some hash".as_bytes()).to_vec();
-        let other_hash = &Hash256::from("another hash".as_bytes()).to_vec();
+        let hash = &Hash256::from([0xAA; 32]).as_bytes().to_vec();
+        let other_hash = &Hash256::from([0xBB; 32]).as_bytes().to_vec();
         db.put(DB_COLUMN, hash, &[0]).unwrap();
 
         assert!(!store.block_hash_exists(other_hash).unwrap());

--- a/eth2/fork_choice/src/bitwise_lmd_ghost.rs
+++ b/eth2/fork_choice/src/bitwise_lmd_ghost.rs
@@ -210,7 +210,7 @@ where
 
             trace!("Child vote length: {}", votes.len());
             for (candidate, votes) in votes.iter() {
-                let candidate_bit: BitVec = BitVec::from_bytes(&candidate);
+                let candidate_bit: BitVec = BitVec::from_bytes(candidate.as_bytes());
 
                 // if the bitmasks don't match, exclude candidate
                 if !bitmask.iter().eq(candidate_bit.iter().take(bit)) {

--- a/eth2/state_processing/src/block_processable.rs
+++ b/eth2/state_processing/src/block_processable.rs
@@ -134,9 +134,10 @@ fn per_block_processing_signature_optional(
     let new_mix = {
         let mut mix = state.latest_randao_mixes
             [state.slot.as_usize() % spec.latest_randao_mixes_length]
+            .as_bytes()
             .to_vec();
         mix.append(&mut ssz_encode(&block.randao_reveal));
-        Hash256::from(&hash(&mix)[..])
+        Hash256::from_slice(&hash(&mix)[..])
     };
 
     state.latest_randao_mixes[state.slot.as_usize() % spec.latest_randao_mixes_length] = new_mix;

--- a/eth2/state_processing/src/epoch_processable.rs
+++ b/eth2/state_processing/src/epoch_processable.rs
@@ -626,7 +626,7 @@ impl EpochProcessable for BeaconState {
 }
 
 fn hash_tree_root<T: TreeHash>(input: Vec<T>) -> Hash256 {
-    Hash256::from(&input.hash_tree_root()[..])
+    Hash256::from_slice(&input.hash_tree_root()[..])
 }
 
 fn winning_root(

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bls = { path = "../utils/bls" }
 boolean-bitfield = { path = "../utils/boolean-bitfield" }
-ethereum-types = "0.4.0"
+ethereum-types = "0.5"
 hashing = { path = "../utils/hashing" }
 honey-badger-split =  { path = "../utils/honey-badger-split" }
 log = "0.4"
@@ -21,6 +21,7 @@ ssz = { path = "../utils/ssz" }
 ssz_derive = { path = "../utils/ssz_derive" }
 swap_or_not_shuffle = { path = "../utils/swap_or_not_shuffle" }
 test_random_derive = { path = "../utils/test_random_derive" }
+int_to_bytes = { path = "../utils/int_to_bytes" }
 
 [dev-dependencies]
 env_logger = "0.6.0"

--- a/eth2/types/src/attestation.rs
+++ b/eth2/types/src/attestation.rs
@@ -16,7 +16,7 @@ pub struct Attestation {
 
 impl Attestation {
     pub fn canonical_root(&self) -> Hash256 {
-        Hash256::from(&self.hash_tree_root()[..])
+        Hash256::from_slice(&self.hash_tree_root()[..])
     }
 
     pub fn signable_message(&self, custody_bit: bool) -> Vec<u8> {

--- a/eth2/types/src/attestation_data.rs
+++ b/eth2/types/src/attestation_data.rs
@@ -35,7 +35,7 @@ impl Eq for AttestationData {}
 
 impl AttestationData {
     pub fn canonical_root(&self) -> Hash256 {
-        Hash256::from(&self.hash_tree_root()[..])
+        Hash256::from_slice(&self.hash_tree_root()[..])
     }
 
     pub fn signable_message(&self, custody_bit: bool) -> Vec<u8> {

--- a/eth2/types/src/attester_slashing/builder.rs
+++ b/eth2/types/src/attester_slashing/builder.rs
@@ -27,8 +27,8 @@ impl AttesterSlashingBuilder {
         let shard = 0;
         let justified_epoch = Epoch::new(0);
         let epoch = Epoch::new(0);
-        let hash_1 = Hash256::from(&[1][..]);
-        let hash_2 = Hash256::from(&[2][..]);
+        let hash_1 = Hash256::from_low_u64_le(1);
+        let hash_2 = Hash256::from_low_u64_le(2);
 
         let mut slashable_attestation_1 = SlashableAttestation {
             validator_indices: validator_indices.to_vec(),

--- a/eth2/types/src/beacon_block.rs
+++ b/eth2/types/src/beacon_block.rs
@@ -42,7 +42,7 @@ impl BeaconBlock {
     }
 
     pub fn canonical_root(&self) -> Hash256 {
-        Hash256::from(&self.hash_tree_root()[..])
+        Hash256::from_slice(&self.hash_tree_root()[..])
     }
 
     pub fn proposal_root(&self, spec: &ChainSpec) -> Hash256 {
@@ -57,7 +57,7 @@ impl BeaconBlock {
             shard: spec.beacon_chain_shard_number,
             block_root: block_without_signature_root,
         };
-        Hash256::from(&proposal.hash_tree_root()[..])
+        Hash256::from_slice(&proposal.hash_tree_root()[..])
     }
 }
 

--- a/eth2/types/src/beacon_state/builder.rs
+++ b/eth2/types/src/beacon_state/builder.rs
@@ -145,8 +145,8 @@ impl BeaconStateBuilder {
         state.previous_calculation_epoch = epoch - 1;
         state.current_calculation_epoch = epoch;
 
-        state.previous_epoch_seed = Hash256::from(&b"previous_seed"[..]);
-        state.current_epoch_seed = Hash256::from(&b"current_seed"[..]);
+        state.previous_epoch_seed = Hash256::from([0x01; 32]);
+        state.current_epoch_seed = Hash256::from([0x02; 32]);
 
         state.previous_justified_epoch = epoch - 2;
         state.justified_epoch = epoch - 1;

--- a/eth2/types/src/proposer_slashing/builder.rs
+++ b/eth2/types/src/proposer_slashing/builder.rs
@@ -25,13 +25,13 @@ impl ProposerSlashingBuilder {
         let proposal_data_1 = ProposalSignedData {
             slot,
             shard,
-            block_root: Hash256::from(&[1][..]),
+            block_root: Hash256::from_low_u64_le(1),
         };
 
         let proposal_data_2 = ProposalSignedData {
             slot,
             shard,
-            block_root: Hash256::from(&[2][..]),
+            block_root: Hash256::from_low_u64_le(2),
         };
 
         let proposal_signature_1 = {

--- a/eth2/types/src/test_utils/address.rs
+++ b/eth2/types/src/test_utils/address.rs
@@ -6,6 +6,6 @@ impl<T: RngCore> TestRandom<T> for Address {
     fn random_for_test(rng: &mut T) -> Self {
         let mut key_bytes = vec![0; 20];
         rng.fill_bytes(&mut key_bytes);
-        Address::from(&key_bytes[..])
+        Address::from_slice(&key_bytes[..])
     }
 }

--- a/eth2/types/src/test_utils/hash256.rs
+++ b/eth2/types/src/test_utils/hash256.rs
@@ -6,6 +6,6 @@ impl<T: RngCore> TestRandom<T> for Hash256 {
     fn random_for_test(rng: &mut T) -> Self {
         let mut key_bytes = vec![0; 32];
         rng.fill_bytes(&mut key_bytes);
-        Hash256::from(&key_bytes[..])
+        Hash256::from_slice(&key_bytes[..])
     }
 }

--- a/eth2/utils/ssz/Cargo.toml
+++ b/eth2/utils/ssz/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.9"
-ethereum-types = "0.4.0"
+ethereum-types = "0.5"
 hashing = { path = "../hashing" }

--- a/eth2/utils/ssz/src/impl_decode.rs
+++ b/eth2/utils/ssz/src/impl_decode.rs
@@ -59,7 +59,7 @@ impl Decodable for H256 {
         if bytes.len() < 32 || bytes.len() - 32 < index {
             Err(DecodeError::TooShort)
         } else {
-            Ok((H256::from(&bytes[index..(index + 32)]), index + 32))
+            Ok((H256::from_slice(&bytes[index..(index + 32)]), index + 32))
         }
     }
 }
@@ -69,7 +69,7 @@ impl Decodable for Address {
         if bytes.len() < 20 || bytes.len() - 20 < index {
             Err(DecodeError::TooShort)
         } else {
-            Ok((Address::from(&bytes[index..(index + 20)]), index + 20))
+            Ok((Address::from_slice(&bytes[index..(index + 20)]), index + 20))
         }
     }
 }
@@ -95,7 +95,7 @@ mod tests {
          */
         let input = vec![42_u8; 32];
         let (decoded, i) = H256::ssz_decode(&input, 0).unwrap();
-        assert_eq!(decoded.to_vec(), input);
+        assert_eq!(decoded.as_bytes(), &input[..]);
         assert_eq!(i, 32);
 
         /*
@@ -104,7 +104,7 @@ mod tests {
         let mut input = vec![42_u8; 32];
         input.push(12);
         let (decoded, i) = H256::ssz_decode(&input, 0).unwrap();
-        assert_eq!(decoded.to_vec()[..], input[0..32]);
+        assert_eq!(decoded.as_bytes(), &input[0..32]);
         assert_eq!(i, 32);
 
         /*

--- a/eth2/utils/ssz/src/impl_encode.rs
+++ b/eth2/utils/ssz/src/impl_encode.rs
@@ -55,13 +55,13 @@ impl Encodable for bool {
 
 impl Encodable for H256 {
     fn ssz_append(&self, s: &mut SszStream) {
-        s.append_encoded_raw(&self.to_vec());
+        s.append_encoded_raw(self.as_bytes());
     }
 }
 
 impl Encodable for Address {
     fn ssz_append(&self, s: &mut SszStream) {
-        s.append_encoded_raw(&self.to_vec());
+        s.append_encoded_raw(self.as_bytes());
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Update to ethereum-types 0.5.0 #216

## Proposed Changes

* Update `ethereum-types` to 0.5(.2)
* Use `from_slice` to convert byte slices to `Hash256`, as `Hash256::from` for slices has been removed
* Add explicit `as_bytes` conversions for `Hash256` to `&[u8]`. Previously not required due to a now-removed `Deref` impl
* Use `int_to_bytes32` in `generate_seed` to avoid confusion ([spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#generate_seed))
* Replace the arbitrary strings used for the epoch seeds in `teleport_to_end_of_epoch` with arbitrary byte arrays
* Add a `Hash256::from_short_slice` mixin to ease compatibility with existing tests that use slices of length less than 32

## Additional Info

I'd like feedback on the last two points in particular, which feel a little bit suspect – particularly `from_short_slice`. We could do away with that extra complexity by using arbitrary byte arrays in the tests instead of strings like `"some hash"`.