### PR TITLE
 Remove SSZ round-trip test duplication

### DIFF
--- a/beacon_node/db/src/stores/macros.rs
+++ b/beacon_node/db/src/stores/macros.rs
@@ -20,7 +20,7 @@ macro_rules! impl_crud_for_store {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! test_crud_for_store {
     ($store: ident, $db_column: expr) => {
         #[test]

--- a/eth2/types/src/attestation.rs
+++ b/eth2/types/src/attestation.rs
@@ -40,29 +40,6 @@ impl Attestation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Attestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Attestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Attestation);
 }

--- a/eth2/types/src/attestation_data.rs
+++ b/eth2/types/src/attestation_data.rs
@@ -50,29 +50,6 @@ impl AttestationData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttestationData);
 }

--- a/eth2/types/src/attestation_data_and_custody_bit.rs
+++ b/eth2/types/src/attestation_data_and_custody_bit.rs
@@ -23,31 +23,6 @@ impl<T: RngCore> TestRandom<T> for AttestationDataAndCustodyBit {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-
-        let original = AttestationDataAndCustodyBit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationDataAndCustodyBit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttestationDataAndCustodyBit);
 }

--- a/eth2/types/src/attester_slashing.rs
+++ b/eth2/types/src/attester_slashing.rs
@@ -17,29 +17,6 @@ pub struct AttesterSlashing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttesterSlashing::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttesterSlashing::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttesterSlashing);
 }

--- a/eth2/types/src/beacon_block.rs
+++ b/eth2/types/src/beacon_block.rs
@@ -64,29 +64,6 @@ impl BeaconBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlock::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlock::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(BeaconBlock);
 }

--- a/eth2/types/src/beacon_block_body.rs
+++ b/eth2/types/src/beacon_block_body.rs
@@ -17,29 +17,6 @@ pub struct BeaconBlockBody {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlockBody::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlockBody::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(BeaconBlockBody);
 }

--- a/eth2/types/src/beacon_state/tests.rs
+++ b/eth2/types/src/beacon_state/tests.rs
@@ -3,7 +3,6 @@
 use super::*;
 use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
 use crate::{BeaconState, ChainSpec};
-use ssz::{ssz_encode, Decodable};
 
 #[test]
 pub fn can_produce_genesis_block() {
@@ -60,25 +59,4 @@ pub fn get_attestation_participants_consistency() {
     }
 }
 
-#[test]
-pub fn test_ssz_round_trip() {
-    let mut rng = XorShiftRng::from_seed([42; 16]);
-    let original = BeaconState::random_for_test(&mut rng);
-
-    let bytes = ssz_encode(&original);
-    let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-    assert_eq!(original, decoded);
-}
-
-#[test]
-pub fn test_hash_tree_root_internal() {
-    let mut rng = XorShiftRng::from_seed([42; 16]);
-    let original = BeaconState::random_for_test(&mut rng);
-
-    let result = original.hash_tree_root_internal();
-
-    assert_eq!(result.len(), 32);
-    // TODO: Add further tests
-    // https://github.com/sigp/lighthouse/issues/170
-}
+ssz_tests!(BeaconState);

--- a/eth2/types/src/casper_slashing.rs
+++ b/eth2/types/src/casper_slashing.rs
@@ -14,29 +14,6 @@ pub struct CasperSlashing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = CasperSlashing::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = CasperSlashing::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(CasperSlashing);
 }

--- a/eth2/types/src/crosslink.rs
+++ b/eth2/types/src/crosslink.rs
@@ -26,29 +26,6 @@ impl Crosslink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Crosslink::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Crosslink::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Crosslink);
 }

--- a/eth2/types/src/deposit.rs
+++ b/eth2/types/src/deposit.rs
@@ -15,29 +15,6 @@ pub struct Deposit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Deposit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Deposit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Deposit);
 }

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -15,29 +15,6 @@ pub struct DepositData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(DepositData);
 }

--- a/eth2/types/src/deposit_input.rs
+++ b/eth2/types/src/deposit_input.rs
@@ -16,29 +16,6 @@ pub struct DepositInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositInput::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositInput::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(DepositInput);
 }

--- a/eth2/types/src/eth1_data.rs
+++ b/eth2/types/src/eth1_data.rs
@@ -15,29 +15,6 @@ pub struct Eth1Data {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1Data::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1Data::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Eth1Data);
 }

--- a/eth2/types/src/eth1_data_vote.rs
+++ b/eth2/types/src/eth1_data_vote.rs
@@ -15,29 +15,6 @@ pub struct Eth1DataVote {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1DataVote::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1DataVote::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Eth1DataVote);
 }

--- a/eth2/types/src/exit.rs
+++ b/eth2/types/src/exit.rs
@@ -15,29 +15,6 @@ pub struct Exit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Exit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Exit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Exit);
 }

--- a/eth2/types/src/fork.rs
+++ b/eth2/types/src/fork.rs
@@ -30,29 +30,6 @@ impl Fork {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Fork::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Fork::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Fork);
 }

--- a/eth2/types/src/lib.rs
+++ b/eth2/types/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 pub mod test_utils;
 
 pub mod attestation;

--- a/eth2/types/src/pending_attestation.rs
+++ b/eth2/types/src/pending_attestation.rs
@@ -16,29 +16,6 @@ pub struct PendingAttestation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = PendingAttestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = PendingAttestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(PendingAttestation);
 }

--- a/eth2/types/src/proposal_signed_data.rs
+++ b/eth2/types/src/proposal_signed_data.rs
@@ -15,29 +15,6 @@ pub struct ProposalSignedData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposalSignedData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposalSignedData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ProposalSignedData);
 }

--- a/eth2/types/src/proposer_slashing.rs
+++ b/eth2/types/src/proposer_slashing.rs
@@ -22,29 +22,6 @@ pub struct ProposerSlashing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposerSlashing::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposerSlashing::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ProposerSlashing);
 }

--- a/eth2/types/src/shard_reassignment_record.rs
+++ b/eth2/types/src/shard_reassignment_record.rs
@@ -14,29 +14,6 @@ pub struct ShardReassignmentRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ShardReassignmentRecord::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ShardReassignmentRecord::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ShardReassignmentRecord);
 }

--- a/eth2/types/src/slashable_attestation.rs
+++ b/eth2/types/src/slashable_attestation.rs
@@ -39,7 +39,6 @@ mod tests {
     use crate::chain_spec::ChainSpec;
     use crate::slot_epoch::{Epoch, Slot};
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
     #[test]
     pub fn test_is_double_vote_true() {
@@ -113,28 +112,7 @@ mod tests {
         );
     }
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableAttestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableAttestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(SlashableAttestation);
 
     fn create_slashable_attestation(
         slot_factor: u64,

--- a/eth2/types/src/slashable_vote_data.rs
+++ b/eth2/types/src/slashable_vote_data.rs
@@ -42,7 +42,6 @@ mod tests {
     use crate::chain_spec::ChainSpec;
     use crate::slot_epoch::{Epoch, Slot};
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
     #[test]
     pub fn test_is_double_vote_true() {
@@ -116,28 +115,7 @@ mod tests {
         );
     }
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableVoteData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableVoteData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(SlashableVoteData);
 
     fn create_slashable_vote_data(
         slot_factor: u64,

--- a/eth2/types/src/slot_epoch.rs
+++ b/eth2/types/src/slot_epoch.rs
@@ -103,8 +103,6 @@ impl<'a> Iterator for SlotIter<'a> {
 #[cfg(test)]
 mod slot_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(Slot);
 }
@@ -112,8 +110,6 @@ mod slot_tests {
 #[cfg(test)]
 mod epoch_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(Epoch);
 

--- a/eth2/types/src/slot_epoch_macros.rs
+++ b/eth2/types/src/slot_epoch_macros.rs
@@ -548,34 +548,6 @@ macro_rules! math_tests {
     };
 }
 
-#[allow(unused_macros)]
-macro_rules! ssz_tests {
-    ($type: ident) => {
-        #[test]
-        pub fn test_ssz_round_trip() {
-            let mut rng = XorShiftRng::from_seed([42; 16]);
-            let original = $type::random_for_test(&mut rng);
-
-            let bytes = ssz_encode(&original);
-            let (decoded, _) = $type::ssz_decode(&bytes, 0).unwrap();
-
-            assert_eq!(original, decoded);
-        }
-
-        #[test]
-        pub fn test_hash_tree_root_internal() {
-            let mut rng = XorShiftRng::from_seed([42; 16]);
-            let original = $type::random_for_test(&mut rng);
-
-            let result = original.hash_tree_root_internal();
-
-            assert_eq!(result.len(), 32);
-            // TODO: Add further tests
-            // https://github.com/sigp/lighthouse/issues/170
-        }
-    };
-}
-
 #[cfg(test)]
 macro_rules! all_tests {
     ($type: ident) => {

--- a/eth2/types/src/slot_epoch_macros.rs
+++ b/eth2/types/src/slot_epoch_macros.rs
@@ -21,6 +21,7 @@ macro_rules! impl_from_into_u64 {
 }
 
 // need to truncate for some fork-choice algorithms
+#[allow(unused_macros)]
 macro_rules! impl_into_u32 {
     ($main: ident) => {
         impl Into<u32> for $main {
@@ -267,7 +268,7 @@ macro_rules! impl_common {
 }
 
 // test macros
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! new_tests {
     ($type: ident) => {
         #[test]
@@ -279,7 +280,7 @@ macro_rules! new_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! from_into_tests {
     ($type: ident, $other: ident) => {
         #[test]
@@ -305,7 +306,7 @@ macro_rules! from_into_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! math_between_tests {
     ($type: ident, $other: ident) => {
         #[test]
@@ -453,7 +454,7 @@ macro_rules! math_between_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! math_tests {
     ($type: ident) => {
         #[test]
@@ -575,7 +576,7 @@ macro_rules! ssz_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! all_tests {
     ($type: ident) => {
         new_tests!($type);

--- a/eth2/types/src/slot_height.rs
+++ b/eth2/types/src/slot_height.rs
@@ -33,11 +33,8 @@ impl SlotHeight {
 }
 
 #[cfg(test)]
-
 mod slot_height_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(SlotHeight);
 }

--- a/eth2/types/src/test_utils/macros.rs
+++ b/eth2/types/src/test_utils/macros.rs
@@ -1,0 +1,34 @@
+#[cfg(test)]
+#[macro_export]
+macro_rules! ssz_tests {
+    ($type: ident) => {
+        #[test]
+        pub fn test_ssz_round_trip() {
+            use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
+            use ssz::{ssz_encode, Decodable};
+
+            let mut rng = XorShiftRng::from_seed([42; 16]);
+            let original = $type::random_for_test(&mut rng);
+
+            let bytes = ssz_encode(&original);
+            let (decoded, _) = $type::ssz_decode(&bytes, 0).unwrap();
+
+            assert_eq!(original, decoded);
+        }
+
+        #[test]
+        pub fn test_hash_tree_root_internal() {
+            use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
+            use ssz::TreeHash;
+
+            let mut rng = XorShiftRng::from_seed([42; 16]);
+            let original = $type::random_for_test(&mut rng);
+
+            let result = original.hash_tree_root_internal();
+
+            assert_eq!(result.len(), 32);
+            // TODO: Add further tests
+            // https://github.com/sigp/lighthouse/issues/170
+        }
+    };
+}

--- a/eth2/types/src/test_utils/mod.rs
+++ b/eth2/types/src/test_utils/mod.rs
@@ -6,6 +6,8 @@ pub mod address;
 pub mod aggregate_signature;
 pub mod bitfield;
 pub mod hash256;
+#[macro_use]
+mod macros;
 pub mod public_key;
 pub mod secret_key;
 pub mod signature;

--- a/eth2/types/src/validator.rs
+++ b/eth2/types/src/validator.rs
@@ -170,18 +170,6 @@ impl<T: RngCore> TestRandom<T> for Validator {
 mod tests {
     use super::*;
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
-
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Validator::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
 
     #[test]
     fn test_validator_can_be_active() {
@@ -206,15 +194,5 @@ mod tests {
         }
     }
 
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Validator::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Validator);
 }

--- a/eth2/types/src/validator_registry_delta_block.rs
+++ b/eth2/types/src/validator_registry_delta_block.rs
@@ -31,29 +31,6 @@ impl Default for ValidatorRegistryDeltaBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ValidatorRegistryDeltaBlock::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root_internal() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ValidatorRegistryDeltaBlock::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root_internal();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ValidatorRegistryDeltaBlock);
 }


### PR DESCRIPTION
## Issue Addressed

#244

## Proposed Changes

Use the `ssz_tests!` macro to de-dupe the SSZ roundtrip tests

## Additional Info

Also removed some instances of `allow(unused_macros)` that were better suited to `cfg(test)`. This should help us catch macros that are actually unused, of which there's currently one – `impl_into_u32` – which seems fine to leave in for now.