### PR TITLE
Updated TreeHash logic as per revised spec

### DIFF
--- a/eth2/types/src/attestation.rs
+++ b/eth2/types/src/attestation.rs
@@ -35,11 +35,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Attestation::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/attestation_data.rs
+++ b/eth2/types/src/attestation_data.rs
@@ -53,11 +53,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = AttestationData::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/attestation_data_and_custody_bit.rs
+++ b/eth2/types/src/attestation_data_and_custody_bit.rs
@@ -42,11 +42,11 @@ mod test {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = AttestationDataAndCustodyBit::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/attester_slashing.rs
+++ b/eth2/types/src/attester_slashing.rs
@@ -35,11 +35,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = AttesterSlashing::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/beacon_block.rs
+++ b/eth2/types/src/beacon_block.rs
@@ -69,11 +69,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = BeaconBlock::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/beacon_block_body.rs
+++ b/eth2/types/src/beacon_block_body.rs
@@ -36,11 +36,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = BeaconBlockBody::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -1269,17 +1269,9 @@ impl TreeHash for BeaconState {
         result.append(&mut self.fork.hash_tree_root());
         result.append(&mut self.validator_registry.hash_tree_root());
         result.append(&mut self.validator_balances.hash_tree_root());
-        result.append(
-            &mut self
-                .validator_registry_update_epoch
-                .hash_tree_root(),
-        );
+        result.append(&mut self.validator_registry_update_epoch.hash_tree_root());
         result.append(&mut self.latest_randao_mixes.hash_tree_root());
-        result.append(
-            &mut self
-                .previous_shuffling_start_shard
-                .hash_tree_root(),
-        );
+        result.append(&mut self.previous_shuffling_start_shard.hash_tree_root());
         result.append(&mut self.current_shuffling_start_shard.hash_tree_root());
         result.append(&mut self.previous_shuffling_epoch.hash_tree_root());
         result.append(&mut self.current_shuffling_epoch.hash_tree_root());

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -1262,42 +1262,42 @@ impl Decodable for BeaconState {
 }
 
 impl TreeHash for BeaconState {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         let mut result: Vec<u8> = vec![];
-        result.append(&mut self.slot.hash_tree_root_internal());
-        result.append(&mut self.genesis_time.hash_tree_root_internal());
-        result.append(&mut self.fork.hash_tree_root_internal());
-        result.append(&mut self.validator_registry.hash_tree_root_internal());
-        result.append(&mut self.validator_balances.hash_tree_root_internal());
+        result.append(&mut self.slot.hash_tree_root());
+        result.append(&mut self.genesis_time.hash_tree_root());
+        result.append(&mut self.fork.hash_tree_root());
+        result.append(&mut self.validator_registry.hash_tree_root());
+        result.append(&mut self.validator_balances.hash_tree_root());
         result.append(
             &mut self
                 .validator_registry_update_epoch
-                .hash_tree_root_internal(),
+                .hash_tree_root(),
         );
-        result.append(&mut self.latest_randao_mixes.hash_tree_root_internal());
+        result.append(&mut self.latest_randao_mixes.hash_tree_root());
         result.append(
             &mut self
                 .previous_shuffling_start_shard
-                .hash_tree_root_internal(),
+                .hash_tree_root(),
         );
-        result.append(&mut self.current_shuffling_start_shard.hash_tree_root_internal());
-        result.append(&mut self.previous_shuffling_epoch.hash_tree_root_internal());
-        result.append(&mut self.current_shuffling_epoch.hash_tree_root_internal());
-        result.append(&mut self.previous_shuffling_seed.hash_tree_root_internal());
-        result.append(&mut self.current_shuffling_seed.hash_tree_root_internal());
-        result.append(&mut self.previous_justified_epoch.hash_tree_root_internal());
-        result.append(&mut self.justified_epoch.hash_tree_root_internal());
-        result.append(&mut self.justification_bitfield.hash_tree_root_internal());
-        result.append(&mut self.finalized_epoch.hash_tree_root_internal());
-        result.append(&mut self.latest_crosslinks.hash_tree_root_internal());
-        result.append(&mut self.latest_block_roots.hash_tree_root_internal());
-        result.append(&mut self.latest_active_index_roots.hash_tree_root_internal());
-        result.append(&mut self.latest_slashed_balances.hash_tree_root_internal());
-        result.append(&mut self.latest_attestations.hash_tree_root_internal());
-        result.append(&mut self.batched_block_roots.hash_tree_root_internal());
-        result.append(&mut self.latest_eth1_data.hash_tree_root_internal());
-        result.append(&mut self.eth1_data_votes.hash_tree_root_internal());
-        result.append(&mut self.deposit_index.hash_tree_root_internal());
+        result.append(&mut self.current_shuffling_start_shard.hash_tree_root());
+        result.append(&mut self.previous_shuffling_epoch.hash_tree_root());
+        result.append(&mut self.current_shuffling_epoch.hash_tree_root());
+        result.append(&mut self.previous_shuffling_seed.hash_tree_root());
+        result.append(&mut self.current_shuffling_seed.hash_tree_root());
+        result.append(&mut self.previous_justified_epoch.hash_tree_root());
+        result.append(&mut self.justified_epoch.hash_tree_root());
+        result.append(&mut self.justification_bitfield.hash_tree_root());
+        result.append(&mut self.finalized_epoch.hash_tree_root());
+        result.append(&mut self.latest_crosslinks.hash_tree_root());
+        result.append(&mut self.latest_block_roots.hash_tree_root());
+        result.append(&mut self.latest_active_index_roots.hash_tree_root());
+        result.append(&mut self.latest_slashed_balances.hash_tree_root());
+        result.append(&mut self.latest_attestations.hash_tree_root());
+        result.append(&mut self.batched_block_roots.hash_tree_root());
+        result.append(&mut self.latest_eth1_data.hash_tree_root());
+        result.append(&mut self.eth1_data_votes.hash_tree_root());
+        result.append(&mut self.deposit_index.hash_tree_root());
         hash(&result)
     }
 }

--- a/eth2/types/src/beacon_state/tests.rs
+++ b/eth2/types/src/beacon_state/tests.rs
@@ -72,11 +72,11 @@ pub fn test_ssz_round_trip() {
 }
 
 #[test]
-pub fn test_hash_tree_root_internal() {
+pub fn test_hash_tree_root() {
     let mut rng = XorShiftRng::from_seed([42; 16]);
     let original = BeaconState::random_for_test(&mut rng);
 
-    let result = original.hash_tree_root_internal();
+    let result = original.hash_tree_root();
 
     assert_eq!(result.len(), 32);
     // TODO: Add further tests

--- a/eth2/types/src/crosslink.rs
+++ b/eth2/types/src/crosslink.rs
@@ -34,11 +34,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Crosslink::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/deposit.rs
+++ b/eth2/types/src/deposit.rs
@@ -33,11 +33,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Deposit::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -33,11 +33,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = DepositData::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/deposit_input.rs
+++ b/eth2/types/src/deposit_input.rs
@@ -34,11 +34,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = DepositInput::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/eth1_data.rs
+++ b/eth2/types/src/eth1_data.rs
@@ -32,11 +32,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Eth1Data::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/eth1_data_vote.rs
+++ b/eth2/types/src/eth1_data_vote.rs
@@ -32,11 +32,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Eth1DataVote::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/fork.rs
+++ b/eth2/types/src/fork.rs
@@ -44,11 +44,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Fork::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/pending_attestation.rs
+++ b/eth2/types/src/pending_attestation.rs
@@ -34,11 +34,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = PendingAttestation::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/proposal.rs
+++ b/eth2/types/src/proposal.rs
@@ -37,11 +37,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Proposal::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/proposer_slashing.rs
+++ b/eth2/types/src/proposer_slashing.rs
@@ -37,11 +37,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = ProposerSlashing::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/shard_reassignment_record.rs
+++ b/eth2/types/src/shard_reassignment_record.rs
@@ -29,11 +29,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = ShardReassignmentRecord::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/slashable_attestation.rs
+++ b/eth2/types/src/slashable_attestation.rs
@@ -132,11 +132,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = SlashableAttestation::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/slot_epoch_macros.rs
+++ b/eth2/types/src/slot_epoch_macros.rs
@@ -207,9 +207,9 @@ macro_rules! impl_ssz {
         }
 
         impl TreeHash for $type {
-            fn hash_tree_root_internal(&self) -> Vec<u8> {
+            fn hash_tree_root(&self) -> Vec<u8> {
                 let mut result: Vec<u8> = vec![];
-                result.append(&mut self.0.hash_tree_root_internal());
+                result.append(&mut self.0.hash_tree_root());
                 hash(&result)
             }
         }
@@ -543,11 +543,11 @@ macro_rules! ssz_tests {
         }
 
         #[test]
-        pub fn test_hash_tree_root_internal() {
+        pub fn test_hash_tree_root() {
             let mut rng = XorShiftRng::from_seed([42; 16]);
             let original = $type::random_for_test(&mut rng);
 
-            let result = original.hash_tree_root_internal();
+            let result = original.hash_tree_root();
 
             assert_eq!(result.len(), 32);
             // TODO: Add further tests

--- a/eth2/types/src/test_utils/macros.rs
+++ b/eth2/types/src/test_utils/macros.rs
@@ -17,14 +17,14 @@ macro_rules! ssz_tests {
         }
 
         #[test]
-        pub fn test_hash_tree_root_internal() {
+        pub fn test_hash_tree_root() {
             use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
             use ssz::TreeHash;
 
             let mut rng = XorShiftRng::from_seed([42; 16]);
             let original = $type::random_for_test(&mut rng);
 
-            let result = original.hash_tree_root_internal();
+            let result = original.hash_tree_root();
 
             assert_eq!(result.len(), 32);
             // TODO: Add further tests

--- a/eth2/types/src/transfer.rs
+++ b/eth2/types/src/transfer.rs
@@ -39,11 +39,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Transfer::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/validator.rs
+++ b/eth2/types/src/validator.rs
@@ -91,11 +91,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = Validator::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/types/src/voluntary_exit.rs
+++ b/eth2/types/src/voluntary_exit.rs
@@ -34,11 +34,11 @@ mod tests {
     }
 
     #[test]
-    pub fn test_hash_tree_root_internal() {
+    pub fn test_hash_tree_root() {
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let original = VoluntaryExit::random_for_test(&mut rng);
 
-        let result = original.hash_tree_root_internal();
+        let result = original.hash_tree_root();
 
         assert_eq!(result.len(), 32);
         // TODO: Add further tests

--- a/eth2/utils/bls/src/aggregate_signature.rs
+++ b/eth2/utils/bls/src/aggregate_signature.rs
@@ -95,7 +95,7 @@ impl Serialize for AggregateSignature {
 }
 
 impl TreeHash for AggregateSignature {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         hash(&self.0.as_bytes())
     }
 }

--- a/eth2/utils/bls/src/public_key.rs
+++ b/eth2/utils/bls/src/public_key.rs
@@ -66,7 +66,7 @@ impl Serialize for PublicKey {
 }
 
 impl TreeHash for PublicKey {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         hash(&self.0.as_bytes())
     }
 }

--- a/eth2/utils/bls/src/secret_key.rs
+++ b/eth2/utils/bls/src/secret_key.rs
@@ -41,7 +41,7 @@ impl Decodable for SecretKey {
 }
 
 impl TreeHash for SecretKey {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         self.0.as_bytes().clone()
     }
 }

--- a/eth2/utils/bls/src/signature.rs
+++ b/eth2/utils/bls/src/signature.rs
@@ -73,7 +73,7 @@ impl Decodable for Signature {
 }
 
 impl TreeHash for Signature {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         hash(&self.0.as_bytes())
     }
 }

--- a/eth2/utils/boolean-bitfield/src/lib.rs
+++ b/eth2/utils/boolean-bitfield/src/lib.rs
@@ -187,8 +187,8 @@ impl Serialize for BooleanBitfield {
 }
 
 impl ssz::TreeHash for BooleanBitfield {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
-        self.to_bytes().hash_tree_root_internal()
+    fn hash_tree_root(&self) -> Vec<u8> {
+        self.to_bytes().hash_tree_root()
     }
 }
 

--- a/eth2/utils/ssz/src/impl_tree_hash.rs
+++ b/eth2/utils/ssz/src/impl_tree_hash.rs
@@ -3,55 +3,55 @@ use super::{merkle_hash, ssz_encode, TreeHash};
 use hashing::hash;
 
 impl TreeHash for u8 {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for u16 {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for u32 {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for u64 {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for usize {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for bool {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for Address {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for H256 {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         ssz_encode(self)
     }
 }
 
 impl TreeHash for [u8] {
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
+    fn hash_tree_root(&self) -> Vec<u8> {
         if self.len() > 32 {
             return hash(&self);
         }
@@ -63,12 +63,12 @@ impl<T> TreeHash for Vec<T>
 where
     T: TreeHash,
 {
-    /// Returns the merkle_hash of a list of hash_tree_root_internal values created
+    /// Returns the merkle_hash of a list of hash_tree_root values created
     /// from the given list.
     /// Note: A byte vector, Vec<u8>, must be converted to a slice (as_slice())
     ///       to be handled properly (i.e. hashed) as byte array.
-    fn hash_tree_root_internal(&self) -> Vec<u8> {
-        let mut tree_hashes = self.iter().map(|x| x.hash_tree_root_internal()).collect();
+    fn hash_tree_root(&self) -> Vec<u8> {
+        let mut tree_hashes = self.iter().map(|x| x.hash_tree_root()).collect();
         merkle_hash(&mut tree_hashes)
     }
 }
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn test_impl_tree_hash_vec() {
-        let result = vec![1u32, 2, 3, 4, 5, 6, 7].hash_tree_root_internal();
+        let result = vec![1u32, 2, 3, 4, 5, 6, 7].hash_tree_root();
         assert_eq!(result.len(), 32);
     }
 }

--- a/eth2/utils/ssz_derive/src/lib.rs
+++ b/eth2/utils/ssz_derive/src/lib.rs
@@ -146,10 +146,10 @@ pub fn ssz_tree_hash_derive(input: TokenStream) -> TokenStream {
 
     let output = quote! {
         impl ssz::TreeHash for #name {
-            fn hash_tree_root_internal(&self) -> Vec<u8> {
+            fn hash_tree_root(&self) -> Vec<u8> {
                 let mut list: Vec<Vec<u8>> = Vec::new();
                 #(
-                    list.push(self.#field_idents.hash_tree_root_internal());
+                    list.push(self.#field_idents.hash_tree_root());
                 )*
 
                 ssz::merkle_hash(&mut list)
@@ -224,7 +224,7 @@ pub fn ssz_signed_root_derive(input: TokenStream) -> TokenStream {
             fn signed_root(&self) -> Vec<u8> {
                 let mut list: Vec<Vec<u8>> = Vec::new();
                 #(
-                    list.push(self.#field_idents.hash_tree_root_internal());
+                    list.push(self.#field_idents.hash_tree_root());
                 )*
 
                 ssz::merkle_hash(&mut list)


### PR DESCRIPTION
## Issue Addressed

#288 

## Proposed Changes

- Chunk size size in merkle_hash is now always 32 bytes
- extend number of chunks, with zero-byte chunks, to the next power of two if necessary
- no more hash_tree_root_internal

