### PR TITLE
Re-re-apply removal of duplicated ssz_tests

### DIFF
--- a/eth2/types/src/attestation.rs
+++ b/eth2/types/src/attestation.rs
@@ -20,29 +20,6 @@ pub struct Attestation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Attestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Attestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Attestation);
 }

--- a/eth2/types/src/attestation_data.rs
+++ b/eth2/types/src/attestation_data.rs
@@ -38,29 +38,6 @@ impl Eq for AttestationData {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttestationData);
 }

--- a/eth2/types/src/attestation_data_and_custody_bit.rs
+++ b/eth2/types/src/attestation_data_and_custody_bit.rs
@@ -25,31 +25,6 @@ impl<T: RngCore> TestRandom<T> for AttestationDataAndCustodyBit {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-
-        let original = AttestationDataAndCustodyBit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttestationDataAndCustodyBit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttestationDataAndCustodyBit);
 }

--- a/eth2/types/src/attester_slashing.rs
+++ b/eth2/types/src/attester_slashing.rs
@@ -16,29 +16,6 @@ pub struct AttesterSlashing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttesterSlashing::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = AttesterSlashing::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(AttesterSlashing);
 }

--- a/eth2/types/src/beacon_block.rs
+++ b/eth2/types/src/beacon_block.rs
@@ -70,29 +70,6 @@ impl BeaconBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlock::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlock::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(BeaconBlock);
 }

--- a/eth2/types/src/beacon_block_body.rs
+++ b/eth2/types/src/beacon_block_body.rs
@@ -21,29 +21,6 @@ pub struct BeaconBlockBody {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlockBody::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = BeaconBlockBody::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(BeaconBlockBody);
 }

--- a/eth2/types/src/beacon_state/tests.rs
+++ b/eth2/types/src/beacon_state/tests.rs
@@ -4,7 +4,6 @@ use super::*;
 use crate::test_utils::TestingBeaconStateBuilder;
 use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
 use crate::{BeaconState, ChainSpec};
-use ssz::{ssz_encode, Decodable};
 
 /// Tests that `get_attestation_participants` is consistent with the result of
 /// get_crosslink_committees_at_slot` with a full bitfield.
@@ -51,25 +50,4 @@ pub fn get_attestation_participants_consistency() {
     }
 }
 
-#[test]
-pub fn test_ssz_round_trip() {
-    let mut rng = XorShiftRng::from_seed([42; 16]);
-    let original = BeaconState::random_for_test(&mut rng);
-
-    let bytes = ssz_encode(&original);
-    let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-    assert_eq!(original, decoded);
-}
-
-#[test]
-pub fn test_hash_tree_root() {
-    let mut rng = XorShiftRng::from_seed([42; 16]);
-    let original = BeaconState::random_for_test(&mut rng);
-
-    let result = original.hash_tree_root();
-
-    assert_eq!(result.len(), 32);
-    // TODO: Add further tests
-    // https://github.com/sigp/lighthouse/issues/170
-}
+ssz_tests!(BeaconState);

--- a/eth2/types/src/crosslink.rs
+++ b/eth2/types/src/crosslink.rs
@@ -19,29 +19,6 @@ pub struct Crosslink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Crosslink::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Crosslink::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Crosslink);
 }

--- a/eth2/types/src/deposit.rs
+++ b/eth2/types/src/deposit.rs
@@ -18,29 +18,6 @@ pub struct Deposit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Deposit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Deposit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Deposit);
 }

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -18,29 +18,6 @@ pub struct DepositData {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositData::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositData::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(DepositData);
 }

--- a/eth2/types/src/deposit_input.rs
+++ b/eth2/types/src/deposit_input.rs
@@ -66,29 +66,6 @@ impl DepositInput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositInput::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = DepositInput::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(DepositInput);
 }

--- a/eth2/types/src/eth1_data.rs
+++ b/eth2/types/src/eth1_data.rs
@@ -17,29 +17,6 @@ pub struct Eth1Data {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1Data::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1Data::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Eth1Data);
 }

--- a/eth2/types/src/eth1_data_vote.rs
+++ b/eth2/types/src/eth1_data_vote.rs
@@ -17,29 +17,6 @@ pub struct Eth1DataVote {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1DataVote::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Eth1DataVote::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Eth1DataVote);
 }

--- a/eth2/types/src/fork.rs
+++ b/eth2/types/src/fork.rs
@@ -29,29 +29,6 @@ impl Fork {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Fork::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Fork::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Fork);
 }

--- a/eth2/types/src/lib.rs
+++ b/eth2/types/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 pub mod test_utils;
 
 pub mod attestation;

--- a/eth2/types/src/pending_attestation.rs
+++ b/eth2/types/src/pending_attestation.rs
@@ -19,29 +19,6 @@ pub struct PendingAttestation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = PendingAttestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = PendingAttestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(PendingAttestation);
 }

--- a/eth2/types/src/proposal.rs
+++ b/eth2/types/src/proposal.rs
@@ -23,30 +23,7 @@ pub struct Proposal {
 mod tests {
     use super::*;
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, SignedRoot, TreeHash};
-
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Proposal::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Proposal::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    use ssz::{SignedRoot, TreeHash};
 
     #[derive(TreeHash)]
     struct SignedProposal {
@@ -75,4 +52,5 @@ mod tests {
         assert_eq!(original.signed_root(), other.hash_tree_root());
     }
 
+    ssz_tests!(Proposal);
 }

--- a/eth2/types/src/proposer_slashing.rs
+++ b/eth2/types/src/proposer_slashing.rs
@@ -18,29 +18,6 @@ pub struct ProposerSlashing {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposerSlashing::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ProposerSlashing::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ProposerSlashing);
 }

--- a/eth2/types/src/shard_reassignment_record.rs
+++ b/eth2/types/src/shard_reassignment_record.rs
@@ -14,29 +14,6 @@ pub struct ShardReassignmentRecord {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ShardReassignmentRecord::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = ShardReassignmentRecord::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(ShardReassignmentRecord);
 }

--- a/eth2/types/src/slashable_attestation.rs
+++ b/eth2/types/src/slashable_attestation.rs
@@ -46,7 +46,6 @@ mod tests {
     use crate::chain_spec::ChainSpec;
     use crate::slot_epoch::{Epoch, Slot};
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
     #[test]
     pub fn test_is_double_vote_true() {
@@ -120,28 +119,7 @@ mod tests {
         );
     }
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableAttestation::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = SlashableAttestation::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(SlashableAttestation);
 
     fn create_slashable_attestation(
         slot_factor: u64,

--- a/eth2/types/src/slot_epoch.rs
+++ b/eth2/types/src/slot_epoch.rs
@@ -103,8 +103,6 @@ impl<'a> Iterator for SlotIter<'a> {
 #[cfg(test)]
 mod slot_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(Slot);
 }
@@ -112,8 +110,6 @@ mod slot_tests {
 #[cfg(test)]
 mod epoch_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(Epoch);
 

--- a/eth2/types/src/slot_epoch_macros.rs
+++ b/eth2/types/src/slot_epoch_macros.rs
@@ -248,7 +248,7 @@ macro_rules! impl_common {
 }
 
 // test macros
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! new_tests {
     ($type: ident) => {
         #[test]
@@ -260,7 +260,7 @@ macro_rules! new_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! from_into_tests {
     ($type: ident, $other: ident) => {
         #[test]
@@ -286,7 +286,7 @@ macro_rules! from_into_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! math_between_tests {
     ($type: ident, $other: ident) => {
         #[test]
@@ -434,7 +434,7 @@ macro_rules! math_between_tests {
     };
 }
 
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! math_tests {
     ($type: ident) => {
         #[test]
@@ -528,35 +528,7 @@ macro_rules! math_tests {
     };
 }
 
-#[allow(unused_macros)]
-macro_rules! ssz_tests {
-    ($type: ident) => {
-        #[test]
-        pub fn test_ssz_round_trip() {
-            let mut rng = XorShiftRng::from_seed([42; 16]);
-            let original = $type::random_for_test(&mut rng);
-
-            let bytes = ssz_encode(&original);
-            let (decoded, _) = $type::ssz_decode(&bytes, 0).unwrap();
-
-            assert_eq!(original, decoded);
-        }
-
-        #[test]
-        pub fn test_hash_tree_root() {
-            let mut rng = XorShiftRng::from_seed([42; 16]);
-            let original = $type::random_for_test(&mut rng);
-
-            let result = original.hash_tree_root();
-
-            assert_eq!(result.len(), 32);
-            // TODO: Add further tests
-            // https://github.com/sigp/lighthouse/issues/170
-        }
-    };
-}
-
-#[allow(unused_macros)]
+#[cfg(test)]
 macro_rules! all_tests {
     ($type: ident) => {
         new_tests!($type);

--- a/eth2/types/src/slot_height.rs
+++ b/eth2/types/src/slot_height.rs
@@ -33,11 +33,8 @@ impl SlotHeight {
 }
 
 #[cfg(test)]
-
 mod slot_height_tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::ssz_encode;
 
     all_tests!(SlotHeight);
 }

--- a/eth2/types/src/test_utils/mod.rs
+++ b/eth2/types/src/test_utils/mod.rs
@@ -13,12 +13,57 @@ mod testing_voluntary_exit_builder;
 pub use generate_deterministic_keypairs::generate_deterministic_keypairs;
 pub use keypairs_file::KeypairsFile;
 pub use rand::{prng::XorShiftRng, SeedableRng};
-pub use test_random::TestRandom;
-pub use testing_attestation_builder::TestingAttestationBuilder;
-pub use testing_attester_slashing_builder::TestingAttesterSlashingBuilder;
-pub use testing_beacon_block_builder::TestingBeaconBlockBuilder;
-pub use testing_beacon_state_builder::{keypairs_path, TestingBeaconStateBuilder};
-pub use testing_deposit_builder::TestingDepositBuilder;
-pub use testing_proposer_slashing_builder::TestingProposerSlashingBuilder;
-pub use testing_transfer_builder::TestingTransferBuilder;
-pub use testing_voluntary_exit_builder::TestingVoluntaryExitBuilder;
+
+pub mod address;
+pub mod aggregate_signature;
+pub mod bitfield;
+pub mod hash256;
+#[macro_use]
+mod macros;
+pub mod public_key;
+pub mod secret_key;
+pub mod signature;
+
+pub trait TestRandom<T>
+where
+    T: RngCore,
+{
+    fn random_for_test(rng: &mut T) -> Self;
+}
+
+impl<T: RngCore> TestRandom<T> for bool {
+    fn random_for_test(rng: &mut T) -> Self {
+        (rng.next_u32() % 2) == 1
+    }
+}
+
+impl<T: RngCore> TestRandom<T> for u64 {
+    fn random_for_test(rng: &mut T) -> Self {
+        rng.next_u64()
+    }
+}
+
+impl<T: RngCore> TestRandom<T> for u32 {
+    fn random_for_test(rng: &mut T) -> Self {
+        rng.next_u32()
+    }
+}
+
+impl<T: RngCore> TestRandom<T> for usize {
+    fn random_for_test(rng: &mut T) -> Self {
+        rng.next_u32() as usize
+    }
+}
+
+impl<T: RngCore, U> TestRandom<T> for Vec<U>
+where
+    U: TestRandom<T>,
+{
+    fn random_for_test(rng: &mut T) -> Self {
+        vec![
+            <U>::random_for_test(rng),
+            <U>::random_for_test(rng),
+            <U>::random_for_test(rng),
+        ]
+    }
+}

--- a/eth2/types/src/test_utils/mod.rs
+++ b/eth2/types/src/test_utils/mod.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+mod macros;
 mod generate_deterministic_keypairs;
 mod keypairs_file;
 mod test_random;
@@ -13,57 +15,12 @@ mod testing_voluntary_exit_builder;
 pub use generate_deterministic_keypairs::generate_deterministic_keypairs;
 pub use keypairs_file::KeypairsFile;
 pub use rand::{prng::XorShiftRng, SeedableRng};
-
-pub mod address;
-pub mod aggregate_signature;
-pub mod bitfield;
-pub mod hash256;
-#[macro_use]
-mod macros;
-pub mod public_key;
-pub mod secret_key;
-pub mod signature;
-
-pub trait TestRandom<T>
-where
-    T: RngCore,
-{
-    fn random_for_test(rng: &mut T) -> Self;
-}
-
-impl<T: RngCore> TestRandom<T> for bool {
-    fn random_for_test(rng: &mut T) -> Self {
-        (rng.next_u32() % 2) == 1
-    }
-}
-
-impl<T: RngCore> TestRandom<T> for u64 {
-    fn random_for_test(rng: &mut T) -> Self {
-        rng.next_u64()
-    }
-}
-
-impl<T: RngCore> TestRandom<T> for u32 {
-    fn random_for_test(rng: &mut T) -> Self {
-        rng.next_u32()
-    }
-}
-
-impl<T: RngCore> TestRandom<T> for usize {
-    fn random_for_test(rng: &mut T) -> Self {
-        rng.next_u32() as usize
-    }
-}
-
-impl<T: RngCore, U> TestRandom<T> for Vec<U>
-where
-    U: TestRandom<T>,
-{
-    fn random_for_test(rng: &mut T) -> Self {
-        vec![
-            <U>::random_for_test(rng),
-            <U>::random_for_test(rng),
-            <U>::random_for_test(rng),
-        ]
-    }
-}
+pub use test_random::TestRandom;
+pub use testing_attestation_builder::TestingAttestationBuilder;
+pub use testing_attester_slashing_builder::TestingAttesterSlashingBuilder;
+pub use testing_beacon_block_builder::TestingBeaconBlockBuilder;
+pub use testing_beacon_state_builder::{keypairs_path, TestingBeaconStateBuilder};
+pub use testing_deposit_builder::TestingDepositBuilder;
+pub use testing_proposer_slashing_builder::TestingProposerSlashingBuilder;
+pub use testing_transfer_builder::TestingTransferBuilder;
+pub use testing_voluntary_exit_builder::TestingVoluntaryExitBuilder;

--- a/eth2/types/src/transfer.rs
+++ b/eth2/types/src/transfer.rs
@@ -24,29 +24,6 @@ pub struct Transfer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Transfer::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Transfer::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Transfer);
 }

--- a/eth2/types/src/validator.rs
+++ b/eth2/types/src/validator.rs
@@ -54,18 +54,6 @@ impl Default for Validator {
 mod tests {
     use super::*;
     use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
-
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Validator::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
 
     #[test]
     fn test_validator_can_be_active() {
@@ -90,15 +78,5 @@ mod tests {
         }
     }
 
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = Validator::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(Validator);
 }

--- a/eth2/types/src/voluntary_exit.rs
+++ b/eth2/types/src/voluntary_exit.rs
@@ -19,29 +19,6 @@ pub struct VoluntaryExit {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-    use ssz::{ssz_encode, Decodable, TreeHash};
 
-    #[test]
-    pub fn test_ssz_round_trip() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = VoluntaryExit::random_for_test(&mut rng);
-
-        let bytes = ssz_encode(&original);
-        let (decoded, _) = <_>::ssz_decode(&bytes, 0).unwrap();
-
-        assert_eq!(original, decoded);
-    }
-
-    #[test]
-    pub fn test_hash_tree_root() {
-        let mut rng = XorShiftRng::from_seed([42; 16]);
-        let original = VoluntaryExit::random_for_test(&mut rng);
-
-        let result = original.hash_tree_root();
-
-        assert_eq!(result.len(), 32);
-        // TODO: Add further tests
-        // https://github.com/sigp/lighthouse/issues/170
-    }
+    ssz_tests!(VoluntaryExit);
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

As per #292, re-re-applies the changes that dedup SSZ tests.

## Additional Info

I'm going to merge this because @michaelsproul made the changes and I've already reviewed them.