### PR TITLE
Add TestingBeaconStateBuilder fn for cloned keypairs

### DIFF
--- a/beacon_node/db/src/stores/beacon_block_store.rs
+++ b/beacon_node/db/src/stores/beacon_block_store.rs
@@ -198,6 +198,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_block_at_slot() {
         let db = Arc::new(MemoryDB::open());
         let bs = Arc::new(BeaconBlockStore::new(db.clone()));

--- a/eth2/fork_choice/tests/tests.rs
+++ b/eth2/fork_choice/tests/tests.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::{fs::File, io::prelude::*, path::PathBuf};
 use types::test_utils::TestingBeaconStateBuilder;
-use types::{BeaconBlock, BeaconBlockBody, ChainSpec, Eth1Data, Hash256, Slot};
+use types::{BeaconBlock, BeaconBlockBody, ChainSpec, Eth1Data, Hash256, Keypair, Slot};
 use yaml_rust::yaml;
 
 // Note: We Assume the block Id's are hex-encoded.
@@ -218,7 +218,7 @@ fn load_test_cases_from_yaml(file_path: &str) -> Vec<yaml_rust::Yaml> {
 // initialise a single validator and state. All blocks will reference this state root.
 fn setup_inital_state(
     fork_choice_algo: &ForkChoiceAlgorithm,
-    no_validators: usize,
+    num_validators: usize,
 ) -> (Box<ForkChoice>, Arc<BeaconBlockStore<MemoryDB>>, Hash256) {
     let db = Arc::new(MemoryDB::open());
     let block_store = Arc::new(BeaconBlockStore::new(db.clone()));
@@ -243,7 +243,7 @@ fn setup_inital_state(
     let spec = ChainSpec::foundation();
 
     let state_builder =
-        TestingBeaconStateBuilder::from_deterministic_keypairs(no_validators, &spec);
+        TestingBeaconStateBuilder::from_single_keypair(num_validators, &Keypair::random(), &spec);
     let (state, _keypairs) = state_builder.build();
 
     let state_root = state.canonical_root();

--- a/eth2/types/src/test_utils/testing_beacon_state_builder.rs
+++ b/eth2/types/src/test_utils/testing_beacon_state_builder.rs
@@ -74,6 +74,22 @@ impl TestingBeaconStateBuilder {
         TestingBeaconStateBuilder::from_keypairs(keypairs, spec)
     }
 
+    /// Uses the given keypair for all validators.
+    pub fn from_single_keypair(
+        validator_count: usize,
+        keypair: &Keypair,
+        spec: &ChainSpec,
+    ) -> Self {
+        debug!("Generating {} cloned keypairs...", validator_count);
+
+        let mut keypairs = Vec::with_capacity(validator_count);
+        for _ in 0..validator_count {
+            keypairs.push(keypair.clone())
+        }
+
+        TestingBeaconStateBuilder::from_keypairs(keypairs, spec)
+    }
+
     /// Creates the builder from an existing set of keypairs.
     pub fn from_keypairs(keypairs: Vec<Keypair>, spec: &ChainSpec) -> Self {
         let validator_count = keypairs.len();


### PR DESCRIPTION
## Issue Addressed
NA

## Proposed Changes

- Add method for creating a testing beacon state where all validators use the same KP.
- Implement method in fork choice tests.
- Ignore long-running db test 

## Additional Info

NA