### PR TITLE
Disable Signature verification in debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ before_install:
   - sudo chown -R $USER /usr/local/include/google
 script:
   - cargo build --verbose --all
+  - cargo build --verbose --release --all
   - cargo test --verbose --all
+  - cargo test --verbose --release --all
   - cargo fmt --all -- --check
 rust:
   - stable

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,22 @@
 pipeline {
-    agent {
+	agent {
 		dockerfile {
 			filename 'Dockerfile'
 			args '-v cargo-cache:/cargocache:rw -e "CARGO_HOME=/cargocache"'
 		}
 	}
-    stages {
-        stage('Build') {
-            steps {
-                sh 'cargo build'
-            }
-        }
-        stage('Test') {
+	stages {
+		stage('Build') {
 			steps {
-				sh 'cargo test --all'
+				sh 'cargo build --verbose --all'
+				sh 'cargo build --verbose --all --release'
 			}
 		}
-    }
+		stage('Test') {
+			steps {
+				sh 'cargo test --verbose --all'
+				sh 'cargo test --verbose --all --release'
+			}
+		}
+	}
 }

--- a/eth2/utils/bls/src/fake_aggregate_signature.rs
+++ b/eth2/utils/bls/src/fake_aggregate_signature.rs
@@ -1,0 +1,117 @@
+use super::{fake_signature::FakeSignature, AggregatePublicKey};
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use serde_hex::{encode as hex_encode, PrefixedHexVisitor};
+use ssz::{
+    decode_ssz_list, hash, ssz_encode, Decodable, DecodeError, Encodable, SszStream, TreeHash,
+};
+
+const SIGNATURE_LENGTH: usize = 48;
+
+/// A BLS aggregate signature.
+///
+/// This struct is a wrapper upon a base type and provides helper functions (e.g., SSZ
+/// serialization).
+#[derive(Debug, PartialEq, Clone, Default, Eq)]
+pub struct FakeAggregateSignature {
+    bytes: Vec<u8>,
+}
+
+impl FakeAggregateSignature {
+    /// Creates a new all-zero's signature
+    pub fn new() -> Self {
+        Self::zero()
+    }
+
+    /// Creates a new all-zero's signature
+    pub fn zero() -> Self {
+        Self {
+            bytes: vec![0; SIGNATURE_LENGTH],
+        }
+    }
+
+    /// Does glorious nothing.
+    pub fn add(&mut self, _signature: &FakeSignature) {
+        // Do nothing.
+    }
+
+    /// _Always_ returns `true`.
+    pub fn verify(
+        &self,
+        _msg: &[u8],
+        _domain: u64,
+        _aggregate_public_key: &AggregatePublicKey,
+    ) -> bool {
+        true
+    }
+
+    /// _Always_ returns `true`.
+    pub fn verify_multiple(
+        &self,
+        _messages: &[&[u8]],
+        _domain: u64,
+        _aggregate_public_keys: &[&AggregatePublicKey],
+    ) -> bool {
+        true
+    }
+}
+
+impl Encodable for FakeAggregateSignature {
+    fn ssz_append(&self, s: &mut SszStream) {
+        s.append_vec(&self.bytes);
+    }
+}
+
+impl Decodable for FakeAggregateSignature {
+    fn ssz_decode(bytes: &[u8], i: usize) -> Result<(Self, usize), DecodeError> {
+        let (sig_bytes, i) = decode_ssz_list(bytes, i)?;
+        Ok((FakeAggregateSignature { bytes: sig_bytes }, i))
+    }
+}
+
+impl Serialize for FakeAggregateSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex_encode(ssz_encode(self)))
+    }
+}
+
+impl<'de> Deserialize<'de> for FakeAggregateSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = deserializer.deserialize_str(PrefixedHexVisitor)?;
+        let (obj, _) = <_>::ssz_decode(&bytes[..], 0)
+            .map_err(|e| serde::de::Error::custom(format!("invalid ssz ({:?})", e)))?;
+        Ok(obj)
+    }
+}
+
+impl TreeHash for FakeAggregateSignature {
+    fn hash_tree_root(&self) -> Vec<u8> {
+        hash(&self.bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{Keypair, Signature};
+    use super::*;
+    use ssz::ssz_encode;
+
+    #[test]
+    pub fn test_ssz_round_trip() {
+        let keypair = Keypair::random();
+
+        let mut original = FakeAggregateSignature::new();
+        original.add(&Signature::new(&[42, 42], 0, &keypair.sk));
+
+        let bytes = ssz_encode(&original);
+        let (decoded, _) = FakeAggregateSignature::ssz_decode(&bytes, 0).unwrap();
+
+        assert_eq!(original, decoded);
+    }
+}

--- a/eth2/utils/bls/src/fake_signature.rs
+++ b/eth2/utils/bls/src/fake_signature.rs
@@ -1,0 +1,117 @@
+use super::serde_vistors::HexVisitor;
+use super::{PublicKey, SecretKey};
+use hex::encode as hex_encode;
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+use ssz::{
+    decode_ssz_list, hash, ssz_encode, Decodable, DecodeError, Encodable, SszStream, TreeHash,
+};
+
+const SIGNATURE_LENGTH: usize = 48;
+
+/// A single BLS signature.
+///
+/// This struct is a wrapper upon a base type and provides helper functions (e.g., SSZ
+/// serialization).
+#[derive(Debug, PartialEq, Clone, Eq)]
+pub struct FakeSignature {
+    bytes: Vec<u8>,
+}
+
+impl FakeSignature {
+    /// Creates a new all-zero's signature
+    pub fn new(_msg: &[u8], _domain: u64, _sk: &SecretKey) -> Self {
+        FakeSignature::zero()
+    }
+
+    /// Creates a new all-zero's signature
+    pub fn zero() -> Self {
+        Self {
+            bytes: vec![0; SIGNATURE_LENGTH],
+        }
+    }
+
+    /// Creates a new all-zero's signature
+    pub fn new_hashed(_x_real_hashed: &[u8], _x_imaginary_hashed: &[u8], _sk: &SecretKey) -> Self {
+        FakeSignature::zero()
+    }
+
+    /// _Always_ returns `true`.
+    pub fn verify(&self, _msg: &[u8], _domain: u64, _pk: &PublicKey) -> bool {
+        true
+    }
+
+    /// _Always_ returns true.
+    pub fn verify_hashed(
+        &self,
+        _x_real_hashed: &[u8],
+        _x_imaginary_hashed: &[u8],
+        _pk: &PublicKey,
+    ) -> bool {
+        true
+    }
+
+    /// Returns a new empty signature.
+    pub fn empty_signature() -> Self {
+        FakeSignature::zero()
+    }
+}
+
+impl Encodable for FakeSignature {
+    fn ssz_append(&self, s: &mut SszStream) {
+        s.append_vec(&self.bytes);
+    }
+}
+
+impl Decodable for FakeSignature {
+    fn ssz_decode(bytes: &[u8], i: usize) -> Result<(Self, usize), DecodeError> {
+        let (sig_bytes, i) = decode_ssz_list(bytes, i)?;
+        Ok((FakeSignature { bytes: sig_bytes }, i))
+    }
+}
+
+impl TreeHash for FakeSignature {
+    fn hash_tree_root(&self) -> Vec<u8> {
+        hash(&self.bytes)
+    }
+}
+
+impl Serialize for FakeSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&hex_encode(ssz_encode(self)))
+    }
+}
+
+impl<'de> Deserialize<'de> for FakeSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = deserializer.deserialize_str(HexVisitor)?;
+        let (pubkey, _) = <_>::ssz_decode(&bytes[..], 0)
+            .map_err(|e| serde::de::Error::custom(format!("invalid ssz ({:?})", e)))?;
+        Ok(pubkey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Keypair;
+    use super::*;
+    use ssz::ssz_encode;
+
+    #[test]
+    pub fn test_ssz_round_trip() {
+        let keypair = Keypair::random();
+
+        let original = FakeSignature::new(&[42, 42], 0, &keypair.sk);
+
+        let bytes = ssz_encode(&original);
+        let (decoded, _) = FakeSignature::ssz_decode(&bytes, 0).unwrap();
+
+        assert_eq!(original, decoded);
+    }
+}

--- a/eth2/utils/bls/src/lib.rs
+++ b/eth2/utils/bls/src/lib.rs
@@ -2,19 +2,33 @@ extern crate bls_aggregates;
 extern crate ssz;
 
 mod aggregate_public_key;
-mod aggregate_signature;
 mod keypair;
 mod public_key;
 mod secret_key;
 mod serde_vistors;
+
+#[cfg(not(debug_assertions))]
+mod aggregate_signature;
+#[cfg(not(debug_assertions))]
 mod signature;
+#[cfg(not(debug_assertions))]
+pub use crate::aggregate_signature::AggregateSignature;
+#[cfg(not(debug_assertions))]
+pub use crate::signature::Signature;
+
+#[cfg(debug_assertions)]
+mod fake_aggregate_signature;
+#[cfg(debug_assertions)]
+mod fake_signature;
+#[cfg(debug_assertions)]
+pub use crate::fake_aggregate_signature::FakeAggregateSignature as AggregateSignature;
+#[cfg(debug_assertions)]
+pub use crate::fake_signature::FakeSignature as Signature;
 
 pub use crate::aggregate_public_key::AggregatePublicKey;
-pub use crate::aggregate_signature::AggregateSignature;
 pub use crate::keypair::Keypair;
 pub use crate::public_key::PublicKey;
 pub use crate::secret_key::SecretKey;
-pub use crate::signature::Signature;
 
 pub const BLS_AGG_SIG_BYTE_SIZE: usize = 96;
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a `FakeSignature` and `FakeAggregateSignature` signature that replace `Signature` and `AggregateSignature` when compiling for debug.

The `Fake...` versions:

- Initialize to all zero bytes.
- Deserialize to whatever compressed bytes given.
- Serialize to whatever bytes are stored.
- Always pass verification
- Don't aggregate

Also updates `travis.yml` to test on release _and_ debug.

## Additional Info

So this means that:

- `$ cargo test`: no signature verification.
- `$ cargo test --release`: signature verification

This was implemented because crypto in debug is veeeery slow (~100x slower than in release).

So now we have faster tests, but to be comprehensive you must also test in `--release`.

Open for discussion on this. Also for better ways to implement it.