### PR TITLE
Listed Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ A few basic steps are needed to get set up:
    5. Install build dependencies (Arch packages are listed here, your distribution will likely be similar):
 	  - `clang`: required by RocksDB.
 	  - `protobuf`: required for protobuf serialization (gRPC).
+	  - `cmake`: required for building protobuf
    6. Navigate to the working directory.
    7. Run the test by using command `cargo test --all`. By running, it will pass all the required test cases.
         If you are doing it for the first time, then you can grab a coffee in the meantime. Usually, it takes time


### PR DESCRIPTION
Added `cmake` as a requirement for building lighthouse, as it is a dependency that must be installed on a fresh arch system.

## Proposed Changes

Minor update to readme, to help anyone else installing a fresh system.