### PR TITLE
`ssz` is ambiguous (name vs any other name during import resolution)

### DIFF
--- a/eth2/utils/ssz/src/macros.rs
+++ b/eth2/utils/ssz/src/macros.rs
@@ -50,8 +50,8 @@ macro_rules! impl_decode_via_from {
 
 #[cfg(test)]
 mod tests {
-    use crate as ssz;
     use self::ssz::{Decode, Encode};
+    use crate as ssz;
 
     #[derive(PartialEq, Debug, Clone, Copy)]
     struct Wrapper(u64);

--- a/eth2/utils/ssz/src/macros.rs
+++ b/eth2/utils/ssz/src/macros.rs
@@ -51,7 +51,7 @@ macro_rules! impl_decode_via_from {
 #[cfg(test)]
 mod tests {
     use crate as ssz;
-    use ssz::{Decode, Encode};
+    use self::ssz::{Decode, Encode};
 
     #[derive(PartialEq, Debug, Clone, Copy)]
     struct Wrapper(u64);


### PR DESCRIPTION
## Issue Addressed

#385 SSZ ambiguous reference in tests module

## Proposed Changes

FIx the execution of tests for nightly toolchain in SSZ modules

## Additional Info

N/A