### PR TITLE
Update instructions to install rustup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ tests and benchmarks which may be of interest.
 
 A few basic steps are needed to get set up:
 
-   1. Install [rustup](https://rustup.rs/).  It's a toolchain manager for Rust (Linux | macos | Windows). For installation run the below command in your terminal `$ curl https://sh.rustup.rs -sSf | sh`
+   1. Install [rustup](https://rustup.rs/).  It's a toolchain manager for Rust (Linux | macOS | Windows). For installation, download the script with `$ curl -f https://sh.rustup.rs > rustup.sh`, review its content (e.g. `$ less ./rustup.sh`) and run the script `$ ./rustup.sh` (you may need to change the permissions to allow execution, i.e. `$ chmod +x rustup.sh`) 
    2. (Linux & MacOS) To configure your current shell run: `$ source $HOME/.cargo/env`
    3. Use the command `rustup show` to get information about the Rust installation. You should see that the
    active toolchain is the stable version.


### PR DESCRIPTION
## Issue Addressed

Insecure `rustup` installation instructions.

## Proposed Changes

Update to the README to suggest users to download and review the installation script prior to execution.
