### PR TITLE
Support multiple bootnodes

### DIFF
--- a/beacon_node/client/src/client_config.rs
+++ b/beacon_node/client/src/client_config.rs
@@ -95,13 +95,15 @@ impl ClientConfig {
         }
 
         // Custom bootnodes
-        // TODO: Handle list of addresses
         if let Some(boot_addresses_str) = args.value_of("boot-nodes") {
-            if let Ok(boot_address) = boot_addresses_str.parse::<Multiaddr>() {
-                config.net_conf.boot_nodes.append(&mut vec![boot_address]);
-            } else {
-                error!(log, "Invalid Bootnode multiaddress"; "Multiaddr" => boot_addresses_str);
-                return Err("Invalid IP Address");
+            let mut boot_addresses_split = boot_addresses_str.split(",");
+            for boot_address in boot_addresses_split {
+                if let Ok(boot_address) = boot_address.parse::<Multiaddr>() {
+                    config.net_conf.boot_nodes.append(&mut vec![boot_address]);
+                } else {
+                    error!(log, "Invalid Bootnode multiaddress"; "Multiaddr" => boot_addresses_str);
+                    return Err("Invalid IP Address");
+                }
             }
         }
 


### PR DESCRIPTION
## Issue Addressed

None.

## Proposed Changes

Fixes the TODO in `main.rs` related to not supporting comma-separated bootnodes in the CLI.

## Additional Info

I encountered this while setting up the Lighthouse image in the eth2 test runner.

Please provide any additional information. For example, future considerations
or information useful for reviewers.