### PR TITLE
Add CLI flag logfile for json logging

### DIFF
--- a/account_manager/src/main.rs
+++ b/account_manager/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
-    let log = slog::Logger::root(drain, o!());
+    let mut log = slog::Logger::root(drain, o!());
 
     // CLI
     let matches = App::new("Lighthouse Accounts Manager")
@@ -22,6 +22,13 @@ fn main() {
                 .long("datadir")
                 .value_name("DIR")
                 .help("Data directory for keys and databases.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("logfile")
+                .long("logfile")
+                .value_name("logfile")
+                .help("File path where output will be written.")
                 .takes_value(true),
         )
         .subcommand(
@@ -47,7 +54,7 @@ fn main() {
         )
         .get_matches();
 
-    let config = ValidatorClientConfig::parse_args(&matches, &log)
+    let config = ValidatorClientConfig::parse_args(&matches, &mut log)
         .expect("Unable to build a configuration for the account manager.");
 
     // Log configuration

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -11,8 +11,9 @@ client = { path = "client" }
 version = { path = "version" }
 clap = "2.32.0"
 slog = { version = "^2.2.3" , features = ["max_level_trace", "release_max_level_debug"] }
-slog-term = "^2.4.0"
 slog-async = "^2.3.0"
+slog-json = "^2.3"
+slog-term = "^2.4.0"
 ctrlc = { version = "3.1.1", features = ["termination"] }
 tokio = "0.1.15"
 tokio-timer = "0.2.10"

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -14,6 +14,8 @@ types = { path = "../../eth2/types" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 error-chain = "0.12.0"
 slog = "^2.2.3"
+slog-async = "^2.3.0"
+slog-json = "^2.3"
 ssz = { path = "../../eth2/utils/ssz" }
 tokio = "0.1.15"
 clap = "2.32.0"

--- a/beacon_node/client/src/client_config.rs
+++ b/beacon_node/client/src/client_config.rs
@@ -1,11 +1,13 @@
 use clap::ArgMatches;
 use fork_choice::ForkChoiceAlgorithm;
 use network::NetworkConfig;
-use slog::error;
+use slog::{error, info, o, Drain};
 use std::fs;
+use std::fs::OpenOptions;
 use std::net::SocketAddr;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::PathBuf;
+use std::sync::Mutex;
 use types::multiaddr::Protocol;
 use types::multiaddr::ToMultiaddr;
 use types::Multiaddr;
@@ -21,6 +23,7 @@ pub enum DBType {
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
     pub data_dir: PathBuf,
+    pub log_file: String,
     pub spec: ChainSpec,
     pub net_conf: network::NetworkConfig,
     pub fork_choice: ForkChoiceAlgorithm,
@@ -45,6 +48,7 @@ impl Default for ClientConfig {
 
         Self {
             data_dir: data_dir.clone(),
+            log_file: "".to_string(),
             // default to foundation for chain specs
             spec: default_spec,
             net_conf: default_net_conf,
@@ -61,7 +65,7 @@ impl Default for ClientConfig {
 
 impl ClientConfig {
     /// Parses the CLI arguments into a `Config` struct.
-    pub fn parse_args(args: ArgMatches, log: &slog::Logger) -> Result<Self, &'static str> {
+    pub fn parse_args(args: ArgMatches, log: &mut slog::Logger) -> Result<Self, &'static str> {
         let mut config = ClientConfig::default();
 
         /* Network related arguments */
@@ -76,7 +80,7 @@ impl ClientConfig {
                     address.append(Protocol::Tcp(port));
                 }
             } else {
-                error!(log, "Invalid port"; "port" => port_str);
+                error!(*log, "Invalid port"; "port" => port_str);
                 return Err("Invalid port");
             }
         }
@@ -89,7 +93,7 @@ impl ClientConfig {
                     .expect("Invalid listen address format");
                 config.net_conf.listen_addresses = vec![multiaddr];
             } else {
-                error!(log, "Invalid IP Address"; "Address" => listen_address_str);
+                error!(*log, "Invalid IP Address"; "Address" => listen_address_str);
                 return Err("Invalid IP Address");
             }
         }
@@ -100,7 +104,7 @@ impl ClientConfig {
             if let Ok(boot_address) = boot_addresses_str.parse::<Multiaddr>() {
                 config.net_conf.boot_nodes.append(&mut vec![boot_address]);
             } else {
-                error!(log, "Invalid Bootnode multiaddress"; "Multiaddr" => boot_addresses_str);
+                error!(*log, "Invalid Bootnode multiaddress"; "Multiaddr" => boot_addresses_str);
                 return Err("Invalid IP Address");
             }
         }
@@ -122,7 +126,7 @@ impl ClientConfig {
             if let Ok(listen_address) = rpc_address.parse::<Ipv4Addr>() {
                 config.rpc_conf.listen_address = listen_address;
             } else {
-                error!(log, "Invalid RPC listen address"; "Address" => rpc_address);
+                error!(*log, "Invalid RPC listen address"; "Address" => rpc_address);
                 return Err("Invalid RPC listen address");
             }
         }
@@ -131,7 +135,7 @@ impl ClientConfig {
             if let Ok(port) = rpc_port.parse::<u16>() {
                 config.rpc_conf.port = port;
             } else {
-                error!(log, "Invalid RPC port"; "port" => rpc_port);
+                error!(*log, "Invalid RPC port"; "port" => rpc_port);
                 return Err("Invalid RPC port");
             }
         }
@@ -140,6 +144,24 @@ impl ClientConfig {
             Some("disk") => config.db_type = DBType::Disk,
             Some("memory") => config.db_type = DBType::Memory,
             _ => unreachable!(), // clap prevents this.
+        };
+
+        /* Logging */
+
+        if let Some(logfile) = args.value_of("logfile") {
+            config.log_file = logfile.to_string();
+            // Panics if bad file
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&config.log_file)
+                .unwrap();
+
+            info!(*log, "Log file specified output will now be written to {} in json", &config.log_file);
+            let drain = Mutex::new(slog_json::Json::default(file)).fuse();
+            let drain = slog_async::Async::new(drain).build().fuse();
+            *log = slog::Logger::root(drain, o!());
         };
 
         Ok(config)

--- a/beacon_node/client/src/client_config.rs
+++ b/beacon_node/client/src/client_config.rs
@@ -158,7 +158,10 @@ impl ClientConfig {
                 .open(&config.log_file)
                 .unwrap();
 
-            info!(*log, "Log file specified output will now be written to {} in json", &config.log_file);
+            info!(
+                *log,
+                "Log file specified output will now be written to {} in json", &config.log_file
+            );
             let drain = Mutex::new(slog_json::Json::default(file)).fuse();
             let drain = slog_async::Async::new(drain).build().fuse();
             *log = slog::Logger::root(drain, o!());

--- a/beacon_node/src/main.rs
+++ b/beacon_node/src/main.rs
@@ -7,7 +7,6 @@ use clap::{App, Arg};
 use client::ClientConfig;
 use slog::{error, o, Drain};
 
-
 fn main() {
     // Logging
     let decorator = slog_term::TermDecorator::new().build();

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -24,8 +24,9 @@ protos = { path = "../protos" }
 slot_clock = { path = "../eth2/utils/slot_clock" }
 types = { path = "../eth2/types" }
 slog = "^2.2.3"
-slog-term = "^2.4.0"
 slog-async = "^2.3.0"
+slog-json = "^2.3"
+slog-term = "^2.4.0"
 tokio = "0.1.18"
 tokio-timer = "0.2.10"
 error-chain = "0.12.0"

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -94,7 +94,10 @@ impl Config {
                 .open(&config.log_file)
                 .unwrap();
 
-            info!(*log, "Log file specified output will now be written to {} in json", &config.log_file);
+            info!(
+                *log,
+                "Log file specified output will now be written to {} in json", &config.log_file
+            );
 
             let drain = Mutex::new(slog_json::Json::default(file)).fuse();
             let drain = slog_async::Async::new(drain).build().fuse();

--- a/validator_client/src/main.rs
+++ b/validator_client/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::CompactFormat::new(decorator).build().fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
-    let log = slog::Logger::root(drain, o!());
+    let mut log = slog::Logger::root(drain, o!());
 
     // CLI
     let matches = App::new("Lighthouse Validator Client")
@@ -30,6 +30,13 @@ fn main() {
                 .long("datadir")
                 .value_name("DIR")
                 .help("Data directory for keys and databases.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("logfile")
+                .long("logfile")
+                .value_name("logfile")
+                .help("File path where output will be written.")
                 .takes_value(true),
         )
         .arg(
@@ -51,7 +58,7 @@ fn main() {
         )
         .get_matches();
 
-    let config = ValidatorClientConfig::parse_args(&matches, &log)
+    let config = ValidatorClientConfig::parse_args(&matches, &mut log)
         .expect("Unable to build a configuration for the validator client.");
 
     // start the validator service.


### PR DESCRIPTION
## Issue Addressed

#382 

## Proposed Changes

Add a CLI flag in validator client, beacon node and account manager `--logger <filepath>`
Logging to file to be done in JSON, logging to terminal to remain formatted in existing style.
