### PR TITLE
Persist chain to store

### DIFF
--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 ssz = { path = "../../eth2/utils/ssz" }
+ssz_derive = { path = "../../eth2/utils/ssz_derive" }
 state_processing = { path = "../../eth2/state_processing" }
 tree_hash = { path = "../../eth2/utils/tree_hash" }
 types = { path = "../../eth2/types" }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -336,6 +336,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         self.canonical_head.read()
     }
 
+    /// Returns the slot of the highest block in the canonical chain.
+    pub fn best_slot(&self) -> Slot {
+        self.canonical_head.read().beacon_block.slot
+    }
+
     /// Updates the canonical `BeaconState` with the supplied state.
     ///
     /// Advances the chain forward to the present slot. This method is better than just setting

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -82,7 +82,7 @@ impl BlockProcessingOutcome {
 pub trait BeaconChainTypes {
     type Store: store::Store;
     type SlotClock: slot_clock::SlotClock;
-    type ForkChoice: fork_choice::ForkChoice;
+    type ForkChoice: fork_choice::ForkChoice<Self::Store>;
     type EthSpec: types::EthSpec;
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -347,6 +347,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// state and calling `catchup_state` as it will not result in an old state being installed and
     /// then having it iteratively updated -- in such a case it's possible for another thread to
     /// find the state at an old slot.
+    ///
+    /// Also persists the `BeaconChain` to the store, in the case the client does not exit
+    /// gracefully.
     pub fn update_state(&self, mut state: BeaconState<T::EthSpec>) -> Result<(), Error> {
         let present_slot = match self.slot_clock.present_slot() {
             Ok(Some(slot)) => slot,
@@ -361,6 +364,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         state.build_all_caches(&self.spec)?;
 
         *self.state.write() = state;
+
+        self.persist()?;
 
         Ok(())
     }

--- a/beacon_node/beacon_chain/src/checkpoint.rs
+++ b/beacon_node/beacon_chain/src/checkpoint.rs
@@ -1,9 +1,10 @@
 use serde_derive::Serialize;
+use ssz_derive::{Decode, Encode};
 use types::{BeaconBlock, BeaconState, EthSpec, Hash256};
 
 /// Represents some block and it's associated state. Generally, this will be used for tracking the
 /// head, justified head and finalized head.
-#[derive(Clone, Serialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, PartialEq, Debug, Encode, Decode)]
 pub struct CheckPoint<E: EthSpec> {
     pub beacon_block: BeaconBlock,
     pub beacon_block_root: Hash256,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -1,6 +1,7 @@
 mod beacon_chain;
 mod checkpoint;
 mod errors;
+mod persisted_beacon_chain;
 
 pub use self::beacon_chain::{
     BeaconChain, BeaconChainTypes, BlockProcessingOutcome, InvalidBlock, ValidBlock,

--- a/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
@@ -1,0 +1,30 @@
+use crate::{BeaconChainTypes, CheckPoint};
+use ssz::{Decode, Encode};
+use ssz_derive::{Decode, Encode};
+use store::{DBColumn, Error as StoreError, StoreItem};
+use types::BeaconState;
+
+/// 32-byte key for accessing the `PersistedBeaconChain`.
+pub const BEACON_CHAIN_DB_KEY: &str = "PERSISTEDBEACONCHAINPERSISTEDBEA";
+
+#[derive(Encode, Decode)]
+pub struct PersistedBeaconChain<T: BeaconChainTypes> {
+    pub canonical_head: CheckPoint<T::EthSpec>,
+    pub finalized_head: CheckPoint<T::EthSpec>,
+    // TODO: operations pool.
+    pub state: BeaconState<T::EthSpec>,
+}
+
+impl<T: BeaconChainTypes> StoreItem for PersistedBeaconChain<T> {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconChain
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &mut [u8]) -> Result<Self, StoreError> {
+        Self::from_ssz_bytes(bytes).map_err(Into::into)
+    }
+}

--- a/beacon_node/client/src/client_config.rs
+++ b/beacon_node/client/src/client_config.rs
@@ -98,7 +98,7 @@ impl ClientConfig {
 
         // Custom bootnodes
         if let Some(boot_addresses_str) = args.value_of("boot-nodes") {
-            let mut boot_addresses_split = boot_addresses_str.split(",");
+            let boot_addresses_split = boot_addresses_str.split(",");
             for boot_address in boot_addresses_split {
                 if let Ok(boot_address) = boot_address.parse::<Multiaddr>() {
                     config.net_conf.boot_nodes.append(&mut vec![boot_address]);

--- a/beacon_node/client/src/client_config.rs
+++ b/beacon_node/client/src/client_config.rs
@@ -98,7 +98,7 @@ impl ClientConfig {
 
         // Custom bootnodes
         if let Some(boot_addresses_str) = args.value_of("boot-nodes") {
-            let boot_addresses_split = boot_addresses_str.split(",");
+            let boot_addresses_split = boot_addresses_str.split(',');
             for boot_address in boot_addresses_split {
                 if let Ok(boot_address) = boot_address.parse::<Multiaddr>() {
                     config.net_conf.boot_nodes.append(&mut vec![boot_address]);

--- a/beacon_node/client/src/error.rs
+++ b/beacon_node/client/src/error.rs
@@ -1,10 +1,6 @@
-// generates error types
 use network;
 
-use error_chain::{
-    error_chain, error_chain_processing, impl_error_chain_kind, impl_error_chain_processed,
-    impl_extract_backtrace,
-};
+use error_chain::error_chain;
 
 error_chain! {
    links  {

--- a/beacon_node/client/src/lib.rs
+++ b/beacon_node/client/src/lib.rs
@@ -50,11 +50,14 @@ where
     /// Generate an instance of the client. Spawn and link all internal sub-processes.
     pub fn new(
         config: ClientConfig,
+        store: T::Store,
         log: slog::Logger,
         executor: &TaskExecutor,
     ) -> error::Result<Self> {
-        // generate a beacon chain
-        let beacon_chain = Arc::new(T::initialise_beacon_chain(&config));
+        let store = Arc::new(store);
+
+        // Load a `BeaconChain` from the store, or create a new one if it does not exist.
+        let beacon_chain = Arc::new(T::initialise_beacon_chain(store));
 
         if beacon_chain.read_slot_clock().is_none() {
             panic!("Cannot start client before genesis!")

--- a/beacon_node/eth2-libp2p/src/error.rs
+++ b/beacon_node/eth2-libp2p/src/error.rs
@@ -1,8 +1,5 @@
 // generates error types
 
-use error_chain::{
-    error_chain, error_chain_processing, impl_error_chain_kind, impl_error_chain_processed,
-    impl_extract_backtrace,
-};
+use error_chain::error_chain;
 
 error_chain! {}

--- a/beacon_node/network/src/beacon_chain.rs
+++ b/beacon_node/network/src/beacon_chain.rs
@@ -5,9 +5,7 @@ use beacon_chain::{
     AttestationValidationError, CheckPoint,
 };
 use eth2_libp2p::rpc::HelloMessage;
-use types::{
-    Attestation, BeaconBlock, BeaconBlockBody, BeaconBlockHeader, Epoch, EthSpec, Hash256, Slot,
-};
+use types::{Attestation, BeaconBlock, BeaconBlockBody, BeaconBlockHeader, Epoch, Hash256, Slot};
 
 pub use beacon_chain::{BeaconChainError, BeaconChainTypes, BlockProcessingOutcome, InvalidBlock};
 

--- a/beacon_node/network/src/error.rs
+++ b/beacon_node/network/src/error.rs
@@ -1,10 +1,7 @@
 // generates error types
 use eth2_libp2p;
 
-use error_chain::{
-    error_chain, error_chain_processing, impl_error_chain_kind, impl_error_chain_processed,
-    impl_extract_backtrace,
-};
+use error_chain::error_chain;
 
 error_chain! {
    links  {

--- a/beacon_node/rpc/src/beacon_chain.rs
+++ b/beacon_node/rpc/src/beacon_chain.rs
@@ -5,7 +5,7 @@ use beacon_chain::{
     AttestationValidationError, BlockProductionError,
 };
 pub use beacon_chain::{BeaconChainError, BeaconChainTypes, BlockProcessingOutcome};
-use types::{Attestation, AttestationData, BeaconBlock, EthSpec};
+use types::{Attestation, AttestationData, BeaconBlock};
 
 /// The RPC's API to the beacon chain.
 pub trait BeaconChain<T: BeaconChainTypes>: Send + Sync {

--- a/beacon_node/src/run.rs
+++ b/beacon_node/src/run.rs
@@ -6,6 +6,7 @@ use futures::sync::oneshot;
 use futures::Future;
 use slog::info;
 use std::cell::RefCell;
+use store::{DiskStore, MemoryStore};
 use tokio::runtime::Builder;
 use tokio::runtime::Runtime;
 use tokio::runtime::TaskExecutor;
@@ -32,8 +33,11 @@ pub fn run_beacon_node(config: ClientConfig, log: &slog::Logger) -> error::Resul
                 "BeaconNode starting";
                 "type" => "TestnetDiskBeaconChainTypes"
             );
+
+            let store = DiskStore::open(&config.db_name).expect("Unable to open DB.");
+
             let client: Client<TestnetDiskBeaconChainTypes> =
-                Client::new(config, log.clone(), &executor)?;
+                Client::new(config, store, log.clone(), &executor)?;
 
             run(client, executor, runtime, log)
         }
@@ -43,8 +47,11 @@ pub fn run_beacon_node(config: ClientConfig, log: &slog::Logger) -> error::Resul
                 "BeaconNode starting";
                 "type" => "TestnetMemoryBeaconChainTypes"
             );
+
+            let store = MemoryStore::open();
+
             let client: Client<TestnetMemoryBeaconChainTypes> =
-                Client::new(config, log.clone(), &executor)?;
+                Client::new(config, store, log.clone(), &executor)?;
 
             run(client, executor, runtime, log)
         }

--- a/eth2/fork_choice/src/bitwise_lmd_ghost.rs
+++ b/eth2/fork_choice/src/bitwise_lmd_ghost.rs
@@ -120,12 +120,11 @@ impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
 
         // not in the cache recursively search for ancestors using a log-lookup
         if let Some(ancestor) = {
-            let ancestor_lookup = self.ancestors
+            let ancestor_lookup = *self.ancestors
                 [log2_int((block_height - target_height - 1u64).as_u64()) as usize]
                 .get(&block_hash)
                 //TODO: Panic if we can't lookup and fork choice fails
-                .expect("All blocks should be added to the ancestor log lookup table")
-                .clone();
+                .expect("All blocks should be added to the ancestor log lookup table");
             self.get_ancestor(ancestor_lookup, target_height, &spec)
         } {
             // add the result to the cache
@@ -152,7 +151,7 @@ impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
         // these have already been weighted by balance
         for (hash, votes) in latest_votes.iter() {
             if let Some(ancestor) = self.get_ancestor(*hash, block_height, spec) {
-                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0).clone();
+                let current_vote_value = *current_votes.get(&ancestor).unwrap_or_else(|| &0);
                 current_votes.insert(ancestor, current_vote_value + *votes);
                 total_vote_count += votes;
             }

--- a/eth2/fork_choice/src/bitwise_lmd_ghost.rs
+++ b/eth2/fork_choice/src/bitwise_lmd_ghost.rs
@@ -48,18 +48,6 @@ pub struct BitwiseLMDGhost<T, E> {
 }
 
 impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
-    pub fn new(store: Arc<T>) -> Self {
-        BitwiseLMDGhost {
-            cache: HashMap::new(),
-            ancestors: vec![HashMap::new(); 16],
-            latest_attestation_targets: HashMap::new(),
-            children: HashMap::new(),
-            max_known_height: SlotHeight::new(0),
-            store,
-            _phantom: PhantomData,
-        }
-    }
-
     /// Finds the latest votes weighted by validator balance. Returns a hashmap of block_hash to
     /// weighted votes.
     pub fn get_latest_votes(
@@ -229,7 +217,19 @@ impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
     }
 }
 
-impl<T: Store, E: EthSpec> ForkChoice for BitwiseLMDGhost<T, E> {
+impl<T: Store, E: EthSpec> ForkChoice<T> for BitwiseLMDGhost<T, E> {
+    fn new(store: Arc<T>) -> Self {
+        BitwiseLMDGhost {
+            cache: HashMap::new(),
+            ancestors: vec![HashMap::new(); 16],
+            latest_attestation_targets: HashMap::new(),
+            children: HashMap::new(),
+            max_known_height: SlotHeight::new(0),
+            store,
+            _phantom: PhantomData,
+        }
+    }
+
     fn add_block(
         &mut self,
         block: &BeaconBlock,

--- a/eth2/fork_choice/src/bitwise_lmd_ghost.rs
+++ b/eth2/fork_choice/src/bitwise_lmd_ghost.rs
@@ -124,8 +124,9 @@ impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
                 [log2_int((block_height - target_height - 1u64).as_u64()) as usize]
                 .get(&block_hash)
                 //TODO: Panic if we can't lookup and fork choice fails
-                .expect("All blocks should be added to the ancestor log lookup table");
-            self.get_ancestor(*ancestor_lookup, target_height, &spec)
+                .expect("All blocks should be added to the ancestor log lookup table")
+                .clone();
+            self.get_ancestor(ancestor_lookup, target_height, &spec)
         } {
             // add the result to the cache
             self.cache.insert(cache_key, ancestor);
@@ -151,7 +152,7 @@ impl<T: Store, E: EthSpec> BitwiseLMDGhost<T, E> {
         // these have already been weighted by balance
         for (hash, votes) in latest_votes.iter() {
             if let Some(ancestor) = self.get_ancestor(*hash, block_height, spec) {
-                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0);
+                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0).clone();
                 current_votes.insert(ancestor, current_vote_value + *votes);
                 total_vote_count += votes;
             }

--- a/eth2/fork_choice/src/lib.rs
+++ b/eth2/fork_choice/src/lib.rs
@@ -21,8 +21,7 @@ pub mod longest_chain;
 pub mod optimized_lmd_ghost;
 pub mod slow_lmd_ghost;
 
-// use store::stores::BeaconBlockAtSlotError;
-// use store::DBError;
+use std::sync::Arc;
 use store::Error as DBError;
 use types::{BeaconBlock, ChainSpec, Hash256};
 
@@ -34,7 +33,10 @@ pub use slow_lmd_ghost::SlowLMDGhost;
 /// Defines the interface for Fork Choices. Each Fork choice will define their own data structures
 /// which can be built in block processing through the `add_block` and `add_attestation` functions.
 /// The main fork choice algorithm is specified in `find_head
-pub trait ForkChoice: Send + Sync {
+pub trait ForkChoice<T>: Send + Sync {
+    /// Create a new `ForkChoice` which reads from `store`.
+    fn new(store: Arc<T>) -> Self;
+
     /// Called when a block has been added. Allows generic block-level data structures to be
     /// built for a given fork-choice.
     fn add_block(
@@ -77,22 +79,6 @@ impl From<DBError> for ForkChoiceError {
         ForkChoiceError::StorageError(format!("{:?}", e))
     }
 }
-
-/*
-impl From<BeaconBlockAtSlotError> for ForkChoiceError {
-    fn from(e: BeaconBlockAtSlotError) -> ForkChoiceError {
-        match e {
-            BeaconBlockAtSlotError::UnknownBeaconBlock(hash) => {
-                ForkChoiceError::MissingBeaconBlock(hash)
-            }
-            BeaconBlockAtSlotError::InvalidBeaconBlock(hash) => {
-                ForkChoiceError::MissingBeaconBlock(hash)
-            }
-            BeaconBlockAtSlotError::DBError(string) => ForkChoiceError::StorageError(string),
-        }
-    }
-}
-*/
 
 /// Fork choice options that are currently implemented.
 #[derive(Debug, Clone)]

--- a/eth2/fork_choice/src/longest_chain.rs
+++ b/eth2/fork_choice/src/longest_chain.rs
@@ -10,16 +10,14 @@ pub struct LongestChain<T> {
     store: Arc<T>,
 }
 
-impl<T: Store> LongestChain<T> {
-    pub fn new(store: Arc<T>) -> Self {
+impl<T: Store> ForkChoice<T> for LongestChain<T> {
+    fn new(store: Arc<T>) -> Self {
         LongestChain {
             head_block_hashes: Vec::new(),
             store,
         }
     }
-}
 
-impl<T: Store> ForkChoice for LongestChain<T> {
     fn add_block(
         &mut self,
         block: &BeaconBlock,

--- a/eth2/fork_choice/src/optimized_lmd_ghost.rs
+++ b/eth2/fork_choice/src/optimized_lmd_ghost.rs
@@ -124,8 +124,9 @@ impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
                 [log2_int((block_height - target_height - 1u64).as_u64()) as usize]
                 .get(&block_hash)
                 //TODO: Panic if we can't lookup and fork choice fails
-                .expect("All blocks should be added to the ancestor log lookup table");
-            self.get_ancestor(*ancestor_lookup, target_height, &spec)
+                .expect("All blocks should be added to the ancestor log lookup table")
+                .clone();
+            self.get_ancestor(ancestor_lookup, target_height, &spec)
         } {
             // add the result to the cache
             self.cache.insert(cache_key, ancestor);
@@ -151,7 +152,7 @@ impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
         // these have already been weighted by balance
         for (hash, votes) in latest_votes.iter() {
             if let Some(ancestor) = self.get_ancestor(*hash, block_height, spec) {
-                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0);
+                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0).clone();
                 current_votes.insert(ancestor, current_vote_value + *votes);
                 total_vote_count += votes;
             }

--- a/eth2/fork_choice/src/optimized_lmd_ghost.rs
+++ b/eth2/fork_choice/src/optimized_lmd_ghost.rs
@@ -120,12 +120,11 @@ impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
 
         // not in the cache recursively search for ancestors using a log-lookup
         if let Some(ancestor) = {
-            let ancestor_lookup = self.ancestors
+            let ancestor_lookup = *self.ancestors
                 [log2_int((block_height - target_height - 1u64).as_u64()) as usize]
                 .get(&block_hash)
                 //TODO: Panic if we can't lookup and fork choice fails
-                .expect("All blocks should be added to the ancestor log lookup table")
-                .clone();
+                .expect("All blocks should be added to the ancestor log lookup table");
             self.get_ancestor(ancestor_lookup, target_height, &spec)
         } {
             // add the result to the cache
@@ -152,7 +151,7 @@ impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
         // these have already been weighted by balance
         for (hash, votes) in latest_votes.iter() {
             if let Some(ancestor) = self.get_ancestor(*hash, block_height, spec) {
-                let current_vote_value = current_votes.get(&ancestor).unwrap_or_else(|| &0).clone();
+                let current_vote_value = *current_votes.get(&ancestor).unwrap_or_else(|| &0);
                 current_votes.insert(ancestor, current_vote_value + *votes);
                 total_vote_count += votes;
             }

--- a/eth2/fork_choice/src/optimized_lmd_ghost.rs
+++ b/eth2/fork_choice/src/optimized_lmd_ghost.rs
@@ -48,18 +48,6 @@ pub struct OptimizedLMDGhost<T, E> {
 }
 
 impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
-    pub fn new(store: Arc<T>) -> Self {
-        OptimizedLMDGhost {
-            cache: HashMap::new(),
-            ancestors: vec![HashMap::new(); 16],
-            latest_attestation_targets: HashMap::new(),
-            children: HashMap::new(),
-            max_known_height: SlotHeight::new(0),
-            store,
-            _phantom: PhantomData,
-        }
-    }
-
     /// Finds the latest votes weighted by validator balance. Returns a hashmap of block_hash to
     /// weighted votes.
     pub fn get_latest_votes(
@@ -200,7 +188,19 @@ impl<T: Store, E: EthSpec> OptimizedLMDGhost<T, E> {
     }
 }
 
-impl<T: Store, E: EthSpec> ForkChoice for OptimizedLMDGhost<T, E> {
+impl<T: Store, E: EthSpec> ForkChoice<T> for OptimizedLMDGhost<T, E> {
+    fn new(store: Arc<T>) -> Self {
+        OptimizedLMDGhost {
+            cache: HashMap::new(),
+            ancestors: vec![HashMap::new(); 16],
+            latest_attestation_targets: HashMap::new(),
+            children: HashMap::new(),
+            max_known_height: SlotHeight::new(0),
+            store,
+            _phantom: PhantomData,
+        }
+    }
+
     fn add_block(
         &mut self,
         block: &BeaconBlock,

--- a/eth2/fork_choice/src/slow_lmd_ghost.rs
+++ b/eth2/fork_choice/src/slow_lmd_ghost.rs
@@ -20,15 +20,6 @@ pub struct SlowLMDGhost<T, E> {
 }
 
 impl<T: Store, E: EthSpec> SlowLMDGhost<T, E> {
-    pub fn new(store: Arc<T>) -> Self {
-        SlowLMDGhost {
-            latest_attestation_targets: HashMap::new(),
-            children: HashMap::new(),
-            store,
-            _phantom: PhantomData,
-        }
-    }
-
     /// Finds the latest votes weighted by validator balance. Returns a hashmap of block_hash to
     /// weighted votes.
     pub fn get_latest_votes(
@@ -94,7 +85,16 @@ impl<T: Store, E: EthSpec> SlowLMDGhost<T, E> {
     }
 }
 
-impl<T: Store, E: EthSpec> ForkChoice for SlowLMDGhost<T, E> {
+impl<T: Store, E: EthSpec> ForkChoice<T> for SlowLMDGhost<T, E> {
+    fn new(store: Arc<T>) -> Self {
+        SlowLMDGhost {
+            latest_attestation_targets: HashMap::new(),
+            children: HashMap::new(),
+            store,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Process when a block is added
     fn add_block(
         &mut self,

--- a/eth2/fork_choice/tests/tests.rs
+++ b/eth2/fork_choice/tests/tests.rs
@@ -194,7 +194,7 @@ fn load_test_cases_from_yaml(file_path: &str) -> Vec<yaml_rust::Yaml> {
 
 fn setup_inital_state<T>(
     // fork_choice_algo: &ForkChoiceAlgorithm,
-    num_validators: usize
+    num_validators: usize,
 ) -> (T, Arc<MemoryStore>, Hash256)
 where
     T: ForkChoice<MemoryStore>,

--- a/eth2/fork_choice/tests/tests.rs
+++ b/eth2/fork_choice/tests/tests.rs
@@ -1,14 +1,11 @@
 #![cfg(not(debug_assertions))]
-// Tests the available fork-choice algorithms
-
+/// Tests the available fork-choice algorithms
 pub use beacon_chain::BeaconChain;
 use bls::Signature;
 use store::MemoryStore;
 use store::Store;
 // use env_logger::{Builder, Env};
-use fork_choice::{
-    BitwiseLMDGhost, ForkChoice, ForkChoiceAlgorithm, LongestChain, OptimizedLMDGhost, SlowLMDGhost,
-};
+use fork_choice::{BitwiseLMDGhost, ForkChoice, LongestChain, OptimizedLMDGhost, SlowLMDGhost};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::{fs::File, io::prelude::*, path::PathBuf};
@@ -25,8 +22,7 @@ fn test_optimized_lmd_ghost() {
     // set up logging
     // Builder::from_env(Env::default().default_filter_or("trace")).init();
 
-    test_yaml_vectors(
-        ForkChoiceAlgorithm::OptimizedLMDGhost,
+    test_yaml_vectors::<OptimizedLMDGhost<MemoryStore, FoundationEthSpec>>(
         "tests/lmd_ghost_test_vectors.yaml",
         100,
     );
@@ -37,8 +33,7 @@ fn test_bitwise_lmd_ghost() {
     // set up logging
     //Builder::from_env(Env::default().default_filter_or("trace")).init();
 
-    test_yaml_vectors(
-        ForkChoiceAlgorithm::BitwiseLMDGhost,
+    test_yaml_vectors::<BitwiseLMDGhost<MemoryStore, FoundationEthSpec>>(
         "tests/bitwise_lmd_ghost_test_vectors.yaml",
         100,
     );
@@ -46,8 +41,7 @@ fn test_bitwise_lmd_ghost() {
 
 #[test]
 fn test_slow_lmd_ghost() {
-    test_yaml_vectors(
-        ForkChoiceAlgorithm::SlowLMDGhost,
+    test_yaml_vectors::<SlowLMDGhost<MemoryStore, FoundationEthSpec>>(
         "tests/lmd_ghost_test_vectors.yaml",
         100,
     );
@@ -55,16 +49,11 @@ fn test_slow_lmd_ghost() {
 
 #[test]
 fn test_longest_chain() {
-    test_yaml_vectors(
-        ForkChoiceAlgorithm::LongestChain,
-        "tests/longest_chain_test_vectors.yaml",
-        100,
-    );
+    test_yaml_vectors::<LongestChain<MemoryStore>>("tests/longest_chain_test_vectors.yaml", 100);
 }
 
 // run a generic test over given YAML test vectors
-fn test_yaml_vectors(
-    fork_choice_algo: ForkChoiceAlgorithm,
+fn test_yaml_vectors<T: ForkChoice<MemoryStore>>(
     yaml_file_path: &str,
     emulated_validators: usize, // the number of validators used to give weights.
 ) {
@@ -94,8 +83,7 @@ fn test_yaml_vectors(
     // process the tests
     for test_case in test_cases {
         // setup a fresh test
-        let (mut fork_choice, store, state_root) =
-            setup_inital_state(&fork_choice_algo, emulated_validators);
+        let (mut fork_choice, store, state_root) = setup_inital_state::<T>(emulated_validators);
 
         // keep a hashmap of block_id's to block_hashes (random hashes to abstract block_id)
         //let mut block_id_map: HashMap<String, Hash256> = HashMap::new();
@@ -204,32 +192,16 @@ fn load_test_cases_from_yaml(file_path: &str) -> Vec<yaml_rust::Yaml> {
     doc["test_cases"].as_vec().unwrap().clone()
 }
 
-// initialise a single validator and state. All blocks will reference this state root.
-fn setup_inital_state(
-    fork_choice_algo: &ForkChoiceAlgorithm,
-    num_validators: usize,
-) -> (Box<ForkChoice>, Arc<MemoryStore>, Hash256) {
+fn setup_inital_state<T>(
+    // fork_choice_algo: &ForkChoiceAlgorithm,
+    num_validators: usize
+) -> (T, Arc<MemoryStore>, Hash256)
+where
+    T: ForkChoice<MemoryStore>,
+{
     let store = Arc::new(MemoryStore::open());
 
-    // the fork choice instantiation
-    let fork_choice: Box<ForkChoice> = match fork_choice_algo {
-        ForkChoiceAlgorithm::OptimizedLMDGhost => {
-            let f: OptimizedLMDGhost<MemoryStore, FoundationEthSpec> =
-                OptimizedLMDGhost::new(store.clone());
-            Box::new(f)
-        }
-        ForkChoiceAlgorithm::BitwiseLMDGhost => {
-            let f: BitwiseLMDGhost<MemoryStore, FoundationEthSpec> =
-                BitwiseLMDGhost::new(store.clone());
-            Box::new(f)
-        }
-        ForkChoiceAlgorithm::SlowLMDGhost => {
-            let f: SlowLMDGhost<MemoryStore, FoundationEthSpec> = SlowLMDGhost::new(store.clone());
-            Box::new(f)
-        }
-        ForkChoiceAlgorithm::LongestChain => Box::new(LongestChain::new(store.clone())),
-    };
-
+    let fork_choice = ForkChoice::new(store.clone());
     let spec = FoundationEthSpec::spec();
 
     let mut state_builder: TestingBeaconStateBuilder<FoundationEthSpec> =

--- a/eth2/utils/fixed_len_vec/src/impls.rs
+++ b/eth2/utils/fixed_len_vec/src/impls.rs
@@ -100,7 +100,7 @@ where
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
-        if bytes.len() == 0 {
+        if bytes.is_empty() {
             Ok(FixedLenVec::from(vec![]))
         } else if T::is_ssz_fixed_len() {
             bytes

--- a/eth2/utils/slot_clock/src/lib.rs
+++ b/eth2/utils/slot_clock/src/lib.rs
@@ -6,8 +6,13 @@ pub use crate::testing_slot_clock::{Error as TestingSlotClockError, TestingSlotC
 use std::time::Duration;
 pub use types::Slot;
 
-pub trait SlotClock: Send + Sync {
+pub trait SlotClock: Send + Sync + Sized {
     type Error;
+
+    /// Create a new `SlotClock`.
+    ///
+    /// Returns an Error if `slot_duration_seconds == 0`.
+    fn new(genesis_slot: Slot, genesis_seconds: u64, slot_duration_seconds: u64) -> Self;
 
     fn present_slot(&self) -> Result<Option<Slot>, Self::Error>;
 

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -18,31 +18,25 @@ pub struct SystemTimeSlotClock {
     slot_duration_seconds: u64,
 }
 
-impl SystemTimeSlotClock {
-    /// Create a new `SystemTimeSlotClock`.
-    ///
-    /// Returns an Error if `slot_duration_seconds == 0`.
-    pub fn new(
-        genesis_slot: Slot,
-        genesis_seconds: u64,
-        slot_duration_seconds: u64,
-    ) -> Result<SystemTimeSlotClock, Error> {
-        if slot_duration_seconds == 0 {
-            Err(Error::SlotDurationIsZero)
-        } else {
-            Ok(Self {
-                genesis_slot,
-                genesis_seconds,
-                slot_duration_seconds,
-            })
-        }
-    }
-}
-
 impl SlotClock for SystemTimeSlotClock {
     type Error = Error;
 
+    /// Create a new `SystemTimeSlotClock`.
+    ///
+    /// Returns an Error if `slot_duration_seconds == 0`.
+    fn new(genesis_slot: Slot, genesis_seconds: u64, slot_duration_seconds: u64) -> Self {
+        Self {
+            genesis_slot,
+            genesis_seconds,
+            slot_duration_seconds,
+        }
+    }
+
     fn present_slot(&self) -> Result<Option<Slot>, Error> {
+        if self.slot_duration_seconds == 0 {
+            return Err(Error::SlotDurationIsZero);
+        }
+
         let syslot_time = SystemTime::now();
         let duration_since_epoch = syslot_time.duration_since(SystemTime::UNIX_EPOCH)?;
         let duration_since_genesis =

--- a/eth2/utils/ssz/src/decode.rs
+++ b/eth2/utils/ssz/src/decode.rs
@@ -102,9 +102,7 @@ impl<'a> SszDecoderBuilder<'a> {
                 .and_then(|o| Some(o.offset))
                 .unwrap_or_else(|| BYTES_PER_LENGTH_OFFSET);
 
-            if previous_offset > offset {
-                return Err(DecodeError::OutOfBoundsByte { i: offset });
-            } else if offset > self.bytes.len() {
+            if (previous_offset > offset) || (offset > self.bytes.len()) {
                 return Err(DecodeError::OutOfBoundsByte { i: offset });
             }
 

--- a/eth2/utils/ssz/src/decode/impls.rs
+++ b/eth2/utils/ssz/src/decode/impls.rs
@@ -54,11 +54,9 @@ impl Decode for bool {
             match bytes[0] {
                 0b0000_0000 => Ok(false),
                 0b0000_0001 => Ok(true),
-                _ => {
-                    return Err(DecodeError::BytesInvalid(
-                        format!("Out-of-range for boolean: {}", bytes[0]).to_string(),
-                    ))
-                }
+                _ => Err(DecodeError::BytesInvalid(
+                    format!("Out-of-range for boolean: {}", bytes[0]).to_string(),
+                )),
             }
         }
     }
@@ -121,7 +119,7 @@ impl<T: Decode> Decode for Vec<T> {
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        if bytes.len() == 0 {
+        if bytes.is_empty() {
             Ok(vec![])
         } else if T::is_ssz_fixed_len() {
             bytes

--- a/validator_client/src/error.rs
+++ b/validator_client/src/error.rs
@@ -1,9 +1,6 @@
 use slot_clock;
 
-use error_chain::{
-    error_chain, error_chain_processing, impl_error_chain_kind, impl_error_chain_processed,
-    impl_extract_backtrace,
-};
+use error_chain::error_chain;
 
 error_chain! {
    links  { }

--- a/validator_client/src/service.rs
+++ b/validator_client/src/service.rs
@@ -155,8 +155,7 @@ impl<B: BeaconNodeDuties + 'static, S: Signer + 'static> Service<B, S> {
 
         // build the validator slot clock
         let slot_clock =
-            SystemTimeSlotClock::new(genesis_slot, genesis_time, config.spec.seconds_per_slot)
-                .expect("Unable to instantiate SystemTimeSlotClock.");
+            SystemTimeSlotClock::new(genesis_slot, genesis_time, config.spec.seconds_per_slot);
 
         let current_slot = slot_clock
             .present_slot()


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Adds a `PersistedBeaconChain` struct.
- Allows `BeaconChain` to go to and from a `Store` via `PersistedBeaconChain`.
- Refactors some runtime components to accommodate loading the chain from the store.

## Additional Info

- Does not persist the `op_pool`. I think this functionality is necessary and a future PR should introduce this feature.
