### PR TITLE
Update BLS library

### DIFF
--- a/eth2/utils/bls/Cargo.toml
+++ b/eth2/utils/bls/Cargo.toml
@@ -5,10 +5,11 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-bls-aggregates = { git = "https://github.com/sigp/signature-schemes", tag = "0.6.1" }
+milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v0.9.0" }
 cached_tree_hash = { path = "../cached_tree_hash" }
 hashing = { path = "../hashing" }
 hex = "0.3"
+rand = "^0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_hex = { path = "../serde_hex" }

--- a/eth2/utils/bls/src/aggregate_public_key.rs
+++ b/eth2/utils/bls/src/aggregate_public_key.rs
@@ -1,5 +1,5 @@
 use super::PublicKey;
-use bls_aggregates::AggregatePublicKey as RawAggregatePublicKey;
+use milagro_bls::AggregatePublicKey as RawAggregatePublicKey;
 
 /// A BLS aggregate public key.
 ///

--- a/eth2/utils/bls/src/aggregate_signature.rs
+++ b/eth2/utils/bls/src/aggregate_signature.rs
@@ -1,8 +1,8 @@
 use super::*;
-use bls_aggregates::{
+use cached_tree_hash::cached_tree_hash_ssz_encoding_as_vector;
+use milagro_bls::{
     AggregatePublicKey as RawAggregatePublicKey, AggregateSignature as RawAggregateSignature,
 };
-use cached_tree_hash::cached_tree_hash_ssz_encoding_as_vector;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_hex::{encode as hex_encode, HexVisitor};

--- a/eth2/utils/bls/src/lib.rs
+++ b/eth2/utils/bls/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate bls_aggregates;
+extern crate milagro_bls;
 extern crate ssz;
 
 #[macro_use]

--- a/eth2/utils/bls/src/public_key.rs
+++ b/eth2/utils/bls/src/public_key.rs
@@ -1,6 +1,6 @@
 use super::{SecretKey, BLS_PUBLIC_KEY_BYTE_SIZE};
-use bls_aggregates::PublicKey as RawPublicKey;
 use cached_tree_hash::cached_tree_hash_ssz_encoding_as_vector;
+use milagro_bls::PublicKey as RawPublicKey;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_hex::{encode as hex_encode, HexVisitor};

--- a/eth2/utils/bls/src/secret_key.rs
+++ b/eth2/utils/bls/src/secret_key.rs
@@ -1,6 +1,6 @@
 use super::BLS_SECRET_KEY_BYTE_SIZE;
-use bls_aggregates::SecretKey as RawSecretKey;
 use hex::encode as hex_encode;
+use milagro_bls::SecretKey as RawSecretKey;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_hex::HexVisitor;
@@ -16,7 +16,7 @@ pub struct SecretKey(RawSecretKey);
 
 impl SecretKey {
     pub fn random() -> Self {
-        SecretKey(RawSecretKey::random())
+        SecretKey(RawSecretKey::random(&mut rand::thread_rng()))
     }
 
     /// Returns the underlying point as compressed bytes.

--- a/eth2/utils/bls/src/signature.rs
+++ b/eth2/utils/bls/src/signature.rs
@@ -1,7 +1,7 @@
 use super::{PublicKey, SecretKey, BLS_SIG_BYTE_SIZE};
-use bls_aggregates::Signature as RawSignature;
 use cached_tree_hash::cached_tree_hash_ssz_encoding_as_vector;
 use hex::encode as hex_encode;
+use milagro_bls::Signature as RawSignature;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use serde_hex::HexVisitor;


### PR DESCRIPTION
## Issue Addressed
NA

## Proposed Changes

Updates our BLS library:

- New version uses SHA2 instead of Keccak
- Pulls library from new library, instead of old archived one.

## Additional Info

NA