### PR TITLE
Updated docker file to include the git-lfs installation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM rust:latest
 
-RUN apt-get update && apt-get install -y clang libclang-dev cmake build-essential git unzip autoconf libtool awscli
+RUN apt-get update && apt-get install -y clang libclang-dev cmake build-essential git unzip autoconf libtool awscli software-properties-common
+
+RUN add-apt-repository -y ppa:git-core/ppa
+
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+
+RUN apt-get install -y git-lfs
 
 RUN git clone https://github.com/google/protobuf.git && \
     cd protobuf && \


### PR DESCRIPTION
## Proposed Changes

The Dockerfile now installs git-lfs before anything, to ensure the CI pipelines work correctly.
