### PR TITLE
Make SSZ compatible with `wasm32` targets

### DIFF
--- a/eth2/utils/hashing/.cargo/config
+++ b/eth2/utils/hashing/.cargo/config
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'

--- a/eth2/utils/hashing/Cargo.toml
+++ b/eth2/utils/hashing/Cargo.toml
@@ -4,5 +4,14 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
-[dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.14.6"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+sha2 = "0.8.0"
+
+[dev-dependencies]
+rustc-hex = "2.0.1"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.2.47"

--- a/eth2/utils/ssz/src/decode/impls.rs
+++ b/eth2/utils/ssz/src/decode/impls.rs
@@ -34,6 +34,11 @@ impl_decodable_for_uint!(u8, 8);
 impl_decodable_for_uint!(u16, 16);
 impl_decodable_for_uint!(u32, 32);
 impl_decodable_for_uint!(u64, 64);
+
+#[cfg(target_pointer_width = "32")]
+impl_decodable_for_uint!(usize, 32);
+
+#[cfg(target_pointer_width = "64")]
 impl_decodable_for_uint!(usize, 64);
 
 impl Decode for bool {

--- a/eth2/utils/ssz/src/encode/impls.rs
+++ b/eth2/utils/ssz/src/encode/impls.rs
@@ -24,6 +24,11 @@ impl_encodable_for_uint!(u8, 8);
 impl_encodable_for_uint!(u16, 16);
 impl_encodable_for_uint!(u32, 32);
 impl_encodable_for_uint!(u64, 64);
+
+#[cfg(target_pointer_width = "32")]
+impl_encodable_for_uint!(usize, 32);
+
+#[cfg(target_pointer_width = "64")]
 impl_encodable_for_uint!(usize, 64);
 
 /// The SSZ "union" type.

--- a/eth2/utils/ssz/src/lib.rs
+++ b/eth2/utils/ssz/src/lib.rs
@@ -46,9 +46,10 @@ pub use encode::{Encode, SszEncoder};
 /// The number of bytes used to represent an offset.
 pub const BYTES_PER_LENGTH_OFFSET: usize = 4;
 /// The maximum value that can be represented using `BYTES_PER_LENGTH_OFFSET`.
-// allows overflow on 32-bit target
-#[allow(const_err)]
-pub const MAX_LENGTH_VALUE: usize = (1 << (BYTES_PER_LENGTH_OFFSET * 8)) - 1;
+#[cfg(target_pointer_width = "32")]
+pub const MAX_LENGTH_VALUE: usize = (std::u32::MAX >> 8 * (4 - BYTES_PER_LENGTH_OFFSET)) as usize;
+#[cfg(target_pointer_width = "64")]
+pub const MAX_LENGTH_VALUE: usize = (std::u64::MAX >> 8 * (8 - BYTES_PER_LENGTH_OFFSET)) as usize;
 
 /// Convenience function to SSZ encode an object supporting ssz::Encode.
 ///

--- a/eth2/utils/ssz/src/lib.rs
+++ b/eth2/utils/ssz/src/lib.rs
@@ -46,6 +46,8 @@ pub use encode::{Encode, SszEncoder};
 /// The number of bytes used to represent an offset.
 pub const BYTES_PER_LENGTH_OFFSET: usize = 4;
 /// The maximum value that can be represented using `BYTES_PER_LENGTH_OFFSET`.
+// allows overflow on 32-bit target
+#[allow(const_err)]
 pub const MAX_LENGTH_VALUE: usize = (1 << (BYTES_PER_LENGTH_OFFSET * 8)) - 1;
 
 /// Convenience function to SSZ encode an object supporting ssz::Encode.


### PR DESCRIPTION
## Issue Addressed
#404 

## Proposed Changes
* added conditional support for `sha2` crate depending on target architecture
* added support for 32-bit architectures