### PR TITLE
Fixed account_manager data dir

### DIFF
--- a/account_manager/src/main.rs
+++ b/account_manager/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use types::test_utils::generate_deterministic_keypair;
 use validator_client::Config as ValidatorClientConfig;
 
-pub const DEFAULT_DATA_DIR: &str = ".lighthouse-account-manager";
+pub const DEFAULT_DATA_DIR: &str = ".lighthouse-validator";
 pub const CLIENT_CONFIG_FILENAME: &str = "account-manager.toml";
 
 fn main() {

--- a/validator_client/src/main.rs
+++ b/validator_client/src/main.rs
@@ -35,6 +35,7 @@ fn main() {
         .arg(
             Arg::with_name("datadir")
                 .long("datadir")
+                .short("d")
                 .value_name("DIR")
                 .help("Data directory for keys and databases.")
                 .takes_value(true),


### PR DESCRIPTION
 - Default data directory for the account_manager, now points to ~/.lighthouse-validator, which is the same data dir as the validator binary.

## Issue Addressed

This fixes #410 
