### PR TITLE
Prepare ssz for publishing on crates.io

### DIFF
--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -20,8 +20,8 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slot_clock = { path = "../../eth2/utils/slot_clock" }
-ssz = { path = "../../eth2/utils/ssz" }
-ssz_derive = { path = "../../eth2/utils/ssz_derive" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz_derive = { path = "../../eth2/utils/ssz_derive" }
 state_processing = { path = "../../eth2/state_processing" }
 tree_hash = { path = "../../eth2/utils/tree_hash" }
 types = { path = "../../eth2/types" }

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -19,7 +19,7 @@ serde = "1.0"
 serde_derive = "1.0"
 error-chain = "0.12.0"
 slog = "^2.2.3"
-ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
 tokio = "0.1.15"
 clap = "2.32.0"
 dirs = "1.0.3"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -12,8 +12,8 @@ libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "b3c32d9a821ae6cc
 types = { path =  "../../eth2/types" }
 serde = "1.0"
 serde_derive = "1.0"
-ssz = { path = "../../eth2/utils/ssz" }
-ssz_derive = { path = "../../eth2/utils/ssz_derive" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz_derive = { path = "../../eth2/utils/ssz_derive" }
 slog = "2.4.1"
 version = { path = "../version" }
 tokio = "0.1.16"

--- a/beacon_node/http_server/Cargo.toml
+++ b/beacon_node/http_server/Cargo.toml
@@ -13,7 +13,7 @@ network = { path = "../network" }
 eth2-libp2p = { path = "../eth2-libp2p" }
 version = { path = "../version" }
 types = { path = "../../eth2/types" }
-ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 protos = { path = "../../protos" }
 grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -14,7 +14,7 @@ eth2-libp2p =  { path = "../eth2-libp2p" }
 version = { path = "../version" }
 types = { path = "../../eth2/types" }
 slog = { version = "^2.2.3" , features = ["max_level_trace", "release_max_level_debug"] }
-ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
 tree_hash = { path = "../../eth2/utils/tree_hash" }
 futures = "0.1.25"
 error-chain = "0.12.0"

--- a/beacon_node/rpc/Cargo.toml
+++ b/beacon_node/rpc/Cargo.toml
@@ -11,7 +11,7 @@ network = { path = "../network" }
 eth2-libp2p = { path = "../eth2-libp2p" }
 version = { path = "../version" }
 types = { path = "../../eth2/types" }
-ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 protos = { path = "../../protos" }
 grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "0.4.10"
 db-key = "0.0.5"
 leveldb = "0.8.4"
 parking_lot = "0.7"
-ssz = { path = "../../eth2/utils/ssz" }
-ssz_derive = { path = "../../eth2/utils/ssz_derive" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz_derive = { path = "../../eth2/utils/ssz_derive" }
 tree_hash = { path = "../../eth2/utils/tree_hash" }
 types = { path =  "../../eth2/types" }

--- a/eth2/lmd_ghost/Cargo.toml
+++ b/eth2/lmd_ghost/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 parking_lot = "0.7"
 store = { path = "../../beacon_node/store" }
-ssz = { path = "../utils/ssz" }
+eth2_ssz = { path = "../utils/ssz" }
 state_processing = { path = "../state_processing" }
 types = { path = "../types" }
 log = "0.4.6"

--- a/eth2/operation_pool/Cargo.toml
+++ b/eth2/operation_pool/Cargo.toml
@@ -11,5 +11,5 @@ itertools = "0.8"
 parking_lot = "0.7"
 types = { path = "../types" }
 state_processing = { path = "../state_processing" }
-ssz = { path = "../utils/ssz" }
-ssz_derive = { path = "../utils/ssz_derive" }
+eth2_ssz = { path = "../utils/ssz" }
+eth2_ssz_derive = { path = "../utils/ssz_derive" }

--- a/eth2/state_processing/Cargo.toml
+++ b/eth2/state_processing/Cargo.toml
@@ -24,8 +24,8 @@ integer-sqrt = "0.1"
 itertools = "0.8"
 log = "0.4"
 merkle_proof = { path = "../utils/merkle_proof" }
-ssz = { path = "../utils/ssz" }
-ssz_derive = { path = "../utils/ssz_derive" }
+eth2_ssz = { path = "../utils/ssz" }
+eth2_ssz_derive = { path = "../utils/ssz_derive" }
 tree_hash = { path = "../utils/tree_hash" }
 tree_hash_derive = { path = "../utils/tree_hash_derive" }
 types = { path = "../types" }

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -26,8 +26,8 @@ serde_derive = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.8"
 slog = "^2.2.3"
-ssz = { path = "../utils/ssz" }
-ssz_derive = { path = "../utils/ssz_derive" }
+eth2_ssz = { path = "../utils/ssz" }
+eth2_ssz_derive = { path = "../utils/ssz_derive" }
 swap_or_not_shuffle = { path = "../utils/swap_or_not_shuffle" }
 test_random_derive = { path = "../utils/test_random_derive" }
 tree_hash = { path = "../utils/tree_hash" }

--- a/eth2/utils/bls/Cargo.toml
+++ b/eth2/utils/bls/Cargo.toml
@@ -13,7 +13,7 @@ rand = "^0.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_hex = { path = "../serde_hex" }
-ssz = { path = "../ssz" }
+eth2_ssz = { path = "../ssz" }
 tree_hash = { path = "../tree_hash" }
 
 [features]

--- a/eth2/utils/boolean-bitfield/Cargo.toml
+++ b/eth2/utils/boolean-bitfield/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 cached_tree_hash = { path = "../cached_tree_hash" }
 serde_hex = { path = "../serde_hex" }
-ssz = { path = "../ssz" }
+eth2_ssz = { path = "../ssz" }
 bit-vec = "0.5.0"
 bit_reverse = "0.1"
 serde = "1.0"

--- a/eth2/utils/boolean-bitfield/fuzz/Cargo.toml
+++ b/eth2/utils/boolean-bitfield/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 cargo-fuzz = true
 
 [dependencies]
-ssz = { path = "../../ssz" }
+eth2_ssz = { path = "../../ssz" }
 
 [dependencies.boolean-bitfield]
 path = ".."

--- a/eth2/utils/fixed_len_vec/Cargo.toml
+++ b/eth2/utils/fixed_len_vec/Cargo.toml
@@ -9,5 +9,5 @@ cached_tree_hash = { path = "../cached_tree_hash" }
 tree_hash = { path = "../tree_hash" }
 serde = "1.0"
 serde_derive = "1.0"
-ssz = { path = "../ssz" }
+eth2_ssz = { path = "../ssz" }
 typenum = "1.10"

--- a/eth2/utils/ssz/Cargo.toml
+++ b/eth2/utils/ssz/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
-name = "ssz"
+name = "eth2_ssz"
 version = "0.1.0"
-authors = ["Paul Hauner <paul@paulhauner.com>"]
+authors = ["Paul Hauner <paul@sigmaprime.io>"]
 edition = "2018"
+description = "SimpleSerialize (SSZ) as used in Ethereum 2.0"
+
+[lib]
+name = "ssz"
 
 [[bench]]
 name = "benches"
@@ -10,7 +14,7 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.2"
-ssz_derive = { path = "../ssz_derive" }
+eth2_ssz_derive = { path = "../ssz_derive" }
 
 [dependencies]
 bytes = "0.4.9"

--- a/eth2/utils/ssz/src/lib.rs
+++ b/eth2/utils/ssz/src/lib.rs
@@ -2,7 +2,7 @@
 //! format designed for use in Ethereum 2.0.
 //!
 //! Conforms to
-//! [v0.6.1](https://github.com/ethereum/eth2.0-specs/blob/v0.6.1/specs/simple-serialize.md) of the
+//! [v0.7.1](https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/simple-serialize.md) of the
 //! Ethereum 2.0 specification.
 //!
 //! ## Example

--- a/eth2/utils/ssz_derive/Cargo.toml
+++ b/eth2/utils/ssz_derive/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
-name = "ssz_derive"
+name = "eth2_ssz_derive"
 version = "0.1.0"
-authors = ["Paul Hauner <paul@paulhauner.com>"]
+authors = ["Paul Hauner <paul@sigmaprime.io>"]
 edition = "2018"
-description = "Procedural derive macros for SSZ encoding and decoding."
+description = "Procedural derive macros to accompany the eth2_ssz crate."
 
 [lib]
+name = "ssz_derive"
 proc-macro = true
 
 [dependencies]
 syn = "0.15"
 quote = "0.6"
-ssz = { path = "../ssz" }
+eth2_ssz = { path = "../ssz" }

--- a/eth2/validator_change/Cargo.toml
+++ b/eth2/validator_change/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 bytes = "0.4.10"
 hashing = { path = "../utils/hashing" }
-ssz = { path = "../utils/ssz" }
+eth2_ssz = { path = "../utils/ssz" }
 types = { path = "../types" }

--- a/tests/ef_tests/Cargo.toml
+++ b/tests/ef_tests/Cargo.toml
@@ -17,7 +17,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_repr = "0.1"
 serde_yaml = "0.8"
-ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz = { path = "../../eth2/utils/ssz" }
 tree_hash = { path = "../../eth2/utils/tree_hash" }
 cached_tree_hash = { path = "../../eth2/utils/cached_tree_hash" }
 state_processing = { path = "../../eth2/state_processing" }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 
 [dependencies]
 bls = { path = "../eth2/utils/bls" }
-ssz = { path = "../eth2/utils/ssz" }
+eth2_ssz = { path = "../eth2/utils/ssz" }
 eth2_config = { path = "../eth2/utils/eth2_config" }
 tree_hash = { path = "../eth2/utils/tree_hash" }
 clap = "2.32.0"


### PR DESCRIPTION
## Issue Addressed

Progress for #422

## Proposed Changes

- Changes the package name of `ssz` to `eth2_ssz`
- Changes the package name of `ssz_derive` to `eth2_ssz_derive`
- Changes the crate-level docs in `ssz` to state that it's up-to-date with `v0.7.1` -- unions have been implemented and no other significant changes were made between `v0.6.3`. (Here's a [diff](https://github.com/ethereum/eth2.0-specs/compare/v0.6.3..v0.7.1) between the two spec versions, for reference)
 
## Additional Info

The `ssz` and `ssz_derive` _package_ names have been changed to `eth2_ssz` and `eth2_ssz_derive`, however their _library_ names remain the same. This means that in `Cargo.toml` you import `eth2_ssz`, but in a `.rs` file you do `use ssz;`.

Additionally, the `eth2_ssz` package is in `eth2/utils/ssz` directory (the directory name does not match the package name, instead it matches the library name). This is a little odd perhaps, but it means we don't break existing links to the package (e.g., [here](https://github.com/ethereum/eth2.0-specs/blob/v0.7.1/specs/simple-serialize.md#implementations)).

I'm keen to hear thoughts on the previous two paragraphs.
