### PR TITLE
Padding efficent merkle root algo

### DIFF
--- a/eth2/utils/tree_hash/Cargo.toml
+++ b/eth2/utils/tree_hash/Cargo.toml
@@ -5,9 +5,11 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dev-dependencies]
+rand = "0.7"
 tree_hash_derive = { path = "../tree_hash_derive" }
 
 [dependencies]
 ethereum-types = "0.5"
 hashing = { path = "../hashing" }
 int_to_bytes = { path = "../int_to_bytes" }
+lazy_static = "0.1"

--- a/eth2/utils/tree_hash/src/impls.rs
+++ b/eth2/utils/tree_hash/src/impls.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::merkleize::merkle_root;
+use crate::merkle_root;
 use ethereum_types::H256;
 use hashing::hash;
 use int_to_bytes::int_to_bytes32;

--- a/eth2/utils/tree_hash/src/lib.rs
+++ b/eth2/utils/tree_hash/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-mod impls;
+pub mod impls;
 mod merkleize_padded;
 mod merkleize_standard;
 
@@ -56,7 +56,7 @@ macro_rules! tree_hash_ssz_encoding_as_vector {
             }
 
             fn tree_hash_root(&self) -> Vec<u8> {
-                tree_hash::merkleize::merkle_root(&ssz::ssz_encode(self))
+                tree_hash::merkle_root(&ssz::ssz_encode(self))
             }
         }
     };

--- a/eth2/utils/tree_hash/src/lib.rs
+++ b/eth2/utils/tree_hash/src/lib.rs
@@ -1,9 +1,17 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub mod impls;
-pub mod merkleize;
-pub mod merkleize_padded;
+mod impls;
+mod merkleize_padded;
+mod merkleize_standard;
+
+pub use merkleize_padded::merkleize_padded;
+pub use merkleize_standard::merkleize_standard;
+
+/// Alias to `merkleize_padded(&bytes, 0)`
+pub fn merkle_root(bytes: &[u8]) -> Vec<u8> {
+    merkleize_padded(&bytes, 0)
+}
 
 pub const BYTES_PER_CHUNK: usize = 32;
 pub const HASHSIZE: usize = 32;

--- a/eth2/utils/tree_hash/src/lib.rs
+++ b/eth2/utils/tree_hash/src/lib.rs
@@ -1,5 +1,9 @@
+#[macro_use]
+extern crate lazy_static;
+
 pub mod impls;
 pub mod merkleize;
+pub mod merkleize_padded;
 
 pub const BYTES_PER_CHUNK: usize = 32;
 pub const HASHSIZE: usize = 32;

--- a/eth2/utils/tree_hash/src/merkleize.rs
+++ b/eth2/utils/tree_hash/src/merkleize.rs
@@ -2,11 +2,10 @@ use super::*;
 use hashing::hash;
 
 pub fn merkle_root(bytes: &[u8]) -> Vec<u8> {
-    // TODO: replace this with a more memory efficient method.
-    efficient_merkleize(&bytes)[0..32].to_vec()
+    standard_merkleize(&bytes)[0..32].to_vec()
 }
 
-pub fn efficient_merkleize(bytes: &[u8]) -> Vec<u8> {
+pub fn standard_merkleize(bytes: &[u8]) -> Vec<u8> {
     // If the bytes are just one chunk (or less than one chunk) just return them.
     if bytes.len() <= HASHSIZE {
         let mut o = bytes.to_vec();

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -227,7 +227,7 @@ impl ChunkStore {
 
 /// Returns a cached padding node for a given height.
 fn get_zero_hash(height: usize) -> &'static [u8] {
-    if height < MAX_TREE_DEPTH {
+    if height <= MAX_TREE_DEPTH {
         &ZERO_HASHES[height]
     } else {
         panic!("Tree exceeds MAX_TREE_DEPTH of {}", MAX_TREE_DEPTH)

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -125,7 +125,7 @@ pub fn merkleize_padded(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
     // in the tree as it is the root does not require hashing.
     //
     // The padding nodes for each height are cached via `lazy static` to simulate non-adjacent
-    // padding nodes (i.e., avoid doing unnessary hashing).
+    // padding nodes (i.e., avoid doing unnecessary hashing).
     for height in 1..height - 1 {
         let child_nodes = chunks.len();
         let parent_nodes = next_even_number(child_nodes) / 2;
@@ -151,7 +151,7 @@ pub fn merkleize_padded(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
                 "Both children should be `BYTES_PER_CHUNK` bytes."
             );
 
-            let hash = hash_concat(&left.to_vec(), &right.to_vec());
+            let hash = hash_concat(left, right);
 
             // Store a parent node.
             chunks

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -4,7 +4,7 @@ use hashing::hash;
 /// The size of the cache that stores padding nodes for a given height.
 ///
 /// Currently, we panic if we encounter a tree with a height larger than `MAX_TREE_DEPTH`.
-pub const MAX_TREE_DEPTH: usize = 32;
+pub const MAX_TREE_DEPTH: usize = 64;
 
 lazy_static! {
     /// Cached zero hashes where `ZERO_HASHES[i]` is the hash of a Merkle tree with 2^i zero leaves.

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -23,8 +23,8 @@ lazy_static! {
 /// leaves.
 ///
 /// First all nodes are extracted from `bytes` and then a padding node is added until the number of
-/// leaf chunks is greater than or equal to `min_leaves`.Set `min_leaves == 0` if no adding padding
-/// should be added to the given `bytes`.
+/// leaf chunks is greater than or equal to `min_leaves`. Callers may set `min_leaves` to `0` if no
+/// adding additional chunks should be added to the given `bytes`.
 ///
 /// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and bytes is returned, potentially
 /// padded out to `BYTES_PER_CHUNK` length with `0`.
@@ -152,7 +152,7 @@ pub fn merkleize_padded(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
                 "Both children should be `BYTES_PER_CHUNK` bytes."
             );
 
-            let hash = hash_concat(&mut left.to_vec(), &mut right.to_vec());
+            let hash = hash_concat(&left.to_vec(), &right.to_vec());
 
             chunks
                 .set(i, &hash)
@@ -230,7 +230,7 @@ fn get_zero_hash(height: usize) -> &'static [u8] {
     if height < MAX_TREE_DEPTH {
         &ZERO_HASHES[height]
     } else {
-        panic!("Tree exceeeds MAX_TREE_DEPTH of {}")
+        panic!("Tree exceeeds MAX_TREE_DEPTH of {}", MAX_TREE_DEPTH)
     }
 }
 

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -154,9 +154,6 @@ pub fn merkleize_padded(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
 
             let hash = hash_concat(&mut left.to_vec(), &mut right.to_vec());
 
-            dbg!(height);
-            dbg!(&hash);
-
             chunks
                 .set(i, &hash)
                 .expect("Buf is adequate size for parent");
@@ -231,7 +228,6 @@ impl ChunkStore {
 /// Returns a cached padding node for a given height.
 fn get_zero_hash(height: usize) -> &'static [u8] {
     if height < MAX_TREE_DEPTH {
-        dbg!(&ZERO_HASHES[height]);
         &ZERO_HASHES[height]
     } else {
         panic!("Tree exceeeds MAX_TREE_DEPTH of {}")

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -1,7 +1,10 @@
 use super::BYTES_PER_CHUNK;
 use hashing::hash;
 
-const MAX_TREE_DEPTH: usize = 32;
+/// The size of the cache that stores padding nodes for a given height.
+///
+/// Currently, we panic if we encounter a tree with a height larger than `MAX_TREE_DEPTH`.
+pub const MAX_TREE_DEPTH: usize = 32;
 
 lazy_static! {
     /// Cached zero hashes where `ZERO_HASHES[i]` is the hash of a Merkle tree with 2^i zero leaves.
@@ -16,13 +19,153 @@ lazy_static! {
     };
 }
 
+/// Merklizes bytes and returns the root, optionally padding the tree out to `min_leaves` number of
+/// leaves.
+///
+/// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and bytes is returned, potentially
+/// padded out to `BYTES_PER_CHUNK` length with `0`.
+///
+/// ## CPU Peformance Properties
+///
+/// A cache of `MAX_TREE_DEPTH` hashes are stored to avoid re-computing the hashes of padding nodes
+/// (or thier parents). In effect, adding padding nodes only incurs one more hash per added height
+/// of the tree.
+///
+/// ## Memory Peformance Properties
+///
+/// This algorithm has two interesting memory usage properties:
+///
+/// 1. It allocates `O(V / 2)` memory, where `V` is the number of leaf chunks with values (i.e.,
+///    leaves that are not padding). In effect, adding padding nodes to a merkle tree has basically
+///    no effect on memory usage.
+/// 2. At each height of the tree it frees half it's memory until it only stores a single chunk.
+///
+/// _Note: there are some minor memory overheads, including a handful of usizes and a list of
+/// `MAX_TREE_DEPTH` hashes as `lazy_static` constants._
+pub fn padded_merklize(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
+    // If the bytes are just one chunk (or less than one chunk) just return them padded to a chunk.
+    if bytes.len() <= BYTES_PER_CHUNK {
+        let mut o = bytes.to_vec();
+        o.resize(BYTES_PER_CHUNK, 0);
+        return o;
+    }
+
+    // The number of leaves that can be made directly from `bytes`.
+    let leaves_with_values = (bytes.len() + (BYTES_PER_CHUNK - 1)) / BYTES_PER_CHUNK;
+
+    // The number of parents that will appear leaves with values.
+    //
+    // I.e., the number of nodes one height above the leaves where one it's children has a value
+    // from `bytes`.
+    let initial_parents_with_values = next_even_number(leaves_with_values) / 2;
+
+    // The number of leaves in the full tree (including padding nodes).
+    let num_leaves = std::cmp::max(
+        leaves_with_values.next_power_of_two(),
+        min_leaves.next_power_of_two(),
+    );
+
+    // The height of the full tree (including padding nodes).
+    let height = num_leaves.trailing_zeros() as usize;
+
+    // A buffer/scratch-space used for storing each round of hashing at each height.
+    //
+    // This buffer is kept as small as possible; it will shrink so it never stores a padding node.
+    let mut chunks = ChunkStore::with_capacity(initial_parents_with_values);
+
+    // Create a parent in the `chunks` buffer for every two chunks in the given `bytes`.
+    //
+    // I.e., do the first round of hashing, hashing from the `bytes` slice and filling the `chunks`
+    // struct.
+    for i in 0..initial_parents_with_values {
+        let start = i * BYTES_PER_CHUNK * 2;
+
+        // Attempt to get two chunks from bytes, padding out if not all bytes are available.
+        let hash = match bytes.get(start..start + BYTES_PER_CHUNK * 2) {
+            // All bytes are available, hash as ususal.
+            Some(slice) => hash(slice),
+            // Unable to get all the bytes.
+            None => {
+                let mut preimage = bytes
+                    .get(start..)
+                    .expect("There should always be two chunks available in bytes")
+                    .to_vec();
+                preimage.resize(BYTES_PER_CHUNK * 2, 0);
+                hash(&preimage)
+            }
+        };
+
+        assert_eq!(
+            hash.len(),
+            BYTES_PER_CHUNK,
+            "Hashes should be exactly one chunk"
+        );
+
+        // Store the parent node.
+        chunks
+            .set(i, &hash)
+            .expect("Buffer should always have capacity for parent nodes")
+    }
+
+    // Iterate through all heights above the leaf nodes and either hash two children or hash a
+    // left child and a right padding node.
+    //
+    // The padding nodes for each height are cached via `lazy static` to simulate non-adjacent
+    // padding nodes (i.e., avoid doing unnessary hashing).
+    for height in 1..height {
+        let child_nodes = chunks.len();
+        let parent_nodes = (child_nodes + child_nodes % 2) / 2;
+
+        // For each of the nodes created in the previous round, either:
+        // - Hash two nodes
+        // - Hash a node and cached padding node.
+        for i in 0..parent_nodes {
+            let (left, right) = match (chunks.get(i * 2), chunks.get(i * 2 + 1)) {
+                (Ok(left), Ok(right)) => (left, right),
+                (Ok(left), Err(_)) => (left, get_zero_hash(height)),
+                (Err(_), Err(_)) => unreachable!("Parent must have one child"),
+                (Err(_), Ok(_)) => unreachable!("Parent must have a left child"),
+            };
+
+            assert!(
+                left.len() == right.len() && right.len() == BYTES_PER_CHUNK,
+                "Both children should be `BYTES_PER_CHUNK` bytes."
+            );
+
+            let hash = hash_concat(&mut left.to_vec(), &mut right.to_vec());
+
+            chunks
+                .set(i, &hash)
+                .expect("Buf is adequate size for parent");
+        }
+
+        // Shrink the buffer so it neatly fits the number of new nodes created in this round.
+        //
+        // The number of `parent_nodes` is either decreasing or stable. It never increases.
+        chunks.truncate(parent_nodes);
+    }
+
+    // There should be a single chunk left in the buffer and it is the Merkle root.
+    let root = chunks.into_vec();
+
+    assert_eq!(root.len(), BYTES_PER_CHUNK, "Only one chunk should remain");
+
+    root
+}
+
+/// A helper struct for storing `BYTES_PER_CHUNK`-byte words in a flat byte array.
+#[derive(Debug)]
 struct ChunkStore(Vec<u8>);
 
 impl ChunkStore {
+    /// Creates a new instance with `chunks` padding nodes.
     fn with_capacity(chunks: usize) -> Self {
         Self(vec![0; chunks * BYTES_PER_CHUNK])
     }
 
+    /// Set the `i`th chunk to `value`.
+    ///
+    /// Returns `Err` if `value.len() != BYTES_PER_CHUNK` or `i` is out-of-bounds.
     fn set(&mut self, i: usize, value: &[u8]) -> Result<(), ()> {
         if i < self.len() && value.len() == BYTES_PER_CHUNK {
             let slice = &mut self.0[i * BYTES_PER_CHUNK..i * BYTES_PER_CHUNK + BYTES_PER_CHUNK];
@@ -33,6 +176,9 @@ impl ChunkStore {
         }
     }
 
+    /// Gets the `i`th chunk.
+    ///
+    /// Returns `Err` if `i` is out-of-bounds.
     fn get(&self, i: usize) -> Result<&[u8], ()> {
         if i < self.len() {
             Ok(&self.0[i * BYTES_PER_CHUNK..i * BYTES_PER_CHUNK + BYTES_PER_CHUNK])
@@ -41,22 +187,28 @@ impl ChunkStore {
         }
     }
 
+    /// Returns the number of chunks presently stored in `self`.
     fn len(&self) -> usize {
         self.0.len() / BYTES_PER_CHUNK
     }
 
+    /// Truncates 'self' to `num_chunks` chunks.
+    ///
+    /// Functionally identical to `Vec::truncate`.
     fn truncate(&mut self, num_chunks: usize) {
         self.0.truncate(num_chunks * BYTES_PER_CHUNK)
     }
 
+    /// Consumes `self`, returning the underlying byte array.
     fn into_vec(self) -> Vec<u8> {
         self.0
     }
 }
 
-fn get_zero_hash(i: usize) -> &'static [u8] {
-    if i < MAX_TREE_DEPTH {
-        &ZERO_HASHES[i]
+/// Returns a cached padding node for a given height.
+fn get_zero_hash(height: usize) -> &'static [u8] {
+    if height < MAX_TREE_DEPTH {
+        &ZERO_HASHES[height]
     } else {
         panic!("Tree exceeeds MAX_TREE_DEPTH of {}")
     }
@@ -73,128 +225,9 @@ fn hash_concat(h1: &[u8], h2: &[u8]) -> Vec<u8> {
     hash(&concat(h1.to_vec(), h2.to_vec()))
 }
 
-/// Merklizes bytes and returns the root, using a minimal amount of memory.
-///
-/// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and bytes is returned, potentially
-/// padded out to `BYTES_PER_CHUNK` length with `0`.
-pub fn padded_merklize(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
-    // If the bytes are just one chunk (or less than one chunk) just return them padded to a chunk.
-    if bytes.len() <= BYTES_PER_CHUNK {
-        let mut o = bytes.to_vec();
-        o.resize(BYTES_PER_CHUNK, 0);
-        return o;
-    }
-
-    // The number of leaves that can be made directly from `bytes`.
-    let leaves_with_values = (bytes.len() + (BYTES_PER_CHUNK - 1)) / BYTES_PER_CHUNK;
-
-    // The number of parents that will appear leaves with values.
-    //
-    // I.e., the number of nodes one height above the leaves where one it's children has a value
-    // from `bytes`.
-    let initial_parents_with_values = (leaves_with_values + leaves_with_values % 2) / 2;
-
-    // The number of leaves in the full tree (including padding nodes).
-    let num_leaves = std::cmp::max(
-        leaves_with_values.next_power_of_two(),
-        min_leaves.next_power_of_two(),
-    );
-
-    // The height of the full tree.
-    let height = num_leaves.trailing_zeros() as usize;
-
-    /*
-    let min_leaves = min_leaves.next_power_of_two();
-    let real_leaves = (bytes.len() + (BYTES_PER_CHUNK - 1)) / BYTES_PER_CHUNK;
-    let total_leaves = std::cmp::max(real_leaves.next_power_of_two(), min_leaves);
-    let height = total_leaves.trailing_zeros() as usize;
-    let initial_parent_nodes = {
-        let even_real_leaves = real_leaves + real_leaves % 2;
-        even_real_leaves / 2
-    };
-    */
-
-    // A buffer/scratch-space used for storing each round of hashing at each height.
-    //
-    // This buffer is kept as small as possible; it will never store a padding node.
-    let mut chunks = ChunkStore::with_capacity(initial_parents_with_values);
-
-    // TODO: remove this.
-    let empty_chunk_hash = hash(&[0; BYTES_PER_CHUNK]);
-
-    for i in 0..initial_parents_with_values {
-        let start = i * BYTES_PER_CHUNK;
-
-        let hash = match bytes.get(start..start + BYTES_PER_CHUNK * 2) {
-            // All bytes are available, hash as ususal.
-            Some(slice) => hash(slice),
-            // Unable to get all the bytes.
-            None => {
-                match bytes.get(start..) {
-                    // Able to get some of the bytes, pad them out.
-                    Some(slice) => {
-                        let mut bytes = slice.to_vec();
-                        bytes.resize(BYTES_PER_CHUNK, 0);
-                        hash(&bytes)
-                    }
-                    // Unable to get any bytes, use the empty-chunk hash.
-                    None => empty_chunk_hash.clone(),
-                }
-            }
-        };
-
-        assert_eq!(
-            hash.len(),
-            BYTES_PER_CHUNK,
-            "Hashes should be exactly one chunk"
-        );
-
-        chunks
-            .set(i, &hash)
-            .expect("buf is adequate size for parents of leaves")
-    }
-
-    dbg!(num_leaves);
-
-    for height in 1..height {
-        let child_nodes = chunks.len();
-        let parent_nodes = (child_nodes + child_nodes % 2) / 2;
-
-        for i in 0..parent_nodes {
-            let (left, right) = match (chunks.get(i * 2), chunks.get(i * 2 + 1)) {
-                (Ok(left), Ok(right)) => (left, right),
-                (Ok(left), Err(_)) => (left, get_zero_hash(height)),
-                (Err(_), Err(_)) => unreachable!("Parent must have one child"),
-                (Err(_), Ok(_)) => unreachable!("Parent must have a left child"),
-            };
-
-            assert_eq!(
-                left.len(),
-                BYTES_PER_CHUNK,
-                "Left child should be correct length."
-            );
-            assert_eq!(
-                right.len(),
-                BYTES_PER_CHUNK,
-                "Right child should be correct length."
-            );
-
-            let mut preimage = left.to_vec();
-            preimage.append(&mut right.to_vec());
-
-            chunks
-                .set(i, &hash(&preimage))
-                .expect("Buf is adequate size for parent");
-        }
-
-        chunks.truncate(parent_nodes);
-    }
-
-    let root = chunks.into_vec();
-
-    assert_eq!(root.len(), 32, "Only one chunk should remain");
-
-    root
+/// Returns the next even number following `n`. If `n` is even, `n` is returned.
+fn next_even_number(n: usize) -> usize {
+    n + n % 2
 }
 
 #[cfg(test)]
@@ -203,46 +236,46 @@ mod test {
     use crate::merkleize::merkle_root as reference_root;
 
     macro_rules! common_tests {
-        ($fn: ident) => {
+        ($get_bytes: ident) => {
             #[test]
             fn zero_value_0_nodes() {
-                test_against_reference(&zero_nodes(0));
+                test_against_reference(&$get_bytes(0 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_1_nodes() {
-                test_against_reference(&zero_nodes(1));
+                test_against_reference(&$get_bytes(1 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_2_nodes() {
-                test_against_reference(&zero_nodes(2));
+                test_against_reference(&$get_bytes(2 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_3_nodes() {
-                test_against_reference(&zero_nodes(3));
+                test_against_reference(&$get_bytes(3 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_4_nodes() {
-                test_against_reference(&zero_nodes(4));
+                test_against_reference(&$get_bytes(4 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_8_nodes() {
-                test_against_reference(&zero_nodes(8));
+                test_against_reference(&$get_bytes(8 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_9_nodes() {
-                test_against_reference(&zero_nodes(9));
+                test_against_reference(&$get_bytes(9 * BYTES_PER_CHUNK));
             }
 
             #[test]
             fn zero_value_range_of_nodes() {
-                for i in 0..1 << 5 {
-                    test_against_reference(&zero_nodes(i));
+                for i in 0..32 * BYTES_PER_CHUNK {
+                    test_against_reference(&$get_bytes(i));
                 }
             }
         };
@@ -251,31 +284,24 @@ mod test {
     mod zero_value {
         use super::*;
 
-        fn zero_nodes(n: usize) -> Vec<u8> {
-            vec![0; BYTES_PER_CHUNK * n]
+        fn zero_bytes(bytes: usize) -> Vec<u8> {
+            vec![0; bytes]
         }
 
-        common_tests!(zero_nodes);
+        common_tests!(zero_bytes);
     }
 
     mod random_value {
         use super::*;
         use rand::RngCore;
 
-        fn zero_nodes(n: usize) -> Vec<u8> {
-            let mut nodes = vec![];
-
-            for _ in 0..n {
-                let mut random_data = [0; BYTES_PER_CHUNK];
-                rand::thread_rng().fill_bytes(&mut random_data);
-
-                nodes.append(&mut random_data.to_vec())
-            }
-
-            nodes
+        fn random_bytes(bytes: usize) -> Vec<u8> {
+            let mut bytes = Vec::with_capacity(bytes);
+            rand::thread_rng().fill_bytes(&mut bytes);
+            bytes
         }
 
-        common_tests!(zero_nodes);
+        common_tests!(random_bytes);
     }
 
     fn test_against_reference(input: &[u8]) {
@@ -283,7 +309,7 @@ mod test {
             reference_root(&input),
             padded_merklize(&input, 0),
             "input.len(): {:?}",
-            input
+            input.len()
         );
     }
 }

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -1,0 +1,289 @@
+use super::BYTES_PER_CHUNK;
+use hashing::hash;
+
+const MAX_TREE_DEPTH: usize = 32;
+
+lazy_static! {
+    /// Cached zero hashes where `ZERO_HASHES[i]` is the hash of a Merkle tree with 2^i zero leaves.
+    static ref ZERO_HASHES: Vec<Vec<u8>> = {
+        let mut hashes = vec![vec![0; 32]; MAX_TREE_DEPTH + 1];
+
+        for i in 0..MAX_TREE_DEPTH {
+            hashes[i + 1] = hash_concat(&hashes[i], &hashes[i]);
+        }
+
+        hashes
+    };
+}
+
+struct ChunkStore(Vec<u8>);
+
+impl ChunkStore {
+    fn with_capacity(chunks: usize) -> Self {
+        Self(vec![0; chunks * BYTES_PER_CHUNK])
+    }
+
+    fn set(&mut self, i: usize, value: &[u8]) -> Result<(), ()> {
+        if i < self.len() && value.len() == BYTES_PER_CHUNK {
+            let slice = &mut self.0[i * BYTES_PER_CHUNK..i * BYTES_PER_CHUNK + BYTES_PER_CHUNK];
+            slice.copy_from_slice(value);
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    fn get(&self, i: usize) -> Result<&[u8], ()> {
+        if i < self.len() {
+            Ok(&self.0[i * BYTES_PER_CHUNK..i * BYTES_PER_CHUNK + BYTES_PER_CHUNK])
+        } else {
+            Err(())
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.0.len() / BYTES_PER_CHUNK
+    }
+
+    fn truncate(&mut self, num_chunks: usize) {
+        self.0.truncate(num_chunks * BYTES_PER_CHUNK)
+    }
+
+    fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+fn get_zero_hash(i: usize) -> &'static [u8] {
+    if i < MAX_TREE_DEPTH {
+        &ZERO_HASHES[i]
+    } else {
+        panic!("Tree exceeeds MAX_TREE_DEPTH of {}")
+    }
+}
+
+/// Concatenate two vectors.
+fn concat(mut vec1: Vec<u8>, mut vec2: Vec<u8>) -> Vec<u8> {
+    vec1.append(&mut vec2);
+    vec1
+}
+
+/// Compute the hash of two other hashes concatenated.
+fn hash_concat(h1: &[u8], h2: &[u8]) -> Vec<u8> {
+    hash(&concat(h1.to_vec(), h2.to_vec()))
+}
+
+/// Merklizes bytes and returns the root, using a minimal amount of memory.
+///
+/// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and bytes is returned, potentially
+/// padded out to `BYTES_PER_CHUNK` length with `0`.
+pub fn padded_merklize(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
+    // If the bytes are just one chunk (or less than one chunk) just return them padded to a chunk.
+    if bytes.len() <= BYTES_PER_CHUNK {
+        let mut o = bytes.to_vec();
+        o.resize(BYTES_PER_CHUNK, 0);
+        return o;
+    }
+
+    // The number of leaves that can be made directly from `bytes`.
+    let leaves_with_values = (bytes.len() + (BYTES_PER_CHUNK - 1)) / BYTES_PER_CHUNK;
+
+    // The number of parents that will appear leaves with values.
+    //
+    // I.e., the number of nodes one height above the leaves where one it's children has a value
+    // from `bytes`.
+    let initial_parents_with_values = (leaves_with_values + leaves_with_values % 2) / 2;
+
+    // The number of leaves in the full tree (including padding nodes).
+    let num_leaves = std::cmp::max(
+        leaves_with_values.next_power_of_two(),
+        min_leaves.next_power_of_two(),
+    );
+
+    // The height of the full tree.
+    let height = num_leaves.trailing_zeros() as usize;
+
+    /*
+    let min_leaves = min_leaves.next_power_of_two();
+    let real_leaves = (bytes.len() + (BYTES_PER_CHUNK - 1)) / BYTES_PER_CHUNK;
+    let total_leaves = std::cmp::max(real_leaves.next_power_of_two(), min_leaves);
+    let height = total_leaves.trailing_zeros() as usize;
+    let initial_parent_nodes = {
+        let even_real_leaves = real_leaves + real_leaves % 2;
+        even_real_leaves / 2
+    };
+    */
+
+    // A buffer/scratch-space used for storing each round of hashing at each height.
+    //
+    // This buffer is kept as small as possible; it will never store a padding node.
+    let mut chunks = ChunkStore::with_capacity(initial_parents_with_values);
+
+    // TODO: remove this.
+    let empty_chunk_hash = hash(&[0; BYTES_PER_CHUNK]);
+
+    for i in 0..initial_parents_with_values {
+        let start = i * BYTES_PER_CHUNK;
+
+        let hash = match bytes.get(start..start + BYTES_PER_CHUNK * 2) {
+            // All bytes are available, hash as ususal.
+            Some(slice) => hash(slice),
+            // Unable to get all the bytes.
+            None => {
+                match bytes.get(start..) {
+                    // Able to get some of the bytes, pad them out.
+                    Some(slice) => {
+                        let mut bytes = slice.to_vec();
+                        bytes.resize(BYTES_PER_CHUNK, 0);
+                        hash(&bytes)
+                    }
+                    // Unable to get any bytes, use the empty-chunk hash.
+                    None => empty_chunk_hash.clone(),
+                }
+            }
+        };
+
+        assert_eq!(
+            hash.len(),
+            BYTES_PER_CHUNK,
+            "Hashes should be exactly one chunk"
+        );
+
+        chunks
+            .set(i, &hash)
+            .expect("buf is adequate size for parents of leaves")
+    }
+
+    dbg!(num_leaves);
+
+    for height in 1..height {
+        let child_nodes = chunks.len();
+        let parent_nodes = (child_nodes + child_nodes % 2) / 2;
+
+        for i in 0..parent_nodes {
+            let (left, right) = match (chunks.get(i * 2), chunks.get(i * 2 + 1)) {
+                (Ok(left), Ok(right)) => (left, right),
+                (Ok(left), Err(_)) => (left, get_zero_hash(height)),
+                (Err(_), Err(_)) => unreachable!("Parent must have one child"),
+                (Err(_), Ok(_)) => unreachable!("Parent must have a left child"),
+            };
+
+            assert_eq!(
+                left.len(),
+                BYTES_PER_CHUNK,
+                "Left child should be correct length."
+            );
+            assert_eq!(
+                right.len(),
+                BYTES_PER_CHUNK,
+                "Right child should be correct length."
+            );
+
+            let mut preimage = left.to_vec();
+            preimage.append(&mut right.to_vec());
+
+            chunks
+                .set(i, &hash(&preimage))
+                .expect("Buf is adequate size for parent");
+        }
+
+        chunks.truncate(parent_nodes);
+    }
+
+    let root = chunks.into_vec();
+
+    assert_eq!(root.len(), 32, "Only one chunk should remain");
+
+    root
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::merkleize::merkle_root as reference_root;
+
+    macro_rules! common_tests {
+        ($fn: ident) => {
+            #[test]
+            fn zero_value_0_nodes() {
+                test_against_reference(&zero_nodes(0));
+            }
+
+            #[test]
+            fn zero_value_1_nodes() {
+                test_against_reference(&zero_nodes(1));
+            }
+
+            #[test]
+            fn zero_value_2_nodes() {
+                test_against_reference(&zero_nodes(2));
+            }
+
+            #[test]
+            fn zero_value_3_nodes() {
+                test_against_reference(&zero_nodes(3));
+            }
+
+            #[test]
+            fn zero_value_4_nodes() {
+                test_against_reference(&zero_nodes(4));
+            }
+
+            #[test]
+            fn zero_value_8_nodes() {
+                test_against_reference(&zero_nodes(8));
+            }
+
+            #[test]
+            fn zero_value_9_nodes() {
+                test_against_reference(&zero_nodes(9));
+            }
+
+            #[test]
+            fn zero_value_range_of_nodes() {
+                for i in 0..1 << 5 {
+                    test_against_reference(&zero_nodes(i));
+                }
+            }
+        };
+    }
+
+    mod zero_value {
+        use super::*;
+
+        fn zero_nodes(n: usize) -> Vec<u8> {
+            vec![0; BYTES_PER_CHUNK * n]
+        }
+
+        common_tests!(zero_nodes);
+    }
+
+    mod random_value {
+        use super::*;
+        use rand::RngCore;
+
+        fn zero_nodes(n: usize) -> Vec<u8> {
+            let mut nodes = vec![];
+
+            for _ in 0..n {
+                let mut random_data = [0; BYTES_PER_CHUNK];
+                rand::thread_rng().fill_bytes(&mut random_data);
+
+                nodes.append(&mut random_data.to_vec())
+            }
+
+            nodes
+        }
+
+        common_tests!(zero_nodes);
+    }
+
+    fn test_against_reference(input: &[u8]) {
+        assert_eq!(
+            reference_root(&input),
+            padded_merklize(&input, 0),
+            "input.len(): {:?}",
+            input
+        );
+    }
+}

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -4,7 +4,9 @@ use hashing::hash;
 /// The size of the cache that stores padding nodes for a given height.
 ///
 /// Currently, we panic if we encounter a tree with a height larger than `MAX_TREE_DEPTH`.
-pub const MAX_TREE_DEPTH: usize = 64;
+///
+/// It is set to 48 as we expect it to be sufficiently high that we won't exceed it.
+pub const MAX_TREE_DEPTH: usize = 48;
 
 lazy_static! {
     /// Cached zero hashes where `ZERO_HASHES[i]` is the hash of a Merkle tree with 2^i zero leaves.
@@ -307,6 +309,16 @@ mod test {
                 for i in 0..32 * BYTES_PER_CHUNK {
                     test_against_reference(&$get_bytes(i), 0);
                 }
+            }
+
+            #[test]
+            fn max_tree_depth_min_nodes() {
+                let input = vec![0; 10 * BYTES_PER_CHUNK];
+                let min_nodes = 2usize.pow(MAX_TREE_DEPTH as u32);
+                assert_eq!(
+                    merkleize_padded(&input, min_nodes),
+                    get_zero_hash(MAX_TREE_DEPTH)
+                );
             }
         };
     }

--- a/eth2/utils/tree_hash/src/merkleize_padded.rs
+++ b/eth2/utils/tree_hash/src/merkleize_padded.rs
@@ -19,23 +19,23 @@ lazy_static! {
     };
 }
 
-/// Merklizes bytes and returns the root, optionally padding the tree out to `min_leaves` number of
+/// Merkleize `bytes` and return the root, optionally padding the tree out to `min_leaves` number of
 /// leaves.
 ///
 /// First all nodes are extracted from `bytes` and then a padding node is added until the number of
 /// leaf chunks is greater than or equal to `min_leaves`. Callers may set `min_leaves` to `0` if no
 /// adding additional chunks should be added to the given `bytes`.
 ///
-/// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and bytes is returned, potentially
+/// If `bytes.len() <= BYTES_PER_CHUNK`, no hashing is done and `bytes` is returned, potentially
 /// padded out to `BYTES_PER_CHUNK` length with `0`.
 ///
-/// ## CPU Peformance
+/// ## CPU Performance
 ///
 /// A cache of `MAX_TREE_DEPTH` hashes are stored to avoid re-computing the hashes of padding nodes
-/// (or thier parents). Therefore, adding padding nodes only incurs one more hash per additional
+/// (or their parents). Therefore, adding padding nodes only incurs one more hash per additional
 /// height of the tree.
 ///
-/// ## Memory Peformance
+/// ## Memory Performance
 ///
 /// This algorithm has two interesting memory usage properties:
 ///
@@ -93,9 +93,9 @@ pub fn merkleize_padded(bytes: &[u8], min_leaves: usize) -> Vec<u8> {
 
         // Hash two chunks, creating a parent chunk.
         let hash = match bytes.get(start..start + BYTES_PER_CHUNK * 2) {
-            // All bytes are available, hash as ususal.
+            // All bytes are available, hash as usual.
             Some(slice) => hash(slice),
-            // Unable to get all the bytes, get a small slice and padd it out.
+            // Unable to get all the bytes, get a small slice and pad it out.
             None => {
                 let mut preimage = bytes
                     .get(start..)
@@ -230,7 +230,7 @@ fn get_zero_hash(height: usize) -> &'static [u8] {
     if height < MAX_TREE_DEPTH {
         &ZERO_HASHES[height]
     } else {
-        panic!("Tree exceeeds MAX_TREE_DEPTH of {}", MAX_TREE_DEPTH)
+        panic!("Tree exceeds MAX_TREE_DEPTH of {}", MAX_TREE_DEPTH)
     }
 }
 

--- a/eth2/utils/tree_hash/src/merkleize_standard.rs
+++ b/eth2/utils/tree_hash/src/merkleize_standard.rs
@@ -1,11 +1,23 @@
 use super::*;
 use hashing::hash;
 
-pub fn merkle_root(bytes: &[u8]) -> Vec<u8> {
-    standard_merkleize(&bytes)[0..32].to_vec()
-}
-
-pub fn standard_merkleize(bytes: &[u8]) -> Vec<u8> {
+/// Merkleizes bytes and returns the root, using a simple algorithm that does not optimize to avoid
+/// processing or storing padding bytes.
+///
+/// The input `bytes` will be padded to ensure that the number of leaves is a power-of-two.
+///
+/// It is likely a better choice to use [merkleize_padded](fn.merkleize_padded.html) instead.
+///
+/// ## CPU Performance
+///
+/// Will hash all nodes in the tree, even if they are padding and pre-determined.
+///
+/// ## Memory Performance
+///
+///  - Duplicates the input `bytes`.
+///  - Stores all internal nodes, even if they are padding.
+///  - Does not free up unused memory during operation.
+pub fn merkleize_standard(bytes: &[u8]) -> Vec<u8> {
     // If the bytes are just one chunk (or less than one chunk) just return them.
     if bytes.len() <= HASHSIZE {
         let mut o = bytes.to_vec();

--- a/eth2/utils/tree_hash_derive/src/lib.rs
+++ b/eth2/utils/tree_hash_derive/src/lib.rs
@@ -150,7 +150,7 @@ pub fn tree_hash_derive(input: TokenStream) -> TokenStream {
                     leaves.append(&mut self.#idents.tree_hash_root());
                 )*
 
-                tree_hash::merkleize::merkle_root(&leaves)
+                tree_hash::merkle_root(&leaves)
             }
         }
     };
@@ -180,7 +180,7 @@ pub fn tree_hash_signed_root_derive(input: TokenStream) -> TokenStream {
                     leaves.append(&mut self.#idents.tree_hash_root());
                 )*
 
-                tree_hash::merkleize::merkle_root(&leaves)
+                tree_hash::merkle_root(&leaves)
             }
         }
     };

--- a/eth2/utils/tree_hash_derive/tests/tests.rs
+++ b/eth2/utils/tree_hash_derive/tests/tests.rs
@@ -1,5 +1,5 @@
 use cached_tree_hash::{CachedTreeHash, TreeHashCache};
-use tree_hash::{merkleize::merkle_root, SignedRoot, TreeHash};
+use tree_hash::{merkle_root, SignedRoot, TreeHash};
 use tree_hash_derive::{CachedTreeHash, SignedRoot, TreeHash};
 
 #[derive(Clone, Debug, TreeHash, CachedTreeHash)]


### PR DESCRIPTION
## Issue Addressed

Related to #432 

## Proposed Changes

Add the `merkleize_partial` merkle root algorithm that is memory efficient when given large amounts of padding nodes. Spec `v0.8.0` has lots of padding nodes, so it makes sense to optimize for it.

Here's an sample from the Rust docs that describes this new algo:

```rust
/// ## CPU Peformance
///
/// A cache of `MAX_TREE_DEPTH` hashes are stored to avoid re-computing the hashes of padding nodes
/// (or thier parents). In effect, adding padding nodes only incurs one more hash per additional height
/// of the tree.
///
/// ## Memory Peformance
///
/// This algorithm has two interesting memory usage properties:
///
/// 1. The maximum memory footprint is roughly `O(V / 2)` memory, where `V` is the number of leaf
///    chunks with values (i.e., leaves that are not padding). The means adding padding nodes to
///    the tree does not increase the memory footprint.
/// 2. At each height of the tree half of the memory is freed until only a single chunk is stored.
/// 3. The input `bytes` are not copied into another list before processing.
```

## Additional Info

There are now two merkle root methods:

- `merkleize_standard`: the previous method. Lots of wasted CPU and memory when there are padding nodes.
- `merkleize_padded`: the new method in this PR.

The entire codebase (except `cached_tree_hash`) has been move across to this method. The old method (`merkleize_standard`) still exists; perhaps it's faster when there are no padding nodes?
