### PR TITLE
Remove unused dependencies

### DIFF
--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -12,5 +12,4 @@ slog-term = "^2.4.0"
 slog-async = "^2.3.0"
 validator_client = { path = "../validator_client" }
 types = { path = "../eth2/types" }
-eth2_config = { path = "../eth2/utils/eth2_config" }
 dirs = "2.0.1"

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -7,12 +7,10 @@ edition = "2018"
 [dependencies]
 eth2_config = { path = "../eth2/utils/eth2_config" }
 types = { path = "../eth2/types" }
-toml = "^0.5"
 store = { path = "./store" }
 client = { path = "client" }
 version = { path = "version" }
 clap = "2.32.0"
-serde = "1.0"
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
 slog-term = "^2.4.0"
 slog-async = "^2.3.0"
@@ -21,6 +19,5 @@ tokio = "0.1.15"
 tokio-timer = "0.2.10"
 futures = "0.1.25"
 exit-future = "0.1.3"
-state_processing = { path = "../eth2/state_processing" }
 env_logger = "0.6.1"
 dirs = "2.0.1"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -5,20 +5,13 @@ authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com
 edition = "2018"
 
 [dependencies]
-bls = { path = "../../eth2/utils/bls" }
-boolean-bitfield = { path = "../../eth2/utils/boolean-bitfield" }
 store = { path = "../store" }
-failure = "0.1"
-failure_derive = "0.1"
-hashing = { path = "../../eth2/utils/hashing" }
 parking_lot = "0.7"
 prometheus = "^0.6"
 log = "0.4"
 operation_pool = { path = "../../eth2/operation_pool" }
-env_logger = "0.6"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 eth2_ssz = { path = "../../eth2/utils/ssz" }
 eth2_ssz_derive = { path = "../../eth2/utils/ssz_derive" }

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2018"
 [dependencies]
 beacon_chain = { path = "../beacon_chain" }
 network = { path = "../network" }
-store = { path = "../store" }
 http_server = { path = "../http_server" }
-eth2-libp2p = { path = "../eth2-libp2p" }
 rpc = { path = "../rpc" }
 prometheus = "^0.6"
 types = { path = "../../eth2/types" }
@@ -19,11 +17,9 @@ slot_clock = { path = "../../eth2/utils/slot_clock" }
 serde = "1.0.93"
 serde_derive = "1.0"
 error-chain = "0.12.0"
-eth2_ssz = { path = "../../eth2/utils/ssz" }
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
 slog-async = "^2.3.0"
 slog-json = "^2.3"
-slog-term = "^2.4.0"
 tokio = "0.1.15"
 clap = "2.32.0"
 dirs = "1.0.3"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
 
 [dependencies]
-beacon_chain =  { path = "../beacon_chain" }
 clap = "2.32.0"
 #SigP repository 
 libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "be5710bbde69d8c5be732c13ba64239e2f370a7b" }

--- a/beacon_node/http_server/Cargo.toml
+++ b/beacon_node/http_server/Cargo.toml
@@ -5,30 +5,19 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-bls = { path = "../../eth2/utils/bls" }
 beacon_chain = { path = "../beacon_chain" }
 iron = "^0.6"
 router = "^0.6"
 network = { path = "../network" }
-eth2-libp2p = { path = "../eth2-libp2p" }
-version = { path = "../version" }
 types = { path = "../../eth2/types" }
-eth2_ssz = { path = "../../eth2/utils/ssz" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
-protos = { path = "../../protos" }
-grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
 persistent = "^0.4"
-protobuf = "2.0.2"
 prometheus = { version = "^0.6", features = ["process"] }
 clap = "2.32.0"
-store = { path = "../store" }
-dirs = "1.0.3"
 futures = "0.1.23"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
-slog-term = "^2.4.0"
-slog-async = "^2.3.0"
 tokio = "0.1.17"
 exit-future = "0.1.4"

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -11,7 +11,6 @@ sloggers = "0.3.2"
 beacon_chain =  { path = "../beacon_chain" }
 store =  { path = "../store" }
 eth2-libp2p =  { path = "../eth2-libp2p" }
-version = { path = "../version" }
 types = { path = "../../eth2/types" }
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
 eth2_ssz = { path = "../../eth2/utils/ssz" }

--- a/beacon_node/rpc/Cargo.toml
+++ b/beacon_node/rpc/Cargo.toml
@@ -12,18 +12,12 @@ eth2-libp2p = { path = "../eth2-libp2p" }
 version = { path = "../version" }
 types = { path = "../../eth2/types" }
 eth2_ssz = { path = "../../eth2/utils/ssz" }
-slot_clock = { path = "../../eth2/utils/slot_clock" }
 protos = { path = "../../protos" }
 grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
-protobuf = "2.0.2"
 clap = "2.32.0"
-store = { path = "../store" }
-dirs = "1.0.3"
 futures = "0.1.23"
 serde = "1.0"
 serde_derive = "1.0"
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
-slog-term = "^2.4.0"
-slog-async = "^2.3.0"
 tokio = "0.1.17"
 exit-future = "0.1.4"

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -8,9 +8,6 @@ edition = "2018"
 tempfile = "3"
 
 [dependencies]
-blake2-rfc = "0.2.18"
-bls = { path = "../../eth2/utils/bls" }
-bytes = "0.4.10"
 db-key = "0.0.5"
 leveldb = "0.8.4"
 parking_lot = "0.7"

--- a/eth2/lmd_ghost/Cargo.toml
+++ b/eth2/lmd_ghost/Cargo.toml
@@ -7,11 +7,7 @@ edition = "2018"
 [dependencies]
 parking_lot = "0.7"
 store = { path = "../../beacon_node/store" }
-eth2_ssz = { path = "../utils/ssz" }
-state_processing = { path = "../state_processing" }
 types = { path = "../types" }
-log = "0.4.6"
-bit-vec = "0.5.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/eth2/state_processing/Cargo.toml
+++ b/eth2/state_processing/Cargo.toml
@@ -17,15 +17,9 @@ serde_yaml = "0.8"
 
 [dependencies]
 bls = { path = "../utils/bls" }
-fnv = "1.0"
-hashing = { path = "../utils/hashing" }
-int_to_bytes = { path = "../utils/int_to_bytes" }
 integer-sqrt = "0.1"
 itertools = "0.8"
-log = "0.4"
 merkle_proof = { path = "../utils/merkle_proof" }
-eth2_ssz = { path = "../utils/ssz" }
-eth2_ssz_derive = { path = "../utils/ssz_derive" }
 tree_hash = { path = "../utils/tree_hash" }
 tree_hash_derive = { path = "../utils/tree_hash_derive" }
 types = { path = "../types" }

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -16,15 +16,12 @@ ethereum-types = "0.5"
 fixed_len_vec = { path = "../utils/fixed_len_vec" }
 hashing = { path = "../utils/hashing" }
 hex = "0.3"
-honey-badger-split =  { path = "../utils/honey-badger-split" }
 int_to_bytes = { path = "../utils/int_to_bytes" }
 log = "0.4"
 rayon = "1.0"
 rand = "0.5.5"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
-serde_yaml = "0.8"
 slog = "^2.2.3"
 eth2_ssz = { path = "../utils/ssz" }
 eth2_ssz_derive = { path = "../utils/ssz_derive" }

--- a/eth2/utils/boolean-bitfield/Cargo.toml
+++ b/eth2/utils/boolean-bitfield/Cargo.toml
@@ -11,7 +11,6 @@ eth2_ssz = { path = "../ssz" }
 bit-vec = "0.5.0"
 bit_reverse = "0.1"
 serde = "1.0"
-serde_derive = "1.0"
 tree_hash = { path = "../tree_hash" }
 
 [dev-dependencies]

--- a/eth2/utils/eth2_config/Cargo.toml
+++ b/eth2/utils/eth2_config/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32.0"
-dirs = "1.0.3"
 serde = "1.0"
 serde_derive = "1.0"
 toml = "^0.5"

--- a/eth2/utils/hashing/Cargo.toml
+++ b/eth2/utils/hashing/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2018"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.14.6"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-sha2 = "0.8.0"
 
 [dev-dependencies]
 rustc-hex = "2.0.1"

--- a/eth2/utils/ssz/Cargo.toml
+++ b/eth2/utils/ssz/Cargo.toml
@@ -18,7 +18,4 @@ criterion = "0.2"
 eth2_ssz_derive = "0.1.0"
 
 [dependencies]
-bytes = "0.4.9"
 ethereum-types = "0.5"
-hex = "0.3"
-yaml-rust = "0.4"

--- a/tests/ef_tests/Cargo.toml
+++ b/tests/ef_tests/Cargo.toml
@@ -24,4 +24,3 @@ state_processing = { path = "../../eth2/state_processing" }
 swap_or_not_shuffle = { path = "../../eth2/utils/swap_or_not_shuffle" }
 types = { path = "../../eth2/types" }
 walkdir = "2"
-yaml-rust = { git = "https://github.com/sigp/yaml-rust", branch = "escape_all_str"}

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -19,7 +19,6 @@ eth2_config = { path = "../eth2/utils/eth2_config" }
 tree_hash = { path = "../eth2/utils/tree_hash" }
 clap = "2.32.0"
 grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
-protobuf = "2.0.2"
 protos = { path = "../protos" }
 slot_clock = { path = "../eth2/utils/slot_clock" }
 types = { path = "../eth2/types" }
@@ -31,7 +30,6 @@ slog-json = "^2.3"
 slog-term = "^2.4.0"
 tokio = "0.1.18"
 tokio-timer = "0.2.10"
-toml = "^0.5"
 error-chain = "0.12.0"
 bincode = "^1.1.2"
 futures = "0.1.25"


### PR DESCRIPTION
## Issue Addressed

Removes unused dependencies. Resolves #408 

## Additional Info

Unused dependencies had to be removed manually. Currently there is no linting option for Rust 2018. Issue for unused dependencies lint https://github.com/rust-lang/rust/issues/57274
