### PR TITLE
Fix underflow in verify_transfer

### DIFF
--- a/eth2/state_processing/src/per_block_processing/verify_transfer.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_transfer.rs
@@ -62,8 +62,8 @@ fn verify_transfer_parametric<T: EthSpec>(
 
     // Verify the sender has adequate balance.
     verify!(
-        time_independent_only || sender_balance >= transfer.amount,
-        Invalid::FromBalanceInsufficient(transfer.amount, sender_balance)
+        time_independent_only || sender_balance >= total_amount,
+        Invalid::FromBalanceInsufficient(total_amount, sender_balance)
     );
 
     // Verify sender balance will not be "dust" (i.e., greater than zero but less than the minimum deposit


### PR DESCRIPTION
## Issue Addressed

Addresses #421.

## Proposed Changes

Verifying that the sender has adequate balance now compares against `total_amount` (_i.e._, `amount + fee`).

## Additional Info

Supersedes #427.
