### PR TITLE
Split network and swarm discovery loop, break each when not ready

### DIFF
--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -105,10 +105,8 @@ fn network_service(
     log: slog::Logger,
 ) -> impl futures::Future<Item = (), Error = eth2_libp2p::error::Error> {
     futures::future::poll_fn(move || -> Result<_, eth2_libp2p::error::Error> {
-        // only end the loop once both major polls are not ready.
-        let mut not_ready_count = 0;
-        while not_ready_count < 2 {
-            not_ready_count = 0;
+        // if the network channel is not ready, try the swarm
+        loop {
             // poll the network channel
             match network_recv.poll() {
                 Ok(Async::Ready(Some(message))) => match message {
@@ -123,7 +121,7 @@ fn network_service(
                         libp2p_service.lock().swarm.publish(topics, *message);
                     }
                 },
-                Ok(Async::NotReady) => not_ready_count += 1,
+                Ok(Async::NotReady) => break,
                 Ok(Async::Ready(None)) => {
                     return Err(eth2_libp2p::error::Error::from("Network channel closed"));
                 }
@@ -131,7 +129,9 @@ fn network_service(
                     return Err(eth2_libp2p::error::Error::from("Network channel error"));
                 }
             }
+        }
 
+        loop {
             // poll the swarm
             match libp2p_service.lock().poll() {
                 Ok(Async::Ready(Some(event))) => match event {
@@ -164,8 +164,8 @@ fn network_service(
                     }
                 },
                 Ok(Async::Ready(None)) => unreachable!("Stream never ends"),
-                Ok(Async::NotReady) => not_ready_count += 1,
-                Err(_) => not_ready_count += 1,
+                Ok(Async::NotReady) => break,
+                Err(_) => break,
             }
         }
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/435

## Proposed Changes
- Split network and swarm discovery into two loops
- Both break when the interface is not ready.

## Additional Info

Testing as mentioned in https://github.com/sigp/lighthouse/issues/435#issuecomment-514860338

> It is important to test to see there is no lag if we do this. Running two nodes with a single validator and watching blocks propagate instantly is a test that this should still work.

I hope the appraoch in the video (3 nodes, 1 validator) reflects that it does not seem to lag:
https://webm.red/C2U8.webm
