### PR TITLE
Use SignatureBytes and PublicKeyBytes for deposits

### DIFF
--- a/eth2/state_processing/src/per_block_processing/errors.rs
+++ b/eth2/state_processing/src/per_block_processing/errors.rs
@@ -349,6 +349,8 @@ pub enum DepositInvalid {
     BadIndex { state: u64, deposit: u64 },
     /// The signature (proof-of-possession) does not match the given pubkey.
     BadSignature,
+    /// The signature does not represent a valid BLS signature.
+    BadSignatureBytes,
     /// The specified `branch` and `index` did not form a valid proof that the deposit is included
     /// in the eth1 deposit root.
     BadMerkleProof,

--- a/eth2/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_deposit.rs
@@ -18,7 +18,9 @@ pub fn verify_deposit_signature<T: EthSpec>(
         deposit
             .data
             .signature
-            .verify(&deposit.data.signed_root(), domain, &deposit.data.pubkey,),
+            .parse_signature()
+            .map(|s| s.verify(&deposit.data.signed_root(), domain, &deposit.data.pubkey,))
+            .unwrap_or(false),
         Invalid::BadSignature
     );
 

--- a/eth2/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_deposit.rs
@@ -16,17 +16,16 @@ pub fn verify_deposit_signature<T: EthSpec>(
     // Note: Deposits are valid across forks, thus the deposit domain is computed
     // with the fork zeroed.
     let domain = spec.get_domain(state.current_epoch(), Domain::Deposit, &Fork::default());
-    let parsed_signature: Result<Signature, _> = (&deposit.data.signature).try_into();
-    match parsed_signature {
-        Err(_) => Err(Error::Invalid(Invalid::BadSignatureBytes)),
-        Ok(signature) => {
-            verify!(
-                signature.verify(&deposit.data.signed_root(), domain, pubkey,),
-                Invalid::BadSignature
-            );
-            Ok(())
-        }
-    }
+    let signature: Signature = (&deposit.data.signature)
+        .try_into()
+        .map_err(|_| Error::Invalid(Invalid::BadSignatureBytes))?;
+
+    verify!(
+        signature.verify(&deposit.data.signed_root(), domain, pubkey),
+        Invalid::BadSignature
+    );
+
+    Ok(())
 }
 
 /// Returns a `Some(validator index)` if a pubkey already exists in the `validators`,

--- a/eth2/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_deposit.rs
@@ -14,17 +14,14 @@ pub fn verify_deposit_signature<T: EthSpec>(
     // Note: Deposits are valid across forks, thus the deposit domain is computed
     // with the fork zeroed.
     let domain = spec.get_domain(state.current_epoch(), Domain::Deposit, &Fork::default());
-    verify!(
-        deposit
-            .data
-            .signature
-            .parse_signature()
-            .map(|s| s.verify(&deposit.data.signed_root(), domain, &deposit.data.pubkey,))
-            .unwrap_or(false),
-        Invalid::BadSignature
-    );
-
-    Ok(())
+    match deposit.data.signature.parse_signature() {
+        Err(_) => Err(Error::Invalid(Invalid::BadSignatureBytes)),
+        Ok(signature) => {
+            verify!(signature.verify(&deposit.data.signed_root(), domain, &deposit.data.pubkey,),
+            Invalid::BadSignature);
+            Ok(())
+        }
+    }
 }
 
 /// Returns a `Some(validator index)` if a pubkey already exists in the `validators`,

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -1,6 +1,6 @@
 use crate::test_utils::TestRandom;
 use crate::*;
-use bls::{PublicKey, SignatureBytes};
+use bls::{PublicKeyBytes, SignatureBytes};
 use std::convert::From;
 
 use serde_derive::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ use tree_hash_derive::{CachedTreeHash, SignedRoot, TreeHash};
     TestRandom,
 )]
 pub struct DepositData {
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,
     pub amount: u64,
     #[signed_root(skip_hashing)]

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -1,6 +1,7 @@
 use crate::test_utils::TestRandom;
 use crate::*;
 use bls::{PublicKey, SignatureBytes};
+use std::convert::From;
 
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -46,7 +47,7 @@ impl DepositData {
         let msg = self.signed_root();
         let domain = spec.get_domain(epoch, Domain::Deposit, fork);
 
-        SignatureBytes::new(Signature::new(msg.as_slice(), domain, secret_key))
+        SignatureBytes::from(Signature::new(msg.as_slice(), domain, secret_key))
     }
 }
 

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -1,6 +1,6 @@
 use crate::test_utils::TestRandom;
 use crate::*;
-use bls::{PublicKey, Signature};
+use bls::{PublicKey, SignatureBytes};
 
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -29,7 +29,7 @@ pub struct DepositData {
     pub withdrawal_credentials: Hash256,
     pub amount: u64,
     #[signed_root(skip_hashing)]
-    pub signature: Signature,
+    pub signature: SignatureBytes,
 }
 
 impl DepositData {
@@ -42,11 +42,11 @@ impl DepositData {
         epoch: Epoch,
         fork: &Fork,
         spec: &ChainSpec,
-    ) -> Signature {
+    ) -> SignatureBytes {
         let msg = self.signed_root();
         let domain = spec.get_domain(epoch, Domain::Deposit, fork);
 
-        Signature::new(msg.as_slice(), domain, secret_key)
+        SignatureBytes::new(Signature::new(msg.as_slice(), domain, secret_key))
     }
 }
 

--- a/eth2/types/src/test_utils/builders/testing_deposit_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_deposit_builder.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bls::{SignatureBytes, get_withdrawal_credentials};
+use bls::{get_withdrawal_credentials, PublicKeyBytes, SignatureBytes};
 
 /// Builds an deposit to be used for testing purposes.
 ///
@@ -14,10 +14,10 @@ impl TestingDepositBuilder {
         let deposit = Deposit {
             proof: vec![].into(),
             data: DepositData {
-                pubkey,
+                pubkey: PublicKeyBytes::from(pubkey),
                 withdrawal_credentials: Hash256::zero(),
                 amount,
-                signature: SignatureBytes::empty_signature(),
+                signature: SignatureBytes::empty(),
             },
         };
 
@@ -34,7 +34,7 @@ impl TestingDepositBuilder {
             &get_withdrawal_credentials(&keypair.pk, spec.bls_withdrawal_prefix_byte)[..],
         );
 
-        self.deposit.data.pubkey = keypair.pk.clone();
+        self.deposit.data.pubkey = PublicKeyBytes::from(keypair.pk.clone());
         self.deposit.data.withdrawal_credentials = withdrawal_credentials;
 
         self.deposit.data.signature =

--- a/eth2/types/src/test_utils/builders/testing_deposit_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_deposit_builder.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bls::get_withdrawal_credentials;
+use bls::{SignatureBytes, get_withdrawal_credentials};
 
 /// Builds an deposit to be used for testing purposes.
 ///
@@ -17,7 +17,7 @@ impl TestingDepositBuilder {
                 pubkey,
                 withdrawal_credentials: Hash256::zero(),
                 amount,
-                signature: Signature::empty_signature(),
+                signature: SignatureBytes::empty_signature(),
             },
         };
 

--- a/eth2/types/src/test_utils/test_random.rs
+++ b/eth2/types/src/test_utils/test_random.rs
@@ -9,6 +9,7 @@ mod hash256;
 mod public_key;
 mod secret_key;
 mod signature;
+mod signature_bytes;
 
 pub trait TestRandom {
     fn random_for_test(rng: &mut impl RngCore) -> Self;
@@ -99,3 +100,4 @@ macro_rules! impl_test_random_for_u8_array {
 
 impl_test_random_for_u8_array!(4);
 impl_test_random_for_u8_array!(32);
+impl_test_random_for_u8_array!(96);

--- a/eth2/types/src/test_utils/test_random.rs
+++ b/eth2/types/src/test_utils/test_random.rs
@@ -7,6 +7,7 @@ mod aggregate_signature;
 mod bitfield;
 mod hash256;
 mod public_key;
+mod public_key_bytes;
 mod secret_key;
 mod signature;
 mod signature_bytes;
@@ -100,4 +101,5 @@ macro_rules! impl_test_random_for_u8_array {
 
 impl_test_random_for_u8_array!(4);
 impl_test_random_for_u8_array!(32);
+impl_test_random_for_u8_array!(48);
 impl_test_random_for_u8_array!(96);

--- a/eth2/types/src/test_utils/test_random/public_key_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/public_key_bytes.rs
@@ -1,0 +1,19 @@
+use std::convert::From;
+
+use bls::{PublicKeyBytes, BLS_PUBLIC_KEY_BYTE_SIZE};
+
+use super::*;
+
+impl TestRandom for PublicKeyBytes {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        //50-50 chance for signature to be "valid" or invalid
+        if bool::random_for_test(rng) {
+            //valid signature
+            PublicKeyBytes::from(PublicKey::random_for_test(rng))
+        } else {
+            //invalid signature, just random bytes
+            PublicKeyBytes::from_bytes(&<[u8; BLS_PUBLIC_KEY_BYTE_SIZE]>::random_for_test(rng))
+                .unwrap()
+        }
+    }
+}

--- a/eth2/types/src/test_utils/test_random/signature_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/signature_bytes.rs
@@ -10,7 +10,7 @@ impl TestRandom for SignatureBytes {
             SignatureBytes::new(Signature::random_for_test(rng))
         } else {
             //invalid signature, just random bytes
-            SignatureBytes::new_from_bytes(&<[u8; BLS_SIG_BYTE_SIZE]>::random_for_test(rng))
+            SignatureBytes::from_bytes(&<[u8; BLS_SIG_BYTE_SIZE]>::random_for_test(rng)).unwrap()
         }
     }
 }

--- a/eth2/types/src/test_utils/test_random/signature_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/signature_bytes.rs
@@ -1,4 +1,4 @@
-use bls::{SecretKey, SignatureBytes, BLS_SIG_BYTE_SIZE};
+use bls::{SignatureBytes, BLS_SIG_BYTE_SIZE};
 
 use super::*;
 use std::convert::From;

--- a/eth2/types/src/test_utils/test_random/signature_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/signature_bytes.rs
@@ -1,0 +1,16 @@
+use bls::{BLS_SIG_BYTE_SIZE, SecretKey, SignatureBytes};
+
+use super::*;
+
+impl TestRandom for SignatureBytes {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        //50-50 chance for signature to be "valid" or invalid
+        if bool::random_for_test(rng) {
+            //valid signature
+            SignatureBytes::new(Signature::random_for_test(rng))
+        } else {
+            //invalid signature, just random bytes
+            SignatureBytes::new_from_bytes(&<[u8; BLS_SIG_BYTE_SIZE]>::random_for_test(rng))
+        }
+    }
+}

--- a/eth2/types/src/test_utils/test_random/signature_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/signature_bytes.rs
@@ -1,4 +1,4 @@
-use bls::{BLS_SIG_BYTE_SIZE, SecretKey, SignatureBytes};
+use bls::{SecretKey, SignatureBytes, BLS_SIG_BYTE_SIZE};
 
 use super::*;
 use std::convert::From;

--- a/eth2/types/src/test_utils/test_random/signature_bytes.rs
+++ b/eth2/types/src/test_utils/test_random/signature_bytes.rs
@@ -1,13 +1,14 @@
 use bls::{BLS_SIG_BYTE_SIZE, SecretKey, SignatureBytes};
 
 use super::*;
+use std::convert::From;
 
 impl TestRandom for SignatureBytes {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
         //50-50 chance for signature to be "valid" or invalid
         if bool::random_for_test(rng) {
             //valid signature
-            SignatureBytes::new(Signature::random_for_test(rng))
+            SignatureBytes::from(Signature::random_for_test(rng))
         } else {
             //invalid signature, just random bytes
             SignatureBytes::from_bytes(&<[u8; BLS_SIG_BYTE_SIZE]>::random_for_test(rng)).unwrap()

--- a/eth2/utils/bls/src/lib.rs
+++ b/eth2/utils/bls/src/lib.rs
@@ -5,10 +5,12 @@ extern crate ssz;
 mod macros;
 mod keypair;
 mod secret_key;
+mod signature_bytes;
 
 pub use crate::keypair::Keypair;
 pub use crate::secret_key::SecretKey;
 pub use milagro_bls::{compress_g2, hash_on_g2};
+pub use crate::signature_bytes::SignatureBytes;
 
 #[cfg(feature = "fake_crypto")]
 mod fake_aggregate_public_key;

--- a/eth2/utils/bls/src/lib.rs
+++ b/eth2/utils/bls/src/lib.rs
@@ -4,13 +4,15 @@ extern crate ssz;
 #[macro_use]
 mod macros;
 mod keypair;
+mod public_key_bytes;
 mod secret_key;
 mod signature_bytes;
 
 pub use crate::keypair::Keypair;
+pub use crate::public_key_bytes::PublicKeyBytes;
 pub use crate::secret_key::SecretKey;
-pub use milagro_bls::{compress_g2, hash_on_g2};
 pub use crate::signature_bytes::SignatureBytes;
+pub use milagro_bls::{compress_g2, hash_on_g2};
 
 #[cfg(feature = "fake_crypto")]
 mod fake_aggregate_public_key;

--- a/eth2/utils/bls/src/macros.rs
+++ b/eth2/utils/bls/src/macros.rs
@@ -157,8 +157,7 @@ macro_rules! bytes_struct {
 
         impl std::convert::From<$type> for $name {
             fn from(obj: $type) -> Self {
-                // how to avoid this unwrap? We know that obj.as_bytes() always has exactly
-                // $byte_size many bytes.
+                // We know that obj.as_bytes() always has exactly $byte_size many bytes.
                 Self::from_bytes(obj.as_ssz_bytes().as_slice()).unwrap()
             }
         }

--- a/eth2/utils/bls/src/macros.rs
+++ b/eth2/utils/bls/src/macros.rs
@@ -86,14 +86,25 @@ macro_rules! impl_cached_tree_hash {
 }
 
 macro_rules! bytes_struct {
-    ($name: ident, $type: ty, $byte_size: expr, $small_name: expr, $ssz_type_size: ident) => {
-        /// Stores `$byte_size` bytes which may or may not represent a valid BLS $small_name.
-        ///
-        /// The `$type` struct performs validation when it is instantiated, where as this struct does not. This struct is
-        /// suitable where we may wish to store bytes that are potentially not a valid $small_name (e.g., from the deposit
-        /// contract).
+    ($name: ident, $type: ty, $byte_size: expr, $small_name: expr, $ssz_type_size: ident,
+     $type_str: expr, $byte_size_str: expr) => {
+        #[doc = "Stores `"]
+        #[doc = $byte_size_str]
+        #[doc = "` bytes which may or may not represent a valid BLS "]
+        #[doc = $small_name]
+        #[doc = ".\n\nThe `"]
+        #[doc = $type_str]
+        #[doc = "` struct performs validation when it is instantiated, where as this struct does \
+                 not. This struct is suitable where we may wish to store bytes that are \
+                 potentially not a valid "]
+        #[doc = $small_name]
+        #[doc = " (e.g., from the deposit contract)."]
         #[derive(Clone)]
         pub struct $name([u8; $byte_size]);
+    };
+    ($name: ident, $type: ty, $byte_size: expr, $small_name: expr, $ssz_type_size: ident) => {
+        bytes_struct!($name, $type, $byte_size, $small_name, $ssz_type_size, stringify!($type),
+        stringify!($byte_size));
 
         impl $name {
             pub fn from_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {

--- a/eth2/utils/bls/src/macros.rs
+++ b/eth2/utils/bls/src/macros.rs
@@ -84,3 +84,101 @@ macro_rules! impl_cached_tree_hash {
         }
     };
 }
+
+macro_rules! bytes_struct {
+    ($name: ident, $type: ty, $byte_size: expr, $small_name: expr, $ssz_type_size: ident) => {
+        /// Stores `$byte_size` bytes which may or may not represent a valid BLS $small_name.
+        ///
+        /// The `$type` struct performs validation when it is instantiated, where as this struct does not. This struct is
+        /// suitable where we may wish to store bytes that are potentially not a valid $small_name (e.g., from the deposit
+        /// contract).
+        #[derive(Clone)]
+        pub struct $name([u8; $byte_size]);
+
+        impl $name {
+            pub fn from_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {
+                Ok(Self(Self::get_bytes(bytes)?))
+            }
+
+            pub fn empty() -> Self {
+                Self([0; $byte_size])
+            }
+
+            pub fn as_bytes(&self) -> Vec<u8> {
+                self.0.to_vec()
+            }
+
+            fn get_bytes(bytes: &[u8]) -> Result<[u8; $byte_size], ssz::DecodeError> {
+                let mut result = [0; $byte_size];
+                if bytes.len() != $byte_size {
+                    Err(ssz::DecodeError::InvalidByteLength {
+                        len: bytes.len(),
+                        expected: $byte_size,
+                    })
+                } else {
+                    result[..].copy_from_slice(bytes);
+                    Ok(result)
+                }
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                self.0[..].fmt(formatter)
+            }
+        }
+
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                &self.0[..] == &other.0[..]
+            }
+        }
+
+        impl Eq for $name {}
+
+        impl std::convert::TryInto<$type> for &$name {
+            type Error = ssz::DecodeError;
+
+            fn try_into(self) -> Result<$type, Self::Error> {
+                <$type>::from_bytes(&self.0[..])
+            }
+        }
+
+        impl std::convert::From<$type> for $name {
+            fn from(obj: $type) -> Self {
+                // how to avoid this unwrap? We know that obj.as_bytes() always has exactly
+                // $byte_size many bytes.
+                Self::from_bytes(obj.as_ssz_bytes().as_slice()).unwrap()
+            }
+        }
+
+        impl_ssz!($name, $byte_size, "$type");
+
+        impl_tree_hash!($name, $ssz_type_size);
+
+        impl_cached_tree_hash!($name, $ssz_type_size);
+
+        impl serde::ser::Serialize for $name {
+            /// Serde serialization is compliant the Ethereum YAML test format.
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::ser::Serializer,
+            {
+                serializer.serialize_str(&hex::encode(ssz::ssz_encode(self)))
+            }
+        }
+
+        impl<'de> serde::de::Deserialize<'de> for $name {
+            /// Serde serialization is compliant the Ethereum YAML test format.
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'de>,
+            {
+                let bytes = deserializer.deserialize_str(serde_hex::HexVisitor)?;
+                let signature = Self::from_ssz_bytes(&bytes[..])
+                    .map_err(|e| serde::de::Error::custom(format!("invalid ssz ({:?})", e)))?;
+                Ok(signature)
+            }
+        }
+    };
+}

--- a/eth2/utils/bls/src/public_key.rs
+++ b/eth2/utils/bls/src/public_key.rs
@@ -151,6 +151,15 @@ mod tests {
     }
 
     #[test]
+    pub fn test_byte_size() {
+        let sk = SecretKey::random();
+        let original = PublicKey::from_secret_key(&sk);
+
+        let bytes = ssz_encode(&original);
+        assert_eq!(bytes.len(), BLS_PUBLIC_KEY_BYTE_SIZE);
+    }
+
+    #[test]
     // TODO: once `CachedTreeHash` is fixed, this test should _not_ panic.
     #[should_panic]
     pub fn test_cached_tree_hash() {

--- a/eth2/utils/bls/src/public_key_bytes.rs
+++ b/eth2/utils/bls/src/public_key_bytes.rs
@@ -1,0 +1,43 @@
+use ssz::{Decode, DecodeError, Encode};
+
+use super::{PublicKey, BLS_PUBLIC_KEY_BYTE_SIZE};
+
+bytes_struct!(
+    PublicKeyBytes,
+    PublicKey,
+    BLS_PUBLIC_KEY_BYTE_SIZE,
+    "public key",
+    U48
+);
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryInto;
+
+    use ssz::ssz_encode;
+
+    use super::super::Keypair;
+    use super::*;
+
+    #[test]
+    pub fn test_valid_public_key() {
+        let keypair = Keypair::random();
+
+        let bytes = ssz_encode(&keypair.pk);
+        let public_key_bytes = PublicKeyBytes::from_bytes(&bytes).unwrap();
+        let public_key: Result<PublicKey, _> = (&public_key_bytes).try_into();
+        assert!(public_key.is_ok());
+        assert_eq!(keypair.pk, public_key.unwrap());
+    }
+
+    #[test]
+    pub fn test_invalid_public_key() {
+        let mut public_key_bytes = [0; BLS_PUBLIC_KEY_BYTE_SIZE];
+        public_key_bytes[0] = 255; //a_flag1 == b_flag1 == c_flag1 == 1 and x1 = 0 shouldn't be allowed
+        let public_key_bytes = PublicKeyBytes::from_bytes(&public_key_bytes[..]);
+        assert!(public_key_bytes.is_ok());
+
+        let public_key: Result<PublicKey, _> = public_key_bytes.as_ref().unwrap().try_into();
+        assert!(public_key.is_err());
+    }
+}

--- a/eth2/utils/bls/src/signature.rs
+++ b/eth2/utils/bls/src/signature.rs
@@ -156,6 +156,15 @@ mod tests {
     }
 
     #[test]
+    pub fn test_byte_size() {
+        let keypair = Keypair::random();
+
+        let signature = Signature::new(&[42, 42], 0, &keypair.sk);
+        let bytes = ssz_encode(&signature);
+        assert_eq!(bytes.len(), BLS_SIG_BYTE_SIZE);
+    }
+
+    #[test]
     // TODO: once `CachedTreeHash` is fixed, this test should _not_ panic.
     #[should_panic]
     pub fn test_cached_tree_hash() {

--- a/eth2/utils/bls/src/signature_bytes.rs
+++ b/eth2/utils/bls/src/signature_bytes.rs
@@ -97,8 +97,20 @@ impl<'de> Deserialize<'de> for SignatureBytes {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::Keypair;
 
-    //test parsing invalid signature
+    #[test]
+    pub fn test_valid_signature() {
+        let keypair = Keypair::random();
+        let original = Signature::new(&[42, 42], 0, &keypair.sk);
+
+        let bytes = ssz_encode(&original);
+        let signature_bytes = SignatureBytes::from_bytes(&bytes).unwrap();
+        let signature = signature_bytes.parse_signature();
+        assert!(signature.is_ok());
+        assert_eq!(original, signature.unwrap());
+    }
+
     #[test]
     pub fn test_invalid_signature() {
         let mut signature_bytes = [0; BLS_SIG_BYTE_SIZE];

--- a/eth2/utils/bls/src/signature_bytes.rs
+++ b/eth2/utils/bls/src/signature_bytes.rs
@@ -9,6 +9,11 @@ use ssz::{Decode, DecodeError, Encode, ssz_encode};
 
 use super::{BLS_SIG_BYTE_SIZE, Signature};
 
+/// Stores `BLS_SIG_BYTE_SIZE` bytes which may or may not represent a valid BLS signature.
+///
+/// The `Signature` struct performs validation when it is instantiated, where as this struct does not. This struct is
+/// suitable where we may wish to store bytes that are potentially not a valid signature (e.g., from the deposit
+/// contract).
 #[derive(Clone)]
 pub struct SignatureBytes([u8; BLS_SIG_BYTE_SIZE]);
 

--- a/eth2/utils/bls/src/signature_bytes.rs
+++ b/eth2/utils/bls/src/signature_bytes.rs
@@ -1,0 +1,106 @@
+use std::cmp::min;
+use std::fmt;
+
+use serde::de::{Deserialize, Deserializer};
+use serde::ser::{Serialize, Serializer};
+
+use serde_hex::HexVisitor;
+use ssz::{Decode, DecodeError, Encode, ssz_encode};
+
+use super::{BLS_SIG_BYTE_SIZE, Signature};
+
+#[derive(Clone)]
+pub struct SignatureBytes([u8; BLS_SIG_BYTE_SIZE]);
+
+impl SignatureBytes {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Ok(Self::new_from_bytes(bytes))
+    }
+
+    pub fn new_from_bytes(bytes: &[u8]) -> Self {
+        Self(Self::get_bytes(bytes))
+    }
+
+    pub fn empty_signature() -> Self {
+        Self::new_from_bytes(&[])
+    }
+
+    pub fn new(signature: Signature) -> Self {
+        Self(Self::get_bytes(signature.as_bytes().as_slice()))
+    }
+
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    pub fn parse_signature(&self) -> Result<Signature, DecodeError> {
+        Signature::from_bytes(&self.0[..])
+    }
+
+    fn get_bytes(bytes: &[u8]) -> [u8; BLS_SIG_BYTE_SIZE] {
+        let mut signature_bytes = [0; BLS_SIG_BYTE_SIZE];
+        let length = min(BLS_SIG_BYTE_SIZE, bytes.len());
+        signature_bytes[..length].copy_from_slice(&bytes[..length]);
+        signature_bytes
+    }
+}
+
+impl fmt::Debug for SignatureBytes {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        self.0[..].fmt(formatter)
+    }
+}
+
+impl PartialEq for SignatureBytes {
+    fn eq(&self, other: &Self) -> bool {
+        &self.0[..] == &other.0[..]
+    }
+}
+
+impl Eq for SignatureBytes {}
+
+impl_ssz!(SignatureBytes, BLS_SIG_BYTE_SIZE, "Signature");
+
+impl_tree_hash!(SignatureBytes, U96);
+
+impl_cached_tree_hash!(SignatureBytes, U96);
+
+impl Serialize for SignatureBytes {
+    /// Serde serialization is compliant the Ethereum YAML test format.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&hex::encode(ssz_encode(self)))
+    }
+}
+
+impl<'de> Deserialize<'de> for SignatureBytes {
+    /// Serde serialization is compliant the Ethereum YAML test format.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let bytes = deserializer.deserialize_str(HexVisitor)?;
+        let signature = Self::from_ssz_bytes(&bytes[..])
+            .map_err(|e| serde::de::Error::custom(format!("invalid ssz ({:?})", e)))?;
+        Ok(signature)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    //test parsing invalid signature
+    #[test]
+    pub fn test_invalid_signature() {
+        let mut signature_bytes = [0; BLS_SIG_BYTE_SIZE];
+        signature_bytes[0] = 255; //a_flag1 == b_flag1 == c_flag1 == 1 and x1 = 0 shouldn't be allowed
+        let signature_bytes = SignatureBytes::from_bytes(&signature_bytes[..]);
+        assert!(signature_bytes.is_ok());
+
+        let signature = signature_bytes.unwrap().parse_signature();
+        assert!(signature.is_err());
+    }
+}

--- a/eth2/utils/bls/src/signature_bytes.rs
+++ b/eth2/utils/bls/src/signature_bytes.rs
@@ -1,110 +1,23 @@
-use std::cmp::min;
-use std::fmt;
-use std::convert::{TryInto, From};
+use ssz::{Decode, DecodeError, Encode};
 
-use serde::de::{Deserialize, Deserializer};
-use serde::ser::{Serialize, Serializer};
+use super::{Signature, BLS_SIG_BYTE_SIZE};
 
-use serde_hex::HexVisitor;
-use ssz::{Decode, DecodeError, Encode, ssz_encode};
-
-use super::{BLS_SIG_BYTE_SIZE, Signature};
-
-/// Stores `BLS_SIG_BYTE_SIZE` bytes which may or may not represent a valid BLS signature.
-///
-/// The `Signature` struct performs validation when it is instantiated, where as this struct does not. This struct is
-/// suitable where we may wish to store bytes that are potentially not a valid signature (e.g., from the deposit
-/// contract).
-#[derive(Clone)]
-pub struct SignatureBytes([u8; BLS_SIG_BYTE_SIZE]);
-
-impl SignatureBytes {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
-        Ok(Self(Self::get_bytes(bytes)?))
-    }
-
-    pub fn empty_signature() -> Self {
-        Self([0; BLS_SIG_BYTE_SIZE])
-    }
-
-    pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
-    fn get_bytes(bytes: &[u8]) -> Result<[u8; BLS_SIG_BYTE_SIZE], DecodeError> {
-        let mut signature_bytes = [0; BLS_SIG_BYTE_SIZE];
-        if bytes.len() != BLS_SIG_BYTE_SIZE {
-            Err(DecodeError::InvalidByteLength {len: bytes.len(), expected: BLS_SIG_BYTE_SIZE})
-        } else {
-            signature_bytes[..].copy_from_slice(bytes);
-            Ok(signature_bytes)
-        }
-    }
-}
-
-impl fmt::Debug for SignatureBytes {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        self.0[..].fmt(formatter)
-    }
-}
-
-impl PartialEq for SignatureBytes {
-    fn eq(&self, other: &Self) -> bool {
-        &self.0[..] == &other.0[..]
-    }
-}
-
-impl Eq for SignatureBytes {}
-
-impl TryInto<Signature> for &SignatureBytes {
-    type Error = DecodeError;
-
-    fn try_into(self) -> Result<Signature, Self::Error> {
-        Signature::from_bytes(&self.0[..])
-    }
-}
-
-impl From<Signature> for SignatureBytes {
-    fn from(signature: Signature) -> Self {
-        // how to avoid this unwrap? We know that signature.as_bytes() always has exactly
-        // BLS_SIG_BYTE_SIZE many bytes.
-        Self::from_bytes(signature.as_bytes().as_slice()).unwrap()
-    }
-}
-
-impl_ssz!(SignatureBytes, BLS_SIG_BYTE_SIZE, "Signature");
-
-impl_tree_hash!(SignatureBytes, U96);
-
-impl_cached_tree_hash!(SignatureBytes, U96);
-
-impl Serialize for SignatureBytes {
-    /// Serde serialization is compliant the Ethereum YAML test format.
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-    {
-        serializer.serialize_str(&hex::encode(ssz_encode(self)))
-    }
-}
-
-impl<'de> Deserialize<'de> for SignatureBytes {
-    /// Serde serialization is compliant the Ethereum YAML test format.
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
-    {
-        let bytes = deserializer.deserialize_str(HexVisitor)?;
-        let signature = Self::from_ssz_bytes(&bytes[..])
-            .map_err(|e| serde::de::Error::custom(format!("invalid ssz ({:?})", e)))?;
-        Ok(signature)
-    }
-}
+bytes_struct!(
+    SignatureBytes,
+    Signature,
+    BLS_SIG_BYTE_SIZE,
+    "signature",
+    U96
+);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::convert::TryInto;
+
+    use ssz::ssz_encode;
+
     use super::super::Keypair;
+    use super::*;
 
     #[test]
     pub fn test_valid_signature() {


### PR DESCRIPTION
SignatureBytes handles signatures stored in bytes and only parses the bytes when the signature is needed. Therefore SignatureBytes never throws errors except when the signature is parsed (which is then handled directly in verify_deposit.

## Issue Addressed

resolves #384

## Proposed Changes

Adds new struct SignatureBytes. Replaces Signature in Deposit by SignatureBytes.
