### PR TITLE
Tree hash benches

### DIFF
--- a/eth2/utils/tree_hash/Cargo.toml
+++ b/eth2/utils/tree_hash/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
+[[bench]]
+name = "benches"
+harness = false
+
 [dev-dependencies]
+criterion = "0.2"
 rand = "0.7"
 tree_hash_derive = { path = "../tree_hash_derive" }
+types = { path = "../../types" }
 
 [dependencies]
 ethereum-types = "0.5"

--- a/eth2/utils/tree_hash/benches/benches.rs
+++ b/eth2/utils/tree_hash/benches/benches.rs
@@ -1,0 +1,49 @@
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use tree_hash::TreeHash;
+use types::test_utils::TestingBeaconStateBuilder;
+use types::{BeaconState, EthSpec, MainnetEthSpec, MinimalEthSpec};
+
+fn build_state<T: EthSpec>(validator_count: usize) -> BeaconState<T> {
+    let (state, _keypairs) = TestingBeaconStateBuilder::from_default_keypairs_file_if_exists(
+        validator_count,
+        &T::default_spec(),
+    )
+    .build();
+
+    assert_eq!(state.validators.len(), validator_count);
+    assert_eq!(state.balances.len(), validator_count);
+    assert!(state.previous_epoch_attestations.is_empty());
+    assert!(state.current_epoch_attestations.is_empty());
+    assert!(state.eth1_data_votes.is_empty());
+    assert!(state.historical_roots.is_empty());
+
+    state
+}
+
+fn bench_suite<T: EthSpec>(c: &mut Criterion, spec_desc: &str, validator_count: usize) {
+    let state = build_state::<T>(validator_count);
+
+    c.bench(
+        &format!("{}/{}_validators", spec_desc, validator_count),
+        Benchmark::new("genesis_state", move |b| {
+            b.iter_batched_ref(
+                || state.clone(),
+                |state| black_box(state.tree_hash_root()),
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+}
+
+fn all_benches(c: &mut Criterion) {
+    bench_suite::<MinimalEthSpec>(c, "minimal", 100_000);
+    bench_suite::<MinimalEthSpec>(c, "minimal", 300_000);
+
+    bench_suite::<MainnetEthSpec>(c, "mainnet", 100_000);
+    bench_suite::<MainnetEthSpec>(c, "mainnet", 300_000);
+}
+
+criterion_group!(benches, all_benches,);
+criterion_main!(benches);

--- a/eth2/utils/tree_hash/benches/benches.rs
+++ b/eth2/utils/tree_hash/benches/benches.rs
@@ -1,12 +1,19 @@
+#[macro_use]
+extern crate lazy_static;
+
 use criterion::Criterion;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark};
 use tree_hash::TreeHash;
-use types::test_utils::TestingBeaconStateBuilder;
-use types::{BeaconState, EthSpec, MainnetEthSpec, MinimalEthSpec};
+use types::test_utils::{generate_deterministic_keypairs, TestingBeaconStateBuilder};
+use types::{BeaconState, EthSpec, Keypair, MainnetEthSpec, MinimalEthSpec};
+
+lazy_static! {
+    static ref KEYPAIRS: Vec<Keypair> = { generate_deterministic_keypairs(300_000) };
+}
 
 fn build_state<T: EthSpec>(validator_count: usize) -> BeaconState<T> {
-    let (state, _keypairs) = TestingBeaconStateBuilder::from_default_keypairs_file_if_exists(
-        validator_count,
+    let (state, _keypairs) = TestingBeaconStateBuilder::from_keypairs(
+        KEYPAIRS[0..validator_count].to_vec(),
         &T::default_spec(),
     )
     .build();

--- a/eth2/utils/tree_hash/examples/flamegraph_beacon_state.rs
+++ b/eth2/utils/tree_hash/examples/flamegraph_beacon_state.rs
@@ -1,0 +1,35 @@
+use tree_hash::TreeHash;
+use types::test_utils::TestingBeaconStateBuilder;
+use types::{BeaconState, EthSpec, MainnetEthSpec};
+
+const TREE_HASH_LOOPS: usize = 1_000;
+const VALIDATOR_COUNT: usize = 1_000;
+
+fn build_state<T: EthSpec>(validator_count: usize) -> BeaconState<T> {
+    let (state, _keypairs) = TestingBeaconStateBuilder::from_default_keypairs_file_if_exists(
+        validator_count,
+        &T::default_spec(),
+    )
+    .build();
+
+    assert_eq!(state.validators.len(), validator_count);
+    assert_eq!(state.balances.len(), validator_count);
+    assert!(state.previous_epoch_attestations.is_empty());
+    assert!(state.current_epoch_attestations.is_empty());
+    assert!(state.eth1_data_votes.is_empty());
+    assert!(state.historical_roots.is_empty());
+
+    state
+}
+
+fn main() {
+    let state = build_state::<MainnetEthSpec>(VALIDATOR_COUNT);
+
+    // This vec is an attempt to ensure the compiler doesn't optimize-out the hashing.
+    let mut vec = Vec::with_capacity(TREE_HASH_LOOPS);
+
+    for _ in 0..TREE_HASH_LOOPS {
+        let root = state.tree_hash_root();
+        vec.push(root[0]);
+    }
+}


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds some benches for tree hashing, as requested by @protolambda. We haven't put much effort into optimizing this, but it seems like the majority of the time is spent in sha2.

To run the benches, navigate to `eth2/utils/tree_hash` and run:

```
$ cargo bench
```

You can use [`cargo-flamegraph`](https://github.com/ferrous-systems/flamegraph) with:

```
$ cargo flamegraph --example flamegraph_beacon_state
```

## Additional Info

Here's the output on my `i7-8700K CPU @ 3.70GHz`:

```
minimal/100000_validators/genesis_state
                        time:   [524.39 ms 535.79 ms 543.48 ms]
                        change: [+0.5340% +2.0554% +3.7095%] (p = 0.02 < 0.05)
                        Change within noise threshold.

minimal/300000_validators/genesis_state
                        time:   [1.5584 s 1.5698 s 1.5789 s]
                        change: [-1.8937% -0.9731% +0.0855%] (p = 0.10 > 0.05)
                        No change in performance detected.

mainnet/100000_validators/genesis_state
                        time:   [603.91 ms 606.82 ms 611.92 ms]
                        change: [-0.9326% +0.5768% +2.1838%] (p = 0.51 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

mainnet/300000_validators/genesis_state
                        time:   [1.6532 s 1.6611 s 1.6718 s]
```