### PR TITLE
Disallow extra bytes in Bitfield from_bytes

### DIFF
--- a/eth2/utils/ssz_types/src/bitfield.rs
+++ b/eth2/utils/ssz_types/src/bitfield.rs
@@ -161,6 +161,7 @@ impl<N: Unsigned + Clone> Bitfield<Variable<N>> {
     ///
     /// Returns `None` if `bytes` are not a valid encoding.
     pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error> {
+        let bytes_len = bytes.len();
         let mut initial_bitfield: Bitfield<Variable<N>> = {
             let num_bits = bytes.len() * 8;
             Bitfield::from_raw_bytes(bytes, num_bits)
@@ -170,6 +171,14 @@ impl<N: Unsigned + Clone> Bitfield<Variable<N>> {
         let len = initial_bitfield
             .highest_set_bit()
             .ok_or_else(|| Error::MissingLengthInformation)?;
+
+        // The length bit should be in the last byte, or else it means we have too many bytes.
+        if len / 8 + 1 != bytes_len {
+            return Err(Error::InvalidByteCount {
+                given: bytes_len,
+                expected: len / 8 + 1,
+            });
+        }
 
         if len <= Self::max_len() {
             initial_bitfield
@@ -819,6 +828,17 @@ mod bitlist {
         assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0001]).is_ok());
         assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0010]).is_err());
         assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0100]).is_err());
+    }
+
+    #[test]
+    fn ssz_decode_extra_bytes() {
+        assert!(BitList0::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList1::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList8::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList16::from_ssz_bytes(&[0b0000_0001, 0b0000_0000]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0, 0]).is_err());
+        assert!(BitList1024::from_ssz_bytes(&[0b1000_0000, 0, 0, 0, 0]).is_err());
     }
 
     #[test]


### PR DESCRIPTION
When I was writing a test for #487 I noticed we seemed to allow extra bytes when decoding from SSZ, which [the spec implies is disallowed](https://github.com/ethereum/eth2.0-specs/blob/v0.8.2/specs/simple-serialize.md#deserialization).

(separate PR so that we can merge the other PR without resolving this discussion first, but also happy to roll them into one)
