### PR TITLE
Fix this link per @blacktemplar to link to the actual crate

### DIFF
--- a/eth2/utils/ssz/README.md
+++ b/eth2/utils/ssz/README.md
@@ -1,3 +1,3 @@
 # simpleserialize (ssz)
 
-![Crates.io](https://img.shields.io/crates/v/eth2_ssz)
+[<img src="https://img.shields.io/crates/v/eth2_ssz">](https://crates.io/crates/eth2_ssz)


### PR DESCRIPTION
## Issue Addressed

#514 Badge was linked to the image of the badge and not the actual crate.

## Proposed Changes

Fixed shield badge to link to the actual crate instead of the image of the badge. 
