### PR TITLE
Tighten private key permissions

### DIFF
--- a/eth2/utils/ssz/fuzz/fuzz_targets/fuzz_target_bool_decode.rs
+++ b/eth2/utils/ssz/fuzz/fuzz_targets/fuzz_target_bool_decode.rs
@@ -2,11 +2,11 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate ssz;
 
-use ssz::{DecodeError, decode};
+use ssz::{DecodeError, Decode};
 
 // Fuzz ssz_decode()
 fuzz_target!(|data: &[u8]| {
-    let result: Result<bool, DecodeError> = decode(data);
+    let result: Result<bool, DecodeError> = bool::from_ssz_bytes(data);
     if data.len() == 1 {
         if data[0] == 1 {
             let val_bool = result.unwrap();
@@ -15,7 +15,7 @@ fuzz_target!(|data: &[u8]| {
             let val_bool = result.unwrap();
             assert!(!val_bool);
         } else {
-            assert_eq!(result, Err(DecodeError::Invalid));
+            assert!(result.is_err());
         }
     } else {
         // Length of 0 should return error

--- a/eth2/utils/ssz/fuzz/fuzz_targets/fuzz_target_bool_encode.rs
+++ b/eth2/utils/ssz/fuzz/fuzz_targets/fuzz_target_bool_encode.rs
@@ -2,15 +2,20 @@
 #[macro_use] extern crate libfuzzer_sys;
 extern crate ssz;
 
-use ssz::SszStream;
+use ssz::Encode;
 
 // Fuzz ssz_encode (via ssz_append)
 fuzz_target!(|data: &[u8]| {
-    let mut ssz = SszStream::new();
+
+    let mut ssz = Vec::new();
+    let mut ssz_new = Vec::new();
+    //let mut ssz = ssz::Encode();
     let mut val_bool = 0;
     if data.len() >= 1 {
         val_bool = data[0] % u8::pow(2, 6);
     }
+
+
 
     ssz.append(&val_bool);
     let ssz = ssz.drain();

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -38,3 +38,4 @@ bincode = "^1.1.2"
 futures = "0.1.25"
 dirs = "2.0.1"
 logging = { path = "../eth2/utils/logging" }
+libc = "0.2"

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -264,12 +264,16 @@ impl Config {
     /// Saves a keypair to a file inside the appropriate validator directory. Returns the saved path filename.
     #[allow(dead_code)]
     pub fn save_key(&self, key: &Keypair) -> Result<PathBuf, Error> {
+        use std::os::unix::fs::PermissionsExt;
         let validator_config_path = self.data_dir.join(key.identifier());
         let key_path = validator_config_path.join(DEFAULT_PRIVATE_KEY_FILENAME);
 
         fs::create_dir_all(&validator_config_path)?;
 
         let mut key_file = File::create(&key_path)?;
+        let mut perm = key_file.metadata()?.permissions();
+        perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
+        key_file.set_permissions(perm)?;
 
         bincode::serialize_into(&mut key_file, &key)
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate libc;
 pub mod config;
 
 pub use crate::config::Config;


### PR DESCRIPTION
## Issue Addressed

The `account_manager` generates private keys and stores them with unnecessary extensive permissions. Indeed, private keys are readable by any user of the system (i.e. `-rw-r--r--` or `0644` permission bits).

## Proposed Changes

- Import `libc` crate for permission bits 
- Change permissions on private key file generation to `-rw-------` (i.e. `0600`)

## Additional Info

The validator client is about to be refactored, but thought I'd submit this now anyway :)