### PR TITLE
Fix the build for Rust 1.38, protobuf releases

### DIFF
--- a/beacon_node/network/src/message_handler.rs
+++ b/beacon_node/network/src/message_handler.rs
@@ -146,15 +146,9 @@ impl<T: BeaconChainTypes + 'static> MessageHandler<T> {
     ) {
         // an error could have occurred.
         match error_response {
-            RPCErrorResponse::InvalidRequest(error) => {
-                warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
-            }
-            RPCErrorResponse::ServerError(error) => {
-                warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
-            }
-            RPCErrorResponse::Unknown(error) => {
-                warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string())
-            }
+            RPCErrorResponse::InvalidRequest(error) => warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
+            RPCErrorResponse::ServerError(error) => warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
+            RPCErrorResponse::Unknown(error) => warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string()),
             RPCErrorResponse::Success(response) => {
                 match response {
                     RPCResponse::Hello(hello_message) => {

--- a/eth2/state_processing/Cargo.toml
+++ b/eth2/state_processing/Cargo.toml
@@ -13,7 +13,7 @@ criterion = "0.2"
 env_logger = "0.6.0"
 serde = "1.0"
 serde_derive = "1.0"
-lazy_static = "0.1"
+lazy_static = "1.4"
 serde_yaml = "0.8"
 eth2_ssz = { path = "../utils/ssz" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }

--- a/eth2/types/src/attestation.rs
+++ b/eth2/types/src/attestation.rs
@@ -58,5 +58,4 @@ mod tests {
     use crate::*;
 
     ssz_tests!(Attestation<MainnetEthSpec>);
-
 }

--- a/eth2/types/src/attestation_data_and_custody_bit.rs
+++ b/eth2/types/src/attestation_data_and_custody_bit.rs
@@ -19,5 +19,4 @@ mod test {
     use super::*;
 
     ssz_tests!(AttestationDataAndCustodyBit);
-
 }

--- a/eth2/types/src/attester_slashing.rs
+++ b/eth2/types/src/attester_slashing.rs
@@ -21,5 +21,4 @@ mod tests {
     use crate::*;
 
     ssz_tests!(AttesterSlashing<MainnetEthSpec>);
-
 }

--- a/eth2/types/src/checkpoint.rs
+++ b/eth2/types/src/checkpoint.rs
@@ -32,5 +32,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(Checkpoint);
-
 }

--- a/eth2/types/src/crosslink.rs
+++ b/eth2/types/src/crosslink.rs
@@ -37,5 +37,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(Crosslink);
-
 }

--- a/eth2/types/src/deposit.rs
+++ b/eth2/types/src/deposit.rs
@@ -21,5 +21,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(Deposit);
-
 }

--- a/eth2/types/src/deposit_data.rs
+++ b/eth2/types/src/deposit_data.rs
@@ -55,5 +55,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(DepositData);
-
 }

--- a/eth2/types/src/eth1_data.rs
+++ b/eth2/types/src/eth1_data.rs
@@ -23,5 +23,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(Eth1Data);
-
 }

--- a/eth2/types/src/historical_batch.rs
+++ b/eth2/types/src/historical_batch.rs
@@ -23,5 +23,4 @@ mod tests {
     pub type FoundationHistoricalBatch = HistoricalBatch<MainnetEthSpec>;
 
     ssz_tests!(FoundationHistoricalBatch);
-
 }

--- a/eth2/types/src/pending_attestation.rs
+++ b/eth2/types/src/pending_attestation.rs
@@ -23,5 +23,4 @@ mod tests {
     use crate::*;
 
     ssz_tests!(PendingAttestation<MainnetEthSpec>);
-
 }

--- a/eth2/types/src/proposer_slashing.rs
+++ b/eth2/types/src/proposer_slashing.rs
@@ -21,5 +21,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(ProposerSlashing);
-
 }

--- a/eth2/types/src/transfer.rs
+++ b/eth2/types/src/transfer.rs
@@ -42,5 +42,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(Transfer);
-
 }

--- a/eth2/types/src/validator.rs
+++ b/eth2/types/src/validator.rs
@@ -117,5 +117,4 @@ mod tests {
     }
 
     ssz_tests!(Validator);
-
 }

--- a/eth2/types/src/voluntary_exit.rs
+++ b/eth2/types/src/voluntary_exit.rs
@@ -35,5 +35,4 @@ mod tests {
     use super::*;
 
     ssz_tests!(VoluntaryExit);
-
 }

--- a/eth2/utils/tree_hash/Cargo.toml
+++ b/eth2/utils/tree_hash/Cargo.toml
@@ -19,4 +19,4 @@ types = { path = "../../types" }
 [dependencies]
 ethereum-types = "0.6"
 eth2_hashing = "0.1"
-lazy_static = "0.1"
+lazy_static = "1.4"

--- a/eth2/utils/tree_hash_derive/src/lib.rs
+++ b/eth2/utils/tree_hash_derive/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
 /// Returns a Vec of `syn::Ident` for each named field in the struct, whilst filtering out fields
@@ -130,8 +130,8 @@ fn get_signed_root_named_field_idents(struct_data: &syn::DataStruct) -> Vec<&syn
 }
 
 fn should_skip_signed_root(field: &syn::Field) -> bool {
-    field
-        .attrs
-        .iter()
-        .any(|attr| attr.into_token_stream().to_string() == "# [ signed_root ( skip_hashing ) ]")
+    field.attrs.iter().any(|attr| {
+        attr.path.is_ident("signed_root")
+            && attr.tts.to_string().replace(" ", "") == "(skip_hashing)"
+    })
 }

--- a/protos/Cargo.toml
+++ b/protos/Cargo.toml
@@ -8,7 +8,7 @@ description = "Google protobuf message and service definitions used in Lighthous
 [dependencies]
 futures = "0.1"
 grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
-protobuf = "2.0"
+protobuf = "~2.8.1"
 
 [build-dependencies]
 protoc-grpcio = "0.3.1"

--- a/validator_client/src/attestation_producer/mod.rs
+++ b/validator_client/src/attestation_producer/mod.rs
@@ -57,21 +57,11 @@ impl<'a, B: BeaconNodeAttestation, S: Signer, E: EthSpec> AttestationProducer<'a
                 "slot" => slot,
             ),
             Err(e) => error!(log, "Attestation production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => {
-                error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string())
-            }
-            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => {
-                error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string())
-            }
-            Ok(ValidatorEvent::PublishAttestationFailed) => {
-                error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string())
-            }
-            Ok(ValidatorEvent::InvalidAttestation) => {
-                error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string())
-            }
-            Ok(v) => {
-                warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v))
-            }
+            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string()),
+            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string()),
+            Ok(ValidatorEvent::PublishAttestationFailed) => error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string()),
+            Ok(ValidatorEvent::InvalidAttestation) => error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string()),
+            Ok(v) => warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v)),
         }
     }
 

--- a/validator_client/src/block_producer/mod.rs
+++ b/validator_client/src/block_producer/mod.rs
@@ -69,18 +69,10 @@ impl<'a, B: BeaconNodeBlock, S: Signer, E: EthSpec> BlockProducer<'a, B, S, E> {
                 "slot" => slot,
             ),
             Err(e) => error!(self.log, "Block production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => {
-                error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string())
-            }
-            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => {
-                error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string())
-            }
-            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => {
-                error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string())
-            }
-            Ok(v) => {
-                warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v))
-            }
+            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string()),
+            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string()),
+            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string()),
+            Ok(v) => warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v)),
         }
     }
 

--- a/validator_client/src/duties/mod.rs
+++ b/validator_client/src/duties/mod.rs
@@ -77,12 +77,8 @@ impl<U: BeaconNodeDuties, S: Signer + Display> DutiesManager<U, S> {
     pub fn run_update(&self, epoch: Epoch, log: slog::Logger) -> Result<Async<()>, ()> {
         match self.update(epoch) {
             Err(error) => error!(log, "Epoch duties poll error"; "error" => format!("{:?}", error)),
-            Ok(UpdateOutcome::NoChange(epoch)) => {
-                debug!(log, "No change in duties"; "epoch" => epoch)
-            }
-            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => {
-                info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties))
-            }
+            Ok(UpdateOutcome::NoChange(epoch)) => debug!(log, "No change in duties"; "epoch" => epoch),
+            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties)),
             Ok(UpdateOutcome::NewDuties(epoch, duties)) => {
                 info!(log, "New duties obtained"; "epoch" => epoch);
                 print_duties(&log, duties);


### PR DESCRIPTION
Lighthouse doesn't build with protobuf 2.9.0, and there's no point upgrading when it's about to be deleted.