### PR TITLE
Change private key file permissions

### DIFF
--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -38,3 +38,4 @@ bincode = "^1.1.2"
 futures = "0.1.25"
 dirs = "2.0.1"
 logging = { path = "../eth2/utils/logging" }
+libc = "0.2"

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -264,13 +264,17 @@ impl Config {
     /// Saves a keypair to a file inside the appropriate validator directory. Returns the saved path filename.
     #[allow(dead_code)]
     pub fn save_key(&self, key: &Keypair) -> Result<PathBuf, Error> {
+        use std::os::unix::fs::PermissionsExt;
         let validator_config_path = self.data_dir.join(key.identifier());
         let key_path = validator_config_path.join(DEFAULT_PRIVATE_KEY_FILENAME);
 
         fs::create_dir_all(&validator_config_path)?;
 
         let mut key_file = File::create(&key_path)?;
-
+        let mut perm = key_file.metadata()?.permissions();
+        perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
+        key_file.set_permissions(perm)?;
+        
         bincode::serialize_into(&mut key_file, &key)
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
         Ok(key_path)

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -271,7 +271,7 @@ impl Config {
         let mut perm = key_file.metadata()?.permissions();
         perm.set_mode((libc::S_IWUSR | libc::S_IRUSR) as u32);
         key_file.set_permissions(perm)?;
-        
+
         bincode::serialize_into(&mut key_file, &key)
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
         Ok(key_path)

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate libc;
 pub mod config;
 
 pub use crate::config::Config;


### PR DESCRIPTION
## Issue Addressed

The `account_manager` generates private keys and stores them with unnecessary extensive permissions. Indeed, private keys are readable by any user of the system (i.e. `-rw-r--r--` or `0644` permission bits).

## Proposed Changes

- Import libc crate for permission bits
- Change permissions on private key file generation to `-rw-------` (i.e. `0600`)

## Additional Info

The validator client is about to be refactored, but thought I'd submit this now anyway :)
