### PR TITLE
Update Milagro BLS to v0.11.0

### DIFF
--- a/eth2/utils/bls/Cargo.toml
+++ b/eth2/utils/bls/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-# FIXME: update sigp repo
-milagro_bls = { git = "https://github.com/michaelsproul/milagro_bls", branch = "little-endian-v0.10" }
+milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v0.11.0" }
 eth2_hashing = { path = "../eth2_hashing" }
 hex = "0.3"
 rand = "^0.5"

--- a/eth2/utils/eth2_interop_keypairs/Cargo.toml
+++ b/eth2/utils/eth2_interop_keypairs/Cargo.toml
@@ -11,7 +11,7 @@ lazy_static = "1.4"
 num-bigint = "0.2"
 eth2_hashing = "0.1"
 hex = "0.3"
-milagro_bls = { git = "https://github.com/michaelsproul/milagro_bls", branch = "little-endian-v0.10" }
+milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v0.11.0" }
 serde_yaml = "0.8"
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
Remove the dependency on my fork of `milagro_bls` by using the new v0.11.0 release
