### PR TITLE
Update README spec version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ user-facing functionality.
 
 Current development overview:
 
-- Specification `v0.8.1` implemented, optimized and passing test vectors.
+- Specification `v0.8.3` implemented, optimized and passing test vectors.
 - Rust-native libp2p with Gossipsub and Discv5.
 - Metrics via Prometheus.
 - Basic gRPC API, soon to be replaced with RESTful HTTP/JSON.


### PR DESCRIPTION
## Issue Addressed

No issue opened.

## Proposed Changes

Small update to README to indicate that lighthouse is compliant with Eth2 v0.8.3.
