### PR TITLE
[WIP] BlockProcessing - Attestation Tests

### DIFF
--- a/beacon_node/network/src/message_handler.rs
+++ b/beacon_node/network/src/message_handler.rs
@@ -146,9 +146,15 @@ impl<T: BeaconChainTypes + 'static> MessageHandler<T> {
     ) {
         // an error could have occurred.
         match error_response {
-            RPCErrorResponse::InvalidRequest(error) => warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
-            RPCErrorResponse::ServerError(error) => warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
-            RPCErrorResponse::Unknown(error) => warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string()),
+            RPCErrorResponse::InvalidRequest(error) => {
+                warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
+            RPCErrorResponse::ServerError(error) => {
+                warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
+            RPCErrorResponse::Unknown(error) => {
+                warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
             RPCErrorResponse::Success(response) => {
                 match response {
                     RPCResponse::Hello(hello_message) => {

--- a/eth2/state_processing/src/common/get_indexed_attestation.rs
+++ b/eth2/state_processing/src/common/get_indexed_attestation.rs
@@ -107,8 +107,22 @@ mod test {
             &spec,
         );
         attestation_builder
-            .sign(&AttestationTestTask::Valid, &bit_0_indices, &bit_0_keys, &state.fork, &spec, false)
-            .sign(&AttestationTestTask::Valid, &bit_1_indices, &bit_1_keys, &state.fork, &spec, true);
+            .sign(
+                &AttestationTestTask::Valid,
+                &bit_0_indices,
+                &bit_0_keys,
+                &state.fork,
+                &spec,
+                false,
+            )
+            .sign(
+                &AttestationTestTask::Valid,
+                &bit_1_indices,
+                &bit_1_keys,
+                &state.fork,
+                &spec,
+                true,
+            );
         let attestation = attestation_builder.build();
 
         let indexed_attestation = get_indexed_attestation(&state, &attestation).unwrap();

--- a/eth2/state_processing/src/common/get_indexed_attestation.rs
+++ b/eth2/state_processing/src/common/get_indexed_attestation.rs
@@ -107,8 +107,8 @@ mod test {
             &spec,
         );
         attestation_builder
-            .sign(&bit_0_indices, &bit_0_keys, &state.fork, &spec, false)
-            .sign(&bit_1_indices, &bit_1_keys, &state.fork, &spec, true);
+            .sign(&AttestationTestTask::Valid, &bit_0_indices, &bit_0_keys, &state.fork, &spec, false)
+            .sign(&AttestationTestTask::Valid, &bit_1_indices, &bit_1_keys, &state.fork, &spec, true);
         let attestation = attestation_builder.build();
 
         let indexed_attestation = get_indexed_attestation(&state, &attestation).unwrap();

--- a/eth2/state_processing/src/common/get_indexed_attestation.rs
+++ b/eth2/state_processing/src/common/get_indexed_attestation.rs
@@ -98,8 +98,14 @@ mod test {
             .map(|validator_index| &keypairs[*validator_index].sk)
             .collect::<Vec<_>>();
 
-        let mut attestation_builder =
-            TestingAttestationBuilder::new(&AttestationTestTask::Valid, &state, &cc.committee, cc.slot, shard, &spec);
+        let mut attestation_builder = TestingAttestationBuilder::new(
+            &AttestationTestTask::Valid,
+            &state,
+            &cc.committee,
+            cc.slot,
+            shard,
+            &spec,
+        );
         attestation_builder
             .sign(&bit_0_indices, &bit_0_keys, &state.fork, &spec, false)
             .sign(&bit_1_indices, &bit_1_keys, &state.fork, &spec, true);

--- a/eth2/state_processing/src/common/get_indexed_attestation.rs
+++ b/eth2/state_processing/src/common/get_indexed_attestation.rs
@@ -99,7 +99,7 @@ mod test {
             .collect::<Vec<_>>();
 
         let mut attestation_builder =
-            TestingAttestationBuilder::new(&state, &cc.committee, cc.slot, shard, &spec);
+            TestingAttestationBuilder::new(&AttestationTestTask::Valid, &state, &cc.committee, cc.slot, shard, &spec);
         attestation_builder
             .sign(&bit_0_indices, &bit_0_keys, &state.fork, &spec, false)
             .sign(&bit_1_indices, &bit_1_keys, &state.fork, &spec, true);

--- a/eth2/state_processing/src/per_block_processing.rs
+++ b/eth2/state_processing/src/per_block_processing.rs
@@ -95,6 +95,7 @@ pub fn per_block_processing<T: EthSpec>(
         BlockSignatureStrategy::NoVerification => VerifySignatures::False,
     };
 
+    // in this function
     process_block_header(state, block, block_signed_root, verify_signatures, spec)?;
 
     // Ensure the current and previous epoch caches are built.
@@ -166,6 +167,7 @@ pub fn process_block_header<T: EthSpec>(
     );
 
     if verify_signatures.is_true() {
+        // in this function
         verify_block_signature(&state, &block, block_signed_root, &spec)?;
     }
 

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -1,5 +1,5 @@
 use tree_hash::SignedRoot;
-use types::test_utils::{TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
 use types::*;
 
 pub struct BlockProcessingBuilder<T: EthSpec> {
@@ -32,6 +32,7 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
 
     pub fn build_with_n_attestations(
         mut self,
+        test_task: &AttestationTestTask,
         num_attestations: u64,
         randao_sk: Option<SecretKey>,
         previous_block_root: Option<Hash256>,
@@ -62,6 +63,7 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
         let all_secret_keys: Vec<&SecretKey> = keypairs.iter().map(|keypair| &keypair.sk).collect();
         let num_attestations = num_attestations;
         self.block_builder.insert_attestations(
+            test_task,
             &state,
             &all_secret_keys,
             num_attestations as usize,

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -63,7 +63,6 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
         }
 
         let all_secret_keys: Vec<&SecretKey> = keypairs.iter().map(|keypair| &keypair.sk).collect();
-        let num_attestations = num_attestations;
         self.block_builder
             .insert_attestations(
                 test_task,

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -1,5 +1,7 @@
 use tree_hash::SignedRoot;
-use types::test_utils::{AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{
+    AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder,
+};
 use types::*;
 
 pub struct BlockProcessingBuilder<T: EthSpec> {
@@ -62,20 +64,20 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
 
         let all_secret_keys: Vec<&SecretKey> = keypairs.iter().map(|keypair| &keypair.sk).collect();
         let num_attestations = num_attestations;
-        self.block_builder.insert_attestations(
-            test_task,
-            &state,
-            &all_secret_keys,
-            num_attestations as usize,
-            spec,
-        )
-        .unwrap();
+        self.block_builder
+            .insert_attestations(
+                test_task,
+                &state,
+                &all_secret_keys,
+                num_attestations as usize,
+                spec,
+            )
+            .unwrap();
 
         let block = self.block_builder.build(&keypair.sk, &state.fork, spec);
 
         (block, state)
     }
-
 
     pub fn build(
         mut self,

--- a/eth2/state_processing/src/per_block_processing/errors.rs
+++ b/eth2/state_processing/src/per_block_processing/errors.rs
@@ -257,8 +257,6 @@ pub enum AttestationInvalid {
     CustodyBitfieldNotSubset,
     /// There was no known committee in this `epoch` for the given shard and slot.
     NoCommitteeForShard { shard: u64, slot: Slot },
-    /// The validator index was unknown.
-    UnknownValidator(u64),
     /// The attestation signature verification failed.
     BadSignature,
     /// The shard block root was not set to zero. This is a phase 0 requirement.

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -312,7 +312,7 @@ fn invalid_attestation_bad_target_too_low() {
         result,
         Err(BlockProcessingError::BeaconStateError(
             BeaconStateError::RelativeEpochError(RelativeEpochError::EpochTooLow {
-                base: Epoch::from(4 as u64),
+                base: state.current_epoch(),
                 other: Epoch::from(0 as u64),
             })
         ))
@@ -342,7 +342,7 @@ fn invalid_attestation_bad_target_too_high() {
         result,
         Err(BlockProcessingError::BeaconStateError(
             BeaconStateError::RelativeEpochError(RelativeEpochError::EpochTooHigh {
-                base: Epoch::from(4 as u64),
+                base: state.current_epoch(),
                 other: Epoch::from(10 as u64),
             })
         ))

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -422,13 +422,41 @@ fn invalid_attestation_custody_bitfield_not_subset() {
         &spec,
     );
 
-    // Expecting CustodyBitfieldNotSubset because we 
+    // Expecting CustodyBitfieldNotSubset because we set custody_bit to true without setting the aggregation bits.
 
     assert_eq!(
         result,
         Err(BlockProcessingError::AttestationInvalid {
             index: 0,
             reason: AttestationInvalid::CustodyBitfieldNotSubset
+        })
+    );
+}
+
+#[test]
+fn invalid_attestation_custody_bitfield_has_set_bits() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::CustodyBitfieldHasSetBits;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting CustodyBitfieldHasSetBits because we set custody bits even though the custody_bit boolean is set to false
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadIndexedAttestation(
+                IndexedAttestationInvalid::CustodyBitfieldHasSetBits
+            )
         })
     );
 }

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -150,6 +150,26 @@ fn valid_attestations() {
 }
 
 #[test]
+fn valid_max_attestations_plus_one() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::Valid;
+    let num_attestations = <MainnetEthSpec as EthSpec>::MaxVoluntaryExits::to_u64() + 1;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, num_attestations, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    assert_eq!(result, Ok(()));
+}
+
+#[test]
 fn invalid_attestation_parent_crosslink_start_epoch() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -406,6 +406,33 @@ fn invalid_attestation_bad_indexed_attestation_bad_signature() {
     );
 }
 
+#[test]
+fn invalid_attestation_custody_bitfield_not_subset() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::CustodyBitfieldNotSubset;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting CustodyBitfieldNotSubset because we 
+
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::CustodyBitfieldNotSubset
+        })
+    );
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -399,9 +399,11 @@ fn invalid_attestation_bad_indexed_attestation_bad_signature() {
         result,
         Err(BlockProcessingError::AttestationInvalid {
             index: 0,
-            reason: AttestationInvalid::BadIndexedAttestation(IndexedAttestationInvalid::BadSignature)
-        }
-    ));
+            reason: AttestationInvalid::BadIndexedAttestation(
+                IndexedAttestationInvalid::BadSignature
+            )
+        })
+    );
 }
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -5,9 +5,10 @@ use super::errors::*;
 use crate::{per_block_processing, BlockSignatureStrategy};
 use tree_hash::SignedRoot;
 use types::*;
+use types::test_utils::AttestationTestTask;
 
 pub const VALIDATOR_COUNT: usize = 100;
-pub const NUM_ATTESTATIONS: u64 = 10;
+pub const NUM_ATTESTATIONS: u64 = 1;
 
 #[test]
 fn valid_block_ok() {
@@ -133,7 +134,8 @@ fn invalid_randao_reveal_signature() {
 fn valid_attestations() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
-    let (block, mut state) = builder.build_with_n_attestations(NUM_ATTESTATIONS, None, None, &spec);
+    let test_task = AttestationTestTask::Valid;
+    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -148,6 +148,51 @@ fn valid_attestations() {
     assert_eq!(result, Ok(()));
 }
 
+#[test]
+fn invalid_attestation_start() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::Start;
+    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting BadParentCrosslinkEndEpoch because we manually set an invalid crosslink end epoch
+    assert_eq!(result, Err(BlockProcessingError::AttestationInvalid {
+        index: 0,
+        reason: AttestationInvalid::BadParentCrosslinkStartEpoch
+    }));
+}
+
+#[test]
+fn invalid_attestation_end() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::End;
+    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting BadParentCrosslinkEndEpoch because we manually set an invalid crosslink end epoch
+    assert_eq!(result, Err(BlockProcessingError::AttestationInvalid {
+        index: 0,
+        reason: AttestationInvalid::BadParentCrosslinkEndEpoch
+    }));
+
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -6,8 +6,8 @@ use crate::{per_block_processing, BlockSignatureStrategy};
 use tree_hash::SignedRoot;
 use types::*;
 
-pub const VALIDATOR_COUNT: usize = 10;
-pub const NUM_ATTESTATIONS: u64 = 2;
+pub const VALIDATOR_COUNT: usize = 100;
+pub const NUM_ATTESTATIONS: u64 = 10;
 
 #[test]
 fn valid_block_ok() {

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -540,31 +540,6 @@ fn invalid_attestation_bad_signature() {
 }
 
 #[test]
-fn invalid_attestation_validator_unknown() {
-    let spec = MainnetEthSpec::default_spec();
-    let builder = get_builder(&spec);
-    let test_task = AttestationTestTask::ValidatorUnknown;
-    let (block, mut state) =
-        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
-
-    let result = per_block_processing(
-        &mut state,
-        &block,
-        None,
-        BlockSignatureStrategy::VerifyIndividual,
-        &spec,
-    );
-
-    unimplemented!("this test is not valid");
-
-    // Expecting ValidatorUnknown because 
-    // assert_eq!(
-    //     result,
-    //     Ok(()),
-    // );
-}
-
-#[test]
 fn invalid_attestation_included_too_early() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
@@ -593,40 +568,6 @@ fn invalid_attestation_included_too_early() {
         })
     );
 }
-
-#[test]
-fn invalid_attestation_included_too_late() {
-    let spec = MainnetEthSpec::default_spec();
-    let builder = get_builder(&spec);
-    let test_task = AttestationTestTask::IncludedTooLate;
-    let (block, mut state) =
-        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
-
-    // state.slot = Slot::from(383 as u64);
-    // state.build_all_caches(&spec);
-
-    let result = per_block_processing(
-        &mut state,
-        &block,
-        None,
-        BlockSignatureStrategy::VerifyIndividual,
-        &spec,
-    );
-
-    // Expecting IncludedTooLate because
-    assert_eq!(
-        result,
-        Err(BlockProcessingError::AttestationInvalid {
-            index: 0,
-            reason: AttestationInvalid::IncludedTooEarly {
-                state: Slot::from(319 as u64),
-                delay: spec.min_attestation_inclusion_delay,
-                attestation: Slot::from(319 as u64)
-            }
-        })
-    );
-}
-
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -377,6 +377,33 @@ fn invalid_attestation_bad_crosslink_data_root() {
     );
 }
 
+#[test]
+fn invalid_attestation_bad_indexed_attestation_bad_signature() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadIndexedAttestationBadSignature;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting BadIndexedAttestation(BadSignature) because we ommitted the aggregation bits in the attestation
+
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadIndexedAttestation(IndexedAttestationInvalid::BadSignature)
+        }
+    ));
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -154,7 +154,7 @@ fn valid_max_attestations_plus_one() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::Valid;
-    let num_attestations = <MainnetEthSpec as EthSpec>::MaxVoluntaryExits::to_u64() + 1;
+    let num_attestations = <MainnetEthSpec as EthSpec>::MaxAttestations::to_u64() + 1;
     let (block, mut state) =
         builder.build_with_n_attestations(&test_task, num_attestations, None, None, &spec);
 
@@ -590,7 +590,7 @@ fn invalid_attestation_included_too_early() {
 }
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
-    let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
+    let mut builder = BlockProcessingBuilder::new(1024, &spec);
 
     // Set the state and block to be in the last slot of the 4th epoch.
     let last_slot_of_epoch =

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -589,6 +589,36 @@ fn invalid_attestation_included_too_early() {
     );
 }
 
+#[test]
+fn invalid_attestation_bad_shard() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadShard;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting BadShard or NoCommitteeForShard because the shard number is higher than ShardCount
+    assert!(
+        result
+            == Err(BlockProcessingError::AttestationInvalid {
+                index: 0,
+                reason: AttestationInvalid::BadShard
+            })
+            || result
+                == Err(BlockProcessingError::BeaconStateError(
+                    BeaconStateError::NoCommitteeForShard
+                ))
+    );
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -353,7 +353,7 @@ fn invalid_attestation_bad_target_too_high() {
 fn invalid_attestation_bad_crosslink_data_root() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
-    let test_task = AttestationTestTask::ShardBlockRootNotZero;
+    let test_task = AttestationTestTask::BadParentCrosslinkDataRoot;
     let (block, mut state) =
         builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -539,6 +539,95 @@ fn invalid_attestation_bad_signature() {
     );
 }
 
+#[test]
+fn invalid_attestation_validator_unknown() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::ValidatorUnknown;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    unimplemented!("this test is not valid");
+
+    // Expecting ValidatorUnknown because 
+    // assert_eq!(
+    //     result,
+    //     Ok(()),
+    // );
+}
+
+#[test]
+fn invalid_attestation_included_too_early() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::IncludedTooEarly;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting IncludedTooEarly because the shard included in the crosslink is bigger than expected
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::IncludedTooEarly {
+                state: Slot::from(319 as u64),
+                delay: spec.min_attestation_inclusion_delay,
+                attestation: Slot::from(319 as u64)
+            }
+        })
+    );
+}
+
+#[test]
+fn invalid_attestation_included_too_late() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::IncludedTooLate;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    // state.slot = Slot::from(383 as u64);
+    // state.build_all_caches(&spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting IncludedTooLate because
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::IncludedTooEarly {
+                state: Slot::from(319 as u64),
+                delay: spec.min_attestation_inclusion_delay,
+                attestation: Slot::from(319 as u64)
+            }
+        })
+    );
+}
+
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -590,7 +590,7 @@ fn invalid_attestation_included_too_early() {
 }
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
-    let mut builder = BlockProcessingBuilder::new(1024, &spec);
+    let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 
     // Set the state and block to be in the last slot of the 4th epoch.
     let last_slot_of_epoch =

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -4,8 +4,8 @@ use super::block_processing_builder::BlockProcessingBuilder;
 use super::errors::*;
 use crate::{per_block_processing, BlockSignatureStrategy};
 use tree_hash::SignedRoot;
-use types::*;
 use types::test_utils::AttestationTestTask;
+use types::*;
 
 pub const VALIDATOR_COUNT: usize = 100;
 pub const NUM_ATTESTATIONS: u64 = 1;
@@ -135,7 +135,8 @@ fn valid_attestations() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::Valid;
-    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -153,7 +154,8 @@ fn invalid_attestation_parent_crosslink_start_epoch() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::BadParentCrosslinkStartEpoch;
-    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -164,10 +166,13 @@ fn invalid_attestation_parent_crosslink_start_epoch() {
     );
 
     // Expecting BadParentCrosslinkEndEpoch because we manually set an invalid crosslink start epoch
-    assert_eq!(result, Err(BlockProcessingError::AttestationInvalid {
-        index: 0,
-        reason: AttestationInvalid::BadParentCrosslinkStartEpoch
-    }));
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadParentCrosslinkStartEpoch
+        })
+    );
 }
 
 #[test]
@@ -175,7 +180,8 @@ fn invalid_attestation_parent_crosslink_end_epoch() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::BadParentCrosslinkEndEpoch;
-    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -186,10 +192,13 @@ fn invalid_attestation_parent_crosslink_end_epoch() {
     );
 
     // Expecting BadParentCrosslinkEndEpoch because we manually set an invalid crosslink end epoch
-    assert_eq!(result, Err(BlockProcessingError::AttestationInvalid {
-        index: 0,
-        reason: AttestationInvalid::BadParentCrosslinkEndEpoch
-    }));
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadParentCrosslinkEndEpoch
+        })
+    );
 }
 
 #[test]
@@ -197,7 +206,8 @@ fn invalid_attestation_parent_crosslink_hash() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::BadParentCrosslinkHash;
-    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -208,11 +218,13 @@ fn invalid_attestation_parent_crosslink_hash() {
     );
 
     // Expecting BadParentCrosslinkHash because we manually set an invalid crosslink parent_root
-    assert_eq!(result, Err(BlockProcessingError::AttestationInvalid {
-        index: 0,
-        reason: AttestationInvalid::BadParentCrosslinkHash
-    }));
-
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadParentCrosslinkHash
+        })
+    );
 }
 
 #[test]
@@ -220,7 +232,8 @@ fn invalid_attestation_no_committee_for_shard() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttestationTestTask::NoCommiteeForShard;
-    let (block, mut state) = builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -231,9 +244,80 @@ fn invalid_attestation_no_committee_for_shard() {
     );
 
     // Expecting NoCommiteeForShard because we manually set the crosslink's shard to be invalid
-    assert_eq!(result, Err(BlockProcessingError::BeaconStateError(BeaconStateError::NoCommitteeForShard)));
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::BeaconStateError(
+            BeaconStateError::NoCommitteeForShard
+        ))
+    );
 }
 
+#[test]
+fn invalid_attestation_badsource() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadSource;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting WrongJustifiedCheckpoint because we manually set the
+    // source field of the AttestationData object to be invalid
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::WrongJustifiedCheckpoint {
+                state: Checkpoint {
+                    epoch: Epoch::from(2 as u64),
+                    root: Hash256::zero(),
+                },
+                attestation: Checkpoint {
+                    epoch: Epoch::from(0 as u64),
+                    root: Hash256::zero(),
+                },
+                is_current: true,
+            }
+        })
+    );
+}
+
+#[test]
+fn invalid_attestation_badtarget() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadTarget;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting EpochTooLow because we manually set the
+    // target field of the AttestationData object to be invalid
+
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::BeaconStateError(
+            BeaconStateError::RelativeEpochError(RelativeEpochError::EpochTooLow {
+                base: Epoch::from(4 as u64),
+                other: Epoch::from(0 as u64),
+            })
+        ))
+    );
+}
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -7,6 +7,7 @@ use tree_hash::SignedRoot;
 use types::*;
 
 pub const VALIDATOR_COUNT: usize = 10;
+pub const NUM_ATTESTATIONS: u64 = 2;
 
 #[test]
 fn valid_block_ok() {
@@ -126,6 +127,23 @@ fn invalid_randao_reveal_signature() {
 
     // should get a BadRandaoSignature error
     assert_eq!(result, Err(BlockProcessingError::RandaoSignatureInvalid));
+}
+
+#[test]
+fn valid_attestations() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let (block, mut state) = builder.build_with_n_attestations(NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    assert_eq!(result, Ok(()));
 }
 
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -273,10 +273,10 @@ fn invalid_attestation_no_committee_for_shard() {
 }
 
 #[test]
-fn invalid_attestation_bad_source() {
+fn invalid_attestation_wrong_justified_checkpoint() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
-    let test_task = AttestationTestTask::BadSource;
+    let test_task = AttestationTestTask::WrongJustifiedCheckpoint;
     let (block, mut state) =
         builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -230,9 +230,8 @@ fn invalid_attestation_no_committee_for_shard() {
         &spec,
     );
 
-    // Missing Comment
+    // Expecting NoCommiteeForShard because we manually set the crosslink's shard to be invalid
     assert_eq!(result, Err(BlockProcessingError::BeaconStateError(BeaconStateError::NoCommitteeForShard)));
-
 }
 
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -461,6 +461,56 @@ fn invalid_attestation_custody_bitfield_has_set_bits() {
     );
 }
 
+#[test]
+fn invalid_attestation_bad_custody_bitfield_len() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadCustodyBitfieldLen;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting InvalidBitfield because the size of the custody_bitfield is bigger than the commitee size.
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::BeaconStateError(
+            BeaconStateError::InvalidBitfield
+        ))
+    );
+}
+
+#[test]
+fn invalid_attestation_bad_aggregation_bitfield_len() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadAggregationBitfieldLen;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting InvalidBitfield because the size of the aggregation_bitfield is bigger than the commitee size.
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::BeaconStateError(
+            BeaconStateError::InvalidBitfield
+        ))
+    );
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -511,6 +511,34 @@ fn invalid_attestation_bad_aggregation_bitfield_len() {
     );
 }
 
+#[test]
+fn invalid_attestation_bad_signature() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttestationTestTask::BadSignature;
+    let (block, mut state) =
+        builder.build_with_n_attestations(&test_task, NUM_ATTESTATIONS, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    // Expecting BadSignature because we're signing with invalid secret_keys
+    assert_eq!(
+        result,
+        Err(BlockProcessingError::AttestationInvalid {
+            index: 0,
+            reason: AttestationInvalid::BadIndexedAttestation(
+                IndexedAttestationInvalid::BadSignature
+            )
+        })
+    );
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/verify_attestation.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_attestation.rs
@@ -28,6 +28,10 @@ pub fn verify_attestation_for_block_inclusion<T: EthSpec>(
     // Check attestation slot.
     let attestation_slot = state.get_attestation_data_slot(&data)?;
 
+    // dbg!(&attestation_slot); // 318 SCOTT
+    // dbg!(spec.min_attestation_inclusion_delay); // 1
+    // dbg!(&state.slot); // 319
+    // dbg!(T::slots_per_epoch()); // 64
     verify!(
         attestation_slot + spec.min_attestation_inclusion_delay <= state.slot,
         Invalid::IncludedTooEarly {
@@ -61,6 +65,7 @@ pub fn verify_attestation_for_state<T: EthSpec>(
     spec: &ChainSpec,
 ) -> Result<()> {
     let data = &attestation.data;
+
     verify!(
         data.crosslink.shard < T::ShardCount::to_u64(),
         Invalid::BadShard

--- a/eth2/state_processing/src/per_block_processing/verify_attestation.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_attestation.rs
@@ -28,11 +28,6 @@ pub fn verify_attestation_for_block_inclusion<T: EthSpec>(
     // Check attestation slot.
     let attestation_slot = state.get_attestation_data_slot(&data)?;
 
-    // dbg!(&attestation_slot); // 318 SCOTT // 319 for 62
-    // dbg!(spec.min_attestation_inclusion_delay); // 1
-    // dbg!(&state.slot); // 319
-    // dbg!(T::slots_per_epoch()); // 64
-    // panic!("STOP");
     verify!(
         attestation_slot + spec.min_attestation_inclusion_delay <= state.slot,
         Invalid::IncludedTooEarly {

--- a/eth2/state_processing/src/per_block_processing/verify_attestation.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_attestation.rs
@@ -28,10 +28,11 @@ pub fn verify_attestation_for_block_inclusion<T: EthSpec>(
     // Check attestation slot.
     let attestation_slot = state.get_attestation_data_slot(&data)?;
 
-    // dbg!(&attestation_slot); // 318 SCOTT
+    // dbg!(&attestation_slot); // 318 SCOTT // 319 for 62
     // dbg!(spec.min_attestation_inclusion_delay); // 1
     // dbg!(&state.slot); // 319
     // dbg!(T::slots_per_epoch()); // 64
+    // panic!("STOP");
     verify!(
         attestation_slot + spec.min_attestation_inclusion_delay <= state.slot,
         Invalid::IncludedTooEarly {

--- a/eth2/state_processing/src/test_utils.rs
+++ b/eth2/state_processing/src/test_utils.rs
@@ -1,5 +1,7 @@
 use log::info;
-use types::test_utils::{AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{
+    AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder,
+};
 use types::{EthSpec, *};
 
 pub struct BlockBuilder<T: EthSpec> {

--- a/eth2/state_processing/src/test_utils.rs
+++ b/eth2/state_processing/src/test_utils.rs
@@ -1,5 +1,5 @@
 use log::info;
-use types::test_utils::{TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{AttestationTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
 use types::{EthSpec, *};
 
 pub struct BlockBuilder<T: EthSpec> {
@@ -113,6 +113,7 @@ impl<T: EthSpec> BlockBuilder<T> {
         let all_secret_keys: Vec<&SecretKey> = keypairs.iter().map(|keypair| &keypair.sk).collect();
         builder
             .insert_attestations(
+                &AttestationTestTask::Valid,
                 &state,
                 &all_secret_keys,
                 self.num_attestations as usize,

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::TestingAttestationDataBuilder;
+use crate::test_utils::{AttestationTestTask, TestingAttestationDataBuilder};
 use crate::*;
 use tree_hash::TreeHash;
 
@@ -13,13 +13,14 @@ pub struct TestingAttestationBuilder<T: EthSpec> {
 impl<T: EthSpec> TestingAttestationBuilder<T> {
     /// Create a new attestation builder.
     pub fn new(
+        test_task: &AttestationTestTask,
         state: &BeaconState<T>,
         committee: &[usize],
         slot: Slot,
         shard: u64,
         spec: &ChainSpec,
     ) -> Self {
-        let data_builder = TestingAttestationDataBuilder::new(state, shard, slot, spec);
+        let data_builder = TestingAttestationDataBuilder::new(test_task, state, shard, slot, spec);
 
         let mut aggregation_bits = BitList::with_capacity(committee.len()).unwrap();
         let mut custody_bits = BitList::with_capacity(committee.len()).unwrap();

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -54,7 +54,7 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
         secret_keys: &[&SecretKey],
         fork: &Fork,
         spec: &ChainSpec,
-        custody_bit: bool,
+        mut custody_bit: bool,
     ) -> &mut Self {
         assert_eq!(
             signing_validators.len(),
@@ -71,6 +71,7 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
 
             match test_task {
                 AttestationTestTask::BadIndexedAttestationBadSignature => (),
+                AttestationTestTask::CustodyBitfieldNotSubset => custody_bit = true,
                 _ => {
                     self.attestation
                         .aggregation_bits

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -22,8 +22,16 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
     ) -> Self {
         let data_builder = TestingAttestationDataBuilder::new(test_task, state, shard, slot, spec);
 
-        let mut aggregation_bits = BitList::with_capacity(committee.len()).unwrap();
-        let mut custody_bits = BitList::with_capacity(committee.len()).unwrap();
+        let mut aggregation_bits_len = committee.len();
+        let mut custody_bits_len = committee.len();
+
+        match test_task {
+            AttestationTestTask::BadAggregationBitfieldLen => aggregation_bits_len += 1,
+            AttestationTestTask::BadCustodyBitfieldLen => custody_bits_len += 1,
+            _ => (),
+        }
+        let mut aggregation_bits = BitList::with_capacity(aggregation_bits_len).unwrap();
+        let mut custody_bits = BitList::with_capacity(custody_bits_len).unwrap();
 
         for i in 0..committee.len() {
             custody_bits.set(i, false).unwrap();

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -109,7 +109,11 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
                 fork,
             );
 
-            let signature = Signature::new(&message, domain, secret_keys[key_index]);
+            let index = match test_task {
+                AttestationTestTask::BadSignature => 0,
+                _ => key_index,
+            };
+            let signature = Signature::new(&message, domain, secret_keys[index]);
             self.attestation.signature.add(&signature)
         }
 

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -24,7 +24,7 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
         let mut aggregation_bits = BitList::with_capacity(committee.len()).unwrap();
         let mut custody_bits = BitList::with_capacity(committee.len()).unwrap();
 
-        for (i, _) in committee.iter().enumerate() {
+        for i in 0..committee.len() {
             custody_bits.set(i, false).unwrap();
             aggregation_bits.set(i, false).unwrap();
         }

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -79,12 +79,14 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
                         .unwrap();
                 }
             }
-
-            if custody_bit {
-                self.attestation
-                    .custody_bits
-                    .set(committee_index, true)
-                    .unwrap();
+            match (custody_bit, test_task) {
+                (true, _) | (_, AttestationTestTask::CustodyBitfieldHasSetBits) => {
+                    self.attestation
+                        .custody_bits
+                        .set(committee_index, true)
+                        .unwrap();
+                }
+                (false, _) => (),
             }
 
             let message = AttestationDataAndCustodyBit {

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -109,9 +109,10 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
                 fork,
             );
 
-            let index = match test_task {
-                AttestationTestTask::BadSignature => 0,
-                _ => key_index,
+            let index = if *test_task == AttestationTestTask::BadSignature {
+                0
+            } else {
+                key_index
             };
             let signature = Signature::new(&message, domain, secret_keys[index]);
             self.attestation.signature.add(&signature)

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -76,7 +76,7 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
                         .aggregation_bits
                         .set(committee_index, true)
                         .unwrap();
-                    }
+                }
             }
 
             if custody_bit {

--- a/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_builder.rs
@@ -49,6 +49,7 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
     /// keypair must be that of the first signing validator.
     pub fn sign(
         &mut self,
+        test_task: &AttestationTestTask,
         signing_validators: &[usize],
         secret_keys: &[&SecretKey],
         fork: &Fork,
@@ -68,10 +69,15 @@ impl<T: EthSpec> TestingAttestationBuilder<T> {
                 .position(|v| *v == *validator_index)
                 .expect("Signing validator not in attestation committee");
 
-            self.attestation
-                .aggregation_bits
-                .set(committee_index, true)
-                .unwrap();
+            match test_task {
+                AttestationTestTask::BadIndexedAttestationBadSignature => (),
+                _ => {
+                    self.attestation
+                        .aggregation_bits
+                        .set(committee_index, true)
+                        .unwrap();
+                    }
+            }
 
             if custody_bit {
                 self.attestation

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -59,6 +59,7 @@ impl TestingAttestationDataBuilder {
         );
         let mut parent_root = Hash256::from_slice(&parent_crosslink.tree_hash_root());
         let mut data_root = Hash256::zero();
+        let beacon_block_root = *state.get_block_root(slot).unwrap();
 
         match test_task {
             AttestationTestTask::BadParentCrosslinkStartEpoch => start = Epoch::from(10 as u64),
@@ -83,9 +84,7 @@ impl TestingAttestationDataBuilder {
                     root: Hash256::zero(),
                 }
             }
-            AttestationTestTask::ShardBlockRootNotZero => data_root = parent_root.clone(),
-            // AttestationTestTask::BadTarget =>
-            // AttestationTestTask::BadBeaconBlockRoot =>
+            AttestationTestTask::BadParentCrosslinkDataRoot => data_root = parent_root,
             _ => (),
         }
         let crosslink = Crosslink {
@@ -98,10 +97,10 @@ impl TestingAttestationDataBuilder {
 
         let data = AttestationData {
             // LMD GHOST vote
-            beacon_block_root: *state.get_block_root(slot).unwrap(), // 0x000
+            beacon_block_root, // 0x000
 
             // FFG Vote
-            source, // Checkpoint {2, 0x000}
+            source, // Checkpoint {2, 0x000} SCOTT
             target, // Checkpoint {4, 0x000}
 
             // Crosslink vote

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -58,6 +58,7 @@ impl TestingAttestationDataBuilder {
             parent_crosslink.end_epoch + spec.max_epochs_per_crosslink,
         );
         let mut parent_root = Hash256::from_slice(&parent_crosslink.tree_hash_root());
+        let mut data_root = Hash256::zero();
 
         match test_task {
             AttestationTestTask::BadParentCrosslinkStartEpoch => start = Epoch::from(10 as u64),
@@ -66,16 +67,23 @@ impl TestingAttestationDataBuilder {
             AttestationTestTask::NoCommiteeForShard => shard += 2,
             AttestationTestTask::BadSource => {
                 source = Checkpoint {
-                    epoch: Epoch::from(8 as u64),
+                    epoch: Epoch::from(0 as u64),
                     root: Hash256::zero(),
                 }
             }
-            AttestationTestTask::BadTarget => {
+            AttestationTestTask::BadTargetTooLow => {
                 target = Checkpoint {
-                    epoch: Epoch::from(8 as u64),
+                    epoch: Epoch::from(0 as u64),
                     root: Hash256::zero(),
                 }
             }
+            AttestationTestTask::BadTargetTooHigh => {
+                target = Checkpoint {
+                    epoch: Epoch::from(10 as u64),
+                    root: Hash256::zero(),
+                }
+            }
+            AttestationTestTask::ShardBlockRootNotZero => data_root = parent_root.clone(),
             // AttestationTestTask::BadTarget =>
             // AttestationTestTask::BadBeaconBlockRoot =>
             _ => (),
@@ -85,7 +93,7 @@ impl TestingAttestationDataBuilder {
             parent_root,
             start_epoch: start, // 0
             end_epoch: end,     // 4
-            data_root: parent_root,
+            data_root,
         };
 
         let data = AttestationData {

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -67,7 +67,7 @@ impl TestingAttestationDataBuilder {
             AttestationTestTask::BadParentCrosslinkHash => parent_root = Hash256::zero(),
             AttestationTestTask::NoCommiteeForShard => shard += 2,
             AttestationTestTask::IncludedTooEarly => shard += 1,
-            AttestationTestTask::BadSource => {
+            AttestationTestTask::WrongJustifiedCheckpoint => {
                 source = Checkpoint {
                     epoch: Epoch::from(0 as u64),
                     root: Hash256::zero(),

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -66,6 +66,7 @@ impl TestingAttestationDataBuilder {
             AttestationTestTask::BadParentCrosslinkEndEpoch => end = Epoch::from(0 as u64),
             AttestationTestTask::BadParentCrosslinkHash => parent_root = Hash256::zero(),
             AttestationTestTask::NoCommiteeForShard => shard += 2,
+            AttestationTestTask::BadShard => shard = T::ShardCount::to_u64(),
             AttestationTestTask::IncludedTooEarly => shard += 1,
             AttestationTestTask::WrongJustifiedCheckpoint => {
                 source = Checkpoint {

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -52,12 +52,12 @@ impl TestingAttestationDataBuilder {
 
         let crosslink = Crosslink {
             shard,
-            parent_root: Hash256::from_slice(&parent_crosslink.tree_hash_root()),
-            start_epoch: parent_crosslink.end_epoch,
+            parent_root: Hash256::from_slice(&parent_crosslink.tree_hash_root()), // 0xc78009fdf07fc56a11f122370658a353aaa542ed63e44c4bc15ff4cd105ab33c
+            start_epoch: parent_crosslink.end_epoch, // 0
             end_epoch: std::cmp::min(
                 target.epoch,
                 parent_crosslink.end_epoch + spec.max_epochs_per_crosslink,
-            ),
+            ), // 4
             data_root: Hash256::zero(),
         };
 

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -66,6 +66,13 @@ impl TestingAttestationDataBuilder {
             AttestationTestTask::BadParentCrosslinkEndEpoch => end = Epoch::from(0 as u64),
             AttestationTestTask::BadParentCrosslinkHash => parent_root = Hash256::zero(),
             AttestationTestTask::NoCommiteeForShard => shard += 2,
+            AttestationTestTask::IncludedTooEarly => shard += 1,
+            // AttestationTestTask::IncludedTooLate => {
+            //     target = Checkpoint {
+            //         epoch: Epoch::from(4 as u64),
+            //         root: Hash256::zero(),
+            //     }
+            // }
             AttestationTestTask::BadSource => {
                 source = Checkpoint {
                     epoch: Epoch::from(0 as u64),
@@ -88,7 +95,7 @@ impl TestingAttestationDataBuilder {
             _ => (),
         }
         let crosslink = Crosslink {
-            shard,
+            shard, // 62
             parent_root,
             start_epoch: start, // 0
             end_epoch: end,     // 4

--- a/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attestation_data_builder.rs
@@ -67,12 +67,6 @@ impl TestingAttestationDataBuilder {
             AttestationTestTask::BadParentCrosslinkHash => parent_root = Hash256::zero(),
             AttestationTestTask::NoCommiteeForShard => shard += 2,
             AttestationTestTask::IncludedTooEarly => shard += 1,
-            // AttestationTestTask::IncludedTooLate => {
-            //     target = Checkpoint {
-            //         epoch: Epoch::from(4 as u64),
-            //         root: Hash256::zero(),
-            //     }
-            // }
             AttestationTestTask::BadSource => {
                 source = Checkpoint {
                     epoch: Epoch::from(0 as u64),
@@ -95,20 +89,20 @@ impl TestingAttestationDataBuilder {
             _ => (),
         }
         let crosslink = Crosslink {
-            shard, // 62
+            shard,
             parent_root,
-            start_epoch: start, // 0
-            end_epoch: end,     // 4
+            start_epoch: start,
+            end_epoch: end,
             data_root,
         };
 
         let data = AttestationData {
             // LMD GHOST vote
-            beacon_block_root, // 0x000
+            beacon_block_root,
 
             // FFG Vote
-            source, // Checkpoint {2, 0x000} SCOTT
-            target, // Checkpoint {4, 0x000}
+            source,
+            target,
 
             // Crosslink vote
             crosslink,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -26,6 +26,7 @@ pub enum AttestationTestTask {
     BadTargetTooHigh,
     BadParentCrosslinkDataRoot,
     BadIndexedAttestationBadSignature,
+    CustodyBitfieldNotSubset,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -31,6 +31,9 @@ pub enum AttestationTestTask {
     BadCustodyBitfieldLen,
     BadAggregationBitfieldLen,
     BadSignature,
+    ValidatorUnknown,
+    IncludedTooEarly,
+    IncludedTooLate,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -15,6 +15,10 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
     pub block: BeaconBlock<T>,
 }
 
+pub enum AttestationTestTask {
+    Valid,
+}
+
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
     /// Create a new builder from genesis.
     pub fn new(spec: &ChainSpec) -> Self {
@@ -103,6 +107,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
     /// to aggregate these split attestations.
     pub fn insert_attestations(
         &mut self,
+        test_task: &AttestationTestTask,
         state: &BeaconState<T>,
         secret_keys: &[&SecretKey],
         num_attestations: usize,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -28,6 +28,8 @@ pub enum AttestationTestTask {
     BadIndexedAttestationBadSignature,
     CustodyBitfieldNotSubset,
     CustodyBitfieldHasSetBits,
+    BadCustodyBitfieldLen,
+    BadAggregationBitfieldLen,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -17,8 +17,10 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
 
 pub enum AttestationTestTask {
     Valid,
-    End,
-    Start,
+    BadParentCrosslinkStartEpoch,
+    BadParentCrosslinkEndEpoch,
+    BadParentCrosslinkHash,
+    NoCommiteeForShard,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -24,6 +24,7 @@ pub enum AttestationTestTask {
     WrongJustifiedCheckpoint,
     BadTargetTooLow,
     BadTargetTooHigh,
+    BadShard,
     BadParentCrosslinkDataRoot,
     BadIndexedAttestationBadSignature,
     CustodyBitfieldNotSubset,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -21,6 +21,8 @@ pub enum AttestationTestTask {
     BadParentCrosslinkEndEpoch,
     BadParentCrosslinkHash,
     NoCommiteeForShard,
+    BadSource,
+    BadTarget,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
@@ -184,8 +186,9 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
         let attestations: Vec<_> = committees
             .par_iter()
             .map(|(slot, committee, signing_validators, shard)| {
-                let mut builder =
-                    TestingAttestationBuilder::new(test_task, state, committee, *slot, *shard, spec);
+                let mut builder = TestingAttestationBuilder::new(
+                    test_task, state, committee, *slot, *shard, spec,
+                );
 
                 let signing_secret_keys: Vec<&SecretKey> = signing_validators
                     .iter()

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -24,7 +24,7 @@ pub enum AttestationTestTask {
     BadSource,
     BadTargetTooLow,
     BadTargetTooHigh,
-    ShardBlockRootNotZero,
+    BadParentCrosslinkDataRoot,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -21,7 +21,7 @@ pub enum AttestationTestTask {
     BadParentCrosslinkEndEpoch,
     BadParentCrosslinkHash,
     NoCommiteeForShard,
-    BadSource,
+    WrongJustifiedCheckpoint,
     BadTargetTooLow,
     BadTargetTooHigh,
     BadParentCrosslinkDataRoot,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -22,7 +22,9 @@ pub enum AttestationTestTask {
     BadParentCrosslinkHash,
     NoCommiteeForShard,
     BadSource,
-    BadTarget,
+    BadTargetTooLow,
+    BadTargetTooHigh,
+    ShardBlockRootNotZero,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -17,6 +17,8 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
 
 pub enum AttestationTestTask {
     Valid,
+    End,
+    Start,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
@@ -181,7 +183,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
             .par_iter()
             .map(|(slot, committee, signing_validators, shard)| {
                 let mut builder =
-                    TestingAttestationBuilder::new(state, committee, *slot, *shard, spec);
+                    TestingAttestationBuilder::new(test_task, state, committee, *slot, *shard, spec);
 
                 let signing_secret_keys: Vec<&SecretKey> = signing_validators
                     .iter()

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -27,6 +27,7 @@ pub enum AttestationTestTask {
     BadParentCrosslinkDataRoot,
     BadIndexedAttestationBadSignature,
     CustodyBitfieldNotSubset,
+    CustodyBitfieldHasSetBits,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -25,6 +25,7 @@ pub enum AttestationTestTask {
     BadTargetTooLow,
     BadTargetTooHigh,
     BadParentCrosslinkDataRoot,
+    BadIndexedAttestationBadSignature,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
@@ -197,6 +198,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
                     .map(|validator_index| secret_keys[*validator_index])
                     .collect();
                 builder.sign(
+                    test_task,
                     signing_validators,
                     &signing_secret_keys,
                     &state.fork,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -30,6 +30,7 @@ pub enum AttestationTestTask {
     CustodyBitfieldHasSetBits,
     BadCustodyBitfieldLen,
     BadAggregationBitfieldLen,
+    BadSignature,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -219,7 +219,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
             .collect();
 
         for attestation in attestations {
-            self.block.body.attestations.push(attestation).unwrap();
+            let _ = self.block.body.attestations.push(attestation);
         }
 
         Ok(())

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -15,6 +15,7 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
     pub block: BeaconBlock<T>,
 }
 
+#[derive(PartialEq)]
 pub enum AttestationTestTask {
     Valid,
     BadParentCrosslinkStartEpoch,

--- a/eth2/types/src/test_utils/builders/testing_beacon_state_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_state_builder.rs
@@ -1,5 +1,5 @@
 use super::super::{generate_deterministic_keypairs, KeypairsFile};
-use crate::test_utils::TestingPendingAttestationBuilder;
+use crate::test_utils::{AttestationTestTask, TestingPendingAttestationBuilder};
 use crate::*;
 use bls::get_withdrawal_credentials;
 use dirs;
@@ -224,6 +224,7 @@ impl<T: EthSpec> TestingBeaconStateBuilder<T> {
 
             for crosslink_committee in committees {
                 let mut builder = TestingPendingAttestationBuilder::new(
+                    &AttestationTestTask::Valid,
                     state,
                     crosslink_committee.shard,
                     slot,

--- a/eth2/types/src/test_utils/builders/testing_pending_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_pending_attestation_builder.rs
@@ -15,7 +15,13 @@ impl<T: EthSpec> TestingPendingAttestationBuilder<T> {
     ///
     /// * The aggregation and custody bitfields will all be empty, they need to be set with
     /// `Self::add_committee_participation`.
-    pub fn new(test_task: &AttestationTestTask, state: &BeaconState<T>, shard: u64, slot: Slot, spec: &ChainSpec) -> Self {
+    pub fn new(
+        test_task: &AttestationTestTask,
+        state: &BeaconState<T>,
+        shard: u64,
+        slot: Slot,
+        spec: &ChainSpec,
+    ) -> Self {
         let data_builder = TestingAttestationDataBuilder::new(test_task, state, shard, slot, spec);
 
         let relative_epoch =

--- a/eth2/types/src/test_utils/builders/testing_pending_attestation_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_pending_attestation_builder.rs
@@ -1,4 +1,4 @@
-use crate::test_utils::TestingAttestationDataBuilder;
+use crate::test_utils::{AttestationTestTask, TestingAttestationDataBuilder};
 use crate::*;
 
 /// Builds an `AttesterSlashing` to be used for testing purposes.
@@ -15,8 +15,8 @@ impl<T: EthSpec> TestingPendingAttestationBuilder<T> {
     ///
     /// * The aggregation and custody bitfields will all be empty, they need to be set with
     /// `Self::add_committee_participation`.
-    pub fn new(state: &BeaconState<T>, shard: u64, slot: Slot, spec: &ChainSpec) -> Self {
-        let data_builder = TestingAttestationDataBuilder::new(state, shard, slot, spec);
+    pub fn new(test_task: &AttestationTestTask, state: &BeaconState<T>, shard: u64, slot: Slot, spec: &ChainSpec) -> Self {
+        let data_builder = TestingAttestationDataBuilder::new(test_task, state, shard, slot, spec);
 
         let relative_epoch =
             RelativeEpoch::from_epoch(state.current_epoch(), slot.epoch(T::slots_per_epoch()))

--- a/validator_client/src/attestation_producer/mod.rs
+++ b/validator_client/src/attestation_producer/mod.rs
@@ -57,11 +57,21 @@ impl<'a, B: BeaconNodeAttestation, S: Signer, E: EthSpec> AttestationProducer<'a
                 "slot" => slot,
             ),
             Err(e) => error!(log, "Attestation production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string()),
-            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string()),
-            Ok(ValidatorEvent::PublishAttestationFailed) => error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string()),
-            Ok(ValidatorEvent::InvalidAttestation) => error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string()),
-            Ok(v) => warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v)),
+            Ok(ValidatorEvent::SignerRejection(_slot)) => {
+                error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string())
+            }
+            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => {
+                error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string())
+            }
+            Ok(ValidatorEvent::PublishAttestationFailed) => {
+                error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string())
+            }
+            Ok(ValidatorEvent::InvalidAttestation) => {
+                error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string())
+            }
+            Ok(v) => {
+                warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v))
+            }
         }
     }
 

--- a/validator_client/src/block_producer/mod.rs
+++ b/validator_client/src/block_producer/mod.rs
@@ -69,10 +69,18 @@ impl<'a, B: BeaconNodeBlock, S: Signer, E: EthSpec> BlockProducer<'a, B, S, E> {
                 "slot" => slot,
             ),
             Err(e) => error!(self.log, "Block production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string()),
-            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string()),
-            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string()),
-            Ok(v) => warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v)),
+            Ok(ValidatorEvent::SignerRejection(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string())
+            }
+            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string())
+            }
+            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string())
+            }
+            Ok(v) => {
+                warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v))
+            }
         }
     }
 

--- a/validator_client/src/duties/mod.rs
+++ b/validator_client/src/duties/mod.rs
@@ -77,8 +77,12 @@ impl<U: BeaconNodeDuties, S: Signer + Display> DutiesManager<U, S> {
     pub fn run_update(&self, epoch: Epoch, log: slog::Logger) -> Result<Async<()>, ()> {
         match self.update(epoch) {
             Err(error) => error!(log, "Epoch duties poll error"; "error" => format!("{:?}", error)),
-            Ok(UpdateOutcome::NoChange(epoch)) => debug!(log, "No change in duties"; "epoch" => epoch),
-            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties)),
+            Ok(UpdateOutcome::NoChange(epoch)) => {
+                debug!(log, "No change in duties"; "epoch" => epoch)
+            }
+            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => {
+                info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties))
+            }
             Ok(UpdateOutcome::NewDuties(epoch, duties)) => {
                 info!(log, "New duties obtained"; "epoch" => epoch);
                 print_duties(&log, duties);


### PR DESCRIPTION
## Issue Addressed

Closes #356 

## Proposed Changes

- [x] Valid: Insert Attestations
- [x] Valid: Insert MaxAttestations + 1 Attestations
- [x] Invalid: BadParentCrossLinkStartEpoch
- [x] Invalid: BadParentCrossLinkEndEpoch
- [x] Invalid: NoCommitteeForShard
- [x] Invalid: BadParentCrossLinkDataRoot
- [x] Invalid: BadTargetTooLow
- [x] Invalid: BadTargetTooHigh
- [x] Invalid: WrongJustifiedCheckpoint
- [x] Invalid: BadIndexedAttestation(BadSignature)
- [x] Invalid: BadShard
- [x] Invalid: IncludedTooEarly
- [ ] Invalid: IncludedTooLate
- [ ] Invalid: BadTargetEpoch
- [x] Invalid: CustodyBitfieldHasSetBits
- [x] Invalid: BadCustodyBitfieldLength (see additional info)
- [x] Invalid: BadAggregationBitfieldLength (see additional info)
- [x] Invalid: CustodyBitfieldNotSubset
- [x] Invalid: BadSignature

## Additional Info

- BadCustodyBitfieldLength is not called in the code, I nevertheless added a test `invalid_attestation_bad_custody_bitfield_len` (the error returned is `BeaconStateError::InvalidBitfield`)
- BadAggregationBitfieldLength is not called in the code, I nevertheless added a test `invalid_attestation_bad_aggregation_bitfield_len` (the error returned is `BeaconStateError::InvalidBitfield`)
- I've removed the `UnknownValidator` variant in the enum as it is never returned.