### PR TITLE
BlockProcessing - AttesterSlashing tests

### DIFF
--- a/beacon_node/network/src/message_handler.rs
+++ b/beacon_node/network/src/message_handler.rs
@@ -146,9 +146,15 @@ impl<T: BeaconChainTypes + 'static> MessageHandler<T> {
     ) {
         // an error could have occurred.
         match error_response {
-            RPCErrorResponse::InvalidRequest(error) => warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
-            RPCErrorResponse::ServerError(error) => warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string()),
-            RPCErrorResponse::Unknown(error) => warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string()),
+            RPCErrorResponse::InvalidRequest(error) => {
+                warn!(self.log, "Peer indicated invalid request";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
+            RPCErrorResponse::ServerError(error) => {
+                warn!(self.log, "Peer internal server error";"peer_id" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
+            RPCErrorResponse::Unknown(error) => {
+                warn!(self.log, "Unknown peer error";"peer" => format!("{:?}", peer_id), "error" => error.as_string())
+            }
             RPCErrorResponse::Success(response) => {
                 match response {
                     RPCResponse::Hello(hello_message) => {

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -1,5 +1,5 @@
 use tree_hash::SignedRoot;
-use types::test_utils::{TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
 use types::*;
 
 pub struct BlockProcessingBuilder<T: EthSpec> {
@@ -32,6 +32,8 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
 
     pub fn build_with_attester_slashing(
         mut self,
+        test_task: AttesterSlashingTestTask,
+        num_attester_slashings: u64,
         randao_sk: Option<SecretKey>,
         previous_block_root: Option<Hash256>,
         spec: &ChainSpec,
@@ -58,9 +60,15 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
             None => builder.set_randao_reveal(&keypair.sk, &state.fork, spec),
         }
 
-        let validator_indices = vec![0];
-        let secret_keys = vec![&keypairs[0].sk];
+        let mut validator_indices = vec![];
+        let mut secret_keys = vec![];
+        for i in 0..num_attester_slashings {
+            validator_indices.push(i);
+            secret_keys.push(&keypairs[i as usize].sk);
+        }
+
         self.block_builder.insert_attester_slashing(
+            test_task,
             &validator_indices,
             &secret_keys,
             &state.fork,

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -1,5 +1,7 @@
 use tree_hash::SignedRoot;
-use types::test_utils::{AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{
+    AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder,
+};
 use types::*;
 
 pub struct BlockProcessingBuilder<T: EthSpec> {

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -34,7 +34,7 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
 
     pub fn build_with_attester_slashing(
         mut self,
-        test_task: AttesterSlashingTestTask,
+        test_task: &AttesterSlashingTestTask,
         num_attester_slashings: u64,
         randao_sk: Option<SecretKey>,
         previous_block_root: Option<Hash256>,
@@ -69,13 +69,15 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
             secret_keys.push(&keypairs[i as usize].sk);
         }
 
-        self.block_builder.insert_attester_slashing(
-            test_task,
-            &validator_indices,
-            &secret_keys,
-            &state.fork,
-            spec,
-        );
+        for _ in 0..num_attester_slashings {
+            self.block_builder.insert_attester_slashing(
+                test_task,
+                &validator_indices,
+                &secret_keys,
+                &state.fork,
+                spec,
+            );
+        }
         let block = self.block_builder.build(&keypair.sk, &state.fork, spec);
 
         (block, state)

--- a/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
+++ b/eth2/state_processing/src/per_block_processing/block_processing_builder.rs
@@ -30,6 +30,47 @@ impl<T: EthSpec> BlockProcessingBuilder<T> {
         self.state_builder.build_caches(&spec).unwrap();
     }
 
+    pub fn build_with_attester_slashing(
+        mut self,
+        randao_sk: Option<SecretKey>,
+        previous_block_root: Option<Hash256>,
+        spec: &ChainSpec,
+    ) -> (BeaconBlock<T>, BeaconState<T>) {
+        let (state, keypairs) = self.state_builder.build();
+        let builder = &mut self.block_builder;
+
+        builder.set_slot(state.slot);
+
+        match previous_block_root {
+            Some(root) => builder.set_parent_root(root),
+            None => builder.set_parent_root(Hash256::from_slice(
+                &state.latest_block_header.signed_root(),
+            )),
+        }
+
+        let proposer_index = state
+            .get_beacon_proposer_index(state.slot, RelativeEpoch::Current, spec)
+            .unwrap();
+        let keypair = &keypairs[proposer_index];
+
+        match randao_sk {
+            Some(sk) => builder.set_randao_reveal(&sk, &state.fork, spec),
+            None => builder.set_randao_reveal(&keypair.sk, &state.fork, spec),
+        }
+
+        let validator_indices = vec![0];
+        let secret_keys = vec![&keypairs[0].sk];
+        self.block_builder.insert_attester_slashing(
+            &validator_indices,
+            &secret_keys,
+            &state.fork,
+            spec,
+        );
+        let block = self.block_builder.build(&keypair.sk, &state.fork, spec);
+
+        (block, state)
+    }
+
     pub fn build(
         mut self,
         randao_sk: Option<SecretKey>,

--- a/eth2/state_processing/src/per_block_processing/errors.rs
+++ b/eth2/state_processing/src/per_block_processing/errors.rs
@@ -190,8 +190,6 @@ pub enum ProposerSlashingInvalid {
 
 #[derive(Debug, PartialEq)]
 pub enum AttesterSlashingInvalid {
-    /// The attestation data is identical, an attestation cannot conflict with itself.
-    AttestationDataIdentical,
     /// The attestations were not in conflict.
     NotSlashable,
     /// The first `IndexedAttestation` was invalid.

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -136,7 +136,7 @@ fn valid_insert_attester_slashing() {
     let test_task = AttesterSlashingTestTask::Valid;
     let num_attester_slashings = 1;
     let (block, mut state) =
-        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+        builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -156,7 +156,7 @@ fn valid_insert_max_attester_slashings_plus_one() {
     let test_task = AttesterSlashingTestTask::Valid;
     let num_attester_slashings = <MainnetEthSpec as EthSpec>::MaxAttesterSlashings::to_u64() + 1;
     let (block, mut state) =
-        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+        builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -176,7 +176,7 @@ fn invalid_attester_slashing_not_slashable() {
     let test_task = AttesterSlashingTestTask::NotSlashable;
     let num_attester_slashings = 1;
     let (block, mut state) =
-        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+        builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -4,8 +4,8 @@ use super::block_processing_builder::BlockProcessingBuilder;
 use super::errors::*;
 use crate::{per_block_processing, BlockSignatureStrategy};
 use tree_hash::SignedRoot;
-use types::*;
 use types::test_utils::AttesterSlashingTestTask;
+use types::*;
 
 pub const VALIDATOR_COUNT: usize = 10;
 
@@ -135,7 +135,8 @@ fn valid_insert_attester_slashing() {
     let builder = get_builder(&spec);
     let test_task = AttesterSlashingTestTask::Valid;
     let num_attester_slashings = 1;
-    let (block, mut state) = builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -154,7 +155,8 @@ fn valid_insert_max_attester_slashings_plus_one() {
     let builder = get_builder(&spec);
     let test_task = AttesterSlashingTestTask::Valid;
     let num_attester_slashings = <MainnetEthSpec as EthSpec>::MaxAttesterSlashings::to_u64() + 1;
-    let (block, mut state) = builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,
@@ -167,14 +169,14 @@ fn valid_insert_max_attester_slashings_plus_one() {
     assert_eq!(result, Ok(()));
 }
 
-
 #[test]
 fn invalid_attester_slashing_not_slashable() {
     let spec = MainnetEthSpec::default_spec();
     let builder = get_builder(&spec);
     let test_task = AttesterSlashingTestTask::NotSlashable;
     let num_attester_slashings = 1;
-    let (block, mut state) = builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
+    let (block, mut state) =
+        builder.build_with_attester_slashing(test_task, num_attester_slashings, None, None, &spec);
 
     let result = per_block_processing(
         &mut state,

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -128,6 +128,23 @@ fn invalid_randao_reveal_signature() {
     assert_eq!(result, Err(BlockProcessingError::RandaoSignatureInvalid));
 }
 
+#[test]
+fn valid_attester_slashing() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let (block, mut state) = builder.build_with_attester_slashing(None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    assert_eq!(result, Ok(()));
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -146,6 +146,7 @@ fn valid_insert_attester_slashing() {
         &spec,
     );
 
+    // Expecting Ok(()) because attester slashing is valid
     assert_eq!(result, Ok(()));
 }
 
@@ -158,6 +159,7 @@ fn valid_insert_max_attester_slashings_plus_one() {
     let (block, mut state) =
         builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
 
+    // Expecting Ok(()) because attester slashings are valid
     let result = per_block_processing(
         &mut state,
         &block,
@@ -186,6 +188,7 @@ fn invalid_attester_slashing_not_slashable() {
         &spec,
     );
 
+    // Expecting NotSlashable because the two attestations are the same
     assert_eq!(
         result,
         Err(BlockProcessingError::AttesterSlashingInvalid {
@@ -212,6 +215,7 @@ fn invalid_attester_slashing_1_invalid() {
         &spec,
     );
 
+    // Expecting IndexedAttestation1Invalid or IndexedAttestationInvalid because Attestation1 has CustodyBitfield bits set.
     assert!(
         result
             == Err(BlockProcessingError::IndexedAttestationInvalid {
@@ -247,6 +251,7 @@ fn invalid_attester_slashing_2_invalid() {
         &spec,
     );
 
+    // Expecting IndexedAttestation2Invalid or IndexedAttestationInvalid because Attestation2 has CustodyBitfield bits set.
     assert!(
         result
             == Err(BlockProcessingError::IndexedAttestationInvalid {

--- a/eth2/state_processing/src/per_block_processing/tests.rs
+++ b/eth2/state_processing/src/per_block_processing/tests.rs
@@ -195,6 +195,76 @@ fn invalid_attester_slashing_not_slashable() {
     );
 }
 
+#[test]
+fn invalid_attester_slashing_1_invalid() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttesterSlashingTestTask::IndexedAttestation1Invalid;
+    let num_attester_slashings = 1;
+    let (block, mut state) =
+        builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    assert!(
+        result
+            == Err(BlockProcessingError::IndexedAttestationInvalid {
+                index: 0,
+                reason: IndexedAttestationInvalid::CustodyBitfieldHasSetBits
+            })
+            || result
+                == Err(BlockProcessingError::AttesterSlashingInvalid {
+                    index: 0,
+                    reason: AttesterSlashingInvalid::IndexedAttestation1Invalid(
+                        BlockOperationError::Invalid(
+                            IndexedAttestationInvalid::CustodyBitfieldHasSetBits
+                        )
+                    )
+                })
+    );
+}
+
+#[test]
+fn invalid_attester_slashing_2_invalid() {
+    let spec = MainnetEthSpec::default_spec();
+    let builder = get_builder(&spec);
+    let test_task = AttesterSlashingTestTask::IndexedAttestation2Invalid;
+    let num_attester_slashings = 1;
+    let (block, mut state) =
+        builder.build_with_attester_slashing(&test_task, num_attester_slashings, None, None, &spec);
+
+    let result = per_block_processing(
+        &mut state,
+        &block,
+        None,
+        BlockSignatureStrategy::VerifyIndividual,
+        &spec,
+    );
+
+    assert!(
+        result
+            == Err(BlockProcessingError::IndexedAttestationInvalid {
+                index: 1,
+                reason: IndexedAttestationInvalid::CustodyBitfieldHasSetBits
+            })
+            || result
+                == Err(BlockProcessingError::AttesterSlashingInvalid {
+                    index: 1,
+                    reason: AttesterSlashingInvalid::IndexedAttestation2Invalid(
+                        BlockOperationError::Invalid(
+                            IndexedAttestationInvalid::CustodyBitfieldHasSetBits
+                        )
+                    )
+                })
+    );
+}
+
 fn get_builder(spec: &ChainSpec) -> (BlockProcessingBuilder<MainnetEthSpec>) {
     let mut builder = BlockProcessingBuilder::new(VALIDATOR_COUNT, &spec);
 

--- a/eth2/state_processing/src/test_utils.rs
+++ b/eth2/state_processing/src/test_utils.rs
@@ -1,5 +1,7 @@
 use log::info;
-use types::test_utils::{AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{
+    AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder,
+};
 use types::{EthSpec, *};
 
 pub struct BlockBuilder<T: EthSpec> {
@@ -102,7 +104,13 @@ impl<T: EthSpec> BlockBuilder<T> {
                 secret_keys.push(&keypairs[validator_index as usize].sk);
             }
 
-            builder.insert_attester_slashing(AttesterSlashingTestTask::Valid, &attesters, &secret_keys, &state.fork, spec);
+            builder.insert_attester_slashing(
+                AttesterSlashingTestTask::Valid,
+                &attesters,
+                &secret_keys,
+                &state.fork,
+                spec,
+            );
         }
         info!(
             "Inserted {} attester slashings.",

--- a/eth2/state_processing/src/test_utils.rs
+++ b/eth2/state_processing/src/test_utils.rs
@@ -105,7 +105,7 @@ impl<T: EthSpec> BlockBuilder<T> {
             }
 
             builder.insert_attester_slashing(
-                AttesterSlashingTestTask::Valid,
+                &AttesterSlashingTestTask::Valid,
                 &attesters,
                 &secret_keys,
                 &state.fork,

--- a/eth2/state_processing/src/test_utils.rs
+++ b/eth2/state_processing/src/test_utils.rs
@@ -1,5 +1,5 @@
 use log::info;
-use types::test_utils::{TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
+use types::test_utils::{AttesterSlashingTestTask, TestingBeaconBlockBuilder, TestingBeaconStateBuilder};
 use types::{EthSpec, *};
 
 pub struct BlockBuilder<T: EthSpec> {
@@ -102,7 +102,7 @@ impl<T: EthSpec> BlockBuilder<T> {
                 secret_keys.push(&keypairs[validator_index as usize].sk);
             }
 
-            builder.insert_attester_slashing(&attesters, &secret_keys, &state.fork, spec);
+            builder.insert_attester_slashing(AttesterSlashingTestTask::Valid, &attesters, &secret_keys, &state.fork, spec);
         }
         info!(
             "Inserted {} attester slashings.",

--- a/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
@@ -64,14 +64,24 @@ impl TestingAttesterSlashingBuilder {
 
         let mut attestation_1 = IndexedAttestation {
             custody_bit_0_indices: validator_indices.to_vec().into(),
-            custody_bit_1_indices: VariableList::empty(),
+            custody_bit_1_indices: match test_task {
+                AttesterSlashingTestTask::IndexedAttestation1Invalid => {
+                    validator_indices.to_vec().into()
+                }
+                _ => VariableList::empty(),
+            },
             data: data_1,
             signature: AggregateSignature::new(),
         };
 
         let mut attestation_2 = IndexedAttestation {
             custody_bit_0_indices: validator_indices.to_vec().into(),
-            custody_bit_1_indices: VariableList::empty(),
+            custody_bit_1_indices: match test_task {
+                AttesterSlashingTestTask::IndexedAttestation2Invalid => {
+                    validator_indices.to_vec().into()
+                }
+                _ => VariableList::empty(),
+            },
             data: data_2,
             signature: AggregateSignature::new(),
         };

--- a/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use crate::test_utils::AttesterSlashingTestTask;
 use tree_hash::TreeHash;
 
 /// Builds an `AttesterSlashing`.
@@ -17,7 +18,7 @@ impl TestingAttesterSlashingBuilder {
     /// - `domain: Domain`
     ///
     /// Where domain is a domain "constant" (e.g., `spec.domain_attestation`).
-    pub fn double_vote<F, T: EthSpec>(validator_indices: &[u64], signer: F) -> AttesterSlashing<T>
+    pub fn double_vote<F, T: EthSpec>(test_task: AttesterSlashingTestTask, validator_indices: &[u64], signer: F) -> AttesterSlashing<T>
     where
         F: Fn(u64, &[u8], Epoch, Domain) -> Signature,
     {
@@ -49,9 +50,18 @@ impl TestingAttesterSlashingBuilder {
             crosslink,
         };
 
-        let data_2 = AttestationData {
-            target: checkpoint_2,
-            ..data_1.clone()
+        let data_2 = match test_task {
+            AttesterSlashingTestTask::NotSlashable => {
+                AttestationData {
+                    ..data_1.clone()
+                }
+            }
+            _ => {
+                AttestationData {
+                    target: checkpoint_2,
+                    ..data_1.clone()
+                }
+            }
         };
 
         let mut attestation_1 = IndexedAttestation {

--- a/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
@@ -54,21 +54,23 @@ impl TestingAttesterSlashingBuilder {
             crosslink,
         };
 
-        let data_2 = match test_task {
-            AttesterSlashingTestTask::NotSlashable => AttestationData { ..data_1.clone() },
-            _ => AttestationData {
+        let data_2 = if *test_task == AttesterSlashingTestTask::NotSlashable {
+            AttestationData { ..data_1.clone() }
+        } else {
+            AttestationData {
                 target: checkpoint_2,
                 ..data_1.clone()
-            },
+            }
         };
 
         let mut attestation_1 = IndexedAttestation {
             custody_bit_0_indices: validator_indices.to_vec().into(),
-            custody_bit_1_indices: match test_task {
-                AttesterSlashingTestTask::IndexedAttestation1Invalid => {
-                    validator_indices.to_vec().into()
-                }
-                _ => VariableList::empty(),
+            custody_bit_1_indices: if *test_task
+                == AttesterSlashingTestTask::IndexedAttestation1Invalid
+            {
+                validator_indices.to_vec().into()
+            } else {
+                VariableList::empty()
             },
             data: data_1,
             signature: AggregateSignature::new(),
@@ -76,11 +78,12 @@ impl TestingAttesterSlashingBuilder {
 
         let mut attestation_2 = IndexedAttestation {
             custody_bit_0_indices: validator_indices.to_vec().into(),
-            custody_bit_1_indices: match test_task {
-                AttesterSlashingTestTask::IndexedAttestation2Invalid => {
-                    validator_indices.to_vec().into()
-                }
-                _ => VariableList::empty(),
+            custody_bit_1_indices: if *test_task
+                == AttesterSlashingTestTask::IndexedAttestation2Invalid
+            {
+                validator_indices.to_vec().into()
+            } else {
+                VariableList::empty()
             },
             data: data_2,
             signature: AggregateSignature::new(),

--- a/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
@@ -19,7 +19,7 @@ impl TestingAttesterSlashingBuilder {
     ///
     /// Where domain is a domain "constant" (e.g., `spec.domain_attestation`).
     pub fn double_vote<F, T: EthSpec>(
-        test_task: AttesterSlashingTestTask,
+        test_task: &AttesterSlashingTestTask,
         validator_indices: &[u64],
         signer: F,
     ) -> AttesterSlashing<T>

--- a/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_attester_slashing_builder.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use crate::test_utils::AttesterSlashingTestTask;
+use crate::*;
 use tree_hash::TreeHash;
 
 /// Builds an `AttesterSlashing`.
@@ -18,7 +18,11 @@ impl TestingAttesterSlashingBuilder {
     /// - `domain: Domain`
     ///
     /// Where domain is a domain "constant" (e.g., `spec.domain_attestation`).
-    pub fn double_vote<F, T: EthSpec>(test_task: AttesterSlashingTestTask, validator_indices: &[u64], signer: F) -> AttesterSlashing<T>
+    pub fn double_vote<F, T: EthSpec>(
+        test_task: AttesterSlashingTestTask,
+        validator_indices: &[u64],
+        signer: F,
+    ) -> AttesterSlashing<T>
     where
         F: Fn(u64, &[u8], Epoch, Domain) -> Signature,
     {
@@ -51,17 +55,11 @@ impl TestingAttesterSlashingBuilder {
         };
 
         let data_2 = match test_task {
-            AttesterSlashingTestTask::NotSlashable => {
-                AttestationData {
-                    ..data_1.clone()
-                }
-            }
-            _ => {
-                AttestationData {
-                    target: checkpoint_2,
-                    ..data_1.clone()
-                }
-            }
+            AttesterSlashingTestTask::NotSlashable => AttestationData { ..data_1.clone() },
+            _ => AttestationData {
+                target: checkpoint_2,
+                ..data_1.clone()
+            },
         };
 
         let mut attestation_1 = IndexedAttestation {

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -89,8 +89,13 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
         fork: &Fork,
         spec: &ChainSpec,
     ) {
-        let attester_slashing =
-            build_double_vote_attester_slashing(test_task, validator_indices, secret_keys, fork, spec);
+        let attester_slashing = build_double_vote_attester_slashing(
+            test_task,
+            validator_indices,
+            secret_keys,
+            fork,
+            spec,
+        );
         self.block
             .body
             .attester_slashings

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -15,6 +15,7 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
     pub block: BeaconBlock<T>,
 }
 
+#[derive(PartialEq)]
 pub enum AttesterSlashingTestTask {
     Valid,
     NotSlashable,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -83,7 +83,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
     /// Inserts a signed, valid `AttesterSlashing` for each validator index in `validator_indices`.
     pub fn insert_attester_slashing(
         &mut self,
-        test_task: AttesterSlashingTestTask,
+        test_task: &AttesterSlashingTestTask,
         validator_indices: &[u64],
         secret_keys: &[&SecretKey],
         fork: &Fork,
@@ -96,11 +96,7 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
             fork,
             spec,
         );
-        self.block
-            .body
-            .attester_slashings
-            .push(attester_slashing)
-            .unwrap();
+        let _ = self.block.body.attester_slashings.push(attester_slashing);
     }
 
     /// Fills the block with `num_attestations` attestations.
@@ -308,7 +304,7 @@ fn build_proposer_slashing<T: EthSpec>(
 ///
 /// Signs the message using a `BeaconChainHarness`.
 fn build_double_vote_attester_slashing<T: EthSpec>(
-    test_task: AttesterSlashingTestTask,
+    test_task: &AttesterSlashingTestTask,
     validator_indices: &[u64],
     secret_keys: &[&SecretKey],
     fork: &Fork,

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -15,6 +15,11 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
     pub block: BeaconBlock<T>,
 }
 
+pub enum AttesterSlashingTestTask {
+    Valid,
+    NotSlashable,
+}
+
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
     /// Create a new builder from genesis.
     pub fn new(spec: &ChainSpec) -> Self {
@@ -78,13 +83,14 @@ impl<T: EthSpec> TestingBeaconBlockBuilder<T> {
     /// Inserts a signed, valid `AttesterSlashing` for each validator index in `validator_indices`.
     pub fn insert_attester_slashing(
         &mut self,
+        test_task: AttesterSlashingTestTask,
         validator_indices: &[u64],
         secret_keys: &[&SecretKey],
         fork: &Fork,
         spec: &ChainSpec,
     ) {
         let attester_slashing =
-            build_double_vote_attester_slashing(validator_indices, secret_keys, fork, spec);
+            build_double_vote_attester_slashing(test_task, validator_indices, secret_keys, fork, spec);
         self.block
             .body
             .attester_slashings
@@ -297,6 +303,7 @@ fn build_proposer_slashing<T: EthSpec>(
 ///
 /// Signs the message using a `BeaconChainHarness`.
 fn build_double_vote_attester_slashing<T: EthSpec>(
+    test_task: AttesterSlashingTestTask,
     validator_indices: &[u64],
     secret_keys: &[&SecretKey],
     fork: &Fork,
@@ -311,5 +318,5 @@ fn build_double_vote_attester_slashing<T: EthSpec>(
         Signature::new(message, domain, secret_keys[key_index])
     };
 
-    TestingAttesterSlashingBuilder::double_vote(validator_indices, signer)
+    TestingAttesterSlashingBuilder::double_vote(test_task, validator_indices, signer)
 }

--- a/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_block_builder.rs
@@ -18,6 +18,8 @@ pub struct TestingBeaconBlockBuilder<T: EthSpec> {
 pub enum AttesterSlashingTestTask {
     Valid,
     NotSlashable,
+    IndexedAttestation1Invalid,
+    IndexedAttestation2Invalid,
 }
 
 impl<T: EthSpec> TestingBeaconBlockBuilder<T> {

--- a/validator_client/src/attestation_producer/mod.rs
+++ b/validator_client/src/attestation_producer/mod.rs
@@ -57,11 +57,21 @@ impl<'a, B: BeaconNodeAttestation, S: Signer, E: EthSpec> AttestationProducer<'a
                 "slot" => slot,
             ),
             Err(e) => error!(log, "Attestation production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string()),
-            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string()),
-            Ok(ValidatorEvent::PublishAttestationFailed) => error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string()),
-            Ok(ValidatorEvent::InvalidAttestation) => error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string()),
-            Ok(v) => warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v)),
+            Ok(ValidatorEvent::SignerRejection(_slot)) => {
+                error!(log, "Attestation production error"; "Error" => "Signer could not sign the attestation".to_string())
+            }
+            Ok(ValidatorEvent::IndexedAttestationNotProduced(_slot)) => {
+                error!(log, "Attestation production error"; "Error" => "Rejected the attestation as it could have been slashed".to_string())
+            }
+            Ok(ValidatorEvent::PublishAttestationFailed) => {
+                error!(log, "Attestation production error"; "Error" => "Beacon node was unable to publish an attestation".to_string())
+            }
+            Ok(ValidatorEvent::InvalidAttestation) => {
+                error!(log, "Attestation production error"; "Error" => "The signed attestation was invalid".to_string())
+            }
+            Ok(v) => {
+                warn!(log, "Unknown result for attestation production"; "Error" => format!("{:?}",v))
+            }
         }
     }
 

--- a/validator_client/src/block_producer/mod.rs
+++ b/validator_client/src/block_producer/mod.rs
@@ -68,10 +68,18 @@ impl<'a, B: BeaconNodeBlock, S: Signer, E: EthSpec> BlockProducer<'a, B, S, E> {
                 "slot" => slot,
             ),
             Err(e) => error!(self.log, "Block production error"; "Error" => format!("{:?}", e)),
-            Ok(ValidatorEvent::SignerRejection(_slot)) => error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string()),
-            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string()),
-            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string()),
-            Ok(v) => warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v)),
+            Ok(ValidatorEvent::SignerRejection(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Signer Could not sign the block".to_string())
+            }
+            Ok(ValidatorEvent::SlashableBlockNotProduced(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Rejected the block as it could have been slashed".to_string())
+            }
+            Ok(ValidatorEvent::BeaconNodeUnableToProduceBlock(_slot)) => {
+                error!(self.log, "Block production error"; "Error" => "Beacon node was unable to produce a block".to_string())
+            }
+            Ok(v) => {
+                warn!(self.log, "Unknown result for block production"; "Error" => format!("{:?}",v))
+            }
         }
     }
 

--- a/validator_client/src/duties/mod.rs
+++ b/validator_client/src/duties/mod.rs
@@ -77,8 +77,12 @@ impl<U: BeaconNodeDuties, S: Signer + Display> DutiesManager<U, S> {
     pub fn run_update(&self, epoch: Epoch, log: slog::Logger) -> Result<Async<()>, ()> {
         match self.update(epoch) {
             Err(error) => error!(log, "Epoch duties poll error"; "error" => format!("{:?}", error)),
-            Ok(UpdateOutcome::NoChange(epoch)) => debug!(log, "No change in duties"; "epoch" => epoch),
-            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties)),
+            Ok(UpdateOutcome::NoChange(epoch)) => {
+                debug!(log, "No change in duties"; "epoch" => epoch)
+            }
+            Ok(UpdateOutcome::DutiesChanged(epoch, duties)) => {
+                info!(log, "Duties changed (potential re-org)"; "epoch" => epoch, "duties" => format!("{:?}", duties))
+            }
             Ok(UpdateOutcome::NewDuties(epoch, duties)) => {
                 info!(log, "New duties obtained"; "epoch" => epoch);
                 print_duties(&log, duties);


### PR DESCRIPTION
## Issue Addressed

Closes #355 

## Proposed Changes

- [x] Valid: Insert valid attester slashing 
- [x] Valid: Insert MaxAttesterSlashing plus one attester slashings
- [x] Invalid: NotSlashable
- [x] Invalid: IndexedAttestation1Invalid
- [x] Invalid: IndexedAttestation1Invalid

## Additional Info

- Removed `AttestationDataIdentical` enum variant as it was never called in the code.