### PR TITLE
Groups beacon node dependencies into single crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 	"eth2/utils/tree_hash_derive",
     "eth2/utils/test_random_derive",
 	"beacon_node",
+	"beacon_node/common",
 	"beacon_node/store",
 	"beacon_node/client",
 	"beacon_node/rest_api",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -12,16 +12,6 @@ types = { path = "../eth2/types" }
 store = { path = "./store" }
 client = { path = "client" }
 version = { path = "version" }
-clap = "2.32.0"
-rand = "0.7"
-slog = { version = "^2.2.3" , features = ["max_level_trace", "release_max_level_trace"] }
-slog-term = "^2.4.0"
-slog-async = "^2.3.0"
-ctrlc = { version = "3.1.1", features = ["termination"] }
-tokio = "0.1.15"
-tokio-timer = "0.2.10"
-futures = "0.1.25"
-exit-future = "0.1.3"
-env_logger = "0.6.1"
-dirs = "2.0.1"
 logging = { path = "../eth2/utils/logging" }
+common = { path = "common" }
+env_logger = "0.6.1"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -12,27 +12,22 @@ write_ssz_files = []  # Writes debugging .ssz files to /tmp during block process
 eth2_config = { path = "../../eth2/utils/eth2_config" }
 merkle_proof = { path = "../../eth2/utils/merkle_proof" }
 store = { path = "../store" }
-parking_lot = "0.7"
-lazy_static = "1.3.0"
 lighthouse_metrics = { path = "../../eth2/utils/lighthouse_metrics" }
 lighthouse_bootstrap = { path = "../../eth2/utils/lighthouse_bootstrap" }
-log = "0.4"
+types = { path = "../../eth2/types" }
+lmd_ghost = { path = "../../eth2/lmd_ghost" }
 operation_pool = { path = "../../eth2/operation_pool" }
-rayon = "1.0"
-serde = "1.0"
-serde_derive = "1.0"
-serde_yaml = "0.8"
-serde_json = "^1.0"
-slog = { version = "^2.2.3" , features = ["max_level_trace"] }
-sloggers = { version = "^0.3" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
 eth2_hashing = { path = "../../eth2/utils/eth2_hashing" }
 eth2_ssz = "0.1"
 eth2_ssz_derive = "0.1"
 state_processing = { path = "../../eth2/state_processing" }
+common = { path = "../common" }
 tree_hash = "0.1"
-types = { path = "../../eth2/types" }
-lmd_ghost = { path = "../../eth2/lmd_ghost" }
+lazy_static = "1.3.0"
+log = "0.4"
+rayon = "1.0"
+serde = "1.0"
 
 [dev-dependencies]
 rand = "0.5.5"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1,3 +1,6 @@
+use common::parking_lot;
+use common::slog;
+
 use crate::checkpoint::CheckPoint;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::eth1_chain::{Eth1Chain, Eth1ChainBackend};

--- a/beacon_node/beacon_chain/src/beacon_chain_builder.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain_builder.rs
@@ -1,3 +1,7 @@
+use common::slog;
+use common::serde_json;
+use common::serde_yaml;
+
 use crate::{BeaconChain, BeaconChainTypes};
 use eth2_hashing::hash;
 use lighthouse_bootstrap::Bootstrapper;

--- a/beacon_node/beacon_chain/src/checkpoint.rs
+++ b/beacon_node/beacon_chain/src/checkpoint.rs
@@ -1,3 +1,5 @@
+use common::serde_derive;
+
 use serde_derive::Serialize;
 use ssz_derive::{Decode, Encode};
 use types::{BeaconBlock, BeaconState, EthSpec, Hash256};

--- a/beacon_node/beacon_chain/src/events.rs
+++ b/beacon_node/beacon_chain/src/events.rs
@@ -1,3 +1,5 @@
+use common::serde_derive;
+
 use serde_derive::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use types::{Attestation, BeaconBlock, Epoch, EthSpec, Hash256};

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -23,7 +23,6 @@ pub use beacon_chain_builder::BeaconChainBuilder;
 pub use eth1_chain::{Eth1ChainBackend, InteropEth1ChainBackend};
 pub use lmd_ghost;
 pub use metrics::scrape_for_metrics;
-pub use parking_lot;
 pub use slot_clock;
 pub use state_processing::per_block_processing::errors::{
     AttestationValidationError, AttesterSlashingValidationError, DepositValidationError,

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1,3 +1,5 @@
+use common::sloggers;
+
 use crate::{
     events::NullEventHandler, AttestationProcessingOutcome, BeaconChain, BeaconChainBuilder,
     BeaconChainTypes, BlockProcessingOutcome, InteropEth1ChainBackend,

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -12,22 +12,9 @@ eth2-libp2p = { path = "../eth2-libp2p" }
 rpc = { path = "../rpc" }
 rest_api = { path = "../rest_api" }
 websocket_server = { path = "../websocket_server" }
-prometheus = "^0.6"
 types = { path = "../../eth2/types" }
 tree_hash = "0.1"
 eth2_config = { path = "../../eth2/utils/eth2_config" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
-serde = "1.0.93"
-serde_derive = "1.0"
-error-chain = "0.12.0"
-serde_yaml = "0.8"
-slog = { version = "^2.2.3" , features = ["max_level_trace"] }
-slog-async = "^2.3.0"
-slog-json = "^2.3"
-tokio = "0.1.15"
-clap = "2.32.0"
-dirs = "1.0.3"
-exit-future = "0.1.3"
-futures = "0.1.25"
-reqwest = "0.9"
-url = "1.2"
+common = { path = "../common" }
+serde = "1.0"

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -1,3 +1,10 @@
+use common::clap;
+use common::slog;
+use common::slog_json;
+use common::slog_async;
+use common::serde_derive;
+use common::dirs;
+
 use clap::ArgMatches;
 use network::NetworkConfig;
 use serde_derive::{Deserialize, Serialize};

--- a/beacon_node/client/src/error.rs
+++ b/beacon_node/client/src/error.rs
@@ -1,6 +1,6 @@
 use network;
 
-use error_chain::error_chain;
+use common::error_chain::error_chain;
 
 error_chain! {
    links  {

--- a/beacon_node/client/src/lib.rs
+++ b/beacon_node/client/src/lib.rs
@@ -1,7 +1,9 @@
-extern crate slog;
+use common::tokio;
+use common::exit_future;
+use common::slog;
+use common::futures;
 
 mod config;
-
 pub mod error;
 pub mod notifier;
 

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -1,3 +1,8 @@
+use common::exit_future;
+use common::slog;
+use common::tokio;
+use common::futures;
+
 use crate::Client;
 use exit_future::Exit;
 use futures::{Future, Stream};

--- a/beacon_node/common/Cargo.toml
+++ b/beacon_node/common/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "common"
+version = "0.1.0"
+authors = ["Age Manning <Age@AgeManning.com>"]
+edition = "2018"
+
+[dependencies]
+bytes = "0.4.12"
+dirs = "2.0.1"
+clap = "2.32.0"
+ctrlc = { version = "3.1.1", features = ["termination"] }
+error-chain = "0.12.0"
+exit-future = "0.1.3"
+fnv = "1.0.6"
+futures = "0.1.25"
+hex = "0.3"
+rand = "0.7"
+parking_lot = "0.7"
+serde_derive = "1.0"
+serde_yaml = "0.8"
+serde_json = "^1.0"
+slog = { version = "^2.4.1" , features = ["max_level_trace"] }
+smallvec = "0.6.10"
+slog-async = "^2.3.0"
+slog-json = "^2.3"
+slog-term = "2.4.1"
+sloggers = { version = "^0.3" }
+tokio = "0.1.16"
+tokio-timer = "0.2.10"
+tokio-io-timeout = "0.3.1"
+tokio-io = "0.1.12"
+url = "1.2"

--- a/beacon_node/common/src/lib.rs
+++ b/beacon_node/common/src/lib.rs
@@ -1,0 +1,27 @@
+
+pub extern crate tokio;
+
+pub extern crate tokio_timer;
+pub extern crate tokio_io_timeout;
+pub extern crate tokio_io;
+
+pub extern crate clap;
+pub extern crate ctrlc;
+pub extern crate dirs;
+pub extern crate error_chain;
+pub extern crate exit_future;
+pub extern crate futures;
+pub extern crate fnv;
+pub extern crate hex;
+pub extern crate parking_lot;
+pub extern crate rand;
+pub extern crate serde_derive;
+pub extern crate serde_json;
+pub extern crate serde_yaml;
+pub extern crate slog;
+pub extern crate slog_term;
+pub extern crate slog_json;
+pub extern crate slog_async;
+pub extern crate sloggers;
+pub extern crate smallvec;
+

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -5,28 +5,15 @@ authors = ["Age Manning <Age@AgeManning.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.32.0"
-hex = "0.3"
 #SigP repository 
 libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "8ac9c744197faaadc0e2b64fed7470ac4e2a41ca" }
 enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "8ac9c744197faaadc0e2b64fed7470ac4e2a41ca", features = ["serde"] }
 types = { path =  "../../eth2/types" }
-serde = "1.0"
-serde_derive = "1.0"
+version = { path = "../version" }
 eth2_ssz = "0.1"
 eth2_ssz_derive = "0.1"
-slog = { version = "^2.4.1" , features = ["max_level_trace"] }
-version = { path = "../version" }
-tokio = "0.1.16"
-futures = "0.1.25"
-error-chain = "0.12.0"
-tokio-timer = "0.2.10"
-dirs = "2.0.1"
-tokio-io = "0.1.12"
-smallvec = "0.6.10"
-fnv = "1.0.6"
-unsigned-varint = "0.2.2"
-bytes = "0.4.12"
-tokio-io-timeout = "0.3.1"
-lazy_static = "1.3.0"
 lighthouse_metrics = { path = "../../eth2/utils/lighthouse_metrics" }
+unsigned-varint = "0.2.2"
+common = { path = "../common" }
+lazy_static = "1.3.0"
+serde = "1.0"

--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -1,3 +1,6 @@
+use common::futures;
+use common::slog;
+
 use crate::config::*;
 use crate::discovery::Discovery;
 use crate::rpc::{RPCEvent, RPCMessage, RPC};

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -1,3 +1,7 @@
+use common::clap;
+use common::dirs;
+use common::serde_derive;
+
 use clap::ArgMatches;
 use enr::Enr;
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder};

--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -1,10 +1,14 @@
+use common::tokio;
+use common::slog;
+use common::tokio_timer;
+
 use crate::metrics;
 use crate::{error, NetworkConfig};
 /// This manages the discovery and management of peers.
 ///
 /// Currently using discv5 for peer discovery.
 ///
-use futures::prelude::*;
+use tokio::prelude::*;
 use libp2p::core::{identity::Keypair, ConnectedPoint, Multiaddr, PeerId};
 use libp2p::discv5::{Discv5, Discv5Event};
 use libp2p::enr::{Enr, EnrBuilder, NodeId};
@@ -13,7 +17,6 @@ use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourAction, PollParameters, Pr
 use slog::{debug, info, warn};
 use std::collections::HashSet;
 use std::fs::File;
-use std::io::prelude::*;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::{Duration, Instant};

--- a/beacon_node/eth2-libp2p/src/error.rs
+++ b/beacon_node/eth2-libp2p/src/error.rs
@@ -1,5 +1,5 @@
 // generates error types
 
-use error_chain::error_chain;
+use common::error_chain::error_chain;
 
 error_chain! {}

--- a/beacon_node/eth2-libp2p/src/rpc/codec/base.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/base.rs
@@ -1,9 +1,9 @@
 //! This handles the various supported encoding mechanism for the Eth 2.0 RPC.
 
 use crate::rpc::{ErrorMessage, RPCErrorResponse, RPCRequest, RPCResponse};
-use bytes::BufMut;
-use bytes::BytesMut;
-use tokio::codec::{Decoder, Encoder};
+use libp2p::bytes::BufMut;
+use libp2p::bytes::BytesMut;
+use common::tokio::codec::{Decoder, Encoder};
 
 pub trait OutboundCodec: Encoder + Decoder {
     type ErrorType;

--- a/beacon_node/eth2-libp2p/src/rpc/codec/mod.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/mod.rs
@@ -5,8 +5,8 @@ use self::base::{BaseInboundCodec, BaseOutboundCodec};
 use self::ssz::{SSZInboundCodec, SSZOutboundCodec};
 use crate::rpc::protocol::RPCError;
 use crate::rpc::{RPCErrorResponse, RPCRequest};
-use bytes::BytesMut;
-use tokio::codec::{Decoder, Encoder};
+use libp2p::bytes::BytesMut;
+use common::tokio::codec::{Decoder, Encoder};
 
 // Known types of codecs
 pub enum InboundCodec {

--- a/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
@@ -4,9 +4,9 @@ use crate::rpc::{
     protocol::{ProtocolId, RPCError},
 };
 use crate::rpc::{ErrorMessage, RPCErrorResponse, RPCRequest, RPCResponse};
-use bytes::{BufMut, Bytes, BytesMut};
+use libp2p::bytes::{BufMut, Bytes, BytesMut};
 use ssz::{Decode, Encode};
-use tokio::codec::{Decoder, Encoder};
+use common::tokio::codec::{Decoder, Encoder};
 use unsigned_varint::codec::UviBytes;
 
 /* Inbound Codec */
@@ -141,7 +141,7 @@ impl Encoder for SSZOutboundCodec {
         };
         // length-prefix
         self.inner
-            .encode(bytes::Bytes::from(bytes), dst)
+            .encode(Bytes::from(bytes), dst)
             .map_err(RPCError::from)
     }
 }

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -3,15 +3,16 @@ use super::protocol::{RPCError, RPCProtocol, RPCRequest};
 use super::RPCEvent;
 use crate::rpc::protocol::{InboundFramed, OutboundFramed};
 use core::marker::PhantomData;
-use fnv::FnvHashMap;
-use futures::prelude::*;
+use common::fnv::FnvHashMap;
+use common::tokio::prelude::*;
+use common::futures::sink::Send;
 use libp2p::core::upgrade::{InboundUpgrade, OutboundUpgrade};
 use libp2p::swarm::protocols_handler::{
     KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,
 };
-use smallvec::SmallVec;
+use common::smallvec::SmallVec;
 use std::time::{Duration, Instant};
-use tokio_io::{AsyncRead, AsyncWrite};
+use common::tokio_io::{AsyncRead, AsyncWrite};
 
 /// The time (in seconds) before a substream that is awaiting a response from the user times out.
 pub const RESPONSE_TIMEOUT: u64 = 10;
@@ -73,7 +74,7 @@ where
 {
     /// A response has been sent, pending writing and flush.
     ResponsePendingSend {
-        substream: futures::sink::Send<InboundFramed<TSubstream>>,
+        substream: Send<InboundFramed<TSubstream>>,
     },
     /// A request has been sent, and we are awaiting a response. This future is driven in the
     /// handler because GOODBYE requests can be handled and responses dropped instantly.

--- a/beacon_node/eth2-libp2p/src/rpc/mod.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/mod.rs
@@ -4,7 +4,7 @@
 //! direct peer-to-peer communication primarily for sending/receiving chain information for
 //! syncing.
 
-use futures::prelude::*;
+use common::tokio::prelude::*;
 use handler::RPCHandler;
 use libp2p::core::ConnectedPoint;
 use libp2p::swarm::{
@@ -13,9 +13,10 @@ use libp2p::swarm::{
 use libp2p::{Multiaddr, PeerId};
 pub use methods::{ErrorMessage, HelloMessage, RPCErrorResponse, RPCResponse, RequestId};
 pub use protocol::{RPCError, RPCProtocol, RPCRequest};
-use slog::o;
+use common::slog::o;
+use common::slog;
 use std::marker::PhantomData;
-use tokio::io::{AsyncRead, AsyncWrite};
+use common::tokio::io::{AsyncRead, AsyncWrite};
 
 pub(crate) mod codec;
 mod handler;

--- a/beacon_node/eth2-libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/protocol.rs
@@ -1,3 +1,6 @@
+use common::tokio;
+use common::futures;
+
 use super::methods::*;
 use crate::rpc::codec::{
     base::{BaseInboundCodec, BaseOutboundCodec},
@@ -16,7 +19,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::prelude::*;
 use tokio::timer::timeout;
 use tokio::util::FutureExt;
-use tokio_io_timeout::TimeoutStream;
+use common::tokio_io_timeout::TimeoutStream;
 
 /// The maximum bytes that can be sent across the RPC.
 const MAX_RPC_SIZE: usize = 4_194_304; // 4M

--- a/beacon_node/eth2-libp2p/src/service.rs
+++ b/beacon_node/eth2-libp2p/src/service.rs
@@ -1,3 +1,8 @@
+use common::futures;
+use common::tokio;
+use common::slog;
+use common::hex;
+
 use crate::behaviour::{Behaviour, BehaviourEvent, PubsubMessage};
 use crate::config::*;
 use crate::error;
@@ -5,7 +10,7 @@ use crate::multiaddr::Protocol;
 use crate::rpc::RPCEvent;
 use crate::NetworkConfig;
 use crate::{Topic, TopicHash};
-use futures::prelude::*;
+use tokio::prelude::*;
 use futures::Stream;
 use libp2p::core::{
     identity::Keypair,
@@ -18,7 +23,6 @@ use libp2p::core::{
 use libp2p::{core, secio, PeerId, Swarm, Transport};
 use slog::{crit, debug, info, trace, warn};
 use std::fs::File;
-use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::time::Duration;
 

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -13,11 +13,6 @@ store =  { path = "../store" }
 eth2-libp2p =  { path = "../eth2-libp2p" }
 types = { path = "../../eth2/types" }
 slog = { version = "^2.2.3" , features = ["max_level_trace"] }
-hex = "0.3"
+common = { path = "../common" }
 eth2_ssz = "0.1"
 tree_hash = "0.1"
-futures = "0.1.25"
-error-chain = "0.12.0"
-tokio = "0.1.16"
-parking_lot = "0.9.0"
-smallvec = "0.6.10"

--- a/beacon_node/network/src/error.rs
+++ b/beacon_node/network/src/error.rs
@@ -1,7 +1,7 @@
 // generates error types
 use eth2_libp2p;
 
-use error_chain::error_chain;
+use common::error_chain::error_chain;
 
 error_chain! {
    links  {

--- a/beacon_node/network/src/message_handler.rs
+++ b/beacon_node/network/src/message_handler.rs
@@ -1,3 +1,7 @@
+use common::futures;
+use common::slog;
+use common::tokio;
+
 use crate::error;
 use crate::service::NetworkMessage;
 use crate::sync::MessageProcessor;

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -1,3 +1,7 @@
+use common::futures;
+use common::tokio;
+use common::parking_lot;
+
 use crate::error;
 use crate::message_handler::{HandlerMessage, MessageHandler};
 use crate::NetworkConfig;
@@ -7,7 +11,7 @@ use eth2_libp2p::Service as LibP2PService;
 use eth2_libp2p::Topic;
 use eth2_libp2p::{Enr, Libp2pEvent, Multiaddr, PeerId, Swarm};
 use eth2_libp2p::{PubsubMessage, RPCEvent};
-use futures::prelude::*;
+use tokio::prelude::*;
 use futures::Stream;
 use parking_lot::Mutex;
 use slog::{debug, info, o, trace};

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -52,13 +52,16 @@
 //! queued for lookup. A round-robin approach is used to request the parent from the known list of
 //! fully sync'd peers. If `PARENT_FAIL_TOLERANCE` attempts at requesting the block fails, we
 //! drop the propagated block and downvote the peer that sent it to us.
+use common::tokio;
+use common::smallvec;
+use common::slog;
 
 use super::simple_sync::{hello_message, NetworkContext, PeerSyncInfo, FUTURE_SLOT_TOLERANCE};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessingOutcome};
 use eth2_libp2p::rpc::methods::*;
 use eth2_libp2p::rpc::{RPCRequest, RequestId};
 use eth2_libp2p::PeerId;
-use futures::prelude::*;
+use tokio::prelude::*;
 use slog::{debug, info, trace, warn, Logger};
 use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};

--- a/beacon_node/network/src/sync/simple_sync.rs
+++ b/beacon_node/network/src/sync/simple_sync.rs
@@ -1,3 +1,7 @@
+use common::tokio;
+use common::slog;
+use common::hex;
+
 use super::manager::SyncMessage;
 use crate::service::NetworkMessage;
 use beacon_chain::{

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1,3 +1,9 @@
+use common::clap;
+use common::rand;
+use common::slog;
+use common::dirs;
+
+
 use clap::ArgMatches;
 use client::{BeaconChainStartMethod, ClientConfig, Eth1BackendMethod, Eth2Config};
 use eth2_config::{read_from_file, write_to_file};

--- a/beacon_node/src/main.rs
+++ b/beacon_node/src/main.rs
@@ -1,3 +1,8 @@
+use common::clap;
+use common::slog;
+use common::slog_term;
+use common::slog_async;
+
 mod config;
 mod run;
 

--- a/beacon_node/src/run.rs
+++ b/beacon_node/src/run.rs
@@ -1,3 +1,10 @@
+use common::tokio;
+use common::tokio_timer;
+use common::futures;
+use common::slog;
+use common::exit_future;
+use common::ctrlc;
+
 use client::{error, notifier, Client, ClientConfig, Eth1BackendMethod, Eth2Config};
 use futures::sync::oneshot;
 use futures::Future;
@@ -7,9 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use store::Store;
 use store::{DiskStore, MemoryStore};
-use tokio::runtime::Builder;
-use tokio::runtime::Runtime;
-use tokio::runtime::TaskExecutor;
+use tokio::runtime::{Builder, Runtime, TaskExecutor};
 use tokio_timer::clock::Clock;
 use types::{EthSpec, InteropEthSpec, MainnetEthSpec, MinimalEthSpec};
 

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -17,4 +17,3 @@ simple_logger = "1.0"
 types = { path = "../eth2/types" }
 state_processing = { path = "../eth2/state_processing" }
 eth2_ssz = { path = "../eth2/utils/ssz" }
-regex = "1.3"

--- a/tests/ef_tests/Cargo.toml
+++ b/tests/ef_tests/Cargo.toml
@@ -26,4 +26,3 @@ tree_hash_derive = "0.2"
 state_processing = { path = "../../eth2/state_processing" }
 swap_or_not_shuffle = { path = "../../eth2/utils/swap_or_not_shuffle" }
 types = { path = "../../eth2/types" }
-walkdir = "2"

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -24,6 +24,8 @@ grpcio = { version = "0.4", default-features = false, features = ["protobuf-code
 protos = { path = "../protos" }
 slot_clock = { path = "../eth2/utils/slot_clock" }
 types = { path = "../eth2/types" }
+tokio = "0.1.22"
+tokio-timer = "0.2.10"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "^1.0"
@@ -31,11 +33,8 @@ slog = { version = "^2.2.3" , features = ["max_level_trace", "release_max_level_
 slog-async = "^2.3.0"
 slog-json = "^2.3"
 slog-term = "^2.4.0"
-tokio = "0.1.18"
-tokio-timer = "0.2.10"
 error-chain = "0.12.0"
 bincode = "^1.1.2"
-futures = "0.1.25"
 dirs = "2.0.1"
 logging = { path = "../eth2/utils/logging" }
 libc = "0.2"

--- a/validator_client/src/duties/mod.rs
+++ b/validator_client/src/duties/mod.rs
@@ -9,7 +9,7 @@ pub use self::beacon_node_duties::{BeaconNodeDuties, BeaconNodeDutiesError};
 use self::epoch_duties::{EpochDuties, EpochDutiesMapError};
 pub use self::epoch_duties::{EpochDutiesMap, WorkInfo};
 use super::signer::Signer;
-use futures::Async;
+use tokio::prelude::Async;
 use slog::{debug, error, info};
 use std::fmt::Display;
 use std::sync::Arc;


### PR DESCRIPTION
## Beacon Node Dependencies Clean

The `beacon_node` has a number of sub crates. Each pull their own external crates. Often we are pulling different versions of the same crate, and keeping track of all of these and their versions is a nightmare. 

I'm suggesting we group all the dependencies into a single crate, which we can use to control the version of all the dependent sub-crates and gives us a single source of truth for most of the external crates we are pulling.

### Cons
- The sub-crates will then depend on the grouping crate and as such may have dependencies on external packages that it otherwise wouldn't. I dont think this is too bad, because if we are compiling the sub-crates, we are doing it for dev work and we will likely have all the dependencies cached anyway, so costs little time.

### Pros
- All external crates are in one spot
- All the versions are consistent

I've updated a few of the sub-crates but not all of them, in case we decide we don't want to go down this path. If we decide this is a good idea, I'll finish the other crates. 
