### PR TITLE
Allow slot clock to work on genesis

### DIFF
--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -29,10 +29,10 @@ impl SlotClock for SystemTimeSlotClock {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
         let genesis = self.genesis_duration;
 
-        if now > genesis {
+        if now >= genesis {
             let since_genesis = now
                 .checked_sub(genesis)
-                .expect("Control flow ensures now is greater than genesis");
+                .expect("Control flow ensures now is greater than or equal to genesis");
             let slot =
                 Slot::from((since_genesis.as_millis() / self.slot_duration.as_millis()) as u64);
             Some(slot + self.genesis_slot)
@@ -50,7 +50,7 @@ impl SlotClock for SystemTimeSlotClock {
             genesis + slot * self.slot_duration
         };
 
-        if now > genesis {
+        if now >= genesis {
             Some(
                 slot_start(self.now()? + 1)
                     .checked_sub(now)

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -100,12 +100,12 @@ mod tests {
         let clock =
             SystemTimeSlotClock::new(genesis_slot, prior_genesis(500), Duration::from_secs(1));
         assert_eq!(clock.now(), Some(Slot::new(0)));
-        assert!(clock.duration_to_next_slot().unwrap() < Duration::from_millis(500));
+        assert!(clock.duration_to_next_slot().unwrap() <= Duration::from_millis(500));
 
         let clock =
             SystemTimeSlotClock::new(genesis_slot, prior_genesis(1_500), Duration::from_secs(1));
         assert_eq!(clock.now(), Some(Slot::new(1)));
-        assert!(clock.duration_to_next_slot().unwrap() < Duration::from_millis(500));
+        assert!(clock.duration_to_next_slot().unwrap() <= Duration::from_millis(500));
     }
 
     #[test]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Allows slot clock to return a slot when it is exactly genesis time.

Attempting to fix a test fail experienced by @pscott.
