### PR TITLE
Only run non-ef tests when executing make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,20 @@ release:
 # Runs the full workspace tests, without downloading any additional test
 # vectors.
 test:
-	cargo test --all --all-features --release
+	cargo test --all --all-features --release --exclude ef_tests
+
+
+# only run the ef-test vectors
+--run-ef-tests: 
+	cargo test --release --manifest-path=$(EF_TESTS)/Cargo.toml --features "ef_tests"
+
+test-ef: make-ef-tests --run-ef-tests
 
 # Runs the entire test suite, downloading test vectors if required.
-test-full: make-ef-tests test
+test-full: 
+	test
+	test-ef
+
 
 # Runs the makefile in the `ef_tests` repo.
 #

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,13 @@ test:
 
 
 # only run the ef-test vectors
---run-ef-tests: 
+run-ef-tests: 
 	cargo test --release --manifest-path=$(EF_TESTS)/Cargo.toml --features "ef_tests"
 
-test-ef: make-ef-tests --run-ef-tests
+test-ef: make-ef-tests run-ef-tests
 
 # Runs the entire test suite, downloading test vectors if required.
-test-full: 
-	test
-	test-ef
+test-full: test test-ef
 
 
 # Runs the makefile in the `ef_tests` repo.


### PR DESCRIPTION
## Issue Addressed

Fixes https://github.com/sigp/lighthouse/issues/578

## Proposed Changes

- Create separate `test-ef` task and execute the normal `test` and `test-ef` when running `test-full`
