### PR TITLE
Depend on sha2 in eth2_hashing for wasm32

### DIFF
--- a/eth2/utils/eth2_hashing/Cargo.toml
+++ b/eth2/utils/eth2_hashing/Cargo.toml
@@ -9,6 +9,9 @@ description = "Hashing primitives used in Ethereum 2.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ring = "0.16.9"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+sha2 = "0.8.0"
+
 [dev-dependencies]
 rustc-hex = "2.0.1"
 


### PR DESCRIPTION
## Issue Addressed

eth2_hashing won't compile for wasm32 targets.

## Proposed Changes

Add a dependency for wasm32 targets on the sha2 crate.
