### PR TITLE
Fix merkle_proof for eth2_hashing refactor

### DIFF
--- a/eth2/utils/merkle_proof/src/lib.rs
+++ b/eth2/utils/merkle_proof/src/lib.rs
@@ -124,7 +124,10 @@ impl MerkleTree {
                     // All other possibilities are invalid MerkleTrees
                     (_, _) => return Err(MerkleTreeError::Invalid),
                 };
-                *hash = hash_concat(left.hash(), right.hash());
+                hash.assign_from_slice(&hash_concat(
+                    left.hash().as_bytes(),
+                    right.hash().as_bytes(),
+                ));
             }
         }
 


### PR DESCRIPTION
My bad: I didn't account for the clash with #574 when merging #584. This should fix the broken build.
