### PR TITLE
Add testing for REST API

### DIFF
--- a/beacon_node/rest_api/Cargo.toml
+++ b/beacon_node/rest_api/Cargo.toml
@@ -24,7 +24,6 @@ state_processing = { path = "../../eth2/state_processing" }
 types = { path = "../../eth2/types" }
 clap = "2.32.0"
 http = "^0.1.17"
-prometheus = { version = "^0.6", features = ["process"] }
 hyper = "0.12.35"
 exit-future = "0.1.3"
 tokio = "0.1.17"
@@ -36,3 +35,8 @@ slot_clock = { path = "../../eth2/utils/slot_clock" }
 hex = "0.3.2"
 parking_lot = "0.9"
 futures = "0.1.25"
+
+[dev-dependencies]
+remote_beacon_node = { path = "../../eth2/utils/remote_beacon_node" }
+node_test_rig = { path = "../../tests/node_test_rig" }
+tree_hash = { path = "../../eth2/utils/tree_hash" }

--- a/beacon_node/rest_api/Cargo.toml
+++ b/beacon_node/rest_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rest_api"
 version = "0.1.0"
-authors = ["Luke Anderson <luke@lukeanderson.com.au>"]
+authors = ["Luke Anderson <luke@sigmaprime.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,28 +12,27 @@ network = { path = "../network" }
 eth2-libp2p = { path = "../eth2-libp2p" }
 store = { path = "../store" }
 version = { path = "../version" }
-serde = { version = "1.0.102", features = ["derive"] }
-serde_json = "1.0.41"
-serde_yaml = "0.8.11"
-slog = "2.5.2"
-slog-term = "2.4.2"
-slog-async = "2.3.0"
-eth2_ssz = "0.1.2"
-eth2_ssz_derive = "0.1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "^1.0"
+serde_yaml = "0.8"
+slog = "^2.2.3"
+slog-term = "^2.4.0"
+slog-async = "^2.3.0"
+eth2_ssz = { path = "../../eth2/utils/ssz" }
+eth2_ssz_derive = { path = "../../eth2/utils/ssz_derive" }
 state_processing = { path = "../../eth2/state_processing" }
 types = { path = "../../eth2/types" }
-clap = "2.33.0"
-http = "0.1.19"
-prometheus = { version = "0.7.0", features = ["process"] }
+clap = "2.32.0"
+http = "^0.1.17"
+prometheus = { version = "^0.6", features = ["process"] }
 hyper = "0.12.35"
-exit-future = "0.1.4"
-tokio = "0.1.22"
-url = "2.1.0"
-lazy_static = "1.4.0"
+exit-future = "0.1.3"
+tokio = "0.1.17"
+url = "2.0"
+lazy_static = "1.3.0"
 eth2_config = { path = "../../eth2/utils/eth2_config" }
 lighthouse_metrics = { path = "../../eth2/utils/lighthouse_metrics" }
 slot_clock = { path = "../../eth2/utils/slot_clock" }
-hex = "0.3"
-parking_lot = "0.9.0"
-futures = "0.1.29"
-
+hex = "0.3.2"
+parking_lot = "0.9"
+futures = "0.1.25"

--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -3,13 +3,13 @@ use crate::response_builder::ResponseBuilder;
 use crate::{ApiError, ApiResult, UrlQuery};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use hyper::{Body, Request};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use ssz_derive::Encode;
 use std::sync::Arc;
 use store::Store;
 use types::{BeaconBlock, BeaconState, Epoch, EthSpec, Hash256, Slot, Validator};
 
-#[derive(Serialize, Encode)]
+#[derive(Serialize, Deserialize, Encode)]
 pub struct HeadResponse {
     pub slot: Slot,
     pub block_root: Hash256,

--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -23,12 +23,10 @@ pub struct HeadResponse {
 }
 
 /// HTTP handler to return a `BeaconBlock` at a given `root` or `slot`.
-pub fn get_head<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = req
-        .extensions()
-        .get::<Arc<BeaconChain<T>>>()
-        .ok_or_else(|| ApiError::ServerError("Beacon chain extension missing".to_string()))?;
-
+pub fn get_head<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let chain_head = beacon_chain.head();
 
     let head = HeadResponse {
@@ -66,12 +64,10 @@ pub struct BlockResponse<T: EthSpec> {
 }
 
 /// HTTP handler to return a `BeaconBlock` at a given `root` or `slot`.
-pub fn get_block<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = req
-        .extensions()
-        .get::<Arc<BeaconChain<T>>>()
-        .ok_or_else(|| ApiError::ServerError("Beacon chain extension missing".to_string()))?;
-
+pub fn get_block<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let query_params = ["root", "slot"];
     let (key, value) = UrlQuery::from_request(&req)?.first_of(&query_params)?;
 
@@ -106,9 +102,10 @@ pub fn get_block<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult
 }
 
 /// HTTP handler to return a `BeaconBlock` root at a given `slot`.
-pub fn get_block_root<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
-
+pub fn get_block_root<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let slot_string = UrlQuery::from_request(&req)?.only_one("slot")?;
     let target = parse_slot(&slot_string)?;
 
@@ -120,8 +117,10 @@ pub fn get_block_root<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiR
 }
 
 /// HTTP handler to return the `Fork` of the current head.
-pub fn get_fork<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
+pub fn get_fork<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body(&beacon_chain.head().beacon_state.fork)
 }
 
@@ -129,9 +128,10 @@ pub fn get_fork<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult 
 ///
 /// The `Epoch` parameter can be any epoch number. If it is not specified,
 /// the current epoch is assumed.
-pub fn get_validators<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
-
+pub fn get_validators<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let epoch = match UrlQuery::from_request(&req) {
         // We have some parameters, so make sure it's the epoch one and parse it
         Ok(query) => query
@@ -168,8 +168,10 @@ pub struct StateResponse<T: EthSpec> {
 ///
 /// Will not return a state if the request slot is in the future. Will return states higher than
 /// the current head by skipping slots.
-pub fn get_state<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
+pub fn get_state<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let head_state = beacon_chain.head().beacon_state;
 
     let (key, value) = match UrlQuery::from_request(&req) {
@@ -214,9 +216,10 @@ pub fn get_state<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult
 ///
 /// Will not return a state if the request slot is in the future. Will return states higher than
 /// the current head by skipping slots.
-pub fn get_state_root<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
-
+pub fn get_state_root<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let slot_string = UrlQuery::from_request(&req)?.only_one("slot")?;
     let slot = parse_slot(&slot_string)?;
 
@@ -228,8 +231,8 @@ pub fn get_state_root<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiR
 /// HTTP handler to return the highest finalized slot.
 pub fn get_current_finalized_checkpoint<T: BeaconChainTypes + 'static>(
     req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
 ) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
     let head_state = beacon_chain.head().beacon_state;
 
     let checkpoint = head_state.finalized_checkpoint.clone();
@@ -238,9 +241,10 @@ pub fn get_current_finalized_checkpoint<T: BeaconChainTypes + 'static>(
 }
 
 /// HTTP handler to return a `BeaconState` at the genesis block.
-pub fn get_genesis_state<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
-
+pub fn get_genesis_state<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     let (_root, state) = state_at_slot(&beacon_chain, Slot::new(0))?;
 
     ResponseBuilder::new(&req)?.body(&state)

--- a/beacon_node/rest_api/src/config.rs
+++ b/beacon_node/rest_api/src/config.rs
@@ -2,6 +2,37 @@ use clap::ArgMatches;
 use serde::{Deserialize, Serialize};
 use std::net::Ipv4Addr;
 
+/// Defines the encoding for the API
+///
+/// The validator client can speak to the beacon node in a number of encodings. Currently both JSON
+/// and YAML are supported.
+#[derive(Clone, Serialize, Deserialize, Copy)]
+pub enum ApiEncodingFormat {
+    JSON,
+    YAML,
+    SSZ,
+}
+
+impl ApiEncodingFormat {
+    pub fn get_content_type(&self) -> &str {
+        match self {
+            ApiEncodingFormat::JSON => "application/json",
+            ApiEncodingFormat::YAML => "application/yaml",
+            ApiEncodingFormat::SSZ => "application/ssz",
+        }
+    }
+}
+
+impl From<&str> for ApiEncodingFormat {
+    fn from(f: &str) -> ApiEncodingFormat {
+        match f {
+            "application/yaml" => ApiEncodingFormat::YAML,
+            "application/ssz" => ApiEncodingFormat::SSZ,
+            _ => ApiEncodingFormat::JSON,
+        }
+    }
+}
+
 /// HTTP REST API Configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {

--- a/beacon_node/rest_api/src/helpers.rs
+++ b/beacon_node/rest_api/src/helpers.rs
@@ -15,10 +15,10 @@ use std::sync::Arc;
 use store::{iter::AncestorIter, Store};
 use tokio::sync::mpsc;
 use types::{
-    Attestation, BeaconBlock, BeaconState, EthSpec, Hash256, RelativeEpoch, Signature, Slot,
+    Attestation, BeaconBlock, BeaconState, Epoch, EthSpec, Hash256, RelativeEpoch, Signature, Slot,
 };
 
-/// Parse a slot from a `0x` preixed string.
+/// Parse a slot.
 ///
 /// E.g., `"1234"`
 pub fn parse_slot(string: &str) -> Result<Slot, ApiError> {
@@ -26,6 +26,16 @@ pub fn parse_slot(string: &str) -> Result<Slot, ApiError> {
         .parse::<u64>()
         .map(Slot::from)
         .map_err(|e| ApiError::BadRequest(format!("Unable to parse slot: {:?}", e)))
+}
+
+/// Parse an epoch.
+///
+/// E.g., `"13"`
+pub fn parse_epoch(string: &str) -> Result<Epoch, ApiError> {
+    string
+        .parse::<u64>()
+        .map(Epoch::from)
+        .map_err(|e| ApiError::BadRequest(format!("Unable to parse epoch: {:?}", e)))
 }
 
 /// Checks the provided request to ensure that the `content-type` header.

--- a/beacon_node/rest_api/src/helpers.rs
+++ b/beacon_node/rest_api/src/helpers.rs
@@ -213,26 +213,6 @@ pub fn implementation_pending_response(_req: Request<Body>) -> ApiResult {
     ))
 }
 
-pub fn get_beacon_chain_from_request<T: BeaconChainTypes + 'static>(
-    req: &Request<Body>,
-) -> Result<(Arc<BeaconChain<T>>), ApiError> {
-    // Get beacon state
-    let beacon_chain = req
-        .extensions()
-        .get::<Arc<BeaconChain<T>>>()
-        .ok_or_else(|| ApiError::ServerError("Beacon chain extension missing".into()))?;
-
-    Ok(beacon_chain.clone())
-}
-
-pub fn get_logger_from_request(req: &Request<Body>) -> slog::Logger {
-    let log = req
-        .extensions()
-        .get::<slog::Logger>()
-        .expect("Should always get the logger from the request, since we put it in there.");
-    log.to_owned()
-}
-
 pub fn publish_beacon_block_to_network<T: BeaconChainTypes + 'static>(
     chan: Arc<RwLock<mpsc::UnboundedSender<NetworkMessage>>>,
     block: BeaconBlock<T::EthSpec>,

--- a/beacon_node/rest_api/src/helpers.rs
+++ b/beacon_node/rest_api/src/helpers.rs
@@ -55,7 +55,7 @@ pub fn parse_signature(string: &str) -> Result<Signature, ApiError> {
             .map_err(|e| ApiError::BadRequest(format!("Unable to parse signature bytes: {:?}", e)))
     } else {
         Err(ApiError::BadRequest(
-            "Signature must have a '0x' prefix".to_string(),
+            "Signature must have a 0x prefix".to_string(),
         ))
     }
 }
@@ -73,7 +73,7 @@ pub fn parse_root(string: &str) -> Result<Hash256, ApiError> {
             .map_err(|e| ApiError::BadRequest(format!("Unable to parse root: {:?}", e)))
     } else {
         Err(ApiError::BadRequest(
-            "Root must have a '0x' prefix".to_string(),
+            "Root must have a 0x prefix".to_string(),
         ))
     }
 }
@@ -90,7 +90,7 @@ pub fn parse_pubkey(string: &str) -> Result<PublicKey, ApiError> {
         Ok(pubkey)
     } else {
         Err(ApiError::BadRequest(
-            "Public key must have a '0x' prefix".to_string(),
+            "Public key must have a 0x prefix".to_string(),
         ))
     }
 }

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -12,6 +12,7 @@ mod metrics;
 mod network;
 mod node;
 mod response_builder;
+mod router;
 mod spec;
 mod url_query;
 mod validator;
@@ -22,10 +23,10 @@ use client_network::Service as NetworkService;
 pub use config::ApiEncodingFormat;
 use error::{ApiError, ApiResult};
 use eth2_config::Eth2Config;
-use futures::future::IntoFuture;
 use hyper::rt::Future;
-use hyper::service::Service;
-use hyper::{Body, Method, Request, Response, Server};
+use hyper::server::conn::AddrStream;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server};
 use parking_lot::RwLock;
 use slog::{info, warn};
 use std::net::SocketAddr;
@@ -41,160 +42,12 @@ pub use beacon::{BlockResponse, HeadResponse, StateResponse};
 pub use config::Config;
 pub use validator::ValidatorDuty;
 
-type BoxFut = Box<dyn Future<Item = Response<Body>, Error = ApiError> + Send>;
-
-pub struct ApiService<T: BeaconChainTypes + 'static> {
-    log: slog::Logger,
-    beacon_chain: Arc<BeaconChain<T>>,
-    db_path: DBPath,
-    network_service: Arc<NetworkService<T>>,
-    network_channel: Arc<RwLock<mpsc::UnboundedSender<NetworkMessage>>>,
-    eth2_config: Arc<Eth2Config>,
-}
+pub type BoxFut = Box<dyn Future<Item = Response<Body>, Error = ApiError> + Send>;
+pub type NetworkChannel = Arc<RwLock<mpsc::UnboundedSender<NetworkMessage>>>;
 
 pub struct NetworkInfo<T: BeaconChainTypes> {
     pub network_service: Arc<NetworkService<T>>,
     pub network_chan: mpsc::UnboundedSender<NetworkMessage>,
-}
-
-fn into_boxfut<F: IntoFuture + 'static>(item: F) -> BoxFut
-where
-    F: IntoFuture<Item = Response<Body>, Error = ApiError>,
-    F::Future: Send,
-{
-    Box::new(item.into_future())
-}
-
-impl<T: BeaconChainTypes> Service for ApiService<T> {
-    type ReqBody = Body;
-    type ResBody = Body;
-    type Error = ApiError;
-    type Future = BoxFut;
-
-    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
-        metrics::inc_counter(&metrics::REQUEST_COUNT);
-        let timer = metrics::start_timer(&metrics::REQUEST_RESPONSE_TIME);
-
-        // Add all the useful bits into the request, so that we can pull them out in the individual
-        // functions.
-        req.extensions_mut()
-            .insert::<slog::Logger>(self.log.clone());
-        req.extensions_mut()
-            .insert::<Arc<BeaconChain<T>>>(self.beacon_chain.clone());
-        req.extensions_mut().insert::<DBPath>(self.db_path.clone());
-        req.extensions_mut()
-            .insert::<Arc<NetworkService<T>>>(self.network_service.clone());
-        req.extensions_mut()
-            .insert::<Arc<RwLock<mpsc::UnboundedSender<NetworkMessage>>>>(
-                self.network_channel.clone(),
-            );
-        req.extensions_mut()
-            .insert::<Arc<Eth2Config>>(self.eth2_config.clone());
-
-        let path = req.uri().path().to_string();
-
-        // Route the request to the correct handler.
-        let result = match (req.method(), path.as_ref()) {
-            // Methods for Client
-            (&Method::GET, "/node/version") => into_boxfut(node::get_version(req)),
-            (&Method::GET, "/node/genesis_time") => into_boxfut(node::get_genesis_time::<T>(req)),
-            (&Method::GET, "/node/syncing") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-
-            // Methods for Network
-            (&Method::GET, "/network/enr") => into_boxfut(network::get_enr::<T>(req)),
-            (&Method::GET, "/network/peer_count") => into_boxfut(network::get_peer_count::<T>(req)),
-            (&Method::GET, "/network/peer_id") => into_boxfut(network::get_peer_id::<T>(req)),
-            (&Method::GET, "/network/peers") => into_boxfut(network::get_peer_list::<T>(req)),
-            (&Method::GET, "/network/listen_port") => {
-                into_boxfut(network::get_listen_port::<T>(req))
-            }
-            (&Method::GET, "/network/listen_addresses") => {
-                into_boxfut(network::get_listen_addresses::<T>(req))
-            }
-
-            // Methods for Beacon Node
-            (&Method::GET, "/beacon/head") => into_boxfut(beacon::get_head::<T>(req)),
-            (&Method::GET, "/beacon/block") => into_boxfut(beacon::get_block::<T>(req)),
-            (&Method::GET, "/beacon/block_root") => into_boxfut(beacon::get_block_root::<T>(req)),
-            (&Method::GET, "/beacon/blocks") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-            (&Method::GET, "/beacon/fork") => into_boxfut(beacon::get_fork::<T>(req)),
-            (&Method::GET, "/beacon/attestations") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-            (&Method::GET, "/beacon/attestations/pending") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-
-            (&Method::GET, "/beacon/validators") => into_boxfut(beacon::get_validators::<T>(req)),
-            (&Method::GET, "/beacon/validators/indicies") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-            (&Method::GET, "/beacon/validators/pubkeys") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-
-            // Methods for Validator
-            (&Method::GET, "/validator/duties") => {
-                into_boxfut(validator::get_validator_duties::<T>(req))
-            }
-            (&Method::GET, "/validator/block") => {
-                into_boxfut(validator::get_new_beacon_block::<T>(req))
-            }
-            (&Method::POST, "/validator/block") => validator::publish_beacon_block::<T>(req),
-            (&Method::GET, "/validator/attestation") => {
-                into_boxfut(validator::get_new_attestation::<T>(req))
-            }
-            (&Method::POST, "/validator/attestation") => validator::publish_attestation::<T>(req),
-
-            (&Method::GET, "/beacon/state") => into_boxfut(beacon::get_state::<T>(req)),
-            (&Method::GET, "/beacon/state_root") => into_boxfut(beacon::get_state_root::<T>(req)),
-            (&Method::GET, "/beacon/state/current_finalized_checkpoint") => {
-                into_boxfut(beacon::get_current_finalized_checkpoint::<T>(req))
-            }
-            (&Method::GET, "/beacon/state/genesis") => {
-                into_boxfut(beacon::get_genesis_state::<T>(req))
-            }
-            //TODO: Add aggreggate/filtered state lookups here, e.g. /beacon/validators/balances
-
-            // Methods for bootstrap and checking configuration
-            (&Method::GET, "/spec") => into_boxfut(spec::get_spec::<T>(req)),
-            (&Method::GET, "/spec/slots_per_epoch") => {
-                into_boxfut(spec::get_slots_per_epoch::<T>(req))
-            }
-            (&Method::GET, "/spec/deposit_contract") => {
-                into_boxfut(helpers::implementation_pending_response(req))
-            }
-            (&Method::GET, "/spec/eth2_config") => into_boxfut(spec::get_eth2_config::<T>(req)),
-
-            (&Method::GET, "/metrics") => into_boxfut(metrics::get_prometheus::<T>(req)),
-
-            _ => Box::new(futures::future::err(ApiError::NotFound(
-                "Request path and/or method not found.".to_owned(),
-            ))),
-        };
-
-        let response = match result.wait() {
-            // Return the `hyper::Response`.
-            Ok(response) => {
-                metrics::inc_counter(&metrics::SUCCESS_COUNT);
-                slog::debug!(self.log, "Request successful: {:?}", path);
-                response
-            }
-            // Map the `ApiError` into `hyper::Response`.
-            Err(e) => {
-                slog::debug!(self.log, "Request failure: {:?}", path);
-                e.into()
-            }
-        };
-
-        metrics::stop_timer(timer);
-
-        Box::new(futures::future::ok(response))
-    }
 }
 
 pub fn start_server<T: BeaconChainTypes>(
@@ -206,46 +59,53 @@ pub fn start_server<T: BeaconChainTypes>(
     eth2_config: Eth2Config,
     log: slog::Logger,
 ) -> Result<(exit_future::Signal, SocketAddr), hyper::Error> {
-    // build a channel to kill the HTTP server
-    let (exit_signal, exit) = exit_future::signal();
+    // Define the function that will build the request handler.
+    let inner_log = log.clone();
+    let eth2_config = Arc::new(eth2_config);
+    let make_service = make_service_fn(move |_socket: &AddrStream| {
+        let beacon_chain = beacon_chain.clone();
+        let log = inner_log.clone();
+        let eth2_config = eth2_config.clone();
+        let network_service = network_info.network_service.clone();
+        let network_channel = Arc::new(RwLock::new(network_info.network_chan.clone()));
+        let db_path = db_path.clone();
 
-    let exit_log = log.clone();
-    let server_exit = exit.and_then(move |_| {
-        info!(exit_log, "API service shutdown");
-        Ok(())
+        service_fn(move |req: Request<Body>| {
+            router::route(
+                req,
+                beacon_chain.clone(),
+                network_service.clone(),
+                network_channel.clone(),
+                eth2_config.clone(),
+                log.clone(),
+                db_path.clone(),
+            )
+        })
     });
 
-    let db_path = DBPath(db_path);
-
-    // Get the address to bind to
     let bind_addr = (config.listen_address, config.port).into();
+    let server = Server::bind(&bind_addr).serve(make_service);
 
-    // Clone our stateful objects, for use in service closure.
-    let server_log = log.clone();
-    let server_bc = beacon_chain.clone();
-    let eth2_config = Arc::new(eth2_config);
-
-    let service = move || -> futures::future::FutureResult<ApiService<T>, String> {
-        futures::future::ok(ApiService {
-            log: server_log.clone(),
-            beacon_chain: server_bc.clone(),
-            db_path: db_path.clone(),
-            network_service: network_info.network_service.clone(),
-            network_channel: Arc::new(RwLock::new(network_info.network_chan.clone())),
-            eth2_config: eth2_config.clone(),
-        })
-    };
-
-    let log_clone = log.clone();
-    let server = Server::bind(&bind_addr).serve(service);
-
+    // Determine the address the server is actually listening on.
+    //
+    // This may be different to `bind_addr` if bind port was 0 (this allows the OS to choose a free
+    // port).
     let actual_listen_addr = server.local_addr();
 
+    // Build a channel to kill the HTTP server.
+    let (exit_signal, exit) = exit_future::signal();
+    let inner_log = log.clone();
+    let server_exit = exit.and_then(move |_| {
+        info!(inner_log, "API service shutdown");
+        Ok(())
+    });
+    // Configure the `hyper` server to gracefully shutdown when the shutdown channel is triggered.
+    let inner_log = log.clone();
     let server_future = server
         .with_graceful_shutdown(server_exit)
         .map_err(move |e| {
             warn!(
-            log_clone,
+            inner_log,
             "API failed to start, Unable to bind"; "address" => format!("{:?}", e)
             )
         });

--- a/beacon_node/rest_api/src/metrics.rs
+++ b/beacon_node/rest_api/src/metrics.rs
@@ -3,7 +3,7 @@ use crate::response_builder::ResponseBuilder;
 use crate::{ApiError, ApiResult, DBPath};
 use beacon_chain::BeaconChainTypes;
 use hyper::{Body, Request};
-use prometheus::{Encoder, TextEncoder};
+use lighthouse_metrics::{Encoder, TextEncoder};
 
 pub use lighthouse_metrics::*;
 
@@ -58,7 +58,7 @@ pub fn get_prometheus<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiR
     beacon_chain::scrape_for_metrics(&beacon_chain);
 
     encoder
-        .encode(&lighthouse_metrics::gather(), &mut buffer)
+        .encode(&lighthouse_metrics::gather()[..], &mut buffer)
         .unwrap();
 
     String::from_utf8(buffer)

--- a/beacon_node/rest_api/src/metrics.rs
+++ b/beacon_node/rest_api/src/metrics.rs
@@ -1,9 +1,10 @@
-use crate::helpers::get_beacon_chain_from_request;
 use crate::response_builder::ResponseBuilder;
-use crate::{ApiError, ApiResult, DBPath};
-use beacon_chain::BeaconChainTypes;
+use crate::{ApiError, ApiResult};
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use hyper::{Body, Request};
 use lighthouse_metrics::{Encoder, TextEncoder};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 pub use lighthouse_metrics::*;
 
@@ -27,15 +28,13 @@ lazy_static! {
 /// # Note
 ///
 /// This is a HTTP handler method.
-pub fn get_prometheus<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
+pub fn get_prometheus<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+    db_path: PathBuf,
+) -> ApiResult {
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
-
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
-    let db_path = req
-        .extensions()
-        .get::<DBPath>()
-        .ok_or_else(|| ApiError::ServerError("DBPath extension missing".to_string()))?;
 
     // There are two categories of metrics:
     //

--- a/beacon_node/rest_api/src/network.rs
+++ b/beacon_node/rest_api/src/network.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 /// HTTP handler to return the list of libp2p multiaddr the client is listening on.
 ///
 /// Returns a list of `Multiaddr`, serialized according to their `serde` impl.
-pub fn get_listen_addresses<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there");
+pub fn get_listen_addresses<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     let multiaddresses: Vec<Multiaddr> = network.listen_multiaddrs();
     ResponseBuilder::new(&req)?.body_no_ssz(&multiaddresses)
 }
@@ -21,54 +20,48 @@ pub fn get_listen_addresses<T: BeaconChainTypes>(req: Request<Body>) -> ApiResul
 /// HTTP handler to return the network port the client is listening on.
 ///
 /// Returns the TCP port number in its plain form (which is also valid JSON serialization)
-pub fn get_listen_port<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there")
-        .clone();
+pub fn get_listen_port<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body(&network.listen_port())
 }
 
 /// HTTP handler to return the Discv5 ENR from the client's libp2p service.
 ///
 /// ENR is encoded as base64 string.
-pub fn get_enr<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there");
+pub fn get_enr<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(&network.local_enr().to_base64())
 }
 
 /// HTTP handler to return the `PeerId` from the client's libp2p service.
 ///
 /// PeerId is encoded as base58 string.
-pub fn get_peer_id<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there");
+pub fn get_peer_id<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(&network.local_peer_id().to_base58())
 }
 
 /// HTTP handler to return the number of peers connected in the client's libp2p service.
-pub fn get_peer_count<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there");
+pub fn get_peer_count<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body(&network.connected_peers())
 }
 
 /// HTTP handler to return the list of peers connected to the client's libp2p service.
 ///
 /// Peers are presented as a list of `PeerId::to_string()`.
-pub fn get_peer_list<T: BeaconChainTypes>(req: Request<Body>) -> ApiResult {
-    let network = req
-        .extensions()
-        .get::<Arc<NetworkService<T>>>()
-        .expect("The network service should always be there, we put it there");
+pub fn get_peer_list<T: BeaconChainTypes>(
+    req: Request<Body>,
+    network: Arc<NetworkService<T>>,
+) -> ApiResult {
     let connected_peers: Vec<String> = network
         .connected_peer_set()
         .iter()

--- a/beacon_node/rest_api/src/node.rs
+++ b/beacon_node/rest_api/src/node.rs
@@ -1,8 +1,8 @@
-use crate::helpers::get_beacon_chain_from_request;
 use crate::response_builder::ResponseBuilder;
 use crate::ApiResult;
-use beacon_chain::BeaconChainTypes;
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use hyper::{Body, Request};
+use std::sync::Arc;
 use version;
 
 /// Read the version string from the current Lighthouse build.
@@ -11,7 +11,9 @@ pub fn get_version(req: Request<Body>) -> ApiResult {
 }
 
 /// Read the genesis time from the current beacon chain state.
-pub fn get_genesis_time<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
+pub fn get_genesis_time<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body(&beacon_chain.head().beacon_state.genesis_time)
 }

--- a/beacon_node/rest_api/src/response_builder.rs
+++ b/beacon_node/rest_api/src/response_builder.rs
@@ -1,47 +1,36 @@
 use super::{ApiError, ApiResult};
+use crate::config::ApiEncodingFormat;
 use http::header;
 use hyper::{Body, Request, Response, StatusCode};
 use serde::Serialize;
 use ssz::Encode;
 
-pub enum Encoding {
-    JSON,
-    SSZ,
-    YAML,
-    TEXT,
-}
-
 pub struct ResponseBuilder {
-    encoding: Encoding,
+    encoding: ApiEncodingFormat,
 }
 
 impl ResponseBuilder {
     pub fn new(req: &Request<Body>) -> Result<Self, ApiError> {
-        let content_header: String = req
+        let accept_header: String = req
             .headers()
-            .get(header::CONTENT_TYPE)
+            .get(header::ACCEPT)
             .map_or(Ok(""), |h| h.to_str())
             .map_err(|e| {
                 ApiError::BadRequest(format!(
-                    "The content-type header contains invalid characters: {:?}",
+                    "The Accept header contains invalid characters: {:?}",
                     e
                 ))
             })
             .map(String::from)?;
 
         // JSON is our default encoding, unless something else is requested.
-        let encoding = match content_header {
-            ref h if h.starts_with("application/ssz") => Encoding::SSZ,
-            ref h if h.starts_with("application/yaml") => Encoding::YAML,
-            ref h if h.starts_with("text/") => Encoding::TEXT,
-            _ => Encoding::JSON,
-        };
+        let encoding = ApiEncodingFormat::from(accept_header.as_str());
         Ok(Self { encoding })
     }
 
     pub fn body<T: Serialize + Encode>(self, item: &T) -> ApiResult {
         match self.encoding {
-            Encoding::SSZ => Response::builder()
+            ApiEncodingFormat::SSZ => Response::builder()
                 .status(StatusCode::OK)
                 .header("content-type", "application/ssz")
                 .body(Body::from(item.as_ssz_bytes()))
@@ -52,7 +41,7 @@ impl ResponseBuilder {
 
     pub fn body_no_ssz<T: Serialize>(self, item: &T) -> ApiResult {
         let (body, content_type) = match self.encoding {
-            Encoding::JSON => (
+            ApiEncodingFormat::JSON => (
                 Body::from(serde_json::to_string(&item).map_err(|e| {
                     ApiError::ServerError(format!(
                         "Unable to serialize response body as JSON: {:?}",
@@ -61,12 +50,12 @@ impl ResponseBuilder {
                 })?),
                 "application/json",
             ),
-            Encoding::SSZ => {
+            ApiEncodingFormat::SSZ => {
                 return Err(ApiError::UnsupportedType(
                     "Response cannot be encoded as SSZ.".into(),
                 ));
             }
-            Encoding::YAML => (
+            ApiEncodingFormat::YAML => (
                 Body::from(serde_yaml::to_string(&item).map_err(|e| {
                     ApiError::ServerError(format!(
                         "Unable to serialize response body as YAML: {:?}",
@@ -75,11 +64,6 @@ impl ResponseBuilder {
                 })?),
                 "application/yaml",
             ),
-            Encoding::TEXT => {
-                return Err(ApiError::UnsupportedType(
-                    "Response cannot be encoded as plain text.".into(),
-                ));
-            }
         };
 
         Response::builder()

--- a/beacon_node/rest_api/src/router.rs
+++ b/beacon_node/rest_api/src/router.rs
@@ -1,0 +1,169 @@
+use crate::{
+    beacon, error::ApiError, helpers, metrics, network, node, spec, validator, BoxFut,
+    NetworkChannel,
+};
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use client_network::Service as NetworkService;
+use eth2_config::Eth2Config;
+use futures::{Future, IntoFuture};
+use hyper::{Body, Error, Method, Request, Response};
+use slog::debug;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+fn into_boxfut<F: IntoFuture + 'static>(item: F) -> BoxFut
+where
+    F: IntoFuture<Item = Response<Body>, Error = ApiError>,
+    F::Future: Send,
+{
+    Box::new(item.into_future())
+}
+
+pub fn route<T: BeaconChainTypes>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+    network_service: Arc<NetworkService<T>>,
+    network_channel: NetworkChannel,
+    eth2_config: Arc<Eth2Config>,
+    local_log: slog::Logger,
+    db_path: PathBuf,
+) -> impl Future<Item = Response<Body>, Error = Error> {
+    metrics::inc_counter(&metrics::REQUEST_COUNT);
+    let timer = metrics::start_timer(&metrics::REQUEST_RESPONSE_TIME);
+
+    let path = req.uri().path().to_string();
+
+    let log = local_log.clone();
+    let request_result: Box<dyn Future<Item = Response<_>, Error = _> + Send> =
+        match (req.method(), path.as_ref()) {
+            // Methods for Client
+            (&Method::GET, "/node/version") => into_boxfut(node::get_version(req)),
+            (&Method::GET, "/node/genesis_time") => {
+                into_boxfut(node::get_genesis_time::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/node/syncing") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+
+            // Methods for Network
+            (&Method::GET, "/network/enr") => {
+                into_boxfut(network::get_enr::<T>(req, network_service))
+            }
+            (&Method::GET, "/network/peer_count") => {
+                into_boxfut(network::get_peer_count::<T>(req, network_service))
+            }
+            (&Method::GET, "/network/peer_id") => {
+                into_boxfut(network::get_peer_id::<T>(req, network_service))
+            }
+            (&Method::GET, "/network/peers") => {
+                into_boxfut(network::get_peer_list::<T>(req, network_service))
+            }
+            (&Method::GET, "/network/listen_port") => {
+                into_boxfut(network::get_listen_port::<T>(req, network_service))
+            }
+            (&Method::GET, "/network/listen_addresses") => {
+                into_boxfut(network::get_listen_addresses::<T>(req, network_service))
+            }
+
+            // Methods for Beacon Node
+            (&Method::GET, "/beacon/head") => into_boxfut(beacon::get_head::<T>(req, beacon_chain)),
+            (&Method::GET, "/beacon/block") => {
+                into_boxfut(beacon::get_block::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/beacon/block_root") => {
+                into_boxfut(beacon::get_block_root::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/beacon/blocks") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+            (&Method::GET, "/beacon/fork") => into_boxfut(beacon::get_fork::<T>(req, beacon_chain)),
+            (&Method::GET, "/beacon/attestations") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+            (&Method::GET, "/beacon/attestations/pending") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+
+            (&Method::GET, "/beacon/validators") => {
+                into_boxfut(beacon::get_validators::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/beacon/validators/indicies") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+            (&Method::GET, "/beacon/validators/pubkeys") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+
+            // Methods for Validator
+            (&Method::GET, "/validator/duties") => {
+                into_boxfut(validator::get_validator_duties::<T>(req, beacon_chain, log))
+            }
+            (&Method::GET, "/validator/block") => {
+                into_boxfut(validator::get_new_beacon_block::<T>(req, beacon_chain))
+            }
+            (&Method::POST, "/validator/block") => {
+                validator::publish_beacon_block::<T>(req, beacon_chain, network_channel, log)
+            }
+            (&Method::GET, "/validator/attestation") => {
+                into_boxfut(validator::get_new_attestation::<T>(req, beacon_chain))
+            }
+            (&Method::POST, "/validator/attestation") => {
+                validator::publish_attestation::<T>(req, beacon_chain, network_channel, log)
+            }
+
+            (&Method::GET, "/beacon/state") => {
+                into_boxfut(beacon::get_state::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/beacon/state_root") => {
+                into_boxfut(beacon::get_state_root::<T>(req, beacon_chain))
+            }
+            (&Method::GET, "/beacon/state/current_finalized_checkpoint") => into_boxfut(
+                beacon::get_current_finalized_checkpoint::<T>(req, beacon_chain),
+            ),
+            (&Method::GET, "/beacon/state/genesis") => {
+                into_boxfut(beacon::get_genesis_state::<T>(req, beacon_chain))
+            }
+            //TODO: Add aggreggate/filtered state lookups here, e.g. /beacon/validators/balances
+
+            // Methods for bootstrap and checking configuration
+            (&Method::GET, "/spec") => into_boxfut(spec::get_spec::<T>(req, beacon_chain)),
+            (&Method::GET, "/spec/slots_per_epoch") => {
+                into_boxfut(spec::get_slots_per_epoch::<T>(req))
+            }
+            (&Method::GET, "/spec/deposit_contract") => {
+                into_boxfut(helpers::implementation_pending_response(req))
+            }
+            (&Method::GET, "/spec/eth2_config") => {
+                into_boxfut(spec::get_eth2_config::<T>(req, eth2_config))
+            }
+
+            (&Method::GET, "/metrics") => {
+                into_boxfut(metrics::get_prometheus::<T>(req, beacon_chain, db_path))
+            }
+
+            _ => Box::new(futures::future::err(ApiError::NotFound(
+                "Request path and/or method not found.".to_owned(),
+            ))),
+        };
+
+    // Map the Rust-friendly `Result` in to a http-friendly response. In effect, this ensures that
+    // any `Err` returned from our response handlers becomes a valid http response to the client
+    // (e.g., a response with a 404 or 500 status).
+    request_result.then(move |result| match result {
+        Ok(response) => {
+            debug!(local_log, "Request successful: {:?}", path);
+            metrics::inc_counter(&metrics::SUCCESS_COUNT);
+            metrics::stop_timer(timer);
+
+            Ok(response)
+        }
+        Err(e) => {
+            let error_response = e.into();
+
+            debug!(local_log, "Request failure: {:?}", path);
+            metrics::stop_timer(timer);
+
+            Ok(error_response)
+        }
+    })
+}

--- a/beacon_node/rest_api/src/spec.rs
+++ b/beacon_node/rest_api/src/spec.rs
@@ -1,26 +1,24 @@
 use super::ApiResult;
-use crate::helpers::get_beacon_chain_from_request;
 use crate::response_builder::ResponseBuilder;
-use crate::ApiError;
-use beacon_chain::BeaconChainTypes;
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_config::Eth2Config;
 use hyper::{Body, Request};
 use std::sync::Arc;
 use types::EthSpec;
 
 /// HTTP handler to return the full spec object.
-pub fn get_spec<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let beacon_chain = get_beacon_chain_from_request::<T>(&req)?;
+pub fn get_spec<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    beacon_chain: Arc<BeaconChain<T>>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(&beacon_chain.spec)
 }
 
 /// HTTP handler to return the full Eth2Config object.
-pub fn get_eth2_config<T: BeaconChainTypes + 'static>(req: Request<Body>) -> ApiResult {
-    let eth2_config = req
-        .extensions()
-        .get::<Arc<Eth2Config>>()
-        .ok_or_else(|| ApiError::ServerError("Eth2Config extension missing".to_string()))?;
-
+pub fn get_eth2_config<T: BeaconChainTypes + 'static>(
+    req: Request<Body>,
+    eth2_config: Arc<Eth2Config>,
+) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(eth2_config.as_ref())
 }
 

--- a/beacon_node/rest_api/src/validator.rs
+++ b/beacon_node/rest_api/src/validator.rs
@@ -1,6 +1,6 @@
 use crate::helpers::{
-    check_content_type_for_json, parse_pubkey, parse_signature, publish_attestation_to_network,
-    publish_beacon_block_to_network,
+    check_content_type_for_json, parse_epoch, parse_pubkey, parse_signature,
+    publish_attestation_to_network, publish_beacon_block_to_network,
 };
 use crate::response_builder::ResponseBuilder;
 use crate::{ApiError, ApiResult, BoxFut, NetworkChannel, UrlQuery};
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use slog::{info, trace, warn, Logger};
 use std::sync::Arc;
 use types::beacon_state::EthSpec;
-use types::{Attestation, BeaconBlock, BitList, Epoch, RelativeEpoch, Shard, Slot};
+use types::{Attestation, BeaconBlock, BitList, RelativeEpoch, Shard, Slot};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ValidatorDuty {
@@ -30,56 +30,46 @@ pub struct ValidatorDuty {
 }
 
 /// HTTP Handler to retrieve a the duties for a set of validators during a particular epoch
+///
+/// The given `epoch` must be within one epoch of the current epoch.
 pub fn get_validator_duties<T: BeaconChainTypes + 'static>(
     req: Request<Body>,
     beacon_chain: Arc<BeaconChain<T>>,
     log: Logger,
 ) -> ApiResult {
     slog::trace!(log, "Validator duties requested of API: {:?}", &req);
+
+    let query = UrlQuery::from_request(&req)?;
+
+    let epoch = query
+        .first_of(&["epoch"])
+        .and_then(|(_key, value)| parse_epoch(&value))?;
+
     let mut head_state = beacon_chain.head().beacon_state;
 
-    slog::trace!(log, "Got head state from request.");
-    // Parse and check query parameters
-    let query = UrlQuery::from_request(&req)?;
     let current_epoch = head_state.current_epoch();
-    let epoch = match query.first_of(&["epoch"]) {
-        Ok((_, v)) => {
-            slog::trace!(log, "Requested epoch {:?}", v);
-            Epoch::new(v.parse::<u64>().map_err(|e| {
-                slog::info!(log, "Invalid epoch {:?}", e);
-                ApiError::BadRequest(format!("Invalid epoch parameter, must be a u64. {:?}", e))
-            })?)
-        }
-        Err(_) => {
-            // epoch not supplied, use the current epoch
-            slog::info!(log, "Using default epoch {:?}", current_epoch);
-            current_epoch
-        }
-    };
-    let relative_epoch = RelativeEpoch::from_epoch(current_epoch, epoch).map_err(|e| {
-        slog::info!(log, "Requested epoch out of range.");
+    let relative_epoch = RelativeEpoch::from_epoch(current_epoch, epoch).map_err(|_| {
         ApiError::BadRequest(format!(
-            "Cannot get RelativeEpoch, epoch out of range: {:?}",
-            e
+            "Epoch must be within one epoch of the current epoch",
         ))
     })?;
-    let validators: Vec<PublicKey> = query
-        .all_of("validator_pubkeys")?
-        .iter()
-        .map(|pk| parse_pubkey(pk))
-        .collect::<Result<Vec<_>, _>>()?;
-    let mut duties: Vec<ValidatorDuty> = Vec::new();
 
-    // Build cache for the requested epoch
     head_state
         .build_committee_cache(relative_epoch, &beacon_chain.spec)
         .map_err(|e| ApiError::ServerError(format!("Unable to build committee cache: {:?}", e)))?;
-    // Get a list of all validators for this epoch
-    let validator_proposers: Vec<usize> = epoch
+    head_state
+        .update_pubkey_cache()
+        .map_err(|e| ApiError::ServerError(format!("Unable to build pubkey cache: {:?}", e)))?;
+
+    // Get a list of all validators for this epoch.
+    //
+    // Used for quickly determining the slot for a proposer.
+    let validator_proposers: Vec<(usize, Slot)> = epoch
         .slot_iter(T::EthSpec::slots_per_epoch())
         .map(|slot| {
             head_state
                 .get_beacon_proposer_index(slot, relative_epoch, &beacon_chain.spec)
+                .map(|i| (i, slot))
                 .map_err(|e| {
                     ApiError::ServerError(format!(
                         "Unable to get proposer index for validator: {:?}",
@@ -87,61 +77,51 @@ pub fn get_validator_duties<T: BeaconChainTypes + 'static>(
                     ))
                 })
         })
-        .collect::<Result<Vec<usize>, _>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
 
-    // Look up duties for each validator
-    for val_pk in validators {
-        let mut duty = ValidatorDuty {
-            validator_pubkey: val_pk.clone(),
-            attestation_slot: None,
-            attestation_shard: None,
-            block_proposal_slot: None,
-        };
+    let duties = query
+        .all_of("validator_pubkeys")?
+        .iter()
+        .map(|string| parse_pubkey(string))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .map(|validator_pubkey| {
+            if let Some(validator_index) = head_state
+                .get_validator_index(&validator_pubkey)
+                .map_err(|e| {
+                    ApiError::ServerError(format!("Unable to read pubkey cache: {:?}", e))
+                })?
+            {
+                let duties = head_state
+                    .get_attestation_duties(validator_index, relative_epoch)
+                    .map_err(|e| {
+                        ApiError::ServerError(format!(
+                            "Unable to obtain attestation duties: {:?}",
+                            e
+                        ))
+                    })?;
 
-        // Get the validator index
-        // If it does not exist in the index, just add a null duty and move on.
-        let val_index: usize = match head_state.get_validator_index(&val_pk) {
-            Ok(Some(i)) => i,
-            Ok(None) => {
-                duties.append(&mut vec![duty]);
-                continue;
+                let block_proposal_slot = validator_proposers
+                    .iter()
+                    .find(|(i, _slot)| validator_index == *i)
+                    .map(|(_i, slot)| *slot);
+
+                Ok(ValidatorDuty {
+                    validator_pubkey,
+                    attestation_slot: duties.map(|d| d.slot),
+                    attestation_shard: duties.map(|d| d.shard),
+                    block_proposal_slot,
+                })
+            } else {
+                Ok(ValidatorDuty {
+                    validator_pubkey,
+                    attestation_slot: None,
+                    attestation_shard: None,
+                    block_proposal_slot: None,
+                })
             }
-            Err(e) => {
-                return Err(ApiError::ServerError(format!(
-                    "Unable to read validator index cache. {:?}",
-                    e
-                )));
-            }
-        };
-
-        // Set attestation duties
-        match head_state.get_attestation_duties(val_index, relative_epoch) {
-            Ok(Some(d)) => {
-                duty.attestation_slot = Some(d.slot);
-                duty.attestation_shard = Some(d.shard);
-            }
-            Ok(None) => {}
-            Err(e) => {
-                return Err(ApiError::ServerError(format!(
-                    "Unable to read cache for attestation duties: {:?}",
-                    e
-                )))
-            }
-        };
-
-        // If the validator is to propose a block, identify the slot
-        if let Some(slot) = validator_proposers.iter().position(|&v| val_index == v) {
-            duty.block_proposal_slot = Some(Slot::new(
-                relative_epoch
-                    .into_epoch(current_epoch)
-                    .start_slot(T::EthSpec::slots_per_epoch())
-                    .as_u64()
-                    + slot as u64,
-            ));
-        }
-
-        duties.append(&mut vec![duty]);
-    }
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
 
     ResponseBuilder::new(&req)?.body_no_ssz(&duties)
 }
@@ -278,9 +258,12 @@ pub fn get_new_attestation<T: BeaconChainTypes + 'static>(
     let present_slot = beacon_chain.slot().map_err(|e| ApiError::ServerError(
         format!("Beacon node is unable to determine present slot, either the state isn't generated or the chain hasn't begun. {:?}", e)
     ))?;
+
+    /*
     if val_duty.slot != present_slot {
         return Err(ApiError::BadRequest(format!("Validator is only able to request an attestation during the slot they are allocated. Current slot: {:?}, allocated slot: {:?}", head_state.slot, val_duty.slot)));
     }
+    */
 
     // Parse the POC bit and insert it into the aggregation bits
     let poc_bit = query
@@ -291,8 +274,10 @@ pub fn get_new_attestation<T: BeaconChainTypes + 'static>(
             ApiError::BadRequest(format!("Invalid slot parameter, must be a u64. {:?}", e))
         })?;
 
-    let mut aggregation_bits = BitList::with_capacity(val_duty.committee_len)
-        .expect("An empty BitList should always be created, or we have bigger problems.");
+    let mut aggregation_bits = BitList::with_capacity(val_duty.committee_len).map_err(|e| {
+        ApiError::ServerError(format!("Unable to create aggregation bitlist: {:?}", e))
+    })?;
+
     aggregation_bits
         .set(val_duty.committee_index, poc_bit)
         .map_err(|e| {

--- a/beacon_node/rest_api/tests/test.rs
+++ b/beacon_node/rest_api/tests/test.rs
@@ -1,0 +1,161 @@
+#![cfg(test)]
+
+use node_test_rig::{
+    environment::{Environment, EnvironmentBuilder},
+    LocalBeaconNode,
+};
+use tree_hash::TreeHash;
+use types::{
+    test_utils::generate_deterministic_keypair, Domain, EthSpec, MinimalEthSpec, Signature, Slot,
+};
+
+type E = MinimalEthSpec;
+
+fn build_env() -> Environment<E> {
+    EnvironmentBuilder::minimal()
+        .null_logger()
+        .expect("should build env logger")
+        .single_thread_tokio_runtime()
+        .expect("should start tokio runtime")
+        .build()
+        .expect("environment should build")
+}
+
+#[test]
+fn validator_block() {
+    let mut env = build_env();
+
+    let spec = E::default_spec();
+
+    let node = LocalBeaconNode::production(env.core_context());
+    let remote_node = node.remote_node().expect("should produce remote node");
+
+    let beacon_chain = node
+        .client
+        .beacon_chain()
+        .expect("client should have beacon chain");
+
+    let fork = beacon_chain.head().beacon_state.fork.clone();
+
+    let slot = Slot::new(1);
+    let randao_reveal = {
+        let proposer_index = beacon_chain
+            .block_proposer(slot)
+            .expect("should get proposer index");
+        let keypair = generate_deterministic_keypair(proposer_index);
+        let epoch = slot.epoch(E::slots_per_epoch());
+        let message = epoch.tree_hash_root();
+        let domain = spec.get_domain(epoch, Domain::Randao, &fork);
+        Signature::new(&message, domain, &keypair.sk)
+    };
+
+    let block = env
+        .runtime()
+        .block_on(
+            remote_node
+                .http
+                .validator()
+                .block(slot, randao_reveal.clone()),
+        )
+        .expect("should fetch block from http api");
+
+    let (expected_block, _state) = node
+        .client
+        .beacon_chain()
+        .expect("client should have beacon chain")
+        .produce_block(randao_reveal, slot)
+        .expect("should produce block");
+
+    assert_eq!(
+        block, expected_block,
+        "the block returned from the API should be as expected"
+    );
+}
+
+#[test]
+fn beacon_state() {
+    let mut env = build_env();
+
+    let node = LocalBeaconNode::production(env.core_context());
+    let remote_node = node.remote_node().expect("should produce remote node");
+
+    let (state_by_slot, root) = env
+        .runtime()
+        .block_on(remote_node.http.beacon().state_by_slot(Slot::new(0)))
+        .expect("should fetch state from http api");
+
+    let (state_by_root, root_2) = env
+        .runtime()
+        .block_on(remote_node.http.beacon().state_by_root(root))
+        .expect("should fetch state from http api");
+
+    let mut db_state = node
+        .client
+        .beacon_chain()
+        .expect("client should have beacon chain")
+        .state_at_slot(Slot::new(0))
+        .expect("should find state");
+    db_state.drop_all_caches();
+
+    assert_eq!(
+        root, root_2,
+        "the two roots returned from the api should be identical"
+    );
+    assert_eq!(
+        root,
+        db_state.canonical_root(),
+        "root from database should match that from the API"
+    );
+    assert_eq!(
+        state_by_slot, db_state,
+        "genesis state by slot from api should match that from the DB"
+    );
+    assert_eq!(
+        state_by_root, db_state,
+        "genesis state by root from api should match that from the DB"
+    );
+}
+
+#[test]
+fn beacon_block() {
+    let mut env = build_env();
+
+    let node = LocalBeaconNode::production(env.core_context());
+    let remote_node = node.remote_node().expect("should produce remote node");
+
+    let (block_by_slot, root) = env
+        .runtime()
+        .block_on(remote_node.http.beacon().block_by_slot(Slot::new(0)))
+        .expect("should fetch block from http api");
+
+    let (block_by_root, root_2) = env
+        .runtime()
+        .block_on(remote_node.http.beacon().block_by_root(root))
+        .expect("should fetch block from http api");
+
+    let db_block = node
+        .client
+        .beacon_chain()
+        .expect("client should have beacon chain")
+        .block_at_slot(Slot::new(0))
+        .expect("should find block")
+        .expect("block should not be none");
+
+    assert_eq!(
+        root, root_2,
+        "the two roots returned from the api should be identical"
+    );
+    assert_eq!(
+        root,
+        db_block.canonical_root(),
+        "root from database should match that from the API"
+    );
+    assert_eq!(
+        block_by_slot, db_block,
+        "genesis block by slot from api should match that from the DB"
+    );
+    assert_eq!(
+        block_by_root, db_block,
+        "genesis block by root from api should match that from the DB"
+    );
+}

--- a/beacon_node/rest_api/tests/test.rs
+++ b/beacon_node/rest_api/tests/test.rs
@@ -1,6 +1,7 @@
 #![cfg(test)]
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
+use futures::Future;
 use node_test_rig::{
     environment::{Environment, EnvironmentBuilder},
     LocalBeaconNode,
@@ -42,6 +43,47 @@ fn get_randao_reveal<T: BeaconChainTypes>(
     Signature::new(&message, domain, &keypair.sk)
 }
 
+/*
+#[test]
+fn validator_block_post() {
+    let mut env = build_env();
+
+    let spec = &E::default_spec();
+
+    let node = LocalBeaconNode::production(env.core_context());
+    let remote_node = node.remote_node().expect("should produce remote node");
+
+    let beacon_chain = node
+        .client
+        .beacon_chain()
+        .expect("client should have beacon chain");
+
+    let slot = Slot::new(1);
+    let randao_reveal = get_randao_reveal(beacon_chain.clone(), slot, spec);
+
+    let block = env
+        .runtime()
+        .block_on(
+            remote_node
+                .http
+                .validator()
+                .produce_block(slot, randao_reveal.clone()),
+        )
+        .expect("should fetch block from http api");
+
+    assert!(env
+        .runtime()
+        .block_on(
+            remote_node
+                .http
+                .validator()
+                .publish_block(block)
+                .and_then(|_| Ok(()))
+        )
+        .is_ok());
+}
+*/
+
 #[test]
 fn validator_block_get() {
     let mut env = build_env();
@@ -65,7 +107,7 @@ fn validator_block_get() {
             remote_node
                 .http
                 .validator()
-                .block(slot, randao_reveal.clone()),
+                .produce_block(slot, randao_reveal.clone()),
         )
         .expect("should fetch block from http api");
 
@@ -91,12 +133,12 @@ fn beacon_state() {
 
     let (state_by_slot, root) = env
         .runtime()
-        .block_on(remote_node.http.beacon().state_by_slot(Slot::new(0)))
+        .block_on(remote_node.http.beacon().get_state_by_slot(Slot::new(0)))
         .expect("should fetch state from http api");
 
     let (state_by_root, root_2) = env
         .runtime()
-        .block_on(remote_node.http.beacon().state_by_root(root))
+        .block_on(remote_node.http.beacon().get_state_by_root(root))
         .expect("should fetch state from http api");
 
     let mut db_state = node
@@ -135,12 +177,12 @@ fn beacon_block() {
 
     let (block_by_slot, root) = env
         .runtime()
-        .block_on(remote_node.http.beacon().block_by_slot(Slot::new(0)))
+        .block_on(remote_node.http.beacon().get_block_by_slot(Slot::new(0)))
         .expect("should fetch block from http api");
 
     let (block_by_root, root_2) = env
         .runtime()
-        .block_on(remote_node.http.beacon().block_by_root(root))
+        .block_on(remote_node.http.beacon().get_block_by_root(root))
         .expect("should fetch block from http api");
 
     let db_block = node

--- a/eth2/utils/lighthouse_metrics/src/lib.rs
+++ b/eth2/utils/lighthouse_metrics/src/lib.rs
@@ -55,7 +55,7 @@
 
 use prometheus::{HistogramOpts, HistogramTimer, Opts};
 
-pub use prometheus::{Histogram, IntCounter, IntGauge, Result};
+pub use prometheus::{Encoder, Histogram, IntCounter, IntGauge, Result, TextEncoder};
 
 /// Collect all the metrics for reporting.
 pub fn gather() -> Vec<prometheus::proto::MetricFamily> {

--- a/eth2/utils/remote_beacon_node/Cargo.toml
+++ b/eth2/utils/remote_beacon_node/Cargo.toml
@@ -12,3 +12,6 @@ url = "1.2"
 serde = "1.0"
 futures = "0.1.25"
 types = { path = "../../../eth2/types" }
+rest_api = { path = "../../../beacon_node/rest_api" }
+hex = "0.3"
+eth2_ssz = { path = "../../../eth2/utils/ssz" }

--- a/eth2/utils/remote_beacon_node/Cargo.toml
+++ b/eth2/utils/remote_beacon_node/Cargo.toml
@@ -15,3 +15,4 @@ types = { path = "../../../eth2/types" }
 rest_api = { path = "../../../beacon_node/rest_api" }
 hex = "0.3"
 eth2_ssz = { path = "../../../eth2/utils/ssz" }
+serde_json = "^1.0"

--- a/eth2/utils/remote_beacon_node/src/lib.rs
+++ b/eth2/utils/remote_beacon_node/src/lib.rs
@@ -6,9 +6,10 @@
 use futures::{Future, IntoFuture};
 use reqwest::r#async::{Client, RequestBuilder};
 use serde::Deserialize;
+use ssz::Encode;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
-use types::{BeaconBlock, BeaconState, EthSpec};
+use types::{BeaconBlock, BeaconState, EthSpec, Signature};
 use types::{Hash256, Slot};
 use url::Url;
 
@@ -53,13 +54,52 @@ impl<E: EthSpec> HttpClient<E> {
         Beacon(self.clone())
     }
 
+    pub fn validator(&self) -> Validator<E> {
+        Validator(self.clone())
+    }
+
     fn url(&self, path: &str) -> Result<Url, Error> {
         self.url.join(path).map_err(|e| e.into())
     }
 
     pub fn get(&self, path: &str) -> Result<RequestBuilder, Error> {
+        // TODO: add timeout
         self.url(path)
             .map(|url| Client::new().get(&url.to_string()))
+    }
+}
+
+/// Provides the functions on the `/beacon` endpoint of the node.
+#[derive(Clone)]
+pub struct Validator<E>(HttpClient<E>);
+
+impl<E: EthSpec> Validator<E> {
+    fn url(&self, path: &str) -> Result<Url, Error> {
+        self.0
+            .url("validator/")
+            .and_then(move |url| url.join(path).map_err(Error::from))
+            .map_err(Into::into)
+    }
+
+    /// Requests a new (unsigned) block from the beacon node.
+    pub fn block(
+        &self,
+        slot: Slot,
+        randao_reveal: Signature,
+    ) -> impl Future<Item = BeaconBlock<E>, Error = Error> {
+        let client = self.0.clone();
+        self.url("block")
+            .into_future()
+            .and_then(move |mut url| {
+                url.query_pairs_mut()
+                    .append_pair("slot", &format!("{}", slot.as_u64()));
+                url.query_pairs_mut()
+                    .append_pair("randao_reveal", &signature_as_string(&randao_reveal));
+                client.get(&url.to_string())
+            })
+            .and_then(|builder| builder.send().map_err(Error::from))
+            .and_then(|response| response.error_for_status().map_err(Error::from))
+            .and_then(|mut success| success.json::<BeaconBlock<E>>().map_err(Error::from))
     }
 }
 
@@ -76,16 +116,32 @@ impl<E: EthSpec> Beacon<E> {
     }
 
     /// Returns the block and block root at the given slot.
-    pub fn block_at_slot(
+    pub fn block_by_slot(
         &self,
         slot: Slot,
+    ) -> impl Future<Item = (BeaconBlock<E>, Hash256), Error = Error> {
+        self.block("slot", format!("{}", slot.as_u64()))
+    }
+
+    /// Returns the block and block root at the given root.
+    pub fn block_by_root(
+        &self,
+        root: Hash256,
+    ) -> impl Future<Item = (BeaconBlock<E>, Hash256), Error = Error> {
+        self.block("root", root_as_string(root))
+    }
+
+    /// Returns the block and block root at the given slot.
+    fn block(
+        &self,
+        query_key: &'static str,
+        query_param: String,
     ) -> impl Future<Item = (BeaconBlock<E>, Hash256), Error = Error> {
         let client = self.0.clone();
         self.url("block")
             .into_future()
             .and_then(move |mut url| {
-                url.query_pairs_mut()
-                    .append_pair("slot", &format!("{}", slot.as_u64()));
+                url.query_pairs_mut().append_pair(query_key, &query_param);
                 client.get(&url.to_string())
             })
             .and_then(|builder| builder.send().map_err(Error::from))
@@ -95,16 +151,32 @@ impl<E: EthSpec> Beacon<E> {
     }
 
     /// Returns the state and state root at the given slot.
-    pub fn state_at_slot(
+    pub fn state_by_slot(
         &self,
         slot: Slot,
+    ) -> impl Future<Item = (BeaconState<E>, Hash256), Error = Error> {
+        self.state("slot", format!("{}", slot.as_u64()))
+    }
+
+    /// Returns the state and state root at the given root.
+    pub fn state_by_root(
+        &self,
+        root: Hash256,
+    ) -> impl Future<Item = (BeaconState<E>, Hash256), Error = Error> {
+        self.state("root", root_as_string(root))
+    }
+
+    /// Returns the state and state root at the given slot.
+    fn state(
+        &self,
+        query_key: &'static str,
+        query_param: String,
     ) -> impl Future<Item = (BeaconState<E>, Hash256), Error = Error> {
         let client = self.0.clone();
         self.url("state")
             .into_future()
             .and_then(move |mut url| {
-                url.query_pairs_mut()
-                    .append_pair("slot", &format!("{}", slot.as_u64()));
+                url.query_pairs_mut().append_pair(query_key, &query_param);
                 client.get(&url.to_string())
             })
             .and_then(|builder| builder.send().map_err(Error::from))
@@ -126,6 +198,14 @@ pub struct BlockResponse<T: EthSpec> {
 pub struct StateResponse<T: EthSpec> {
     pub beacon_state: BeaconState<T>,
     pub root: Hash256,
+}
+
+fn root_as_string(root: Hash256) -> String {
+    format!("0x{:?}", root)
+}
+
+fn signature_as_string(signature: &Signature) -> String {
+    format!("0x{}", hex::encode(signature.as_ssz_bytes()))
 }
 
 impl From<reqwest::Error> for Error {

--- a/tests/node_test_rig/src/lib.rs
+++ b/tests/node_test_rig/src/lib.rs
@@ -63,5 +63,7 @@ fn testing_client_config() -> (ClientConfig, TempDir) {
         genesis_time: 13_371_337,
     };
 
+    client_config.dummy_eth1_backend = true;
+
     (client_config, tempdir)
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Major:

- Fixes an application-wide deadlock whenever a `POST` request is made.
- Fixes a panic whenever validator duties are pulled from the HTTP server

- Add a test suite for the `rest_api` that spins up a `ProductionBeaconNode` and ensures that the data returned from the API matches the data directly from the source (e.g., the `BeaconChain`).
- Replaces the `ApiService` struct with a `make_service_fn` solution.
- No longer attach state (e.g., `BeaconChain`) to the `req.extensions()`, instead just pass them as function parameters.
- Adds methods to the `RemoteBeaconNode` struct so they can be used for testing.

## Notes

- ~~Blocked on #542~~
- Uses code from #537
