### PR TITLE
Set the gitlab docker image to latest

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 #Adapted from https://users.rust-lang.org/t/my-gitlab-config-docs-tests/16396
 
 default:
-  image: 'sigp/lighthouse:eth1'
+  image: 'sigp/lighthouse:latest'
   cache:
     paths:
       - tests/ef_tests/*-v0.8.3.tar.gz


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Sets the gitlab docker image back to to `lighthouse:latest` after I set it (incorrectly) in the `eth1` PR.