### PR TITLE
Add in docs instructions to install ganache-cli to run some tests

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -6,6 +6,8 @@
 	- Use the `stable` toolchain (it's the default).
 1. Install build dependencies using your package manager.
     - `clang`, `protobuf`, `libssl-dev`, `cmake`
+1. Install `ganache-cli` to be able to run eth1 blockchain tests
+   - Run `npm install -g ganache-cli`
 1. Clone the [github.com/sigp/lighthouse](https://github.com/sigp/lighthouse)
    repository.
 1. Run `$ make` to build Lighthouse.


### PR DESCRIPTION
Today in "_Become a contributor by adding one line of documentation_".

Tests were failing on a fresh computer until installed `ganache-cli` :grimacing: 

### Before

```
[...]

---- http::incrementing_deposits stdout ----
thread 'http::incrementing_deposits' panicked at 'should start eth1 environment: "Failed to start ganche-cli. Is it ganache-cli installed and available on $PATH? Error: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }"', src/libcore/result.rs:999:5

[...]

failures:
    auto_update::can_auto_update
    deposit_tree::cache_consistency
    deposit_tree::double_update
    deposit_tree::updating
    eth1_cache::big_skip
    eth1_cache::double_update
    eth1_cache::pruning
    eth1_cache::simple_scenario
    http::incrementing_deposits

test result: FAILED. 0 passed; 9 failed; 0 ignored; 0 measured; 0 filtered out

[...]
```

### After

```
[...]

test http::incrementing_deposits ... ok
test auto_update::can_auto_update ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

[...]
```