### PR TITLE
Correct ENR update and log formatting

### DIFF
--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -77,7 +77,7 @@ impl<TSubstream> Discovery<TSubstream> {
             None => String::from(""),
         };
 
-        info!(log, "ENR Initialised"; "ENR" => local_enr.to_base64(), "Seq" => local_enr.seq());
+        info!(log, "ENR Initialised"; "enr" => local_enr.to_base64(), "seq" => local_enr.seq());
         debug!(log, "Discv5 Node ID Initialised"; "node_id" => format!("{}",local_enr.node_id()));
 
         // the last parameter enables IP limiting. 2 Nodes on the same /24 subnet per bucket and 10
@@ -110,8 +110,8 @@ impl<TSubstream> Discovery<TSubstream> {
         })
     }
 
-    /// Allows the application layer to update the `ip` and `port` of the local ENR. The second
-    /// parameter defines whether the port is a TPC port. If false, this is interpreted as a UDP
+    /// Allows the application layer to update the `IP` and `port` of the local ENR. The second
+    /// parameter defines whether the port is a TCP port. If false, this is interpreted as a UDP
     /// port.
     pub fn update_local_enr(&mut self, socket: std::net::SocketAddr, is_tcp: bool) {
         // discv5 checks to see if an update is necessary before performing it, so we do not
@@ -251,7 +251,7 @@ where
                 }
                 Ok(Async::NotReady) => break,
                 Err(e) => {
-                    warn!(self.log, "Discovery peer search failed"; "Error" => format!("{:?}", e));
+                    warn!(self.log, "Discovery peer search failed"; "error" => format!("{:?}", e));
                 }
             }
         }
@@ -266,7 +266,7 @@ where
                             // query.
                         }
                         Discv5Event::SocketUpdated(socket) => {
-                            info!(self.log, "Address updated"; "IP" => format!("{}",socket.ip()));
+                            info!(self.log, "Address updated"; "ip" => format!("{}",socket.ip()), "port" => format!("{}", socket.port()));
                             metrics::inc_counter(&metrics::ADDRESS_UPDATE_COUNT);
                             let mut address = Multiaddr::from(socket.ip());
                             address.push(Protocol::Tcp(self.tcp_port));

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -204,6 +204,11 @@ where
         &mut self,
         out: <RPCProtocol as InboundUpgrade<TSubstream>>::Output,
     ) {
+        // update the keep alive timeout if there are no more remaining outbound streams
+        if let KeepAlive::Until(_) = self.keep_alive {
+            self.keep_alive = KeepAlive::Until(Instant::now() + self.inactive_timeout);
+        }
+
         let (req, substream) = out;
         // drop the stream and return a 0 id for goodbye "requests"
         if let r @ RPCRequest::Goodbye(_) = req {

--- a/beacon_node/eth2-libp2p/src/service.rs
+++ b/beacon_node/eth2-libp2p/src/service.rs
@@ -219,6 +219,7 @@ impl Stream for Service {
         if !self.verified_listen_address {
             let multiaddr = Swarm::listeners(&self.swarm).next();
             if let Some(multiaddr) = multiaddr {
+                self.verified_listen_address = true;
                 if let Some(socket_addr) = multiaddr_to_socket_addr(multiaddr) {
                     self.swarm.update_local_enr_socket(socket_addr, true);
                 }


### PR DESCRIPTION
This adds a few minor corrections. 

- Corrects the Lighthouse ENR IP update logic
- Resets the `KeepAlive` timeout for the RPC on incoming connections (this realistically has no effect in lighthouse as gossipsub maintains a permanent connection) but it's added for logical consistency
- Corrects some formatting in discovery logs