### PR TITLE
Specify master branch for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An open-source Ethereum 2.0 client, written in Rust and maintained by Sigma Prim
 
 [![Build Status]][Build Link] [![Book Status]][Book Link] [![RustDoc Status]][RustDoc Link] [![Chat Badge]][Chat Link] [![Swagger Badge]][Swagger Link]
 
-[Build Status]: https://github.com/sigp/lighthouse/workflows/test-suite/badge.svg
+[Build Status]: https://github.com/sigp/lighthouse/workflows/test-suite/badge.svg?branch=master
 [Build Link]: https://github.com/sigp/lighthouse/actions
 [Chat Badge]: https://img.shields.io/badge/chat-discord-%237289da
 [Chat Link]: https://discord.gg/cyAszAh


### PR DESCRIPTION
## Issue Addressed

Ensures that the badge on the readme only refers to tests on the master branch. Presently it just refers to the latest test.
