### PR TITLE
Add test for when skip slots remove all active validators

### DIFF
--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -12,9 +12,14 @@ use beacon_chain::{
     BlockProcessingOutcome,
 };
 use rand::Rng;
+use state_processing::{
+    per_slot_processing, per_slot_processing::Error as SlotProcessingError, EpochProcessingError,
+};
 use store::Store;
 use types::test_utils::{SeedableRng, TestRandom, XorShiftRng};
-use types::{Deposit, EthSpec, Hash256, Keypair, MinimalEthSpec, RelativeEpoch, Slot};
+use types::{
+    BeaconStateError, Deposit, EthSpec, Hash256, Keypair, MinimalEthSpec, RelativeEpoch, Slot,
+};
 
 // Should ideally be divisible by 3.
 pub const VALIDATOR_COUNT: usize = 24;
@@ -30,6 +35,30 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<HarnessType<Minimal
     harness.advance_slot();
 
     harness
+}
+
+#[test]
+fn massive_skips() {
+    let harness = get_harness(8);
+    let spec = &MinimalEthSpec::default_spec();
+    let mut state = harness.chain.head().beacon_state;
+
+    // Run per_slot_processing until it returns an error.
+    let error = loop {
+        match per_slot_processing(&mut state, spec) {
+            Ok(_) => continue,
+            Err(e) => break e,
+        }
+    };
+
+    assert!(state.slot > 1, "the state should skip at least one slot");
+    assert_eq!(
+        error,
+        SlotProcessingError::EpochProcessingError(EpochProcessingError::BeaconStateError(
+            BeaconStateError::InsufficientValidators
+        )),
+        "should return error indicating that validators have been slashed out"
+    )
 }
 
 #[test]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Inspired by @arnetheduck in a Discord chat, this test ensures that we don't panic when we skip so far into the future that all validators are slashed.

## Notes

Only adds a test, does not change actual "business" logic.
