### PR TITLE
Add maximum slot limit when processing blocks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -47,8 +47,8 @@ pub const GRAFFITI: &str = "sigp/lighthouse-0.0.0-prerelease";
 const WRITE_BLOCK_PROCESSING_SSZ: bool = cfg!(feature = "write_ssz_files");
 
 /// Maximum block slot number. Block with slots bigger than this constant will NOT be processed.
-// Approximately 100 years (2^28 * SLOTS_PER_EPOCH / SECONDS_PER_DAY / 365)
-// with SLOTS_PER_EPOCH == 12 and SECONDS_PER_DAY == 86400
+// Approximately 100 years (2^28 * SECONDS_PER_SLOT / SECONDS_PER_DAY / 365)
+// with SECONDS_PER_SLOT == 12 and SECONDS_PER_DAY == 86400
 const MAXIMUM_BLOCK_SLOT_NUMBER: u64 = 268_435_456;
 
 #[derive(Debug, PartialEq)]

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -49,7 +49,7 @@ const WRITE_BLOCK_PROCESSING_SSZ: bool = cfg!(feature = "write_ssz_files");
 /// Maximum block slot number. Block with slots bigger than this constant will NOT be processed.
 // Approximately 100 years (2^28 * SLOTS_PER_EPOCH / SECONDS_PER_DAY / 365)
 // with SLOTS_PER_EPOCH == 12 and SECONDS_PER_DAY == 86400
-const MAXIMUM_BLOCK_SLOT_NUMBER: u64 = 268435456;
+const MAXIMUM_BLOCK_SLOT_NUMBER: u64 = 268_435_456;
 
 #[derive(Debug, PartialEq)]
 pub enum BlockProcessingOutcome {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -38,7 +38,7 @@ use types::*;
 // Must be 32-bytes or panic.
 //
 //                          |-------must be this long------|
-pub const GRAFFITI: &str = "sigp/lighthouse-0.0.0-prerelease";
+pub const GRAFFITI: &str = "sigp/lighthouse-0.1.0-prerelease";
 
 /// If true, everytime a block is processed the pre-state, post-state and block are written to SSZ
 /// files in the temp directory.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -47,9 +47,7 @@ pub const GRAFFITI: &str = "sigp/lighthouse-0.0.0-prerelease";
 const WRITE_BLOCK_PROCESSING_SSZ: bool = cfg!(feature = "write_ssz_files");
 
 /// Maximum block slot number. Block with slots bigger than this constant will NOT be processed.
-// Approximately 100 years (2^28 * SECONDS_PER_SLOT / SECONDS_PER_DAY / 365)
-// with SECONDS_PER_SLOT == 12 and SECONDS_PER_DAY == 86400
-const MAXIMUM_BLOCK_SLOT_NUMBER: u64 = 268_435_456;
+const MAXIMUM_BLOCK_SLOT_NUMBER: u64 = 4_294_967_296; // 2^32
 
 #[derive(Debug, PartialEq)]
 pub enum BlockProcessingOutcome {


### PR DESCRIPTION
## Issue Addressed

Closes #661 

## Proposed Changes

Add a maximum slot limit after which we won't process incoming blocks anymore.

## Additional Info

This number is 2^28 (`268_435_456`). If we let `SECONDS_PER_SLOT = 12` and `SECONDS_PER_DAY = 6400`, then we can see that `2^28 * 12 / 86400 / 365` ~= 102 years, or about the number of years first mentioned in #661 .
Fun fact, if we were to use 2^64, we'd be fine for about `7 019 309 008 260` years, or about 7 trillion years.