### PR TITLE
Faster BeaconState enc/dec

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -454,7 +454,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Returns the validator index (if any) for the given public key.
     ///
     /// Information is retrieved from the present `beacon_state.validators`.
-    pub fn validator_index(&self, pubkey: &PublicKey) -> Option<usize> {
+    pub fn validator_index(&self, pubkey: &PublicKeyBytes) -> Option<usize> {
         for (i, validator) in self.head().beacon_state.validators.iter().enumerate() {
             if validator.pubkey == *pubkey {
                 return Some(i);

--- a/beacon_node/rest_api/src/helpers.rs
+++ b/beacon_node/rest_api/src/helpers.rs
@@ -1,6 +1,6 @@
 use crate::{ApiError, ApiResult};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
-use bls::PublicKey;
+use bls::PublicKeyBytes;
 use eth2_libp2p::{PubsubMessage, Topic};
 use eth2_libp2p::{
     BEACON_ATTESTATION_TOPIC, BEACON_BLOCK_TOPIC, TOPIC_ENCODING_POSTFIX, TOPIC_PREFIX,
@@ -99,12 +99,12 @@ pub fn parse_root(string: &str) -> Result<Hash256, ApiError> {
 }
 
 /// Parse a PublicKey from a `0x` prefixed hex string
-pub fn parse_pubkey(string: &str) -> Result<PublicKey, ApiError> {
+pub fn parse_pubkey_bytes(string: &str) -> Result<PublicKeyBytes, ApiError> {
     const PREFIX: &str = "0x";
     if string.starts_with(PREFIX) {
         let pubkey_bytes = hex::decode(string.trim_start_matches(PREFIX))
             .map_err(|e| ApiError::BadRequest(format!("Invalid hex string: {:?}", e)))?;
-        let pubkey = PublicKey::from_bytes(pubkey_bytes.as_slice()).map_err(|e| {
+        let pubkey = PublicKeyBytes::from_bytes(pubkey_bytes.as_slice()).map_err(|e| {
             ApiError::BadRequest(format!("Unable to deserialize public key: {:?}.", e))
         })?;
         Ok(pubkey)

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -37,7 +37,7 @@ use tokio::runtime::TaskExecutor;
 use tokio::sync::mpsc;
 use url_query::UrlQuery;
 
-pub use crate::helpers::parse_pubkey;
+pub use crate::helpers::parse_pubkey_bytes;
 pub use beacon::{BlockResponse, HeadResponse, StateResponse};
 pub use config::Config;
 pub use validator::{BulkValidatorDutiesRequest, ValidatorDuty};

--- a/beacon_node/rest_api/tests/test.rs
+++ b/beacon_node/rest_api/tests/test.rs
@@ -6,6 +6,7 @@ use node_test_rig::{
     testing_client_config, ClientConfig, ClientGenesis, LocalBeaconNode,
 };
 use remote_beacon_node::{PublishStatus, ValidatorDuty};
+use std::convert::TryInto;
 use std::sync::Arc;
 use tree_hash::TreeHash;
 use types::{
@@ -182,7 +183,7 @@ fn validator_duties_bulk() {
         .beacon_state
         .validators
         .iter()
-        .map(|v| v.pubkey.clone())
+        .map(|v| (&v.pubkey).try_into().expect("pubkey should be valid"))
         .collect::<Vec<_>>();
 
     let duties = env
@@ -219,7 +220,7 @@ fn validator_duties() {
         .beacon_state
         .validators
         .iter()
-        .map(|v| v.pubkey.clone())
+        .map(|v| (&v.pubkey).try_into().expect("pubkey should be valid"))
         .collect::<Vec<_>>();
 
     let duties = env
@@ -270,10 +271,16 @@ fn check_duties<T: BeaconChainTypes>(
         .iter()
         .zip(duties.iter())
         .for_each(|(validator, duty)| {
-            assert_eq!(*validator, duty.validator_pubkey, "pubkey should match");
+            assert_eq!(
+                *validator,
+                (&duty.validator_pubkey)
+                    .try_into()
+                    .expect("should be valid pubkey"),
+                "pubkey should match"
+            );
 
             let validator_index = state
-                .get_validator_index(validator)
+                .get_validator_index(&validator.clone().into())
                 .expect("should have pubkey cache")
                 .expect("pubkey should exist");
 

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
+[[bench]]
+name = "benches"
+harness = false
+
 [dev-dependencies]
 tempfile = "3.1.0"
 sloggers = "0.3.2"
+criterion = "0.3.0"
+rayon = "1.2.0"
 
 [dependencies]
 db-key = "0.0.5"

--- a/beacon_node/store/benches/benches.rs
+++ b/beacon_node/store/benches/benches.rs
@@ -1,0 +1,114 @@
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use rayon::prelude::*;
+use ssz::{Decode, Encode};
+use std::convert::TryInto;
+use store::BeaconStateStorageContainer;
+use types::{
+    test_utils::generate_deterministic_keypair, BeaconState, Epoch, Eth1Data, EthSpec, Hash256,
+    MainnetEthSpec, Validator,
+};
+
+fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
+    let spec = &E::default_spec();
+    let eth1_data = Eth1Data {
+        deposit_root: Hash256::zero(),
+        deposit_count: 0,
+        block_hash: Hash256::zero(),
+    };
+
+    let mut state = BeaconState::new(0, eth1_data, spec);
+
+    for i in 0..validator_count {
+        state.balances.push(i as u64).expect("should add balance");
+    }
+
+    state.validators = (0..validator_count)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .par_iter()
+        .map(|&i| Validator {
+            pubkey: generate_deterministic_keypair(i).pk.into(),
+            withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
+            effective_balance: spec.max_effective_balance,
+            slashed: false,
+            activation_eligibility_epoch: Epoch::new(0),
+            activation_epoch: Epoch::new(0),
+            exit_epoch: Epoch::from(u64::max_value()),
+            withdrawable_epoch: Epoch::from(u64::max_value()),
+        })
+        .collect::<Vec<_>>()
+        .into();
+
+    state.build_all_caches(spec).expect("should build caches");
+
+    state
+}
+
+fn all_benches(c: &mut Criterion) {
+    let validator_count = 16_384;
+    let state = get_state::<MainnetEthSpec>(validator_count);
+    let storage_container = BeaconStateStorageContainer::new(&state);
+    let state_bytes = storage_container.as_ssz_bytes();
+
+    let inner_state = state.clone();
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("encode/beacon_state", move |b| {
+            b.iter_batched_ref(
+                || inner_state.clone(),
+                |state| black_box(BeaconStateStorageContainer::new(state).as_ssz_bytes()),
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+
+    let inner_state = state.clone();
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("encode/beacon_state/tree_hash_cache", move |b| {
+            b.iter_batched_ref(
+                || inner_state.tree_hash_cache.clone(),
+                |tree_hash_cache| black_box(tree_hash_cache.as_ssz_bytes()),
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+
+    let inner_state = state.clone();
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("encode/beacon_state/committee_cache[0]", move |b| {
+            b.iter_batched_ref(
+                || inner_state.committee_caches[0].clone(),
+                |committee_cache| black_box(committee_cache.as_ssz_bytes()),
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("decode/beacon_state", move |b| {
+            b.iter_batched_ref(
+                || state_bytes.clone(),
+                |bytes| {
+                    let state: BeaconState<MainnetEthSpec> =
+                        BeaconStateStorageContainer::from_ssz_bytes(&bytes)
+                            .expect("should decode")
+                            .try_into()
+                            .expect("should convert into state");
+                    black_box(state)
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+}
+
+criterion_group!(benches, all_benches,);
+criterion_main!(benches);

--- a/beacon_node/store/examples/ssz_encode_state.rs
+++ b/beacon_node/store/examples/ssz_encode_state.rs
@@ -1,0 +1,63 @@
+//! These examples only really exist so we can use them for flamegraph. If they get annoying to
+//! maintain, feel free to delete.
+
+use rayon::prelude::*;
+use ssz::{Decode, Encode};
+use std::convert::TryInto;
+use store::BeaconStateStorageContainer;
+use types::{
+    test_utils::generate_deterministic_keypair, BeaconState, Epoch, Eth1Data, EthSpec, Hash256,
+    MainnetEthSpec, Validator,
+};
+
+type E = MainnetEthSpec;
+
+fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
+    let spec = &E::default_spec();
+    let eth1_data = Eth1Data {
+        deposit_root: Hash256::zero(),
+        deposit_count: 0,
+        block_hash: Hash256::zero(),
+    };
+
+    let mut state = BeaconState::new(0, eth1_data, spec);
+
+    for i in 0..validator_count {
+        state.balances.push(i as u64).expect("should add balance");
+    }
+
+    state.validators = (0..validator_count)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .par_iter()
+        .map(|&i| Validator {
+            pubkey: generate_deterministic_keypair(i).pk.into(),
+            withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
+            effective_balance: spec.max_effective_balance,
+            slashed: false,
+            activation_eligibility_epoch: Epoch::new(0),
+            activation_epoch: Epoch::new(0),
+            exit_epoch: Epoch::from(u64::max_value()),
+            withdrawable_epoch: Epoch::from(u64::max_value()),
+        })
+        .collect::<Vec<_>>()
+        .into();
+
+    state.build_all_caches(spec).expect("should build caches");
+
+    state
+}
+
+fn main() {
+    let validator_count = 1_024;
+    let state = get_state::<E>(validator_count);
+    let storage_container = BeaconStateStorageContainer::new(&state);
+
+    for _ in 0..1024 {
+        let container_bytes = storage_container.as_ssz_bytes();
+        let _: BeaconState<E> = BeaconStateStorageContainer::from_ssz_bytes(&container_bytes)
+            .expect("should decode")
+            .try_into()
+            .expect("should convert into state");
+    }
+}

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -53,14 +53,21 @@ pub struct StorageContainer<T: EthSpec> {
 impl<T: EthSpec> StorageContainer<T> {
     /// Create a new instance for storing a `BeaconState`.
     pub fn new(state: &BeaconState<T>) -> Self {
+        let mut state = state.clone();
+
+        let mut committee_caches = vec![CommitteeCache::default(); CACHED_EPOCHS];
+
+        for i in 0..CACHED_EPOCHS {
+            std::mem::swap(&mut state.committee_caches[i], &mut committee_caches[i]);
+        }
+
+        let tree_hash_cache =
+            std::mem::replace(&mut state.tree_hash_cache, BeaconTreeHashCache::default());
+
         Self {
-            state: state.clone(),
-            committee_caches: state
-                .committee_caches
-                .iter()
-                .map(|cache| cache.clone())
-                .collect(),
-            tree_hash_cache: state.tree_hash_cache.clone(),
+            state,
+            committee_caches,
+            tree_hash_cache,
         }
     }
 }

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -44,10 +44,10 @@ pub fn get_full_state<S: Store, E: EthSpec>(
 /// A container for storing `BeaconState` components.
 // TODO: would be more space efficient with the caches stored separately and referenced by hash
 #[derive(Encode, Decode)]
-struct StorageContainer {
+pub struct StorageContainer {
     state_bytes: Vec<u8>,
-    committee_caches_bytes: Vec<Vec<u8>>,
-    tree_hash_cache_bytes: Vec<u8>,
+    committee_caches: Vec<CommitteeCache>,
+    tree_hash_cache: BeaconTreeHashCache,
 }
 
 impl StorageContainer {
@@ -59,12 +59,14 @@ impl StorageContainer {
             committee_caches_bytes.push(cache.as_ssz_bytes());
         }
 
-        let tree_hash_cache_bytes = state.tree_hash_cache.as_ssz_bytes();
-
         Self {
             state_bytes: state.as_ssz_bytes(),
-            committee_caches_bytes,
-            tree_hash_cache_bytes,
+            committee_caches: state
+                .committee_caches
+                .iter()
+                .map(|cache| cache.clone())
+                .collect(),
+            tree_hash_cache: state.tree_hash_cache.clone(),
         }
     }
 }
@@ -72,20 +74,20 @@ impl StorageContainer {
 impl<T: EthSpec> TryInto<BeaconState<T>> for StorageContainer {
     type Error = Error;
 
-    fn try_into(self) -> Result<BeaconState<T>, Error> {
+    fn try_into(mut self) -> Result<BeaconState<T>, Error> {
         let mut state: BeaconState<T> = BeaconState::from_ssz_bytes(&self.state_bytes)?;
 
-        for i in 0..CACHED_EPOCHS {
-            let bytes = &self.committee_caches_bytes.get(i).ok_or_else(|| {
-                Error::SszDecodeError(DecodeError::BytesInvalid(
+        for i in (0..CACHED_EPOCHS).rev() {
+            if i >= self.committee_caches.len() {
+                return Err(Error::SszDecodeError(DecodeError::BytesInvalid(
                     "Insufficient committees for BeaconState".to_string(),
-                ))
-            })?;
+                )));
+            };
 
-            state.committee_caches[i] = CommitteeCache::from_ssz_bytes(bytes)?;
+            state.committee_caches[i] = self.committee_caches.remove(i);
         }
 
-        state.tree_hash_cache = BeaconTreeHashCache::from_ssz_bytes(&self.tree_hash_cache_bytes)?;
+        state.tree_hash_cache = self.tree_hash_cache;
 
         Ok(state)
     }

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -31,6 +31,7 @@ pub use self::memory_store::MemoryStore;
 pub use self::migrate::Migrate;
 pub use self::partial_beacon_state::PartialBeaconState;
 pub use errors::Error;
+pub use impls::beacon_state::StorageContainer as BeaconStateStorageContainer;
 pub use metrics::scrape_for_metrics;
 pub use types::*;
 

--- a/eth2/state_processing/src/per_block_processing.rs
+++ b/eth2/state_processing/src/per_block_processing.rs
@@ -440,7 +440,7 @@ pub fn process_deposit<T: EthSpec>(
     };
     // Get an `Option<u64>` where `u64` is the validator index if this deposit public key
     // already exists in the beacon_state.
-    let validator_index = get_existing_validator_index(state, &pubkey)
+    let validator_index = get_existing_validator_index(state, &deposit.data.pubkey)
         .map_err(|e| e.into_with_index(deposit_index))?;
 
     let amount = deposit.data.amount;
@@ -457,7 +457,7 @@ pub fn process_deposit<T: EthSpec>(
 
         // Create a new validator.
         let validator = Validator {
-            pubkey,
+            pubkey: pubkey.into(),
             withdrawal_credentials: deposit.data.withdrawal_credentials,
             activation_eligibility_epoch: spec.far_future_epoch,
             activation_epoch: spec.far_future_epoch,

--- a/eth2/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/eth2/state_processing/src/per_block_processing/verify_deposit.rs
@@ -35,7 +35,7 @@ pub fn verify_deposit_signature(deposit_data: &DepositData, spec: &ChainSpec) ->
 /// Errors if the state's `pubkey_cache` is not current.
 pub fn get_existing_validator_index<T: EthSpec>(
     state: &BeaconState<T>,
-    pub_key: &PublicKey,
+    pub_key: &PublicKeyBytes,
 ) -> Result<Option<u64>> {
     let validator_index = state.get_validator_index(pub_key)?;
     Ok(validator_index.map(|idx| idx as u64))

--- a/eth2/types/Cargo.toml
+++ b/eth2/types/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com>"]
 edition = "2018"
 
+[[bench]]
+name = "benches"
+harness = false
+
 [dependencies]
 bls = { path = "../utils/bls" }
 compare_fields = { path = "../utils/compare_fields" }
@@ -37,3 +41,4 @@ tempfile = "3.1.0"
 [dev-dependencies]
 env_logger = "0.7.1"
 serde_json = "1.0.41"
+criterion = "0.3.0"

--- a/eth2/types/benches/benches.rs
+++ b/eth2/types/benches/benches.rs
@@ -1,0 +1,74 @@
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use ssz::{Decode, Encode};
+use types::{
+    test_utils::generate_deterministic_keypair, BeaconState, Eth1Data, EthSpec, Hash256,
+    MinimalEthSpec, Validator,
+};
+
+fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
+    let spec = &E::default_spec();
+    let eth1_data = Eth1Data {
+        deposit_root: Hash256::zero(),
+        deposit_count: 0,
+        block_hash: Hash256::zero(),
+    };
+
+    let mut state = BeaconState::new(0, eth1_data, spec);
+
+    for i in 0..validator_count {
+        state.balances.push(i as u64).expect("should add balance");
+        state
+            .validators
+            .push(Validator {
+                pubkey: generate_deterministic_keypair(i).pk,
+                withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
+                effective_balance: i as u64,
+                slashed: i % 2 == 0,
+                activation_eligibility_epoch: i.into(),
+                activation_epoch: i.into(),
+                exit_epoch: i.into(),
+                withdrawable_epoch: i.into(),
+            })
+            .expect("should add validator");
+    }
+
+    state
+}
+
+fn all_benches(c: &mut Criterion) {
+    let validator_count = 1_024;
+    let state = get_state::<MinimalEthSpec>(validator_count);
+    let state_bytes = state.as_ssz_bytes();
+
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("encode/beacon_state", move |b| {
+            b.iter_batched_ref(
+                || state.clone(),
+                |state| black_box(state.as_ssz_bytes()),
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+
+    c.bench(
+        &format!("{}_validators", validator_count),
+        Benchmark::new("decode/beacon_state", move |b| {
+            b.iter_batched_ref(
+                || state_bytes.clone(),
+                |bytes| {
+                    let state: BeaconState<MinimalEthSpec> =
+                        BeaconState::from_ssz_bytes(&bytes).expect("should decode");
+                    black_box(state)
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        })
+        .sample_size(10),
+    );
+}
+
+criterion_group!(benches, all_benches,);
+criterion_main!(benches);

--- a/eth2/types/benches/benches.rs
+++ b/eth2/types/benches/benches.rs
@@ -1,9 +1,10 @@
 use criterion::Criterion;
 use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use rayon::prelude::*;
 use ssz::{Decode, Encode};
 use types::{
     test_utils::generate_deterministic_keypair, BeaconState, Eth1Data, EthSpec, Hash256,
-    MinimalEthSpec, Validator,
+    MainnetEthSpec, Validator,
 };
 
 fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
@@ -18,27 +19,31 @@ fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
 
     for i in 0..validator_count {
         state.balances.push(i as u64).expect("should add balance");
-        state
-            .validators
-            .push(Validator {
-                pubkey: generate_deterministic_keypair(i).pk.into(),
-                withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
-                effective_balance: i as u64,
-                slashed: i % 2 == 0,
-                activation_eligibility_epoch: i.into(),
-                activation_epoch: i.into(),
-                exit_epoch: i.into(),
-                withdrawable_epoch: i.into(),
-            })
-            .expect("should add validator");
     }
+
+    state.validators = (0..validator_count)
+        .into_iter()
+        .collect::<Vec<_>>()
+        .par_iter()
+        .map(|&i| Validator {
+            pubkey: generate_deterministic_keypair(i).pk.into(),
+            withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
+            effective_balance: i as u64,
+            slashed: i % 2 == 0,
+            activation_eligibility_epoch: i.into(),
+            activation_epoch: i.into(),
+            exit_epoch: i.into(),
+            withdrawable_epoch: i.into(),
+        })
+        .collect::<Vec<_>>()
+        .into();
 
     state
 }
 
 fn all_benches(c: &mut Criterion) {
-    let validator_count = 1_024;
-    let state = get_state::<MinimalEthSpec>(validator_count);
+    let validator_count = 16_384;
+    let state = get_state::<MainnetEthSpec>(validator_count);
     let state_bytes = state.as_ssz_bytes();
 
     c.bench(
@@ -59,7 +64,7 @@ fn all_benches(c: &mut Criterion) {
             b.iter_batched_ref(
                 || state_bytes.clone(),
                 |bytes| {
-                    let state: BeaconState<MinimalEthSpec> =
+                    let state: BeaconState<MainnetEthSpec> =
                         BeaconState::from_ssz_bytes(&bytes).expect("should decode");
                     black_box(state)
                 },

--- a/eth2/types/benches/benches.rs
+++ b/eth2/types/benches/benches.rs
@@ -21,7 +21,7 @@ fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
         state
             .validators
             .push(Validator {
-                pubkey: generate_deterministic_keypair(i).pk,
+                pubkey: generate_deterministic_keypair(i).pk.into(),
                 withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
                 effective_balance: i as u64,
                 slashed: i % 2 == 0,

--- a/eth2/types/examples/ssz_encode_state.rs
+++ b/eth2/types/examples/ssz_encode_state.rs
@@ -24,7 +24,7 @@ fn get_state(validator_count: usize) -> BeaconState<E> {
         state
             .validators
             .push(Validator {
-                pubkey: generate_deterministic_keypair(i).pk,
+                pubkey: generate_deterministic_keypair(i).pk.into(),
                 withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
                 effective_balance: i as u64,
                 slashed: i % 2 == 0,

--- a/eth2/types/examples/ssz_encode_state.rs
+++ b/eth2/types/examples/ssz_encode_state.rs
@@ -1,0 +1,47 @@
+use ssz::{Decode, Encode};
+use types::{
+    test_utils::generate_deterministic_keypair, BeaconState, Eth1Data, EthSpec, Hash256,
+    MinimalEthSpec, Validator,
+};
+
+type E = MinimalEthSpec;
+
+fn get_state(validator_count: usize) -> BeaconState<E> {
+    let spec = &E::default_spec();
+    let eth1_data = Eth1Data {
+        deposit_root: Hash256::zero(),
+        deposit_count: 0,
+        block_hash: Hash256::zero(),
+    };
+
+    let mut state = BeaconState::new(0, eth1_data, spec);
+
+    for i in 0..validator_count {
+        state.balances.push(i as u64).expect("should add balance");
+        state
+            .validators
+            .push(Validator {
+                pubkey: generate_deterministic_keypair(i).pk,
+                withdrawal_credentials: Hash256::from_low_u64_le(i as u64),
+                effective_balance: i as u64,
+                slashed: i % 2 == 0,
+                activation_eligibility_epoch: i.into(),
+                activation_epoch: i.into(),
+                exit_epoch: i.into(),
+                withdrawable_epoch: i.into(),
+            })
+            .expect("should add validator");
+    }
+
+    state
+}
+
+fn main() {
+    let validator_count = 1_024;
+    let state = get_state(validator_count);
+
+    for _ in 0..1_024 {
+        let state_bytes = state.as_ssz_bytes();
+        let _: BeaconState<E> = BeaconState::from_ssz_bytes(&state_bytes).expect("should decode");
+    }
+}

--- a/eth2/types/examples/ssz_encode_state.rs
+++ b/eth2/types/examples/ssz_encode_state.rs
@@ -1,3 +1,6 @@
+//! These examples only really exist so we can use them for flamegraph. If they get annoying to
+//! maintain, feel free to delete.
+
 use ssz::{Decode, Encode};
 use types::{
     test_utils::generate_deterministic_keypair, BeaconState, Eth1Data, EthSpec, Hash256,

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -268,7 +268,7 @@ impl<T: EthSpec> BeaconState<T> {
     /// returns `None`.
     ///
     /// Requires a fully up-to-date `pubkey_cache`, returns an error if this is not the case.
-    pub fn get_validator_index(&self, pubkey: &PublicKey) -> Result<Option<usize>, Error> {
+    pub fn get_validator_index(&self, pubkey: &PublicKeyBytes) -> Result<Option<usize>, Error> {
         if self.pubkey_cache.len() == self.validators.len() {
             Ok(self.pubkey_cache.get(pubkey))
         } else {
@@ -852,7 +852,7 @@ impl<T: EthSpec> BeaconState<T> {
             .enumerate()
             .skip(self.pubkey_cache.len())
         {
-            let success = self.pubkey_cache.insert(validator.pubkey.clone(), i);
+            let success = self.pubkey_cache.insert(validator.pubkey.clone().into(), i);
             if !success {
                 return Err(Error::PubkeyCacheInconsistent);
             }

--- a/eth2/types/src/beacon_state/pubkey_cache.rs
+++ b/eth2/types/src/beacon_state/pubkey_cache.rs
@@ -10,7 +10,7 @@ pub struct PubkeyCache {
     /// len, as it does not increase when duplicate keys are added. Duplicate keys are used during
     /// testing.
     len: usize,
-    map: HashMap<PublicKey, ValidatorIndex>,
+    map: HashMap<PublicKeyBytes, ValidatorIndex>,
 }
 
 impl PubkeyCache {
@@ -23,7 +23,7 @@ impl PubkeyCache {
     ///
     /// The added index must equal the number of validators already added to the map. This ensures
     /// that an index is never skipped.
-    pub fn insert(&mut self, pubkey: PublicKey, index: ValidatorIndex) -> bool {
+    pub fn insert(&mut self, pubkey: PublicKeyBytes, index: ValidatorIndex) -> bool {
         if index == self.len {
             self.map.insert(pubkey, index);
             self.len += 1;
@@ -34,7 +34,7 @@ impl PubkeyCache {
     }
 
     /// Looks up a validator index's by their public key.
-    pub fn get(&self, pubkey: &PublicKey) -> Option<ValidatorIndex> {
+    pub fn get(&self, pubkey: &PublicKeyBytes) -> Option<ValidatorIndex> {
         self.map.get(pubkey).copied()
     }
 }

--- a/eth2/types/src/test_utils/builders/testing_beacon_state_builder.rs
+++ b/eth2/types/src/test_utils/builders/testing_beacon_state_builder.rs
@@ -109,7 +109,7 @@ impl<T: EthSpec> TestingBeaconStateBuilder<T> {
                 ));
 
                 Validator {
-                    pubkey: keypair.pk.clone(),
+                    pubkey: keypair.pk.clone().into(),
                     withdrawal_credentials,
                     // All validators start active.
                     activation_eligibility_epoch: T::genesis_epoch(),

--- a/eth2/types/src/validator.rs
+++ b/eth2/types/src/validator.rs
@@ -1,4 +1,4 @@
-use crate::{test_utils::TestRandom, Epoch, Hash256, PublicKey};
+use crate::{test_utils::TestRandom, Epoch, Hash256, PublicKeyBytes};
 
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.9.1
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
 pub struct Validator {
-    pub pubkey: PublicKey,
+    pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,
     pub effective_balance: u64,
     pub slashed: bool,
@@ -46,7 +46,7 @@ impl Default for Validator {
     /// Yields a "default" `Validator`. Primarily used for testing.
     fn default() -> Self {
         Self {
-            pubkey: PublicKey::default(),
+            pubkey: PublicKeyBytes::empty(),
             withdrawal_credentials: Hash256::default(),
             activation_eligibility_epoch: Epoch::from(std::u64::MAX),
             activation_epoch: Epoch::from(std::u64::MAX),

--- a/eth2/utils/bls/src/lib.rs
+++ b/eth2/utils/bls/src/lib.rs
@@ -14,7 +14,7 @@ pub use crate::public_key_bytes::PublicKeyBytes;
 pub use crate::secret_key::SecretKey;
 pub use crate::signature_bytes::SignatureBytes;
 pub use milagro_bls::{compress_g2, hash_on_g2, G1Point};
-pub use signature_set::{verify_signature_sets, SignatureSet, SignedMessage};
+pub use signature_set::{verify_signature_sets, G1Ref, SignatureSet, SignedMessage};
 
 #[cfg(feature = "fake_crypto")]
 mod fake_aggregate_public_key;

--- a/eth2/utils/bls/src/macros.rs
+++ b/eth2/utils/bls/src/macros.rs
@@ -128,6 +128,12 @@ macro_rules! bytes_struct {
             }
         }
 
+        impl std::hash::Hash for $name {
+            fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+                self.0.hash(state)
+            }
+        }
+
         impl Eq for $name {}
 
         impl std::convert::TryInto<$type> for &$name {

--- a/eth2/utils/remote_beacon_node/src/lib.rs
+++ b/eth2/utils/remote_beacon_node/src/lib.rs
@@ -260,7 +260,10 @@ impl<E: EthSpec> Validator<E> {
 
         let bulk_request = BulkValidatorDutiesRequest {
             epoch,
-            pubkeys: validator_pubkeys.to_vec(),
+            pubkeys: validator_pubkeys
+                .iter()
+                .map(|pubkey| pubkey.clone().into())
+                .collect(),
         };
 
         self.url("duties")

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -1,8 +1,11 @@
-use crate::{duties_service::DutiesService, validator_store::ValidatorStore};
+use crate::{
+    duties_service::{DutiesService, ValidatorDuty},
+    validator_store::ValidatorStore,
+};
 use environment::RuntimeContext;
 use exit_future::Signal;
 use futures::{Future, Stream};
-use remote_beacon_node::{PublishStatus, RemoteBeaconNode, ValidatorDuty};
+use remote_beacon_node::{PublishStatus, RemoteBeaconNode};
 use slog::{crit, info, trace};
 use slot_clock::SlotClock;
 use std::collections::HashMap;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Changes the type of `Validator.pubkey` to be `PublicKeyBytes` instead of `PublicKey` this saw a couple of orders magnitude decrease in the time it takes to SSZ decode the state.
