### PR TITLE
Add block/state caching on beacon chain

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -463,8 +463,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .ok_or_else(|| Error::NoStateForSlot(slot))?;
 
             Ok(self
-                .store
-                .get_state(&state_root, Some(slot))?
+                .get_state_caching(&state_root, Some(slot))?
                 .ok_or_else(|| Error::NoStateForSlot(slot))?)
         }
     }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1272,7 +1272,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let state_root_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_STATE_ROOT);
 
-        let state_root = state.canonical_root();
+        let state_root = state.update_tree_hash_cache()?;
 
         write_state(
             &format!("state_post_block_{}", block_root),

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1221,7 +1221,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Transition the parent state to the block slot.
         let mut state: BeaconState<T::EthSpec> = parent_state;
-        for i in state.slot.as_u64()..block.slot.as_u64() {
+        let distance = block.slot.as_u64().saturating_sub(state.slot.as_u64());
+        for i in 0..distance {
             if i > 0 {
                 intermediate_states.push(state.clone());
             }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -94,6 +94,13 @@ pub enum AttestationProcessingOutcome {
     Invalid(AttestationValidationError),
 }
 
+pub struct HeadInfo {
+    pub slot: Slot,
+    pub block_root: Hash256,
+    pub state_root: Hash256,
+    pub finalized_checkpoint: types::Checkpoint,
+}
+
 pub trait BeaconChainTypes: Send + Sync + 'static {
     type Store: store::Store<Self::EthSpec>;
     type StoreMigrator: store::Migrate<Self::Store, Self::EthSpec>;
@@ -416,6 +423,20 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// now.
     pub fn head(&self) -> CheckPoint<T::EthSpec> {
         self.canonical_head.read().clone()
+    }
+
+    /// Returns info representing the head block and state.
+    ///
+    /// A summarized version of `Self::head` that involves less cloning.
+    pub fn head_info(&self) -> HeadInfo {
+        let head = self.canonical_head.read();
+
+        HeadInfo {
+            slot: head.beacon_block.slot,
+            block_root: head.beacon_block_root,
+            state_root: head.beacon_state_root,
+            finalized_checkpoint: head.beacon_state.finalized_checkpoint.clone(),
+        }
     }
 
     /// Returns the current heads of the `BeaconChain`. For the canonical head, see `Self::head`.
@@ -861,11 +882,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             //
             // This is likely overly restrictive, we could store the attestation for later
             // processing.
-            let head_epoch = self
-                .head()
-                .beacon_block
-                .slot
-                .epoch(T::EthSpec::slots_per_epoch());
+            let head_epoch = self.head_info().slot.epoch(T::EthSpec::slots_per_epoch());
             let attestation_epoch = attestation.data.slot.epoch(T::EthSpec::slots_per_epoch());
 
             // Only log a warning if our head is in a reasonable place to verify this attestation.
@@ -927,7 +944,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // - The highest valid finalized epoch we've ever seen (i.e., the head).
         // - The finalized epoch that this attestation was created against.
         let finalized_epoch = std::cmp::max(
-            self.head().beacon_state.finalized_checkpoint.epoch,
+            self.head_info().finalized_checkpoint.epoch,
             state.finalized_checkpoint.epoch,
         );
 
@@ -1134,8 +1151,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let full_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_TIMES);
 
         let finalized_slot = self
-            .head()
-            .beacon_state
+            .head_info()
             .finalized_checkpoint
             .epoch
             .start_slot(T::EthSpec::slots_per_epoch());
@@ -1476,7 +1492,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let beacon_block_root = self.fork_choice.find_head(&self)?;
 
         // If a new head was chosen.
-        let result = if beacon_block_root != self.head().beacon_block_root {
+        let result = if beacon_block_root != self.head_info().block_root {
             metrics::inc_counter(&metrics::FORK_CHOICE_CHANGED_HEAD);
 
             let beacon_block: BeaconBlock<T::EthSpec> = self
@@ -1488,10 +1504,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .get_state_caching(&beacon_state_root, Some(beacon_block.slot))?
                 .ok_or_else(|| Error::MissingBeaconState(beacon_state_root))?;
 
-            let previous_slot = self.head().beacon_block.slot;
+            let previous_slot = self.head_info().slot;
             let new_slot = beacon_block.slot;
 
-            let is_reorg = self.head().beacon_block_root != beacon_block.parent_root;
+            let is_reorg = self.head_info().block_root != beacon_block.parent_root;
 
             // If we switched to a new chain (instead of building atop the present chain).
             if is_reorg {
@@ -1499,7 +1515,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 warn!(
                     self.log,
                     "Beacon chain re-org";
-                    "previous_head" => format!("{}", self.head().beacon_block_root),
+                    "previous_head" => format!("{}", self.head_info().block_root),
                     "previous_slot" => previous_slot,
                     "new_head_parent" => format!("{}", beacon_block.parent_root),
                     "new_head" => format!("{}", beacon_block_root),
@@ -1518,7 +1534,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 );
             };
 
-            let old_finalized_epoch = self.head().beacon_state.finalized_checkpoint.epoch;
+            let old_finalized_epoch = self.head_info().finalized_checkpoint.epoch;
             let new_finalized_epoch = beacon_state.finalized_checkpoint.epoch;
             let finalized_root = beacon_state.finalized_checkpoint.root;
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1274,6 +1274,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let state_root = state.update_tree_hash_cache()?;
 
+        metrics::stop_timer(state_root_timer);
+
         write_state(
             &format!("state_post_block_{}", block_root),
             &state,
@@ -1286,8 +1288,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 local: state_root,
             });
         }
-
-        metrics::stop_timer(state_root_timer);
 
         let db_write_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_DB_WRITE);
 
@@ -1463,7 +1463,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &self.spec,
         )?;
 
-        let state_root = state.canonical_root();
+        let state_root = state.update_tree_hash_cache()?;
 
         block.state_root = state_root;
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -270,8 +270,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .get_block_caching(&block_root)?
             .ok_or_else(|| Error::MissingBeaconBlock(block_root))?;
         let state = self
-            .store
-            .get_state(&block.state_root, Some(block.slot))?
+            .get_state_caching(&block.state_root, Some(block.slot))?
             .ok_or_else(|| Error::MissingBeaconState(block.state_root))?;
         let iter = BlockRootsIterator::owned(self.store.clone(), state);
         Ok(ReverseBlockRootIterator::new(
@@ -1490,14 +1489,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             metrics::inc_counter(&metrics::FORK_CHOICE_CHANGED_HEAD);
 
             let beacon_block: BeaconBlock<T::EthSpec> = self
-                .store
-                .get(&beacon_block_root)?
+                .get_block_caching(&beacon_block_root)?
                 .ok_or_else(|| Error::MissingBeaconBlock(beacon_block_root))?;
 
             let beacon_state_root = beacon_block.state_root;
             let beacon_state: BeaconState<T::EthSpec> = self
-                .store
-                .get_state(&beacon_state_root, Some(beacon_block.slot))?
+                .get_state_caching(&beacon_state_root, Some(beacon_block.slot))?
                 .ok_or_else(|| Error::MissingBeaconState(beacon_state_root))?;
 
             let previous_slot = self.head().beacon_block.slot;

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,3 +1,4 @@
+use crate::checkpoint_cache::CheckPointCache;
 use crate::eth1_chain::CachingEth1Backend;
 use crate::events::NullEventHandler;
 use crate::head_tracker::HeadTracker;
@@ -374,6 +375,7 @@ where
                 .event_handler
                 .ok_or_else(|| "Cannot build without an event handler".to_string())?,
             head_tracker: self.head_tracker.unwrap_or_default(),
+            checkpoint_cache: CheckPointCache::default(),
             log: log.clone(),
         };
 

--- a/beacon_node/beacon_chain/src/checkpoint_cache.rs
+++ b/beacon_node/beacon_chain/src/checkpoint_cache.rs
@@ -1,0 +1,99 @@
+use crate::checkpoint::CheckPoint;
+use crate::metrics;
+use parking_lot::RwLock;
+use types::{BeaconBlock, BeaconState, EthSpec, Hash256};
+
+const CACHE_SIZE: usize = 4;
+
+struct Inner<T: EthSpec> {
+    oldest: usize,
+    limit: usize,
+    checkpoints: Vec<CheckPoint<T>>,
+}
+
+impl<T: EthSpec> Default for Inner<T> {
+    fn default() -> Self {
+        Self {
+            oldest: 0,
+            limit: CACHE_SIZE,
+            checkpoints: vec![],
+        }
+    }
+}
+
+pub struct CheckPointCache<T: EthSpec> {
+    inner: RwLock<Inner<T>>,
+}
+
+impl<T: EthSpec> Default for CheckPointCache<T> {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(Inner::default()),
+        }
+    }
+}
+
+impl<T: EthSpec> CheckPointCache<T> {
+    pub fn insert(&self, checkpoint: &CheckPoint<T>) {
+        if self
+            .inner
+            .read()
+            .checkpoints
+            .iter()
+            // This is `O(n)` but whilst `n == 4` it ain't no thing.
+            .any(|local| local.beacon_state_root == checkpoint.beacon_state_root)
+        {
+            // Adding a known checkpoint to the cache should be a no-op.
+            return;
+        }
+
+        let mut inner = self.inner.write();
+
+        if inner.checkpoints.len() < inner.limit {
+            inner.checkpoints.push(checkpoint.clone())
+        } else {
+            let i = inner.oldest; // to satisfy the borrow checker.
+            inner.checkpoints[i] = checkpoint.clone();
+            inner.oldest += 1;
+            inner.oldest %= inner.limit;
+        }
+    }
+
+    pub fn get_state(&self, state_root: &Hash256) -> Option<BeaconState<T>> {
+        self.inner
+            .read()
+            .checkpoints
+            .iter()
+            // Also `O(n)`.
+            .find(|checkpoint| checkpoint.beacon_state_root == *state_root)
+            .map(|checkpoint| {
+                metrics::inc_counter(&metrics::CHECKPOINT_CACHE_HITS);
+
+                checkpoint.beacon_state.clone()
+            })
+            .or_else(|| {
+                metrics::inc_counter(&metrics::CHECKPOINT_CACHE_MISSES);
+
+                None
+            })
+    }
+
+    pub fn get_block(&self, block_root: &Hash256) -> Option<BeaconBlock<T>> {
+        self.inner
+            .read()
+            .checkpoints
+            .iter()
+            // Also `O(n)`.
+            .find(|checkpoint| checkpoint.beacon_block_root == *block_root)
+            .map(|checkpoint| {
+                metrics::inc_counter(&metrics::CHECKPOINT_CACHE_HITS);
+
+                checkpoint.beacon_block.clone()
+            })
+            .or_else(|| {
+                metrics::inc_counter(&metrics::CHECKPOINT_CACHE_MISSES);
+
+                None
+            })
+    }
+}

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -5,6 +5,7 @@ extern crate lazy_static;
 mod beacon_chain;
 pub mod builder;
 mod checkpoint;
+mod checkpoint_cache;
 mod errors;
 pub mod eth1_chain;
 pub mod events;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -150,6 +150,14 @@ lazy_static! {
         try_create_histogram("beacon_persist_chain", "Time taken to update the canonical head");
 
     /*
+     * Checkpoint cache
+     */
+    pub static ref CHECKPOINT_CACHE_HITS: Result<IntCounter> =
+        try_create_int_counter("beacon_checkpoint_cache_hits_total", "Count of times checkpoint cache fulfils request");
+    pub static ref CHECKPOINT_CACHE_MISSES: Result<IntCounter> =
+        try_create_int_counter("beacon_checkpoint_cache_misses_total", "Count of times checkpoint cache fulfils request");
+
+    /*
      * Chain Head
      */
     pub static ref UPDATE_HEAD_TIMES: Result<Histogram> =

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -52,17 +52,9 @@ pub struct StorageContainer<T: EthSpec> {
 impl<T: EthSpec> StorageContainer<T> {
     /// Create a new instance for storing a `BeaconState`.
     pub fn new(state: &BeaconState<T>) -> Self {
-        let mut state = state.clone();
-
-        let mut committee_caches = vec![CommitteeCache::default(); CACHED_EPOCHS];
-
-        for i in 0..CACHED_EPOCHS {
-            std::mem::swap(&mut state.committee_caches[i], &mut committee_caches[i]);
-        }
-
         Self {
-            state,
-            committee_caches,
+            state: state.clone_without_caches(),
+            committee_caches: state.committee_caches.to_vec(),
         }
     }
 }

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -2,7 +2,7 @@ use crate::*;
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use std::convert::TryInto;
-use types::beacon_state::{BeaconTreeHashCache, CommitteeCache, CACHED_EPOCHS};
+use types::beacon_state::{CommitteeCache, CACHED_EPOCHS};
 
 pub fn store_full_state<S: Store<E>, E: EthSpec>(
     store: &S,
@@ -47,7 +47,6 @@ pub fn get_full_state<S: Store<E>, E: EthSpec>(
 pub struct StorageContainer<T: EthSpec> {
     state: BeaconState<T>,
     committee_caches: Vec<CommitteeCache>,
-    tree_hash_cache: BeaconTreeHashCache,
 }
 
 impl<T: EthSpec> StorageContainer<T> {
@@ -61,13 +60,9 @@ impl<T: EthSpec> StorageContainer<T> {
             std::mem::swap(&mut state.committee_caches[i], &mut committee_caches[i]);
         }
 
-        let tree_hash_cache =
-            std::mem::replace(&mut state.tree_hash_cache, BeaconTreeHashCache::default());
-
         Self {
             state,
             committee_caches,
-            tree_hash_cache,
         }
     }
 }
@@ -87,8 +82,6 @@ impl<T: EthSpec> TryInto<BeaconState<T>> for StorageContainer<T> {
 
             state.committee_caches[i] = self.committee_caches.remove(i);
         }
-
-        state.tree_hash_cache = self.tree_hash_cache;
 
         Ok(state)
     }

--- a/eth2/types/src/beacon_state.rs
+++ b/eth2/types/src/beacon_state.rs
@@ -909,6 +909,39 @@ impl<T: EthSpec> BeaconState<T> {
     pub fn drop_tree_hash_cache(&mut self) {
         self.tree_hash_cache = BeaconTreeHashCache::default();
     }
+
+    pub fn clone_without_caches(&self) -> Self {
+        BeaconState {
+            genesis_time: self.genesis_time,
+            slot: self.slot,
+            fork: self.fork.clone(),
+            latest_block_header: self.latest_block_header.clone(),
+            block_roots: self.block_roots.clone(),
+            state_roots: self.state_roots.clone(),
+            historical_roots: self.historical_roots.clone(),
+            eth1_data: self.eth1_data.clone(),
+            eth1_data_votes: self.eth1_data_votes.clone(),
+            eth1_deposit_index: self.eth1_deposit_index,
+            validators: self.validators.clone(),
+            balances: self.balances.clone(),
+            randao_mixes: self.randao_mixes.clone(),
+            slashings: self.slashings.clone(),
+            previous_epoch_attestations: self.previous_epoch_attestations.clone(),
+            current_epoch_attestations: self.current_epoch_attestations.clone(),
+            justification_bits: self.justification_bits.clone(),
+            previous_justified_checkpoint: self.previous_justified_checkpoint.clone(),
+            current_justified_checkpoint: self.current_justified_checkpoint.clone(),
+            finalized_checkpoint: self.finalized_checkpoint.clone(),
+            committee_caches: [
+                CommitteeCache::default(),
+                CommitteeCache::default(),
+                CommitteeCache::default(),
+            ],
+            pubkey_cache: PubkeyCache::default(),
+            exit_cache: ExitCache::default(),
+            tree_hash_cache: BeaconTreeHashCache::default(),
+        }
+    }
 }
 
 impl From<RelativeEpochError> for Error {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds basic caching of blocks/states to the beacon chain so it doesn't need to read the DB so much.
