### PR TITLE
Fix slot timer

### DIFF
--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -281,7 +281,7 @@ impl Speedo {
         let count = speeds.len();
         let sum: f64 = speeds.iter().sum();
 
-        if count > 0 {
+        if count > 0 && sum > 0.0 {
             Some(sum / f64::from(count as u32))
         } else {
             None


### PR DESCRIPTION
## Issue Addressed

Fixes #687 

## Proposed Changes

Returns `None` from `slots_per_second` if sum is 0 as described in https://github.com/sigp/lighthouse/issues/687#issuecomment-563903793
