### PR TITLE
est_time for syncing is lower than distance

### DIFF
--- a/book/src/become-a-validator.md
+++ b/book/src/become-a-validator.md
@@ -45,6 +45,8 @@ log:
 Dec 09 12:57:18.026 INFO Syncing                                 distance: 16837 slots (2 days 8 hrs), ...
 ```
 
+Don't be overly concerned about the "distance" because "est_time" for syncing will be much lower.
+
 It has finished syncing once you see the following (truncated) log:
 
 ```


### PR DESCRIPTION
If I understood correctly, this should help avoid misunderstanding of how long a sync might take.

(Another option may be a code change that log for INFO Syncing will display est_time first, before the distance.)
