### PR TITLE
Specify exact version for rust in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:latest
+FROM rust:1.39.0
+
 
 COPY . lighthouse
 RUN cd lighthouse && make


### PR DESCRIPTION
## Issue Addressed
Ran into issue with latest not pulling the correct version of rust.

## Proposed Changes
Explicit definition of rust version number to be used.