### PR TITLE
Make eth1 caching work with fast synced node

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -484,6 +484,7 @@ impl Service {
         let cache_3 = self.inner.clone();
         let cache_4 = self.inner.clone();
         let cache_5 = self.inner.clone();
+        let log = self.log.clone();
 
         let block_cache_truncation = self.config().block_cache_truncation;
         let max_blocks_per_update = self
@@ -545,18 +546,26 @@ impl Service {
             stream::unfold(
                 required_block_numbers,
                 move |mut block_numbers| match block_numbers.next() {
-                    Some(block_number) => Some(
-                        download_eth1_block(cache_2.clone(), block_number)
-                            .map(|v| (v, block_numbers)),
-                    ),
+                    Some(block_number) => {
+                        let cached = download_eth1_block(cache_2.clone(), block_number);
+                        let http = download_eth1_block_http(cache_2.clone(), block_number);
+                        Some(cached.join(http).map(|v| (v, block_numbers)))
+                    }
                     None => None,
                 },
             )
-            .fold(0, move |sum, eth1_block| {
+            .fold(0, move |sum, (eth1_block_cached, eth1_block_http)| {
+                debug!(
+                    log,
+                    "Comparing eth1_block deposit count";
+                    "equal" => eth1_block_cached.deposit_count == eth1_block_http.deposit_count,
+                    "original" => format!("{:?}", eth1_block_http.deposit_count),
+                    "cached" => format!("{:?}", eth1_block_cached.deposit_count),
+                );
                 cache_3
                     .block_cache
                     .write()
-                    .insert_root_or_child(eth1_block)
+                    .insert_root_or_child(eth1_block_http)
                     .map_err(Error::FailedToInsertEth1Block)?;
 
                 Ok(sum + 1)
@@ -632,6 +641,43 @@ fn download_eth1_block<'a>(
     )
     .map_err(Error::BlockDownloadFailed)
     .map(move |http_block| Eth1Block {
+        hash: http_block.hash,
+        number: http_block.number,
+        timestamp: http_block.timestamp,
+        deposit_root,
+        deposit_count,
+    })
+}
+
+fn download_eth1_block_http<'a>(
+    cache: Arc<Inner>,
+    block_number: u64,
+) -> impl Future<Item = Eth1Block, Error = Error> + 'a {
+    // Performs a `get_blockByNumber` call to an eth1 node.
+    get_block(
+        &cache.config.read().endpoint,
+        block_number,
+        Duration::from_millis(GET_BLOCK_TIMEOUT_MILLIS),
+    )
+    .map_err(Error::BlockDownloadFailed)
+    .join3(
+        // Perform 2x `eth_call` via an eth1 node to read the deposit contract root and count.
+        get_deposit_root(
+            &cache.config.read().endpoint,
+            &cache.config.read().deposit_contract_address,
+            block_number,
+            Duration::from_millis(GET_DEPOSIT_ROOT_TIMEOUT_MILLIS),
+        )
+        .map_err(Error::GetDepositRootFailed),
+        get_deposit_count(
+            &cache.config.read().endpoint,
+            &cache.config.read().deposit_contract_address,
+            block_number,
+            Duration::from_millis(GET_DEPOSIT_COUNT_TIMEOUT_MILLIS),
+        )
+        .map_err(Error::GetDepositCountFailed),
+    )
+    .map(|(http_block, deposit_root, deposit_count)| Eth1Block {
         hash: http_block.hash,
         number: http_block.number,
         timestamp: http_block.timestamp,

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -484,7 +484,6 @@ impl Service {
         let cache_3 = self.inner.clone();
         let cache_4 = self.inner.clone();
         let cache_5 = self.inner.clone();
-        let log = self.log.clone();
 
         let block_cache_truncation = self.config().block_cache_truncation;
         let max_blocks_per_update = self
@@ -546,26 +545,18 @@ impl Service {
             stream::unfold(
                 required_block_numbers,
                 move |mut block_numbers| match block_numbers.next() {
-                    Some(block_number) => {
-                        let cached = download_eth1_block(cache_2.clone(), block_number);
-                        let http = download_eth1_block_http(cache_2.clone(), block_number);
-                        Some(cached.join(http).map(|v| (v, block_numbers)))
-                    }
+                    Some(block_number) => Some(
+                        download_eth1_block(cache_2.clone(), block_number)
+                            .map(|v| (v, block_numbers)),
+                    ),
                     None => None,
                 },
             )
-            .fold(0, move |sum, (eth1_block_cached, eth1_block_http)| {
-                debug!(
-                    log,
-                    "Comparing eth1_block deposit count";
-                    "equal" => eth1_block_cached.deposit_count == eth1_block_http.deposit_count,
-                    "original" => format!("{:?}", eth1_block_http.deposit_count),
-                    "cached" => format!("{:?}", eth1_block_cached.deposit_count),
-                );
+            .fold(0, move |sum, eth1_block| {
                 cache_3
                     .block_cache
                     .write()
-                    .insert_root_or_child(eth1_block_http)
+                    .insert_root_or_child(eth1_block)
                     .map_err(Error::FailedToInsertEth1Block)?;
 
                 Ok(sum + 1)
@@ -641,43 +632,6 @@ fn download_eth1_block<'a>(
     )
     .map_err(Error::BlockDownloadFailed)
     .map(move |http_block| Eth1Block {
-        hash: http_block.hash,
-        number: http_block.number,
-        timestamp: http_block.timestamp,
-        deposit_root,
-        deposit_count,
-    })
-}
-
-fn download_eth1_block_http<'a>(
-    cache: Arc<Inner>,
-    block_number: u64,
-) -> impl Future<Item = Eth1Block, Error = Error> + 'a {
-    // Performs a `get_blockByNumber` call to an eth1 node.
-    get_block(
-        &cache.config.read().endpoint,
-        block_number,
-        Duration::from_millis(GET_BLOCK_TIMEOUT_MILLIS),
-    )
-    .map_err(Error::BlockDownloadFailed)
-    .join3(
-        // Perform 2x `eth_call` via an eth1 node to read the deposit contract root and count.
-        get_deposit_root(
-            &cache.config.read().endpoint,
-            &cache.config.read().deposit_contract_address,
-            block_number,
-            Duration::from_millis(GET_DEPOSIT_ROOT_TIMEOUT_MILLIS),
-        )
-        .map_err(Error::GetDepositRootFailed),
-        get_deposit_count(
-            &cache.config.read().endpoint,
-            &cache.config.read().deposit_contract_address,
-            block_number,
-            Duration::from_millis(GET_DEPOSIT_COUNT_TIMEOUT_MILLIS),
-        )
-        .map_err(Error::GetDepositCountFailed),
-    )
-    .map(|(http_block, deposit_root, deposit_count)| Eth1Block {
         hash: http_block.hash,
         number: http_block.number,
         timestamp: http_block.timestamp,

--- a/beacon_node/eth1/tests/test.rs
+++ b/beacon_node/eth1/tests/test.rs
@@ -711,3 +711,80 @@ mod http {
         }
     }
 }
+
+mod fast {
+    use super::*;
+
+    // Adds deposits into deposit cache and matches deposit_count and deposit_root
+    // with the deposit count and root computed from the deposit cache.
+    #[test]
+    fn deposit_cache_query() {
+        let mut env = new_env();
+        let log = env.core_context().log;
+        let runtime = env.runtime();
+
+        let eth1 = runtime
+            .block_on(GanacheEth1Instance::new())
+            .expect("should start eth1 environment");
+        let deposit_contract = &eth1.deposit_contract;
+        let web3 = eth1.web3();
+
+        let now = get_block_number(runtime, &web3);
+        let service = Service::new(
+            Config {
+                endpoint: eth1.endpoint(),
+                deposit_contract_address: deposit_contract.address(),
+                deposit_contract_deploy_block: now,
+                lowest_cached_block_number: now,
+                follow_distance: 0,
+                block_cache_truncation: None,
+                ..Config::default()
+            },
+            log,
+        );
+        let n = 10;
+        let deposits: Vec<_> = (0..n).into_iter().map(|_| random_deposit_data()).collect();
+        for deposit in &deposits {
+            deposit_contract
+                .deposit(runtime, deposit.clone())
+                .expect("should perform a deposit");
+            // Mine an extra block between deposits to test for corner cases
+            runtime
+                .block_on(eth1.ganache.evm_mine())
+                .expect("should mine block");
+        }
+
+        runtime
+            .block_on(service.update_deposit_cache())
+            .expect("should perform update");
+
+        assert!(
+            service.deposit_cache_len() >= n,
+            "should have imported n deposits"
+        );
+
+        for block_num in 1..=get_block_number(runtime, &web3) {
+            let expected_deposit_count = blocking_deposit_count(runtime, &eth1, block_num);
+            let expected_deposit_root = blocking_deposit_root(runtime, &eth1, block_num);
+
+            let deposit_count = service
+                .deposits()
+                .read()
+                .cache
+                .get_deposit_count_from_cache(block_num);
+            let deposit_root = service
+                .deposits()
+                .read()
+                .cache
+                .get_deposit_root_from_cache(block_num);
+            assert_eq!(
+                expected_deposit_count, deposit_count,
+                "deposit count from cache should match queried"
+            );
+            assert_eq!(
+                expected_deposit_root, deposit_root,
+                "deposit root from cache should match queried"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Addresses #637 

## Proposed Changes

Adds methods to fetch `deposit_root` and `deposit_count` at any block height and uses them to populate the `BlockCache` in place of the calls to read contract state directly at previous blocks.