### PR TITLE
Store states in the DB before their blocks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1322,8 +1322,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // Store the block and state.
-        self.store.put(&block_root, &block)?;
+        // NOTE: we store the block *after* the state to guard against inconsistency in the event of
+        // a crash, as states are usually looked up from blocks, not the other way around. A better
+        // solution would be to use a database transaction (once our choice of database and API
+        // settles down).
+        // See: https://github.com/sigp/lighthouse/issues/692
         self.store.put_state(&state_root, &state)?;
+        self.store.put(&block_root, &block)?;
 
         metrics::stop_timer(db_write_timer);
 


### PR DESCRIPTION
## Issue Addressed

#692

## Proposed Changes

We've been seeing a few issues with database inconsistency on the testnet, so this is a quick patch to hopefully address those issues. I'd like to address the issue more thoroughly once our choice of DB has settled down (or we come up with an API to abstract over atomic transactions in different DBs).
