### PR TITLE
Clean up database metrics, add freezer DB size

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1200,13 +1200,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             });
         }
 
-        if self.store.exists::<BeaconBlock<T::EthSpec>>(&block_root)? {
-            return Ok(BlockProcessingOutcome::BlockIsAlreadyKnown);
-        }
-
         // Records the time taken to load the block and state from the database during block
         // processing.
         let db_read_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_DB_READ);
+
+        if self.store.exists::<BeaconBlock<T::EthSpec>>(&block_root)? {
+            return Ok(BlockProcessingOutcome::BlockIsAlreadyKnown);
+        }
 
         // Load the blocks parent block from the database, returning invalid if that block is not
         // found.

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -314,10 +314,10 @@ where
             network_info,
             client_config
                 .create_db_path()
-                .expect("unable to read datadir"),
+                .map_err(|_| "unable to read data dir")?,
             client_config
                 .create_freezer_db_path()
-                .expect("unable to read freezer DB dir"),
+                .map_err(|_| "unable to read freezer DB dir")?,
             eth2_config.clone(),
             context.log,
         )

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -315,6 +315,9 @@ where
             client_config
                 .create_db_path()
                 .expect("unable to read datadir"),
+            client_config
+                .create_freezer_db_path()
+                .expect("unable to read freezer DB dir"),
             eth2_config.clone(),
             context.log,
         )

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -56,6 +56,7 @@ pub fn start_server<T: BeaconChainTypes>(
     beacon_chain: Arc<BeaconChain<T>>,
     network_info: NetworkInfo<T>,
     db_path: PathBuf,
+    freezer_db_path: PathBuf,
     eth2_config: Eth2Config,
     log: slog::Logger,
 ) -> Result<(exit_future::Signal, SocketAddr), hyper::Error> {
@@ -70,6 +71,7 @@ pub fn start_server<T: BeaconChainTypes>(
         let network_service = network_info.network_service.clone();
         let network_channel = Arc::new(RwLock::new(network_info.network_chan.clone()));
         let db_path = db_path.clone();
+        let freezer_db_path = freezer_db_path.clone();
 
         service_fn(move |req: Request<Body>| {
             router::route(
@@ -80,6 +82,7 @@ pub fn start_server<T: BeaconChainTypes>(
                 eth2_config.clone(),
                 log.clone(),
                 db_path.clone(),
+                freezer_db_path.clone(),
             )
         })
     });

--- a/beacon_node/rest_api/src/metrics.rs
+++ b/beacon_node/rest_api/src/metrics.rs
@@ -32,6 +32,7 @@ pub fn get_prometheus<T: BeaconChainTypes>(
     req: Request<Body>,
     beacon_chain: Arc<BeaconChain<T>>,
     db_path: PathBuf,
+    freezer_db_path: PathBuf,
 ) -> ApiResult {
     let mut buffer = vec![];
     let encoder = TextEncoder::new();
@@ -53,7 +54,7 @@ pub fn get_prometheus<T: BeaconChainTypes>(
     // a string that can be returned via HTTP.
 
     slot_clock::scrape_for_metrics::<T::EthSpec, T::SlotClock>(&beacon_chain.slot_clock);
-    store::scrape_for_metrics(&db_path);
+    store::scrape_for_metrics(&db_path, &freezer_db_path);
     beacon_chain::scrape_for_metrics(&beacon_chain);
 
     encoder

--- a/beacon_node/rest_api/src/router.rs
+++ b/beacon_node/rest_api/src/router.rs
@@ -27,6 +27,7 @@ pub fn route<T: BeaconChainTypes>(
     eth2_config: Arc<Eth2Config>,
     local_log: slog::Logger,
     db_path: PathBuf,
+    freezer_db_path: PathBuf,
 ) -> impl Future<Item = Response<Body>, Error = Error> {
     metrics::inc_counter(&metrics::REQUEST_COUNT);
     let timer = metrics::start_timer(&metrics::REQUEST_RESPONSE_TIME);
@@ -143,9 +144,12 @@ pub fn route<T: BeaconChainTypes>(
                 into_boxfut(spec::get_eth2_config::<T>(req, eth2_config))
             }
 
-            (&Method::GET, "/metrics") => {
-                into_boxfut(metrics::get_prometheus::<T>(req, beacon_chain, db_path))
-            }
+            (&Method::GET, "/metrics") => into_boxfut(metrics::get_prometheus::<T>(
+                req,
+                beacon_chain,
+                db_path,
+                freezer_db_path,
+            )),
 
             _ => Box::new(futures::future::err(ApiError::NotFound(
                 "Request path and/or method not found.".to_owned(),

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -9,12 +9,15 @@ pub fn store_full_state<S: Store<E>, E: EthSpec>(
     state_root: &Hash256,
     state: &BeaconState<E>,
 ) -> Result<(), Error> {
-    let timer = metrics::start_timer(&metrics::BEACON_STATE_WRITE_TIMES);
+    let total_timer = metrics::start_timer(&metrics::BEACON_STATE_WRITE_TIMES);
+    let overhead_timer = metrics::start_timer(&metrics::BEACON_STATE_WRITE_OVERHEAD_TIMES);
 
     let bytes = StorageContainer::new(state).as_ssz_bytes();
+    metrics::stop_timer(overhead_timer);
+
     let result = store.put_bytes(DBColumn::BeaconState.into(), state_root.as_bytes(), &bytes);
 
-    metrics::stop_timer(timer);
+    metrics::stop_timer(total_timer);
     metrics::inc_counter(&metrics::BEACON_STATE_WRITE_COUNT);
     metrics::inc_counter_by(&metrics::BEACON_STATE_WRITE_BYTES, bytes.len() as i64);
 
@@ -25,13 +28,15 @@ pub fn get_full_state<S: Store<E>, E: EthSpec>(
     store: &S,
     state_root: &Hash256,
 ) -> Result<Option<BeaconState<E>>, Error> {
-    let timer = metrics::start_timer(&metrics::BEACON_STATE_READ_TIMES);
+    let total_timer = metrics::start_timer(&metrics::BEACON_STATE_READ_TIMES);
 
     match store.get_bytes(DBColumn::BeaconState.into(), state_root.as_bytes())? {
         Some(bytes) => {
+            let overhead_timer = metrics::start_timer(&metrics::BEACON_STATE_READ_OVERHEAD_TIMES);
             let container = StorageContainer::from_ssz_bytes(&bytes)?;
 
-            metrics::stop_timer(timer);
+            metrics::stop_timer(overhead_timer);
+            metrics::stop_timer(total_timer);
             metrics::inc_counter(&metrics::BEACON_STATE_READ_COUNT);
             metrics::inc_counter_by(&metrics::BEACON_STATE_READ_BYTES, bytes.len() as i64);
 

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -1,29 +1,31 @@
 pub use lighthouse_metrics::{set_gauge, try_create_int_gauge, *};
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::Path;
 
 lazy_static! {
     /*
      * General
      */
     pub static ref DISK_DB_SIZE: Result<IntGauge> =
-        try_create_int_gauge("store_disk_db_size", "Size of the on-disk database (bytes)");
+        try_create_int_gauge("store_disk_db_size", "Size of the main on-disk database (bytes)");
+    pub static ref FREEZER_DB_SIZE: Result<IntGauge> =
+        try_create_int_gauge("store_freezer_db_size", "Size of the on-disk freezer database (bytes)");
     pub static ref DISK_DB_WRITE_BYTES: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_write_bytes_total",
-        "Number of bytes attempted to be written to the on-disk DB"
+        "Number of bytes attempted to be written to the main on-disk DB"
     );
     pub static ref DISK_DB_READ_BYTES: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_read_bytes_total",
-        "Number of bytes read from the on-disk DB"
+        "Number of bytes read from the main on-disk DB"
     );
     pub static ref DISK_DB_READ_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_read_count_total",
-        "Total number of reads to the on-disk DB"
+        "Total number of reads to the main on-disk DB"
     );
     pub static ref DISK_DB_WRITE_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_write_count_total",
-        "Total number of writes to the on-disk DB"
+        "Total number of writes to the main on-disk DB"
     );
     pub static ref DISK_DB_READ_TIMES: Result<Histogram> = try_create_histogram(
         "store_disk_db_read_seconds",
@@ -35,16 +37,20 @@ lazy_static! {
     );
     pub static ref DISK_DB_EXISTS_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_exists_count_total",
-        "Total number of checks if a key is in the on-disk DB"
+        "Total number of checks if a key is in the main on-disk DB"
     );
     pub static ref DISK_DB_DELETE_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_delete_count_total",
-        "Total number of deletions from the on-disk DB"
+        "Total number of deletions from the main on-disk DB"
     );
     /*
      * Beacon State
      */
     pub static ref BEACON_STATE_READ_TIMES: Result<Histogram> = try_create_histogram(
+        "store_beacon_state_read_seconds",
+        "Total time required to read a BeaconState from the database"
+    );
+    pub static ref BEACON_STATE_READ_OVERHEAD_TIMES: Result<Histogram> = try_create_histogram(
         "store_beacon_state_read_overhead_seconds",
         "Overhead on reading a beacon state from the DB (e.g., decoding)"
     );
@@ -57,6 +63,10 @@ lazy_static! {
         "Total number of beacon state bytes read from the DB"
     );
     pub static ref BEACON_STATE_WRITE_TIMES: Result<Histogram> = try_create_histogram(
+        "store_beacon_state_write_seconds",
+        "Total time required to write a BeaconState to the database"
+    );
+    pub static ref BEACON_STATE_WRITE_OVERHEAD_TIMES: Result<Histogram> = try_create_histogram(
         "store_beacon_state_write_overhead_seconds",
         "Overhead on writing a beacon state to the DB (e.g., encoding)"
     );
@@ -98,15 +108,21 @@ lazy_static! {
 }
 
 /// Updates the global metrics registry with store-related information.
-pub fn scrape_for_metrics(db_path: &PathBuf) {
-    let db_size = if let Ok(iter) = fs::read_dir(db_path) {
+pub fn scrape_for_metrics(db_path: &Path, freezer_db_path: &Path) {
+    let db_size = size_of_dir(db_path);
+    set_gauge(&DISK_DB_SIZE, db_size as i64);
+    let freezer_db_size = size_of_dir(freezer_db_path);
+    set_gauge(&FREEZER_DB_SIZE, freezer_db_size as i64);
+}
+
+fn size_of_dir(path: &Path) -> u64 {
+    if let Ok(iter) = fs::read_dir(path) {
         iter.filter_map(std::result::Result::ok)
             .map(size_of_dir_entry)
             .sum()
     } else {
         0
-    };
-    set_gauge(&DISK_DB_SIZE, db_size as i64);
+    }
 }
 
 fn size_of_dir_entry(dir: fs::DirEntry) -> u64 {

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -8,24 +8,24 @@ lazy_static! {
      * General
      */
     pub static ref DISK_DB_SIZE: Result<IntGauge> =
-        try_create_int_gauge("store_disk_db_size", "Size of the main on-disk database (bytes)");
+        try_create_int_gauge("store_disk_db_size", "Size of the hot on-disk database (bytes)");
     pub static ref FREEZER_DB_SIZE: Result<IntGauge> =
         try_create_int_gauge("store_freezer_db_size", "Size of the on-disk freezer database (bytes)");
     pub static ref DISK_DB_WRITE_BYTES: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_write_bytes_total",
-        "Number of bytes attempted to be written to the main on-disk DB"
+        "Number of bytes attempted to be written to the hot on-disk DB"
     );
     pub static ref DISK_DB_READ_BYTES: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_read_bytes_total",
-        "Number of bytes read from the main on-disk DB"
+        "Number of bytes read from the hot on-disk DB"
     );
     pub static ref DISK_DB_READ_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_read_count_total",
-        "Total number of reads to the main on-disk DB"
+        "Total number of reads to the hot on-disk DB"
     );
     pub static ref DISK_DB_WRITE_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_write_count_total",
-        "Total number of writes to the main on-disk DB"
+        "Total number of writes to the hot on-disk DB"
     );
     pub static ref DISK_DB_READ_TIMES: Result<Histogram> = try_create_histogram(
         "store_disk_db_read_seconds",
@@ -37,11 +37,11 @@ lazy_static! {
     );
     pub static ref DISK_DB_EXISTS_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_exists_count_total",
-        "Total number of checks if a key is in the main on-disk DB"
+        "Total number of checks if a key is in the hot on-disk DB"
     );
     pub static ref DISK_DB_DELETE_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_disk_db_delete_count_total",
-        "Total number of deletions from the main on-disk DB"
+        "Total number of deletions from the hot on-disk DB"
     );
     /*
      * Beacon State


### PR DESCRIPTION
* Cleans up the `BeaconState` overhead metrics so that they once again measure overhead.
* Adds new metrics for total time to read/write `BeaconState`s.
* Includes an extra call to the store in the `BLOCK_PROCESSING_DB_READ` metric.
* Adds a metric for the size of the freezer database.