### PR TITLE
Fix gossipsub test

### DIFF
--- a/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
@@ -83,7 +83,11 @@ fn test_gossipsub_full_mesh_publish() {
     // set up the logging. The level and enabled or not
     let log = common::build_log(Level::Info, false);
 
-    let num_nodes = 20;
+    // Note: This test does not propagate gossipsub messages.
+    // Having `num_nodes` > `mesh_n_high` may give inconsistent results
+    // as nodes may get pruned out of the mesh before the gossipsub message
+    // is published to them.
+    let num_nodes = 12;
     let mut nodes = common::build_full_mesh(log, num_nodes, Some(11320));
     let mut publishing_node = nodes.pop().unwrap();
     let pubsub_message = PubsubMessage::Block(vec![0; 4]);


### PR DESCRIPTION
## Issue Addressed

Closes #717. 

## Proposed Changes

Reduces the num_nodes from 20 to 12.

Gossipsub has a configurable parameter `mesh_n_high` (default=12) for maximum peers in the gossipsub mesh for every topic. If the number of peers for any topic exceeds `mesh_n_high`, the protocol removes peers from the mesh to get back within the specified limit. The test was giving inconsistent results with `num_nodes = 20` as nodes were getting removed from the mesh before the gossipsub message was published to them. Changing it to 12 ensures we don't hit `mesh_n_high`.


## Additional info

Ran the test 100 times in debug and release and it terminated successfully every time.