### PR TITLE
Add simulator to CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -54,5 +54,7 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
+    - name: Install ganache-cli
+      run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim
       run: cargo run --release --bin beacon_chain_sim

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -49,3 +49,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build the root Dockerfile
       run: docker build .
+  simulator-ubuntu:
+    runs-on: ubuntu-latest
+    needs: cargo-fmt
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run the beacon chain sim
+      run: cargo run --release --bin beacon_chain_sim


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds the beacon chain simulator I built a while back into CI. The simulator:

- Creates a ganache CLI instance to simulate the eth1 chain.
- Deploys the deposit contract
- Submits a bunch of deposits
- Spins up 4x validator nodes, each with one validator client and an equal share of the previous deposits.
- Peers the nodes
- Ensures the nodes find genesis from the eth1 chain
- Allows the nodes to run for several epochs and uses the HTTP API to ensure they all finalize on the same things.

In effect, this is a quite comprehensive end-to-end test of the beacon node + validator client system.
