### PR TITLE
Lean ancestor iterator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3873,6 +3873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "store"
 version = "0.1.0"
 dependencies = [
+ "beacon_chain 0.1.0",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "db-key 0.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz 0.1.2",

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -13,6 +13,7 @@ tempfile = "3.1.0"
 sloggers = "0.3.2"
 criterion = "0.3.0"
 rayon = "1.2.0"
+beacon_chain = { path = "../../beacon_node/beacon_chain" }
 
 [dependencies]
 db-key = "0.0.5"

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -115,8 +115,6 @@ impl<E: EthSpec, U: Store<E>> Iterator for LeanReverseAncestorIter<E, U> {
             return None;
         }
 
-        // dbg!(self.prev_slot);
-
         if let Some(root) = self.roots.pop() {
             self.prev_slot -= 1;
 

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -6,6 +6,147 @@ use types::{
     typenum::Unsigned, BeaconBlock, BeaconState, BeaconStateError, EthSpec, Hash256, Slot,
 };
 
+/// Specifies whether or not the `LeanReverseAncestorIter` should store block or state roots.
+#[derive(Clone, Copy)]
+enum LeanReverseAncestorIterTarget {
+    BlockRoots,
+    StateRoots,
+}
+
+/// Provides a "lean" reverse ancestor iterator which may serve `state.block_roots` or
+/// `state.state_roots`.
+///
+/// It is lean because:
+///
+///  - It does not hold a whole `BeaconState`, only the roots it needs.
+///  - It can store less than `SLOTS_PER_HISTORICAL_ROOT` values, making it a handly little cache
+///  of roots (e.g., you can store `n` roots in memory and only need to load from state when you go
+///  back more than `n` entries).
+///
+///  It does not presently take advantage of the freezer DB, it just loads states in their
+///  entirety. However, the fundamental design of this struct should make it rather partial to this
+///  optimization in the future.
+pub struct LeanReverseAncestorIter<E: EthSpec, U: Store<E>> {
+    roots: Vec<Hash256>,
+    next_state: (Hash256, Slot),
+    prev_slot: Slot,
+    store: Arc<U>,
+    target: LeanReverseAncestorIterTarget,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec, U: Store<E>> LeanReverseAncestorIter<E, U> {
+    /// Returns an iterator over all `state.block_roots` for all slots _prior_ to the given `state.slot` till genesis.
+    pub fn block_roots(store: Arc<U>, state: &BeaconState<E>, len: usize) -> Option<Self> {
+        Self::new(store, state, len, LeanReverseAncestorIterTarget::BlockRoots)
+    }
+
+    /// Returns an iterator over all `state.state_roots` for all slots _prior_ to the given `state.slot` till genesis.
+    pub fn state_roots(store: Arc<U>, state: &BeaconState<E>, len: usize) -> Option<Self> {
+        Self::new(store, state, len, LeanReverseAncestorIterTarget::StateRoots)
+    }
+
+    fn new(
+        store: Arc<U>,
+        state: &BeaconState<E>,
+        max_len: usize,
+        target: LeanReverseAncestorIterTarget,
+    ) -> Option<Self> {
+        if max_len > E::SlotsPerHistoricalRoot::to_usize() || max_len == 0 {
+            return None;
+        }
+
+        // First we try and use the backtrack state. This should reduce the amount state-replaying
+        // required.
+        let (mut next_state_root, mut next_state_slot) =
+            next_historical_root_backtrack_state_root(&state)?;
+
+        // This _shouldn't_ underflow, however in the case it does we advantage of saturation
+        // subtraction on `Slot`.
+        let mut len = (state.slot - next_state_slot).as_usize();
+
+        // When the `len` is short, the typical backtrack state root may be too far in the past and
+        // state roots will get skipped. In this case we just pick the earliest possible state
+        // (this may involve replaying some states).
+        if len > max_len {
+            // Taking advantage of saturating subtraction on `Slot`.
+            next_state_slot = state.slot - max_len as u64;
+            next_state_root = *state.get_state_root(next_state_slot).ok()?;
+            len = max_len;
+        }
+
+        let prev_slot = state.slot;
+        let mut roots = Vec::with_capacity(len);
+        for i in 0..len as u64 {
+            if prev_slot - i > 0 {
+                // Taking advantage of saturating subtraction.
+                let slot = prev_slot - (i + 1);
+
+                // This one-by-one copying of roots is not ideal, however it simplifies the
+                // routine greatly.
+                let root = match target {
+                    LeanReverseAncestorIterTarget::BlockRoots => state.get_block_root(slot),
+                    LeanReverseAncestorIterTarget::StateRoots => state.get_state_root(slot),
+                }
+                .ok()?;
+
+                roots.push(*root)
+            } else {
+                break;
+            }
+        }
+
+        Some(Self {
+            roots,
+            next_state: (next_state_root, next_state_slot),
+            prev_slot,
+            store,
+            target,
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<E: EthSpec, U: Store<E>> Iterator for LeanReverseAncestorIter<E, U> {
+    type Item = (Hash256, Slot);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.prev_slot == 0 {
+            return None;
+        }
+
+        // dbg!(self.prev_slot);
+
+        if let Some(root) = self.roots.pop() {
+            self.prev_slot -= 1;
+
+            Some((root, self.prev_slot))
+        } else {
+            let (next_state_root, next_state_slot) = self.next_state;
+
+            let state = self
+                .store
+                .get_state(&next_state_root, Some(next_state_slot))
+                .ok()??;
+
+            std::mem::replace(
+                self,
+                LeanReverseAncestorIter::new(
+                    self.store.clone(),
+                    &state,
+                    // Note: regardless of the length of the current iterator, the new iterator
+                    // always has the full length. This will consume more memory for short
+                    // iterations but involve less DB reads for long iterations.
+                    E::SlotsPerHistoricalRoot::to_usize(),
+                    self.target,
+                )?,
+            );
+
+            self.next()
+        }
+    }
+}
+
 /// Implemented for types that have ancestors (e.g., blocks, states) that may be iterated over.
 ///
 /// ## Note
@@ -243,13 +384,24 @@ fn next_historical_root_backtrack_state<E: EthSpec, S: Store<E>>(
     store: &S,
     current_state: &BeaconState<E>,
 ) -> Option<BeaconState<E>> {
+    let (new_state_root, new_state_slot) =
+        next_historical_root_backtrack_state_root(current_state)?;
+    store
+        .get_state(&new_state_root, Some(new_state_slot))
+        .ok()?
+}
+
+/// Fetch the next state root to use whilst backtracking in `*RootsIterator`.
+fn next_historical_root_backtrack_state_root<E: EthSpec>(
+    current_state: &BeaconState<E>,
+) -> Option<(Hash256, Slot)> {
     // For compatibility with the freezer database's restore points, we load a state at
     // a restore point slot (thus avoiding replaying blocks). In the case where we're
     // not frozen, this just means we might not jump back by the maximum amount on
     // our first jump (i.e. at most 1 extra state load).
     let new_state_slot = slot_of_prev_restore_point::<E>(current_state.slot);
     let new_state_root = current_state.get_state_root(new_state_slot).ok()?;
-    store.get_state(new_state_root, Some(new_state_slot)).ok()?
+    Some((*new_state_root, new_state_slot))
 }
 
 /// Compute the slot of the last guaranteed restore point in the freezer database.

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -56,6 +56,21 @@ impl<E: EthSpec, U: Store<E>> LeanReverseAncestorIter<E, U> {
             return None;
         }
 
+        // It is impossible to iterate through roots prior to genesis. If requested, we generate an
+        // iterator with mostly junk values that will simply return `None` on the first call to
+        // `next()`.
+        if state.slot == 0 {
+            return Some(Self {
+                roots: vec![],
+                next_state: (Hash256::random(), Slot::new(0)),
+                // Setting slot to 0 should guarantee that `next()` will return `None`.
+                prev_slot: Slot::new(0),
+                store,
+                target,
+                _phantom: PhantomData,
+            });
+        }
+
         // First we try and use the backtrack state. This should reduce the amount state-replaying
         // required.
         let (mut next_state_root, mut next_state_slot) =

--- a/beacon_node/store/tests/tests.rs
+++ b/beacon_node/store/tests/tests.rs
@@ -3,7 +3,7 @@
 use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, HarnessType,
 };
-use store::{iter::LeanReverseAncestorIter, Store};
+use store::{iter::AncestorRoots, Store};
 use types::{
     test_utils::generate_deterministic_keypairs, BeaconBlock, EthSpec, Hash256, MinimalEthSpec,
     Slot, Unsigned,
@@ -98,14 +98,13 @@ fn lean_ancestor_iterators_checks(
     let store = harness.chain.store.clone();
     let state = &harness.chain.head().beacon_state;
 
-    let block_roots: Vec<(Hash256, Slot)> =
-        LeanReverseAncestorIter::block_roots(store.clone(), state, len)
-            .expect("should create iter")
-            .collect();
-    let state_roots: Vec<(Hash256, Slot)> =
-        LeanReverseAncestorIter::state_roots(store.clone(), state, len)
-            .expect("should create iter")
-            .collect();
+    let mut block_ancestors =
+        AncestorRoots::block_roots(store.clone(), state, len).expect("should create block roots");
+    let mut state_ancestors =
+        AncestorRoots::state_roots(store.clone(), state, len).expect("should create state roots");
+
+    let block_roots: Vec<(Hash256, Slot)> = block_ancestors.iter().collect();
+    let state_roots: Vec<(Hash256, Slot)> = state_ancestors.iter().collect();
 
     assert_eq!(
         block_roots.len(),

--- a/beacon_node/store/tests/tests.rs
+++ b/beacon_node/store/tests/tests.rs
@@ -1,4 +1,4 @@
-#![cfg(not(debug_assertions))]
+// #![cfg(not(debug_assertions))]
 
 use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, HarnessType,
@@ -22,9 +22,40 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<HarnessType<Minimal
 }
 
 #[test]
-fn lean_ancestor_iterators() {
-    let num_blocks_produced = <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() * 3;
+fn lean_ancestor_iterators_genesis() {
+    let harness = get_harness(24);
 
+    let lengths = vec![
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize(),
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() - 1,
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() / 2,
+        3,
+        2,
+        1,
+    ];
+
+    for len in lengths {
+        lean_ancestor_iterators_checks(&harness, 0, len);
+    }
+}
+
+#[test]
+fn lean_ancestor_iterators_len_half_historical_roots() {
+    lean_ancestor_iterators_test(<E as EthSpec>::SlotsPerHistoricalRoot::to_usize() / 2);
+}
+
+#[test]
+fn lean_ancestor_iterators_len_1_times_historical_roots() {
+    lean_ancestor_iterators_test(<E as EthSpec>::SlotsPerHistoricalRoot::to_usize());
+}
+
+#[test]
+fn lean_ancestor_iterators_len_3_times_historical_roots() {
+    lean_ancestor_iterators_test(<E as EthSpec>::SlotsPerHistoricalRoot::to_usize() * 3);
+}
+
+/// Run a test on the ancestor iterators given a chain of length `num_blocks_produced + 1`.
+fn lean_ancestor_iterators_test(num_blocks_produced: usize) {
     let harness = get_harness(24);
 
     harness.extend_chain(
@@ -44,11 +75,12 @@ fn lean_ancestor_iterators() {
     ];
 
     for len in lengths {
-        lean_ancestor_iterators_test(&harness, num_blocks_produced, len);
+        lean_ancestor_iterators_checks(&harness, num_blocks_produced, len);
     }
 }
 
-fn lean_ancestor_iterators_test(
+/// Generate iterators and check them against the harness.
+fn lean_ancestor_iterators_checks(
     harness: &BeaconChainHarness<HarnessType<MinimalEthSpec>>,
     num_blocks_produced: usize,
     len: usize,
@@ -76,6 +108,11 @@ fn lean_ancestor_iterators_test(
         num_blocks_produced as usize,
         "should contain all produced blocks"
     );
+
+    if state.slot == 0 {
+        // No need to run the following tests for the genesis case.
+        return;
+    }
 
     assert!(
         block_roots.iter().any(|(_root, slot)| *slot == 0),

--- a/beacon_node/store/tests/tests.rs
+++ b/beacon_node/store/tests/tests.rs
@@ -1,4 +1,4 @@
-// #![cfg(not(debug_assertions))]
+#![cfg(not(debug_assertions))]
 
 use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, HarnessType,
@@ -21,22 +21,40 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<HarnessType<Minimal
     harness
 }
 
-#[test]
-fn lean_ancestor_iterators_genesis() {
-    let harness = get_harness(24);
-
-    let lengths = vec![
+/// Some lengths to test with.
+fn test_lengths() -> Vec<usize> {
+    vec![
         <E as EthSpec>::SlotsPerHistoricalRoot::to_usize(),
         <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() - 1,
         <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() / 2,
         3,
         2,
         1,
-    ];
+    ]
+}
 
-    for len in lengths {
+#[test]
+fn lean_ancestor_iterators_genesis() {
+    let harness = get_harness(24);
+
+    for len in test_lengths() {
         lean_ancestor_iterators_checks(&harness, 0, len);
     }
+}
+
+#[test]
+fn lean_ancestor_iterators_len_1() {
+    lean_ancestor_iterators_test(1);
+}
+
+#[test]
+fn lean_ancestor_iterators_len_2() {
+    lean_ancestor_iterators_test(2);
+}
+
+#[test]
+fn lean_ancestor_iterators_len_3() {
+    lean_ancestor_iterators_test(3);
 }
 
 #[test]
@@ -65,16 +83,7 @@ fn lean_ancestor_iterators_test(num_blocks_produced: usize) {
         AttestationStrategy::SomeValidators(vec![]),
     );
 
-    let lengths = vec![
-        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize(),
-        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() - 1,
-        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() / 2,
-        3,
-        2,
-        1,
-    ];
-
-    for len in lengths {
+    for len in test_lengths() {
         lean_ancestor_iterators_checks(&harness, num_blocks_produced, len);
     }
 }

--- a/beacon_node/store/tests/tests.rs
+++ b/beacon_node/store/tests/tests.rs
@@ -1,0 +1,117 @@
+#![cfg(not(debug_assertions))]
+
+use beacon_chain::test_utils::{
+    AttestationStrategy, BeaconChainHarness, BlockStrategy, HarnessType,
+};
+use store::iter::LeanReverseAncestorIter;
+use types::{
+    test_utils::generate_deterministic_keypairs, EthSpec, Hash256, MinimalEthSpec, Slot, Unsigned,
+};
+
+type E = MinimalEthSpec;
+
+fn get_harness(validator_count: usize) -> BeaconChainHarness<HarnessType<MinimalEthSpec>> {
+    let harness = BeaconChainHarness::new(
+        MinimalEthSpec,
+        generate_deterministic_keypairs(validator_count),
+    );
+
+    harness.advance_slot();
+
+    harness
+}
+
+#[test]
+fn lean_ancestor_iterators() {
+    let num_blocks_produced = <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() * 3;
+
+    let harness = get_harness(24);
+
+    harness.extend_chain(
+        num_blocks_produced as usize,
+        BlockStrategy::OnCanonicalHead,
+        // No need to produce attestations for this test.
+        AttestationStrategy::SomeValidators(vec![]),
+    );
+
+    let lengths = vec![
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize(),
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() - 1,
+        <E as EthSpec>::SlotsPerHistoricalRoot::to_usize() / 2,
+        3,
+        2,
+        1,
+    ];
+
+    for len in lengths {
+        lean_ancestor_iterators_test(&harness, num_blocks_produced, len);
+    }
+}
+
+fn lean_ancestor_iterators_test(
+    harness: &BeaconChainHarness<HarnessType<MinimalEthSpec>>,
+    num_blocks_produced: usize,
+    len: usize,
+) {
+    let store = harness.chain.store.clone();
+    let state = &harness.chain.head().beacon_state;
+
+    let block_roots: Vec<(Hash256, Slot)> =
+        LeanReverseAncestorIter::block_roots(store.clone(), state, len)
+            .expect("should create iter")
+            .collect();
+    let state_roots: Vec<(Hash256, Slot)> =
+        LeanReverseAncestorIter::state_roots(store.clone(), state, len)
+            .expect("should create iter")
+            .collect();
+
+    assert_eq!(
+        block_roots.len(),
+        state_roots.len(),
+        "should be an equal amount of block and state roots"
+    );
+
+    assert_eq!(
+        block_roots.len(),
+        num_blocks_produced as usize,
+        "should contain all produced blocks"
+    );
+
+    assert!(
+        block_roots.iter().any(|(_root, slot)| *slot == 0),
+        "should contain genesis block root"
+    );
+    assert!(
+        state_roots.iter().any(|(_root, slot)| *slot == 0),
+        "should contain genesis state root"
+    );
+
+    block_roots.windows(2).for_each(|x| {
+        assert_eq!(
+            x[1].1,
+            x[0].1 - 1,
+            "block root slots should be decreasing by one"
+        )
+    });
+    state_roots.windows(2).for_each(|x| {
+        assert_eq!(
+            x[1].1,
+            x[0].1 - 1,
+            "state root slots should be decreasing by one"
+        )
+    });
+
+    let head = &harness.chain.head();
+
+    assert!(
+        *block_roots.first().expect("should have some block roots")
+            != (head.beacon_block_root, head.beacon_block.slot),
+        "first block root and slot should not be for the head block"
+    );
+
+    assert!(
+        *state_roots.first().expect("should have some state roots")
+            != (head.beacon_state_root, head.beacon_state.slot),
+        "first state root and slot should not be for the head state"
+    );
+}


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Introduces the `LeanReverseAncestorIterator`, which has the following properties:

- Stores a customizable-length `Vec<Hash256>` and only replenishes it when required
    - Does not store an entire `BeaconState`
- Favors landing on historical root backtrack states.
- Handles both block and state roots without code duplication.

Reason for implementing:

- For fork choice we're going to need a little cache of previous roots so we can reduce our DB reads. This iterator can act as a cache that is able to provide some roots from memory before needing to go to the DB.
- Something similar will also likely be handy when we're pruning dead forks (we have to find highest common ancestors).
- I think it's a good format to be optimized for:
    - Freezer db
    - Partial reading of beacon state (e.g., we can replenish this by only deserializing a couple of fields of the state).
