### PR TITLE
Enable bulk signature verification

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1271,7 +1271,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut state,
             &block,
             Some(block_root),
-            BlockSignatureStrategy::VerifyIndividual,
+            BlockSignatureStrategy::VerifyBulk,
             &self.spec,
         ) {
             Err(BlockProcessingError::BeaconStateError(e)) => {

--- a/tests/ef_tests/src/cases/sanity_blocks.rs
+++ b/tests/ef_tests/src/cases/sanity_blocks.rs
@@ -84,7 +84,7 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
                     &mut state,
                     block,
                     None,
-                    BlockSignatureStrategy::VerifyIndividual,
+                    BlockSignatureStrategy::VerifyBulk,
                     spec,
                 )?;
 


### PR DESCRIPTION
## Issue Addressed

Closes #734 

## Proposed Changes

- Ensured all EF tests were running with VerifyBulk
- Change the strategy in the `process_block_internal` function.

## Additional Info

I had a look at other places where `BlockSignatureStrategy::VerifyIndividual` was used.
- It's used all over the place in the [`per_block_processing`](https://github.com/sigp/lighthouse/blob/master/eth2/state_processing/src/per_block_processing.rs) file. I believe this is desired?
- It's also used here https://github.com/sigp/lighthouse/blob/e7de1b3339818614b209049bc1bbdb4622aef06f/lcli/src/transition_blocks.rs#L67-L72  I don't know if this one should be changed?
- Finally it's used for benches here https://github.com/sigp/lighthouse/blob/e7de1b3339818614b209049bc1bbdb4622aef06f/eth2/state_processing/benches/benches.rs#L93-L115  Should this one be changed too?