### PR TITLE
Add log-format option to CLI

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -249,7 +249,7 @@ fn run<T: EthSpec>(env_builder: EnvironmentBuilder<T>, matches: &ArgMatches) {
     let env = env_builder
         .multi_threaded_tokio_runtime()
         .expect("should start tokio runtime")
-        .async_logger("trace")
+        .async_logger("trace", None)
         .expect("should start null logger")
         .build()
         .expect("should build env");

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -15,7 +15,6 @@ use std::cell::RefCell;
 use std::ffi::OsStr;
 use std::fs::{rename as FsRename, OpenOptions};
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime, TaskExecutor};
 use types::{EthSpec, InteropEthSpec, MainnetEthSpec, MinimalEthSpec};
@@ -279,7 +278,7 @@ impl<E: EthSpec> Environment<E> {
         let log_format = log_format.unwrap_or("JSON");
         let drain = match log_format.to_uppercase().as_str() {
             "JSON" => {
-                let drain = Mutex::new(slog_json::Json::default(file)).fuse();
+                let drain = slog_json::Json::default(file).fuse();
                 slog_async::Async::new(drain).build()
             }
             _ => return Err("Logging format provided is not supported".to_string()),

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -104,7 +104,7 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
         debug_level: &str,
         log_format: Option<&str>,
     ) -> Result<Self, String> {
-        // Setting up initial logger to either be to JSON formatted or formatted for a terminal.
+        // Setting up the initial logger format and building it.
         let drain = if let Some(format) = log_format {
             match format.to_uppercase().as_str() {
                 "JSON" => {

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -43,6 +43,13 @@ fn main() {
                 .long("logfile")
                 .value_name("FILE")
                 .help("File path where output will be written.")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::with_name("log-format")
+                .long("log-format")
+                .value_name("FORMAT")
+                .help("Specifies the format used for logging (JSON, YAML...)")
                 .takes_value(true),
         )
         .arg(
@@ -99,8 +106,10 @@ fn run<E: EthSpec>(
         .value_of("debug-level")
         .ok_or_else(|| "Expected --debug-level flag".to_string())?;
 
+    let log_format = matches.value_of("log-format");
+
     let mut environment = environment_builder
-        .async_logger(debug_level)?
+        .async_logger(debug_level, log_format)?
         .multi_threaded_tokio_runtime()?
         .build()?;
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
                 .long("logfile")
                 .value_name("FILE")
                 .help("File path where output will be written.")
-                .takes_value(true)
+                .takes_value(true),
         )
         .arg(
             Arg::with_name("log-format")

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -42,14 +42,17 @@ fn main() {
             Arg::with_name("logfile")
                 .long("logfile")
                 .value_name("FILE")
-                .help("File path where output will be written.")
+                .help(
+                    "File path where output will be written. Default file logging format is JSON.",
+                )
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("log-format")
                 .long("log-format")
                 .value_name("FORMAT")
-                .help("Specifies the format used for logging (JSON, YAML...)")
+                .help("Specifies the format used for logging.")
+                .possible_values(&["JSON"])
                 .takes_value(true),
         )
         .arg(
@@ -119,7 +122,7 @@ fn run<E: EthSpec>(
         let path = log_path
             .parse::<PathBuf>()
             .map_err(|e| format!("Failed to parse log path: {:?}", e))?;
-        environment.log_to_json_file(path, debug_level)?;
+        environment.log_to_json_file(path, debug_level, log_format)?;
     }
 
     if std::mem::size_of::<usize>() != 8 {

--- a/tests/beacon_chain_sim/src/main.rs
+++ b/tests/beacon_chain_sim/src/main.rs
@@ -41,6 +41,7 @@ fn main() {
     let nodes = 4;
     let validators_per_node = 20;
     let log_level = "debug";
+    let log_format = None;
     let speed_up_factor = 4;
     let end_after_checks = true;
 
@@ -49,6 +50,7 @@ fn main() {
         validators_per_node,
         speed_up_factor,
         log_level,
+        log_format,
         end_after_checks,
     ) {
         Ok(()) => println!("Simulation exited successfully"),
@@ -64,10 +66,11 @@ fn async_sim(
     validators_per_node: usize,
     speed_up_factor: u64,
     log_level: &str,
+    log_format: Option<&str>,
     end_after_checks: bool,
 ) -> Result<(), String> {
     let mut env = EnvironmentBuilder::minimal()
-        .async_logger(log_level)?
+        .async_logger(log_level, log_format)?
         .multi_threaded_tokio_runtime()?
         .build()?;
 


### PR DESCRIPTION
## Issue Addressed

Closes #740 

## Proposed Changes

- Add `--log-format` option to enable users to specify their desired logging format.
- Add appropriate documentation

## Additional Info

This option currently only supports the `JSON` format but I've set up the code to easily be able to add other formats.