### PR TITLE
got Docker image down to 138mb from 1.8gb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM rust:1.39.0
-
-
+FROM rust:1.39.0 AS builder
 COPY . lighthouse
 RUN cd lighthouse && make && cargo clean
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get install -y libssl-dev
+COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse


### PR DESCRIPTION
## Issue Addressed

Addresses issue 748

## Proposed Changes

Use multi-stage builds to save on the Docker image size.  (see https://docs.docker.com/develop/develop-images/multistage-build/ for more info)

## Additional Info

This assumes that the rust image is going to continue to be debian:buster. It could be switched to alpine if you want to save another 60mb or so. But, some people like "bash" vs. "ash". 
