### PR TITLE
add command line args

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,4 +57,4 @@ jobs:
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim
-      run: cargo run --release --bin beacon_chain_sim
+      run: cargo run --release --bin beacon_chain_sim -- -e

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,7 @@ dependencies = [
 name = "beacon_chain_sim"
 version = "0.1.0"
 dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth1_test_rig 0.1.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tests/beacon_chain_sim/Cargo.toml
+++ b/tests/beacon_chain_sim/Cargo.toml
@@ -15,3 +15,4 @@ futures = "0.1.29"
 tokio = "0.1.22"
 eth1_test_rig = { path = "../eth1_test_rig" }
 env_logger = "0.7.1"
+clap = "2.32.0"


### PR DESCRIPTION
## Issue Addressed

There was a comment in the code to convert variables to command line arguments.

## Proposed Changes

Add command line arguments so the beacon chain simulator can use different values.

## Additional Info

Novice rust developer. Please provide feedback.
