### PR TITLE
Update notice about testnet being down

### DIFF
--- a/book/src/become-a-validator.md
+++ b/book/src/become-a-validator.md
@@ -2,8 +2,8 @@
 
 ---
 
-**The lighthouse testnet is currently down, we expect to raise a new one
-before the 22nd of December. See [Lighthouse Update #20](https://lighthouse.sigmaprime.io/update-20.html)
+**The lighthouse testnet is currently down, we expect to raise a new one soon.
+See [Lighthouse Update #20](https://lighthouse.sigmaprime.io/update-20.html)
 for more information.**
 
 ---


### PR DESCRIPTION
## Issue Addressed

I noticed this whilst addressing #771 

## Proposed Changes

Updates the header about our testnet being down. We didn't end up announcing the testnet yet (however it has been up since the 22nd).
