### PR TITLE
Discv5 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ name = "backtrace-sys"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "2.6.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.48"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -508,7 +508,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -545,7 +545,7 @@ dependencies = [
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tree_hash 0.1.1",
  "types 0.1.0",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "websocket_server 0.1.0",
 ]
 
@@ -588,7 +588,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -671,7 +671,7 @@ dependencies = [
  "cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "csv 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1007,12 +1007,13 @@ dependencies = [
 [[package]]
 name = "enr"
 version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "libsecp256k1 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1119,7 +1120,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz 0.1.2",
  "eth2_ssz_derive 0.1.0",
@@ -1127,7 +1128,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "lighthouse_metrics 0.1.0",
  "lru 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1163,7 +1164,7 @@ dependencies = [
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1482,12 +1483,12 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1786,10 +1787,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "js-sys"
-version = "0.3.33"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1893,35 +1894,35 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-core-derive 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-deflate 0.5.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-discv5 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-dns 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-floodsub 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-gossipsub 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-identify 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-kad 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-mdns 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-mplex 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-noise 0.11.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-ping 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-plaintext 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-secio 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-tcp 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-uds 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-wasm-ext 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-websocket 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-yamux 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-core-derive 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-deflate 0.5.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-discv5 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-dns 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-floodsub 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-gossipsub 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-identify 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-kad 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-mdns 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-mplex 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-noise 0.11.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-ping 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-plaintext 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-secio 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-tcp 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-uds 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-wasm-ext 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-websocket 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-yamux 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1933,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "asn1_der 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1945,15 +1946,15 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsecp256k1 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "multistream-select 0.6.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "multistream-select 0.6.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1977,34 +1978,34 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.5.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-discv5"
 version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "arrayvec 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "bigint 4.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "libsecp256k1 0.3.1 (git+https://github.com/SigP/libsecp256k1?branch=ecdh_generalise)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2019,10 +2020,10 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-dns-unofficial 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2030,15 +2031,15 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cuckoofilter 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2048,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2056,8 +2057,8 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2073,14 +2074,14 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2092,18 +2093,18 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2119,16 +2120,16 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dns-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2141,12 +2142,12 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2157,13 +2158,13 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.11.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2177,14 +2178,14 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
- "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
+ "libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2194,14 +2195,14 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2209,39 +2210,39 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "aes-ctr 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "sha2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-swarm"
 version = "0.3.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2251,13 +2252,13 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2267,10 +2268,10 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2278,42 +2279,42 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.6.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-websocket"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "soketto 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libp2p-yamux"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "yamux 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2353,7 +2354,7 @@ name = "libz-sys"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2552,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.14"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2560,7 +2561,7 @@ name = "mime_guess"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2625,7 +2626,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.6.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2690,7 +2691,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2798,7 +2799,7 @@ version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2837,24 +2838,24 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.6.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "data-encoding 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)",
+ "parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)",
  "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parity-multihash"
 version = "0.2.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3048,7 +3049,7 @@ dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3149,7 +3150,7 @@ name = "rand"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3192,7 +3193,7 @@ name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3247,7 +3248,7 @@ name = "rand_os"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3394,7 +3395,7 @@ dependencies = [
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3444,7 +3445,7 @@ dependencies = [
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tree_hash 0.1.1",
  "types 0.1.0",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version 0.1.0",
 ]
 
@@ -3453,12 +3454,12 @@ name = "ring"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -3518,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e#c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e"
+source = "git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e#555d99dbb96017448cb019a4881258ad748d877e"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4299,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4646,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4754,30 +4755,30 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.7.0"
+version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4787,64 +4788,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-macro-support 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-futures 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-test-macro 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-test-macro 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4853,7 +4854,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-webidl"
-version = "0.2.56"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4862,7 +4863,7 @@ dependencies = [
  "proc-macro2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "weedle 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -4872,23 +4873,23 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "send_wrapper 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.33"
+version = "0.3.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "sourcefile 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5048,7 +5049,7 @@ dependencies = [
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha-1 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -5172,7 +5173,7 @@ dependencies = [
 "checksum bs58 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c95ee6bba9d950218b6cc910cf62bc9e0a171d0f4537e3627b0f54d08549b188"
 "checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
-"checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
+"checksum bumpalo 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5fb8038c1ddc0a5f73787b130f4cc75151e96ed33e417fde765eb5a81e3532f4"
 "checksum byte-slice-cast 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
@@ -5181,7 +5182,7 @@ dependencies = [
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum c_linked_list 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
-"checksum cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)" = "f52a465a666ca3d838ebbf08b241383421412fe7ebb463527bba275526d89f76"
+"checksum cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)" = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
@@ -5211,7 +5212,7 @@ dependencies = [
 "checksum crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a2f4a431c5c9f662e1200b7c7f02c34e91361150e382089a8f2dec3ba680cbda"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
+"checksum csv 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "11f8cbd084b9a431d52dfac0b8428a26b68f1061138a7bea18aa56b9cdf55266"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ctr 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
@@ -5230,7 +5231,7 @@ dependencies = [
 "checksum ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)" = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
-"checksum enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
+"checksum enr 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
@@ -5259,7 +5260,7 @@ dependencies = [
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum get_if_addrs 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
 "checksum get_if_addrs-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-"checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
+"checksum getrandom 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"
 "checksum hashbrown 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8e6073d0ca812575946eb5f35ff68dbe519907b25c42530389ff946dc84c6ead"
@@ -5291,7 +5292,7 @@ dependencies = [
 "checksum ipnet 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f4b06b21db0228860c8dfd17d2106c49c7c6bd07477a4036985347d84def04"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum js-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "367647c532db6f1555d7151e619540ec5f713328235b8c062c6b4f63e84adfe3"
+"checksum js-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "7889c7c36282151f6bf465be4700359318aef36baa951462382eae49e9577cf9"
 "checksum jsonrpc-core 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97b83fdc5e0218128d0d270f2f2e7a5ea716f3240c8518a58bc89e6716ba8581"
 "checksum keccak 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -5302,28 +5303,28 @@ dependencies = [
 "checksum leveldb-sys 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71f46429bb70612c3e939aaeed27ffd31a24a773d21728a1a426e4089d6778d2"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libflate 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
-"checksum libp2p 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-core-derive 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-deflate 0.5.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-discv5 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-dns 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-floodsub 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-gossipsub 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-identify 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-kad 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-mdns 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-mplex 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-noise 0.11.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-ping 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-plaintext 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-secio 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-tcp 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-uds 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-wasm-ext 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-websocket 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum libp2p-yamux 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
+"checksum libp2p 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-core 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-core-derive 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-deflate 0.5.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-discv5 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-dns 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-floodsub 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-gossipsub 0.1.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-identify 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-kad 0.13.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-mdns 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-mplex 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-noise 0.11.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-ping 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-plaintext 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-secio 0.13.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-swarm 0.3.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-tcp 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-uds 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-wasm-ext 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-websocket 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum libp2p-yamux 0.13.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
 "checksum libsecp256k1 0.3.1 (git+https://github.com/SigP/libsecp256k1?branch=ecdh_generalise)" = "<none>"
 "checksum libsecp256k1 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "df6edf84fd62aad1c93932b39324eaeda3912c1d26bc18dfaee6293848e49a50"
 "checksum libz-sys 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
@@ -5341,14 +5342,14 @@ dependencies = [
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
 "checksum milagro_bls 0.11.0 (git+https://github.com/sigp/milagro_bls?tag=v0.11.1)" = "<none>"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+"checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 "checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "52403fe290012ce777c4626790c8951324a2b9e3316b3143779c72b029742f19"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum multistream-select 0.6.1 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
+"checksum multistream-select 0.6.1 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
@@ -5365,8 +5366,8 @@ dependencies = [
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
-"checksum parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
-"checksum parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
+"checksum parity-multiaddr 0.6.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
+"checksum parity-multihash 0.2.0 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
 "checksum parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f747c06d9f3b2ad387ac881b9667298c81b1243aa9833f086e05996937c35507"
 "checksum parity-send-wrapper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -5430,7 +5431,7 @@ dependencies = [
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
-"checksum rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e)" = "<none>"
+"checksum rw-stream-sink 0.1.2 (git+https://github.com/SigP/rust-libp2p/?rev=555d99dbb96017448cb019a4881258ad748d877e)" = "<none>"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
@@ -5507,7 +5508,7 @@ dependencies = [
 "checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-io-timeout 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "135ce81f15cfd7982fac684f9057a1299eebeb79e98a8a709969b9aa51123129"
 "checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
-"checksum tokio-rustls 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1df2fa53ac211c136832f530ccb081af9af891af22d685a9493e232c7a359bc2"
+"checksum tokio-rustls 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d7cf08f990090abd6c6a73cab46fed62f85e8aef8b99e4b918a9f4a637f0676"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f0c32ffea4827978e9aa392d2f743d973c1dfa3730a2ed3f22ce1e6984da848c"
@@ -5539,7 +5540,7 @@ dependencies = [
 "checksum unsigned-varint 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f0023a96687fe169081e8adce3f65e3874426b7886e9234d490af2dc077959"
 "checksum untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60369ef7a31de49bcb3f6ca728d4ba7300d9a1658f94c727d4cab8c8d9f4aece"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
+"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
@@ -5548,19 +5549,19 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
-"checksum wasm-bindgen 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "99de4b68939a880d530aed51289a7c7baee154e3ea8ac234b542c49da7134aaf"
-"checksum wasm-bindgen-backend 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "b58e66a093a7b7571cb76409763c495b8741ac4319ac20acc2b798f6766d92ee"
+"checksum wasi 0.9.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+"checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"
+"checksum wasm-bindgen-backend 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "11cdb95816290b525b32587d76419facd99662a07e59d3cdb560488a819d9a45"
 "checksum wasm-bindgen-futures 0.3.27 (registry+https://github.com/rust-lang/crates.io-index)" = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
-"checksum wasm-bindgen-futures 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3bf1b55e0dc85085cfab2c0c520b977afcf16ac5801ee0de8dde42a4f5649b2a"
-"checksum wasm-bindgen-macro 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "a80f89daea7b0a67b11f6e9f911422ed039de9963dce00048a653b63d51194bf"
-"checksum wasm-bindgen-macro-support 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "4f9dbc3734ad6cff6b76b75b7df98c06982becd0055f651465a08f769bca5c61"
-"checksum wasm-bindgen-shared 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "d907984f8506b3554eab48b8efff723e764ddbf76d4cd4a3fe4196bc00c49a70"
-"checksum wasm-bindgen-test 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "87d10750e72390ddfaad9420525f4e3ed565408586c859aa2bf91f8ebad65774"
-"checksum wasm-bindgen-test-macro 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "5b84bb462de0772abdec0394671153f280483828f883cbaa12d71f6142196a01"
-"checksum wasm-bindgen-webidl 0.2.56 (registry+https://github.com/rust-lang/crates.io-index)" = "f85a3825a459cf6a929d03bacb54dca37a614d43032ad1343ef2d4822972947d"
+"checksum wasm-bindgen-futures 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8bbdd49e3e28b40dec6a9ba8d17798245ce32b019513a845369c641b275135d9"
+"checksum wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "574094772ce6921576fb6f2e3f7497b8a76273b6db092be18fc48a082de09dc3"
+"checksum wasm-bindgen-macro-support 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
+"checksum wasm-bindgen-shared 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "f5e7e61fc929f4c0dddb748b102ebf9f632e2b8d739f2016542b4de2965a9601"
+"checksum wasm-bindgen-test 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0ec352c44d1726b6c2bec524612b1c81e34a7d858f597a6c71f8e018c82e"
+"checksum wasm-bindgen-test-macro 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "97837a6e83ab24a4b3a38d44a257e13335b54f4b4548b2c9d71edd0bf570cb4f"
+"checksum wasm-bindgen-webidl 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "ef012a0d93fc0432df126a8eaf547b2dce25a8ce9212e1d3cbeef5c11157975d"
 "checksum wasm-timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "aa3e01d234bb71760e685cfafa5e2c96f8ad877c161a721646356651069e26ac"
-"checksum web-sys 0.3.33 (registry+https://github.com/rust-lang/crates.io-index)" = "2fb60433d0dc12c803b9b017b3902d80c9451bab78d27bc3210bf2a7b96593f1"
+"checksum web-sys 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf97caf6aa8c2b1dac90faf0db529d9d63c93846cca4911856f78a83cebf53b"
 "checksum web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "076f34ed252d74a8521e3b013254b1a39f94a98f23aae7cfc85cda6e7b395664"
 "checksum webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7e664e770ac0110e2384769bcc59ed19e329d81f555916a6e072714957b81b4"
 "checksum webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e" }
-enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "c0c71fa4d7e6621cafe2c087d1aa1bc60dd9116e", features = ["serde"] }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "555d99dbb96017448cb019a4881258ad748d877e" }
+enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "555d99dbb96017448cb019a4881258ad748d877e", features = ["serde"] }
 types = { path =  "../../eth2/types" }
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "555d99dbb96017448cb019a4881258ad748d877e" }
-enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "555d99dbb96017448cb019a4881258ad748d877e", features = ["serde"] }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "735313ebda6a98604929f6c4606aefac19e00760" }
+enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "735313ebda6a98604929f6c4606aefac19e00760", features = ["serde"] }
 types = { path =  "../../eth2/types" }
 serde = "1.0.102"
 serde_derive = "1.0.102"


### PR DESCRIPTION
Updates discv5 to use delay queue's to handle session and message timeouts. 

This PR fixes a bug where discovery never completes, leaving nodes stuck to their original peers.

Should also see speed improvements