### PR TITLE
Increase default slots per restore point to 2048

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1,5 +1,4 @@
 use clap::{App, Arg, SubCommand};
-use store::StoreConfig;
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new("beacon_node")
@@ -196,14 +195,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("slots-per-restore-point")
                 .value_name("SLOT_COUNT")
                 .help("Specifies how often a freezer DB restore point should be stored. \
-                       DO NOT CHANGE AFTER INITIALIZATION.")
+                       DO NOT DECREASE AFTER INITIALIZATION. [default: 2048 (mainnet) or 64 (minimal)]")
                 .takes_value(true)
-                .default_value(
-                    Box::leak(
-                        format!("{}", StoreConfig::default().slots_per_restore_point)
-                            .into_boxed_str()
-                    )
-                )
         )
         /*
          * The "testnet" sub-command.

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -258,6 +258,11 @@ pub fn get_configs<E: EthSpec>(
         client_config.store.slots_per_restore_point = slots_per_restore_point
             .parse()
             .map_err(|_| "slots-per-restore-point is not a valid integer".to_string())?;
+    } else {
+        client_config.store.slots_per_restore_point = std::cmp::min(
+            E::slots_per_historical_root() as u64,
+            store::config::DEFAULT_SLOTS_PER_RESTORE_POINT,
+        );
     }
 
     if eth2_config.spec_constants != client_config.spec_constants {

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -5,6 +5,9 @@ use types::{EthSpec, MinimalEthSpec};
 /// Default directory name for the freezer database under the top-level data dir.
 const DEFAULT_FREEZER_DB_DIR: &str = "freezer_db";
 
+/// Default value for the freezer DB's restore point frequency.
+pub const DEFAULT_SLOTS_PER_RESTORE_POINT: u64 = 2048;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoreConfig {
     /// Name of the directory inside the data directory where the main "hot" DB is located.
@@ -20,6 +23,7 @@ impl Default for StoreConfig {
         Self {
             db_name: "chain_db".to_string(),
             freezer_db_path: None,
+            // Safe default for tests, shouldn't ever be read by a CLI node.
             slots_per_restore_point: MinimalEthSpec::slots_per_historical_root() as u64,
         }
     }


### PR DESCRIPTION
This should reduce disk usage by 32x while keeping historical state queries to
less than 10s. If historical states are required quickly, the minimum SPRP of 32
can be set on the CLI.