### PR TITLE
Notifier errors

### DIFF
--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -37,6 +37,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
 ) -> Result<Signal, String> {
     let log_1 = context.log.clone();
     let log_2 = context.log.clone();
+    let log_3 = context.log.clone();
 
     let slot_duration = Duration::from_millis(milliseconds_per_slot);
     let duration_to_next_slot = beacon_chain
@@ -162,8 +163,15 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
 
             Ok(())
         })
-        .then(|_| {
-            Ok(())
+        .then(move |result| {
+            match result {
+                Ok(()) => Ok(()),
+                Err(e) => Ok(error!(
+                    log_3,
+                    "Notifier failed to notify";
+                    "error" => format!("{:?}", e)
+                ))
+            }
         });
 
     let (exit_signal, exit) = exit_future::signal();

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -161,6 +161,9 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
             };
 
             Ok(())
+        })
+        .then(|_| {
+            Ok(())
         });
 
     let (exit_signal, exit) = exit_future::signal();


### PR DESCRIPTION
## Issue Addressed

Resolves #778 (hopefully)

## Proposed Changes

Ensures that the notifier does not stop when an error is raised, instead it logs an error and keeps working for future times.
