### PR TITLE
Remove outdated cli options from docs

### DIFF
--- a/book/src/testnets.md
+++ b/book/src/testnets.md
@@ -71,13 +71,11 @@ $ lighthouse bn testnet --spec minimal -f file ssz /tmp/genesis.ssz
 To start a brand-new validator client (with no history) use:
 
 ```bash
-$ lighthouse vc testnet -b insecure 0 8
+$ lighthouse vc testnet insecure 0 8
 ```
 
 > Notes:
 >
-> - The `-b` flag means the validator client will "bootstrap" specs and config
->   from the beacon node.
 > - The `insecure` command dictates that the [interop keypairs](https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#pubkeyprivkey-generation)
 >   will be used.
 > - The `0 8` indicates that this validator client should manage 8 validators,
@@ -125,20 +123,6 @@ the `--boot-nodes` command.
 
 ```bash
 $ lighthouse bn --boot-nodes -IW4QB2Hi8TPuEzQ41Cdf1r2AUU1FFVFDBJdJyOkWk2qXpZfFZQy2YnJIyoT_5fnbtrXUouoskmydZl4pIg90clIkYUDgmlwhH8AAAGDdGNwgiMog3VkcIIjKIlzZWNwMjU2azGhAjg0-DsTkQynhJCRnLLttBK1RS78lmUkLa-wgzAi-Ob5
-```
-
-### Avoid port clashes when starting nodes
-
-Starting a second Lighthouse node on the same machine will fail due to TCP/UDP
-port collisions. Use the `-b` (`--port-bump`) flag to increase all listening
-ports by some `n`.
-
-#### Example:
-
-Increase all ports by `10` (using multiples of `10` is recommended).
-
-```bash
-$ lighthouse bn -b 10
 ```
 
 ### Start a testnet with a custom slot time


### PR DESCRIPTION
## Issue Addressed

#795 

## Proposed Changes

The docs in the lighthouse book has some outdated cli arguments. Remove the commands which aren't consistent with current version of lighthouse.
