### PR TITLE
Super/Silky smooth syncs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -10,7 +10,6 @@ use crate::persisted_beacon_chain::{PersistedBeaconChain, BEACON_CHAIN_DB_KEY};
 use crate::timeout_rw_lock::TimeoutRwLock;
 use lmd_ghost::LmdGhost;
 use operation_pool::{OperationPool, PersistedOperationPool};
-use parking_lot::RwLock;
 use slog::{debug, error, info, trace, warn, Logger};
 use slot_clock::SlotClock;
 use ssz::Encode;

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -711,19 +711,17 @@ where
         }
 
         // establish outbound substreams
-        if !self.dial_queue.is_empty() {
-            if self.dial_negotiated < self.max_dial_negotiated {
-                self.dial_negotiated += 1;
-                let rpc_event = self.dial_queue.remove(0);
-                self.dial_queue.shrink_to_fit();
-                if let RPCEvent::Request(id, req) = rpc_event {
-                    return Ok(Async::Ready(
-                        ProtocolsHandlerEvent::OutboundSubstreamRequest {
-                            protocol: SubstreamProtocol::new(req.clone()),
-                            info: RPCEvent::Request(id, req),
-                        },
-                    ));
-                }
+        if !self.dial_queue.is_empty() && self.dial_negotiated < self.max_dial_negotiated {
+            self.dial_negotiated += 1;
+            let rpc_event = self.dial_queue.remove(0);
+            self.dial_queue.shrink_to_fit();
+            if let RPCEvent::Request(id, req) = rpc_event {
+                return Ok(Async::Ready(
+                    ProtocolsHandlerEvent::OutboundSubstreamRequest {
+                        protocol: SubstreamProtocol::new(req.clone()),
+                        info: RPCEvent::Request(id, req),
+                    },
+                ));
             }
         }
         Ok(Async::NotReady)

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -314,6 +314,7 @@ where
                     substream: out,
                     request,
                 };
+                debug!(self.log, "Added outbound substream id"; "substream_id" => id);
                 self.outbound_substreams
                     .insert(id, (awaiting_stream, delay_key));
             }
@@ -418,6 +419,8 @@ where
         };
         if self.pending_error.is_none() {
             self.pending_error = Some((request_id, error));
+        } else {
+            crit!(self.log, "Couldn't add error");
         }
     }
 
@@ -448,6 +451,7 @@ where
                 }
                 ProtocolsHandlerUpgrErr::Timeout | ProtocolsHandlerUpgrErr::Timer => {
                     // negotiation timeout, mark the request as failed
+                    debug!(self.log, "Active substreams before timeout"; "len" => self.outbound_substreams.len());
                     return Ok(Async::Ready(ProtocolsHandlerEvent::Custom(
                         RPCEvent::Error(
                             request_id,
@@ -711,6 +715,7 @@ where
             if self.dial_negotiated < self.max_dial_negotiated {
                 self.dial_negotiated += 1;
                 let rpc_event = self.dial_queue.remove(0);
+                self.dial_queue.shrink_to_fit();
                 if let RPCEvent::Request(id, req) = rpc_event {
                     return Ok(Async::Ready(
                         ProtocolsHandlerEvent::OutboundSubstreamRequest {
@@ -720,8 +725,6 @@ where
                     ));
                 }
             }
-        } else {
-            self.dial_queue.shrink_to_fit();
         }
         Ok(Async::NotReady)
     }

--- a/beacon_node/network/src/message_processor.rs
+++ b/beacon_node/network/src/message_processor.rs
@@ -562,9 +562,9 @@ impl<T: BeaconChainTypes> MessageProcessor<T> {
                         self.log,
                         "Processed attestation";
                         "source" => "gossip",
-                        "outcome" => format!("{:?}", outcome),
                         "peer" => format!("{:?}",peer_id),
-                        "data" => format!("{:?}", msg.data)
+                        "block_root" => format!("{}", msg.data.beacon_block_root),
+                        "slot" => format!("{}", msg.data.slot),
                     );
                 }
                 AttestationProcessingOutcome::UnknownHeadBlock { beacon_block_root } => {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -695,7 +695,7 @@ impl<T: BeaconChainTypes> Future for SyncManager<T> {
                         self.range_sync.handle_block_process_result(
                             &mut self.network,
                             process_id,
-                            batch,
+                            *batch,
                             result,
                         );
                     }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -45,9 +45,9 @@ use fnv::FnvHashMap;
 use futures::prelude::*;
 use slog::{crit, debug, error, info, trace, warn, Logger};
 use smallvec::SmallVec;
+use std::boxed::Box;
 use std::collections::HashSet;
 use std::ops::Sub;
-use std::sync::Arc;
 use std::sync::Weak;
 use tokio::sync::{mpsc, oneshot};
 use types::{BeaconBlock, EthSpec, Hash256};
@@ -99,7 +99,7 @@ pub enum SyncMessage<T: EthSpec> {
     /// A batch has been processed by the block processor thread.
     BatchProcessed {
         process_id: u64,
-        batch: Arc<Batch<T>>,
+        batch: Box<Batch<T>>,
         result: BatchProcessResult,
     },
 }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -34,7 +34,7 @@
 //! subsequently search for parents if needed.
 
 use super::network_context::SyncNetworkContext;
-use super::range_sync::RangeSync;
+use super::range_sync::{Batch, BatchProcessResult, RangeSync};
 use crate::message_processor::PeerSyncInfo;
 use crate::service::NetworkMessage;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessingOutcome};
@@ -47,6 +47,7 @@ use slog::{crit, debug, error, info, trace, warn, Logger};
 use smallvec::SmallVec;
 use std::collections::HashSet;
 use std::ops::Sub;
+use std::sync::Arc;
 use std::sync::Weak;
 use tokio::sync::{mpsc, oneshot};
 use types::{BeaconBlock, EthSpec, Hash256};
@@ -94,6 +95,13 @@ pub enum SyncMessage<T: EthSpec> {
 
     /// An RPC Error has occurred on a request.
     RPCError(PeerId, RequestId),
+
+    /// A batch has been processed by the block processor thread.
+    BatchProcessed {
+        process_id: u64,
+        batch: Arc<Batch<T>>,
+        result: BatchProcessResult,
+    },
 }
 
 /// Maintains a sequential list of parents to lookup and the lookup's current state.

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -18,6 +18,17 @@ impl std::ops::Deref for BatchId {
         &self.0
     }
 }
+impl std::ops::DerefMut for BatchId {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::convert::From<u64> for BatchId {
+    fn from(id: u64) -> Self {
+        BatchId(id)
+    }
+}
 
 /// A collection of sequential blocks that are requested from peers in a single RPC request.
 #[derive(PartialEq, Debug)]

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -1,16 +1,29 @@
+use super::chain::BLOCKS_PER_BATCH;
+use eth2_libp2p::rpc::methods::*;
 use eth2_libp2p::rpc::RequestId;
 use eth2_libp2p::PeerId;
 use fnv::FnvHashMap;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::ops::Sub;
 use types::{BeaconBlock, EthSpec, Hash256, Slot};
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct BatchId(pub u64);
+
+impl std::ops::Deref for BatchId {
+    type Target = u64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// A collection of sequential blocks that are requested from peers in a single RPC request.
-#[derive(PartialEq)]
+#[derive(PartialEq, Debug)]
 pub struct Batch<T: EthSpec> {
     /// The ID of the batch, these are sequential.
-    pub id: u64,
+    pub id: BatchId,
     /// The requested start slot of the batch, inclusive.
     pub start_slot: Slot,
     /// The requested end slot of batch, exclusive.
@@ -27,9 +40,41 @@ pub struct Batch<T: EthSpec> {
     pub downloaded_blocks: Vec<BeaconBlock<T>>,
 }
 
+impl<T: EthSpec> Eq for Batch<T> {}
+
+impl<T: EthSpec> Batch<T> {
+    pub fn new(
+        id: BatchId,
+        start_slot: Slot,
+        end_slot: Slot,
+        head_root: Hash256,
+        peer_id: PeerId,
+    ) -> Self {
+        Batch {
+            id,
+            start_slot,
+            end_slot,
+            head_root,
+            _original_peer: peer_id.clone(),
+            current_peer: peer_id,
+            retries: 0,
+            downloaded_blocks: Vec::new(),
+        }
+    }
+
+    pub fn to_blocks_by_range_request(&self) -> BlocksByRangeRequest {
+        BlocksByRangeRequest {
+            head_block_root: self.head_root,
+            start_slot: self.start_slot.into(),
+            count: std::cmp::min(BLOCKS_PER_BATCH, self.end_slot.sub(self.start_slot).into()),
+            step: 1,
+        }
+    }
+}
+
 impl<T: EthSpec> Ord for Batch<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
+        self.id.0.cmp(&other.id.0)
     }
 }
 
@@ -81,6 +126,11 @@ impl<T: EthSpec> PendingBatches<T> {
         } else {
             None
         }
+    }
+
+    /// The number of current pending batch requests.
+    pub fn len(&self) -> usize {
+        self.batches.len()
     }
 
     /// Adds a block to the batches if the request id exists. Returns None if there is no batch

--- a/beacon_node/network/src/sync/range_sync/batch_processing.rs
+++ b/beacon_node/network/src/sync/range_sync/batch_processing.rs
@@ -72,7 +72,7 @@ fn process_batch<T: BeaconChainTypes>(
                     }
                     BlockProcessingOutcome::ParentUnknown { parent } => {
                         // blocks should be sequential and all parents should exist
-                        trace!(
+                        warn!(
                             log, "Parent block is unknown";
                             "parent_root" => format!("{}", parent),
                             "baby_block_slot" => block.slot,
@@ -98,7 +98,7 @@ fn process_batch<T: BeaconChainTypes>(
                     } => {
                         if present_slot + FUTURE_SLOT_TOLERANCE >= block_slot {
                             // The block is too far in the future, drop it.
-                            trace!(
+                            warn!(
                                 log, "Block is ahead of our slot clock";
                                 "msg" => "block for future slot rejected, check your time",
                                 "present_slot" => present_slot,
@@ -114,7 +114,7 @@ fn process_batch<T: BeaconChainTypes>(
                             ));
                         } else {
                             // The block is in the future, but not too far.
-                            trace!(
+                            debug!(
                                 log, "Block is slightly ahead of our slot clock, ignoring.";
                                 "present_slot" => present_slot,
                                 "block_slot" => block_slot,
@@ -123,14 +123,14 @@ fn process_batch<T: BeaconChainTypes>(
                         }
                     }
                     BlockProcessingOutcome::WouldRevertFinalizedSlot { .. } => {
-                        trace!(
+                        debug!(
                             log, "Finalized or earlier block processed";
                             "outcome" => format!("{:?}", outcome),
                         );
                         // block reached our finalized slot or was earlier, move to the next block
                     }
                     BlockProcessingOutcome::GenesisBlock => {
-                        trace!(
+                        debug!(
                             log, "Genesis block was processed";
                             "outcome" => format!("{:?}", outcome),
                         );

--- a/beacon_node/network/src/sync/range_sync/batch_processing.rs
+++ b/beacon_node/network/src/sync/range_sync/batch_processing.rs
@@ -1,0 +1,187 @@
+use super::batch::Batch;
+use crate::message_processor::FUTURE_SLOT_TOLERANCE;
+use crate::sync::manager::SyncMessage;
+use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessingOutcome};
+use slog::{debug, error, trace, warn};
+use std::sync::{Arc, Weak};
+use tokio::sync::mpsc;
+
+/// The result of attempting to process a batch of blocks.
+// TODO: When correct batch error handling occurs, we will include an error type.
+#[derive(Debug)]
+pub enum BatchProcessResult {
+    /// The batch was completed successfully.
+    Success,
+    /// The batch processing failed.
+    Failed,
+}
+
+// TODO: Refactor to async fn, with stable futures
+pub fn spawn_batch_processor<T: BeaconChainTypes>(
+    chain: Weak<BeaconChain<T>>,
+    process_id: u64,
+    batch: Arc<Batch<T::EthSpec>>,
+    sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
+    log: slog::Logger,
+) {
+    std::thread::spawn(move || {
+        debug!(log, "Processing batch"; "batch_id" => *batch.id);
+        let batch_id = batch.id.clone();
+        let result = match process_batch(chain, batch, &log) {
+            Ok(_) => BatchProcessResult::Success,
+            Err(_) => BatchProcessResult::Failed,
+        };
+
+        sync_send
+            .try_send(SyncMessage::BatchProcessed {
+                process_id,
+                batch,
+                result,
+            })
+            .unwrap_or_else(|_| {
+                debug!(
+                    log,
+                    "Batch result could not inform sync. Likely shutting down."
+                );
+            });
+    });
+}
+
+// Helper function to process block batches which only consumes the chain and blocks to process
+fn process_batch<T: BeaconChainTypes>(
+    chain: Weak<BeaconChain<T>>,
+    batch: Arc<Batch<T::EthSpec>>,
+    log: &slog::Logger,
+) -> Result<(), String> {
+    let mut successful_block_import = false;
+    for block in &batch.downloaded_blocks {
+        if let Some(chain) = chain.upgrade() {
+            let processing_result = chain.process_block(block.clone());
+
+            if let Ok(outcome) = processing_result {
+                match outcome {
+                    BlockProcessingOutcome::Processed { block_root } => {
+                        // The block was valid and we processed it successfully.
+                        trace!(
+                            log, "Imported block from network";
+                            "slot" => block.slot,
+                            "block_root" => format!("{}", block_root),
+                        );
+                        successful_block_import = true;
+                    }
+                    BlockProcessingOutcome::ParentUnknown { parent } => {
+                        // blocks should be sequential and all parents should exist
+                        trace!(
+                            log, "Parent block is unknown";
+                            "parent_root" => format!("{}", parent),
+                            "baby_block_slot" => block.slot,
+                        );
+                        if successful_block_import {
+                            run_fork_choice(chain, log);
+                        }
+                        return Err(format!(
+                            "Block at slot {} has an unknown parent.",
+                            block.slot
+                        ));
+                    }
+                    BlockProcessingOutcome::BlockIsAlreadyKnown => {
+                        // this block is already known to us, move to the next
+                        debug!(
+                            log, "Imported a block that is already known";
+                            "block_slot" => block.slot,
+                        );
+                    }
+                    BlockProcessingOutcome::FutureSlot {
+                        present_slot,
+                        block_slot,
+                    } => {
+                        if present_slot + FUTURE_SLOT_TOLERANCE >= block_slot {
+                            // The block is too far in the future, drop it.
+                            trace!(
+                                log, "Block is ahead of our slot clock";
+                                "msg" => "block for future slot rejected, check your time",
+                                "present_slot" => present_slot,
+                                "block_slot" => block_slot,
+                                "FUTURE_SLOT_TOLERANCE" => FUTURE_SLOT_TOLERANCE,
+                            );
+                            if successful_block_import {
+                                run_fork_choice(chain, log);
+                            }
+                            return Err(format!(
+                                "Block at slot {} is too far in the future",
+                                block.slot
+                            ));
+                        } else {
+                            // The block is in the future, but not too far.
+                            trace!(
+                                log, "Block is slightly ahead of our slot clock, ignoring.";
+                                "present_slot" => present_slot,
+                                "block_slot" => block_slot,
+                                "FUTURE_SLOT_TOLERANCE" => FUTURE_SLOT_TOLERANCE,
+                            );
+                        }
+                    }
+                    BlockProcessingOutcome::WouldRevertFinalizedSlot { .. } => {
+                        trace!(
+                            log, "Finalized or earlier block processed";
+                            "outcome" => format!("{:?}", outcome),
+                        );
+                        // block reached our finalized slot or was earlier, move to the next block
+                    }
+                    BlockProcessingOutcome::GenesisBlock => {
+                        trace!(
+                            log, "Genesis block was processed";
+                            "outcome" => format!("{:?}", outcome),
+                        );
+                    }
+                    _ => {
+                        warn!(
+                            log, "Invalid block received";
+                            "msg" => "peer sent invalid block",
+                            "outcome" => format!("{:?}", outcome),
+                        );
+                        if successful_block_import {
+                            run_fork_choice(chain, log);
+                        }
+                        return Err(format!("Invalid block at slot {}", block.slot));
+                    }
+                }
+            } else {
+                warn!(
+                    log, "BlockProcessingFailure";
+                    "msg" => "unexpected condition in processing block.",
+                    "outcome" => format!("{:?}", processing_result)
+                );
+                if successful_block_import {
+                    run_fork_choice(chain, log);
+                }
+                return Err(format!(
+                    "Unexpected block processing error: {:?}",
+                    processing_result
+                ));
+            }
+        } else {
+            return Ok(()); // terminate early due to dropped beacon chain
+        }
+    }
+
+    Ok(())
+}
+
+/// Runs fork-choice on a given chain. This is used during block processing after one successful
+/// block import.
+fn run_fork_choice<T: BeaconChainTypes>(chain: Arc<BeaconChain<T>>, log: &slog::Logger) {
+    match chain.fork_choice() {
+        Ok(()) => trace!(
+            log,
+            "Fork choice success";
+            "location" => "batch processing"
+        ),
+        Err(e) => error!(
+            log,
+            "Fork choice failed";
+            "error" => format!("{:?}", e),
+            "location" => "batch import error"
+        ),
+    }
+}

--- a/beacon_node/network/src/sync/range_sync/batch_processing.rs
+++ b/beacon_node/network/src/sync/range_sync/batch_processing.rs
@@ -21,13 +21,12 @@ pub fn spawn_batch_processor<T: BeaconChainTypes>(
     chain: Weak<BeaconChain<T>>,
     process_id: u64,
     batch: Arc<Batch<T::EthSpec>>,
-    sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
+    mut sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
     log: slog::Logger,
 ) {
     std::thread::spawn(move || {
         debug!(log, "Processing batch"; "batch_id" => *batch.id);
-        let batch_id = batch.id.clone();
-        let result = match process_batch(chain, batch, &log) {
+        let result = match process_batch(chain, batch.clone(), &log) {
             Ok(_) => BatchProcessResult::Success,
             Err(_) => BatchProcessResult::Failed,
         };

--- a/beacon_node/network/src/sync/range_sync/batch_processing.rs
+++ b/beacon_node/network/src/sync/range_sync/batch_processing.rs
@@ -25,11 +25,13 @@ pub fn spawn_batch_processor<T: BeaconChainTypes>(
     log: slog::Logger,
 ) {
     std::thread::spawn(move || {
-        debug!(log, "Processing batch"; "batch_id" => *batch.id);
+        debug!(log, "Processing batch"; "id" => *batch.id);
         let result = match process_batch(chain, batch.clone(), &log) {
             Ok(_) => BatchProcessResult::Success,
             Err(_) => BatchProcessResult::Failed,
         };
+
+        debug!(log, "Batch processed"; "id" => *batch.id, "result" => format!("{:?}", result));
 
         sync_send
             .try_send(SyncMessage::BatchProcessed {

--- a/beacon_node/network/src/sync/range_sync/batch_processing.rs
+++ b/beacon_node/network/src/sync/range_sync/batch_processing.rs
@@ -166,6 +166,11 @@ fn process_batch<T: BeaconChainTypes>(
         }
     }
 
+    // Batch completed successfully, run fork choice.
+    if let Some(chain) = chain.upgrade() {
+        run_fork_choice(chain, log);
+    }
+
     Ok(())
 }
 

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -260,8 +260,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             return None;
         }
 
-        debug!(self.log, "Batch processed"; "id" => *batch.id);
-
         // double check batches are processed in order
         // TODO: Remove for prod
         if batch.id != self.to_be_processed_id {
@@ -293,6 +291,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     ProcessingResult::RemoveChain
                 } else {
                     // chain is not completed
+
+                    // attempt to request more batches
+                    while self.send_range_request(network) {}
 
                     // attempt to process more batches
                     self.process_completed_batches();

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -5,6 +5,7 @@ use crate::sync::SyncMessage;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::rpc::RequestId;
 use eth2_libp2p::PeerId;
+use rand::prelude::*;
 use slog::{crit, debug, warn};
 use std::collections::HashSet;
 use std::sync::{Arc, Weak};
@@ -500,7 +501,11 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     ///
     /// This is used to create the next request.
     fn get_next_peer(&self) -> Option<PeerId> {
-        for peer in self.peer_pool.iter() {
+        // randomize the peers for load balancing
+        let mut rng = rand::thread_rng();
+        let mut peers = self.peer_pool.iter().collect::<Vec<_>>();
+        peers.shuffle(&mut rng);
+        for peer in peers {
             if self.pending_batches.peer_is_idle(peer) {
                 return Some(peer.clone());
             }

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -18,7 +18,7 @@ use types::{BeaconBlock, Hash256, Slot};
 /// to do so.
 //TODO: Make this dynamic based on peer's bandwidth
 //TODO: This is lower due to current thread design. Modify once rebuilt.
-pub const BLOCKS_PER_BATCH: u64 = 25;
+pub const BLOCKS_PER_BATCH: u64 = 50;
 
 /// The number of times to retry a batch before the chain is considered failed and removed.
 const MAX_BATCH_RETRIES: u8 = 5;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -198,9 +198,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
         if self.state == ChainSyncingState::Syncing {
             // pre-emptively request more blocks from peers whilst we process current blocks,
-            if !self.send_range_request(network) {
-                debug!(self.log, "No peer available for next batch.")
-            }
+            while self.send_range_request(network) {}
         }
 
         // Try and process any completed batches. This will spawn a new task to process any blocks
@@ -261,6 +259,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             // batch process doesn't belong to this chain
             return None;
         }
+
+        debug!(self.log, "Batch processed"; "id" => *batch.id);
 
         // double check batches are processed in order
         // TODO: Remove for prod

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -150,7 +150,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         } else {
             // A stream termination has been sent. This batch has ended. Process a completed batch.
             let batch = self.pending_batches.remove(request_id)?;
-            Some(self.handle_completed_batch(network, batch))
+            self.handle_completed_batch(network, batch);
+            Some(())
         }
     }
 
@@ -513,7 +514,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Returns a peer if there exists a peer which does not currently have a pending request.

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -1,15 +1,15 @@
-use crate::message_processor::FUTURE_SLOT_TOLERANCE;
+use super::batch::{Batch, BatchId, PendingBatches};
+use super::batch_processing::{spawn_batch_processor, BatchProcessResult};
 use crate::sync::network_context::SyncNetworkContext;
-use crate::sync::range_sync::batch::{Batch, PendingBatches};
-use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessingOutcome};
-use eth2_libp2p::rpc::methods::*;
+use crate::sync::SyncMessage;
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::rpc::RequestId;
 use eth2_libp2p::PeerId;
-use slog::{crit, debug, error, trace, warn, Logger};
+use slog::{crit, debug, warn};
 use std::collections::HashSet;
-use std::ops::Sub;
-use std::sync::Weak;
-use types::{BeaconBlock, EthSpec, Hash256, Slot};
+use std::sync::{Arc, Weak};
+use tokio::sync::mpsc;
+use types::{BeaconBlock, Hash256, Slot};
 
 /// Blocks are downloaded in batches from peers. This constant specifies how many blocks per batch
 /// is requested. There is a timeout for each batch request. If this value is too high, we will
@@ -18,10 +18,13 @@ use types::{BeaconBlock, EthSpec, Hash256, Slot};
 /// to do so.
 //TODO: Make this dynamic based on peer's bandwidth
 //TODO: This is lower due to current thread design. Modify once rebuilt.
-const BLOCKS_PER_BATCH: u64 = 25;
+pub const BLOCKS_PER_BATCH: u64 = 25;
 
 /// The number of times to retry a batch before the chain is considered failed and removed.
 const MAX_BATCH_RETRIES: u8 = 5;
+
+/// The maximum number of batches to queue before requesting more.
+const BATCH_BUFFER_SIZE: u8 = 5;
 
 /// A return type for functions that act on a `Chain` which informs the caller whether the chain
 /// has been completed and should be removed or to be kept if further processing is
@@ -29,32 +32,6 @@ const MAX_BATCH_RETRIES: u8 = 5;
 pub enum ProcessingResult {
     KeepChain,
     RemoveChain,
-}
-
-impl<T: EthSpec> Eq for Batch<T> {}
-
-impl<T: EthSpec> Batch<T> {
-    fn new(id: u64, start_slot: Slot, end_slot: Slot, head_root: Hash256, peer_id: PeerId) -> Self {
-        Batch {
-            id,
-            start_slot,
-            end_slot,
-            head_root,
-            _original_peer: peer_id.clone(),
-            current_peer: peer_id,
-            retries: 0,
-            downloaded_blocks: Vec::new(),
-        }
-    }
-
-    fn to_blocks_by_range_request(&self) -> BlocksByRangeRequest {
-        BlocksByRangeRequest {
-            head_block_root: self.head_root,
-            start_slot: self.start_slot.into(),
-            count: std::cmp::min(BLOCKS_PER_BATCH, self.end_slot.sub(self.start_slot).into()),
-            step: 1,
-        }
-    }
 }
 
 /// A chain of blocks that need to be downloaded. Peers who claim to contain the target head
@@ -77,21 +54,37 @@ pub struct SyncingChain<T: BeaconChainTypes> {
     /// The batches that have been downloaded and are awaiting processing and/or validation.
     completed_batches: Vec<Batch<T::EthSpec>>,
 
+    /// Batches that have been processed and awaiting validation before being removed.
+    processed_batches: Vec<Batch<T::EthSpec>>,
+
     /// The peers that agree on the `target_head_slot` and `target_head_root` as a canonical chain
     /// and thus available to download this chain from.
     pub peer_pool: HashSet<PeerId>,
 
     /// The next batch_id that needs to be downloaded.
-    to_be_downloaded_id: u64,
+    to_be_downloaded_id: BatchId,
 
     /// The next batch id that needs to be processed.
-    to_be_processed_id: u64,
+    to_be_processed_id: BatchId,
 
     /// The last batch id that was processed.
-    last_processed_id: u64,
+    last_processed_id: BatchId,
 
     /// The current state of the chain.
     pub state: ChainSyncingState,
+
+    /// A random id given to a batch process request. This is None if there is no ongoing batch
+    /// process.
+    current_processing_id: Option<u64>,
+
+    /// A send channel to the sync manager. This is given to the batch processor thread to report
+    /// back once batch processing has completed.
+    sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
+
+    chain: Weak<BeaconChain<T>>,
+
+    /// A reference to the sync logger.
+    log: slog::Logger,
 }
 
 #[derive(PartialEq)]
@@ -110,6 +103,9 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         target_head_slot: Slot,
         target_head_root: Hash256,
         peer_id: PeerId,
+        sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
+        chain: Weak<BeaconChain<T>>,
+        log: slog::Logger,
     ) -> Self {
         let mut peer_pool = HashSet::new();
         peer_pool.insert(peer_id);
@@ -120,11 +116,16 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             target_head_root,
             pending_batches: PendingBatches::new(),
             completed_batches: Vec::new(),
+            processed_batches: Vec::new(),
             peer_pool,
-            to_be_downloaded_id: 1,
-            to_be_processed_id: 1,
-            last_processed_id: 0,
+            to_be_downloaded_id: BatchId(1),
+            to_be_processed_id: BatchId(1),
+            last_processed_id: BatchId(0),
             state: ChainSyncingState::Stopped,
+            current_processing_id: None,
+            sync_send,
+            chain,
+            log,
         }
     }
 
@@ -136,49 +137,44 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     /// batch.
     pub fn on_block_response(
         &mut self,
-        chain: &Weak<BeaconChain<T>>,
         network: &mut SyncNetworkContext,
         request_id: RequestId,
         beacon_block: &Option<BeaconBlock<T::EthSpec>>,
-        log: &slog::Logger,
-    ) -> Option<ProcessingResult> {
+    ) -> Option<()> {
         if let Some(block) = beacon_block {
             // This is not a stream termination, simply add the block to the request
-            self.pending_batches.add_block(&request_id, block.clone())?;
-            return Some(ProcessingResult::KeepChain);
+            self.pending_batches.add_block(&request_id, block.clone())
         } else {
             // A stream termination has been sent. This batch has ended. Process a completed batch.
             let batch = self.pending_batches.remove(&request_id)?;
-            Some(self.process_completed_batch(chain.clone(), network, batch, log))
+            Some(self.handle_completed_batch(network, batch))
         }
     }
 
     /// A completed batch has been received, process the batch.
     /// This will return `ProcessingResult::KeepChain` if the chain has not completed or
     /// failed indicating that further batches are required.
-    fn process_completed_batch(
+    fn handle_completed_batch(
         &mut self,
-        chain: Weak<BeaconChain<T>>,
         network: &mut SyncNetworkContext,
         batch: Batch<T::EthSpec>,
-        log: &slog::Logger,
-    ) -> ProcessingResult {
+    ) {
         // An entire batch of blocks has been received. This functions checks to see if it can be processed,
         // remove any batches waiting to be verified and if this chain is syncing, request new
         // blocks for the peer.
-        debug!(log, "Completed batch received"; "id"=>batch.id, "blocks"=>batch.downloaded_blocks.len(), "awaiting_batches" => self.completed_batches.len());
+        debug!(self.log, "Completed batch received"; "id"=> *batch.id, "blocks"=>batch.downloaded_blocks.len(), "awaiting_batches" => self.completed_batches.len());
 
         // verify the range of received blocks
         // Note that the order of blocks is verified in block processing
         if let Some(last_slot) = batch.downloaded_blocks.last().map(|b| b.slot) {
             // the batch is non-empty
             if batch.start_slot > batch.downloaded_blocks[0].slot || batch.end_slot < last_slot {
-                warn!(log, "BlocksByRange response returned out of range blocks"; 
+                warn!(self.log, "BlocksByRange response returned out of range blocks"; 
                           "response_initial_slot" => batch.downloaded_blocks[0].slot, 
                           "requested_initial_slot" => batch.start_slot);
                 network.downvote_peer(batch.current_peer);
                 self.to_be_processed_id = batch.id; // reset the id back to here, when incrementing, it will check against completed batches
-                return ProcessingResult::KeepChain;
+                return;
             }
         }
 
@@ -200,120 +196,265 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         // already be processed but not verified and therefore have Id's less than
         // `self.to_be_processed_id`.
 
-        //TODO: Run the processing of blocks in a separate thread. Build a queue of completed
-        //blocks here, manage the queue and process them in another thread as they become
-        //available.
-
         if self.state == ChainSyncingState::Syncing {
             // pre-emptively request more blocks from peers whilst we process current blocks,
-            if !self.send_range_request(network, log) {
-                debug!(log, "No peer available for next batch.")
+            if !self.send_range_request(network) {
+                debug!(self.log, "No peer available for next batch.")
             }
         }
 
-        // Try and process batches sequentially in the ordered list.
-        let current_process_id = self.to_be_processed_id;
-        // keep track of the number of successful batches to decide whether to run fork choice
-        let mut successful_block_process = false;
+        // Try and process any completed batches. This will spawn a new task to process any blocks
+        // that are ready to be processed.
+        self.process_completed_batches();
+    }
 
-        for batch in self
-            .completed_batches
-            .iter()
-            .filter(|batch| batch.id >= current_process_id)
+    /// Tries to process any batches if there are any available and we are not currently processing
+    /// other batches.
+    fn process_completed_batches(&mut self) {
+        // Only process one batch at a time
+        if self.current_processing_id.is_some() {
+            return;
+        }
+
+        // Check if the next batch is to be processed
+        while !self.completed_batches.is_empty()
+            && self.completed_batches[0].id == self.to_be_processed_id
         {
-            if batch.id != self.to_be_processed_id {
-                // there are no batches to be processed at the moment
-                break;
-            }
-
+            let batch = self.completed_batches.remove(0);
             if batch.downloaded_blocks.is_empty() {
-                // the batch was empty, progress to the next block
-                self.to_be_processed_id += 1;
+                // The batch was empty, consider this processed and move to the next batch
+                self.processed_batches.push(batch);
+                *self.to_be_processed_id += 1;
                 continue;
             }
 
-            // process the batch
-            // Keep track of successful batches. Run fork choice after all waiting batches have
-            // been processed.
-            debug!(log, "Processing batch"; "batch_id" => batch.id);
-            match process_batch(chain.clone(), batch, log) {
-                Ok(_) => {
-                    // batch was successfully processed
-                    self.last_processed_id = self.to_be_processed_id;
-                    self.to_be_processed_id += 1;
-                    successful_block_process = true;
-                }
-                Err(e) => {
-                    warn!(log, "Block processing error"; "error"=> format!("{:?}", e));
-
-                    if successful_block_process {
-                        if let Some(chain) = chain.upgrade() {
-                            match chain.fork_choice() {
-                                Ok(()) => trace!(
-                                    log,
-                                    "Fork choice success";
-                                    "location" => "batch import error"
-                                ),
-                                Err(e) => error!(
-                                    log,
-                                    "Fork choice failed";
-                                    "error" => format!("{:?}", e),
-                                    "location" => "batch import error"
-                                ),
-                            }
-                        }
-                    }
-
-                    // batch processing failed
-                    // this could be because this batch is invalid, or a previous invalidated batch
-                    // is invalid. We need to find out which and downvote the peer that has sent us
-                    // an invalid batch.
-
-                    // firstly remove any validated batches
-                    return self.handle_invalid_batch(chain, network);
-                }
-            }
+            // send the batch to the batch processor thread
+            return self.process_batch(batch);
         }
-        // If we have processed batches, run fork choice
-        if successful_block_process {
-            if let Some(chain) = chain.upgrade() {
-                match chain.fork_choice() {
-                    Ok(()) => trace!(
-                        log,
-                        "Fork choice success";
-                        "location" => "batch import success"
-                    ),
-                    Err(e) => error!(
-                        log,
-                        "Fork choice failed";
-                        "error" => format!("{:?}", e),
-                        "location" => "batch import success"
-                    ),
-                }
-            }
+    }
+
+    /// Sends a batch to the batch processor.
+    fn process_batch(&mut self, batch: Batch<T::EthSpec>) {
+        let batch = Arc::new(batch);
+        // only spawn one instance at a time
+        let processing_id: u64 = rand::random();
+        self.current_processing_id = Some(processing_id);
+        spawn_batch_processor(
+            self.chain,
+            processing_id,
+            batch,
+            self.sync_send.clone(),
+            self.log.clone(),
+        );
+    }
+
+    /// The block processor has completed processing a batch. This function handles the result
+    /// of the batch processor.
+    pub fn on_batch_process_result(
+        &mut self,
+        network: &mut SyncNetworkContext,
+        processing_id: u64,
+        batch: Arc<Batch<T::EthSpec>>,
+        result: BatchProcessResult,
+    ) -> Option<ProcessingResult> {
+        if Some(processing_id) != self.current_processing_id {
+            // batch process doesn't belong to this chain
+            return None;
         }
 
-        // remove any validated batches
-        let last_processed_id = self.last_processed_id;
-        self.completed_batches
-            .retain(|batch| batch.id >= last_processed_id);
+        let batch = batch.into_raw();
+        // double check batches are processed in order
+        // TODO: Remove for prod
+        if batch.id != self.to_be_processed_id {
+            crit!(self.log, "Batch processed out of order"; "processed_batch_id" => *batch.id, "expected_id" => *self.to_be_processed_id);
+        }
 
-        // check if the chain has completed syncing
-        if self.start_slot + self.last_processed_id * BLOCKS_PER_BATCH >= self.target_head_slot {
-            // chain is completed
+        self.current_processing_id = None;
+
+        let res = match result {
+            BatchProcessResult::Success => {
+                *self.to_be_processed_id += 1;
+                // This variable accounts for skip slots and batches that were not actually
+                // processed due to having no blocks.
+                self.last_processed_id = batch.id;
+
+                // remove any validated batches
+                let last_processed_id = self.last_processed_id;
+                self.processed_batches
+                    .retain(|batch| batch.id.0 >= last_processed_id.0);
+
+                // add the current batch to finalized batches to be removed.
+                self.processed_batches.push(batch);
+
+                // check if the chain has completed syncing
+                if self.start_slot + *self.last_processed_id * BLOCKS_PER_BATCH
+                    >= self.target_head_slot
+                {
+                    // chain is completed
+                    ProcessingResult::RemoveChain
+                } else {
+                    // chain is not completed
+
+                    // attempt to process more batches
+                    self.process_completed_batches();
+
+                    // keep the chain
+                    ProcessingResult::KeepChain
+                }
+            }
+            BatchProcessResult::Failed => {
+                // batch processing failed
+                // this could be because this batch is invalid, or a previous invalidated batch
+                // is invalid. We need to find out which and downvote the peer that has sent us
+                // an invalid batch.
+
+                // firstly remove any validated batches
+                self.handle_invalid_batch(network);
+            }
+        };
+
+        Some(res);
+    }
+
+    pub fn stop_syncing(&mut self) {
+        self.state = ChainSyncingState::Stopped;
+    }
+
+    // Either a new chain, or an old one with a peer list
+    /// This chain has been requested to start syncing.
+    ///
+    /// This could be new chain, or an old chain that is being resumed.
+    pub fn start_syncing(&mut self, network: &mut SyncNetworkContext, local_finalized_slot: Slot) {
+        // A local finalized slot is provided as other chains may have made
+        // progress whilst this chain was Stopped or paused. If so, update the `processed_batch_id` to
+        // accommodate potentially downloaded batches from other chains. Also prune any old batches
+        // awaiting processing
+
+        // Only important if the local head is more than a batch worth of blocks ahead of
+        // what this chain believes is downloaded
+        let batches_ahead = local_finalized_slot
+            .as_u64()
+            .saturating_sub(self.start_slot.as_u64() + *self.last_processed_id * BLOCKS_PER_BATCH)
+            / BLOCKS_PER_BATCH;
+
+        if batches_ahead != 0 {
+            // there are `batches_ahead` whole batches that have been downloaded by another
+            // chain. Set the current processed_batch_id to this value.
+            debug!(self.log, "Updating chains processed batches"; "old_completed_slot" => self.start_slot + *self.last_processed_id*BLOCKS_PER_BATCH, "new_completed_slot" => self.start_slot + (*self.last_processed_id + batches_ahead)*BLOCKS_PER_BATCH);
+            self.last_processed_id.0 += batches_ahead;
+
+            if self.start_slot + *self.last_processed_id * BLOCKS_PER_BATCH
+                > self.target_head_slot.as_u64()
+            {
+                crit!(
+                    self.log,
+                    "Current head slot is above the target head";
+                    "target_head_slot" => self.target_head_slot.as_u64(),
+                    "new_start" => self.start_slot + *self.last_processed_id * BLOCKS_PER_BATCH,
+                );
+                return;
+            }
+
+            // update the `to_be_downloaded_id`
+            if self.to_be_downloaded_id.0 < self.last_processed_id.0 {
+                self.to_be_downloaded_id = self.last_processed_id;
+            }
+
+            let last_processed_id = self.last_processed_id;
+            self.completed_batches
+                .retain(|batch| batch.id.0 > last_processed_id.0);
+            self.processed_batches
+                .retain(|batch| batch.id.0 >= last_processed_id.0);
+        }
+
+        // start processing batches if needed
+        self.process_completed_batches();
+
+        // Now begin requesting blocks from the peer pool, until all peers are exhausted.
+        while self.send_range_request(network) {}
+
+        self.state = ChainSyncingState::Syncing;
+    }
+
+    /// Add a peer to the chain.
+    ///
+    /// If the chain is active, this starts requesting batches from this peer.
+    pub fn add_peer(&mut self, network: &mut SyncNetworkContext, peer_id: PeerId) {
+        self.peer_pool.insert(peer_id.clone());
+        // do not request blocks if the chain is not syncing
+        if let ChainSyncingState::Stopped = self.state {
+            debug!(self.log, "Peer added to a non-syncing chain"; "peer_id" => format!("{:?}", peer_id));
+            return;
+        }
+
+        // find the next batch and request it from any peers if we need to
+        while self.send_range_request(network) {}
+    }
+
+    /// Sends a STATUS message to all peers in the peer pool.
+    pub fn status_peers(&self, network: &mut SyncNetworkContext) {
+        for peer_id in self.peer_pool.iter() {
+            network.status_peer(self.chain, peer_id.clone());
+        }
+    }
+
+    /// An RPC error has occurred.
+    ///
+    /// Checks if the request_id is associated with this chain. If so, attempts to re-request the
+    /// batch. If the batch has exceeded the number of retries, returns
+    /// Some(`ProcessingResult::RemoveChain)`. Returns `None` if the request isn't related to
+    /// this chain.
+    pub fn inject_error(
+        &mut self,
+        network: &mut SyncNetworkContext,
+        peer_id: &PeerId,
+        request_id: &RequestId,
+    ) -> Option<ProcessingResult> {
+        if let Some(batch) = self.pending_batches.remove(&request_id) {
+            warn!(self.log, "Batch failed. RPC Error"; "id" => *batch.id, "retries" => batch.retries, "peer" => format!("{:?}", peer_id));
+
+            Some(self.failed_batch(network, batch))
+        } else {
+            None
+        }
+    }
+
+    /// A batch has failed.
+    ///
+    /// Attempts to re-request from another peer in the peer pool (if possible) and returns
+    /// `ProcessingResult::RemoveChain` if the number of retries on the batch exceeds
+    /// `MAX_BATCH_RETRIES`.
+    pub fn failed_batch(
+        &mut self,
+        network: &mut SyncNetworkContext,
+        mut batch: Batch<T::EthSpec>,
+    ) -> ProcessingResult {
+        batch.retries += 1;
+
+        // TODO: Handle partially downloaded batches. Update this when building a new batch
+        // processor thread.
+
+        if batch.retries > MAX_BATCH_RETRIES {
+            // chain is unrecoverable, remove it
             ProcessingResult::RemoveChain
         } else {
-            // chain is not completed
+            // try to re-process the request using a different peer, if possible
+            let current_peer = &batch.current_peer;
+            let new_peer = self
+                .peer_pool
+                .iter()
+                .find(|peer| *peer != current_peer)
+                .unwrap_or_else(|| current_peer);
+
+            batch.current_peer = new_peer.clone();
+            debug!(self.log, "Re-Requesting batch"; "start_slot" => batch.start_slot, "end_slot" => batch.end_slot, "id" => *batch.id, "peer" => format!("{:?}", batch.current_peer), "head_root"=> format!("{}", batch.head_root));
+            self.send_batch(network, batch);
             ProcessingResult::KeepChain
         }
     }
 
     /// An invalid batch has been received that could not be processed.
-    fn handle_invalid_batch(
-        &mut self,
-        _chain: Weak<BeaconChain<T>>,
-        network: &mut SyncNetworkContext,
-    ) -> ProcessingResult {
+    fn handle_invalid_batch(&mut self, network: &mut SyncNetworkContext) -> ProcessingResult {
         // The current batch could not be processed, indicating either the current or previous
         // batches are invalid
 
@@ -334,100 +475,13 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         ProcessingResult::RemoveChain
     }
 
-    pub fn stop_syncing(&mut self) {
-        self.state = ChainSyncingState::Stopped;
-    }
-
-    // Either a new chain, or an old one with a peer list
-    /// This chain has been requested to start syncing.
-    ///
-    /// This could be new chain, or an old chain that is being resumed.
-    pub fn start_syncing(
-        &mut self,
-        network: &mut SyncNetworkContext,
-        local_finalized_slot: Slot,
-        log: &slog::Logger,
-    ) {
-        // A local finalized slot is provided as other chains may have made
-        // progress whilst this chain was Stopped or paused. If so, update the `processed_batch_id` to
-        // accommodate potentially downloaded batches from other chains. Also prune any old batches
-        // awaiting processing
-
-        // Only important if the local head is more than a batch worth of blocks ahead of
-        // what this chain believes is downloaded
-        let batches_ahead = local_finalized_slot
-            .as_u64()
-            .saturating_sub(self.start_slot.as_u64() + self.last_processed_id * BLOCKS_PER_BATCH)
-            / BLOCKS_PER_BATCH;
-
-        if batches_ahead != 0 {
-            // there are `batches_ahead` whole batches that have been downloaded by another
-            // chain. Set the current processed_batch_id to this value.
-            debug!(log, "Updating chains processed batches"; "old_completed_slot" => self.start_slot + self.last_processed_id*BLOCKS_PER_BATCH, "new_completed_slot" => self.start_slot + (self.last_processed_id + batches_ahead)*BLOCKS_PER_BATCH);
-            self.last_processed_id += batches_ahead;
-
-            if self.start_slot + self.last_processed_id * BLOCKS_PER_BATCH
-                > self.target_head_slot.as_u64()
-            {
-                crit!(
-                    log,
-                    "Current head slot is above the target head";
-                    "target_head_slot" => self.target_head_slot.as_u64(),
-                    "new_start" => self.start_slot + self.last_processed_id * BLOCKS_PER_BATCH,
-                );
-                return;
-            }
-
-            // update the `to_be_downloaded_id`
-            if self.to_be_downloaded_id < self.last_processed_id {
-                self.to_be_downloaded_id = self.last_processed_id;
-            }
-
-            let last_processed_id = self.last_processed_id;
-            self.completed_batches
-                .retain(|batch| batch.id >= last_processed_id.saturating_sub(1));
-        }
-
-        // Now begin requesting blocks from the peer pool, until all peers are exhausted.
-        while self.send_range_request(network, log) {}
-
-        self.state = ChainSyncingState::Syncing;
-    }
-
-    /// Add a peer to the chain.
-    ///
-    /// If the chain is active, this starts requesting batches from this peer.
-    pub fn add_peer(
-        &mut self,
-        network: &mut SyncNetworkContext,
-        peer_id: PeerId,
-        log: &slog::Logger,
-    ) {
-        self.peer_pool.insert(peer_id.clone());
-        // do not request blocks if the chain is not syncing
-        if let ChainSyncingState::Stopped = self.state {
-            debug!(log, "Peer added to a non-syncing chain"; "peer_id" => format!("{:?}", peer_id));
-            return;
-        }
-
-        // find the next batch and request it from the peer
-        self.send_range_request(network, log);
-    }
-
-    /// Sends a STATUS message to all peers in the peer pool.
-    pub fn status_peers(&self, chain: Weak<BeaconChain<T>>, network: &mut SyncNetworkContext) {
-        for peer_id in self.peer_pool.iter() {
-            network.status_peer(chain.clone(), peer_id.clone());
-        }
-    }
-
     /// Requests the next required batch from a peer. Returns true, if there was a peer available
     /// to send a request and there are batches to request, false otherwise.
-    fn send_range_request(&mut self, network: &mut SyncNetworkContext, log: &slog::Logger) -> bool {
+    fn send_range_request(&mut self, network: &mut SyncNetworkContext) -> bool {
         // find the next pending batch and request it from the peer
         if let Some(peer_id) = self.get_next_peer() {
             if let Some(batch) = self.get_next_batch(peer_id) {
-                debug!(log, "Requesting batch"; "start_slot" => batch.start_slot, "end_slot" => batch.end_slot, "id" => batch.id, "peer" => format!("{:?}", batch.current_peer), "head_root"=> format!("{}", batch.head_root));
+                debug!(self.log, "Requesting batch"; "start_slot" => batch.start_slot, "end_slot" => batch.end_slot, "id" => *batch.id, "peer" => format!("{:?}", batch.current_peer), "head_root"=> format!("{}", batch.head_root));
                 // send the batch
                 self.send_batch(network, batch);
                 return true;
@@ -448,38 +502,46 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         None
     }
 
-    /// Requests the provided batch from the provided peer.
-    fn send_batch(&mut self, network: &mut SyncNetworkContext, batch: Batch<T::EthSpec>) {
-        let request = batch.to_blocks_by_range_request();
-        if let Ok(request_id) = network.blocks_by_range_request(batch.current_peer.clone(), request)
-        {
-            // add the batch to pending list
-            self.pending_batches.insert(request_id, batch);
-        }
-    }
-
     /// Returns the next required batch from the chain if it exists. If there are no more batches
     /// required, `None` is returned.
     fn get_next_batch(&mut self, peer_id: PeerId) -> Option<Batch<T::EthSpec>> {
+        // only request batches up to the buffer size limit
+        if self
+            .completed_batches
+            .len()
+            .saturating_add(self.pending_batches.len())
+            > BATCH_BUFFER_SIZE as usize
+        {
+            return None;
+        }
+
+        // don't request batches beyond the target head slot
         let batch_start_slot =
             self.start_slot + self.to_be_downloaded_id.saturating_sub(1) * BLOCKS_PER_BATCH;
         if batch_start_slot > self.target_head_slot {
             return None;
         }
+        // truncate the batch to the target head of the chain
         let batch_end_slot = std::cmp::min(
             batch_start_slot + BLOCKS_PER_BATCH,
             self.target_head_slot.saturating_add(1u64),
         );
 
         let batch_id = self.to_be_downloaded_id;
-        // find the next batch id. The largest of the next sequential idea, of the next uncompleted
+
+        // Find the next batch id. The largest of the next sequential id, or the next uncompleted
         // id
-        let max_completed_id =
-            self.completed_batches
-                .iter()
-                .fold(0, |max, batch| if batch.id > max { batch.id } else { max });
-        self.to_be_downloaded_id =
-            std::cmp::max(self.to_be_downloaded_id + 1, max_completed_id + 1);
+        let max_completed_id = self
+            .completed_batches
+            .iter()
+            .last()
+            .map(|x| x.id.0)
+            .unwrap_or_else(|| 0);
+        // TODO: Check if this is necessary
+        self.to_be_downloaded_id = BatchId(std::cmp::max(
+            self.to_be_downloaded_id.0 + 1,
+            max_completed_id + 1,
+        ));
 
         Some(Batch::new(
             batch_id,
@@ -490,167 +552,13 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         ))
     }
 
-    /// An RPC error has occurred.
-    ///
-    /// Checks if the request_id is associated with this chain. If so, attempts to re-request the
-    /// batch. If the batch has exceeded the number of retries, returns
-    /// Some(`ProcessingResult::RemoveChain)`. Returns `None` if the request isn't related to
-    /// this chain.
-    pub fn inject_error(
-        &mut self,
-        network: &mut SyncNetworkContext,
-        peer_id: &PeerId,
-        request_id: &RequestId,
-        log: &slog::Logger,
-    ) -> Option<ProcessingResult> {
-        if let Some(batch) = self.pending_batches.remove(&request_id) {
-            warn!(log, "Batch failed. RPC Error"; "id" => batch.id, "retries" => batch.retries, "peer" => format!("{:?}", peer_id));
-
-            Some(self.failed_batch(network, batch, log))
-        } else {
-            None
+    /// Requests the provided batch from the provided peer.
+    fn send_batch(&mut self, network: &mut SyncNetworkContext, batch: Batch<T::EthSpec>) {
+        let request = batch.to_blocks_by_range_request();
+        if let Ok(request_id) = network.blocks_by_range_request(batch.current_peer.clone(), request)
+        {
+            // add the batch to pending list
+            self.pending_batches.insert(request_id, batch);
         }
     }
-
-    /// A batch has failed.
-    ///
-    /// Attempts to re-request from another peer in the peer pool (if possible) and returns
-    /// `ProcessingResult::RemoveChain` if the number of retries on the batch exceeds
-    /// `MAX_BATCH_RETRIES`.
-    pub fn failed_batch(
-        &mut self,
-        network: &mut SyncNetworkContext,
-        mut batch: Batch<T::EthSpec>,
-        log: &Logger,
-    ) -> ProcessingResult {
-        batch.retries += 1;
-
-        // TODO: Handle partially downloaded batches. Update this when building a new batch
-        // processor thread.
-
-        if batch.retries > MAX_BATCH_RETRIES {
-            // chain is unrecoverable, remove it
-            ProcessingResult::RemoveChain
-        } else {
-            // try to re-process the request using a different peer, if possible
-            let current_peer = &batch.current_peer;
-            let new_peer = self
-                .peer_pool
-                .iter()
-                .find(|peer| *peer != current_peer)
-                .unwrap_or_else(|| current_peer);
-
-            batch.current_peer = new_peer.clone();
-            debug!(log, "Re-Requesting batch"; "start_slot" => batch.start_slot, "end_slot" => batch.end_slot, "id" => batch.id, "peer" => format!("{:?}", batch.current_peer), "head_root"=> format!("{}", batch.head_root));
-            self.send_batch(network, batch);
-            ProcessingResult::KeepChain
-        }
-    }
-}
-
-// Helper function to process block batches which only consumes the chain and blocks to process
-fn process_batch<T: BeaconChainTypes>(
-    chain: Weak<BeaconChain<T>>,
-    batch: &Batch<T::EthSpec>,
-    log: &Logger,
-) -> Result<(), String> {
-    for block in &batch.downloaded_blocks {
-        if let Some(chain) = chain.upgrade() {
-            let processing_result = chain.process_block(block.clone());
-
-            if let Ok(outcome) = processing_result {
-                match outcome {
-                    BlockProcessingOutcome::Processed { block_root } => {
-                        // The block was valid and we processed it successfully.
-                        trace!(
-                            log, "Imported block from network";
-                            "slot" => block.slot,
-                            "block_root" => format!("{}", block_root),
-                        );
-                    }
-                    BlockProcessingOutcome::ParentUnknown { parent } => {
-                        // blocks should be sequential and all parents should exist
-                        trace!(
-                            log, "Parent block is unknown";
-                            "parent_root" => format!("{}", parent),
-                            "baby_block_slot" => block.slot,
-                        );
-                        return Err(format!(
-                            "Block at slot {} has an unknown parent.",
-                            block.slot
-                        ));
-                    }
-                    BlockProcessingOutcome::BlockIsAlreadyKnown => {
-                        // this block is already known to us, move to the next
-                        debug!(
-                            log, "Imported a block that is already known";
-                            "block_slot" => block.slot,
-                        );
-                    }
-                    BlockProcessingOutcome::FutureSlot {
-                        present_slot,
-                        block_slot,
-                    } => {
-                        if present_slot + FUTURE_SLOT_TOLERANCE >= block_slot {
-                            // The block is too far in the future, drop it.
-                            trace!(
-                                log, "Block is ahead of our slot clock";
-                                "msg" => "block for future slot rejected, check your time",
-                                "present_slot" => present_slot,
-                                "block_slot" => block_slot,
-                                "FUTURE_SLOT_TOLERANCE" => FUTURE_SLOT_TOLERANCE,
-                            );
-                            return Err(format!(
-                                "Block at slot {} is too far in the future",
-                                block.slot
-                            ));
-                        } else {
-                            // The block is in the future, but not too far.
-                            trace!(
-                                log, "Block is slightly ahead of our slot clock, ignoring.";
-                                "present_slot" => present_slot,
-                                "block_slot" => block_slot,
-                                "FUTURE_SLOT_TOLERANCE" => FUTURE_SLOT_TOLERANCE,
-                            );
-                        }
-                    }
-                    BlockProcessingOutcome::WouldRevertFinalizedSlot { .. } => {
-                        trace!(
-                            log, "Finalized or earlier block processed";
-                            "outcome" => format!("{:?}", outcome),
-                        );
-                        // block reached our finalized slot or was earlier, move to the next block
-                    }
-                    BlockProcessingOutcome::GenesisBlock => {
-                        trace!(
-                            log, "Genesis block was processed";
-                            "outcome" => format!("{:?}", outcome),
-                        );
-                    }
-                    _ => {
-                        warn!(
-                            log, "Invalid block received";
-                            "msg" => "peer sent invalid block",
-                            "outcome" => format!("{:?}", outcome),
-                        );
-                        return Err(format!("Invalid block at slot {}", block.slot));
-                    }
-                }
-            } else {
-                warn!(
-                    log, "BlockProcessingFailure";
-                    "msg" => "unexpected condition in processing block.",
-                    "outcome" => format!("{:?}", processing_result)
-                );
-                return Err(format!(
-                    "Unexpected block processing error: {:?}",
-                    processing_result
-                ));
-            }
-        } else {
-            return Ok(()); // terminate early due to dropped beacon chain
-        }
-    }
-
-    Ok(())
 }

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -194,6 +194,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     }
 
     /// Add a new finalized chain to the collection and starts syncing it.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_head_chain(
         &mut self,
         network: &mut SyncNetworkContext,

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -2,8 +2,11 @@
 //! peers.
 
 mod batch;
+mod batch_processing;
 mod chain;
 mod chain_collection;
 mod range;
 
+pub use batch::Batch;
+pub use batch_processing::BatchProcessResult;
 pub use range::RangeSync;


### PR DESCRIPTION
This PR shifts block processing into it's own thread freeing the global runtime from the bulky task of block processing.

This should resolve a lot of the issues we have been having with locks, timeouts and failed syncing issues. 

Currently a new thread is spawned in order to process a batch of blocks. This will later be converted to a blocking task when we transition into stable futures.