### PR TITLE
Correct discovery address CLI functionality

### DIFF
--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -20,8 +20,9 @@ pub struct Config {
     /// The TCP port that libp2p listens on.
     pub libp2p_port: u16,
 
-    /// The address to broadcast to peers about which address we are listening on.
-    pub discovery_address: std::net::IpAddr,
+    /// The address to broadcast to peers about which address we are listening on. None indicates
+    /// that no discovery address has been set in the CLI args.
+    pub discovery_address: Option<std::net::IpAddr>,
 
     /// UDP port that discovery listens on.
     pub discovery_port: u16,
@@ -86,7 +87,7 @@ impl Default for Config {
             network_dir,
             listen_address: "127.0.0.1".parse().expect("valid ip address"),
             libp2p_port: 9000,
-            discovery_address: "127.0.0.1".parse().expect("valid ip address"),
+            discovery_address: None,
             discovery_port: 9000,
             max_peers: 10,
             secret_key_hex: None,

--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -310,7 +310,9 @@ fn load_enr(
     // Note: Discovery should update the ENR record's IP to the external IP as seen by the
     // majority of our peers.
     let mut local_enr = EnrBuilder::new("v4")
-        .ip(config.discovery_address)
+        .ip(config
+            .discovery_address
+            .unwrap_or_else(|| "127.0.0.1".parse().expect("valid id")))
         .tcp(config.libp2p_port)
         .udp(config.discovery_port)
         .build(&local_key)
@@ -325,7 +327,8 @@ fn load_enr(
                 match Enr::from_str(&enr_string) {
                     Ok(enr) => {
                         if enr.node_id() == local_enr.node_id() {
-                            if enr.ip().map(Into::into) == Some(config.discovery_address)
+                            if (config.discovery_address.is_none()
+                                || enr.ip().map(Into::into) == config.discovery_address)
                                 && enr.tcp() == Some(config.libp2p_port)
                                 && enr.udp() == Some(config.discovery_port)
                             {
@@ -333,6 +336,12 @@ fn load_enr(
                                 // the stored ENR has the same configuration, use it
                                 return Ok(enr);
                             }
+                            debug!(log, "disc addr"; "disc" => format!("{:?}", config.discovery_address),
+                            "tcp" => format!("{:?}", enr.tcp()),
+                            "etcp" => format!("{:?}", config.libp2p_port),
+                            "udp" => format!("{:?}", enr.udp()),
+                            "eudp" => format!("{:?}", config.discovery_port)
+                            );
 
                             // same node id, different configuration - update the sequence number
                             let new_seq_no = enr.seq().checked_add(1).ok_or_else(|| "ENR sequence number on file is too large. Remove it to generate a new NodeId")?;

--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -336,12 +336,6 @@ fn load_enr(
                                 // the stored ENR has the same configuration, use it
                                 return Ok(enr);
                             }
-                            debug!(log, "disc addr"; "disc" => format!("{:?}", config.discovery_address),
-                            "tcp" => format!("{:?}", enr.tcp()),
-                            "etcp" => format!("{:?}", config.libp2p_port),
-                            "udp" => format!("{:?}", enr.udp()),
-                            "eudp" => format!("{:?}", config.discovery_port)
-                            );
 
                             // same node id, different configuration - update the sequence number
                             let new_seq_no = enr.seq().checked_add(1).ok_or_else(|| "ENR sequence number on file is too large. Remove it to generate a new NodeId")?;

--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -312,7 +312,7 @@ fn load_enr(
     let mut local_enr = EnrBuilder::new("v4")
         .ip(config
             .discovery_address
-            .unwrap_or_else(|| "127.0.0.1".parse().expect("valid id")))
+            .unwrap_or_else(|| "127.0.0.1".parse().expect("valid ip")))
         .tcp(config.libp2p_port)
         .udp(config.discovery_port)
         .build(&local_key)

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -90,7 +90,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("discovery-address")
                 .value_name("ADDRESS")
                 .help("The IP address to broadcast to other peers on how to reach this node. \
-                       Default will load previous values from disk failing this it is set to 127.0.01 \
+                       Default will load previous values from disk failing this it is set to 127.0.0.1 \
                        and will be updated when connecting to other nodes on the network.")
                 .takes_value(true),
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -90,7 +90,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("discovery-address")
                 .value_name("ADDRESS")
                 .help("The IP address to broadcast to other peers on how to reach this node. \
-                       Default is determined automatically.")
+                       Default will load previous values from disk failing this it is set to 127.0.01 \
+                       and will be updated when connecting to other nodes on the network.")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
The CLI listen address was setting the discovery address. This meant that the ENR would never be loaded from disc and constantly be reloaded. 

Now, without specifying the discovery address in the CLI, previously saved ENR's with correct external IP's will be loaded by default, rather than replacing with a default and having to update once receiving pings from external peers.