### PR TITLE
Optimize block production

### DIFF
--- a/eth2/operation_pool/src/lib.rs
+++ b/eth2/operation_pool/src/lib.rs
@@ -96,6 +96,8 @@ impl<T: EthSpec> OperationPool<T> {
     }
 
     /// Get a list of attestations for inclusion in a block.
+    /// 
+    /// NOTE: Assumes that all attestations in the operation_pool are valid.
     pub fn get_attestations(
         &self,
         state: &BeaconState<T>,
@@ -125,7 +127,7 @@ impl<T: EthSpec> OperationPool<T> {
                 verify_attestation_for_block_inclusion(
                     state,
                     attestation,
-                    VerifySignatures::True,
+                    VerifySignatures::False,
                     spec,
                 )
                 .is_ok()

--- a/eth2/operation_pool/src/lib.rs
+++ b/eth2/operation_pool/src/lib.rs
@@ -96,7 +96,7 @@ impl<T: EthSpec> OperationPool<T> {
     }
 
     /// Get a list of attestations for inclusion in a block.
-    /// 
+    ///
     /// NOTE: Assumes that all attestations in the operation_pool are valid.
     pub fn get_attestations(
         &self,

--- a/eth2/operation_pool/src/max_cover.rs
+++ b/eth2/operation_pool/src/max_cover.rs
@@ -54,9 +54,6 @@ where
         .filter(|x| x.item.score() != 0)
         .collect();
 
-    if all_items.len() <= limit {
-        return all_items.iter().map(|x| x.item.object()).collect();
-    }
     let mut result = vec![];
 
     for _ in 0..limit {

--- a/eth2/operation_pool/src/max_cover.rs
+++ b/eth2/operation_pool/src/max_cover.rs
@@ -54,6 +54,9 @@ where
         .filter(|x| x.item.score() != 0)
         .collect();
 
+    if all_items.len() <= limit {
+        return all_items.iter().map(|x| x.item.object()).collect();
+    }
     let mut result = vec![];
 
     for _ in 0..limit {


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

- Remove Signature Verification on block production

## Additional Info

When I ran tests locally I found out that this should be something like 1000x improvement on block production (scaling with the number of attestations in the op_pool...). 💃 

I would ask for the reviewer to make sure that disabling this verification will not cause any harm. I have checked twice for myself. The only place (that I'm aware of) where we call `op_pool.insert_attestation` is here:
https://github.com/sigp/lighthouse/blob/7396cd2cabb7f0a2e031ed6a4188e2a19bb7b331/beacon_node/beacon_chain/src/beacon_chain.rs#L1084-L1085

where we just verified that attestations had valid signatures
https://github.com/sigp/lighthouse/blob/7396cd2cabb7f0a2e031ed6a4188e2a19bb7b331/beacon_node/beacon_chain/src/beacon_chain.rs#L1048

I am pretty sure this should be safe but having someone else double check won't hurt.