### PR TITLE
Add helper for getting parameters from requests

### DIFF
--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -36,7 +36,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::runtime::TaskExecutor;
 use tokio::sync::mpsc;
-use url_query::UrlQuery;
+use url_query::{AskedParams, UrlParams, UrlQuery};
 
 pub use crate::helpers::parse_pubkey_bytes;
 pub use beacon::{

--- a/beacon_node/rest_api/src/url_query.rs
+++ b/beacon_node/rest_api/src/url_query.rs
@@ -1,10 +1,152 @@
 use crate::helpers::{parse_committee_index, parse_epoch, parse_signature, parse_slot};
 use crate::ApiError;
 use hyper::Request;
+use std::collections::{HashMap, HashSet};
 use types::{CommitteeIndex, Epoch, Signature, Slot};
 
-/// Provides handy functions for parsing the query parameters of a URL.
+#[derive(Default)]
+pub struct UrlParams {
+    pub required: HashMap<String, String>,
+    pub optional: HashMap<String, String>,
+    pub all_of: HashMap<String, Vec<String>>,
+    pub first_of: HashMap<String, String>,
+}
 
+#[derive(PartialEq, Debug)]
+enum Necessity {
+    Required,
+    Optional,
+    AllOf,
+    FirstOf,
+}
+
+pub struct AskedParams {
+    first_of: Vec<String>,
+    map: HashMap<String, Necessity>,
+}
+
+pub struct AskedParamsBuilder {
+    req: Vec<String>,
+    opt: Vec<String>,
+    all_of: Vec<String>,
+    first_of: Vec<String>,
+}
+
+impl AskedParamsBuilder {
+    pub fn build(self) -> Result<AskedParams, ApiError> {
+        let total_length =
+            self.req.len() + self.opt.len() + self.all_of.len() + self.first_of.len();
+        let mut uniq = HashSet::new();
+        for x in self.req.iter() {
+            if x.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "Requested parameter is empty".to_string(),
+                ));
+            }
+            if !uniq.insert(x.clone()) {
+                return Err(ApiError::BadRequest(format!(
+                    "Duplicate parameter: {:?}",
+                    x
+                )));
+            }
+        }
+        for x in self.opt.iter() {
+            if x.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "Requested parameter is empty".to_string(),
+                ));
+            }
+            if !uniq.insert(x.clone()) {
+                return Err(ApiError::BadRequest(format!(
+                    "Duplicate parameter: {:?}",
+                    x
+                )));
+            }
+        }
+        for x in self.all_of.iter() {
+            if x.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "Requested parameter is empty".to_string(),
+                ));
+            }
+            if !uniq.insert(x.clone()) {
+                return Err(ApiError::BadRequest(format!(
+                    "Duplicate parameter: {:?}",
+                    x
+                )));
+            }
+        }
+        for x in self.first_of.iter() {
+            if x.is_empty() {
+                return Err(ApiError::BadRequest(
+                    "Requested parameter is empty".to_string(),
+                ));
+            }
+            if !uniq.insert(x.clone()) {
+                return Err(ApiError::BadRequest(format!(
+                    "Duplicate parameter: {:?}",
+                    x
+                )));
+            }
+        }
+        let mut map = HashMap::with_capacity(total_length);
+        map.extend(
+            self.req
+                .iter()
+                .map(|key| (key.to_string(), Necessity::Required)),
+        );
+        map.extend(
+            self.opt
+                .iter()
+                .map(|key| (key.to_string(), Necessity::Optional)),
+        );
+        map.extend(
+            self.all_of
+                .iter()
+                .map(|key| (key.to_string(), Necessity::AllOf)),
+        );
+        map.extend(
+            self.first_of
+                .iter()
+                .map(|key| (key.to_string(), Necessity::FirstOf)),
+        );
+        Ok(AskedParams {
+            first_of: vec![],
+            map,
+        })
+    }
+
+    pub fn required(mut self, req: &[&str]) -> Self {
+        self.req = req.iter().map(|i| i.to_string()).collect();
+        self
+    }
+
+    pub fn optional(mut self, opt: &[&str]) -> Self {
+        self.opt = opt.iter().map(|i| i.to_string()).collect();
+        self
+    }
+
+    pub fn all_of(mut self, all_of: &[&str]) -> Self {
+        self.all_of = all_of.iter().map(|i| i.to_string()).collect();
+        self
+    }
+
+    pub fn first_of(mut self, first_of: &[&str]) -> Self {
+        self.first_of = first_of.iter().map(|i| i.to_string()).collect();
+        self
+    }
+
+    pub fn new() -> Self {
+        Self {
+            req: vec![],
+            opt: vec![],
+            all_of: vec![],
+            first_of: vec![],
+        }
+    }
+}
+
+/// Provides handy functions for parsing the query parameters of a URL.
 #[derive(Clone, Copy)]
 pub struct UrlQuery<'a>(url::form_urlencoded::Parse<'a>);
 
@@ -31,6 +173,53 @@ impl<'a> UrlQuery<'a> {
                     keys
                 ))
             })
+    }
+
+    pub fn get_params(mut self, asked: &mut AskedParams) -> Result<UrlParams, ApiError> {
+        let mut params = UrlParams::default();
+
+        for data in self.0 {
+            let param_name = data.0.to_string();
+            let param_value = data.1.to_string();
+            match asked.map.get(&param_name) {
+                Some(Necessity::Required) => {
+                    assert_eq!(asked.map.remove(&param_name), Some(Necessity::Required));
+                    params.required.insert(param_name, param_value);
+                }
+                Some(Necessity::Optional) => {
+                    asked.map.remove(&param_name);
+                    params.optional.insert(param_name, param_value);
+                }
+                Some(Necessity::AllOf) => {
+                    asked.map.remove(&param_name);
+                    params.all_of.insert(param_name, vec![param_value]);
+                }
+                Some(Necessity::FirstOf) => {
+                    for asked in asked.first_of.iter() {
+                        unimplemented!()
+                    }
+                    params.first_of.insert(param_name, param_value);
+                }
+                None => {
+                    if let Some(v) = params.all_of.get_mut(&param_name) {
+                        v.push(param_value);
+                    } else {
+                        return Err(ApiError::BadRequest(format!(
+                            "Unexpected parameter: {:?}",
+                            param_name
+                        )));
+                    }
+                }
+            }
+        }
+
+        if !asked.map.is_empty() && asked.map.values().any(|k| *k != Necessity::Optional) {
+            return Err(ApiError::BadRequest(
+                "The request is missing a required parameter".to_string(),
+            ));
+        }
+
+        Ok(params)
     }
 
     /// Returns the first `(key, value)` pair found where the `key` is in `keys`, if any.
@@ -156,5 +345,108 @@ mod test {
             Ok(("c".to_string(), "100".to_string()))
         );
         assert!(get_query().first_of(&["nothing"]).is_err());
+    }
+
+    #[test]
+    fn get_params_required_param() {
+        let url = url::Url::parse("http://lighthouse.io/cats").unwrap();
+        let get_query = || UrlQuery(url.query_pairs());
+        let mut asked_params = AskedParamsBuilder::new()
+            .build()
+            .expect("should have built AskedParams");
+        let res = get_query()
+            .get_params(&mut asked_params)
+            .expect("should have a value");
+        assert_eq!(res.required, HashMap::new());
+        assert!(res.optional.is_empty());
+        assert!(res.all_of.is_empty());
+        assert!(res.first_of.is_empty());
+
+        let asked_params = AskedParamsBuilder::new().required(&[""]).build();
+        assert!(asked_params.is_err());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["a"])
+            .build()
+            .expect("should have built AskedParams");
+        let builder = AskedParamsBuilder::new();
+        let res = get_query().get_params(&mut asked_params);
+        assert!(res.is_err());
+
+        let url = url::Url::parse("http://lighthouse.io/cats?a=42").unwrap();
+        let get_query = || UrlQuery(url.query_pairs());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["a"])
+            .build()
+            .expect("should have built AskedParams");
+
+        let res = get_query()
+            .get_params(&mut asked_params)
+            .expect("should have a value");
+
+        let map: HashMap<String, String> = [("a".to_string(), "42".to_string())]
+            .into_iter()
+            .cloned()
+            .collect();
+        assert_eq!(res.required, map);
+        assert!(res.optional.is_empty());
+        assert!(res.all_of.is_empty());
+        assert!(res.first_of.is_empty());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["a", "b"])
+            .build()
+            .expect("should have built AskedParams");
+
+        let res = get_query().get_params(&mut asked_params);
+
+        assert!(res.is_err());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["b", "a"])
+            .build()
+            .expect("should have built AskedParams");
+
+        let res = get_query().get_params(&mut asked_params);
+
+        assert!(res.is_err());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["b"])
+            .build()
+            .expect("should have built AskedParams");
+
+        let res = get_query().get_params(&mut asked_params);
+
+        assert!(res.is_err());
+
+        let mut asked_params = AskedParamsBuilder::new().required(&["a", "a"]).build();
+        assert!(asked_params.is_err());
+
+        let url = url::Url::parse("http://lighthouse.io/cats?a=42&b=1337&c=0").unwrap();
+        let get_query = || UrlQuery(url.query_pairs());
+
+        let mut asked_params = AskedParamsBuilder::new()
+            .required(&["c", "b", "a"])
+            .build()
+            .expect("should have built AskedParams");
+
+        let res = get_query()
+            .get_params(&mut asked_params)
+            .expect("should have a value");
+
+        let map: HashMap<String, String> = [
+            ("a".to_string(), "42".to_string()),
+            ("b".to_string(), "1337".to_string()),
+            ("c".to_string(), "0".to_string()),
+        ]
+        .into_iter()
+        .cloned()
+        .collect();
+        assert_eq!(res.required, map);
+        assert!(res.optional.is_empty());
+        assert!(res.all_of.is_empty());
+        assert!(res.first_of.is_empty());
     }
 }


### PR DESCRIPTION
## Issue Addressed

Fixes #825 

## Proposed Changes

In #825 we stated that parameters were too loose (you can for example call `/beacon/head?state=0&foo=bar`

This PR implements some helper tools to fix that.
I struggled to find a more simple way to implement that. This seems like a bit of over-engineering, and if someone has a better way of implementing it I'd be happy to start all over again!

## Additional Info

- [x] Implement get_params and other helpers
- [ ] Add additional tests
- [ ] Remove actual "first_of" and other parameter getters
- [ ] Add macros to clean up code
- [ ] Remove Strings and clones as much as possible