### PR TITLE
Prevent duplicate gossipsub loops/message amplification

### DIFF
--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -79,7 +79,7 @@ impl<TSubstream: AsyncRead + AsyncWrite> Behaviour<TSubstream> {
             discovery: Discovery::new(local_key, net_conf, log)?,
             ping: Ping::new(ping_config),
             identify,
-            seen_gossip_messages: LruCache::new(256),
+            seen_gossip_messages: LruCache::new(100_000),
             events: Vec::new(),
             log: behaviour_log,
         })

--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -46,7 +46,7 @@ pub struct Behaviour<TSubstream: AsyncRead + AsyncWrite> {
     /// A cache of recently seen gossip messages. This is used to filter out any possible
     /// duplicates that may still be seen over gossipsub.
     #[behaviour(ignore)]
-    seen_gossip_messages: LruCache<PubsubMessage, ()>,
+    seen_gossip_messages: LruCache<MessageId, ()>,
     /// Logger for behaviour actions.
     #[behaviour(ignore)]
     log: slog::Logger,
@@ -105,7 +105,7 @@ impl<TSubstream: AsyncRead + AsyncWrite> NetworkBehaviourEventProcess<GossipsubE
 
                 // Note: We are keeping track here of the peer that sent us the message, not the
                 // peer that originally published the message.
-                if self.seen_gossip_messages.put(msg.clone(), ()).is_none() {
+                if self.seen_gossip_messages.put(id.clone(), ()).is_none() {
                     // if this message isn't a duplicate, notify the network
                     self.events.push(BehaviourEvent::GossipMessage {
                         id,


### PR DESCRIPTION
## Description

The gossipsub protocol content-addresses messages. It has an internal LRUCache which prevents duplicates of size 256. Lighthouse currently has the same. 

It is possible with large number of validators, voting on different heads to produce many more attestations than 256 in a single slot. If such a cycle (greater than 256 unique gossipsub messages) occur twice, the second will be re-propagated forming a loop which amplifies through the gossipsub network. 

Although further validation rules will be applied to objects in lighthouse before re-propagation, this PR increases the duplicates cache to 100,000 which will prevent such issues for non-malicious validator nodes < 100,000 (which should suit our current purposes). 