### PR TITLE
Add flag to disable the networking stack

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -284,7 +284,7 @@ where
             .runtime_context
             .as_ref()
             .ok_or_else(|| "http_server requires a runtime_context")?
-            .service_context("http".into());
+            .service_context("client_builder".into());
         let network = self.libp2p_network.clone();
         let network_send = self.libp2p_network_send.clone();
 

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -11,6 +11,9 @@ use std::time::Duration;
 #[serde(default)]
 /// Network configuration for lighthouse.
 pub struct Config {
+    /// If false, the network will not be started.
+    pub enabled: bool,
+
     /// Data directory where node's keyfile is stored
     pub network_dir: PathBuf,
 
@@ -84,6 +87,7 @@ impl Default for Config {
         };
 
         Config {
+            enabled: true,
             network_dir,
             listen_address: "127.0.0.1".parse().expect("valid ip address"),
             libp2p_port: 9000,

--- a/beacon_node/rest_api/src/network.rs
+++ b/beacon_node/rest_api/src/network.rs
@@ -1,4 +1,4 @@
-use crate::error::ApiResult;
+use crate::error::{ApiError, ApiResult};
 use crate::response_builder::ResponseBuilder;
 use crate::NetworkService;
 use beacon_chain::BeaconChainTypes;
@@ -6,13 +6,17 @@ use eth2_libp2p::{Multiaddr, PeerId};
 use hyper::{Body, Request};
 use std::sync::Arc;
 
+const NETWORK_ERROR_MSG: &str = "Network is not running";
+
 /// HTTP handler to return the list of libp2p multiaddr the client is listening on.
 ///
 /// Returns a list of `Multiaddr`, serialized according to their `serde` impl.
 pub fn get_listen_addresses<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     let multiaddresses: Vec<Multiaddr> = network.listen_multiaddrs();
     ResponseBuilder::new(&req)?.body_no_ssz(&multiaddresses)
 }
@@ -22,8 +26,10 @@ pub fn get_listen_addresses<T: BeaconChainTypes>(
 /// Returns the TCP port number in its plain form (which is also valid JSON serialization)
 pub fn get_listen_port<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     ResponseBuilder::new(&req)?.body(&network.listen_port())
 }
 
@@ -32,8 +38,10 @@ pub fn get_listen_port<T: BeaconChainTypes>(
 /// ENR is encoded as base64 string.
 pub fn get_enr<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     ResponseBuilder::new(&req)?.body_no_ssz(&network.local_enr().to_base64())
 }
 
@@ -42,16 +50,20 @@ pub fn get_enr<T: BeaconChainTypes>(
 /// PeerId is encoded as base58 string.
 pub fn get_peer_id<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     ResponseBuilder::new(&req)?.body_no_ssz(&network.local_peer_id().to_base58())
 }
 
 /// HTTP handler to return the number of peers connected in the client's libp2p service.
 pub fn get_peer_count<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     ResponseBuilder::new(&req)?.body(&network.connected_peers())
 }
 
@@ -60,8 +72,10 @@ pub fn get_peer_count<T: BeaconChainTypes>(
 /// Peers are presented as a list of `PeerId::to_string()`.
 pub fn get_peer_list<T: BeaconChainTypes>(
     req: Request<Body>,
-    network: Arc<NetworkService<T>>,
+    network_opt: Option<Arc<NetworkService<T>>>,
 ) -> ApiResult {
+    let network = network_opt.ok_or_else(|| ApiError::NotFound(NETWORK_ERROR_MSG.to_string()))?;
+
     let connected_peers: Vec<String> = network
         .connected_peer_set()
         .iter()

--- a/beacon_node/rest_api/src/router.rs
+++ b/beacon_node/rest_api/src/router.rs
@@ -24,8 +24,8 @@ where
 pub fn route<T: BeaconChainTypes>(
     req: Request<Body>,
     beacon_chain: Arc<BeaconChain<T>>,
-    network_service: Arc<NetworkService<T>>,
-    network_channel: NetworkChannel,
+    network_service: Option<Arc<NetworkService<T>>>,
+    network_channel: Option<NetworkChannel>,
     eth2_config: Arc<Eth2Config>,
     local_log: slog::Logger,
     db_path: PathBuf,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -39,6 +39,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
          * Network parameters.
          */
         .arg(
+            Arg::with_name("disable-networking")
+                .long("disable-networking")
+                .help("P2P networking is disabled if present. Use for testing only.")
+        )
+        .arg(
             Arg::with_name("zero-ports")
                 .long("zero-ports")
                 .short("z")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -88,6 +88,10 @@ pub fn get_configs<E: EthSpec>(
     /*
      * Networking
      */
+    if cli_args.is_present("disable-networking") {
+        client_config.network.enabled = false;
+    }
+
     // If a network dir has been specified, override the `datadir` definition.
     if let Some(dir) = cli_args.value_of("network-dir") {
         client_config.network.network_dir = PathBuf::from(dir);

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -125,9 +125,15 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
                 let builder = builder
                     .system_time_slot_clock()?
                     .websocket_event_handler(client_config.websocket_server.clone())?
-                    .build_beacon_chain()?
-                    .libp2p_network(&client_config.network)?
-                    .notifier()?;
+                    .build_beacon_chain()?;
+
+                let builder = if client_config.network.enabled {
+                    builder.libp2p_network(&client_config.network)?
+                } else {
+                    builder
+                };
+
+                let builder = builder.notifier()?;
 
                 let builder = if client_config.rest_api.enabled {
                     builder.http_server(&client_config, &http_eth2_config)?


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Adds a CLI flag to the beacon node to disable the networking stack. Useful for isolating components during debugging or if you just want so peace and quiet from @AgeManning's constant pinging and gossiping.