### PR TITLE
Attempt to remove a tree hash from block replaying

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -575,8 +575,8 @@ impl<E: EthSpec> HotColdDB<E> {
             // Include the block at the end slot (if any), it needs to be
             // replayed in order to construct the canonical state at `end_slot`.
             .filter(|block| block.message.slot <= end_slot)
-            // Exclude the block at the start slot (if any), because it has already
-            // been applied to the starting state.
+            // Include the block at the start slot (if any). Whilst it doesn't need to be applied
+            // to the state, it contains a potentially useful state root.
             .take_while(|block| block.message.slot > start_slot)
             .collect::<Vec<_>>();
         blocks.reverse();
@@ -607,6 +607,10 @@ impl<E: EthSpec> HotColdDB<E> {
         };
 
         for (i, block) in blocks.iter().enumerate() {
+            if block.message.slot <= state.slot {
+                continue;
+            }
+
             while state.slot < block.message.slot {
                 let state_root = state_root_from_prev_block(i, &state);
                 per_slot_processing(&mut state, state_root, &self.spec)

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -577,7 +577,7 @@ impl<E: EthSpec> HotColdDB<E> {
             .filter(|block| block.message.slot <= end_slot)
             // Include the block at the start slot (if any). Whilst it doesn't need to be applied
             // to the state, it contains a potentially useful state root.
-            .take_while(|block| block.message.slot > start_slot)
+            .take_while(|block| block.message.slot >= start_slot)
             .collect::<Vec<_>>();
         blocks.reverse();
         Ok(blocks)


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

I noticed there's a tree hash happening during block replay (I'm so deep in our heap now, I see and feel _all_ allocations, there is no escape).

This PR loads an extra block but saves a tree hash.

I only mildly know what I'm doing in the `Store`, @michaelsproul I'm sure you'll be keen to get your peepers on this.
