### PR TITLE
Remove temporary heap allocations during shuffling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4023,7 +4023,6 @@ dependencies = [
  "eth2_hashing 0.1.1",
  "ethereum-types 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "int_to_bytes 0.1.0",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/eth2/utils/eth2_hashing/src/lib.rs
+++ b/eth2/utils/eth2_hashing/src/lib.rs
@@ -5,7 +5,7 @@
 //! defining it once in this crate makes it easy to replace.
 
 #[cfg(not(target_arch = "wasm32"))]
-use ring::digest::{digest, Context, SHA256};
+pub use ring::digest::{digest, Context, SHA256};
 
 #[cfg(target_arch = "wasm32")]
 use sha2::{Digest, Sha256};

--- a/eth2/utils/swap_or_not_shuffle/Cargo.toml
+++ b/eth2/utils/swap_or_not_shuffle/Cargo.toml
@@ -17,3 +17,4 @@ ethereum-types = "0.8.0"
 [dependencies]
 eth2_hashing = "0.1.0"
 int_to_bytes = { path = "../int_to_bytes" }
+ethereum-types = "0.8.0"

--- a/eth2/utils/swap_or_not_shuffle/Cargo.toml
+++ b/eth2/utils/swap_or_not_shuffle/Cargo.toml
@@ -16,5 +16,4 @@ ethereum-types = "0.8.0"
 
 [dependencies]
 eth2_hashing = "0.1.0"
-int_to_bytes = { path = "../int_to_bytes" }
 ethereum-types = "0.8.0"

--- a/eth2/utils/swap_or_not_shuffle/src/compute_shuffled_index.rs
+++ b/eth2/utils/swap_or_not_shuffle/src/compute_shuffled_index.rs
@@ -1,5 +1,5 @@
+use crate::Hash256;
 use eth2_hashing::{Context, SHA256};
-use ethereum_types::H256 as Hash256;
 use std::cmp::max;
 
 /// Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.

--- a/eth2/utils/swap_or_not_shuffle/src/compute_shuffled_index.rs
+++ b/eth2/utils/swap_or_not_shuffle/src/compute_shuffled_index.rs
@@ -1,5 +1,5 @@
-use eth2_hashing::hash;
-use int_to_bytes::{int_to_bytes1, int_to_bytes4};
+use eth2_hashing::{Context, SHA256};
+use ethereum_types::H256 as Hash256;
 use std::cmp::max;
 
 /// Return `p(index)` in a pseudorandom permutation `p` of `0...list_size-1` with ``seed`` as entropy.
@@ -43,27 +43,35 @@ pub fn compute_shuffled_index(
 fn do_round(seed: &[u8], index: usize, pivot: usize, round: u8, list_size: usize) -> Option<usize> {
     let flip = (pivot + (list_size - index)) % list_size;
     let position = max(index, flip);
-    let source = hash_with_round_and_position(seed, round, position)?;
+    let source = hash_with_round_and_position(seed, round, position);
     let byte = source[(position % 256) / 8];
     let bit = (byte >> (position % 8)) % 2;
     Some(if bit == 1 { flip } else { index })
 }
 
-fn hash_with_round_and_position(seed: &[u8], round: u8, position: usize) -> Option<Vec<u8>> {
-    let mut seed = seed.to_vec();
-    seed.append(&mut int_to_bytes1(round));
+fn hash_with_round_and_position(seed: &[u8], round: u8, position: usize) -> Hash256 {
+    let mut context = Context::new(&SHA256);
+
+    context.update(seed);
+    context.update(&[round]);
     /*
      * Note: the specification has an implicit assertion in `int_to_bytes4` that `position / 256 <
      * 2**24`. For efficiency, we do not check for that here as it is checked in `compute_shuffled_index`.
      */
-    seed.append(&mut int_to_bytes4((position / 256) as u32));
-    Some(hash(&seed[..]))
+    context.update(&(position / 256).to_le_bytes()[0..4]);
+
+    let digest = context.finish();
+    Hash256::from_slice(digest.as_ref())
 }
 
-fn hash_with_round(seed: &[u8], round: u8) -> Vec<u8> {
-    let mut seed = seed.to_vec();
-    seed.append(&mut int_to_bytes1(round));
-    hash(&seed[..])
+fn hash_with_round(seed: &[u8], round: u8) -> Hash256 {
+    let mut context = Context::new(&SHA256);
+
+    context.update(seed);
+    context.update(&[round]);
+
+    let digest = context.finish();
+    Hash256::from_slice(digest.as_ref())
 }
 
 fn bytes_to_int64(slice: &[u8]) -> u64 {

--- a/eth2/utils/swap_or_not_shuffle/src/lib.rs
+++ b/eth2/utils/swap_or_not_shuffle/src/lib.rs
@@ -19,3 +19,5 @@ mod shuffle_list;
 
 pub use compute_shuffled_index::compute_shuffled_index;
 pub use shuffle_list::shuffle_list;
+
+type Hash256 = ethereum_types::H256;


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Removes a bunch of heap allocations during shuffling. These allocations were accounting for >25% of all allocations when running a 100k testnet for several hours.
