### PR TITLE
Add checks for eth1 chain connection before inserting to op pool

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -977,8 +977,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             // Provide the valid attestation to op pool, which may choose to retain the
             // attestation for inclusion in a future block.
-            self.op_pool
-                .insert_attestation(attestation, state, &self.spec)?;
+            if self.eth1_chain.is_some() {
+                self.op_pool
+                    .insert_attestation(attestation, state, &self.spec)?;
+            };
 
             // Update the metrics.
             metrics::inc_counter(&metrics::ATTESTATION_PROCESSING_SUCCESSES);
@@ -993,7 +995,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         exit: SignedVoluntaryExit,
     ) -> Result<(), ExitValidationError> {
         match self.wall_clock_state() {
-            Ok(state) => self.op_pool.insert_voluntary_exit(exit, &state, &self.spec),
+            Ok(state) => {
+                if self.eth1_chain.is_some() {
+                    self.op_pool.insert_voluntary_exit(exit, &state, &self.spec)
+                } else {
+                    Ok(())
+                }
+            }
             Err(e) => {
                 error!(
                     &self.log,
@@ -1013,8 +1021,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<(), ProposerSlashingValidationError> {
         match self.wall_clock_state() {
             Ok(state) => {
-                self.op_pool
-                    .insert_proposer_slashing(proposer_slashing, &state, &self.spec)
+                if self.eth1_chain.is_some() {
+                    self.op_pool
+                        .insert_proposer_slashing(proposer_slashing, &state, &self.spec)
+                } else {
+                    Ok(())
+                }
             }
             Err(e) => {
                 error!(
@@ -1035,8 +1047,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<(), AttesterSlashingValidationError> {
         match self.wall_clock_state() {
             Ok(state) => {
-                self.op_pool
-                    .insert_attester_slashing(attester_slashing, &state, &self.spec)
+                if self.eth1_chain.is_some() {
+                    self.op_pool
+                        .insert_attester_slashing(attester_slashing, &state, &self.spec)
+                } else {
+                    Ok(())
+                }
             }
             Err(e) => {
                 error!(

--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -518,15 +518,21 @@ pub fn proposer_slashing<T: BeaconChainTypes>(
         .and_then(move |proposer_slashing| {
             let spec = &beacon_chain.spec;
             let state = &beacon_chain.head().unwrap().beacon_state;
-            beacon_chain
-                .op_pool
-                .insert_proposer_slashing(proposer_slashing, state, spec)
-                .map_err(|e| {
-                    ApiError::BadRequest(format!(
-                        "Error while inserting proposer slashing: {:?}",
-                        e
-                    ))
-                })
+            if beacon_chain.eth1_chain.is_some() {
+                beacon_chain
+                    .op_pool
+                    .insert_proposer_slashing(proposer_slashing, state, spec)
+                    .map_err(|e| {
+                        ApiError::BadRequest(format!(
+                            "Error while inserting proposer slashing: {:?}",
+                            e
+                        ))
+                    })
+            } else {
+                Err(ApiError::BadRequest(
+                    "Cannot insert proposer slashing on node without Eth1 connection.".to_string(),
+                ))
+            }
         })
         .and_then(|_| response_builder?.body(&true));
 
@@ -554,15 +560,21 @@ pub fn attester_slashing<T: BeaconChainTypes>(
         .and_then(move |attester_slashing| {
             let spec = &beacon_chain.spec;
             let state = &beacon_chain.head().unwrap().beacon_state;
-            beacon_chain
-                .op_pool
-                .insert_attester_slashing(attester_slashing, state, spec)
-                .map_err(|e| {
-                    ApiError::BadRequest(format!(
-                        "Error while inserting attester slashing: {:?}",
-                        e
-                    ))
-                })
+            if beacon_chain.eth1_chain.is_some() {
+                beacon_chain
+                    .op_pool
+                    .insert_attester_slashing(attester_slashing, state, spec)
+                    .map_err(|e| {
+                        ApiError::BadRequest(format!(
+                            "Error while inserting attester slashing: {:?}",
+                            e
+                        ))
+                    })
+            } else {
+                Err(ApiError::BadRequest(
+                    "Cannot insert attester slashing on node without Eth1 connection.".to_string(),
+                ))
+            }
         })
         .and_then(|_| response_builder?.body(&true));
 


### PR DESCRIPTION
## Issue Addressed

#864 

## Proposed Changes

Add checks for the existence  of `eth1_chain` before attempting to insert into the operation pool.
