### PR TITLE
Add msg length check

### DIFF
--- a/eth2/utils/bls/src/impls/herumi.rs
+++ b/eth2/utils/bls/src/impls/herumi.rs
@@ -46,6 +46,9 @@ impl TSignature<PublicKey> for Signature {
     }
 
     fn verify(&self, pubkey: &PublicKey, msg: &[u8]) -> bool {
+        if msg.len() != MSG_SIZE {
+            return false;
+        }
         self.verify(pubkey, msg)
     }
 

--- a/eth2/utils/bls/src/impls/milagro.rs
+++ b/eth2/utils/bls/src/impls/milagro.rs
@@ -80,7 +80,7 @@ impl TSignature<PublicKey> for Signature {
     }
 
     fn verify(&self, pubkey: &PublicKey, msg: &[u8]) -> bool {
-        if self.is_empty {
+        if self.is_empty || msg.len() != MSG_SIZE {
             false
         } else {
             self.signature.verify(msg, pubkey)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add a check to ensure that message have length of 32 bytes.

## Additional Info

Message length checks will now be removed from [`milagro_bls`](https://github.com/sigp/milagro_bls/) to conform to the standards and ensure the library is usable for other purposes.
