### PR TITLE
Fix port conflict

### DIFF
--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -65,6 +65,8 @@ mod tests {
         let executor = runtime.executor();
 
         let mut config = NetworkConfig::default();
+        config.libp2p_port = 21212;
+        config.discovery_port = 21212;
         config.boot_nodes = enrs.clone();
         runtime
             .block_on_all(


### PR DESCRIPTION
## Issue Addressed

Address #871 

## Proposed Changes

Change the `libp2p` and `discovery` ports in the `dht_persistence` test to some random number to avoid port clashes when tests are run.

## Additional Info

We could also probably use the `unused_port` function here as an alternative to coming up with seemingly random port numbers for tests. https://github.com/sigp/lighthouse/blob/371e5adcf89d99a5958b802cf9925a990bd66ba6/beacon_node/src/config.rs#L602
