### PR TITLE
Add a GitHub action to publish The Book

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,30 @@
+name: mdbook
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-upload-to-s3:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Setup mdBook
+        uses: peaceiris/actions-mdbook@v1
+        with:
+          mdbook-version: '0.3.5'
+
+      - run: mdbook build
+        working-directory: book
+
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: 'ap-southeast-2'
+          SOURCE_DIR: 'book/book'


### PR DESCRIPTION
## Issue Addressed

The [Lighthouse Book](https://lighthouse-book.sigmaprime.io/) is currently out of date.

## Proposed Changes

Add an GitHub action that builds and uploads (to S3) the latest version on every merge to `master`.

## Additional Info

This PR has been shown to successfully build and upload (with hook branch set to `update-book` temporarily) http://adam-lighthouse-book-dev.s3-website-ap-southeast-2.amazonaws.com/: https://github.com/adaszko/lighthouse/runs/472525745?check_suite_focus=true

The plan for merging:
1. Add 3 new secrets to the [sigmap/lighthouse](https://github.com/sigp/lighthouse) project:
    - `AWS_S3_BUCKET` (it should be set to the S3 bucket name behind https://lighthouse-book.sigmaprime.io/)
    - `AWS_ACCESS_KEY_ID`
    - `AWS_SECRET_ACCESS_KEY`
1. Merge this PR to master
1. Observe if the first merged PR to `master` triggers a successful `mdbook / build-and-upload-to-s3` job