### PR TITLE
Use --locked, upgrade Dockerfile Rust version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:1.41.1 AS builder
 COPY . lighthouse
 RUN cd lighthouse && make
-RUN cd lighthouse && cargo install --path lcli
+RUN cd lighthouse && cargo install --path lcli --locked
 
 FROM debian:buster-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.41.0 AS builder
+FROM rust:1.41.1 AS builder
 COPY . lighthouse
 RUN cd lighthouse && make
 RUN cd lighthouse && cargo install --path lcli

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EF_TESTS = "tests/ef_tests"
 #
 # Binaries will most likely be found in `./target/release`
 install:
-	cargo install --path lighthouse --force
+	cargo install --path lighthouse --force --locked
 
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Use `--locked` when using `cargo install` so the lockfile is respected (see https://github.com/rust-lang/cargo/issues/7169)
- Updates the Rust version in the Dockerfile.
