### PR TITLE
Peer manager

### DIFF
--- a/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
@@ -1,0 +1,548 @@
+use crate::PeerId;
+use slog::warn;
+use std::collections::HashMap;
+use std::time::Instant;
+use PeerConnectionStatus::*;
+
+/// A peer's reputation
+pub type Rep = i32;
+
+/// The default starting reputation for an unknown peer.
+const DEFAULT_REPUTATION: Rep = 50;
+
+/// Storage of known peers, their reputation and information
+pub struct PeerDB {
+    /// The collection of known connected peers, their status and reputation
+    peers: HashMap<PeerId, PeerInfo>,
+    /// Tracking of number of disconnected nodes
+    n_dc: usize,
+    /// Max number of disconnected nodes to remember
+    max_dc_peers: usize,
+    /// PeerDB's logger
+    log: slog::Logger,
+}
+
+/// A collection of information about a peer
+#[derive(Debug)]
+pub struct PeerInfo {
+    /// The connection status of the peer
+    _status: PeerStatus,
+    /// The peers reputation
+    reputation: Rep,
+    /// Client managing this peer
+    _client: Option<Client>,
+    /// Connection status of this peer
+    connection_status: PeerConnectionStatus,
+}
+
+/// Connection Status of the peer
+#[derive(Debug, Clone)]
+pub enum PeerConnectionStatus {
+    Connected {
+        /// number of ingoing connections
+        n_in: u8,
+        /// number of outgoing connections
+        n_out: u8,
+    },
+    Disconnected {
+        /// last time the peer was connected or discovered
+        since: Instant,
+    },
+    Banned {
+        /// moment when the peer was banned
+        since: Instant,
+    },
+    Unknown {
+        /// time since we know of this peer
+        since: Instant,
+    },
+}
+
+/// Representation of the client managing a peer
+#[derive(Debug)]
+pub struct Client {
+    /// The client's name (Ex: lighthouse, prism, nimbus, etc)
+    _client_name: String,
+    /// The client's version
+    _version: u8,
+}
+
+#[derive(Debug)]
+pub enum PeerStatus {
+    /// The peer is healthy
+    Healthy,
+    /// The peer is clogged. It has not been responding to requests on time
+    Clogged,
+}
+
+impl Default for PeerConnectionStatus {
+    fn default() -> Self {
+        Unknown {
+            since: Instant::now(),
+        }
+    }
+}
+
+impl PeerConnectionStatus {
+    /// Checks if the status is connected
+    pub fn is_connected(&self) -> bool {
+        match self {
+            Connected { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Checks if the status is banned
+    pub fn is_banned(&self) -> bool {
+        match self {
+            Banned { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Checks if the status is disconnected
+    pub fn is_disconnected(&self) -> bool {
+        match self {
+            Disconnected { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Modifies the status to Connected and increases the number of ingoing
+    /// connections by one
+    pub fn connect_ingoing(&mut self) {
+        match self {
+            Connected { n_in, .. } => *n_in += 1,
+            Disconnected { .. } | Banned { .. } | Unknown { .. } => {
+                *self = Connected { n_in: 1, n_out: 0 }
+            }
+        }
+    }
+
+    /// Modifies the status to Connected and increases the number of outgoing
+    /// connections by one
+    pub fn connect_outgoing(&mut self) {
+        match self {
+            Connected { n_out, .. } => *n_out += 1,
+            Disconnected { .. } | Banned { .. } | Unknown { .. } => {
+                *self = Connected { n_in: 0, n_out: 1 }
+            }
+        }
+    }
+
+    /// Modifies the status to Disconnected and sets the last seen instant to now
+    pub fn disconnect(&mut self) {
+        *self = Disconnected {
+            since: Instant::now(),
+        };
+    }
+
+    /// Modifies the status to Banned
+    pub fn ban(&mut self) {
+        *self = Banned {
+            since: Instant::now(),
+        };
+    }
+
+    pub fn connections(&self) -> (u8, u8) {
+        match self {
+            Connected { n_in, n_out } => (*n_in, *n_out),
+            _ => (0, 0),
+        }
+    }
+}
+
+impl Default for PeerStatus {
+    fn default() -> Self {
+        PeerStatus::Healthy
+    }
+}
+
+impl Default for PeerInfo {
+    fn default() -> PeerInfo {
+        PeerInfo {
+            reputation: DEFAULT_REPUTATION,
+            _status: Default::default(),
+            _client: None,
+            connection_status: Default::default(),
+        }
+    }
+}
+
+impl PeerDB {
+    pub fn new(max_dc_peers: usize, log: &slog::Logger) -> Self {
+        Self {
+            max_dc_peers,
+            log: log.clone(),
+            n_dc: 0,
+            peers: HashMap::new(),
+        }
+    }
+    /// Gives the reputation of a peer, or DEFAULT_REPUTATION if it is unknown
+    pub fn reputation(&self, peer_id: &PeerId) -> Rep {
+        self.peers
+            .get(peer_id)
+            .map_or(DEFAULT_REPUTATION, |info| info.reputation)
+    }
+
+    /// Gives the ids of all known peers
+    pub fn peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers.keys()
+    }
+
+    /// Returns a peer's info, if known
+    pub fn peer_info(&self, peer_id: &PeerId) -> Option<&PeerInfo> {
+        self.peers.get(peer_id)
+    }
+
+    /// Gives the ids of all known connected peers
+    pub fn connected_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.connection_status.is_connected())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the ids of all known disconnected peers
+    pub fn disconnected_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.connection_status.is_disconnected())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Gives the ids of all known banned peers
+    pub fn banned_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.connection_status.is_banned())
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    /// Returns a vector containing peers (their ids and info), sorted by
+    /// reputation from highest to lowest, and filtered using `is_status`
+    pub fn best_peers_by_status<F>(&self, is_status: F) -> Vec<(&PeerId, &PeerInfo)>
+    where
+        F: Fn(&PeerConnectionStatus) -> bool,
+    {
+        let mut by_status = self
+            .peers
+            .iter()
+            .filter(|(_, info)| is_status(&info.connection_status))
+            .collect::<Vec<_>>();
+        by_status.sort_by_key(|(_, info)| Rep::max_value() - info.reputation);
+        by_status
+    }
+
+    /// Returns the peer with highest reputation that satisfies `is_status`
+    pub fn best_by_status<F>(&self, is_status: F) -> Option<&PeerId>
+    where
+        F: Fn(&PeerConnectionStatus) -> bool,
+    {
+        self.peers
+            .iter()
+            .filter(|(_, info)| is_status(&info.connection_status))
+            .max_by_key(|(_, info)| info.reputation)
+            .map(|(id, _)| id)
+    }
+
+    /// Sets a peer as connected with an ingoing connection
+    pub fn connect_ingoing(&mut self, peer_id: &PeerId) {
+        let info = self
+            .peers
+            .entry(peer_id.clone())
+            .or_insert_with(|| Default::default());
+
+        if info.connection_status.is_disconnected() {
+            self.n_dc -= 1;
+        }
+        info.connection_status.connect_ingoing();
+    }
+
+    /// Sets a peer as connected with an outgoing connection
+    pub fn connect_outgoing(&mut self, peer_id: &PeerId) {
+        let info = self
+            .peers
+            .entry(peer_id.clone())
+            .or_insert_with(|| Default::default());
+
+        if info.connection_status.is_disconnected() {
+            self.n_dc -= 1;
+        }
+        info.connection_status.connect_outgoing();
+    }
+
+    /// Sets the peer as disconnected
+    pub fn disconnect(&mut self, peer_id: &PeerId) {
+        let log_ref = &self.log;
+        let info = self.peers.entry(peer_id.clone()).or_insert_with(|| {
+            warn!(log_ref, "Disconnecting unknown peer";
+                    "peer_id" => format!("{:?}",peer_id));
+            PeerInfo::default()
+        });
+
+        if !info.connection_status.is_disconnected() {
+            info.connection_status.disconnect();
+            self.n_dc += 1;
+        }
+        self.shrink_to_fit();
+    }
+
+    /// Drops the peers with the lowest reputation so that the number of
+    /// disconnected peers is less than MAX_DC_PEERS
+    pub fn shrink_to_fit(&mut self) {
+        // for caution, but the difference should never be > 1
+        while self.n_dc > self.max_dc_peers {
+            let to_drop = self
+                .peers
+                .iter()
+                .filter(|(_, info)| info.connection_status.is_disconnected())
+                .min_by_key(|(_, info)| info.reputation)
+                .map(|(id, _)| id.clone())
+                .unwrap(); // should be safe since n_dc > MAX_DC_PEERS > 0
+            self.peers.remove(&to_drop);
+            self.n_dc -= 1;
+        }
+    }
+
+    /// Sets a peer as banned
+    pub fn ban(&mut self, peer_id: &PeerId) {
+        let log_ref = &self.log;
+        let info = self.peers.entry(peer_id.clone()).or_insert_with(|| {
+            warn!(log_ref, "Banning unknown peer";
+                    "peer_id" => format!("{:?}",peer_id));
+            PeerInfo::default()
+        });
+        if info.connection_status.is_disconnected() {
+            self.n_dc -= 1;
+        }
+        info.connection_status.ban();
+    }
+
+    /// Inserts a new peer with the default PeerInfo if it is not already present
+    /// Returns if the peer was new to the PeerDB
+    pub fn new_peer(&mut self, peer_id: &PeerId) -> bool {
+        if !self.peers.contains_key(peer_id) {
+            self.peers.insert(peer_id.clone(), Default::default());
+            return true;
+        }
+        false
+    }
+
+    /// Sets the reputation of peer
+    pub fn set_reputation(&mut self, peer_id: &PeerId, rep: Rep) {
+        let log_ref = &self.log;
+        self.peers
+            .entry(peer_id.clone())
+            .or_insert_with(|| {
+                warn!(log_ref, "Setting the reputation of an unknown peer";
+                    "peer_id" => format!("{:?}",peer_id));
+                PeerInfo::default()
+            })
+            .reputation = rep;
+    }
+
+    /// Adds to a peer's reputation by `change`. If the reputation exceeds Rep's
+    /// upper (lower) bounds, it stays at the maximum (minimum) value
+    pub fn add_reputation(&mut self, peer_id: &PeerId, change: Rep) {
+        let log_ref = &self.log;
+        let info = self.peers.entry(peer_id.clone()).or_insert_with(|| {
+            warn!(log_ref, "Adding to the reputation of an unknown peer";
+                    "peer_id" => format!("{:?}",peer_id));
+            PeerInfo::default()
+        });
+        info.reputation = info.reputation.saturating_add(change);
+    }
+
+    pub fn connection_status(&self, peer_id: &PeerId) -> PeerConnectionStatus {
+        self.peer_info(peer_id)
+            .map_or(PeerConnectionStatus::default(), |info| {
+                info.connection_status.clone()
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slog::{o, Drain};
+
+    pub fn build_log(level: slog::Level, enabled: bool) -> slog::Logger {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+
+        if enabled {
+            slog::Logger::root(drain.filter_level(level).fuse(), o!())
+        } else {
+            slog::Logger::root(drain.filter(|_| false).fuse(), o!())
+        }
+    }
+
+    fn get_db(max_dc_peers: usize) -> PeerDB {
+        let log = build_log(slog::Level::Debug, true);
+        PeerDB::new(max_dc_peers, &log)
+    }
+
+    #[test]
+    fn test_peer_connected_successfully() {
+        let mut pdb: PeerDB = get_db(2);
+        let random_peer = PeerId::random();
+
+        let (n_in, n_out) = (10, 20);
+        for _ in 0..n_in {
+            pdb.connect_ingoing(&random_peer);
+        }
+        for _ in 0..n_out {
+            pdb.connect_outgoing(&random_peer);
+        }
+
+        // the peer is known
+        let peer_info = pdb.peer_info(&random_peer);
+        assert!(peer_info.is_some());
+        // this is the only peer
+        assert_eq!(pdb.peers().count(), 1);
+        // the peer has the default reputation
+        assert_eq!(pdb.reputation(&random_peer), DEFAULT_REPUTATION);
+        // it should be connected, and therefore not counted as disconnected
+        assert_eq!(pdb.n_dc, 0);
+        assert!(peer_info.unwrap().connection_status.is_connected());
+        assert_eq!(
+            peer_info.unwrap().connection_status.connections(),
+            (n_in, n_out)
+        );
+    }
+
+    #[test]
+    fn test_set_reputation() {
+        let mut pdb: PeerDB = get_db(2);
+        let random_peer = PeerId::random();
+        pdb.connect_ingoing(&random_peer);
+
+        let mut rep = Rep::min_value();
+        pdb.set_reputation(&random_peer, rep);
+        assert_eq!(pdb.reputation(&random_peer), rep);
+
+        rep = Rep::max_value();
+        pdb.set_reputation(&random_peer, rep);
+        assert_eq!(pdb.reputation(&random_peer), rep);
+
+        rep = Rep::max_value() / 100;
+        pdb.set_reputation(&random_peer, rep);
+        assert_eq!(pdb.reputation(&random_peer), rep);
+    }
+
+    #[test]
+    fn test_reputation_change() {
+        let mut pdb: PeerDB = get_db(2);
+
+        // 0 change does not change de reputation
+        let random_peer = PeerId::random();
+        let change: Rep = 0;
+        pdb.connect_ingoing(&random_peer);
+        pdb.add_reputation(&random_peer, change);
+        assert_eq!(pdb.reputation(&random_peer), DEFAULT_REPUTATION);
+
+        // overflowing change is capped
+        let random_peer = PeerId::random();
+        let change = Rep::max_value();
+        pdb.connect_ingoing(&random_peer);
+        pdb.add_reputation(&random_peer, change);
+        assert_eq!(pdb.reputation(&random_peer), Rep::max_value());
+    }
+
+    #[test]
+    fn test_disconnected_are_bounded() {
+        let mut pdb = get_db(1);
+
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        pdb.connect_ingoing(&p0);
+        pdb.connect_ingoing(&p1);
+        assert_eq!(pdb.n_dc, 0);
+
+        pdb.disconnect(&p0);
+        assert_eq!(pdb.n_dc, 1);
+
+        pdb.disconnect(&p1);
+        assert_eq!(pdb.n_dc, 1);
+    }
+
+    #[test]
+    fn test_best_peers() {
+        let mut pdb = get_db(1);
+
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        pdb.new_peer(&p0);
+        pdb.new_peer(&p1);
+        pdb.new_peer(&p2);
+        pdb.connect_ingoing(&p0);
+        pdb.connect_ingoing(&p1);
+        pdb.connect_ingoing(&p2);
+        pdb.set_reputation(&p0, 70);
+        pdb.set_reputation(&p1, 100);
+        pdb.set_reputation(&p2, 50);
+
+        let best_peers = pdb.best_peers_by_status(PeerConnectionStatus::is_connected);
+        assert!(vec![&p1, &p0, &p2]
+            .into_iter()
+            .eq(best_peers.into_iter().map(|p| p.0)));
+    }
+
+    #[test]
+    fn test_the_best_peer() {
+        let mut pdb = get_db(1);
+
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        pdb.new_peer(&p0);
+        pdb.new_peer(&p1);
+        pdb.new_peer(&p2);
+        pdb.connect_ingoing(&p0);
+        pdb.connect_ingoing(&p1);
+        pdb.connect_ingoing(&p2);
+        pdb.set_reputation(&p0, 70);
+        pdb.set_reputation(&p1, 100);
+        pdb.set_reputation(&p2, 50);
+
+        let the_best = pdb.best_by_status(PeerConnectionStatus::is_connected);
+        assert!(the_best.is_some());
+        // Consistency check
+        let best_peers = pdb.best_peers_by_status(PeerConnectionStatus::is_connected);
+        assert_eq!(the_best, best_peers.into_iter().map(|p| p.0).next());
+    }
+
+    #[test]
+    fn test_disconnected_consistency() {
+        // remove the dc bound from the test
+        let mut pdb = get_db(usize::max_value());
+
+        let random_peer = PeerId::random();
+
+        pdb.new_peer(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+
+        pdb.connect_ingoing(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+        pdb.disconnect(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+
+        pdb.connect_outgoing(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+        pdb.disconnect(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+
+        pdb.ban(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+        pdb.disconnect(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+
+        pdb.disconnect(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+        pdb.disconnect(&random_peer);
+        assert_eq!(pdb.n_dc, pdb.disconnected_peers().count());
+    }
+}


### PR DESCRIPTION
## Issue Addressed
#883 

## Proposed Changes

A PeerDB and some basics for a Peer Manager

## Additional Info

This is a extremely simple version which I hope will provide ground for some discussions
Things that come to mind at this point:
- It does not produce an event when a peer is connected, and I think this could be useful
- There are a lot of missing `PeerAction`s (or similar) _if_ we expect the reputation to change by a different value between -for example- an invalid message in a protocol vs another one.
- In general there are utility functions which may be not useful in practice, or functions that are needed but are not present. Having a more clear use case should give some light here
- For now there is no handler for the peer manager since the version of `futures` we are using does not have cross-task communication capabilities (afaik)
