### PR TITLE
fix typo in httpnetwork doc

### DIFF
--- a/book/src/http_network.md
+++ b/book/src/http_network.md
@@ -42,7 +42,7 @@ Requests the count of peers connected to the client.
 
 | Property | Specification |
 | --- |--- |
-Path | `/network/peer_id`
+Path | `/network/peer_count`
 Method | GET
 JSON Encoding | Number
 Query Parameters | None


### PR DESCRIPTION
## Issue Addressed

902

## Proposed Changes

It fixes a type in the documentation for network/peer_count endpoint at https://lighthouse-book.sigmaprime.io/http_network.html#networkpeer_count

