### PR TITLE
Book corrections to allow http api access for docker use

### DIFF
--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -49,7 +49,7 @@ $ docker run lighthouse:local lighthouse --help
 You can run a Docker beacon node with the following command:
 
 ```bash
-$ docker run -p 9000:9000 -p 5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
+$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
 ```
 
 > The `-p` and `-v` and values are described below.
@@ -81,5 +81,5 @@ If you use the `--http` flag you may also want to expose the HTTP port with `-p
 5052:5052`.
 
 ```bash
-$ docker run -p 9000:9000 -p 5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
+$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
 ```

--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -49,7 +49,7 @@ $ docker run lighthouse:local lighthouse --help
 You can run a Docker beacon node with the following command:
 
 ```bash
-$ docker run -p 9000:9000 -p 5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse beacon --http
+$ docker run -p 9000:9000 -p 5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
 ```
 
 > The `-p` and `-v` and values are described below.
@@ -81,5 +81,5 @@ If you use the `--http` flag you may also want to expose the HTTP port with `-p
 5052:5052`.
 
 ```bash
-$ docker run -p 9000:9000 -p 5052:5052 sigp/lighthouse lighthouse beacon --http
+$ docker run -p 9000:9000 -p 5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
 ```

--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -78,7 +78,7 @@ $ docker run -p 9000:9000 sigp/lighthouse lighthouse beacon
 ```
 
 If you use the `--http` flag you may also want to expose the HTTP port with `-p
-5052:5052`.
+127.0.0.1:5052:5052`.
 
 ```bash
 $ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0


### PR DESCRIPTION
User's on discord has issues with docker and hitting the http api. 

The docs currently are misleading and will confuse users.

This updates the docs around docker allowing users to hit the http api server externally.