### PR TITLE
Fix master failing test

### DIFF
--- a/eth2/types/src/test_utils/test_random/secret_key.rs
+++ b/eth2/types/src/test_utils/test_random/secret_key.rs
@@ -2,17 +2,7 @@ use super::*;
 use bls::SecretKey;
 
 impl TestRandom for SecretKey {
-    fn random_for_test(rng: &mut impl RngCore) -> Self {
-        let mut key_bytes = vec![0; 48];
-        rng.fill_bytes(&mut key_bytes);
-        /*
-         * An `unreachable!` is used here as there's no reason why you cannot construct a key from a
-         * fixed-length byte slice. Also, this should only be used during testing so a panic is
-         * acceptable.
-         */
-        match SecretKey::from_bytes(&key_bytes) {
-            Ok(key) => key,
-            Err(_) => unreachable!(),
-        }
+    fn random_for_test(_rng: &mut impl RngCore) -> Self {
+        SecretKey::random()
     }
 }

--- a/eth2/utils/bls/src/secret_key.rs
+++ b/eth2/utils/bls/src/secret_key.rs
@@ -79,8 +79,12 @@ mod tests {
 
     #[test]
     pub fn test_ssz_round_trip() {
-        let original =
-            SecretKey::from_bytes(b"jzjxxgjajfjrmgodszzsgqccmhnyvetcuxobhtynojtpdtbj").unwrap();
+        let byte_key = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 70, 211, 210, 129, 231, 69, 162, 234,
+            16, 15, 244, 214, 126, 201, 0, 85, 28, 239, 82, 121, 208, 190, 223, 6, 169, 202, 86,
+            236, 197, 218, 3, 69,
+        ];
+        let original = SecretKey::from_bytes(&byte_key).unwrap();
 
         let bytes = ssz_encode(&original);
         let decoded = SecretKey::from_ssz_bytes(&bytes).unwrap();


### PR DESCRIPTION
## Issue Addressed

Master currently fails if `cargo update` is applied. The mock BLS key used to test ssz encoding is not of the correct range. The new BLS throws a panic and the test fails. 

This PR specifies a valid BLS key for the test.