### PR TITLE
Discovery v0.2.0 Update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5ca2cd0adc3f48f9e9ea5a6bbdf9ccc0bfade884847e484d452414c7ccffb3"
+
+[[package]]
 name = "beacon_chain"
 version = "0.2.0"
 dependencies = [
@@ -1082,20 +1088,21 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+version = "0.1.0-alpha.3"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.12.0",
  "bs58 0.3.0",
- "clap",
+ "ed25519-dalek",
  "hex 0.4.2",
  "libp2p-core",
- "libsecp256k1 0.3.5",
+ "libsecp256k1",
  "log 0.4.8",
  "rand 0.7.3",
  "rlp",
  "serde",
  "sha3",
+ "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -1199,7 +1206,6 @@ version = "0.2.0"
 dependencies = [
  "base64 0.11.0",
  "dirs",
- "enr",
  "error-chain",
  "eth2_ssz",
  "eth2_ssz_derive",
@@ -2044,10 +2050,9 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
- "enr",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -2084,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "asn1_der",
  "bs58 0.3.0",
@@ -2094,7 +2099,7 @@ dependencies = [
  "fnv",
  "futures",
  "lazy_static",
- "libsecp256k1 0.3.5",
+ "libsecp256k1",
  "log 0.4.8",
  "multistream-select",
  "parity-multiaddr",
@@ -2119,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "quote 1.0.3",
  "syn 1.0.16",
@@ -2128,7 +2133,7 @@ dependencies = [
 [[package]]
 name = "libp2p-deflate"
 version = "0.5.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "flate2",
  "futures",
@@ -2139,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "libp2p-discv5"
 version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "arrayvec 0.4.12",
  "bigint",
@@ -2151,12 +2156,12 @@ dependencies = [
  "hkdf",
  "libp2p-core",
  "libp2p-swarm",
- "libsecp256k1 0.3.1",
+ "libsecp256k1",
  "log 0.4.8",
  "openssl",
  "parity-multiaddr",
  "parity-multihash",
- "rand 0.6.5",
+ "rand 0.7.3",
  "rlp",
  "sha2",
  "smallvec 0.6.13",
@@ -2170,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2181,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bs58 0.3.0",
  "bytes",
@@ -2199,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.1.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "base64 0.10.1",
  "bs58 0.2.5",
@@ -2224,7 +2229,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -2243,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.13.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "arrayvec 0.5.1",
  "bytes",
@@ -2270,7 +2275,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "data-encoding",
  "dns-parser",
@@ -2292,7 +2297,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "fnv",
@@ -2308,7 +2313,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.11.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "curve25519-dalek 1.2.3",
@@ -2328,7 +2333,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -2345,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -2360,7 +2365,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.13.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "aes-ctr",
  "bytes",
@@ -2389,7 +2394,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.3.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2402,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -2418,7 +2423,7 @@ dependencies = [
 [[package]]
 name = "libp2p-uds"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -2429,7 +2434,7 @@ dependencies = [
 [[package]]
 name = "libp2p-wasm-ext"
 version = "0.6.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "futures",
  "js-sys",
@@ -2443,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -2461,27 +2466,13 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.13.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "futures",
  "libp2p-core",
  "log 0.4.8",
  "tokio-io",
  "yamux",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.3.1"
-source = "git+https://github.com/SigP/libsecp256k1?branch=ecdh_generalise#5858db8d1b280417f5866582df2cd0c63983d928"
-dependencies = [
- "arrayref",
- "digest",
- "hmac-drbg",
- "rand 0.6.5",
- "sha2",
- "subtle 2.2.2",
- "typenum",
 ]
 
 [[package]]
@@ -2775,7 +2766,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.6.1"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",
@@ -3008,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.6.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "arrayref",
  "bs58 0.3.0",
@@ -3025,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "parity-multihash"
 version = "0.2.0"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "blake2",
  "bytes",
@@ -3801,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.1.2"
-source = "git+https://github.com/SigP/rust-libp2p/?rev=49c95c4c4242f1c9f08558a3daac5e9ecac290d5#49c95c4c4242f1c9f08558a3daac5e9ecac290d5"
+source = "git+https://github.com/SigP/rust-libp2p?rev=0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6#0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6"
 dependencies = [
  "bytes",
  "futures",

--- a/beacon_node/beacon_chain/tests/attestation_tests.rs
+++ b/beacon_node/beacon_chain/tests/attestation_tests.rs
@@ -56,7 +56,7 @@ fn attestation_validity() {
         .expect("should get at least one attestation");
 
     assert_eq!(
-        chain.process_attestation(valid_attestation.clone()),
+        chain.process_attestation(valid_attestation.clone(), Some(false)),
         Ok(AttestationProcessingOutcome::Processed),
         "should accept valid attestation"
     );
@@ -71,7 +71,7 @@ fn attestation_validity() {
     assert_eq!(
         harness
             .chain
-            .process_attestation(epoch_mismatch_attestation),
+            .process_attestation(epoch_mismatch_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::BadTargetEpoch),
         "should not accept attestation where the slot is not in the same epoch as the target"
     );
@@ -85,7 +85,9 @@ fn attestation_validity() {
     early_attestation.data.slot = (current_epoch + 1).start_slot(MainnetEthSpec::slots_per_epoch());
 
     assert_eq!(
-        harness.chain.process_attestation(early_attestation),
+        harness
+            .chain
+            .process_attestation(early_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::FutureEpoch {
             attestation_epoch: current_epoch + 1,
             current_epoch
@@ -118,7 +120,9 @@ fn attestation_validity() {
         .expect("should get at least one late attestation");
 
     assert_eq!(
-        harness.chain.process_attestation(late_attestation),
+        harness
+            .chain
+            .process_attestation(late_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::PastEpoch {
             attestation_epoch: current_epoch - 2,
             current_epoch
@@ -134,7 +138,9 @@ fn attestation_validity() {
     bad_target_attestation.data.target.root = Hash256::from_low_u64_be(42);
 
     assert_eq!(
-        harness.chain.process_attestation(bad_target_attestation),
+        harness
+            .chain
+            .process_attestation(bad_target_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::UnknownTargetRoot(
             Hash256::from_low_u64_be(42)
         )),
@@ -149,7 +155,9 @@ fn attestation_validity() {
     future_block_attestation.data.slot -= 1;
 
     assert_eq!(
-        harness.chain.process_attestation(future_block_attestation),
+        harness
+            .chain
+            .process_attestation(future_block_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::AttestsToFutureBlock {
             block: current_slot,
             attestation: current_slot - 1
@@ -165,7 +173,9 @@ fn attestation_validity() {
     bad_head_attestation.data.beacon_block_root = Hash256::from_low_u64_be(42);
 
     assert_eq!(
-        harness.chain.process_attestation(bad_head_attestation),
+        harness
+            .chain
+            .process_attestation(bad_head_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::UnknownHeadBlock {
             beacon_block_root: Hash256::from_low_u64_be(42)
         }),
@@ -183,7 +193,9 @@ fn attestation_validity() {
     bad_signature_attestation.signature = agg_sig;
 
     assert_eq!(
-        harness.chain.process_attestation(bad_signature_attestation),
+        harness
+            .chain
+            .process_attestation(bad_signature_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::InvalidSignature),
         "should not accept bad_signature attestation"
     );
@@ -199,7 +211,7 @@ fn attestation_validity() {
     assert_eq!(
         harness
             .chain
-            .process_attestation(empty_bitfield_attestation),
+            .process_attestation(empty_bitfield_attestation, Some(false)),
         Ok(AttestationProcessingOutcome::EmptyAggregationBitfield),
         "should not accept empty_bitfield attestation"
     );
@@ -247,7 +259,7 @@ fn attestation_that_skips_epochs() {
         .expect("should get at least one attestation");
 
     assert_eq!(
-        harness.chain.process_attestation(attestation),
+        harness.chain.process_attestation(attestation, Some(false)),
         Ok(AttestationProcessingOutcome::Processed),
         "should process attestation that skips slots"
     );

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -306,7 +306,7 @@ fn epoch_boundary_state_attestation_processing() {
             .epoch;
         let res = harness
             .chain
-            .process_attestation_internal(attestation.clone());
+            .process_attestation_internal(attestation.clone(), Some(true));
 
         let current_epoch = harness.chain.epoch().expect("should get epoch");
         let attestation_epoch = attestation.data.target.epoch;

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -449,7 +449,7 @@ fn attestations_with_increasing_slots() {
 
     for attestation in attestations {
         let attestation_epoch = attestation.data.target.epoch;
-        let res = harness.chain.process_attestation(attestation);
+        let res = harness.chain.process_attestation(attestation, Some(false));
 
         if attestation_epoch + 1 < current_epoch {
             assert_eq!(

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -410,7 +410,7 @@ impl Service {
                         .map(|vec| {
                             let first = vec.first().cloned().unwrap_or_else(|| 0);
                             let last = vec.last().map(|n| n + 1).unwrap_or_else(|| 0);
-                            (first..last)
+                            first..last
                         })
                         .collect::<Vec<Range<u64>>>()
                 })

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "49c95c4c4242f1c9f08558a3daac5e9ecac290d5" }
-enr =  { git = "https://github.com/SigP/rust-libp2p/", rev = "49c95c4c4242f1c9f08558a3daac5e9ecac290d5", features = ["serde"] }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6" 
 types = { path =  "../../eth2/types" }
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6" 
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "0cb9d504c7be6a7bcfc87feeafdb6847d8083fc6" }
 types = { path =  "../../eth2/types" }
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -1,7 +1,7 @@
 use crate::discovery::Discovery;
 use crate::rpc::{RPCEvent, RPCMessage, RPC};
+use crate::Enr;
 use crate::{error, GossipTopic, NetworkConfig, NetworkGlobals, PubsubMessage, TopicHash};
-use enr::Enr;
 use futures::prelude::*;
 use libp2p::{
     core::identity::Keypair,

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -31,6 +31,9 @@ pub struct Config {
     /// The udp port to broadcast to peers in order to reach back for discovery.
     pub enr_udp_port: Option<u16>,
 
+    /// The tcp port to broadcast to peers in order to reach back for libp2p services.
+    pub enr_tcp_port: Option<u16>,
+
     /// Target number of connected peers.
     pub max_peers: usize,
 
@@ -120,6 +123,7 @@ impl Default for Config {
             discovery_port: 9000,
             enr_address: None,
             enr_udp_port: None,
+            enr_tcp_port: None,
             max_peers: 10,
             secret_key_hex: None,
             gs_config,

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -1,6 +1,6 @@
 use crate::types::{GossipEncoding, GossipKind, GossipTopic};
-use enr::Enr;
-use libp2p::discv5::Discv5ConfigBuilder;
+use crate::Enr;
+use libp2p::discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId};
 use libp2p::Multiaddr;
 use serde_derive::{Deserialize, Serialize};
@@ -31,16 +31,6 @@ pub struct Config {
     /// The udp port to broadcast to peers in order to reach back for discovery.
     pub enr_udp_port: Option<u16>,
 
-    /// Whether to allow discovery to automatically update the external address based on PONG
-    /// responses.
-    pub auto_update_enr_address: bool,
-
-    /// An optional parameter to specify the discovery address as a DNS entry. Lighthouse will
-    /// periodically check the DNS address and update the local ENR node record if the IP changes.
-    ///
-    /// Note: A value here will disable `auto_update_enr_address`.
-    pub enr_dns_address: Option<String>,
-
     /// Target number of connected peers.
     pub max_peers: usize,
 
@@ -55,6 +45,7 @@ pub struct Config {
     pub gs_config: GossipsubConfig,
 
     /// Discv5 configuration parameters.
+    #[serde(skip)]
     pub discv5_config: Discv5Config,
 
     /// List of nodes to initially connect to.
@@ -129,8 +120,6 @@ impl Default for Config {
             discovery_port: 9000,
             enr_address: None,
             enr_udp_port: None,
-            auto_update_enr_address: true,
-            enr_dns_address: None,
             max_peers: 10,
             secret_key_hex: None,
             gs_config,

--- a/beacon_node/eth2-libp2p/src/discovery.rs
+++ b/beacon_node/eth2-libp2p/src/discovery.rs
@@ -342,6 +342,10 @@ fn load_enr(local_key: Keypair, config: &NetworkConfig, log: &slog::Logger) -> R
         if let Some(udp_port) = config.enr_udp_port {
             builder.udp(udp_port);
         }
+        // we always give it our listening tcp port
+        // TODO: Add uPnP support to map udp and tcp ports
+        let tcp_port = config.enr_tcp_port.unwrap_or_else(|| config.libp2p_port);
+        builder.tcp(tcp_port);
 
         builder
             .tcp(config.libp2p_port)
@@ -357,10 +361,11 @@ fn load_enr(local_key: Keypair, config: &NetworkConfig, log: &slog::Logger) -> R
             Ok(_) => {
                 match Enr::from_str(&enr_string) {
                     Ok(enr) => {
+                        let tcp_port = config.enr_tcp_port.unwrap_or_else(|| config.libp2p_port);
                         if enr.node_id() == local_enr.node_id() {
                             if (config.enr_address.is_none()
                                 || enr.ip().map(Into::into) == config.enr_address)
-                                && enr.tcp() == Some(config.libp2p_port)
+                                && enr.tcp() == Some(tcp_port)
                                 && (config.enr_udp_port.is_none()
                                     || enr.udp() == config.enr_udp_port)
                             {

--- a/beacon_node/eth2-libp2p/src/lib.rs
+++ b/beacon_node/eth2-libp2p/src/lib.rs
@@ -13,9 +13,11 @@ pub mod rpc;
 mod service;
 pub mod types;
 
+// shift this type into discv5
+pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;
+
 pub use crate::types::{error, GossipTopic, NetworkGlobals, PeerInfo, PubsubData, PubsubMessage};
 pub use config::Config as NetworkConfig;
-pub use libp2p::enr::Enr;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr};
 pub use libp2p::{PeerId, Swarm};

--- a/beacon_node/eth2-libp2p/tests/common/mod.rs
+++ b/beacon_node/eth2-libp2p/tests/common/mod.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-use enr::Enr;
+use eth2_libp2p::Enr;
 use eth2_libp2p::Multiaddr;
 use eth2_libp2p::NetworkConfig;
 use eth2_libp2p::Service as LibP2PService;
@@ -32,6 +32,9 @@ pub fn build_config(
 
     config.libp2p_port = port; // tcp port
     config.discovery_port = port; // udp port
+    config.enr_tcp_port = Some(port);
+    config.enr_udp_port = Some(port);
+    config.enr_address = Some("127.0.0.1".parse().unwrap());
     config.boot_nodes.append(&mut boot_nodes);
     config.secret_key_hex = secret_key;
     config.network_dir = path.into_path();
@@ -56,7 +59,9 @@ pub fn build_libp2p_instance(
 
 #[allow(dead_code)]
 pub fn get_enr(node: &LibP2PService<E>) -> Enr {
-    node.swarm.discovery().local_enr().clone()
+    let enr = node.swarm.discovery().local_enr().clone();
+    dbg!(enr.multiaddr());
+    enr
 }
 
 // Returns `n` libp2p peers in fully connected topology.
@@ -66,7 +71,7 @@ pub fn build_full_mesh(
     n: usize,
     start_port: Option<u16>,
 ) -> Vec<LibP2PService<E>> {
-    let base_port = start_port.unwrap_or(9000);
+    let base_port = start_port.unwrap_or(10000);
     let mut nodes: Vec<LibP2PService<E>> = (base_port..base_port + n as u16)
         .map(|p| build_libp2p_instance(p, vec![], None, log.clone()))
         .collect();

--- a/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
@@ -89,23 +89,27 @@ fn test_gossipsub_forward() {
 #[test]
 fn test_gossipsub_full_mesh_publish() {
     // set up the logging. The level and enabled or not
-    let log = common::build_log(Level::Info, false);
+    let log = common::build_log(Level::Debug, false);
 
     // Note: This test does not propagate gossipsub messages.
     // Having `num_nodes` > `mesh_n_high` may give inconsistent results
     // as nodes may get pruned out of the mesh before the gossipsub message
     // is published to them.
     let num_nodes = 12;
+    dbg!("here");
     let mut nodes = common::build_full_mesh(log, num_nodes, Some(11320));
     let mut publishing_node = nodes.pop().unwrap();
     let spec = E::default_spec();
+    dbg!("here");
     let empty_block = BeaconBlock::empty(&spec);
+    dbg!("here");
     let signed_block = SignedBeaconBlock {
         message: empty_block,
         signature: Signature::empty_signature(),
     };
     let data = PubsubData::BeaconBlock(Box::new(signed_block));
     let pubsub_message = PubsubMessage::new(GossipEncoding::SSZ, data);
+    dbg!("here");
     let publishing_topic: String = "/eth2/beacon_block/ssz".into();
     let mut subscribed_count = 0;
     let mut received_count = 0;
@@ -137,6 +141,7 @@ fn test_gossipsub_full_mesh_publish() {
             // Publish on beacon block topic
             if topic == TopicHash::from_raw("/eth2/beacon_block/ssz") {
                 subscribed_count += 1;
+                dbg!("here");
                 if subscribed_count == num_nodes - 1 {
                     publishing_node.swarm.publish(vec![pubsub_message.clone()]);
                 }

--- a/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
@@ -96,20 +96,16 @@ fn test_gossipsub_full_mesh_publish() {
     // as nodes may get pruned out of the mesh before the gossipsub message
     // is published to them.
     let num_nodes = 12;
-    dbg!("here");
     let mut nodes = common::build_full_mesh(log, num_nodes, Some(11320));
     let mut publishing_node = nodes.pop().unwrap();
     let spec = E::default_spec();
-    dbg!("here");
     let empty_block = BeaconBlock::empty(&spec);
-    dbg!("here");
     let signed_block = SignedBeaconBlock {
         message: empty_block,
         signature: Signature::empty_signature(),
     };
     let data = PubsubData::BeaconBlock(Box::new(signed_block));
     let pubsub_message = PubsubMessage::new(GossipEncoding::SSZ, data);
-    dbg!("here");
     let publishing_topic: String = "/eth2/beacon_block/ssz".into();
     let mut subscribed_count = 0;
     let mut received_count = 0;
@@ -141,7 +137,6 @@ fn test_gossipsub_full_mesh_publish() {
             // Publish on beacon block topic
             if topic == TopicHash::from_raw("/eth2/beacon_block/ssz") {
                 subscribed_count += 1;
-                dbg!("here");
                 if subscribed_count == num_nodes - 1 {
                     publishing_node.swarm.publish(vec![pubsub_message.clone()]);
                 }

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -1,15 +1,13 @@
-use beacon_chain::BeaconChainTypes;
 use eth2_libp2p::Enr;
 use rlp;
 use std::sync::Arc;
-use store::Store;
-use store::{DBColumn, Error as StoreError, SimpleStoreItem};
-use types::Hash256;
+use store::{DBColumn, Error as StoreError, SimpleStoreItem, Store};
+use types::{EthSpec, Hash256};
 
 /// 32-byte key for accessing the `DhtEnrs`.
 pub const DHT_DB_KEY: &str = "PERSISTEDDHTPERSISTEDDHTPERSISTE";
 
-pub fn load_dht<T: BeaconChainTypes>(store: Arc<T::Store>) -> Vec<Enr> {
+pub fn load_dht<T: Store<E>, E: EthSpec>(store: Arc<T>) -> Vec<Enr> {
     // Load DHT from store
     let key = Hash256::from_slice(&DHT_DB_KEY.as_bytes());
     match store.get(&key) {
@@ -22,8 +20,8 @@ pub fn load_dht<T: BeaconChainTypes>(store: Arc<T::Store>) -> Vec<Enr> {
 }
 
 /// Attempt to persist the ENR's in the DHT to `self.store`.
-pub fn persist_dht<T: BeaconChainTypes>(
-    store: Arc<T::Store>,
+pub fn persist_dht<T: Store<E>, E: EthSpec>(
+    store: Arc<T>,
     enrs: Vec<Enr>,
 ) -> Result<(), store::Error> {
     let key = Hash256::from_slice(&DHT_DB_KEY.as_bytes());

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -75,7 +75,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         // launch libp2p service
         let (network_globals, mut libp2p) = LibP2PService::new(config, network_log.clone())?;
 
-        for enr in load_dht::<T>(store.clone()) {
+        for enr in load_dht::<T::Store, T::EthSpec>(store.clone()) {
             libp2p.swarm.add_enr(enr);
         }
 
@@ -135,7 +135,7 @@ fn spawn_service<T: BeaconChainTypes>(
                         "Number of peers" => format!("{}", enrs.len()),
                     );
 
-                    match persist_dht::<T>(service.store.clone(), enrs) {
+                    match persist_dht::<T::Store, T::EthSpec>(service.store.clone(), enrs) {
                         Err(e) => error!(
                             log,
                             "Failed to persist DHT on drop";

--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -1,4 +1,4 @@
-//#[cfg(not(debug_assertions))]
+#[cfg(not(debug_assertions))]
 #[cfg(test)]
 mod tests {
     use crate::persisted_dht::load_dht;
@@ -10,7 +10,6 @@ mod tests {
     use sloggers::{null::NullLoggerBuilder, Build};
     use std::str::FromStr;
     use std::sync::Arc;
-    use store::MemoryStore;
     use tokio::runtime::Runtime;
     use types::{test_utils::generate_deterministic_keypairs, MinimalEthSpec};
 

--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -1,8 +1,8 @@
-#[cfg(not(debug_assertions))]
+//#[cfg(not(debug_assertions))]
 #[cfg(test)]
 mod tests {
     use crate::persisted_dht::load_dht;
-    use crate::{NetworkConfig, Service};
+    use crate::{NetworkConfig, NetworkService};
     use beacon_chain::test_utils::BeaconChainHarness;
     use eth2_libp2p::Enr;
     use futures::{Future, IntoFuture};
@@ -44,14 +44,14 @@ mod tests {
             .block_on_all(
                 // Create a new network service which implicitly gets dropped at the
                 // end of the block.
-                Service::new(beacon_chain.clone(), &config, &executor, log.clone())
+                NetworkService::start(beacon_chain.clone(), &config, &executor, log.clone())
                     .into_future()
-                    .and_then(move |(_service, _)| Ok(())),
+                    .and_then(move |(_globals, _service, _exit)| Ok(())),
             )
             .unwrap();
 
         // Load the persisted dht from the store
-        let persisted_enrs = load_dht::<MemoryStore<MinimalEthSpec>, MinimalEthSpec>(store);
+        let persisted_enrs = load_dht(store);
         assert!(
             persisted_enrs.contains(&enrs[0]),
             "should have persisted the first ENR to store"

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -63,6 +63,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("discovery-port")
+                .long("discovery-port")
+                .value_name("PORT")
+                .help("The UDP port that discovery will listen on.")
+                .default_value("9000")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("maxpeers")
                 .long("maxpeers")
                 .help("The maximum number of peers.")
@@ -85,6 +93,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("enr-tcp-port")
+                .long("enr-tcp-port")
+                .value_name("PORT")
+                .help("The TCP port of the local ENR. Set this only if you are sure other nodes can connect to your local node on this port.\
+                    The --port flag is used if this is not set.")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("enr-address")
                 .long("enr-address")
                 .value_name("ADDRESS")
@@ -93,6 +109,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 Discovery will automatically find your external address,if possible.
            ")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("enr-match")
+                .short("e")
+                .long("enr-match")
+                .help("Sets the local ENR IP address and port to match those set for lighthouse. \
+                Specifically, the IP address will be the value of --listen-address and the UDP port will be --discovery-port.")
         )
         .arg(
             Arg::with_name("disable-enr-auto-update")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -78,20 +78,28 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("discovery-port")
-                .long("disc-port")
+            Arg::with_name("enr-udp-port")
+                .long("enr-udp-port")
                 .value_name("PORT")
-                .help("The discovery UDP port.")
-                .default_value("9000")
+                .help("The UDP port of the local ENR. Set this only if you are sure other nodes can connect to your local node on this port.")
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("discovery-address")
-                .long("discovery-address")
+            Arg::with_name("enr-address")
+                .long("enr-address")
                 .value_name("ADDRESS")
                 .help("The IP address to broadcast to other peers on how to reach this node. \
-                       Default will load previous values from disk failing this it is set to 127.0.0.1 \
-                       and will be updated when connecting to other nodes on the network.")
+                Set this only if you are sure other nodes can connect to your local node on this address. \
+                Discovery will automatically find your external address,if possible.
+           ")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("disable-enr-auto-update")
+                .short("s")
+                .long("disable-enr-auto-update")
+                .help("Discovery automatically updates the nodes local ENR with an external IP address and port as seen by other peers on the network. \
+                This disables this feature, fixing the ENR's IP/PORT to those specified on boot.")
                 .takes_value(true),
         )
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -5,7 +5,7 @@ use eth2_libp2p::{Enr, GossipTopic, Multiaddr};
 use eth2_testnet_config::Eth2TestnetConfig;
 use genesis::recent_genesis_time;
 use rand::{distributions::Alphanumeric, Rng};
-use slog::{crit, info, warn, Logger};
+use slog::{crit, info, Logger};
 use ssz::Encode;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr};
@@ -143,18 +143,24 @@ pub fn get_configs<E: EthSpec>(
         client_config.network.topics = topics;
     }
 
-    if let Some(discovery_address_str) = cli_args.value_of("discovery-address") {
-        client_config.network.discovery_address = Some(
-            discovery_address_str
+    if let Some(enr_address_str) = cli_args.value_of("enr-address") {
+        client_config.network.enr_address = Some(
+            enr_address_str
                 .parse()
-                .map_err(|_| format!("Invalid discovery address: {:?}", discovery_address_str))?,
+                .map_err(|_| format!("Invalid discovery address: {:?}", enr_address_str))?,
         )
     }
 
-    if let Some(disc_port_str) = cli_args.value_of("disc-port") {
-        client_config.network.discovery_port = disc_port_str
-            .parse::<u16>()
-            .map_err(|_| format!("Invalid discovery port: {}", disc_port_str))?;
+    if let Some(enr_udp_port_str) = cli_args.value_of("enr-udp-port") {
+        client_config.network.enr_udp_port = Some(
+            enr_udp_port_str
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid discovery port: {}", enr_udp_port_str))?,
+        );
+    }
+
+    if cli_args.is_present("disable_enr_auto_update") {
+        client_config.network.discv5_config.enr_update = false;
     }
 
     if let Some(p2p_priv_key) = cli_args.value_of("p2p-priv-key") {
@@ -301,8 +307,8 @@ pub fn get_configs<E: EthSpec>(
      * Discovery address is set to localhost by default.
      */
     if cli_args.is_present("zero-ports") {
-        if client_config.network.discovery_address == Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))) {
-            client_config.network.discovery_address = None
+        if client_config.network.enr_address == Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))) {
+            client_config.network.enr_address = None
         }
         client_config.network.libp2p_port =
             unused_port("tcp").map_err(|e| format!("Failed to get port for libp2p: {}", e))?;
@@ -312,15 +318,6 @@ pub fn get_configs<E: EthSpec>(
         client_config.websocket_server.port = 0;
     }
 
-    // ENR IP needs to be explicit for node to be discoverable
-    if client_config.network.discovery_address == Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))) {
-        warn!(
-            log,
-            "Discovery address cannot be 0.0.0.0, Setting to to 127.0.0.1"
-        );
-        client_config.network.discovery_address =
-            Some("127.0.0.1".parse().expect("Valid IP address"))
-    }
     Ok((client_config, eth2_config, log))
 }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -116,6 +116,13 @@ pub fn get_configs<E: EthSpec>(
         client_config.network.discovery_port = port;
     }
 
+    if let Some(port_str) = cli_args.value_of("discovery-port") {
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid port: {}", port_str))?;
+        client_config.network.discovery_port = port;
+    }
+
     if let Some(boot_enr_str) = cli_args.value_of("boot-nodes") {
         client_config.network.boot_nodes = boot_enr_str
             .split(',')
@@ -157,6 +164,19 @@ pub fn get_configs<E: EthSpec>(
                 .parse::<u16>()
                 .map_err(|_| format!("Invalid discovery port: {}", enr_udp_port_str))?,
         );
+    }
+
+    if let Some(enr_tcp_port_str) = cli_args.value_of("enr-tcp-port") {
+        client_config.network.enr_tcp_port = Some(
+            enr_tcp_port_str
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid ENR TCP port: {}", enr_tcp_port_str))?,
+        );
+    }
+
+    if cli_args.is_present("enr-match") {
+        client_config.network.enr_address = Some(client_config.network.listen_address);
+        client_config.network.enr_udp_port = Some(client_config.network.discovery_port);
     }
 
     if cli_args.is_present("disable_enr_auto_update") {

--- a/eth2/operation_pool/src/lib.rs
+++ b/eth2/operation_pool/src/lib.rs
@@ -669,11 +669,16 @@ mod release_tests {
                     spec,
                     None,
                 );
-                op_pool.insert_attestation(att, &state.fork, spec).unwrap();
+                op_pool
+                    .insert_aggregate_attestation(att, &state.fork, spec)
+                    .unwrap();
             }
         }
 
-        assert_eq!(op_pool.attestations.read().len(), committees.len());
+        assert_eq!(
+            op_pool.aggregate_attestations.read().len(),
+            committees.len()
+        );
         assert_eq!(op_pool.num_attestations(), committees.len());
 
         // Before the min attestation inclusion delay, get_attestations shouldn't return anything.
@@ -701,13 +706,15 @@ mod release_tests {
         );
 
         // Prune attestations shouldn't do anything at this point.
-        op_pool.prune_attestations(state);
+        let epoch = state.slot.epoch(MainnetEthSpec::slots_per_epoch());
+        op_pool.prune_attestations(&epoch);
         assert_eq!(op_pool.num_attestations(), committees.len());
 
         // But once we advance to more than an epoch after the attestation, it should prune it
         // out of existence.
         state.slot += 2 * MainnetEthSpec::slots_per_epoch();
-        op_pool.prune_attestations(state);
+        let epoch = state.slot.epoch(MainnetEthSpec::slots_per_epoch());
+        op_pool.prune_attestations(&epoch);
         assert_eq!(op_pool.num_attestations(), 0);
     }
 
@@ -738,9 +745,11 @@ mod release_tests {
                 None,
             );
             op_pool
-                .insert_attestation(att.clone(), &state.fork, spec)
+                .insert_aggregate_attestation(att.clone(), &state.fork, spec)
                 .unwrap();
-            op_pool.insert_attestation(att, &state.fork, spec).unwrap();
+            op_pool
+                .insert_aggregate_attestation(att, &state.fork, spec)
+                .unwrap();
         }
 
         assert_eq!(op_pool.num_attestations(), committees.len());
@@ -777,13 +786,18 @@ mod release_tests {
                     spec,
                     None,
                 );
-                op_pool.insert_attestation(att, &state.fork, spec).unwrap();
+                op_pool
+                    .insert_aggregate_attestation(att, &state.fork, spec)
+                    .unwrap();
             }
         }
 
         // The attestations should get aggregated into two attestations that comprise all
         // validators.
-        assert_eq!(op_pool.attestations.read().len(), committees.len());
+        assert_eq!(
+            op_pool.aggregate_attestations.read().len(),
+            committees.len()
+        );
         assert_eq!(op_pool.num_attestations(), 2 * committees.len());
     }
 
@@ -825,7 +839,9 @@ mod release_tests {
                     spec,
                     if i == 0 { None } else { Some(0) },
                 );
-                op_pool.insert_attestation(att, &state.fork, spec).unwrap();
+                op_pool
+                    .insert_aggregate_attestation(att, &state.fork, spec)
+                    .unwrap();
             }
         };
 
@@ -840,7 +856,10 @@ mod release_tests {
         let num_small = target_committee_size / small_step_size;
         let num_big = target_committee_size / big_step_size;
 
-        assert_eq!(op_pool.attestations.read().len(), committees.len());
+        assert_eq!(
+            op_pool.aggregate_attestations.read().len(),
+            committees.len()
+        );
         assert_eq!(
             op_pool.num_attestations(),
             (num_small + num_big) * committees.len()
@@ -898,7 +917,9 @@ mod release_tests {
                     spec,
                     if i == 0 { None } else { Some(0) },
                 );
-                op_pool.insert_attestation(att, &state.fork, spec).unwrap();
+                op_pool
+                    .insert_aggregate_attestation(att, &state.fork, spec)
+                    .unwrap();
             }
         };
 
@@ -913,7 +934,10 @@ mod release_tests {
         let num_small = target_committee_size / small_step_size;
         let num_big = target_committee_size / big_step_size;
 
-        assert_eq!(op_pool.attestations.read().len(), committees.len());
+        assert_eq!(
+            op_pool.aggregate_attestations.read().len(),
+            committees.len()
+        );
         assert_eq!(
             op_pool.num_attestations(),
             (num_small + num_big) * committees.len()


### PR DESCRIPTION
## Overview

This PR provides a number of updates to lighthouse and discv5

Lighthouse is now able to configure discv5 to fine-tune the DHT. This is done via a `Discv5Config`. This allows us now to tweak and modify discv5 from within lighthouse. 

This update also removes NAT'd peers from our DHT, which should make peer lookups significantly faster.

The logic for how a local ENR is created and handled is also modified. If no specific IP/PORT is given, then it does not get specified in the ENR, unless the ENR updates itself (which, by default, will only happen if the peer isn't behing a NAT).

We have extra CLI functionality to prevent the automatic ENR IP/PORT address modification for users wishing to use a fixed static known external IP/PORT. 