### PR TITLE
Allow slot clock to handle clock disparity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "serde_yaml 0.8.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sloggers 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "slot_clock 0.1.0",
+ "slot_clock 0.2.0",
  "state_processing 0.1.0",
  "store 0.1.0",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -534,7 +534,7 @@ dependencies = [
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sloggers 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "slot_clock 0.1.0",
+ "slot_clock 0.2.0",
  "store 0.1.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3442,7 +3442,7 @@ dependencies = [
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slot_clock 0.1.0",
+ "slot_clock 0.2.0",
  "state_processing 0.1.0",
  "store 0.1.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3866,10 +3866,11 @@ dependencies = [
 
 [[package]]
 name = "slot_clock"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lighthouse_metrics 0.1.0",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "types 0.1.0",
 ]
 
@@ -4710,7 +4711,7 @@ dependencies = [
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "slot_clock 0.1.0",
+ "slot_clock 0.2.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/eth2/utils/slot_clock/Cargo.toml
+++ b/eth2/utils/slot_clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slot_clock"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
@@ -8,3 +8,4 @@ edition = "2018"
 types = { path = "../../types" }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
+parking_lot = "0.9.0"

--- a/eth2/utils/slot_clock/src/lib.rs
+++ b/eth2/utils/slot_clock/src/lib.rs
@@ -42,6 +42,9 @@ pub trait SlotClock: Send + Sync + Sized {
     /// Returns the duration until the first slot of the next epoch.
     fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration>;
 
+    /// Returns the duration between UNIX epoch and the start of the 0'th slot.
+    fn genesis_duration(&self) -> Duration;
+
     /// Indicates if the slot now is within (inclusive) the given `low_slot`
     /// and `high_slot`, accounting for a `tolerance` on either side of the
     /// range.
@@ -58,7 +61,8 @@ pub trait SlotClock: Send + Sync + Sized {
         }
 
         let to_duration = |slot: Slot| -> Option<Duration> {
-            Some(self.slot_duration() * slot.as_u64().try_into().ok()?)
+            let raw_duration = self.slot_duration() * slot.as_u64().try_into().ok()?;
+            raw_duration.checked_add(self.genesis_duration())
         };
 
         let high = to_duration(high_slot)?.checked_add(self.slot_duration())?;

--- a/eth2/utils/slot_clock/src/lib.rs
+++ b/eth2/utils/slot_clock/src/lib.rs
@@ -1,27 +1,37 @@
 #[macro_use]
 extern crate lazy_static;
 
+mod manual_slot_clock;
 mod metrics;
 mod system_time_slot_clock;
-mod testing_slot_clock;
 
 use std::time::Duration;
 
+pub use crate::manual_slot_clock::ManualSlotClock;
+pub use crate::manual_slot_clock::ManualSlotClock as TestingSlotClock;
 pub use crate::system_time_slot_clock::SystemTimeSlotClock;
-pub use crate::testing_slot_clock::TestingSlotClock;
 pub use metrics::scrape_for_metrics;
+use std::convert::TryInto;
 pub use types::Slot;
 
 /// A clock that reports the current slot.
 ///
 /// The clock is not required to be monotonically increasing and may go backwards.
 pub trait SlotClock: Send + Sync + Sized {
-    /// Creates a new slot clock where the first slot is `genesis_slot`, genesis occured
+    /// Creates a new slot clock where the first slot is `genesis_slot`, genesis occurred
     /// `genesis_duration` after the `UNIX_EPOCH` and each slot is `slot_duration` apart.
     fn new(genesis_slot: Slot, genesis_duration: Duration, slot_duration: Duration) -> Self;
 
     /// Returns the slot at this present time.
     fn now(&self) -> Option<Slot>;
+
+    /// Returns the present time as a duration since the UNIX epoch.
+    ///
+    /// Returns `None` if the present time is before the UNIX epoch (unlikely).
+    fn now_duration(&self) -> Option<Duration>;
+
+    /// Returns the slot of the given duration since the UNIX epoch.
+    fn slot_of(&self, now: Duration) -> Option<Slot>;
 
     /// Returns the duration between slots
     fn slot_duration(&self) -> Duration;
@@ -31,4 +41,30 @@ pub trait SlotClock: Send + Sync + Sized {
 
     /// Returns the duration until the first slot of the next epoch.
     fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration>;
+
+    /// Indicates if the slot now is within (inclusive) the given `low_slot`
+    /// and `high_slot`, accounting for a `tolerance` on either side of the
+    /// range.
+    ///
+    /// Returns `None` if:
+    ///
+    /// - The current slot is unknown.
+    /// - `low_slot > high_slot`
+    /// - The `high_slot` or `low_slot` are unable to be converted into a `u32`.
+    /// - There is an integer overflow during evaluation.
+    fn now_is_within(&self, low_slot: Slot, high_slot: Slot, tolerance: Duration) -> Option<bool> {
+        if low_slot > high_slot {
+            return None;
+        }
+
+        let to_duration = |slot: Slot| -> Option<Duration> {
+            Some(self.slot_duration() * slot.as_u64().try_into().ok()?)
+        };
+
+        let high = to_duration(high_slot)?.checked_add(self.slot_duration())?;
+        let low = to_duration(low_slot)?;
+        let now = self.now_duration()?;
+
+        Some(low <= now.checked_add(tolerance)? && now < high.checked_add(tolerance)?)
+    }
 }

--- a/eth2/utils/slot_clock/src/lib.rs
+++ b/eth2/utils/slot_clock/src/lib.rs
@@ -61,7 +61,9 @@ pub trait SlotClock: Send + Sync + Sized {
         }
 
         let to_duration = |slot: Slot| -> Option<Duration> {
-            let raw_duration = self.slot_duration() * slot.as_u64().try_into().ok()?;
+            let raw_duration = self
+                .slot_duration()
+                .checked_mul(slot.as_u64().try_into().ok()?)?;
             raw_duration.checked_add(self.genesis_duration())
         };
 

--- a/eth2/utils/slot_clock/src/manual_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/manual_slot_clock.rs
@@ -1,0 +1,202 @@
+use super::SlotClock;
+use parking_lot::RwLock;
+use std::convert::TryInto;
+use std::time::Duration;
+use types::Slot;
+
+/// Determines the present slot based upon a manually-incremented UNIX timestamp.
+pub struct ManualSlotClock {
+    genesis_slot: Slot,
+    /// Duration from UNIX epoch to genesis.
+    genesis_duration: Duration,
+    /// Duration from UNIX epoch to right now.
+    current_time: RwLock<Duration>,
+    /// The length of each slot.
+    slot_duration: Duration,
+}
+
+impl Clone for ManualSlotClock {
+    fn clone(&self) -> Self {
+        ManualSlotClock {
+            genesis_slot: self.genesis_slot.clone(),
+            genesis_duration: self.genesis_duration.clone(),
+            current_time: RwLock::new(self.current_time.read().clone()),
+            slot_duration: self.slot_duration.clone(),
+        }
+    }
+}
+
+impl ManualSlotClock {
+    pub fn set_slot(&self, slot: u64) {
+        let slots_since_genesis = slot
+            .checked_sub(self.genesis_slot.as_u64())
+            .expect("slot must be post-genesis")
+            .try_into()
+            .expect("slot must fit within a u32");
+        *self.current_time.write() =
+            self.genesis_duration + self.slot_duration * slots_since_genesis;
+    }
+
+    pub fn advance_slot(&self) {
+        self.set_slot(self.now().unwrap().as_u64() + 1)
+    }
+
+    pub fn duration_to_next_slot_from(&self, now: Duration) -> Option<Duration> {
+        let genesis = self.genesis_duration;
+
+        let slot_start = |slot: Slot| -> Duration {
+            let slot = slot.as_u64() as u32;
+            genesis + slot * self.slot_duration
+        };
+
+        if now >= genesis {
+            Some(
+                slot_start(self.slot_of(now)? + 1)
+                    .checked_sub(now)
+                    .expect("The next slot cannot start before now"),
+            )
+        } else {
+            Some(
+                genesis
+                    .checked_sub(now)
+                    .expect("Control flow ensures genesis is greater than or equal to now"),
+            )
+        }
+    }
+
+    pub fn duration_to_next_epoch_from(
+        &self,
+        now: Duration,
+        slots_per_epoch: u64,
+    ) -> Option<Duration> {
+        let genesis = self.genesis_duration;
+
+        let slot_start = |slot: Slot| -> Duration {
+            let slot = slot.as_u64() as u32;
+            genesis + slot * self.slot_duration
+        };
+
+        let epoch_start_slot = self
+            .now()
+            .map(|slot| slot.epoch(slots_per_epoch))
+            .map(|epoch| (epoch + 1).start_slot(slots_per_epoch))?;
+
+        if now >= genesis {
+            Some(
+                slot_start(epoch_start_slot)
+                    .checked_sub(now)
+                    .expect("The next epoch cannot start before now"),
+            )
+        } else {
+            Some(
+                genesis
+                    .checked_sub(now)
+                    .expect("Control flow ensures genesis is greater than or equal to now"),
+            )
+        }
+    }
+}
+
+impl SlotClock for ManualSlotClock {
+    fn new(genesis_slot: Slot, genesis_duration: Duration, slot_duration: Duration) -> Self {
+        if slot_duration.as_millis() == 0 {
+            panic!("ManualSlotClock cannot have a < 1ms slot duration");
+        }
+
+        Self {
+            genesis_slot,
+            current_time: RwLock::new(genesis_duration.clone()),
+            genesis_duration,
+            slot_duration,
+        }
+    }
+
+    fn now(&self) -> Option<Slot> {
+        self.slot_of(*self.current_time.read())
+    }
+
+    fn now_duration(&self) -> Option<Duration> {
+        Some(*self.current_time.read())
+    }
+
+    fn slot_of(&self, now: Duration) -> Option<Slot> {
+        let genesis = self.genesis_duration;
+
+        if now >= genesis {
+            let since_genesis = now
+                .checked_sub(genesis)
+                .expect("Control flow ensures now is greater than or equal to genesis");
+            let slot =
+                Slot::from((since_genesis.as_millis() / self.slot_duration.as_millis()) as u64);
+            Some(slot + self.genesis_slot)
+        } else {
+            None
+        }
+    }
+
+    fn duration_to_next_slot(&self) -> Option<Duration> {
+        self.duration_to_next_slot_from(*self.current_time.read())
+    }
+
+    fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration> {
+        self.duration_to_next_epoch_from(*self.current_time.read(), slots_per_epoch)
+    }
+
+    fn slot_duration(&self) -> Duration {
+        self.slot_duration
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slot_now() {
+        let clock = ManualSlotClock::new(
+            Slot::new(10),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        );
+        assert_eq!(clock.now(), Some(Slot::new(10)));
+        clock.set_slot(123);
+        assert_eq!(clock.now(), Some(Slot::new(123)));
+    }
+
+    #[test]
+    fn test_now_is_within() {
+        let clock =
+            ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), Duration::from_secs(1));
+
+        let now_is_within = |low: u64, high: u64, tolerance: Duration| -> bool {
+            clock
+                .now_is_within(Slot::from(low), Slot::from(high), tolerance)
+                .unwrap()
+        };
+
+        *clock.current_time.write() = Duration::from_secs(0);
+        assert!(now_is_within(0, 0, Duration::from_secs(0)));
+        assert!(now_is_within(0, 1, Duration::from_secs(0)));
+        assert!(now_is_within(0, 10, Duration::from_secs(0)));
+        assert!(!now_is_within(1, 1, Duration::from_secs(0)));
+        assert!(!now_is_within(1, 10, Duration::from_secs(0)));
+
+        *clock.current_time.write() = Duration::from_secs(1);
+        assert!(now_is_within(0, 1, Duration::from_secs(0)));
+        assert!(now_is_within(1, 1, Duration::from_secs(0)));
+        assert!(now_is_within(0, 10, Duration::from_secs(0)));
+        assert!(now_is_within(1, 10, Duration::from_secs(0)));
+        assert!(!now_is_within(0, 0, Duration::from_secs(0)));
+        assert!(!now_is_within(2, 3, Duration::from_secs(0)));
+
+        *clock.current_time.write() = Duration::from_millis(2200);
+        assert!(now_is_within(2, 2, Duration::from_millis(0)));
+        assert!(now_is_within(1, 1, Duration::from_millis(201)));
+        assert!(!now_is_within(1, 1, Duration::from_millis(200)));
+
+        *clock.current_time.write() = Duration::from_millis(2800);
+        assert!(now_is_within(2, 2, Duration::from_millis(0)));
+        assert!(now_is_within(3, 3, Duration::from_millis(200)));
+        assert!(!now_is_within(3, 3, Duration::from_millis(199)));
+    }
+}

--- a/eth2/utils/slot_clock/src/manual_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/manual_slot_clock.rs
@@ -142,7 +142,10 @@ impl SlotClock for ManualSlotClock {
         self.duration_to_next_epoch_from(*self.current_time.read(), slots_per_epoch)
     }
 
-    /// Returns the duration between UNIX epoch and the start of the 0'th slot.
+    fn genesis_slot(&self) -> Slot {
+        self.genesis_slot
+    }
+
     fn genesis_duration(&self) -> Duration {
         self.genesis_duration
     }
@@ -168,23 +171,27 @@ mod tests {
         assert_eq!(clock.now(), Some(Slot::new(123)));
     }
 
-    fn run_now_is_within_test(genesis: Duration) {
-        let clock = ManualSlotClock::new(Slot::new(0), genesis, Duration::from_secs(1));
+    fn run_now_is_within_test(genesis_slot: Slot, genesis_duration: Duration) {
+        let clock = ManualSlotClock::new(genesis_slot, genesis_duration, Duration::from_secs(1));
 
         let now_is_within = |low: u64, high: u64, tolerance: Duration| -> bool {
             clock
-                .now_is_within(Slot::from(low), Slot::from(high), tolerance)
+                .now_is_within(
+                    Slot::from(low) + genesis_slot,
+                    Slot::from(high) + genesis_slot,
+                    tolerance,
+                )
                 .unwrap()
         };
 
-        *clock.current_time.write() = genesis + Duration::from_secs(0);
+        *clock.current_time.write() = genesis_duration + Duration::from_secs(0);
         assert!(now_is_within(0, 0, Duration::from_secs(0)));
         assert!(now_is_within(0, 1, Duration::from_secs(0)));
         assert!(now_is_within(0, 10, Duration::from_secs(0)));
         assert!(!now_is_within(1, 1, Duration::from_secs(0)));
         assert!(!now_is_within(1, 10, Duration::from_secs(0)));
 
-        *clock.current_time.write() = genesis + Duration::from_secs(1);
+        *clock.current_time.write() = genesis_duration + Duration::from_secs(1);
         assert!(now_is_within(0, 1, Duration::from_secs(0)));
         assert!(now_is_within(1, 1, Duration::from_secs(0)));
         assert!(now_is_within(0, 10, Duration::from_secs(0)));
@@ -192,12 +199,12 @@ mod tests {
         assert!(!now_is_within(0, 0, Duration::from_secs(0)));
         assert!(!now_is_within(2, 3, Duration::from_secs(0)));
 
-        *clock.current_time.write() = genesis + Duration::from_millis(2200);
+        *clock.current_time.write() = genesis_duration + Duration::from_millis(2200);
         assert!(now_is_within(2, 2, Duration::from_millis(0)));
         assert!(now_is_within(1, 1, Duration::from_millis(201)));
         assert!(!now_is_within(1, 1, Duration::from_millis(200)));
 
-        *clock.current_time.write() = genesis + Duration::from_millis(2800);
+        *clock.current_time.write() = genesis_duration + Duration::from_millis(2800);
         assert!(now_is_within(2, 2, Duration::from_millis(0)));
         assert!(now_is_within(3, 3, Duration::from_millis(200)));
         assert!(!now_is_within(3, 3, Duration::from_millis(199)));
@@ -205,16 +212,22 @@ mod tests {
 
     #[test]
     fn test_now_is_within_genesis_0_secs() {
-        run_now_is_within_test(Duration::from_secs(0))
+        run_now_is_within_test(Slot::new(0), Duration::from_secs(0));
+        run_now_is_within_test(Slot::new(1), Duration::from_secs(0));
+        run_now_is_within_test(Slot::new(3), Duration::from_secs(0));
     }
 
     #[test]
     fn test_now_is_within_genesis_2_millis() {
-        run_now_is_within_test(Duration::from_millis(2))
+        run_now_is_within_test(Slot::new(0), Duration::from_millis(2));
+        run_now_is_within_test(Slot::new(1), Duration::from_millis(2));
+        run_now_is_within_test(Slot::new(3), Duration::from_millis(2));
     }
 
     #[test]
     fn test_now_is_within_genesis_1_secs() {
-        run_now_is_within_test(Duration::from_secs(1))
+        run_now_is_within_test(Slot::new(0), Duration::from_secs(1));
+        run_now_is_within_test(Slot::new(1), Duration::from_secs(1));
+        run_now_is_within_test(Slot::new(3), Duration::from_secs(1));
     }
 }

--- a/eth2/utils/slot_clock/src/manual_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/manual_slot_clock.rs
@@ -41,58 +41,47 @@ impl ManualSlotClock {
         self.set_slot(self.now().unwrap().as_u64() + 1)
     }
 
+    /// Returns the duration between UNIX epoch and the start of `slot`.
+    pub fn start_of(&self, slot: Slot) -> Option<Duration> {
+        let slot = slot
+            .as_u64()
+            .checked_sub(self.genesis_slot.as_u64())?
+            .try_into()
+            .ok()?;
+        let unadjusted_slot_duration = self.slot_duration.checked_mul(slot)?;
+
+        self.genesis_duration.checked_add(unadjusted_slot_duration)
+    }
+
+    /// Returns the duration from `now` until the start of `slot`.
+    ///
+    /// Will return `None` if `now` is later than the start of `slot`.
+    pub fn duration_to_slot(&self, slot: Slot, now: Duration) -> Option<Duration> {
+        self.start_of(slot)?.checked_sub(now)
+    }
+
+    /// Returns the duration between `now` and the start of the next slot.
     pub fn duration_to_next_slot_from(&self, now: Duration) -> Option<Duration> {
-        let genesis = self.genesis_duration;
-
-        let slot_start = |slot: Slot| -> Duration {
-            let slot = slot.as_u64() as u32;
-            genesis + slot * self.slot_duration
-        };
-
-        if now >= genesis {
-            Some(
-                slot_start(self.slot_of(now)? + 1)
-                    .checked_sub(now)
-                    .expect("The next slot cannot start before now"),
-            )
+        if now < self.genesis_duration {
+            self.genesis_duration.checked_sub(now)
         } else {
-            Some(
-                genesis
-                    .checked_sub(now)
-                    .expect("Control flow ensures genesis is greater than or equal to now"),
-            )
+            self.duration_to_slot(self.slot_of(now)? + 1, now)
         }
     }
 
+    /// Returns the duration between `now` and the start of the next epoch.
     pub fn duration_to_next_epoch_from(
         &self,
         now: Duration,
         slots_per_epoch: u64,
     ) -> Option<Duration> {
-        let genesis = self.genesis_duration;
-
-        let slot_start = |slot: Slot| -> Duration {
-            let slot = slot.as_u64() as u32;
-            genesis + slot * self.slot_duration
-        };
-
-        let epoch_start_slot = self
-            .now()
-            .map(|slot| slot.epoch(slots_per_epoch))
-            .map(|epoch| (epoch + 1).start_slot(slots_per_epoch))?;
-
-        if now >= genesis {
-            Some(
-                slot_start(epoch_start_slot)
-                    .checked_sub(now)
-                    .expect("The next epoch cannot start before now"),
-            )
+        if now < self.genesis_duration {
+            self.genesis_duration.checked_sub(now)
         } else {
-            Some(
-                genesis
-                    .checked_sub(now)
-                    .expect("Control flow ensures genesis is greater than or equal to now"),
-            )
+            let next_epoch_start_slot =
+                (self.slot_of(now)?.epoch(slots_per_epoch) + 1).start_slot(slots_per_epoch);
+
+            self.duration_to_slot(next_epoch_start_slot, now)
         }
     }
 }
@@ -165,6 +154,102 @@ mod tests {
         assert_eq!(clock.now(), Some(Slot::new(10)));
         clock.set_slot(123);
         assert_eq!(clock.now(), Some(Slot::new(123)));
+    }
+
+    #[test]
+    fn start_of() {
+        // Genesis slot and genesis duration 0.
+        let clock =
+            ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), Duration::from_secs(1));
+        assert_eq!(clock.start_of(Slot::new(0)), Some(Duration::from_secs(0)));
+        assert_eq!(clock.start_of(Slot::new(1)), Some(Duration::from_secs(1)));
+        assert_eq!(clock.start_of(Slot::new(2)), Some(Duration::from_secs(2)));
+
+        // Genesis slot 1 and genesis duration 10.
+        let clock = ManualSlotClock::new(
+            Slot::new(0),
+            Duration::from_secs(10),
+            Duration::from_secs(1),
+        );
+        assert_eq!(clock.start_of(Slot::new(0)), Some(Duration::from_secs(10)));
+        assert_eq!(clock.start_of(Slot::new(1)), Some(Duration::from_secs(11)));
+        assert_eq!(clock.start_of(Slot::new(2)), Some(Duration::from_secs(12)));
+
+        // Genesis slot 1 and genesis duration 0.
+        let clock =
+            ManualSlotClock::new(Slot::new(1), Duration::from_secs(0), Duration::from_secs(1));
+        assert_eq!(clock.start_of(Slot::new(0)), None);
+        assert_eq!(clock.start_of(Slot::new(1)), Some(Duration::from_secs(0)));
+        assert_eq!(clock.start_of(Slot::new(2)), Some(Duration::from_secs(1)));
+
+        // Genesis slot 1 and genesis duration 10.
+        let clock = ManualSlotClock::new(
+            Slot::new(1),
+            Duration::from_secs(10),
+            Duration::from_secs(1),
+        );
+        assert_eq!(clock.start_of(Slot::new(0)), None);
+        assert_eq!(clock.start_of(Slot::new(1)), Some(Duration::from_secs(10)));
+        assert_eq!(clock.start_of(Slot::new(2)), Some(Duration::from_secs(11)));
+    }
+
+    #[test]
+    fn test_duration_to_next_slot() {
+        let slot_duration = Duration::from_secs(1);
+
+        // Genesis time is now.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(0);
+        assert_eq!(clock.duration_to_next_slot(), Some(Duration::from_secs(1)));
+
+        // Genesis time is in the future.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(10), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(0);
+        assert_eq!(clock.duration_to_next_slot(), Some(Duration::from_secs(10)));
+
+        // Genesis time is in the past.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(10);
+        assert_eq!(clock.duration_to_next_slot(), Some(Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn test_duration_to_next_epoch() {
+        let slot_duration = Duration::from_secs(1);
+        let slots_per_epoch = 32;
+
+        // Genesis time is now.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(0);
+        assert_eq!(
+            clock.duration_to_next_epoch(slots_per_epoch),
+            Some(Duration::from_secs(32))
+        );
+
+        // Genesis time is in the future.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(10), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(0);
+        assert_eq!(
+            clock.duration_to_next_epoch(slots_per_epoch),
+            Some(Duration::from_secs(10))
+        );
+
+        // Genesis time is in the past.
+        let clock = ManualSlotClock::new(Slot::new(0), Duration::from_secs(0), slot_duration);
+        *clock.current_time.write() = Duration::from_secs(10);
+        assert_eq!(
+            clock.duration_to_next_epoch(slots_per_epoch),
+            Some(Duration::from_secs(22))
+        );
+
+        // Genesis time is in the past.
+        let clock = ManualSlotClock::new(
+            Slot::new(0),
+            Duration::from_secs(0),
+            Duration::from_secs(12),
+        );
+        *clock.current_time.write() = Duration::from_secs(72_333);
+        assert!(clock.duration_to_next_epoch(slots_per_epoch).is_some(),);
     }
 
     #[test]

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -1,4 +1,4 @@
-use super::SlotClock;
+use super::{ManualSlotClock, SlotClock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use types::Slot;
 
@@ -7,95 +7,41 @@ pub use std::time::SystemTimeError;
 /// Determines the present slot based upon the present system time.
 #[derive(Clone)]
 pub struct SystemTimeSlotClock {
-    genesis_slot: Slot,
-    genesis_duration: Duration,
-    slot_duration: Duration,
+    clock: ManualSlotClock,
 }
 
 impl SlotClock for SystemTimeSlotClock {
     fn new(genesis_slot: Slot, genesis_duration: Duration, slot_duration: Duration) -> Self {
-        if slot_duration.as_millis() == 0 {
-            panic!("SystemTimeSlotClock cannot have a < 1ms slot duration.");
-        }
-
         Self {
-            genesis_slot,
-            genesis_duration,
-            slot_duration,
+            clock: ManualSlotClock::new(genesis_slot, genesis_duration, slot_duration),
         }
     }
 
     fn now(&self) -> Option<Slot> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-        let genesis = self.genesis_duration;
+        self.clock.slot_of(now)
+    }
 
-        if now >= genesis {
-            let since_genesis = now
-                .checked_sub(genesis)
-                .expect("Control flow ensures now is greater than or equal to genesis");
-            let slot =
-                Slot::from((since_genesis.as_millis() / self.slot_duration.as_millis()) as u64);
-            Some(slot + self.genesis_slot)
-        } else {
-            None
-        }
+    fn now_duration(&self) -> Option<Duration> {
+        SystemTime::now().duration_since(UNIX_EPOCH).ok()
+    }
+
+    fn slot_of(&self, now: Duration) -> Option<Slot> {
+        self.clock.slot_of(now)
     }
 
     fn duration_to_next_slot(&self) -> Option<Duration> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-        let genesis = self.genesis_duration;
-
-        let slot_start = |slot: Slot| -> Duration {
-            let slot = slot.as_u64() as u32;
-            genesis + slot * self.slot_duration
-        };
-
-        if now >= genesis {
-            Some(
-                slot_start(self.now()? + 1)
-                    .checked_sub(now)
-                    .expect("The next slot cannot start before now"),
-            )
-        } else {
-            Some(
-                genesis
-                    .checked_sub(now)
-                    .expect("Control flow ensures genesis is greater than or equal to now"),
-            )
-        }
+        self.clock.duration_to_next_slot_from(now)
     }
 
     fn duration_to_next_epoch(&self, slots_per_epoch: u64) -> Option<Duration> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-        let genesis = self.genesis_duration;
-
-        let slot_start = |slot: Slot| -> Duration {
-            let slot = slot.as_u64() as u32;
-            genesis + slot * self.slot_duration
-        };
-
-        let epoch_start_slot = self
-            .now()
-            .map(|slot| slot.epoch(slots_per_epoch))
-            .map(|epoch| (epoch + 1).start_slot(slots_per_epoch))?;
-
-        if now >= genesis {
-            Some(
-                slot_start(epoch_start_slot)
-                    .checked_sub(now)
-                    .expect("The next epoch cannot start before now"),
-            )
-        } else {
-            Some(
-                genesis
-                    .checked_sub(now)
-                    .expect("Control flow ensures genesis is greater than or equal to now"),
-            )
-        }
+        self.clock.duration_to_next_epoch_from(now, slots_per_epoch)
     }
 
     fn slot_duration(&self) -> Duration {
-        self.slot_duration
+        self.clock.slot_duration()
     }
 }
 

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -40,7 +40,10 @@ impl SlotClock for SystemTimeSlotClock {
         self.clock.duration_to_next_epoch_from(now, slots_per_epoch)
     }
 
-    /// Returns the duration between UNIX epoch and the start of the 0'th slot.
+    fn genesis_slot(&self) -> Slot {
+        self.clock.genesis_slot()
+    }
+
     fn genesis_duration(&self) -> Duration {
         self.clock.genesis_duration()
     }

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -40,6 +40,11 @@ impl SlotClock for SystemTimeSlotClock {
         self.clock.duration_to_next_epoch_from(now, slots_per_epoch)
     }
 
+    /// Returns the duration between UNIX epoch and the start of the 0'th slot.
+    fn genesis_duration(&self) -> Duration {
+        self.clock.genesis_duration()
+    }
+
     fn slot_duration(&self) -> Duration {
         self.clock.slot_duration()
     }

--- a/eth2/utils/slot_clock/src/system_time_slot_clock.rs
+++ b/eth2/utils/slot_clock/src/system_time_slot_clock.rs
@@ -40,16 +40,12 @@ impl SlotClock for SystemTimeSlotClock {
         self.clock.duration_to_next_epoch_from(now, slots_per_epoch)
     }
 
-    fn genesis_slot(&self) -> Slot {
-        self.clock.genesis_slot()
-    }
-
-    fn genesis_duration(&self) -> Duration {
-        self.clock.genesis_duration()
-    }
-
     fn slot_duration(&self) -> Duration {
         self.clock.slot_duration()
+    }
+
+    fn genesis_slot(&self) -> Slot {
+        self.clock.genesis_slot()
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Resolves #938

## Proposed Changes

This PR is based off initial work by @michaelsproul.

The purpose is to provide functions for checking that blocks/attestations are within some slot range with a tolerance (`MAXIMUM_GOSSIP_CLOCK_DISPARITY`), as specified in the [v0.11.0 networking spec](https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/p2p-interface.md#global-topics).
