### PR TITLE
Github: Add version to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,6 +2,11 @@
 
 Please provide a brief description of the issue.
 
+## Version
+
+Please provide your Lighthouse and Rust version. Are you building from
+`master`, which commit?
+
 ## Present Behaviour
 
 Describe the present behaviour of the application, with regards to this


### PR DESCRIPTION
## Issue Addressed

There is no underlying issue addressed.

## Proposed Changes

I propose to query the lighthouse and rust version in the Github issue template.

## Additional Info

Usually, you always want to ask "Did you try turning it off and on again?" and "Which version/branch are you running?"
