### PR TITLE
Enable --eth1 flag when --eth1-endpoint is suppilied

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -187,7 +187,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("eth1-endpoint")
                 .long("eth1-endpoint")
                 .value_name("HTTP-ENDPOINT")
-                .help("Specifies the server for a web3 connection to the Eth1 chain.")
+                .help("Specifies the server for a web3 connection to the Eth1 chain. Also enables the --eth1 flag.")
                 .takes_value(true)
                 .default_value("http://127.0.0.1:8545")
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -216,6 +216,7 @@ pub fn get_configs<E: EthSpec>(
 
     // Defines the URL to reach the eth1 node.
     if let Some(val) = cli_args.value_of("eth1-endpoint") {
+        client_config.sync_eth1_chain = true;
         client_config.eth1.endpoint = val.to_string();
     }
 


### PR DESCRIPTION
## Issue Addressed

Addresses a comment raised here: https://github.com/sigp/lighthouse/issues/936#issuecomment-601142201

## Proposed Changes

Enables the `--eth1` functionality when the `--eth1-endpoint` flag is supplied. It seems reasonable to assume that supplying an eth1-endpoint means you wish to use it.
