### PR TITLE
Fix race condition in the syncing sim

### DIFF
--- a/tests/simulator/src/local_network.rs
+++ b/tests/simulator/src/local_network.rs
@@ -94,7 +94,7 @@ impl<E: EthSpec> LocalNetwork<E> {
                         .expect("bootnode must have a network"),
                 );
             })
-            .expect("should have atleast one node");
+            .expect("should have at least one node");
 
         let index = self.beacon_nodes.read().len();
 

--- a/tests/simulator/src/sync_sim.rs
+++ b/tests/simulator/src/sync_sim.rs
@@ -94,8 +94,10 @@ pub fn verify_two_nodes_sync<E: EthSpec>(
         // Add beacon nodes
         network
             .add_beacon_node(beacon_config.clone())
-            .join(network.add_beacon_node(beacon_config.clone()))
-            .map(|_| network)
+            .map(|_| (network, beacon_config))
+            .and_then(|(network, beacon_config)| {
+                network.add_beacon_node(beacon_config).map(|_| network)
+            })
     })
     .and_then(move |network| {
         // Delay for `sync_delay` epochs before verifying synced state.

--- a/tests/simulator/src/sync_sim.rs
+++ b/tests/simulator/src/sync_sim.rs
@@ -130,8 +130,10 @@ pub fn verify_in_between_sync<E: EthSpec>(
         // Add a beacon node
         network
             .add_beacon_node(beacon_config.clone())
-            .join(network.add_beacon_node(beacon_config.clone()))
-            .map(|_| network)
+            .map(|_| (network, beacon_config))
+            .and_then(|(network, beacon_config)| {
+                network.add_beacon_node(beacon_config).map(|_| network)
+            })
     })
     .and_then(move |network| {
         // Delay before adding additional syncing nodes.


### PR DESCRIPTION
## Issue Addressed

The syncing sim had a race condition where it was reading nodes from  a RwLock without waiting for the write update. This meant that multiple nodes being added had the same node_id, which is really annoying to debug.
