### PR TITLE
Fix bug when resuming from DB prior to genesis

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -178,6 +178,19 @@ where
             .map_err(|e| format!("DB error whilst reading eth1 cache: {:?}", e))
     }
 
+    /// Returns true if `self.store` contains a persisted beacon chain.
+    pub fn store_contains_beacon_chain(&self) -> Result<bool, String> {
+        let store = self
+            .store
+            .clone()
+            .ok_or_else(|| "load_from_store requires a store.".to_string())?;
+
+        Ok(store
+            .get::<PersistedBeaconChain>(&Hash256::from_slice(&BEACON_CHAIN_DB_KEY))
+            .map_err(|e| format!("DB error when reading persisted beacon chain: {:?}", e))?
+            .is_some())
+    }
+
     /// Attempt to load an existing chain from the builder's `Store`.
     ///
     /// May initialize several components; including the op_pool and finalized checkpoints.

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -116,7 +116,7 @@ where
     /// called later in order to actually instantiate the `BeaconChain`.
     pub fn beacon_chain_builder(
         mut self,
-        mut client_genesis: ClientGenesis,
+        client_genesis: ClientGenesis,
         config: ClientConfig,
     ) -> impl Future<Item = Self, Error = String> {
         let store = self.store.clone();
@@ -151,18 +151,25 @@ where
                 Ok((builder, spec, context))
             })
             .and_then(move |(builder, spec, context)| {
-                if client_genesis == ClientGenesis::Resume
-                    && !builder
-                        .store_contains_beacon_chain()
-                        .unwrap_or_else(|_| false)
-                {
-                    client_genesis = ClientGenesis::default();
-                    info!(
-                        context.log,
-                        "Using default genesis method";
-                        "method" => format!("{:?}", client_genesis)
-                    );
-                }
+                let chain_exists = builder
+                    .store_contains_beacon_chain()
+                    .unwrap_or_else(|_| false);
+
+                // If the client is expect to resume but there's no beacon chain in the database,
+                // use the `DepositContract` method. This scenario is quite common when the client
+                // is shutdown before finding genesis via eth1.
+                //
+                // Alternatively, if there's a beacon chain in the database then always resume
+                // using it.
+                let client_genesis = if client_genesis == ClientGenesis::Resume && !chain_exists {
+                    info!(context.log, "Defaulting to deposit contract genesis");
+
+                    ClientGenesis::DepositContract
+                } else if chain_exists {
+                    ClientGenesis::Resume
+                } else {
+                    client_genesis
+                };
 
                 let genesis_state_future: Box<dyn Future<Item = _, Error = _> + Send> =
                     match client_genesis {

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -12,7 +12,7 @@ const TESTNET_SPEC_CONSTANTS: &str = "minimal";
 const DEFAULT_FREEZER_DB_DIR: &str = "freezer_db";
 
 /// Defines how the client should initialize the `BeaconChain` and other components.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub enum ClientGenesis {
     /// Reads the genesis state and other persisted data from the `Store`.
     Resume,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

When trying to generate a genesis state from the eth1 chain, if the user exited before genesis had been found the next time they started an error would be returned saying there's no persisted beacon chain in the database.

This PR adds the following logic:

1. If the client is supposed to resume but there's no `PersistedBeaconChain` in the database, then use the `DepositContract` method to start.
1. _Always_ resume from the DB if it contains a `PersistedBeaconChain`.

(1) is not perfect, since it's possible that the user started with some other genesis method (e.g., `SszFile`) and then exited _just_ before the `BeaconChain` was created and persisted to disk. With this code, the next time they boot they'll be forced to the `DepositContract` start method. Fixing this edge case is non-trivial and I think this PR is an improvement from what we have now.