### PR TITLE
Don't override the fork in `lcli eth1-genesis` 

### DIFF
--- a/lcli/src/eth1_genesis.rs
+++ b/lcli/src/eth1_genesis.rs
@@ -28,7 +28,7 @@ pub fn run<T: EthSpec>(mut env: Environment<T>, matches: &ArgMatches) -> Result<
     let mut eth2_testnet_config: Eth2TestnetConfig<T> =
         Eth2TestnetConfig::load(testnet_dir.clone())?;
 
-    let mut spec = eth2_testnet_config
+    let spec = eth2_testnet_config
         .yaml_config
         .as_ref()
         .ok_or_else(|| "The testnet directory must contain a spec config".to_string())?
@@ -39,8 +39,6 @@ pub fn run<T: EthSpec>(mut env: Environment<T>, matches: &ArgMatches) -> Result<
                 &env.core_context().eth2_config.spec_constants
             )
         })?;
-
-    spec.genesis_fork_version = [1, 3, 3, 7];
 
     let mut config = Eth1Config::default();
     config.endpoint = endpoint.to_string();

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -32,6 +32,7 @@ fn main() {
         .arg(
             Arg::with_name("spec")
                 .short("s")
+                .long("spec")
                 .value_name("STRING")
                 .takes_value(true)
                 .required(true)


### PR DESCRIPTION
## Issue Addressed

- Resolves #947

## Proposed Changes

Don't override the genesis fork in the `lcli eth1-genesis` command. Before this fix, if the fork was different to `[1, 3, 3, 7]` then all deposits will be declared invalid and genesis will never trigger. This was a relic from before `GENESIS_FORK_VERSION` was included as a constant.

Also, allows for `--spec` as well as `-s`. I noticed that @q9f was using this on their [blog](https://dev.to/q9/how-to-run-your-own-beacon-chain-e70) but it wasn't supported by us. It makes sense, I added it.

I used the above blog post to generate the same testnet dir used by @q9f and successfully produced a genesis state. See below:

```
lcli eth1-genesis --eth1-endpoint https://rpc.goerli.mudit.blog/ --testnet-dir ~/.lighthouse/schlesi

2020-03-23 18:11:47,354 INFO  [lcli::eth1_genesis] Starting service to produce genesis BeaconState from eth1
2020-03-23 18:11:47,354 INFO  [lcli::eth1_genesis] Connecting to eth1 http endpoint: https://rpc.goerli.mudit.blog/
Mar 23 18:12:04.661 DEBG No eth1 genesis block found             cache_head: None, cached_deposits: 0, cached_blocks: 0, min_validator_count: 16, min_genesis_time: 1584316800, latest_block_timestamp: None
Mar 23 18:12:21.714 DEBG No eth1 genesis block found             cache_head: None, cached_deposits: 0, cached_blocks: 0, min_validator_count: 16, min_genesis_time: 1584316800, latest_block_timestamp: None
Mar 23 18:12:39.007 INFO Minimum genesis deposit count met       block_number: 2366961, deposit_count: 16
Mar 23 18:12:49.362 TRCE Eth1 block inspected for genesis        validators: 16, active_validators: 16
Mar 23 18:12:49.362 DEBG All genesis conditions met              eth1_block_height: 2366961
Mar 23 18:12:49.446 INFO Deposit contract genesis complete       validator_count: 16, eth1_block_height: 2366961
```