### PR TITLE
V0.11.0 network update

### DIFF
--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -1,4 +1,4 @@
-use crate::types::{GossipEncoding, GossipKind, GossipTopic};
+use crate::types::GossipKind;
 use crate::Enr;
 use libp2p::discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub::{GossipsubConfig, GossipsubConfigBuilder, GossipsubMessage, MessageId};
@@ -61,7 +61,7 @@ pub struct Config {
     pub client_version: String,
 
     /// List of extra topics to initially subscribe to as strings.
-    pub topics: Vec<GossipTopic>,
+    pub topics: Vec<GossipKind>,
 
     /// Introduces randomization in network propagation of messages. This should only be set for
     /// testing purposes and will likely be removed in future versions.
@@ -78,11 +78,11 @@ impl Default for Config {
 
         // The default topics that we will initially subscribe to
         let topics = vec![
-            GossipTopic::new(GossipKind::BeaconBlock, GossipEncoding::SSZ),
-            GossipTopic::new(GossipKind::BeaconAggregateAndProof, GossipEncoding::SSZ),
-            GossipTopic::new(GossipKind::VoluntaryExit, GossipEncoding::SSZ),
-            GossipTopic::new(GossipKind::ProposerSlashing, GossipEncoding::SSZ),
-            GossipTopic::new(GossipKind::AttesterSlashing, GossipEncoding::SSZ),
+            GossipKind::BeaconBlock,
+            GossipKind::BeaconAggregateAndProof,
+            GossipKind::VoluntaryExit,
+            GossipKind::ProposerSlashing,
+            GossipKind::AttesterSlashing,
         ];
 
         // The function used to generate a gossipsub message id

--- a/beacon_node/eth2-libp2p/src/lib.rs
+++ b/beacon_node/eth2-libp2p/src/lib.rs
@@ -16,7 +16,7 @@ pub mod types;
 // shift this type into discv5
 pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;
 
-pub use crate::types::{error, GossipTopic, NetworkGlobals, PeerInfo, PubsubData, PubsubMessage};
+pub use crate::types::{error, GossipTopic, NetworkGlobals, PeerInfo, PubsubMessage};
 pub use config::Config as NetworkConfig;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr};

--- a/beacon_node/eth2-libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/methods.rs
@@ -13,7 +13,7 @@ pub type RequestId = usize;
 #[derive(Encode, Decode, Clone, Debug, PartialEq)]
 pub struct StatusMessage {
     /// The fork version of the chain we are broadcasting.
-    pub fork_version: [u8; 4],
+    pub fork_digest: [u8; 4],
 
     /// Latest finalized root.
     pub finalized_root: Hash256,
@@ -101,9 +101,6 @@ impl ssz::Decode for GoodbyeReason {
 /// Request a number of beacon block roots from a peer.
 #[derive(Encode, Decode, Clone, Debug, PartialEq)]
 pub struct BlocksByRangeRequest {
-    /// The hash tree root of a block on the requested chain.
-    pub head_block_root: Hash256,
-
     /// The starting slot to request blocks.
     pub start_slot: u64,
 
@@ -238,7 +235,7 @@ impl ErrorMessage {
 
 impl std::fmt::Display for StatusMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Status Message: Fork Version: {:?}, Finalized Root: {}, Finalized Epoch: {}, Head Root: {}, Head Slot: {}", self.fork_version, self.finalized_root, self.finalized_epoch, self.head_root, self.head_slot)
+        write!(f, "Status Message: Fork Digest: {:?}, Finalized Root: {}, Finalized Epoch: {}, Head Root: {}, Head Slot: {}", self.fork_digest, self.finalized_root, self.finalized_epoch, self.head_root, self.head_slot)
     }
 }
 
@@ -283,8 +280,8 @@ impl std::fmt::Display for BlocksByRangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Head Block Root: {},  Start Slot: {}, Count: {}, Step: {}",
-            self.head_block_root, self.start_slot, self.count, self.step
+            "Start Slot: {}, Count: {}, Step: {}",
+            self.start_slot, self.count, self.step
         )
     }
 }

--- a/beacon_node/eth2-libp2p/src/types/mod.rs
+++ b/beacon_node/eth2-libp2p/src/types/mod.rs
@@ -6,5 +6,5 @@ mod topics;
 
 pub use globals::NetworkGlobals;
 pub use peer_info::{EnrBitfield, PeerInfo};
-pub use pubsub::{PubsubData, PubsubMessage};
+pub use pubsub::PubsubMessage;
 pub use topics::{GossipEncoding, GossipKind, GossipTopic};

--- a/beacon_node/eth2-libp2p/src/types/topics.rs
+++ b/beacon_node/eth2-libp2p/src/types/topics.rs
@@ -23,11 +23,14 @@ pub const ATTESTER_SLASHING_TOPIC: &str = "attester_slashing";
 pub struct GossipTopic {
     /// The encoding of the topic.
     encoding: GossipEncoding,
+    /// The fork digest of the topic,
+    fork_digest: [u8; 4],
     /// The kind of topic.
     kind: GossipKind,
 }
 
 /// Enum that brings these topics into the rust type system.
+// NOTE: There is intentionally no unknown type here. We only allow known gossipsub topics.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum GossipKind {
     /// Topic for publishing beacon blocks.
@@ -44,6 +47,19 @@ pub enum GossipKind {
     AttesterSlashing,
 }
 
+impl std::fmt::Display for GossipKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GossipKind::BeaconBlock => write!(f, "beacon_block"),
+            GossipKind::BeaconAggregateAndProof => write!(f, "beacon_aggregate_and_proof"),
+            GossipKind::CommitteeIndex(subnet_id) => write!(f, "committee_index_{}", **subnet_id),
+            GossipKind::VoluntaryExit => write!(f, "voluntary_exit"),
+            GossipKind::ProposerSlashing => write!(f, "proposer_slashing"),
+            GossipKind::AttesterSlashing => write!(f, "attester_slashing"),
+        }
+    }
+}
+
 /// The known encoding types for gossipsub messages.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum GossipEncoding {
@@ -52,13 +68,22 @@ pub enum GossipEncoding {
 }
 
 impl GossipTopic {
-    pub fn new(kind: GossipKind, encoding: GossipEncoding) -> Self {
-        GossipTopic { encoding, kind }
+    pub fn new(kind: GossipKind, encoding: GossipEncoding, fork_digest: [u8; 4]) -> Self {
+        GossipTopic {
+            encoding,
+            kind,
+            fork_digest,
+        }
     }
 
     /// Returns the encoding type for the gossipsub topic.
     pub fn encoding(&self) -> &GossipEncoding {
         &self.encoding
+    }
+
+    /// Returns a mutable reference to the fork digest of the gossipsub topic.
+    pub fn digest(&mut self) -> &mut [u8; 4] {
+        &mut self.fork_digest
     }
 
     /// Returns the kind of message expected on the gossipsub topic.
@@ -68,12 +93,25 @@ impl GossipTopic {
 
     pub fn decode(topic: &str) -> Result<Self, String> {
         let topic_parts: Vec<&str> = topic.split('/').collect();
-        if topic_parts.len() == 4 && topic_parts[1] == TOPIC_PREFIX {
-            let encoding = match topic_parts[3] {
+        if topic_parts.len() == 5 && topic_parts[1] == TOPIC_PREFIX {
+            let digest_bytes = hex::decode(topic_parts[2])
+                .map_err(|e| format!("Could not decode fork_digest hex: {}", e))?;
+
+            if digest_bytes.len() != 4 {
+                return Err(format!(
+                    "Invalid gossipsub fork digest size: {}",
+                    digest_bytes.len()
+                ));
+            }
+
+            let mut fork_digest = [0; 4];
+            fork_digest.copy_from_slice(&digest_bytes);
+
+            let encoding = match topic_parts[4] {
                 SSZ_ENCODING_POSTFIX => GossipEncoding::SSZ,
                 _ => return Err(format!("Unknown encoding: {}", topic)),
             };
-            let kind = match topic_parts[2] {
+            let kind = match topic_parts[3] {
                 BEACON_BLOCK_TOPIC => GossipKind::BeaconBlock,
                 BEACON_AGGREGATE_AND_PROOF_TOPIC => GossipKind::BeaconAggregateAndProof,
                 VOLUNTARY_EXIT_TOPIC => GossipKind::VoluntaryExit,
@@ -85,7 +123,11 @@ impl GossipTopic {
                 },
             };
 
-            return Ok(GossipTopic { encoding, kind });
+            return Ok(GossipTopic {
+                encoding,
+                kind,
+                fork_digest,
+            });
         }
 
         Err(format!("Unknown topic: {}", topic))
@@ -115,7 +157,13 @@ impl Into<String> for GossipTopic {
                 COMMITEE_INDEX_TOPIC_PREFIX, *index, COMMITEE_INDEX_TOPIC_POSTFIX
             ),
         };
-        format!("/{}/{}/{}", TOPIC_PREFIX, kind, encoding)
+        format!(
+            "/{}/{}/{}/{}",
+            TOPIC_PREFIX,
+            hex::encode(self.fork_digest),
+            kind,
+            encoding
+        )
     }
 }
 

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -29,7 +29,7 @@ fn test_status_rpc() {
 
     // Dummy STATUS RPC message
     let rpc_request = RPCRequest::Status(StatusMessage {
-        fork_version: [0; 4],
+        fork_digest: [0; 4],
         finalized_root: Hash256::from_low_u64_be(0),
         finalized_epoch: Epoch::new(1),
         head_root: Hash256::from_low_u64_be(0),
@@ -38,7 +38,7 @@ fn test_status_rpc() {
 
     // Dummy STATUS RPC message
     let rpc_response = RPCResponse::Status(StatusMessage {
-        fork_version: [0; 4],
+        fork_digest: [0; 4],
         finalized_root: Hash256::from_low_u64_be(0),
         finalized_epoch: Epoch::new(1),
         head_root: Hash256::from_low_u64_be(0),
@@ -142,7 +142,6 @@ fn test_blocks_by_range_chunked_rpc() {
 
     // BlocksByRange Request
     let rpc_request = RPCRequest::BlocksByRange(BlocksByRangeRequest {
-        head_block_root: Hash256::from_low_u64_be(0),
         start_slot: 0,
         count: messages_to_send,
         step: 0,
@@ -275,7 +274,6 @@ fn test_blocks_by_range_single_empty_rpc() {
 
     // BlocksByRange Request
     let rpc_request = RPCRequest::BlocksByRange(BlocksByRangeRequest {
-        head_block_root: Hash256::from_low_u64_be(0),
         start_slot: 0,
         count: 10,
         step: 0,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -43,7 +43,7 @@ impl<T: EthSpec> SyncNetworkContext<T> {
                     self.log,
                     "Sending Status Request";
                     "peer" => format!("{:?}", peer_id),
-                    "fork_version" => format!("{:?}", status_message.fork_version),
+                    "fork_digest" => format!("{:?}", status_message.fork_digest),
                     "finalized_root" => format!("{:?}", status_message.finalized_root),
                     "finalized_epoch" => format!("{:?}", status_message.finalized_epoch),
                     "head_root" => format!("{}", status_message.head_root),

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -9,7 +9,7 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::Sub;
-use types::{EthSpec, Hash256, SignedBeaconBlock, Slot};
+use types::{EthSpec, SignedBeaconBlock, Slot};
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct BatchId(pub u64);
@@ -41,8 +41,6 @@ pub struct Batch<T: EthSpec> {
     pub start_slot: Slot,
     /// The requested end slot of batch, exclusive.
     pub end_slot: Slot,
-    /// The hash of the chain root to requested from the peer.
-    pub head_root: Hash256,
     /// The peer that was originally assigned to the batch.
     pub original_peer: PeerId,
     /// The peer that is currently assigned to the batch.
@@ -61,18 +59,11 @@ pub struct Batch<T: EthSpec> {
 impl<T: EthSpec> Eq for Batch<T> {}
 
 impl<T: EthSpec> Batch<T> {
-    pub fn new(
-        id: BatchId,
-        start_slot: Slot,
-        end_slot: Slot,
-        head_root: Hash256,
-        peer_id: PeerId,
-    ) -> Self {
+    pub fn new(id: BatchId, start_slot: Slot, end_slot: Slot, peer_id: PeerId) -> Self {
         Batch {
             id,
             start_slot,
             end_slot,
-            head_root,
             original_peer: peer_id.clone(),
             current_peer: peer_id,
             retries: 0,
@@ -84,7 +75,6 @@ impl<T: EthSpec> Batch<T> {
 
     pub fn to_blocks_by_range_request(&self) -> BlocksByRangeRequest {
         BlocksByRangeRequest {
-            head_block_root: self.head_root,
             start_slot: self.start_slot.into(),
             count: std::cmp::min(BLOCKS_PER_BATCH, self.end_slot.sub(self.start_slot).into()),
             step: 1,

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -449,7 +449,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             "end_slot" => batch.end_slot,
             "id" => *batch.id,
             "peer" => format!("{}", batch.current_peer),
-            "head_root"=> format!("{}", batch.head_root),
             "retries" => batch.retries,
             "re-processes" =>  batch.reprocess_retries);
         self.send_batch(network, batch);
@@ -578,8 +577,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 "start_slot" => batch.start_slot,
                 "end_slot" => batch.end_slot,
                 "id" => *batch.id,
-                "peer" => format!("{:?}", batch.current_peer),
-                "head_root"=> format!("{}", batch.head_root));
+                "peer" => format!("{:?}", batch.current_peer));
             self.send_batch(network, batch);
             ProcessingResult::KeepChain
         }
@@ -603,8 +601,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                     "start_slot" => batch.start_slot,
                     "end_slot" => batch.end_slot,
                     "id" => *batch.id,
-                    "peer" => format!("{}", batch.current_peer),
-                    "head_root"=> format!("{}", batch.head_root));
+                    "peer" => format!("{}", batch.current_peer));
                 // send the batch
                 self.send_batch(network, batch);
                 return true;
@@ -675,7 +672,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             batch_id,
             batch_start_slot,
             batch_end_slot,
-            self.target_head_root,
             peer_id,
         ))
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -126,14 +126,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("topics")
-                .long("topics")
-                .value_name("STRING")
-                .help("One or more comma-delimited gossipsub topic strings to subscribe to. Default \
-                       is determined automatically.")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("libp2p-addresses")
                 .long("libp2p-addresses")
                 .value_name("MULTIADDR")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1,7 +1,7 @@
 use clap::ArgMatches;
 use client::{config::DEFAULT_DATADIR, ClientConfig, ClientGenesis, Eth2Config};
 use eth2_config::{read_from_file, write_to_file};
-use eth2_libp2p::{Enr, GossipTopic, Multiaddr};
+use eth2_libp2p::{Enr, Multiaddr};
 use eth2_testnet_config::Eth2TestnetConfig;
 use genesis::recent_genesis_time;
 use rand::{distributions::Alphanumeric, Rng};
@@ -139,15 +139,6 @@ pub fn get_configs<E: EthSpec>(
                     .map_err(|_| format!("Invalid Multiaddr: {}", multiaddr))
             })
             .collect::<Result<Vec<Multiaddr>>>()?;
-    }
-
-    if let Some(topics_str) = cli_args.value_of("topics") {
-        let mut topics = Vec::new();
-        let topic_list = topics_str.split(',').collect::<Vec<_>>();
-        for topic_str in topic_list {
-            topics.push(GossipTopic::decode(topic_str)?);
-        }
-        client_config.network.topics = topics;
     }
 
     if let Some(enr_address_str) = cli_args.value_of("enr-address") {


### PR DESCRIPTION
Updates the networking side to v0.11.0. 

- Removes `head-block-root` from `blocks_by_range` requests
- Modifies status message to use `fork_digest`
- Mixes in `fork-digest` into the `STATUS` RPC message

Updates fork upgrade logic to unsubscribe/re-subscribe on a fork change

Resolves #957 
