### PR TITLE
order of operations fix in the duration_to_next_slot calculation

### DIFF
--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -311,13 +311,13 @@ impl<T: BeaconChainTypes> AttestationService<T> {
                         .saturating_sub(current_slot)
                         .saturating_sub(1u64);
 
-                    duration_to_next_slot
-                        .checked_add(slot_duration)
-                        .ok_or_else(|| "Overflow in adding slot_duration attestation time")?
+                    slot_duration
                         .checked_mul(slots_until_subscribe.as_u64() as u32)
                         .ok_or_else(|| {
                             "Overflow in multiplying number of slots in attestation time"
                         })?
+                        .checked_add(duration_to_next_slot)
+                        .ok_or_else(|| "Overflow in adding duration_to_next_slot attestation time")?
                         .checked_sub(advance_subscription_duration)
                         .unwrap_or_else(|| Duration::from_secs(0))
                 };

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -303,24 +303,14 @@ impl<T: BeaconChainTypes> AttestationService<T> {
                     .expect("ADVANCE_SUBSCRIPTION_TIME cannot be too large");
 
                 // calculate the time to subscribe to the subnet
-                let duration_to_subscribe = {
-                    // The -1 is done here to exclude the current slot duration, as we will use
-                    // `duration_to_next_slot`.
-                    let slots_until_subscribe = exact_subnet
-                        .slot
-                        .saturating_sub(current_slot)
-                        .saturating_sub(1u64);
+                let duration_to_subscribe = self
+                    .beacon_chain
+                    .slot_clock
+                    .duration_to_slot(exact_subnet.slot)
+                    .ok_or_else(|| "Unable to determine duration to next subscription slot")?
+                    .checked_sub(advance_subscription_duration)
+                    .unwrap_or_else(|| Duration::from_secs(0));
 
-                    slot_duration
-                        .checked_mul(slots_until_subscribe.as_u64() as u32)
-                        .ok_or_else(|| {
-                            "Overflow in multiplying number of slots in attestation time"
-                        })?
-                        .checked_add(duration_to_next_slot)
-                        .ok_or_else(|| "Overflow in adding duration_to_next_slot attestation time")?
-                        .checked_sub(advance_subscription_duration)
-                        .unwrap_or_else(|| Duration::from_secs(0))
-                };
                 // the duration until we no longer need this subscription. We assume a single slot is
                 // sufficient.
                 let expected_end_subscription_duration = duration_to_subscribe

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -307,7 +307,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
                     .beacon_chain
                     .slot_clock
                     .duration_to_slot(exact_subnet.slot)
-                    .ok_or_else(|| "Unable to determine duration to next subscription slot")?
+                    .ok_or_else(|| "Unable to determine duration to subscription slot")?
                     .checked_sub(advance_subscription_duration)
                     .unwrap_or_else(|| Duration::from_secs(0));
 


### PR DESCRIPTION
## Proposed Changes

duration_to_subscribe is being calculated as:

(duration_to_next_slot + slot_duration) * slots_until_subscribe

when it should be:

duration_to_next_slot + (slot_duration * slots_until_subscribe)

which was causing subscription messages to be produced late