### PR TITLE
Add snappy encoding to gossipsub messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,6 +1207,7 @@ dependencies = [
  "slog-stdlog 4.0.0",
  "slog-term",
  "smallvec 1.2.0",
+ "snap",
  "tempdir",
  "tokio",
  "tokio-io-timeout",
@@ -4172,6 +4173,12 @@ name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
+
+[[package]]
+name = "snap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fb9b0bb877b35a1cc1474a3b43d9c226a2625311760cdda2cbccbc0c7a8376"
 
 [[package]]
 name = "snow"

--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -31,6 +31,7 @@ lru = "0.4.3"
 parking_lot = "0.9.0"
 sha2 = "0.8.0"
 base64 = "0.11.0"
+snap = "1"
 
 [dev-dependencies]
 slog-stdlog = "4.0.0"

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -8,6 +8,8 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::time::Duration;
 
+pub const GOSSIP_MAX_SIZE: usize = 1_048_576;
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 /// Network configuration for lighthouse.
@@ -98,7 +100,7 @@ impl Default for Config {
         // Note: The topics by default are sent as plain strings. Hashes are an optional
         // parameter.
         let gs_config = GossipsubConfigBuilder::new()
-            .max_transmit_size(1_048_576)
+            .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_secs(20)) // TODO: Reduce for mainnet
             .manual_propagation() // require validation before propagation
             .no_source_id()

--- a/beacon_node/eth2-libp2p/src/types/topics.rs
+++ b/beacon_node/eth2-libp2p/src/types/topics.rs
@@ -7,6 +7,7 @@ use types::SubnetId;
 // For example /eth2/beacon_block/ssz
 pub const TOPIC_PREFIX: &str = "eth2";
 pub const SSZ_ENCODING_POSTFIX: &str = "ssz";
+pub const SSZ_SNAPPY_ENCODING_POSTFIX: &str = "ssz_snappy";
 pub const BEACON_BLOCK_TOPIC: &str = "beacon_block";
 pub const BEACON_AGGREGATE_AND_PROOF_TOPIC: &str = "beacon_aggregate_and_proof";
 // for speed and easier string manipulation, committee topic index is split into a prefix and a
@@ -65,6 +66,14 @@ impl std::fmt::Display for GossipKind {
 pub enum GossipEncoding {
     /// Messages are encoded with SSZ.
     SSZ,
+    /// Messages are encoded with SSZSnappy.
+    SSZSnappy,
+}
+
+impl Default for GossipEncoding {
+    fn default() -> Self {
+        GossipEncoding::SSZSnappy
+    }
 }
 
 impl GossipTopic {
@@ -109,6 +118,7 @@ impl GossipTopic {
 
             let encoding = match topic_parts[4] {
                 SSZ_ENCODING_POSTFIX => GossipEncoding::SSZ,
+                SSZ_SNAPPY_ENCODING_POSTFIX => GossipEncoding::SSZSnappy,
                 _ => return Err(format!("Unknown encoding: {}", topic)),
             };
             let kind = match topic_parts[3] {
@@ -144,6 +154,7 @@ impl Into<String> for GossipTopic {
     fn into(self) -> String {
         let encoding = match self.encoding {
             GossipEncoding::SSZ => SSZ_ENCODING_POSTFIX,
+            GossipEncoding::SSZSnappy => SSZ_SNAPPY_ENCODING_POSTFIX,
         };
 
         let kind = match self.kind {

--- a/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
@@ -35,7 +35,7 @@ fn test_gossipsub_forward() {
     };
     let pubsub_message = PubsubMessage::BeaconBlock(Box::new(signed_block));
     let publishing_topic: String = pubsub_message
-        .topics(GossipEncoding::SSZ, [0, 0, 0, 0])
+        .topics(GossipEncoding::default(), [0, 0, 0, 0])
         .first()
         .unwrap()
         .clone()
@@ -108,7 +108,7 @@ fn test_gossipsub_full_mesh_publish() {
     };
     let pubsub_message = PubsubMessage::BeaconBlock(Box::new(signed_block));
     let publishing_topic: String = pubsub_message
-        .topics(GossipEncoding::SSZ, [0, 0, 0, 0])
+        .topics(GossipEncoding::default(), [0, 0, 0, 0])
         .first()
         .unwrap()
         .clone()


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Adds snappy encoding/decoding to gossipsub messages. The default topic encoding that we subscribe to and publish on is set to `ssz_snappy`