### PR TITLE
Global Sync access

### DIFF
--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -12,7 +12,7 @@ libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "4e3003d5283040fe
 types = { path =  "../../eth2/types" }
 hashmap_delay = { path = "../../eth2/utils/hashmap_delay" }
 eth2_ssz_types = { path =  "../../eth2/utils/ssz_types" }
-serde = "1.0.102"
+serde = { version = "1.0.102", features = ["derive"] }
 serde_derive = "1.0.102"
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"

--- a/beacon_node/eth2-libp2p/src/lib.rs
+++ b/beacon_node/eth2-libp2p/src/lib.rs
@@ -20,6 +20,6 @@ pub use config::Config as NetworkConfig;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr};
 pub use libp2p::{PeerId, Swarm};
-pub use peer_manager::{PeerDB, PeerInfo};
+pub use peer_manager::{PeerDB, PeerInfo, PeerSyncStatus};
 pub use rpc::RPCEvent;
 pub use service::Service;

--- a/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
@@ -15,7 +15,7 @@ use types::EthSpec;
 mod peer_info;
 mod peerdb;
 
-pub use peer_info::PeerInfo;
+pub use peer_info::{PeerInfo, PeerSyncStatus};
 /// The minimum reputation before a peer is disconnected.
 // Most likely this needs tweaking
 const MINIMUM_REPUTATION_BEFORE_BAN: Rep = 20;
@@ -196,14 +196,14 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn connect_ingoing(&mut self, peer_id: &PeerId) -> bool {
         self.update_reputations();
         let mut peerdb = self.network_globals.peers.write();
-        peerdb.new_peer(peer_id);
         if !peerdb.connection_status(peer_id).is_banned() {
             peerdb.connect_ingoing(peer_id);
+            // start a ping and status timer for the peer
+            self.ping_peers.insert(peer_id.clone());
+            self.status_peers.insert(peer_id.clone());
+
             return true;
         }
-        // start a ping and status timer for the peer
-        self.ping_peers.insert(peer_id.clone());
-        self.status_peers.insert(peer_id.clone());
 
         false
     }
@@ -213,14 +213,14 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn connect_outgoing(&mut self, peer_id: &PeerId) -> bool {
         self.update_reputations();
         let mut peerdb = self.network_globals.peers.write();
-        peerdb.new_peer(peer_id);
         if !peerdb.connection_status(peer_id).is_banned() {
             peerdb.connect_outgoing(peer_id);
+            // start a ping and status timer for the peer
+            self.ping_peers.insert(peer_id.clone());
+            self.status_peers.insert(peer_id.clone());
+
             return true;
         }
-        // start a ping and status timer for the peer
-        self.ping_peers.insert(peer_id.clone());
-        self.status_peers.insert(peer_id.clone());
 
         false
     }

--- a/beacon_node/eth2-libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peer_info.rs
@@ -1,7 +1,7 @@
 use super::peerdb::{Rep, DEFAULT_REPUTATION};
 use crate::rpc::MetaData;
 use std::time::Instant;
-use types::{EthSpec, SubnetId};
+use types::{EthSpec, Slot, SubnetId};
 use PeerConnectionStatus::*;
 
 /// Information about a given connected peer.
@@ -17,7 +17,7 @@ pub struct PeerInfo<T: EthSpec> {
     pub connection_status: PeerConnectionStatus,
     /// The current syncing state of the peer. The state may be determined after it's initial
     /// connection.
-    pub syncing_status: PeerSyncingStatus,
+    pub sync_status: PeerSyncStatus,
     /// The ENR subnet bitfield of the peer. This may be determined after it's initial
     /// connection.
     pub meta_data: Option<MetaData<T>>,
@@ -33,7 +33,7 @@ impl<TSpec: EthSpec> Default for PeerInfo<TSpec> {
                 _version: vec![0],
             },
             connection_status: Default::default(),
-            syncing_status: PeerSyncingStatus::Unknown,
+            sync_status: PeerSyncStatus::Unknown,
             meta_data: None,
         }
     }
@@ -98,14 +98,18 @@ pub enum PeerConnectionStatus {
     },
 }
 
-#[derive(Debug, Clone)]
-pub enum PeerSyncingStatus {
-    /// At the current state as our node.
-    Synced,
-    /// The peer is further ahead than our node and useful for block downloads.
-    Ahead,
+#[derive(Debug, Clone, PartialEq)]
+pub enum PeerSyncStatus {
+    /// At the current state as our node or ahead of us.
+    Synced {
+        /// The last known head slot from the peer's handshake.
+        status_head_slot: Slot,
+    },
     /// Is behind our current head and not useful for block downloads.
-    Behind,
+    Behind {
+        /// The last known head slot from the peer's handshake.
+        status_head_slot: Slot,
+    },
     /// Not currently known as a STATUS handshake has not occurred.
     Unknown,
 }

--- a/beacon_node/eth2-libp2p/src/types/mod.rs
+++ b/beacon_node/eth2-libp2p/src/types/mod.rs
@@ -1,6 +1,7 @@
 pub mod error;
 mod globals;
 mod pubsub;
+mod sync_state;
 mod topics;
 
 use types::{BitVector, EthSpec};
@@ -12,4 +13,5 @@ pub type Enr = libp2p::discv5::enr::Enr<libp2p::discv5::enr::CombinedKey>;
 
 pub use globals::NetworkGlobals;
 pub use pubsub::PubsubMessage;
+pub use sync_state::SyncState;
 pub use topics::{GossipEncoding, GossipKind, GossipTopic};

--- a/beacon_node/eth2-libp2p/src/types/sync_state.rs
+++ b/beacon_node/eth2-libp2p/src/types/sync_state.rs
@@ -1,20 +1,22 @@
+use serde::{Deserialize, Serialize};
 use types::{Hash256, Slot};
 
-#[derive(Debug, Clone)]
 /// The current state of the node.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SyncState {
     /// The node is performing a long-range (batch) sync over a finalized chain.
     /// In this state, parent lookups are disabled.
-    SyncingFinalized { head_slot: Slot, head_root: Hash256 },
-
+    SyncingFinalized {
+        start_slot: Slot,
+        head_slot: Slot,
+        head_root: Hash256,
+    },
     /// The node is performing a long-range (batch) sync over one or many head chains.
     /// In this state parent lookups are disabled.
-    SyncingHead,
-
+    SyncingHead { start_slot: Slot, head_slot: Slot },
     /// The node is up to date with all known peers and is connected to at least one
     /// fully synced peer. In this state, parent lookups are enabled.
     Synced,
-
     /// No useful peers are connected. Long-range sync's cannot proceed and we have no useful
     /// peers to download parents for. More peers need to be connected before we can proceed.
     Stalled,
@@ -24,7 +26,7 @@ impl PartialEq for SyncState {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (SyncState::SyncingFinalized { .. }, SyncState::SyncingFinalized { .. }) => true,
-            (SyncState::SyncingHead, SyncState::SyncingHead) => true,
+            (SyncState::SyncingHead { .. }, SyncState::SyncingHead { .. }) => true,
             (SyncState::Synced, SyncState::Synced) => true,
             (SyncState::Stalled, SyncState::Stalled) => true,
             _ => false,
@@ -37,7 +39,7 @@ impl SyncState {
     pub fn is_syncing(&self) -> bool {
         match self {
             SyncState::SyncingFinalized { .. } => true,
-            SyncState::SyncingHead => true,
+            SyncState::SyncingHead { .. } => true,
             SyncState::Synced => false,
             SyncState::Stalled => false,
         }

--- a/beacon_node/eth2-libp2p/src/types/sync_state.rs
+++ b/beacon_node/eth2-libp2p/src/types/sync_state.rs
@@ -1,0 +1,64 @@
+use types::{Hash256, Slot};
+
+#[derive(Debug, Clone)]
+/// The current state of the node.
+pub enum SyncState {
+    /// The node is performing a long-range (batch) sync over a finalized chain.
+    /// In this state, parent lookups are disabled.
+    SyncingFinalized { head_slot: Slot, head_root: Hash256 },
+
+    /// The node is performing a long-range (batch) sync over one or many head chains.
+    /// In this state parent lookups are disabled.
+    SyncingHead,
+
+    /// The node is up to date with all known peers and is connected to at least one
+    /// fully synced peer. In this state, parent lookups are enabled.
+    Synced,
+
+    /// No useful peers are connected. Long-range sync's cannot proceed and we have no useful
+    /// peers to download parents for. More peers need to be connected before we can proceed.
+    Stalled,
+}
+
+impl PartialEq for SyncState {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (SyncState::SyncingFinalized { .. }, SyncState::SyncingFinalized { .. }) => true,
+            (SyncState::SyncingHead, SyncState::SyncingHead) => true,
+            (SyncState::Synced, SyncState::Synced) => true,
+            (SyncState::Stalled, SyncState::Stalled) => true,
+            _ => false,
+        }
+    }
+}
+
+impl SyncState {
+    /// Returns a boolean indicating the node is currently performing a long-range sync.
+    pub fn is_syncing(&self) -> bool {
+        match self {
+            SyncState::SyncingFinalized { .. } => true,
+            SyncState::SyncingHead => true,
+            SyncState::Synced => false,
+            SyncState::Stalled => false,
+        }
+    }
+
+    /// Returns true if the node is synced.
+    pub fn is_synced(&self) -> bool {
+        match self {
+            SyncState::Synced => true,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Display for SyncState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SyncState::SyncingFinalized { .. } => write!(f, "Syncing Finalized Chain"),
+            SyncState::SyncingHead { .. } => write!(f, "Syncing Head Chain"),
+            SyncState::Synced { .. } => write!(f, "Synced"),
+            SyncState::Stalled { .. } => write!(f, "Stalled"),
+        }
+    }
+}

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -172,7 +172,16 @@ impl<T: BeaconChainTypes> Processor<T> {
 
     /// Process a `Status` response from a peer.
     pub fn on_status_response(&mut self, peer_id: PeerId, status: StatusMessage) {
-        trace!(self.log, "StatusResponse"; "peer" => format!("{:?}", peer_id));
+        trace!(
+            self.log,
+            "Received Status Response";
+            "peer" => format!("{:?}", peer_id),
+            "fork_digest" => format!("{:?}", status.fork_digest),
+            "finalized_root" => format!("{:?}", status.finalized_root),
+            "finalized_epoch" => format!("{:?}", status.finalized_epoch),
+            "head_root" => format!("{}", status.head_root),
+            "head_slot" => format!("{}", status.head_slot),
+        );
 
         // Process the status message, without sending back another status.
         self.process_status(peer_id, status);
@@ -270,7 +279,7 @@ impl<T: BeaconChainTypes> Processor<T> {
             .exists::<SignedBeaconBlock<T::EthSpec>>(&remote.head_root)
             .unwrap_or_else(|_| false)
         {
-            trace!(
+            debug!(
                 self.log, "Peer with known chain found";
                 "peer" => format!("{:?}", peer_id),
                 "remote_head_slot" => remote.head_slot,

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
 };
 use eth2_libp2p::rpc::methods::*;
 use eth2_libp2p::rpc::{RPCEvent, RPCRequest, RPCResponse, RequestId};
-use eth2_libp2p::PeerId;
+use eth2_libp2p::{NetworkGlobals, PeerId};
 use slog::{debug, error, o, trace, warn};
 use ssz::Encode;
 use std::sync::Arc;
@@ -70,6 +70,7 @@ impl<T: BeaconChainTypes> Processor<T> {
     pub fn new(
         executor: &tokio::runtime::TaskExecutor,
         beacon_chain: Arc<BeaconChain<T>>,
+        network_globals: Arc<NetworkGlobals<T::EthSpec>>,
         network_send: mpsc::UnboundedSender<NetworkMessage<T::EthSpec>>,
         log: &slog::Logger,
     ) -> Self {
@@ -78,7 +79,8 @@ impl<T: BeaconChainTypes> Processor<T> {
         // spawn the sync thread
         let (sync_send, _sync_exit) = crate::sync::manager::spawn(
             executor,
-            Arc::downgrade(&beacon_chain),
+            beacon_chain.clone(),
+            network_globals,
             network_send.clone(),
             sync_logger,
         );

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -65,15 +65,8 @@ impl<T: BeaconChainTypes> NetworkService<T> {
     )> {
         // build the network channel
         let (network_send, network_recv) = mpsc::unbounded_channel::<NetworkMessage<T::EthSpec>>();
-        // Get a reference to the beacon chain store
+        // get a reference to the beacon chain store
         let store = beacon_chain.store.clone();
-        // launch the router task
-        let router_send = Router::spawn(
-            beacon_chain.clone(),
-            network_send.clone(),
-            executor,
-            network_log.clone(),
-        )?;
 
         let propagation_percentage = config.propagation_percentage;
 
@@ -95,7 +88,18 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         // This is currently used to obtain the listening addresses from the libp2p service.
         let initial_delay = Delay::new(Instant::now() + Duration::from_secs(1));
 
-        // create the attestation service
+        // launch derived network services
+
+        // router task
+        let router_send = Router::spawn(
+            beacon_chain.clone(),
+            network_globals.clone(),
+            network_send.clone(),
+            executor,
+            network_log.clone(),
+        )?;
+
+        // attestation service
         let attestation_service =
             AttestationService::new(beacon_chain.clone(), network_globals.clone(), &network_log);
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -8,7 +8,7 @@ use eth2_libp2p::rpc::methods::*;
 use eth2_libp2p::rpc::{RPCEvent, RPCRequest, RequestId};
 use eth2_libp2p::PeerId;
 use slog::{debug, trace, warn};
-use std::sync::Weak;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use types::EthSpec;
 
@@ -34,24 +34,22 @@ impl<T: EthSpec> SyncNetworkContext<T> {
 
     pub fn status_peer<U: BeaconChainTypes>(
         &mut self,
-        chain: Weak<BeaconChain<U>>,
+        chain: Arc<BeaconChain<U>>,
         peer_id: PeerId,
     ) {
-        if let Some(chain) = chain.upgrade() {
-            if let Some(status_message) = status_message(&chain) {
-                debug!(
-                    self.log,
-                    "Sending Status Request";
-                    "peer" => format!("{:?}", peer_id),
-                    "fork_digest" => format!("{:?}", status_message.fork_digest),
-                    "finalized_root" => format!("{:?}", status_message.finalized_root),
-                    "finalized_epoch" => format!("{:?}", status_message.finalized_epoch),
-                    "head_root" => format!("{}", status_message.head_root),
-                    "head_slot" => format!("{}", status_message.head_slot),
-                );
+        if let Some(status_message) = status_message(&chain) {
+            debug!(
+                self.log,
+                "Sending Status Request";
+                "peer" => format!("{:?}", peer_id),
+                "fork_digest" => format!("{:?}", status_message.fork_digest),
+                "finalized_root" => format!("{:?}", status_message.finalized_root),
+                "finalized_epoch" => format!("{:?}", status_message.finalized_epoch),
+                "head_root" => format!("{}", status_message.head_root),
+                "head_slot" => format!("{}", status_message.head_slot),
+            );
 
-                let _ = self.send_rpc_request(peer_id, RPCRequest::Status(status_message));
-            }
+            let _ = self.send_rpc_request(peer_id, RPCRequest::Status(status_message));
         }
     }
 

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -278,7 +278,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                 // if there are no more finalized chains, re-status all known peers awaiting a head
                 // sync
                 match self.chains.state() {
-                    RangeSyncState::Idle | RangeSyncState::Head => {
+                    RangeSyncState::Idle | RangeSyncState::Head { .. } => {
                         for peer_id in self.awaiting_head_peers.drain() {
                             network.status_peer(self.beacon_chain.clone(), peer_id);
                         }

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -40,7 +40,7 @@
 //!  and further batches are requested as current blocks are being processed.
 
 use super::chain::ProcessingResult;
-use super::chain_collection::{ChainCollection, SyncState};
+use super::chain_collection::{ChainCollection, RangeSyncState};
 use super::BatchId;
 use crate::router::processor::PeerSyncInfo;
 use crate::sync::block_processor::BatchProcessResult;
@@ -48,10 +48,10 @@ use crate::sync::manager::SyncMessage;
 use crate::sync::network_context::SyncNetworkContext;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::rpc::RequestId;
-use eth2_libp2p::PeerId;
-use slog::{debug, error, trace, warn};
+use eth2_libp2p::{NetworkGlobals, PeerId};
+use slog::{debug, error, trace};
 use std::collections::HashSet;
-use std::sync::Weak;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use types::{EthSpec, SignedBeaconBlock};
 
@@ -60,7 +60,7 @@ use types::{EthSpec, SignedBeaconBlock};
 /// holds the current state of the long range sync.
 pub struct RangeSync<T: BeaconChainTypes> {
     /// The beacon chain for processing.
-    beacon_chain: Weak<BeaconChain<T>>,
+    beacon_chain: Arc<BeaconChain<T>>,
     /// A collection of chains that need to be downloaded. This stores any head or finalized chains
     /// that need to be downloaded.
     chains: ChainCollection<T>,
@@ -77,13 +77,14 @@ pub struct RangeSync<T: BeaconChainTypes> {
 
 impl<T: BeaconChainTypes> RangeSync<T> {
     pub fn new(
-        beacon_chain: Weak<BeaconChain<T>>,
+        beacon_chain: Arc<BeaconChain<T>>,
+        network_globals: Arc<NetworkGlobals<T::EthSpec>>,
         sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
         log: slog::Logger,
     ) -> Self {
         RangeSync {
             beacon_chain: beacon_chain.clone(),
-            chains: ChainCollection::new(beacon_chain),
+            chains: ChainCollection::new(beacon_chain, network_globals, log.clone()),
             awaiting_head_peers: HashSet::new(),
             sync_send,
             log,
@@ -118,21 +119,14 @@ impl<T: BeaconChainTypes> RangeSync<T> {
         // determine if we need to run a sync to the nearest finalized state or simply sync to
         // its current head
 
-        let (chain, local_info) = match self.beacon_chain.upgrade() {
-            Some(chain) => match PeerSyncInfo::from_chain(&chain) {
-                Some(local) => (chain, local),
-                None => {
-                    return error!(
-                        self.log,
-                        "Failed to get peer sync info";
-                        "msg" => "likely due to head lock contention"
-                    )
-                }
-            },
+        let local_info = match PeerSyncInfo::from_chain(&self.beacon_chain) {
+            Some(local) => local,
             None => {
-                return warn!(self.log,
-                    "Beacon chain dropped. Peer not considered for sync";
-                    "peer_id" => format!("{:?}", peer_id));
+                return error!(
+                    self.log,
+                    "Failed to get peer sync info";
+                    "msg" => "likely due to head lock contention"
+                )
             }
         };
 
@@ -148,10 +142,13 @@ impl<T: BeaconChainTypes> RangeSync<T> {
         self.remove_peer(network, &peer_id);
 
         // remove any out-of-date chains
-        self.chains.purge_outdated_chains(network, &self.log);
+        self.chains.purge_outdated_chains(network);
 
         if remote_finalized_slot > local_info.head_slot
-            && !chain.fork_choice.contains_block(&remote.finalized_root)
+            && !self
+                .beacon_chain
+                .fork_choice
+                .contains_block(&remote.finalized_root)
         {
             debug!(self.log, "Finalization sync peer joined"; "peer_id" => format!("{:?}", peer_id));
             // Finalized chain search
@@ -171,7 +168,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                 chain.add_peer(network, peer_id);
 
                 // check if the new peer's addition will favour a new syncing chain.
-                self.chains.update_finalized(network, &self.log);
+                self.chains.update_finalized(network);
             } else {
                 // there is no finalized chain that matches this peer's last finalized target
                 // create a new finalized chain
@@ -183,9 +180,8 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     remote_finalized_slot,
                     peer_id,
                     self.sync_send.clone(),
-                    &self.log,
                 );
-                self.chains.update_finalized(network, &self.log);
+                self.chains.update_finalized(network);
             }
         } else {
             if self.chains.is_finalizing_sync() {
@@ -216,10 +212,9 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     remote.head_slot,
                     peer_id,
                     self.sync_send.clone(),
-                    &self.log,
                 );
             }
-            self.chains.update_finalized(network, &self.log);
+            self.chains.update_finalized(network);
         }
     }
 
@@ -274,7 +269,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                 chain.status_peers(network);
 
                 // update the state of the collection
-                self.chains.update_finalized(network, &self.log);
+                self.chains.update_finalized(network);
 
                 // set the state to a head sync, to inform the manager that we are awaiting a
                 // head chain.
@@ -282,13 +277,13 @@ impl<T: BeaconChainTypes> RangeSync<T> {
 
                 // if there are no more finalized chains, re-status all known peers awaiting a head
                 // sync
-                match self.chains.sync_state() {
-                    SyncState::Idle | SyncState::Head => {
+                match self.chains.state() {
+                    RangeSyncState::Idle | RangeSyncState::Head => {
                         for peer_id in self.awaiting_head_peers.drain() {
                             network.status_peer(self.beacon_chain.clone(), peer_id);
                         }
                     }
-                    SyncState::Finalized => {} // Have more finalized chains to complete
+                    RangeSyncState::Finalized { .. } => {} // Have more finalized chains to complete
                 }
             }
             Some((_, ProcessingResult::KeepChain)) => {}
@@ -308,7 +303,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                         chain.status_peers(network);
 
                         // update the state of the collection
-                        self.chains.update_finalized(network, &self.log);
+                        self.chains.update_finalized(network);
                     }
                     Some((_, ProcessingResult::KeepChain)) => {}
                     None => {
@@ -318,15 +313,6 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     }
                 }
             }
-        }
-    }
-
-    /// Public method to indicate the current state of the long range sync.
-    pub fn is_syncing(&self) -> bool {
-        match self.chains.sync_state() {
-            SyncState::Finalized => true,
-            SyncState::Head => true,
-            SyncState::Idle => false,
         }
     }
 
@@ -344,7 +330,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
         self.remove_peer(network, peer_id);
 
         // update the state of the collection
-        self.chains.update_finalized(network, &self.log);
+        self.chains.update_finalized(network);
     }
 
     /// When a peer gets removed, both the head and finalized chains need to be searched to check which pool the peer is in. The chain may also have a batch or batches awaiting
@@ -370,7 +356,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
         {
             // the chain needed to be removed
             debug!(self.log, "Chain being removed due to failed batch");
-            self.chains.remove_chain(network, index, &self.log);
+            self.chains.remove_chain(network, index);
         }
     }
 
@@ -392,7 +378,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
             Some((_, ProcessingResult::KeepChain)) => {} // error handled chain persists
             Some((index, ProcessingResult::RemoveChain)) => {
                 debug!(self.log, "Chain being removed due to RPC error");
-                self.chains.remove_chain(network, index, &self.log)
+                self.chains.remove_chain(network, index)
             }
             None => {} // request wasn't in the finalized chains, check the head chains
         }

--- a/beacon_node/rest_api/src/node.rs
+++ b/beacon_node/rest_api/src/node.rs
@@ -27,7 +27,7 @@ pub fn syncing<T: EthSpec>(
             start_slot,
             head_slot,
         } => (start_slot, head_slot),
-        SyncState::Synced | SyncState::Stalled => (Slot::from(0u64), Slot::from(0u64)),
+        SyncState::Synced | SyncState::Stalled => (Slot::from(0u64), current_slot),
     };
 
     let sync_status = SyncingStatus {

--- a/beacon_node/rest_api/src/node.rs
+++ b/beacon_node/rest_api/src/node.rs
@@ -7,3 +7,7 @@ use version;
 pub fn get_version(req: Request<Body>) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(&version::version())
 }
+
+pub fn syncing(req: Request<Body>, network: Arc<NetworkGlobals<T::EthSpec>>) -> ApiResult {
+    ResponseBuilder::new(&req)?.body_no_ssz(&version::version())
+}

--- a/beacon_node/rest_api/src/node.rs
+++ b/beacon_node/rest_api/src/node.rs
@@ -1,6 +1,10 @@
 use crate::response_builder::ResponseBuilder;
 use crate::ApiResult;
+use eth2_libp2p::{types::SyncState, NetworkGlobals};
 use hyper::{Body, Request};
+use rest_types::{SyncingResponse, SyncingStatus};
+use std::sync::Arc;
+use types::{EthSpec, Slot};
 use version;
 
 /// Read the version string from the current Lighthouse build.
@@ -8,6 +12,39 @@ pub fn get_version(req: Request<Body>) -> ApiResult {
     ResponseBuilder::new(&req)?.body_no_ssz(&version::version())
 }
 
-pub fn syncing(req: Request<Body>, network: Arc<NetworkGlobals<T::EthSpec>>) -> ApiResult {
-    ResponseBuilder::new(&req)?.body_no_ssz(&version::version())
+pub fn syncing<T: EthSpec>(
+    req: Request<Body>,
+    network: Arc<NetworkGlobals<T>>,
+    current_slot: Slot,
+) -> ApiResult {
+    let (starting_slot, highest_slot) = match network.sync_state() {
+        SyncState::SyncingFinalized {
+            start_slot,
+            head_slot,
+            ..
+        }
+        | SyncState::SyncingHead {
+            start_slot,
+            head_slot,
+        } => (start_slot, head_slot),
+        SyncState::Synced | SyncState::Stalled => (Slot::from(0u64), Slot::from(0u64)),
+    };
+
+    let sync_status = SyncingStatus {
+        starting_slot,
+        current_slot,
+        highest_slot,
+    };
+
+    ResponseBuilder::new(&req)?.body(&SyncingResponse {
+        is_syncing: network.is_syncing(),
+        sync_status,
+    })
+}
+
+pub fn lighthouse_syncing<T: EthSpec>(
+    req: Request<Body>,
+    network: Arc<NetworkGlobals<T>>,
+) -> ApiResult {
+    ResponseBuilder::new(&req)?.body_no_ssz(&network.sync_state())
 }

--- a/book/src/http.md
+++ b/book/src/http.md
@@ -14,6 +14,7 @@ detail:
 
 Endpoint | Description |
 | --- | -- |
+[`/node`](./node.md) | General information about the beacon node.
 [`/beacon`](./http_beacon.md) | General information about the beacon chain.
 [`/validator`](./http_validator.md) | Provides functionality to validator clients.
 [`/consensus`](./http_consensus.md) | Proof-of-stake voting statistics.

--- a/book/src/http_node.md
+++ b/book/src/http_node.md
@@ -1,0 +1,86 @@
+# Lighthouse REST API: `/node`
+
+The `/node` endpoints provide information about the lighthouse beacon node.
+
+## Endpoints
+
+HTTP Path | Description |
+| --- | -- |
+[`/node/version`](#nodeversion) | Get the node's version.
+[`/node/syncing`](#nodesyncing) | Get the node's syncing status.
+[`/node/syncing`](#nodelighthouse_syncing) | Get the node's syncing status
+(Lighthouse specific).
+
+## `/node/version`
+
+Requests the beacon node's version.
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/node/version`
+Method | GET
+JSON Encoding | String 
+Query Parameters | None
+Typical Responses | 200
+
+### Example Response
+
+```json
+"Lighthouse-0.2.0-unstable"
+```
+
+## `/node/syncing`
+
+Requests the syncing status of the beacon node.
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/node/syncing`
+Method | GET
+JSON Encoding | Object
+Query Parameters | None
+Typical Responses | 200
+
+### Example Response
+
+```json
+{
+	is_syncing: true,
+	sync_status: {
+	    starting_slot: 1213123123123123123123123122,
+    	current_slot: 1213123123123123123123123122,
+    	highest_slot: 1213123123123123123123123122,
+	}
+}
+```
+
+## `/node/lighthouse_syncing`
+
+Requests the syncing state of a Lighthouse beacon node. Lighthouse as a
+custom sync protocol, this request gets Lighthouse-specific sync information.
+
+### HTTP Specification
+
+| Property | Specification |
+| --- |--- |
+Path | `/node/lighthouse_syncing`
+Method | GET
+JSON Encoding | Object
+Query Parameters | None
+Typical Responses | 200
+
+### Example Response
+
+```json
+{
+	"syncing_finalized": {
+		"start_slot": 10,
+		"head_slot": 20,
+		"head_root":"0x0000000000000000000000000000000000000000000000000100000000000000"
+		}
+}
+```

--- a/book/src/http_node.md
+++ b/book/src/http_node.md
@@ -21,7 +21,7 @@ Requests the beacon node's version.
 | --- |--- |
 Path | `/node/version`
 Method | GET
-JSON Encoding | String 
+JSON Encoding | String
 Query Parameters | None
 Typical Responses | 200
 
@@ -51,9 +51,9 @@ Typical Responses | 200
 {
 	is_syncing: true,
 	sync_status: {
-	    starting_slot: 1213123123123123123123123122,
-    	current_slot: 1213123123123123123123123122,
-    	highest_slot: 1213123123123123123123123122,
+	    starting_slot: 0,
+    	current_slot: 100,
+    	highest_slot: 200,
 	}
 }
 ```
@@ -75,12 +75,30 @@ Typical Responses | 200
 
 ### Example Response
 
+If the node is undergoing a finalization sync:
 ```json
 {
-	"syncing_finalized": {
+	"SyncingFinalized": {
 		"start_slot": 10,
 		"head_slot": 20,
-		"head_root":"0x0000000000000000000000000000000000000000000000000100000000000000"
-		}
+		"head_root":"0x74020d0e3c3c02d2ea6279d5760f7d0dd376c4924beaaec4d5c0cefd1c0c4465"
+	}
+}
+```
+
+If the node is undergoing a head chain sync:
+```json
+{
+	"SyncingHead": {
+		"start_slot":0,
+		"head_slot":1195
+	}
+}
+```
+
+If the node is synced
+```json
+{
+"Synced"
 }
 ```

--- a/eth2/utils/rest_types/src/lib.rs
+++ b/eth2/utils/rest_types/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod beacon;
 mod consensus;
+mod node;
 mod validator;
 
 pub use beacon::{
@@ -16,3 +17,5 @@ pub use validator::{
 };
 
 pub use consensus::{IndividualVote, IndividualVotesRequest, IndividualVotesResponse};
+
+pub use node::{SyncingResponse, SyncingStatus};

--- a/eth2/utils/rest_types/src/node.rs
+++ b/eth2/utils/rest_types/src/node.rs
@@ -1,0 +1,32 @@
+//! Collection of types for the /node HTTP
+use serde::{Deserialize, Serialize};
+use ssz_derive::{Decode, Encode};
+use types::Slot;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode, Decode)]
+/// The current syncing status of the node.
+pub struct SyncingStatus {
+    /// The starting slot of sync.
+    ///
+    /// For a finalized sync, this is the start slot of the current finalized syncing
+    /// chain.
+    ///
+    /// For head sync this is the last finalized slot.
+    pub starting_slot: Slot,
+    /// The current slot.
+    pub current_slot: Slot,
+    /// The highest known slot. For the current syncing chain.
+    ///
+    /// For a finalized sync, the target finalized slot.
+    /// For head sync, this is the highest known slot of all head chains.
+    pub highest_slot: Slot,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode, Decode)]
+/// The response for the /node/syncing HTTP GET.
+pub struct SyncingResponse {
+    /// Is the node syncing.
+    pub is_syncing: bool,
+    /// The current sync status.
+    pub sync_status: SyncingStatus,
+}


### PR DESCRIPTION
## Description

Connects the sync logic and manager to use the peer database and modify a global node sync state. 

Key functionality added:
- All Status'd peers now store a specific syncing state
- The node has an accessible sync state indicating the current state of the sync manager
- Two http API methods have been added: `/node/syncing`  and `/node/lighthouse_syncing`

This resolves #810 