### PR TITLE
add handling of failed batches that imported blocks

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -103,7 +103,7 @@ pub enum BlockError {
     InvalidSignature,
     /// The provided block is from an earlier slot than its parent.
     BlockIsNotLaterThanParent { block_slot: Slot, state_slot: Slot },
-    /// At least one block in the chain segement did not have it's parent root set to the root of
+    /// At least one block in the chain segment did not have it's parent root set to the root of
     /// the prior block.
     NonLinearParentRoots,
     /// The slots of the blocks in the chain segment were not strictly increasing. I.e., a child
@@ -153,7 +153,7 @@ impl From<DBError> for BlockError {
 ///
 /// ## Errors
 ///
-/// The given `chain_segement` must span no more than two epochs, otherwise an error will be
+/// The given `chain_segment` must span no more than two epochs, otherwise an error will be
 /// returned.
 pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     chain_segment: Vec<(Hash256, SignedBeaconBlock<T::EthSpec>)>,
@@ -592,7 +592,7 @@ fn check_block_against_finalized_slot<T: BeaconChainTypes>(
     }
 }
 
-/// Performs simple, cheap checks to ensure that the block is relevant to imported.
+/// Performs simple, cheap checks to ensure that the block is relevant to be imported.
 ///
 /// `Ok(block_root)` is returned if the block passes these checks and should progress with
 /// verification (viz., it is relevant).

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -21,7 +21,8 @@ mod timeout_rw_lock;
 mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
-    AttestationProcessingOutcome, AttestationType, BeaconChain, BeaconChainTypes, StateSkipConfig,
+    AttestationProcessingOutcome, AttestationType, BeaconChain, BeaconChainTypes,
+    ChainSegmentResult, StateSkipConfig,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::errors::{BeaconChainError, BlockProductionError};


### PR DESCRIPTION
## Issue Addressed

Closes #970

## Proposed Changes

- Created a `ChainSegmentResult`, either `Successful` or `Failed`. In both cases it carries the info of number of `imported_blocks`, and in the failed case, the `BlockError`.
- Added `BatchProcessResult::Partial` to signal a failed batch with at least one successfully verified and imported block.
- Updated the logic to handle `BatchProcessResult::Partial`, as a summary:
  - It removes all previous batches (mark as valid) and downvote peers using the same logic from the successful case. 
  - Check if the batch can be retried using the same logic of the failure case.

## Additional Info

- `process_chain_segment` no longer returns a `Vec` (`roots`), since it was only used to check its length. It returns instead the number of `imported_blocks`
- I added the logic of the partial processing result to the best of my understanding but it needs a check
- Having now the number of imported blocks I tried to fill in some gaps on the `TODO: run fork choice?` notes using the code that is present in master, but this ofc needs also a good check.
 - While reading some docs to understand stuff I found a couple of typos and corrected them, but strictly speaking they are unrelated to the current| issue. if you think I should put them in another commit/ another pr/ revert them completely just let me know
