### PR TITLE
Shifts tests to use random ports

### DIFF
--- a/beacon_node/eth2-libp2p/tests/common/mod.rs
+++ b/beacon_node/eth2-libp2p/tests/common/mod.rs
@@ -4,6 +4,7 @@ use eth2_libp2p::Multiaddr;
 use eth2_libp2p::NetworkConfig;
 use eth2_libp2p::Service as LibP2PService;
 use slog::{debug, error, o, Drain};
+use std::net::{TcpListener, UdpSocket};
 use std::time::Duration;
 use tempdir::TempDir;
 
@@ -17,6 +18,38 @@ pub fn build_log(level: slog::Level, enabled: bool) -> slog::Logger {
     } else {
         slog::Logger::root(drain.filter(|_| false).fuse(), o!())
     }
+}
+
+// A bit of hack to find an unused port.
+///
+/// Does not guarantee that the given port is unused after the function exists, just that it was
+/// unused before the function started (i.e., it does not reserve a port).
+pub fn unused_port(transport: &str) -> Result<u16, String> {
+    let local_addr = match transport {
+        "tcp" => {
+            let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| {
+                format!("Failed to create TCP listener to find unused port: {:?}", e)
+            })?;
+            listener.local_addr().map_err(|e| {
+                format!(
+                    "Failed to read TCP listener local_addr to find unused port: {:?}",
+                    e
+                )
+            })?
+        }
+        "udp" => {
+            let socket = UdpSocket::bind("127.0.0.1:0")
+                .map_err(|e| format!("Failed to create UDP socket to find unused port: {:?}", e))?;
+            socket.local_addr().map_err(|e| {
+                format!(
+                    "Failed to read UDP socket local_addr to find unused port: {:?}",
+                    e
+                )
+            })?
+        }
+        _ => return Err("Invalid transport to find unused port".into()),
+    };
+    Ok(local_addr.port())
 }
 
 pub fn build_config(

--- a/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/gossipsub_tests.rs
@@ -21,7 +21,8 @@ fn test_gossipsub_forward() {
     let log = common::build_log(Level::Info, false);
 
     let num_nodes = 20;
-    let mut nodes = common::build_linear(log.clone(), num_nodes, Some(19000));
+    let base_port = common::unused_port("tcp").unwrap();
+    let mut nodes = common::build_linear(log.clone(), num_nodes, Some(base_port));
     let mut received_count = 0;
     let pubsub_message = PubsubMessage::Block(vec![0; 4]);
     let publishing_topic: String = "/eth2/beacon_block/ssz".into();
@@ -88,7 +89,8 @@ fn test_gossipsub_full_mesh_publish() {
     // as nodes may get pruned out of the mesh before the gossipsub message
     // is published to them.
     let num_nodes = 12;
-    let mut nodes = common::build_full_mesh(log, num_nodes, Some(11320));
+    let base_port = common::unused_port("tcp").unwrap();
+    let mut nodes = common::build_full_mesh(log, num_nodes, Some(base_port));
     let mut publishing_node = nodes.pop().unwrap();
     let pubsub_message = PubsubMessage::Block(vec![0; 4]);
     let publishing_topic: String = "/eth2/beacon_block/ssz".into();

--- a/beacon_node/eth2-libp2p/tests/noise.rs
+++ b/beacon_node/eth2-libp2p/tests/noise.rs
@@ -114,12 +114,14 @@ fn test_secio_noise_fallback() {
 
     let log = common::build_log(log_level, enable_logging);
 
-    let noisy_config = common::build_config(56010, vec![], None);
+    let port = common::unused_port("tcp").unwrap();
+    let noisy_config = common::build_config(port, vec![], None);
     let mut noisy_node = Service::new(&noisy_config, log.clone())
         .expect("should build a libp2p instance")
         .1;
 
-    let secio_config = common::build_config(56011, vec![common::get_enr(&noisy_node)], None);
+    let port = common::unused_port("tcp").unwrap();
+    let secio_config = common::build_config(port, vec![common::get_enr(&noisy_node)], None);
 
     // Building a custom Libp2pService from outside the crate isn't possible because of
     // private fields in the Libp2pService struct. A swarm is good enough for testing

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -21,7 +21,8 @@ fn test_status_rpc() {
     let log = common::build_log(log_level, enable_logging);
 
     // get sender/receiver
-    let (mut sender, mut receiver) = common::build_node_pair(&log, 10500);
+    let port = common::unused_port("tcp").unwrap();
+    let (mut sender, mut receiver) = common::build_node_pair(&log, port);
 
     // Dummy STATUS RPC message
     let rpc_request = RPCRequest::Status(StatusMessage {
@@ -134,7 +135,8 @@ fn test_blocks_by_range_chunked_rpc() {
     let log = common::build_log(log_level, enable_logging);
 
     // get sender/receiver
-    let (mut sender, mut receiver) = common::build_node_pair(&log, 10505);
+    let port = common::unused_port("tcp").unwrap();
+    let (mut sender, mut receiver) = common::build_node_pair(&log, port);
 
     // BlocksByRange Request
     let rpc_request = RPCRequest::BlocksByRange(BlocksByRangeRequest {
@@ -261,7 +263,8 @@ fn test_blocks_by_range_single_empty_rpc() {
     let log = common::build_log(log_level, enable_logging);
 
     // get sender/receiver
-    let (mut sender, mut receiver) = common::build_node_pair(&log, 10510);
+    let port = common::unused_port("tcp").unwrap();
+    let (mut sender, mut receiver) = common::build_node_pair(&log, port);
 
     // BlocksByRange Request
     let rpc_request = RPCRequest::BlocksByRange(BlocksByRangeRequest {
@@ -385,7 +388,8 @@ fn test_blocks_by_root_chunked_rpc() {
     let log = common::build_log(log_level, enable_logging);
 
     // get sender/receiver
-    let (mut sender, mut receiver) = common::build_node_pair(&log, 10515);
+    let port = common::unused_port("tcp").unwrap();
+    let (mut sender, mut receiver) = common::build_node_pair(&log, port);
 
     // BlocksByRoot Request
     let rpc_request = RPCRequest::BlocksByRoot(BlocksByRootRequest {
@@ -509,7 +513,8 @@ fn test_goodbye_rpc() {
     let log = common::build_log(log_level, enable_logging);
 
     // get sender/receiver
-    let (mut sender, mut receiver) = common::build_node_pair(&log, 10520);
+    let port = common::unused_port("tcp").unwrap();
+    let (mut sender, mut receiver) = common::build_node_pair(&log, port);
 
     // Goodbye Request
     let rpc_request = RPCRequest::Goodbye(GoodbyeReason::ClientShutdown);


### PR DESCRIPTION
Some tests appear to overlap on ports and fail CI non-deterministically. 

This shifts some of the tests to use random open ports. Although there is still a chance ports can clash (as some tests use sequential port numbers) the probability of clashes should be low enough that it doesn't warrant changing the tests to check for random ports for each node. 

Should CI continue to fail, a more rigorous method should be employed.