### PR TITLE
Update CLI defaults and book

### DIFF
--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -119,15 +119,16 @@ impl Default for Config {
             .ping_interval(Duration::from_secs(300))
             .build();
 
+        // NOTE: Some of these get overridden by the corresponding CLI default values.
         Config {
             network_dir,
-            listen_address: "127.0.0.1".parse().expect("valid ip address"),
+            listen_address: "0.0.0.0".parse().expect("valid ip address"),
             libp2p_port: 9000,
             discovery_port: 9000,
             enr_address: None,
             enr_udp_port: None,
             enr_tcp_port: None,
-            max_peers: 10,
+            max_peers: 50,
             secret_key_hex: None,
             gs_config,
             discv5_config,

--- a/beacon_node/eth2-libp2p/src/service.rs
+++ b/beacon_node/eth2-libp2p/src/service.rs
@@ -80,6 +80,7 @@ impl<TSpec: EthSpec> Service<TSpec> {
         ));
 
         info!(log, "Libp2p Service"; "peer_id" => format!("{:?}", enr.peer_id()));
+        debug!(log, "Attempting to open listening ports"; "address" => format!("{}", config.listen_address), "tcp_port" => config.libp2p_port, "udp_port" => config.discovery_port);
 
         let mut swarm = {
             // Set up the transport - tcp/ws with noise/secio and mplex/yamux

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -57,15 +57,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("discovery-port")
                 .long("discovery-port")
                 .value_name("PORT")
-                .help("The UDP port that discovery will listen on.")
-                .default_value("9000")
+                .help("The UDP port that discovery will listen on. Defaults to `port`")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("maxpeers")
                 .long("maxpeers")
                 .help("The maximum number of peers.")
-                .default_value("10")
+                .default_value("50")
                 .takes_value(true),
         )
         .arg(

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
             Arg::with_name("debug-level")
                 .long("debug-level")
                 .value_name("LEVEL")
-                .help("The title of the spec constants for chain config.")
+                .help("The verbosity level for emitting logs.")
                 .takes_value(true)
                 .possible_values(&["info", "debug", "trace", "warn", "error", "crit"])
                 .default_value("info"),


### PR DESCRIPTION
- Corrects issues with default UDP ports
- Displays the current data directory
- Updates the lighthouse book for setting up local testnets

Resolves #997 