### PR TITLE
Temporary integration of peer manager

### DIFF
--- a/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
@@ -140,7 +140,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             .map(|(id, _)| id)
     }
 
-    /// Gets the connection status of the peer.
+    /// Returns the peer's connection status. Returns unknown if the peer is not in the DB.
     pub fn connection_status(&self, peer_id: &PeerId) -> PeerConnectionStatus {
         self.peer_info(peer_id)
             .map_or(PeerConnectionStatus::default(), |info| {

--- a/beacon_node/eth2-libp2p/src/rpc/mod.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/mod.rs
@@ -175,4 +175,8 @@ pub enum RPCMessage<TSpec: EthSpec> {
     RPC(PeerId, RPCEvent<TSpec>),
     PeerDialed(PeerId),
     PeerDisconnected(PeerId),
+    // TODO: This is a hack to give access to connections to peer manager. Remove this once
+    // behaviour is re-written
+    PeerConnectedHack(PeerId, ConnectedPoint),
+    PeerDisconnectedHack(PeerId, ConnectedPoint),
 }


### PR DESCRIPTION
## Description

The peer manager needs to control the connection and disconnection of peers. Currently the manager lives on the global network behaviour. Because we are currently using a core-derive of libp2p we don't have access to behaviour events, such as when peers connect and disconnect. 

Previously the discovery behaviour had been handling this logic. As a workaround (while we upgrade to stable futures and write a custom global behaviour), the RPC injects messages into the global behaviour which then sends them to the peer manager. 

This logic will be updated once a custom behaviour is written.