### PR TITLE
Minor useability updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ EF_TESTS = "tests/ef_tests"
 # Binaries will most likely be found in `./target/release`
 install:
 	cargo install --path lighthouse --force --locked
+	cargo install --path lcli --force --locked
 
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors.

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -23,7 +23,7 @@ Typical users may install `lighthouse` to `CARGO_HOME` with `cargo install
 `PATH` environment variable"](https://www.rust-lang.org/tools/install) for more
 information.
 
-For develeopers, we recommend building Lighthouse using the `$ cargo build --release
+For developers, we recommend building Lighthouse using the `$ cargo build --release
 --bin lighthouse` command and executing binaries from the
 `<lighthouse-repository>/target/release` directory. This is more ergonomic when
 modifying and rebuilding regularly.
@@ -33,7 +33,6 @@ modifying and rebuilding regularly.
 Each binary supports the `--help` flag, this is the best source of
 documentation.
 
-
 ```bash
 $ lighthouse beacon_node --help
 ```
@@ -42,22 +41,15 @@ $ lighthouse beacon_node --help
 $ lighthouse validator_client --help
 ```
 
-## Beacon Node
+## Creating a new database/testnet
 
-The `$ lighthouse beacon_node` (or `$ lighthouse bn`) command has two primary
-tasks:
+Lighthouse should run out-of-the box and connect to the current testnet
+maintained by Sigma Prime.
 
-- **Resuming** an existing database with `$ lighthouse bn`.
-- **Creating** a new testnet database using `$ lighthouse bn testnet`.
-
-## Creating a new database
-
-Use the `$ lighthouse bn testnet` command (see [testnets](./testnets.md) for
-more information).
+However, for developers, testnets can be created by following the instructions
+outlined in [testnets](./testnets.md). The steps listed here will create a
+local database specified to a new testnet. 
 
 ## Resuming from an existing database
 
-Once a database has been created, it can be resumed by running `$ lighthouse bn`.
-
-Presently, you are not allowed to call `$ lighthouse bn` unless you have first
-created a database using `$ lighthouse bn testnet`.
+Once a database/testnet has been created, it can be resumed by running `$ lighthouse bn`.

--- a/book/src/local-testnets.md
+++ b/book/src/local-testnets.md
@@ -55,7 +55,7 @@ Once you have `lcli` installed, create a new testnet directory with:
 lcli new-testnet
 ```
 
-> - This will create a "mainnet" spec testnet. To create a minimal spec use `lcli --spec minim new-testnet`.
+> - This will create a "mainnet" spec testnet. To create a minimal spec use `lcli --spec minimal new-testnet`.
 > - The `lcli new-testnet` command has many options, use `lcli new-testnet --help` to see them.
 
 ### 1.3 Create a genesis state

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -339,7 +339,7 @@ fn main() {
                         .long("genesis-fork-version")
                         .value_name("HEX")
                         .takes_value(true)
-                        .default_value("0x01030307")    // [1, 3, 3, 7]
+                        .default_value("0x00000000") 
                         .help("Used to avoid reply attacks between testnets. Recommended to set to
                               non-default."),
                 )


### PR DESCRIPTION
## Description

Minor usability updates.

- `lcli` is now a required binary for spinning up local testnets. This PR adds `lcli` to the makefile to be installed alongside lighthouse.
- Minor updates to the lighthouse book surrounding the creation of local testnets