### PR TITLE
Clean RPC names versions and encodings

### DIFF
--- a/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
@@ -1,7 +1,7 @@
 use crate::rpc::methods::*;
 use crate::rpc::{
     codec::base::OutboundCodec,
-    protocol::{Protocol, ProtocolId, RPCError},
+    protocol::{Encoding, Protocol, ProtocolId, RPCError},
 };
 use crate::rpc::{ErrorMessage, RPCErrorResponse, RPCRequest, RPCResponse};
 use libp2p::bytes::{BufMut, Bytes, BytesMut};
@@ -25,7 +25,7 @@ impl<T: EthSpec> SSZInboundCodec<T> {
         uvi_codec.set_max_len(max_packet_size);
 
         // this encoding only applies to ssz.
-        debug_assert!(protocol.encoding.as_str() == "ssz");
+        debug_assert_eq!(protocol.encoding, Encoding::SSZ);
 
         SSZInboundCodec {
             inner: uvi_codec,
@@ -143,7 +143,7 @@ impl<TSpec: EthSpec> SSZOutboundCodec<TSpec> {
         uvi_codec.set_max_len(max_packet_size);
 
         // this encoding only applies to ssz.
-        debug_assert!(protocol.encoding.as_str() == "ssz");
+        debug_assert_eq!(protocol.encoding, Encoding::SSZ);
 
         SSZOutboundCodec {
             inner: uvi_codec,

--- a/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/ssz.rs
@@ -1,7 +1,7 @@
 use crate::rpc::methods::*;
 use crate::rpc::{
     codec::base::OutboundCodec,
-    protocol::{Encoding, Protocol, ProtocolId, RPCError},
+    protocol::{Encoding, Protocol, ProtocolId, RPCError, Version},
 };
 use crate::rpc::{ErrorMessage, RPCErrorResponse, RPCRequest, RPCResponse};
 use libp2p::bytes::{BufMut, Bytes, BytesMut};
@@ -79,38 +79,33 @@ impl<TSpec: EthSpec> Decoder for SSZInboundCodec<TSpec> {
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         match self.inner.decode(src).map_err(RPCError::from) {
             Ok(Some(packet)) => match self.protocol.message_name {
-                Protocol::Status => match self.protocol.version.as_str() {
-                    "1" => Ok(Some(RPCRequest::Status(StatusMessage::from_ssz_bytes(
+                Protocol::Status => match self.protocol.version {
+                    Version::V1 => Ok(Some(RPCRequest::Status(StatusMessage::from_ssz_bytes(
                         &packet,
                     )?))),
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::Goodbye => match self.protocol.version.as_str() {
-                    "1" => Ok(Some(RPCRequest::Goodbye(GoodbyeReason::from_ssz_bytes(
+                Protocol::Goodbye => match self.protocol.version {
+                    Version::V1 => Ok(Some(RPCRequest::Goodbye(GoodbyeReason::from_ssz_bytes(
                         &packet,
                     )?))),
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::BlocksByRange => match self.protocol.version.as_str() {
-                    "1" => Ok(Some(RPCRequest::BlocksByRange(
+                Protocol::BlocksByRange => match self.protocol.version {
+                    Version::V1 => Ok(Some(RPCRequest::BlocksByRange(
                         BlocksByRangeRequest::from_ssz_bytes(&packet)?,
                     ))),
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::BlocksByRoot => match self.protocol.version.as_str() {
-                    "1" => Ok(Some(RPCRequest::BlocksByRoot(BlocksByRootRequest {
+                Protocol::BlocksByRoot => match self.protocol.version {
+                    Version::V1 => Ok(Some(RPCRequest::BlocksByRoot(BlocksByRootRequest {
                         block_roots: Vec::from_ssz_bytes(&packet)?,
                     }))),
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::Ping => match self.protocol.version.as_str() {
-                    "1" => Ok(Some(RPCRequest::Ping(Ping {
+                Protocol::Ping => match self.protocol.version {
+                    Version::V1 => Ok(Some(RPCRequest::Ping(Ping {
                         data: u64::from_ssz_bytes(&packet)?,
                     }))),
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::MetaData => match self.protocol.version.as_str() {
-                    "1" => {
+                Protocol::MetaData => match self.protocol.version {
+                    Version::V1 => {
                         if packet.len() > 0 {
                             Err(RPCError::Custom(
                                 "Get metadata request should be empty".into(),
@@ -119,9 +114,7 @@ impl<TSpec: EthSpec> Decoder for SSZInboundCodec<TSpec> {
                             Ok(Some(RPCRequest::MetaData(PhantomData)))
                         }
                     }
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                _ => unreachable!("Cannot negotiate an unknown protocol"),
             },
             Ok(None) => Ok(None),
             Err(e) => Err(e),
@@ -189,40 +182,34 @@ impl<TSpec: EthSpec> Decoder for SSZOutboundCodec<TSpec> {
             // clear the buffer and return an empty object
             src.clear();
             match self.protocol.message_name {
-                Protocol::Status => match self.protocol.version.as_str() {
-                    "1" => Err(RPCError::Custom(
+                Protocol::Status => match self.protocol.version {
+                    Version::V1 => Err(RPCError::Custom(
                         "Status stream terminated unexpectedly".into(),
                     )), // cannot have an empty HELLO message. The stream has terminated unexpectedly
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
                 Protocol::Goodbye => {
                     Err(RPCError::InvalidProtocol("GOODBYE doesn't have a response"))
                 }
-                Protocol::BlocksByRange => match self.protocol.version.as_str() {
-                    "1" => Err(RPCError::Custom(
+                Protocol::BlocksByRange => match self.protocol.version {
+                    Version::V1 => Err(RPCError::Custom(
                         "Status stream terminated unexpectedly, empty block".into(),
                     )), // cannot have an empty block message.
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::BlocksByRoot => match self.protocol.version.as_str() {
-                    "1" => Err(RPCError::Custom(
+                Protocol::BlocksByRoot => match self.protocol.version {
+                    Version::V1 => Err(RPCError::Custom(
                         "Status stream terminated unexpectedly, empty block".into(),
                     )), // cannot have an empty block message.
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::Ping => match self.protocol.version.as_str() {
-                    "1" => Err(RPCError::Custom(
+                Protocol::Ping => match self.protocol.version {
+                    Version::V1 => Err(RPCError::Custom(
                         "PING stream terminated unexpectedly".into(),
                     )), // cannot have an empty block message.
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                Protocol::MetaData => match self.protocol.version.as_str() {
-                    "1" => Err(RPCError::Custom(
+                Protocol::MetaData => match self.protocol.version {
+                    Version::V1 => Err(RPCError::Custom(
                         "Metadata stream terminated unexpectedly".into(),
                     )), // cannot have an empty block message.
-                    _ => unreachable!("Cannot negotiate an unknown version"),
                 },
-                _ => unreachable!("Cannot negotiate an unknown protocol"),
             }
         } else {
             match self.inner.decode(src).map_err(RPCError::from) {
@@ -231,38 +218,33 @@ impl<TSpec: EthSpec> Decoder for SSZOutboundCodec<TSpec> {
                     let raw_bytes = packet.take();
 
                     match self.protocol.message_name {
-                        Protocol::Status => match self.protocol.version.as_str() {
-                            "1" => Ok(Some(RPCResponse::Status(StatusMessage::from_ssz_bytes(
-                                &raw_bytes,
-                            )?))),
-                            _ => unreachable!("Cannot negotiate an unknown version"),
+                        Protocol::Status => match self.protocol.version {
+                            Version::V1 => Ok(Some(RPCResponse::Status(
+                                StatusMessage::from_ssz_bytes(&raw_bytes)?,
+                            ))),
                         },
                         Protocol::Goodbye => {
                             Err(RPCError::InvalidProtocol("GOODBYE doesn't have a response"))
                         }
-                        Protocol::BlocksByRange => match self.protocol.version.as_str() {
-                            "1" => Ok(Some(RPCResponse::BlocksByRange(Box::new(
+                        Protocol::BlocksByRange => match self.protocol.version {
+                            Version::V1 => Ok(Some(RPCResponse::BlocksByRange(Box::new(
                                 SignedBeaconBlock::from_ssz_bytes(&raw_bytes)?,
                             )))),
-                            _ => unreachable!("Cannot negotiate an unknown version"),
                         },
-                        Protocol::BlocksByRoot => match self.protocol.version.as_str() {
-                            "1" => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
+                        Protocol::BlocksByRoot => match self.protocol.version {
+                            Version::V1 => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
                                 SignedBeaconBlock::from_ssz_bytes(&raw_bytes)?,
                             )))),
-                            _ => unreachable!("Cannot negotiate an unknown version"),
                         },
-                        Protocol::Ping => match self.protocol.version.as_str() {
-                            "1" => Ok(Some(RPCResponse::Pong(Ping {
+                        Protocol::Ping => match self.protocol.version {
+                            Version::V1 => Ok(Some(RPCResponse::Pong(Ping {
                                 data: u64::from_ssz_bytes(&raw_bytes)?,
                             }))),
-                            _ => unreachable!("Cannot negotiate an unknown version"),
                         },
-                        Protocol::MetaData => match self.protocol.version.as_str() {
-                            "1" => Ok(Some(RPCResponse::MetaData(MetaData::from_ssz_bytes(
-                                &raw_bytes,
-                            )?))),
-                            _ => unreachable!("Cannot negotiate an unknown version"),
+                        Protocol::MetaData => match self.protocol.version {
+                            Version::V1 => Ok(Some(RPCResponse::MetaData(
+                                MetaData::from_ssz_bytes(&raw_bytes)?,
+                            ))),
                         },
                     }
                 }

--- a/beacon_node/eth2-libp2p/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/codec/ssz_snappy.rs
@@ -1,7 +1,7 @@
 use crate::rpc::methods::*;
 use crate::rpc::{
     codec::base::OutboundCodec,
-    protocol::{Protocol, ProtocolId, RPCError},
+    protocol::{Encoding, Protocol, ProtocolId, RPCError},
 };
 use crate::rpc::{ErrorMessage, RPCErrorResponse, RPCRequest, RPCResponse};
 use libp2p::bytes::BytesMut;
@@ -31,7 +31,7 @@ impl<T: EthSpec> SSZSnappyInboundCodec<T> {
     pub fn new(protocol: ProtocolId, max_packet_size: usize) -> Self {
         let uvi_codec = Uvi::default();
         // this encoding only applies to ssz_snappy.
-        debug_assert!(protocol.encoding.as_str() == "ssz_snappy");
+        debug_assert_eq!(protocol.encoding, Encoding::SSZSnappy);
 
         SSZSnappyInboundCodec {
             inner: uvi_codec,
@@ -190,7 +190,7 @@ impl<TSpec: EthSpec> SSZSnappyOutboundCodec<TSpec> {
     pub fn new(protocol: ProtocolId, max_packet_size: usize) -> Self {
         let uvi_codec = Uvi::default();
         // this encoding only applies to ssz_snappy.
-        debug_assert!(protocol.encoding.as_str() == "ssz_snappy");
+        debug_assert_eq!(protocol.encoding, Encoding::SSZSnappy);
 
         SSZSnappyOutboundCodec {
             inner: uvi_codec,

--- a/beacon_node/eth2-libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/protocol.rs
@@ -50,6 +50,13 @@ pub enum Protocol {
     MetaData,
 }
 
+/// RPC Versions
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Version {
+    /// Version 1 of RPC
+    V1,
+}
+
 /// RPC Encondings supported.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Encoding {
@@ -81,6 +88,15 @@ impl std::fmt::Display for Encoding {
     }
 }
 
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let repr = match self {
+            Version::V1 => "1",
+        };
+        f.write_str(repr)
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RPCProtocol<TSpec: EthSpec> {
     pub phantom: PhantomData<TSpec>,
@@ -93,18 +109,18 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
     /// The list of supported RPC protocols for Lighthouse.
     fn protocol_info(&self) -> Self::InfoIter {
         vec![
-            ProtocolId::new(Protocol::Status, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::Status, "1", Encoding::SSZ),
-            ProtocolId::new(Protocol::Goodbye, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::Goodbye, "1", Encoding::SSZ),
-            ProtocolId::new(Protocol::BlocksByRange, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::BlocksByRange, "1", Encoding::SSZ),
-            ProtocolId::new(Protocol::BlocksByRoot, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::BlocksByRoot, "1", Encoding::SSZ),
-            ProtocolId::new(Protocol::Ping, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::Ping, "1", Encoding::SSZ),
-            ProtocolId::new(Protocol::MetaData, "1", Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::MetaData, "1", Encoding::SSZ),
+            ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZ),
+            ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZ),
+            ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZ),
+            ProtocolId::new(Protocol::BlocksByRoot, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::BlocksByRoot, Version::V1, Encoding::SSZ),
+            ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZ),
+            ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZ),
         ]
     }
 }
@@ -116,7 +132,7 @@ pub struct ProtocolId {
     pub message_name: Protocol,
 
     /// The version of the RPC.
-    pub version: String,
+    pub version: Version,
 
     /// The encoding of the RPC.
     pub encoding: Encoding,
@@ -127,7 +143,7 @@ pub struct ProtocolId {
 
 /// An RPC protocol ID.
 impl ProtocolId {
-    pub fn new(message_name: Protocol, version: &str, encoding: Encoding) -> Self {
+    pub fn new(message_name: Protocol, version: Version, encoding: Encoding) -> Self {
         let protocol_id = format!(
             "{}/{}/{}/{}",
             PROTOCOL_PREFIX, message_name, version, encoding
@@ -135,7 +151,7 @@ impl ProtocolId {
 
         ProtocolId {
             message_name,
-            version: version.into(),
+            version: version,
             encoding,
             protocol_id,
         }
@@ -194,7 +210,7 @@ where
                     BaseInboundCodec::new(SSZSnappyInboundCodec::new(protocol, MAX_RPC_SIZE));
                 InboundCodec::SSZSnappy(ssz_snappy_codec)
             }
-            Encoding::SSZ | _ => {
+            Encoding::SSZ => {
                 let ssz_codec = BaseInboundCodec::new(SSZInboundCodec::new(protocol, MAX_RPC_SIZE));
                 InboundCodec::SSZ(ssz_codec)
             }
@@ -260,28 +276,28 @@ impl<TSpec: EthSpec> RPCRequest<TSpec> {
         match self {
             // add more protocols when versions/encodings are supported
             RPCRequest::Status(_) => vec![
-                ProtocolId::new(Protocol::Status, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::Status, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZ),
             ],
             RPCRequest::Goodbye(_) => vec![
-                ProtocolId::new(Protocol::Goodbye, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::Goodbye, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZ),
             ],
             RPCRequest::BlocksByRange(_) => vec![
-                ProtocolId::new(Protocol::BlocksByRange, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::BlocksByRange, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZ),
             ],
             RPCRequest::BlocksByRoot(_) => vec![
-                ProtocolId::new(Protocol::BlocksByRoot, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::BlocksByRoot, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::BlocksByRoot, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::BlocksByRoot, Version::V1, Encoding::SSZ),
             ],
             RPCRequest::Ping(_) => vec![
-                ProtocolId::new(Protocol::Ping, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::Ping, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZ),
             ],
             RPCRequest::MetaData(_) => vec![
-                ProtocolId::new(Protocol::MetaData, "1", Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::MetaData, "1", Encoding::SSZ),
+                ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZ),
             ],
         }
     }
@@ -356,7 +372,7 @@ where
                     BaseOutboundCodec::new(SSZSnappyOutboundCodec::new(protocol, MAX_RPC_SIZE));
                 OutboundCodec::SSZSnappy(ssz_snappy_codec)
             }
-            Encoding::SSZ | _ => {
+            Encoding::SSZ => {
                 let ssz_codec =
                     BaseOutboundCodec::new(SSZOutboundCodec::new(protocol, MAX_RPC_SIZE));
                 OutboundCodec::SSZ(ssz_codec)


### PR DESCRIPTION
## Issue Addressed

Closes #1000 a.k.a goodbye `unreachable`s

## Proposed Changes

move names, versions, and encodings to be enums

## Additional Info

I have the feeling these three should be mirrored in some decoding/de-serialization. If this is the case, could someone point me where?
