### PR TITLE
Shift gossip duplication into gossipsub

### DIFF
--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "2b6d002161f142b1db350f6d1302b4a84a1d4234" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "8517d93012e9a5cc1d61fbee52c8da59727347ed" }
 types = { path =  "../../eth2/types" }
 hashmap_delay = { path = "../../eth2/utils/hashmap_delay" }
 eth2_ssz_types = { path =  "../../eth2/utils/ssz_types" }

--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -49,6 +49,7 @@ pub struct Behaviour<TSubstream: AsyncRead + AsyncWrite, TSpec: EthSpec> {
     /// A cache of recently seen gossip messages. This is used to filter out any possible
     /// duplicates that may still be seen over gossipsub.
     #[behaviour(ignore)]
+    // TODO: Remove this
     seen_gossip_messages: LruCache<MessageId, ()>,
     /// A collections of variables accessible outside the network service.
     #[behaviour(ignore)]
@@ -354,7 +355,7 @@ impl<TSubstream: AsyncRead + AsyncWrite, TSpec: EthSpec>
                             debug!(self.log, "Could not decode gossipsub message"; "error" => format!("{}", e))
                         }
                         Ok(msg) => {
-                            warn!(self.log, "A duplicate gossipsub message was received"; "message_source" => format!("{}", gs_msg.source), "propagated_peer" => format!("{}",propagation_source), "message" => format!("{}", msg));
+                            crit!(self.log, "A duplicate gossipsub message was received"; "message_source" => format!("{}", gs_msg.source), "propagated_peer" => format!("{}",propagation_source), "message" => format!("{}", msg));
                         }
                     }
                 }

--- a/beacon_node/eth2-libp2p/src/behaviour.rs
+++ b/beacon_node/eth2-libp2p/src/behaviour.rs
@@ -349,7 +349,14 @@ impl<TSubstream: AsyncRead + AsyncWrite, TSpec: EthSpec>
                         }
                     }
                 } else {
-                    warn!(self.log, "A duplicate gossipsub message was received"; "message" => format!("{:?}", gs_msg));
+                    match PubsubMessage::<TSpec>::decode(&gs_msg.topics, &gs_msg.data) {
+                        Err(e) => {
+                            debug!(self.log, "Could not decode gossipsub message"; "error" => format!("{}", e))
+                        }
+                        Ok(msg) => {
+                            warn!(self.log, "A duplicate gossipsub message was received"; "message_source" => format!("{}", gs_msg.source), "propagated_peer" => format!("{}",propagation_source), "message" => format!("{}", msg));
+                        }
+                    }
                 }
             }
             GossipsubEvent::Subscribed { peer_id, topic } => {

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -103,7 +103,7 @@ impl Default for Config {
             .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_secs(20)) // TODO: Reduce for mainnet
             .manual_propagation() // require validation before propagation
-            //    .no_source_id()
+            .no_source_id()
             .message_id_fn(gossip_message_id)
             .build();
 

--- a/beacon_node/eth2-libp2p/src/config.rs
+++ b/beacon_node/eth2-libp2p/src/config.rs
@@ -103,7 +103,7 @@ impl Default for Config {
             .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_secs(20)) // TODO: Reduce for mainnet
             .manual_propagation() // require validation before propagation
-            .no_source_id()
+            //    .no_source_id()
             .message_id_fn(gossip_message_id)
             .build();
 

--- a/beacon_node/eth2-libp2p/src/types/pubsub.rs
+++ b/beacon_node/eth2-libp2p/src/types/pubsub.rs
@@ -172,3 +172,30 @@ impl<T: EthSpec> PubsubMessage<T> {
         }
     }
 }
+
+impl<T: EthSpec> std::fmt::Display for PubsubMessage<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PubsubMessage::BeaconBlock(block) => write!(
+                f,
+                "Beacon Block: slot: {}, proposer_index: {}",
+                block.message.slot, block.message.proposer_index
+            ),
+            PubsubMessage::AggregateAndProofAttestation(att) => write!(
+                f,
+                "Aggregate and Proof: slot: {}, index: {}, aggregator_index: {}",
+                att.message.aggregate.data.slot,
+                att.message.aggregate.data.index,
+                att.message.aggregator_index,
+            ),
+            PubsubMessage::Attestation(data) => write!(
+                f,
+                "Attestation: subnet_id: {}, attestation_slot: {}, attestation_index: {}",
+                *data.0, data.1.data.slot, data.1.data.index,
+            ),
+            PubsubMessage::VoluntaryExit(_data) => write!(f, "Voluntary Exit"),
+            PubsubMessage::ProposerSlashing(_data) => write!(f, "Proposer Slashing"),
+            PubsubMessage::AttesterSlashing(_data) => write!(f, "Attester Slashing"),
+        }
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Gossip message duplication has been increased in gossipsub lifting the burden from lighthouse. 

This is a temporary measure until we upgrade to stable futures and modify the underlying gossipsub
