### PR TITLE
Add debug log when gossip block recieved

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -304,6 +304,10 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             Err(BlockError::ProposalSignatureInvalid)
         }
     }
+
+    pub fn block_root(&self) -> Hash256 {
+        self.block_root
+    }
 }
 
 impl<T: BeaconChainTypes> IntoFullyVerifiedBlock<T> for GossipVerifiedBlock<T> {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -112,7 +112,6 @@ pub fn get_config<E: EthSpec>(
             .map_err(|_| format!("Invalid port: {}", port_str))?;
         client_config.network.libp2p_port = port;
         client_config.network.discovery_port = port;
-        dbg!(&client_config.network.discovery_port);
     }
 
     if let Some(port_str) = cli_args.value_of("discovery-port") {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

At the moment it's quite difficult to tell when a gossip block has been received since the logs are in `trace`. This adds a helpful `debug` message.