### PR TITLE
Discv5 bug-fix

### DIFF
--- a/beacon_node/eth2-libp2p/Cargo.toml
+++ b/beacon_node/eth2-libp2p/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 hex = "0.3"
 # rust-libp2p is presently being sourced from a Sigma Prime fork of the
 # `libp2p/rust-libp2p` repository.
-libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "8517d93012e9a5cc1d61fbee52c8da59727347ed" }
+libp2p =  { git = "https://github.com/SigP/rust-libp2p", rev = "37b7e9349cf3e724da02bbd4b5dd6c054c2d56d3" }
 types = { path =  "../../eth2/types" }
 hashmap_delay = { path = "../../eth2/utils/hashmap_delay" }
 eth2_ssz_types = { path =  "../../eth2/utils/ssz_types" }


### PR DESCRIPTION
## Issue Addressed

An edge-case in discovery could cause a panic when running in debug. This also prevent early addition of nodes into the DHT.