### PR TITLE
Add chain_id in range syncing to avoid wrong dispatching of batch res…

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -35,7 +35,7 @@
 
 use super::block_processor::{spawn_block_processor, BatchProcessResult, ProcessId};
 use super::network_context::SyncNetworkContext;
-use super::range_sync::{BatchId, RangeSync};
+use super::range_sync::{BatchId, ChainId, RangeSync};
 use crate::router::processor::PeerSyncInfo;
 use crate::service::NetworkMessage;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProcessingOutcome};
@@ -99,6 +99,7 @@ pub enum SyncMessage<T: EthSpec> {
 
     /// A batch has been processed by the block processor thread.
     BatchProcessed {
+        chain_id: ChainId,
         batch_id: BatchId,
         downloaded_blocks: Vec<SignedBeaconBlock<T>>,
         result: BatchProcessResult,
@@ -724,12 +725,14 @@ impl<T: BeaconChainTypes> Future for SyncManager<T> {
                         self.inject_error(peer_id, request_id);
                     }
                     SyncMessage::BatchProcessed {
+                        chain_id,
                         batch_id,
                         downloaded_blocks,
                         result,
                     } => {
                         self.range_sync.handle_block_process_result(
                             &mut self.network,
+                            chain_id,
                             batch_id,
                             downloaded_blocks,
                             result,

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -305,7 +305,9 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         peer_id: PeerId,
         sync_send: mpsc::UnboundedSender<SyncMessage<T::EthSpec>>,
     ) {
+        let chain_id = rand::random();
         self.finalized_chains.push(SyncingChain::new(
+            chain_id,
             local_finalized_slot,
             target_slot,
             target_head,
@@ -334,7 +336,9 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         });
         self.head_chains.retain(|chain| !chain.peer_pool.is_empty());
 
+        let chain_id = rand::random();
         let mut new_head_chain = SyncingChain::new(
+            chain_id,
             remote_finalized_slot,
             target_slot,
             target_head,

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -8,4 +8,5 @@ mod range;
 
 pub use batch::Batch;
 pub use batch::BatchId;
+pub use chain::ChainId;
 pub use range::RangeSync;


### PR DESCRIPTION

## Issue Addressed

batch ids collide while returning results to the chains, this PR solves it by adding a chain_id

## Proposed Changes

add `chain_id`, propagate where needed and match against it when claiming a batch result
