### PR TITLE
Update Syncing logic

### DIFF
--- a/beacon_node/eth2-libp2p/src/lib.rs
+++ b/beacon_node/eth2-libp2p/src/lib.rs
@@ -20,6 +20,6 @@ pub use config::Config as NetworkConfig;
 pub use libp2p::gossipsub::{MessageId, Topic, TopicHash};
 pub use libp2p::{multiaddr, Multiaddr};
 pub use libp2p::{PeerId, Swarm};
-pub use peer_manager::{PeerDB, PeerInfo, PeerSyncStatus};
+pub use peer_manager::{PeerDB, PeerInfo, PeerSyncStatus, SyncInfo};
 pub use rpc::RPCEvent;
 pub use service::{Service, NETWORK_KEY_FILENAME};

--- a/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
@@ -16,9 +16,11 @@ use types::EthSpec;
 
 mod client;
 mod peer_info;
+mod peer_sync_status;
 mod peerdb;
 
-pub use peer_info::{PeerInfo, PeerSyncStatus};
+pub use peer_info::PeerInfo;
+pub use peer_sync_status::{PeerSyncStatus, SyncInfo};
 /// The minimum reputation before a peer is disconnected.
 // Most likely this needs tweaking
 const _MINIMUM_REPUTATION_BEFORE_BAN: Rep = 20;

--- a/beacon_node/eth2-libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peer_info.rs
@@ -1,5 +1,6 @@
 use super::client::Client;
 use super::peerdb::{Rep, DEFAULT_REPUTATION};
+use super::PeerSyncStatus;
 use crate::rpc::MetaData;
 use crate::Multiaddr;
 use serde::{
@@ -7,7 +8,7 @@ use serde::{
     Serialize,
 };
 use std::time::Instant;
-use types::{EthSpec, Slot, SubnetId};
+use types::{EthSpec, SubnetId};
 use PeerConnectionStatus::*;
 
 /// Information about a given connected peer.
@@ -128,23 +129,6 @@ impl Serialize for PeerConnectionStatus {
             }
         }
     }
-}
-
-#[derive(Clone, Debug, Serialize)]
-/// The current sync status of the peer.
-pub enum PeerSyncStatus {
-    /// At the current state as our node or ahead of us.
-    Synced {
-        /// The last known head slot from the peer's handshake.
-        status_head_slot: Slot,
-    },
-    /// Is behind our current head and not useful for block downloads.
-    Behind {
-        /// The last known head slot from the peer's handshake.
-        status_head_slot: Slot,
-    },
-    /// Not currently known as a STATUS handshake has not occurred.
-    Unknown,
 }
 
 impl Default for PeerConnectionStatus {

--- a/beacon_node/eth2-libp2p/src/peer_manager/peer_sync_status.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peer_sync_status.rs
@@ -1,0 +1,104 @@
+//! Handles individual sync status for peers.
+
+use serde::Serialize;
+use types::{Epoch, Hash256, Slot};
+
+#[derive(Clone, Debug, Serialize)]
+/// The current sync status of the peer.
+pub enum PeerSyncStatus {
+    /// At the current state as our node or ahead of us.
+    Synced { info: SyncInfo },
+    /// The peer has greater knowledge about the canonical chain than we do.
+    Advanced { info: SyncInfo },
+    /// Is behind our current head and not useful for block downloads.
+    Behind { info: SyncInfo },
+    /// Not currently known as a STATUS handshake has not occurred.
+    Unknown,
+}
+
+/// This is stored inside the PeerSyncStatus and is very similar to `PeerSyncInfo` in the
+/// `Network` crate.
+#[derive(Clone, Debug, Serialize)]
+pub struct SyncInfo {
+    pub status_head_slot: Slot,
+    pub status_head_root: Hash256,
+    pub status_finalized_epoch: Epoch,
+    pub status_finalized_root: Hash256,
+}
+
+impl PeerSyncStatus {
+    /// Returns true if the peer has advanced knowledge of the chain.
+    pub fn is_advanced(&self) -> bool {
+        match self {
+            PeerSyncStatus::Advanced { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the peer is up to date with the current chain.
+    pub fn is_synced(&self) -> bool {
+        match self {
+            PeerSyncStatus::Synced { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the peer is behind the current chain.
+    pub fn is_behind(&self) -> bool {
+        match self {
+            PeerSyncStatus::Behind { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Updates the sync state given a fully synced peer.
+    /// Returns true if the state has changed.
+    pub fn update_synced(&mut self, info: SyncInfo) -> bool {
+        let new_state = PeerSyncStatus::Synced { info };
+
+        match self {
+            PeerSyncStatus::Synced { .. } => {
+                *self = new_state;
+                false // state was not updated
+            }
+            _ => {
+                *self = new_state;
+                true
+            }
+        }
+    }
+
+    /// Updates the sync state given a peer that is further ahead in the chain than us.
+    /// Returns true if the state has changed.
+    pub fn update_ahead(&mut self, info: SyncInfo) -> bool {
+        let new_state = PeerSyncStatus::Advanced { info };
+
+        match self {
+            PeerSyncStatus::Advanced { .. } => {
+                *self = new_state;
+                false // state was not updated
+            }
+            _ => {
+                *self = new_state;
+                true
+            }
+        }
+    }
+
+    /// Updates the sync state given a peer that is behind us in the chain.
+    /// Returns true if the state has changed.
+    pub fn update_behind(&mut self, info: SyncInfo) -> bool {
+        let new_state = PeerSyncStatus::Behind { info };
+
+        match self {
+            PeerSyncStatus::Behind { .. } => {
+                *self = new_state;
+                false // state was not updated
+            }
+            _ => {
+                *self = new_state;
+                true
+            }
+        }
+    }
+}

--- a/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/peerdb.rs
@@ -1,4 +1,5 @@
-use super::peer_info::{PeerConnectionStatus, PeerInfo, PeerSyncStatus};
+use super::peer_info::{PeerConnectionStatus, PeerInfo};
+use super::peer_sync_status::PeerSyncStatus;
 use crate::rpc::methods::MetaData;
 use crate::PeerId;
 use slog::{crit, warn};
@@ -101,7 +102,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         self.peers
             .iter()
             .filter(|(_, info)| {
-                if let PeerSyncStatus::Synced { .. } = info.sync_status {
+                if info.sync_status.is_synced() || info.sync_status.is_advanced() {
                     return info.connection_status.is_connected();
                 }
                 false

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -1,5 +1,5 @@
 use crate::service::NetworkMessage;
-use crate::sync::SyncMessage;
+use crate::sync::{PeerSyncInfo, SyncMessage};
 use beacon_chain::{
     AttestationProcessingOutcome, AttestationType, BeaconChain, BeaconChainTypes, BlockError,
     BlockProcessingOutcome, GossipVerifiedBlock,
@@ -22,34 +22,6 @@ use types::{
 /// If a block is more than `FUTURE_SLOT_TOLERANCE` slots ahead of our slot clock, we drop it.
 /// Otherwise we queue it.
 pub(crate) const FUTURE_SLOT_TOLERANCE: u64 = 1;
-
-/// Keeps track of syncing information for known connected peers.
-#[derive(Clone, Copy, Debug)]
-pub struct PeerSyncInfo {
-    fork_digest: [u8; 4],
-    pub finalized_root: Hash256,
-    pub finalized_epoch: Epoch,
-    pub head_root: Hash256,
-    pub head_slot: Slot,
-}
-
-impl From<StatusMessage> for PeerSyncInfo {
-    fn from(status: StatusMessage) -> PeerSyncInfo {
-        PeerSyncInfo {
-            fork_digest: status.fork_digest,
-            finalized_root: status.finalized_root,
-            finalized_epoch: status.finalized_epoch,
-            head_root: status.head_root,
-            head_slot: status.head_slot,
-        }
-    }
-}
-
-impl PeerSyncInfo {
-    pub fn from_chain<T: BeaconChainTypes>(chain: &Arc<BeaconChain<T>>) -> Option<PeerSyncInfo> {
-        Some(Self::from(status_message(chain)?))
-    }
-}
 
 /// Processes validated messages from the network. It relays necessary data to the syncing thread
 /// and processes blocks from the pubsub network.

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -4,6 +4,8 @@
 mod block_processor;
 pub mod manager;
 mod network_context;
+mod peer_sync_info;
 mod range_sync;
 
 pub use manager::SyncMessage;
+pub use peer_sync_info::PeerSyncInfo;

--- a/beacon_node/network/src/sync/peer_sync_info.rs
+++ b/beacon_node/network/src/sync/peer_sync_info.rs
@@ -84,9 +84,11 @@ impl PeerSyncInfo {
         if remote.finalized_epoch == self.finalized_epoch
             && remote.finalized_root == self.finalized_root
         {
-            // that we within SLOT_IMPORT_TOLERANCE of our two heads
-            if remote.head_slot.sub(self.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE
-                || self.head_slot.sub(remote.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE
+            // that we are within SLOT_IMPORT_TOLERANCE of our two heads
+            if (self.head_slot >= remote.head_slot
+                && self.head_slot.sub(remote.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
+                || (self.head_slot < remote.head_slot)
+                    && remote.head_slot.sub(self.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE
             {
                 return true;
             }

--- a/beacon_node/network/src/sync/peer_sync_info.rs
+++ b/beacon_node/network/src/sync/peer_sync_info.rs
@@ -1,0 +1,112 @@
+use super::manager::SLOT_IMPORT_TOLERANCE;
+use crate::router::processor::status_message;
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use eth2_libp2p::rpc::methods::*;
+use eth2_libp2p::SyncInfo;
+use std::ops::Sub;
+use std::sync::Arc;
+use types::{Epoch, Hash256, Slot};
+
+///
+/// Keeps track of syncing information for known connected peers.
+#[derive(Clone, Copy, Debug)]
+pub struct PeerSyncInfo {
+    pub fork_digest: [u8; 4],
+    pub finalized_root: Hash256,
+    pub finalized_epoch: Epoch,
+    pub head_root: Hash256,
+    pub head_slot: Slot,
+}
+
+/// The type of peer relative to our current state.
+pub enum PeerSyncType {
+    /// The peer is on our chain and is fully synced with respect to our chain.
+    FullySynced,
+    /// The peer has a greater knowledge of the chain that us that warrants a full sync.
+    Advanced,
+    /// A peer is behind in the sync and not useful to us for downloading blocks.
+    Behind,
+}
+
+impl From<StatusMessage> for PeerSyncInfo {
+    fn from(status: StatusMessage) -> PeerSyncInfo {
+        PeerSyncInfo {
+            fork_digest: status.fork_digest,
+            finalized_root: status.finalized_root,
+            finalized_epoch: status.finalized_epoch,
+            head_root: status.head_root,
+            head_slot: status.head_slot,
+        }
+    }
+}
+
+impl Into<SyncInfo> for PeerSyncInfo {
+    fn into(self) -> SyncInfo {
+        SyncInfo {
+            status_head_slot: self.head_slot,
+            status_head_root: self.head_root,
+            status_finalized_epoch: self.finalized_epoch,
+            status_finalized_root: self.finalized_root,
+        }
+    }
+}
+
+impl PeerSyncInfo {
+    /// Derives the peer sync information from a beacon chain.
+    pub fn from_chain<T: BeaconChainTypes>(chain: &Arc<BeaconChain<T>>) -> Option<PeerSyncInfo> {
+        Some(Self::from(status_message(chain)?))
+    }
+
+    /// Given another peer's `PeerSyncInfo` this will determine how useful that peer is for us in
+    /// regards to syncing.  This returns the peer sync type that can then be handled by the
+    /// `SyncManager`.
+    pub fn peer_sync_type(&self, remote_peer_sync_info: &PeerSyncInfo) -> PeerSyncType {
+        // check if the peer is fully synced with our current chain
+        if self.is_fully_synced_peer(remote_peer_sync_info) {
+            PeerSyncType::FullySynced
+        }
+        // if not, check if the peer is ahead of our chain
+        else if self.is_ahead_peer(remote_peer_sync_info) {
+            PeerSyncType::Advanced
+        } else {
+            // the peer must be behind and not useful
+            PeerSyncType::Behind
+        }
+    }
+
+    /// Determines if another peer is fully synced with the current peer.
+    ///
+    /// A fully synced peer is a peer whose finalized epoch and hash match our own and their
+    /// head is within SLOT_IMPORT_TOLERANCE of our own.
+    /// In this case we ignore any batch/range syncing.
+    fn is_fully_synced_peer(&self, remote: &PeerSyncInfo) -> bool {
+        // ensure we are on the same chain, with minor differing heads
+        if remote.finalized_epoch == self.finalized_epoch
+            && remote.finalized_root == self.finalized_root
+        {
+            // that we within SLOT_IMPORT_TOLERANCE of our two heads
+            if remote.head_slot.sub(self.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE
+                || self.head_slot.sub(remote.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Determines if a peer has more knowledge about the current chain than we do.
+    ///
+    /// There are two conditions here.
+    /// 1) The peer could have a head slot that is greater
+    /// than SLOT_IMPORT_TOLERANCE of our current head.
+    /// 2) The peer has a greater finalized slot/epoch than our own.
+    fn is_ahead_peer(&self, remote: &PeerSyncInfo) -> bool {
+        if remote.head_slot.sub(self.head_slot).as_usize() > SLOT_IMPORT_TOLERANCE
+            || self.finalized_epoch < remote.finalized_epoch
+        {
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -4,9 +4,9 @@
 //! with this struct to to simplify the logic of the other layers of sync.
 
 use super::chain::{ChainSyncingState, SyncingChain};
-use crate::router::processor::PeerSyncInfo;
 use crate::sync::manager::SyncMessage;
 use crate::sync::network_context::SyncNetworkContext;
+use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::{types::SyncState, NetworkGlobals, PeerId};
 use slog::{debug, error, info};

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -110,10 +110,9 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     }
 
     /// Updates the global sync state and logs any changes.
-    fn update_sync_state(&mut self, state: RangeSyncState) {
+    pub fn update_sync_state(&mut self) {
         // if there is no range sync occurring, the state is either synced or not based on
         // connected peers.
-        self.state = state;
 
         if self.state == RangeSyncState::Idle {
             // there is no range sync, let the state of peers determine the global node sync state
@@ -150,7 +149,8 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         if let RangeSyncState::Head { .. } = self.state {
             if self.head_chains.is_empty() {
                 // Update the global network state to either synced or stalled.
-                self.update_sync_state(RangeSyncState::Idle);
+                self.state = RangeSyncState::Idle;
+                self.update_sync_state();
             }
         }
     }
@@ -165,13 +165,14 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                 .head_info()
                 .map(|info| info.slot)
                 .unwrap_or_else(|_| Slot::from(0u64));
+
             // NOTE: This will modify the /node/syncing API to show current slot for all fields
             // while we update peers to look for new potentially HEAD chains.
             let temp_head_state = RangeSyncState::Head {
                 start_slot: current_slot,
                 head_slot: current_slot,
             };
-            self.update_sync_state(temp_head_state);
+            self.state = temp_head_state;
         }
     }
 
@@ -249,7 +250,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                     head_slot: chain.target_head_slot,
                     head_root: chain.target_head_root,
                 };
-                self.update_sync_state(state);
+                self.state = state;
 
                 // Stop the current chain from syncing
                 self.finalized_chains[index].stop_syncing();
@@ -269,11 +270,11 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                 head_slot: chain.target_head_slot,
                 head_root: chain.target_head_root,
             };
-            self.update_sync_state(state);
+            self.state = state;
         } else {
             // There are no finalized chains, update the state.
             if self.head_chains.is_empty() {
-                self.update_sync_state(RangeSyncState::Idle);
+                self.state = RangeSyncState::Idle;
             } else {
                 // for the syncing API, we find the minimal start_slot and the maximum
                 // target_slot of all head chains to report back.
@@ -291,7 +292,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                     start_slot: min_slot,
                     head_slot: max_slot,
                 };
-                self.update_sync_state(head_state);
+                self.state = head_state;
             }
         }
     }

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -169,6 +169,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
 
                 // check if the new peer's addition will favour a new syncing chain.
                 self.chains.update_finalized(network);
+                self.chains.update_sync_state();
             } else {
                 // there is no finalized chain that matches this peer's last finalized target
                 // create a new finalized chain
@@ -182,6 +183,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     self.sync_send.clone(),
                 );
                 self.chains.update_finalized(network);
+                self.chains.update_sync_state();
             }
         } else {
             if self.chains.is_finalizing_sync() {
@@ -215,6 +217,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                 );
             }
             self.chains.update_finalized(network);
+            self.chains.update_sync_state();
         }
     }
 
@@ -272,15 +275,17 @@ impl<T: BeaconChainTypes> RangeSync<T> {
             Some((index, ProcessingResult::RemoveChain)) => {
                 let chain = self.chains.remove_finalized_chain(index);
                 debug!(self.log, "Finalized chain removed"; "start_slot" => chain.start_slot.as_u64(), "end_slot" => chain.target_head_slot.as_u64());
-                // the chain is complete, re-status it's peers
-                chain.status_peers(network);
-
                 // update the state of the collection
                 self.chains.update_finalized(network);
 
-                // set the state to a head sync, to inform the manager that we are awaiting a
+                // the chain is complete, re-status it's peers
+                chain.status_peers(network);
+
+                // set the state to a head sync if there are no finalized chains, to inform the manager that we are awaiting a
                 // head chain.
                 self.chains.set_head_sync();
+                // Update the global variables
+                self.chains.update_sync_state();
 
                 // if there are no more finalized chains, re-status all known peers awaiting a head
                 // sync
@@ -312,6 +317,8 @@ impl<T: BeaconChainTypes> RangeSync<T> {
 
                         // update the state of the collection
                         self.chains.update_finalized(network);
+                        // update the global state and log any change
+                        self.chains.update_sync_state();
                     }
                     Some((_, ProcessingResult::KeepChain)) => {}
                     None => {
@@ -339,6 +346,8 @@ impl<T: BeaconChainTypes> RangeSync<T> {
 
         // update the state of the collection
         self.chains.update_finalized(network);
+        // update the global state and inform the user
+        self.chains.update_sync_state();
     }
 
     /// When a peer gets removed, both the head and finalized chains need to be searched to check which pool the peer is in. The chain may also have a batch or batches awaiting

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -42,10 +42,10 @@
 use super::chain::{ChainId, ProcessingResult};
 use super::chain_collection::{ChainCollection, RangeSyncState};
 use super::BatchId;
-use crate::router::processor::PeerSyncInfo;
 use crate::sync::block_processor::BatchProcessResult;
 use crate::sync::manager::SyncMessage;
 use crate::sync::network_context::SyncNetworkContext;
+use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::rpc::RequestId;
 use eth2_libp2p::{NetworkGlobals, PeerId};

--- a/tests/simulator/src/cli.rs
+++ b/tests/simulator/src/cli.rs
@@ -78,27 +78,31 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                         .short("s")
                         .long("speedup")
                         .takes_value(true)
-                        .help("Speed up factor for eth1 blocks and slot production (default 15)"),
+                        .default_value("15")
+                        .help("Speed up factor for eth1 blocks and slot production"),
                 )
                 .arg(
                     Arg::with_name("initial_delay")
                         .short("i")
                         .long("initial_delay")
                         .takes_value(true)
-                        .help("Epoch delay for new beacon node to start syncing (default 50)"),
+                        .default_value("5")
+                        .help("Epoch delay for new beacon node to start syncing"),
                 )
                 .arg(
                     Arg::with_name("sync_timeout")
                         .long("sync_timeout")
                         .takes_value(true)
-                        .help("Number of epochs after which newly added beacon nodes must be synced (default 10)"),
+                        .default_value("10")
+                        .help("Number of epochs after which newly added beacon nodes must be synced"),
                 )
                 .arg(
                     Arg::with_name("strategy")
                         .long("strategy")
                         .takes_value(true)
+                        .default_value("all")
                         .possible_values(&["one-node", "two-nodes", "mixed", "all"])
-                        .help("Sync verification strategy to run. (default all)"),
+                        .help("Sync verification strategy to run."),
                 ),
         )
 }

--- a/tests/simulator/src/sync_sim.rs
+++ b/tests/simulator/src/sync_sim.rs
@@ -12,14 +12,14 @@ use tokio::timer::Interval;
 use types::{Epoch, EthSpec};
 
 pub fn run_syncing_sim(matches: &ArgMatches) -> Result<(), String> {
-    let initial_delay = value_t!(matches, "initial_delay", u64).unwrap_or(50);
-    let sync_delay = value_t!(matches, "sync_delay", u64).unwrap_or(10);
-    let speed_up_factor = value_t!(matches, "speedup", u64).unwrap_or(15);
-    let strategy = value_t!(matches, "strategy", String).unwrap_or("all".into());
+    let initial_delay = value_t!(matches, "initial_delay", u64).unwrap();
+    let sync_timeout = value_t!(matches, "sync_timeout", u64).unwrap();
+    let speed_up_factor = value_t!(matches, "speedup", u64).unwrap();
+    let strategy = value_t!(matches, "strategy", String).unwrap();
 
     println!("Syncing Simulator:");
     println!(" initial_delay:{}", initial_delay);
-    println!(" sync delay:{}", sync_delay);
+    println!(" sync timeout: {}", sync_timeout);
     println!(" speed up factor:{}", speed_up_factor);
     println!(" strategy:{}", strategy);
 
@@ -29,7 +29,7 @@ pub fn run_syncing_sim(matches: &ArgMatches) -> Result<(), String> {
     syncing_sim(
         speed_up_factor,
         initial_delay,
-        sync_delay,
+        sync_timeout,
         strategy,
         log_level,
         log_format,
@@ -39,7 +39,7 @@ pub fn run_syncing_sim(matches: &ArgMatches) -> Result<(), String> {
 fn syncing_sim(
     speed_up_factor: u64,
     initial_delay: u64,
-    sync_delay: u64,
+    sync_timeout: u64,
     strategy: String,
     log_level: &str,
     log_format: Option<&str>,
@@ -108,7 +108,7 @@ fn syncing_sim(
                     beacon_config.clone(),
                     slot_duration,
                     initial_delay,
-                    sync_delay,
+                    sync_timeout,
                 ))
                 .join(final_future)
                 .map(|_| network)


### PR DESCRIPTION
## Issue Addressed

- Sync Handles peers that have a matching head slot but are on a forked chain
- Allows block parent lookup even when syncing
- Improves the syncing manager add_peer logic
- Adds further information into the peer status sync manager
- Minor corrections to the syncing sim