### PR TITLE
Allow lcli new-testnet to optionally overwrite files

### DIFF
--- a/eth2/utils/eth2_testnet_config/src/lib.rs
+++ b/eth2/utils/eth2_testnet_config/src/lib.rs
@@ -64,9 +64,11 @@ impl<E: EthSpec> Eth2TestnetConfig<E> {
         })
     }
 
-    // Write the files to the directory, only if the directory doesn't already exist.
-    pub fn write_to_file(&self, base_dir: PathBuf) -> Result<(), String> {
-        if base_dir.exists() {
+    // Write the files to the directory.
+    //
+    // Overwrites files if specified to do so.
+    pub fn write_to_file(&self, base_dir: PathBuf, overwrite: bool) -> Result<(), String> {
+        if base_dir.exists() && !overwrite {
             return Err("Testnet directory already exists".to_string());
         }
 
@@ -252,7 +254,7 @@ mod tests {
         };
 
         testnet
-            .write_to_file(base_dir.clone())
+            .write_to_file(base_dir.clone(), false)
             .expect("should write to file");
 
         let decoded = Eth2TestnetConfig::load(base_dir).expect("should load struct");

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -255,6 +255,13 @@ fn main() {
                     supplied the values will remain the default for the --spec flag",
                 )
                 .arg(
+                    Arg::with_name("force")
+                        .long("force")
+                        .short("f")
+                        .takes_value(false)
+                        .help("Overwrites any previous testnet configurations"),
+                )
+                .arg(
                     Arg::with_name("min-genesis-time")
                         .long("min-genesis-time")
                         .value_name("UNIX_SECONDS")

--- a/lcli/src/new_testnet.rs
+++ b/lcli/src/new_testnet.rs
@@ -15,11 +15,15 @@ pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
     let deposit_contract_address: Address = parse_required(matches, "deposit-contract-address")?;
     let deposit_contract_deploy_block = parse_required(matches, "deposit-contract-deploy-block")?;
 
+    let overwrite_files = matches.is_present("force");
+
     if testnet_dir_path.exists() {
-        return Err(format!(
-            "{:?} already exists, will not overwrite",
-            testnet_dir_path
-        ));
+        if !overwrite_files {
+            return Err(format!(
+                "{:?} already exists, will not overwrite. Use --force to overwrite",
+                testnet_dir_path
+            ));
+        }
     }
 
     let mut spec = T::default_spec();
@@ -57,5 +61,5 @@ pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
         yaml_config: Some(YamlConfig::from_spec::<T>(&spec)),
     };
 
-    testnet.write_to_file(testnet_dir_path)
+    testnet.write_to_file(testnet_dir_path, overwrite_files)
 }


### PR DESCRIPTION
## Issue Addressed

I have been creating a variety of testnet configurations. The `new-testnet` command refuses to overwrite any files in a current testnet directory. 

This PR allows lcli to overwrite files if the user provides the `--force` flag.