### PR TITLE
Add feature flag for writing ssz pre/post to disk

### DIFF
--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/lib.rs"
 [dev-dependencies]
 node_test_rig = { path = "../tests/node_test_rig" }
 
+[features]
+write_ssz_files = ["beacon_chain/write_ssz_files"]  # Writes debugging .ssz files to /tmp during block processing.
+
 [dependencies]
 eth2_config = { path = "../eth2/utils/eth2_config" }
 beacon_chain = { path = "beacon_chain" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com
 edition = "2018"
 
 [features]
-
 write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
 
 [dependencies]

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
+[features]
+write_ssz_files = ["beacon_node/write_ssz_files"]  # Writes debugging .ssz files to /tmp during block processing.
+
 [dependencies]
 beacon_node = { "path" = "../beacon_node" }
 tokio = "0.1.22"


### PR DESCRIPTION
## Issue Addressed

This adds back a feature that allows us to write pre-state, post-state and block to disk . This feature existed before but got lost in a recent refactor. The only difference now is that the feature flag has been pushed up so it can be accessed from the `lighthouse` binary:

```bash
cd lighthouse
cargo run --release --features write_ssz_files -- beacon_node --http
```
