### PR TITLE
Fix mapping bug in YamlConfig

### DIFF
--- a/eth2/types/src/chain_spec.rs
+++ b/eth2/types/src/chain_spec.rs
@@ -355,6 +355,7 @@ impl ChainSpec {
             persistent_committee_period: 128,
             min_genesis_delay: 300,
             milliseconds_per_slot: 6_000,
+            safe_slots_to_update_justified: 2,
             network_id: 2, // lighthouse testnet network id
             boot_nodes,
             ..ChainSpec::mainnet()
@@ -625,9 +626,9 @@ impl YamlConfig {
 
             // Validator
             eth1_follow_distance: spec.eth1_follow_distance,
-            target_aggregators_per_committee: 0,
-            random_subnets_per_validator: 0,
-            epochs_per_random_subnet_subscription: 0,
+            target_aggregators_per_committee: spec.target_aggregators_per_committee,
+            random_subnets_per_validator: spec.random_subnets_per_validator,
+            epochs_per_random_subnet_subscription: spec.epochs_per_random_subnet_subscription,
             seconds_per_eth1_block: spec.seconds_per_eth1_block,
         }
     }

--- a/tests/ef_tests/tests/tests.rs
+++ b/tests/ef_tests/tests/tests.rs
@@ -13,7 +13,9 @@ fn config_test<E: EthSpec + TypeName>() {
         .join("config.yaml");
     let yaml_config = YamlConfig::from_file(&config_path).expect("config file loads OK");
     let spec = E::default_spec();
+    let yaml_from_spec = YamlConfig::from_spec::<E>(&spec);
     assert_eq!(yaml_config.apply_to_chain_spec::<E>(&spec), Some(spec));
+    assert_eq!(yaml_from_spec, yaml_config);
 }
 
 #[test]


### PR DESCRIPTION
Fix an issue whereby some new fields of the chainspec weren't being plumbed through in `YamlConfig::from_spec`. Add a test that checks the `ChainSpec -> YamlConfig` direction of the mapping on the real `minimal` and `mainnet` configs
