### PR TITLE
Ensure genesis is not triggered too early

### DIFF
--- a/eth2/state_processing/src/lib.rs
+++ b/eth2/state_processing/src/lib.rs
@@ -10,7 +10,10 @@ pub mod per_epoch_processing;
 pub mod per_slot_processing;
 pub mod test_utils;
 
-pub use genesis::{initialize_beacon_state_from_eth1, is_valid_genesis_state, process_activations};
+pub use genesis::{
+    eth2_genesis_time, initialize_beacon_state_from_eth1, is_valid_genesis_state,
+    process_activations,
+};
 pub use per_block_processing::{
     block_signature_verifier, errors::BlockProcessingError, per_block_processing, signature_sets,
     BlockSignatureStrategy, BlockSignatureVerifier, VerifySignatures,


### PR DESCRIPTION
## Issue Addressed

- Resolves #1051

## Proposed Changes

Ensures that genesis is not triggered to early.

Thanks for @q9f for picking this one up.

We should add some tests to find regression here, but I don't think that would be the best use of my time at this moment. I've raised in issue to track tests over at #1053.
