### PR TITLE
[lcli] the fork version is now inferred from the spec and can also be…

### DIFF
--- a/lcli/src/interop_genesis.rs
+++ b/lcli/src/interop_genesis.rs
@@ -1,5 +1,5 @@
 use clap::ArgMatches;
-use clap_utils::{parse_ssz_optional};
+use clap_utils::parse_ssz_optional;
 use environment::Environment;
 use eth2_testnet_config::Eth2TestnetConfig;
 use genesis::interop_genesis_state;

--- a/lcli/src/interop_genesis.rs
+++ b/lcli/src/interop_genesis.rs
@@ -1,4 +1,5 @@
 use clap::ArgMatches;
+use clap_utils::{parse_ssz_optional};
 use environment::Environment;
 use eth2_testnet_config::Eth2TestnetConfig;
 use genesis::interop_genesis_state;
@@ -49,7 +50,9 @@ pub fn run<T: EthSpec>(mut env: Environment<T>, matches: &ArgMatches) -> Result<
             )
         })?;
 
-    spec.genesis_fork_version = [1, 3, 3, 7];
+    if let Some(v) = parse_ssz_optional(matches, "genesis-fork-version")? {
+        spec.genesis_fork_version = v;
+    }
 
     let keypairs = generate_deterministic_keypairs(validator_count);
     let genesis_state = interop_genesis_state(&keypairs, genesis_time, &spec)?;

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -225,6 +225,14 @@ fn main() {
                         .takes_value(true)
                         .help("The value for state.genesis_time. Defaults to now."),
                 )
+                .arg(
+                    Arg::with_name("genesis-fork-version")
+                        .long("genesis-fork-version")
+                        .value_name("HEX")
+                        .takes_value(true)
+                        .help("Used to avoid reply attacks between testnets. Recommended to set to
+                              non-default."),
+                )
         )
         .subcommand(
             SubCommand::with_name("change-genesis-time")


### PR DESCRIPTION
## Proposed Changes

The fork version is now inferred from the spec and can also be overridden for the interop-genesis subcommand with a command line flag just like for the new-testnet subcommand - no more hardcoded `1337` value. This helps with interop scripts with other clients - to easily generate the same genesis ssz files.
