### PR TITLE
beacon/notifier: display block information for current slot

### DIFF
--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -122,6 +122,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 );
             } else {
                 if sync_state.is_synced() {
+                    let block_info = if current_slot > head_slot { format!("   …  empty") } else { format!("{}", head_root) };
                     info!(
                         log_2,
                         "Synced";
@@ -129,6 +130,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                         "finalized_root" => format!("{}", finalized_root),
                         "finalized_epoch" => finalized_epoch,
                         "epoch" => current_epoch,
+                        "block" => block_info,
                         "slot" => current_slot,
                     );
                 } else {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Each slot can contain either a block or nothing at all. The normal `INFO` level sync log should display block hash if there is any or "empty" if there is none. 

## Additional Info

![Screenshot at 2020-04-29 12-44-58](https://user-images.githubusercontent.com/58883403/80587900-a9732d00-8a17-11ea-816b-a4a6c4944db6.png)
