### PR TITLE
Patch for tokio_timer::wheel::level_for panic

### DIFF
--- a/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
@@ -97,7 +97,12 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             // received a ping
             // reset the to-ping timer for this peer
             debug!(self.log, "Received a ping request"; "peer_id" => format!("{}", peer_id), "seq_no" => seq);
-            self.ping_peers.insert(peer_id.clone());
+            /*
+            * Commented out to try and hot-patch around a panic:
+            *
+            * https://github.com/sigp/lighthouse/issues/1067
+               self.ping_peers.insert(peer_id.clone());
+            */
 
             // if the sequence number is unknown send update the meta data of the peer.
             if let Some(meta_data) = &peer_info.meta_data {

--- a/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2-libp2p/src/peer_manager/mod.rs
@@ -319,7 +319,7 @@ impl<TSpec: EthSpec> Stream for PeerManager<TSpec> {
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         // poll the timeouts for pings and status'
         while let Async::Ready(Some(peer_id)) = self.ping_peers.poll().map_err(|e| {
-            error!(self.log, "Failed to check for peers to ping"; "error" => format!("{}",e));
+            error!(self.log, "Failed to check for peers to ping"; "error" => format!("{:?}",e));
         })? {
             debug!(self.log, "Pinging peer"; "peer_id" => format!("{}", peer_id));
             // add the ping timer back
@@ -328,7 +328,7 @@ impl<TSpec: EthSpec> Stream for PeerManager<TSpec> {
         }
 
         while let Async::Ready(Some(peer_id)) = self.status_peers.poll().map_err(|e| {
-            error!(self.log, "Failed to check for peers to status"; "error" => format!("{}",e));
+            error!(self.log, "Failed to check for peers to status"; "error" => format!("{:?}",e));
         })? {
             debug!(self.log, "Sending Status to peer"; "peer_id" => format!("{}", peer_id));
             // add the status timer back

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -604,7 +604,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
         // process any peer discovery events
         while let Async::Ready(Some(exact_subnet)) =
                     self.discover_peers.poll().map_err(|e| {
-                        error!(self.log, "Failed to check for peer discovery requests"; "error"=> format!("{}", e));
+                        error!(self.log, "Failed to check for peer discovery requests"; "error"=> format!("{:?}", e));
                     })?
                 {
                     self.handle_discover_peers(exact_subnet);
@@ -612,7 +612,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
 
         // process any subscription events
         while let Async::Ready(Some(exact_subnet)) = self.subscriptions.poll().map_err(|e| {
-                        error!(self.log, "Failed to check for subnet subscription times"; "error"=> format!("{}", e));
+                        error!(self.log, "Failed to check for subnet subscription times"; "error"=> format!("{:?}", e));
                     })?
                 {
                     self.handle_subscriptions(exact_subnet);
@@ -620,7 +620,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
 
         // process any un-subscription events
         while let Async::Ready(Some(exact_subnet)) = self.unsubscriptions.poll().map_err(|e| {
-                        error!(self.log, "Failed to check for subnet unsubscription times"; "error"=> format!("{}", e));
+                        error!(self.log, "Failed to check for subnet unsubscription times"; "error"=> format!("{:?}", e));
                     })?
                 {
                     self.handle_unsubscriptions(exact_subnet);
@@ -628,7 +628,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
 
         // process any random subnet expiries
         while let Async::Ready(Some(subnet)) = self.random_subnets.poll().map_err(|e| {
-                        error!(self.log, "Failed to check for random subnet cycles"; "error"=> format!("{}", e));
+                        error!(self.log, "Failed to check for random subnet cycles"; "error"=> format!("{:?}", e));
                     })?
                 {
                     self.handle_random_subnet_expiry(subnet);
@@ -636,7 +636,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
 
         // process any known validator expiries
         while let Async::Ready(Some(_validator_index)) = self.known_validators.poll().map_err(|e| {
-                        error!(self.log, "Failed to check for random subnet cycles"; "error"=> format!("{}", e));
+                        error!(self.log, "Failed to check for random subnet cycles"; "error"=> format!("{:?}", e));
                     })?
                 {
                     let _ = self.handle_known_validator_expiry();

--- a/eth2/utils/hashmap_delay/src/lib.rs
+++ b/eth2/utils/hashmap_delay/src/lib.rs
@@ -19,3 +19,9 @@ mod hashset_delay;
 
 pub use crate::hashmap_delay::HashMapDelay;
 pub use crate::hashset_delay::HashSetDelay;
+
+#[derive(Debug)]
+pub enum Error {
+    TimerError(tokio_timer::Error),
+    MissingValue,
+}


### PR DESCRIPTION
## Issue Addressed

- #1067

## Proposed Changes

- Adds some more detail to the error for `HashSetDelay` and `HashMapDelay`
- Removes the `ping_peers.insert` in `ping_request` (caused [this panic](https://github.com/sigp/lighthouse/issues/1067#issuecomment-621318614))

## Additional Info

I don't think this fixes the root cause of the issue, it's just a patch for the meantime. This is why I haven't set it to close #1067, which has more detail on my troubleshooting process.