### PR TITLE
Avoid implicit validator status assumption

### DIFF
--- a/eth2/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/eth2/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -15,29 +15,24 @@ pub fn process_registry_updates<T: EthSpec>(
     // We assume it's safe to re-order the change in eligibility and `initiate_validator_exit`.
     // Rest assured exiting validators will still be exited in the same order as in the spec.
     let current_epoch = state.current_epoch();
-    let is_exiting_validator = |validator: &Validator| {
+    let is_ejectable = |validator: &Validator| {
         validator.is_active_at(current_epoch)
             && validator.effective_balance <= spec.ejection_balance
     };
-    let (eligible_validators, exiting_validators): (Vec<_>, Vec<_>) = state
+    let indices_to_update: Vec<_> = state
         .validators
         .iter()
         .enumerate()
         .filter(|(_, validator)| {
-            validator.is_eligible_for_activation_queue(spec) || is_exiting_validator(validator)
+            validator.is_eligible_for_activation_queue(spec) || is_ejectable(validator)
         })
-        .partition_map(|(index, validator)| {
-            if validator.is_eligible_for_activation_queue(spec) {
-                Either::Left(index)
-            } else {
-                Either::Right(index)
-            }
-        });
-    for index in eligible_validators {
-        state.validators[index].activation_eligibility_epoch = current_epoch + 1;
-    }
-    for index in exiting_validators {
-        initiate_validator_exit(state, index, spec)?;
+    for index in indices_to_update {
+        if state.validators[index].is_eligible_for_activation_queue(spec) {
+            state.validators[index].activation_eligibility_epoch = current_epoch + 1;
+        }
+        if is_ejectable(validator) {
+            initiate_validator_exit(state, index, spec)?;
+        }
     }
 
     // Queue validators eligible for activation and not dequeued for activation prior to finalized epoch

--- a/eth2/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/eth2/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -30,7 +30,7 @@ pub fn process_registry_updates<T: EthSpec>(
         if state.validators[index].is_eligible_for_activation_queue(spec) {
             state.validators[index].activation_eligibility_epoch = current_epoch + 1;
         }
-        if is_ejectable(validator) {
+        if is_ejectable(state.validators[index]) {
             initiate_validator_exit(state, index, spec)?;
         }
     }


### PR DESCRIPTION
The `partition_map` implicitly assumes that validators cannot be both `is_eligible_for_activation_queue` and `is_exiting_validator`. While this assumption is true it feels a bit "dangerous". Besides being more readable the refactor is also shorter and more efficient :) Also rename `is_exiting_validator ` to `is_ejectable` (more to the point).