### PR TITLE
Two changes to `process_eth1_data`

### DIFF
--- a/eth2/state_processing/src/per_block_processing.rs
+++ b/eth2/state_processing/src/per_block_processing.rs
@@ -256,9 +256,9 @@ pub fn get_new_eth1_data<T: EthSpec>(
     state: &BeaconState<T>,
     eth1_data: &Eth1Data,
 ) -> Result<Option<Eth1Data>, ArithError> {
-    // Return early when `state.eth1_data` cannot change (redundant vote or insufficient total votes).
-    let max_votes = state.eth1_data_votes.count()
-    if max_votes.safe_mul(2)? <= T::SlotsPerEth1VotingPeriod::to_usize() || state.eth1_data == eth1_data {
+    // Return early when `state.eth1_data` cannot change (insufficient total votes or redundant vote).
+    let total_votes = state.eth1_data_votes.count()
+    if total_votes.safe_mul(2)? <= T::SlotsPerEth1VotingPeriod::to_usize() || state.eth1_data == eth1_data {
         return Ok(None)
     }
 


### PR DESCRIPTION
Two changes to `process_eth1_data`:

1) Push `eth1_data` to `state.eth1_data_votes` early as done in the spec to ease auditing. (Why was it done the current way?)
2) Add a fast path for performance. Possibly relevant when doing full historical synchs.
