### PR TITLE
Add note about building from testnet5

### DIFF
--- a/book/src/become-a-validator.md
+++ b/book/src/become-a-validator.md
@@ -21,6 +21,7 @@ There are two, different ways to install and start a Lighthouse validator:
 
 2. [Building from source](./become-a-validator-source.md): this is a little more involved, however it
    gives a more hands-on experience.
+   - Note: to connect to the testnet you must build from the `testnet5` branch, `master` will not work.
 
 Once you've completed **either one** of these steps, you can move onto the next step.
 


### PR DESCRIPTION
## Issue Addressed

- Resolves #1061

## Proposed Changes

Adds an extra note to the "Become a Validator" docs to remind users to build from `testnet5`.
