### PR TITLE
Add skip-slots command to lcli

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -10,6 +10,7 @@ mod interop_genesis;
 mod new_testnet;
 mod parse_hex;
 mod refund_deposit_contract;
+mod skip_slots;
 mod transition_blocks;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -75,6 +76,32 @@ fn main() {
                         .takes_value(true)
                         .default_value("./genesis_state.yaml")
                         .help("Output file for generated state."),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("skip-slots")
+                .about("Performs a state transition from some state across some number of skip slots")
+                .arg(
+                    Arg::with_name("pre-state")
+                        .value_name("BEACON_STATE")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Path to a SSZ file of the pre-state."),
+                )
+                .arg(
+                    Arg::with_name("slots")
+                        .value_name("SLOT_COUNT")
+                        .takes_value(true)
+                        .required(true)
+                        .help("Number of slots to skip before outputting a state.."),
+                )
+                .arg(
+                    Arg::with_name("output")
+                        .value_name("SSZ_FILE")
+                        .takes_value(true)
+                        .required(true)
+                        .default_value("./output.ssz")
+                        .help("Path to output a SSZ file."),
                 ),
         )
         .subcommand(
@@ -488,6 +515,9 @@ fn run<T: EthSpec>(env_builder: EnvironmentBuilder<T>, matches: &ArgMatches) -> 
         }
         ("transition-blocks", Some(matches)) => run_transition_blocks::<T>(matches)
             .map_err(|e| format!("Failed to transition blocks: {}", e)),
+        ("skip-slots", Some(matches)) => {
+            skip_slots::run::<T>(matches).map_err(|e| format!("Failed to skip slots: {}", e))
+        }
         ("pretty-hex", Some(matches)) => {
             run_parse_hex::<T>(matches).map_err(|e| format!("Failed to pretty print hex: {}", e))
         }

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -1,0 +1,55 @@
+use crate::transition_blocks::load_from_ssz;
+use clap::ArgMatches;
+use ssz::Encode;
+use state_processing::per_slot_processing;
+use std::fs::File;
+use std::io::prelude::*;
+use std::path::PathBuf;
+use types::{BeaconState, EthSpec};
+
+pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
+    let pre_state_path = matches
+        .value_of("pre-state")
+        .ok_or_else(|| "No pre-state file supplied".to_string())?
+        .parse::<PathBuf>()
+        .map_err(|e| format!("Failed to parse pre-state path: {}", e))?;
+
+    let slots = matches
+        .value_of("slots")
+        .ok_or_else(|| "No slots supplied".to_string())?
+        .parse::<usize>()
+        .map_err(|e| format!("Failed to parse slots: {}", e))?;
+
+    let output_path = matches
+        .value_of("output")
+        .ok_or_else(|| "No output file supplied".to_string())?
+        .parse::<PathBuf>()
+        .map_err(|e| format!("Failed to parse output path: {}", e))?;
+
+    info!("Using minimal spec");
+    info!("Pre-state path: {:?}", pre_state_path);
+    info!("Slots: {:?}", slots);
+
+    let mut state: BeaconState<T> = load_from_ssz(pre_state_path)?;
+
+    let spec = &T::default_spec();
+
+    state
+        .build_all_caches(spec)
+        .map_err(|e| format!("Unable to build caches: {:?}", e))?;
+
+    // Transition the parent state to the block slot.
+    for i in 0..slots {
+        per_slot_processing(&mut state, None, spec)
+            .map_err(|e| format!("Failed to advance slot on iteration {}: {:?}", i, e))?;
+    }
+
+    let mut output_file =
+        File::create(output_path).map_err(|e| format!("Unable to create output file: {:?}", e))?;
+
+    output_file
+        .write_all(&state.as_ssz_bytes())
+        .map_err(|e| format!("Unable to write to output file: {:?}", e))?;
+
+    Ok(())
+}

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -76,7 +76,7 @@ fn do_transition<T: EthSpec>(
     Ok(pre_state)
 }
 
-fn load_from_ssz<T: Decode>(path: PathBuf) -> Result<T, String> {
+pub fn load_from_ssz<T: Decode>(path: PathBuf) -> Result<T, String> {
     let mut file =
         File::open(path.clone()).map_err(|e| format!("Unable to open file {:?}: {:?}", path, e))?;
     let mut bytes = vec![];


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Allows `lcli` to take some SSZ encoded state, run `n` skip slots on it and output the resulting state.
