### PR TITLE
Improve genesis service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,7 +560,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -622,6 +628,7 @@ dependencies = [
  "sloggers",
  "slot_clock",
  "store",
+ "time 0.2.16",
  "timer",
  "tokio 0.2.20",
  "toml",
@@ -991,6 +998,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
@@ -1909,7 +1922,7 @@ dependencies = [
  "log 0.3.9",
  "mime 0.2.6",
  "num_cpus",
- "time",
+ "time 0.1.43",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -1934,7 +1947,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "rustc_version",
- "time",
+ "time 0.1.43",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
@@ -1964,7 +1977,7 @@ dependencies = [
  "log 0.4.8",
  "net2",
  "pin-project",
- "time",
+ "time 0.1.43",
  "tokio 0.2.20",
  "tower-service",
  "want 0.3.0",
@@ -3675,7 +3688,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "time",
+ "time 0.1.43",
  "tokio 0.2.20",
  "tokio-tls 0.3.1",
  "url 2.1.1",
@@ -3781,7 +3794,7 @@ dependencies = [
  "libsqlite3-sys",
  "lru-cache",
  "memchr",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -3806,7 +3819,7 @@ dependencies = [
  "libc",
  "rand 0.3.23",
  "rustc-serialize",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -4365,6 +4378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "standback"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4b8c631c998468961a9ea159f064c5c8499b95b5e4a34b77849d45949d540"
+
+[[package]]
 name = "state_processing"
 version = "0.2.0"
 dependencies = [
@@ -4407,6 +4426,55 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "store"
@@ -4612,6 +4680,44 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "time"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a51cadc5b1eec673a685ff7c33192ff7b7603d0b75446fb354939ee615acb15"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.1",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9b6e9f095bc105e183e3cd493d72579be3181ad4004fceb01adbe9eecab2d"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -39,3 +39,4 @@ environment = { path = "../../lighthouse/environment" }
 eth2_ssz = "0.1.2"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
+time = "0.2.16"

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -217,12 +217,12 @@ fn seconds_pretty(secs: f64) -> String {
         return "--".into();
     }
 
-    let t = time::Duration::seconds_f64(secs);
+    let d = time::Duration::seconds_f64(secs);
 
-    let weeks = t.whole_weeks();
-    let days = t.whole_days();
-    let hours = t.whole_hours();
-    let minutes = t.whole_minutes();
+    let weeks = d.whole_weeks();
+    let days = d.whole_days();
+    let hours = d.whole_hours();
+    let minutes = d.whole_minutes();
 
     if weeks > 0 {
         format!("{:.0} weeks {:.0} days", weeks, days % DAYS_PER_WEEK)

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -167,6 +167,13 @@ impl Service {
         &self.inner.deposit_cache
     }
 
+    /// Removes all blocks from the cache, except for the latest block.
+    ///
+    /// We don't remove the latest blocks so we don't lose track of the latest block.
+    pub fn clear_block_cache(&self) {
+        self.inner.block_cache.write().truncate(1)
+    }
+
     /// Drop the block cache, replacing it with an empty one.
     pub fn drop_block_cache(&self) {
         *(self.inner.block_cache.write()) = BlockCache::default();

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -142,9 +142,9 @@ impl Eth1GenesisService {
                 } else {
                     info!(
                         log,
-                        "Waiting for adequate deposits";
-                        "min_genesis_active_validator_count" => spec.min_genesis_active_validator_count,
-                        "total_deposit_count" => eth1_service.deposit_cache_len(),
+                        "Waiting for more deposits";
+                        "min_genesis_active_validators" => spec.min_genesis_active_validator_count,
+                        "total_deposits" => eth1_service.deposit_cache_len(),
                     );
 
                     delay_for(update_interval).await;
@@ -204,9 +204,9 @@ impl Eth1GenesisService {
                     info!(
                         log,
                         "Waiting for more validators";
-                        "min_genesis_active_validator_count" => spec.min_genesis_active_validator_count,
-                        "total_deposit_count" => total_deposit_count,
-                        "active_validator_count" => active_validator_count,
+                        "min_genesis_active_validators" => spec.min_genesis_active_validator_count,
+                        "total_deposits" => total_deposit_count,
+                        "active_validators" => active_validator_count,
                     );
                 }
             } else {
@@ -220,9 +220,9 @@ impl Eth1GenesisService {
                     log,
                     "Waiting for adequate eth1 timestamp";
                     "estimated_wait" => format!(
-                        "{}-{} secs",
-                        estimated_wait_low,
-                        estimated_wait_high
+                        "{}-{} mins",
+                        estimated_wait_low / 60,
+                        estimated_wait_high / 60
                     ),
                 );
             }

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -210,20 +210,12 @@ impl Eth1GenesisService {
                     );
                 }
             } else {
-                let estimated_genesis =
-                    spec.min_genesis_time.saturating_sub(spec.min_genesis_delay);
-
-                let estimated_wait_high = estimated_genesis.saturating_sub(latest_timestamp);
-                let estimated_wait_low = estimated_wait_high.saturating_sub(spec.min_genesis_delay);
-
                 info!(
                     log,
                     "Waiting for adequate eth1 timestamp";
-                    "estimated_wait" => format!(
-                        "{}-{} mins",
-                        estimated_wait_low / 60,
-                        estimated_wait_high / 60
-                    ),
+                    "ming_genesis_delay" => spec.min_genesis_delay,
+                    "genesis_time" => spec.min_genesis_time,
+                    "latest_eth1_timestamp" => latest_timestamp,
                 );
             }
 

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use tokio::time::delay_for;
 use types::{BeaconState, ChainSpec, Deposit, Eth1Data, EthSpec, Hash256};
 
-/// The number of blocks that pulled per request whilst waiting for genesis.
+/// The number of blocks that are pulled per request whilst waiting for genesis.
 const BLOCKS_PER_GENESIS_POLL: usize = 99;
 
 /// Stats about the eth1 genesis process.
@@ -377,8 +377,11 @@ impl Eth1GenesisService {
         eth1_block: &Eth1Block,
         spec: &ChainSpec,
     ) -> Result<BeaconState<E>, String> {
+        let genesis_time = eth2_genesis_time(eth1_block.timestamp, spec)
+            .map_err(|e| format!("Unable to set genesis time: {:?}", e))?;
+
         let mut state: BeaconState<E> = BeaconState::new(
-            0,
+            genesis_time,
             Eth1Data {
                 block_hash: Hash256::zero(),
                 deposit_root: Hash256::zero(),
@@ -386,9 +389,6 @@ impl Eth1GenesisService {
             },
             &spec,
         );
-
-        state.genesis_time = eth2_genesis_time(eth1_block.timestamp, spec)
-            .map_err(|e| format!("Unable to set genesis time: {:?}", e))?;
 
         self.deposit_logs_at_block(eth1_block.number)
             .iter()

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -1,20 +1,30 @@
 pub use crate::{common::genesis_deposits, interop::interop_genesis_state};
 pub use eth1::Config as Eth1Config;
 
-use eth1::{DepositLog, Eth1Block, Service};
-use parking_lot::Mutex;
+use eth1::{DepositLog, Eth1Block, Service as Eth1Service};
 use slog::{debug, error, info, trace, Logger};
 use state_processing::{
     eth2_genesis_time, initialize_beacon_state_from_eth1, is_valid_genesis_state,
     per_block_processing::process_deposit, process_activations,
 };
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Arc,
+};
 use std::time::Duration;
 use tokio::time::delay_for;
 use types::{BeaconState, ChainSpec, Deposit, Eth1Data, EthSpec, Hash256};
 
 /// The number of blocks that pulled per request whilst waiting for genesis.
 const BLOCKS_PER_GENESIS_POLL: usize = 99;
+
+/// Stats about the eth1 genesis process.
+pub struct Statistics {
+    highest_processed_block: AtomicU64,
+    active_validator_count: AtomicUsize,
+    total_deposit_count: AtomicUsize,
+    latest_timestamp: AtomicU64,
+}
 
 /// Provides a service that connects to some Eth1 HTTP JSON-RPC endpoint and maintains a cache of eth1
 /// blocks and deposits, listening for the eth1 block that triggers eth2 genesis and returning the
@@ -24,13 +34,9 @@ const BLOCKS_PER_GENESIS_POLL: usize = 99;
 #[derive(Clone)]
 pub struct Eth1GenesisService {
     /// The underlying service. Access to this object is only required for testing and diagnosis.
-    pub core: Service,
-    /// The highest block number we've processed and determined it does not trigger genesis.
-    highest_processed_block: Arc<Mutex<Option<u64>>>,
-    /// Enabled when the genesis service should start downloading blocks.
-    ///
-    /// It is disabled until there are enough deposit logs to start syncing.
-    sync_blocks: Arc<Mutex<bool>>,
+    pub eth1_service: Eth1Service,
+    /// Statistics about genesis progress.
+    stats: Arc<Statistics>,
 }
 
 impl Eth1GenesisService {
@@ -59,17 +65,21 @@ impl Eth1GenesisService {
         };
 
         Self {
-            core: Service::new(config, log),
-            highest_processed_block: Arc::new(Mutex::new(None)),
-            sync_blocks: Arc::new(Mutex::new(false)),
+            eth1_service: Eth1Service::new(config, log),
+            stats: Arc::new(Statistics {
+                highest_processed_block: AtomicU64::new(0),
+                active_validator_count: AtomicUsize::new(0),
+                total_deposit_count: AtomicUsize::new(0),
+                latest_timestamp: AtomicU64::new(0),
+            }),
         }
     }
 
     fn first_viable_eth1_block(&self, min_genesis_active_validator_count: usize) -> Option<u64> {
-        if self.core.deposit_cache_len() < min_genesis_active_validator_count {
+        if self.eth1_service.deposit_cache_len() < min_genesis_active_validator_count {
             None
         } else {
-            self.core
+            self.eth1_service
                 .deposits()
                 .read()
                 .cache
@@ -87,16 +97,22 @@ impl Eth1GenesisService {
     /// - `Err(e)` if there is some internal error during updates.
     pub async fn wait_for_genesis_state<E: EthSpec>(
         &self,
-        initial_update_interval: Duration,
+        update_interval: Duration,
         spec: ChainSpec,
     ) -> Result<BeaconState<E>, String> {
-        let service = self.clone();
-        let log = service.core.log.clone();
-        let min_genesis_active_validator_count = spec.min_genesis_active_validator_count;
-        let min_genesis_time = spec.min_genesis_time;
+        let eth1_service = &self.eth1_service;
+        let log = &eth1_service.log;
+
+        let mut sync_blocks = false;
+        let mut highest_processed_block = None;
+
+        info!(
+            log,
+            "Importing eth1 deposit logs";
+        );
 
         loop {
-            let update_result = Service::update_deposit_cache(self.core.clone())
+            let update_result = Eth1Service::update_deposit_cache(eth1_service.clone())
                 .await
                 .map_err(|e| format!("{:?}", e));
 
@@ -108,96 +124,121 @@ impl Eth1GenesisService {
                 )
             }
 
-            // Do not exit the loop if there is an error whilst updating.
-            // Only enable the `sync_blocks` flag if there are enough deposits to feasibly
-            // trigger genesis.
-            //
-            // Note: genesis is triggered by the _active_ validator count, not just the
-            // deposit count, so it's possible that block downloads are started too early.
-            // This is just wasteful, not erroneous.
-            let mut sync_blocks = self.sync_blocks.lock();
+            self.stats
+                .total_deposit_count
+                .store(eth1_service.deposit_cache_len(), Ordering::Relaxed);
 
-            if !(*sync_blocks) {
+            if !sync_blocks {
                 if let Some(viable_eth1_block) =
-                    self.first_viable_eth1_block(min_genesis_active_validator_count as usize)
+                    self.first_viable_eth1_block(spec.min_genesis_active_validator_count as usize)
                 {
                     info!(
                         log,
-                        "Minimum genesis deposit count met";
-                        "deposit_count" => min_genesis_active_validator_count,
-                        "block_number" => viable_eth1_block,
+                        "Importing eth1 blocks";
                     );
-                    self.core.set_lowest_cached_block(viable_eth1_block);
-                    *sync_blocks = true
+                    self.eth1_service.set_lowest_cached_block(viable_eth1_block);
+                    sync_blocks = true
+                } else {
+                    info!(
+                        log,
+                        "Waiting for adequate deposits";
+                        "min_genesis_active_validator_count" => spec.min_genesis_active_validator_count,
+                        "total_deposit_count" => eth1_service.deposit_cache_len(),
+                    );
+
+                    delay_for(update_interval).await;
+
+                    continue;
                 }
             }
 
-            let should_update_block_cache = *sync_blocks;
-            if should_update_block_cache {
-                let update_result = Service::update_block_cache(self.core.clone()).await;
-                if let Err(e) = update_result {
+            // Download new eth1 blocks into the cache.
+            let blocks_imported = match Eth1Service::update_block_cache(eth1_service.clone()).await
+            {
+                Ok(outcome) => {
+                    debug!(
+                        log,
+                        "Imported eth1 blocks";
+                        "latest_block_timestamp" => eth1_service.latest_block_timestamp(),
+                        "cache_head" => self.highest_safe_block(),
+                        "count" => outcome.blocks_imported,
+                    );
+                    outcome.blocks_imported
+                }
+                Err(e) => {
                     error!(
                         log,
                         "Failed to update eth1 block cache";
                         "error" => format!("{:?}", e)
                     );
+                    0
                 }
             };
-            if let Some(genesis_state) = self
-                .scan_new_blocks::<E>(&spec)
-                .map_err(|e| format!("Failed to scan for new blocks: {}", e))?
+
+            // Scan the new eth1 blocks, searching for genesis.
+            if let Some(genesis_state) =
+                self.scan_new_blocks::<E>(&mut highest_processed_block, &spec)?
             {
-                break Ok(genesis_state);
-            } else {
-                debug!(
+                info!(
                     log,
-                    "No eth1 genesis block found";
-                    "latest_block_timestamp" => self.core.latest_block_timestamp(),
-                    "min_genesis_time" => min_genesis_time,
-                    "min_validator_count" => min_genesis_active_validator_count,
-                    "cached_blocks" => self.core.block_cache_len(),
-                    "cached_deposits" => self.core.deposit_cache_len(),
-                    "cache_head" => self.highest_known_block(),
+                    "Genesis ceremony complete";
+                    "genesis_validators" => genesis_state.get_active_validator_indices(E::genesis_epoch()).len(),
+                    "genesis_time" => genesis_state.genesis_time,
                 );
+                break Ok(genesis_state);
             }
 
             // Drop all the scanned blocks as they are no longer required.
-            service.core.clear_block_cache();
+            eth1_service.clear_block_cache();
 
-            // If it's time to sync blocks and the latest block timestamp is prior to min
-            // genesis time then start doing updates much more frequently, this will help us
-            // find genesis much quicker.
-            let update_interval = if *sync_blocks {
-                match service.core.latest_block_timestamp() {
-                    Some(t) if t < spec.min_genesis_time => {
-                        // Safe from overflow due to match guard.
-                        let time_until = spec.min_genesis_time - t;
+            // Load some statistics from the atomics.
+            let active_validator_count = self.stats.active_validator_count.load(Ordering::Relaxed);
+            let total_deposit_count = self.stats.total_deposit_count.load(Ordering::Relaxed);
+            let latest_timestamp = self.stats.latest_timestamp.load(Ordering::Relaxed);
 
-                        if time_until > spec.seconds_per_eth1_block * 2 {
-                            Duration::from_millis(50)
-                        } else {
-                            initial_update_interval
-                        }
-                    }
-                    _ => initial_update_interval,
+            // Perform some logging.
+            if timestamp_can_trigger_genesis(latest_timestamp, &spec)? {
+                // Indicate that we are awaiting adequate active validators.
+                if (active_validator_count as u64) < spec.min_genesis_active_validator_count {
+                    info!(
+                        log,
+                        "Waiting for more validators";
+                        "min_genesis_active_validator_count" => spec.min_genesis_active_validator_count,
+                        "total_deposit_count" => total_deposit_count,
+                        "active_validator_count" => active_validator_count,
+                    );
                 }
             } else {
-                initial_update_interval
-            };
+                let estimated_genesis =
+                    spec.min_genesis_time.saturating_sub(spec.min_genesis_delay);
 
-            // Avoid holding the write lock during the delay.
-            drop(sync_blocks);
+                let estimated_wait_high = estimated_genesis.saturating_sub(latest_timestamp);
+                let estimated_wait_low = estimated_wait_high.saturating_sub(spec.min_genesis_delay);
 
-            // **WARNING** `delay_for` panics on error
-            delay_for(update_interval).await;
+                info!(
+                    log,
+                    "Waiting for adequate eth1 timestamp";
+                    "estimated_wait" => format!(
+                        "{}-{} secs",
+                        estimated_wait_low,
+                        estimated_wait_high
+                    ),
+                );
+            }
+
+            // If we imported the full number of blocks, poll again in a short amount of time.
+            //
+            // We assume that if we imported a large chunk of blocks then we're some distance from
+            // the head and we should sync faster.
+            if blocks_imported >= BLOCKS_PER_GENESIS_POLL {
+                delay_for(Duration::from_millis(50)).await;
+            } else {
+                delay_for(update_interval).await;
+            }
         }
     }
 
     /// Processes any new blocks that have appeared since this function was last run.
-    ///
-    /// A `highest_processed_block` value is stored in `self`. This function will find any blocks
-    /// in it's caches that have a higher block number than `highest_processed_block` and check to
-    /// see if they would trigger an Eth2 genesis.
     ///
     /// Blocks are always tested in increasing order, starting with the lowest unknown block
     /// number in the cache.
@@ -209,90 +250,80 @@ impl Eth1GenesisService {
     /// - `Err(_)` if there was some internal error.
     fn scan_new_blocks<E: EthSpec>(
         &self,
+        highest_processed_block: &mut Option<u64>,
         spec: &ChainSpec,
     ) -> Result<Option<BeaconState<E>>, String> {
-        let genesis_trigger_eth1_block = self
-            .core
-            .blocks()
-            .read()
-            .iter()
-            // Filter out any blocks that would result in a genesis time that is earlier than
-            // `MIN_GENESIS_TIME`.
+        let eth1_service = &self.eth1_service;
+        let log = &eth1_service.log;
+
+        for block in eth1_service.blocks().read().iter() {
+            // It's possible that the block and deposit caches aren't synced. Ignore any blocks
+            // which are not safe for both caches.
             //
-            // Note: any `SafeArith` errors are suppressed here; we simply skip blocks that cause
-            // overflow/div-by-zero.
-            .filter(|block| {
-                eth2_genesis_time(block.timestamp, spec)
-                    .map_or(false, |t| t >= spec.min_genesis_time)
-            })
-            // The block cache might be more recently updated than deposit cache. Restrict any
-            // block numbers that are not known by all caches.
-            .filter(|block| {
-                self.highest_known_block()
-                    .map(|n| block.number <= n)
-                    .unwrap_or_else(|| true)
-            })
-            .find(|block| {
-                let mut highest_processed_block = self.highest_processed_block.lock();
-                let block_number = block.number;
+            // Don't update the highest processed block since we want to come back and process this
+            // again later.
+            if self.highest_safe_block().map_or(true, |n| block.number > n) {
+                continue;
+            }
 
-                let next_new_block_number =
-                    highest_processed_block.map(|n| n + 1).unwrap_or_else(|| 0);
+            // Ignore any block that has already been processed or update the highest processed
+            // block.
+            if highest_processed_block.map_or(false, |highest| highest >= block.number) {
+                continue;
+            } else {
+                self.stats
+                    .highest_processed_block
+                    .store(block.number, Ordering::Relaxed);
+                self.stats
+                    .latest_timestamp
+                    .store(block.timestamp, Ordering::Relaxed);
 
-                if block_number < next_new_block_number {
-                    return false;
-                }
+                *highest_processed_block = Some(block.number)
+            }
 
-                self.is_valid_genesis_eth1_block::<E>(block, &spec, &self.core.log)
-                    .and_then(|val| {
-                        *highest_processed_block = Some(block.number);
-                        Ok(val)
-                    })
-                    .map(|is_valid| {
-                        if !is_valid {
-                            info!(
-                                self.core.log,
-                                "Inspected new eth1 block";
-                                "msg" => "did not trigger genesis",
-                                "block_number" => block_number
-                            );
-                        };
-                        is_valid
-                    })
-                    .unwrap_or_else(|_| {
-                        error!(
-                            self.core.log,
-                            "Failed to detect if eth1 block triggers genesis";
-                            "eth1_block_number" => block.number,
-                            "eth1_block_hash" => format!("{}", block.hash),
-                        );
-                        false
-                    })
-            })
-            .cloned();
+            // Ignore any block with an insufficient timestamp.
+            if !timestamp_can_trigger_genesis(block.timestamp, spec)? {
+                trace!(
+                    log,
+                    "Insufficient block timestamp";
+                    "min_genesis_delay" => spec.min_genesis_delay,
+                    "min_genesis_time" => spec.min_genesis_time,
+                    "eth1_block_timestamp" => block.timestamp,
+                    "eth1_block_number" => block.number,
+                );
+                continue;
+            }
 
-        if let Some(eth1_block) = genesis_trigger_eth1_block {
-            debug!(
-                self.core.log,
-                "All genesis conditions met";
-                "eth1_block_height" => eth1_block.number,
-            );
+            // Generate a potential beacon state for this eth1 block.
+            //
+            // Note: this state is fully valid, some fields have been bypassed to make verification
+            // faster.
+            let state = self.cheap_state_at_eth1_block::<E>(block, &spec)?;
+            let active_validator_count =
+                state.get_active_validator_indices(E::genesis_epoch()).len();
 
-            let genesis_state = self
-                .genesis_from_eth1_block(eth1_block.clone(), &spec)
-                .map_err(|e| format!("Failed to generate valid genesis state : {}", e))?;
+            self.stats
+                .active_validator_count
+                .store(active_validator_count, Ordering::Relaxed);
 
-            info!(
-                self.core.log,
-                "Deposit contract genesis complete";
-                "eth1_block_height" => eth1_block.number,
-                "validator_count" => genesis_state.validators.len(),
-            );
+            if is_valid_genesis_state(&state, spec) {
+                let genesis_state = self
+                    .genesis_from_eth1_block(block.clone(), &spec)
+                    .map_err(|e| format!("Failed to generate valid genesis state : {}", e))?;
 
-            Ok(Some(genesis_state))
-        } else {
-            Ok(None)
+                return Ok(Some(genesis_state));
+            } else {
+                trace!(
+                    log,
+                    "Insufficient active validators";
+                    "min_genesis_active_validator_count" => format!("{}", spec.min_genesis_active_validator_count),
+                    "active_validators" => active_validator_count,
+                    "eth1_block_number" => block.number,
+                );
+            }
         }
+
+        Ok(None)
     }
 
     /// Produces an eth2 genesis `BeaconState` from the given `eth1_block`.
@@ -308,7 +339,7 @@ impl Eth1GenesisService {
         spec: &ChainSpec,
     ) -> Result<BeaconState<E>, String> {
         let deposit_logs = self
-            .core
+            .eth1_service
             .deposits()
             .read()
             .cache
@@ -332,84 +363,77 @@ impl Eth1GenesisService {
         }
     }
 
-    /// A cheap (compared to using `initialize_beacon_state_from_eth1) method for determining if some
-    /// `target_block` will trigger genesis.
-    fn is_valid_genesis_eth1_block<E: EthSpec>(
+    /// Generates an incomplete `BeaconState` for some `eth1_block` that can be used for checking
+    /// to see if that `eth1_block` triggers eth2 genesis.
+    ///
+    /// Note: the returned `BeaconState` should **not** be used as the genesis state, it is
+    /// incomplete.
+    fn cheap_state_at_eth1_block<E: EthSpec>(
         &self,
-        target_block: &Eth1Block,
+        eth1_block: &Eth1Block,
         spec: &ChainSpec,
-        log: &Logger,
-    ) -> Result<bool, String> {
-        if target_block.timestamp < spec.min_genesis_time {
-            Ok(false)
-        } else {
-            let mut local_state: BeaconState<E> = BeaconState::new(
-                0,
-                Eth1Data {
-                    block_hash: Hash256::zero(),
-                    deposit_root: Hash256::zero(),
-                    deposit_count: 0,
-                },
-                &spec,
-            );
+    ) -> Result<BeaconState<E>, String> {
+        let mut state: BeaconState<E> = BeaconState::new(
+            0,
+            Eth1Data {
+                block_hash: Hash256::zero(),
+                deposit_root: Hash256::zero(),
+                deposit_count: 0,
+            },
+            &spec,
+        );
 
-            local_state.genesis_time = target_block.timestamp;
+        state.genesis_time = eth2_genesis_time(eth1_block.timestamp, spec)
+            .map_err(|e| format!("Unable to set genesis time: {:?}", e))?;
 
-            self.deposit_logs_at_block(target_block.number)
-                .iter()
-                // TODO: add the signature field back.
-                //.filter(|deposit_log| deposit_log.signature_is_valid)
-                .map(|deposit_log| Deposit {
-                    proof: vec![Hash256::zero(); spec.deposit_contract_tree_depth as usize].into(),
-                    data: deposit_log.deposit_data.clone(),
-                })
-                .try_for_each(|deposit| {
-                    // No need to verify proofs in order to test if some block will trigger genesis.
-                    const PROOF_VERIFICATION: bool = false;
+        self.deposit_logs_at_block(eth1_block.number)
+            .iter()
+            .map(|deposit_log| Deposit {
+                // Generate a bogus proof.
+                //
+                // The deposits are coming directly from our own deposit tree to there's no need to
+                // make proofs about their inclusion in it.
+                proof: vec![Hash256::zero(); spec.deposit_contract_tree_depth as usize].into(),
+                data: deposit_log.deposit_data.clone(),
+            })
+            .try_for_each(|deposit| {
+                // Skip proof verification (see comment about bogus proof generation).
+                const PROOF_VERIFICATION: bool = false;
 
-                    // Note: presently all the signatures are verified each time this function is
-                    // run.
-                    //
-                    // It would be more efficient to pre-verify signatures, filter out the invalid
-                    // ones and disable verification for `process_deposit`.
-                    //
-                    // This is only more efficient in scenarios where `min_genesis_time` occurs
-                    // _before_ `min_validator_count` is met. We're unlikely to see this scenario
-                    // in testnets (`min_genesis_time` is usually `0`) and I'm not certain it will
-                    // happen for the real, production deposit contract.
+                // Note: presently all the signatures are verified each time this function is
+                // run.
+                //
+                // It would be more efficient to pre-verify signatures, filter out the invalid
+                // ones and disable verification for `process_deposit`.
+                //
+                // This is only more efficient in scenarios where `min_genesis_time` occurs
+                // _before_ `min_validator_count` is met. We're unlikely to see this scenario
+                // in testnets (`min_genesis_time` is usually `0`) and I'm not certain it will
+                // happen for the real, production deposit contract.
 
-                    process_deposit(&mut local_state, &deposit, spec, PROOF_VERIFICATION)
-                        .map_err(|e| format!("Error whilst processing deposit: {:?}", e))
-                })?;
+                process_deposit(&mut state, &deposit, spec, PROOF_VERIFICATION)
+                    .map_err(|e| format!("Error whilst processing deposit: {:?}", e))
+            })?;
 
-            process_activations(&mut local_state, spec)
-                .map_err(|e| format!("Error whilst processing activations: {:?}", e))?;
-            let is_valid = is_valid_genesis_state(&local_state, spec);
+        process_activations(&mut state, spec)
+            .map_err(|e| format!("Error whilst processing activations: {:?}", e))?;
 
-            trace!(
-                log,
-                "Eth1 block inspected for genesis";
-                "active_validators" => local_state.get_active_validator_indices(local_state.current_epoch()).len(),
-                "validators" => local_state.validators.len()
-            );
-
-            Ok(is_valid)
-        }
+        Ok(state)
     }
 
     /// Returns the `block_number` of the highest (by block number) block in the cache.
     ///
     /// Takes the lower block number of the deposit and block caches to ensure this number is safe.
-    fn highest_known_block(&self) -> Option<u64> {
-        let block_cache = self.core.blocks().read().highest_block_number()?;
-        let deposit_cache = self.core.deposits().read().last_processed_block?;
+    fn highest_safe_block(&self) -> Option<u64> {
+        let block_cache = self.eth1_service.blocks().read().highest_block_number()?;
+        let deposit_cache = self.eth1_service.deposits().read().last_processed_block?;
 
         Some(std::cmp::min(block_cache, deposit_cache))
     }
 
     /// Returns all deposit logs included in `block_number` and all prior blocks.
     fn deposit_logs_at_block(&self, block_number: u64) -> Vec<DepositLog> {
-        self.core
+        self.eth1_service
             .deposits()
             .read()
             .cache
@@ -419,8 +443,23 @@ impl Eth1GenesisService {
             .collect()
     }
 
-    /// Returns the `Service` contained in `self`.
-    pub fn into_core_service(self) -> Service {
-        self.core
+    /// Returns statistics about the process of waiting for genesis.
+    pub fn statistics(&self) -> &Statistics {
+        &self.stats
     }
+
+    /// Returns the `Service` contained in `self`.
+    pub fn into_core_service(self) -> Eth1Service {
+        self.eth1_service
+    }
+}
+
+/// Returns `false` for a timestamp that would result in a genesis time that is earlier than
+/// `MIN_GENESIS_TIME`.
+///
+/// Note: any `SafeArith` errors are suppressed here; we simply return zero.
+fn timestamp_can_trigger_genesis(timestamp: u64, spec: &ChainSpec) -> Result<bool, String> {
+    eth2_genesis_time(timestamp, spec)
+        .map(|t| t >= spec.min_genesis_time)
+        .map_err(|e| format!("Arith error when during genesis calculation: {:?}", e))
 }

--- a/beacon_node/genesis/src/lib.rs
+++ b/beacon_node/genesis/src/lib.rs
@@ -3,6 +3,6 @@ mod eth1_genesis_service;
 mod interop;
 
 pub use eth1::Config as Eth1Config;
-pub use eth1_genesis_service::Eth1GenesisService;
+pub use eth1_genesis_service::{Eth1GenesisService, Statistics};
 pub use interop::interop_genesis_state;
 pub use types::test_utils::generate_deterministic_keypairs;


### PR DESCRIPTION
## Issue Addressed

- Resolves #1186
- Resolves #1178

## Proposed Changes

Applies the following to `Eth1GenesisService`:

- Fixes a bug where genesis was being triggered too late.
  - The candidate `BeaconState` was using `eth1_block.timestamp` as the genesis time, not `eth2_genesis_time(eth1_block.timestamp)`.
- Increases polling speed when we're trying to catch up to the eth1 head
  - Previously all polling happened at 7s intervals, this made it quite slow to catch up to the head.
- Improves logging UX.
- Adds an `Eth1GenesisService::statistics` method which returns statistics useful for future HTTP API upgrades.
- Removes unnecessary clones.

## TODO

- [x] Obtain genesis state roots from other Witti clients and ensure our root matches. (We match Prysm and Teku)
