### PR TITLE
beacon/eth1: degrade log to debug level

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -644,7 +644,7 @@ impl Service {
                 .unwrap_or_else(|| "n/a".into());
 
             if blocks_imported > 0 {
-                info!(
+                debug!(
                     service_1.log,
                     "Imported eth1 block(s)";
                     "latest_block_age" => latest_block_mins,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Degrade the `Imported eth1 block(s)` log message to `debug!` level.

## Additional Info

I personally believe it's too noisy in the `info!` log. I don't have any hard feelings about this. If you believe this should be info-level, just reject my PR :)