### PR TITLE
Add first Server Sent Events API endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-option"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0db678acb667b525ac40a324fc5f7d3390e29239b31c7327bb8157f5b4fff593"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +278,7 @@ version = "0.1.2"
 dependencies = [
  "bitvec",
  "bls",
+ "bus",
  "environment",
  "eth1",
  "eth2_config",
@@ -479,6 +486,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5356f1d23ee24a1f785a56d1d1a5f0fd5b0f6a0c0fb2412ce11da71649ab78f6"
 
 [[package]]
+name = "bus"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e66e1779f5b1440f1a58220ba3b3ded4427175f0a9fb8d7066521f8b4e8f2b"
+dependencies = [
+ "atomic-option",
+ "crossbeam-channel",
+ "num_cpus",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
 name = "byte-slice-cast"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +635,7 @@ name = "client"
 version = "0.1.2"
 dependencies = [
  "beacon_chain",
+ "bus",
  "dirs",
  "environment",
  "error-chain",
@@ -3822,6 +3842,7 @@ dependencies = [
  "assert_matches",
  "beacon_chain",
  "bls",
+ "bus",
  "environment",
  "eth2-libp2p",
  "eth2_config",
@@ -3852,6 +3873,7 @@ dependencies = [
  "tokio 0.2.21",
  "tree_hash",
  "types",
+ "uhttp_sse",
  "url 2.1.1",
  "version",
 ]
@@ -5371,6 +5393,12 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
 ]
+
+[[package]]
+name = "uhttp_sse"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ff93345ba2206230b1bb1aa3ece1a63dd9443b7531024575d16a0680a59444"
 
 [[package]]
 name = "uint"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -47,6 +47,7 @@ bitvec = "0.17.4"
 bls = { path = "../../crypto/bls" }
 safe_arith = { path = "../../consensus/safe_arith" }
 environment = { path = "../../lighthouse/environment" }
+bus = "2.2.3"
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -40,3 +40,4 @@ eth2_ssz = "0.1.2"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 time = "0.2.16"
+bus = "2.2.3"

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -1,6 +1,7 @@
 use crate::config::{ClientGenesis, Config as ClientConfig};
 use crate::notifier::spawn_notifier;
 use crate::Client;
+use beacon_chain::events::ServerSentEvents;
 use beacon_chain::{
     builder::{BeaconChainBuilder, Witness},
     eth1_chain::{CachingEth1Backend, Eth1Chain},
@@ -9,12 +10,14 @@ use beacon_chain::{
     store::{HotColdDB, MemoryStore, Store, StoreConfig},
     BeaconChain, BeaconChainTypes, Eth1ChainBackend, EventHandler,
 };
+use bus::Bus;
 use environment::RuntimeContext;
 use eth1::{Config as Eth1Config, Service as Eth1Service};
 use eth2_config::Eth2Config;
 use eth2_libp2p::NetworkGlobals;
 use genesis::{interop_genesis_state, Eth1GenesisService};
 use network::{NetworkConfig, NetworkMessage, NetworkService};
+use parking_lot::Mutex;
 use slog::info;
 use ssz::Decode;
 use std::net::SocketAddr;
@@ -23,7 +26,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use timer::spawn_timer;
 use tokio::sync::mpsc::UnboundedSender;
-use types::{test_utils::generate_deterministic_keypairs, BeaconState, ChainSpec, EthSpec};
+use types::{
+    test_utils::generate_deterministic_keypairs, BeaconState, ChainSpec, EthSpec,
+    SignedBeaconBlockHash,
+};
 use websocket_server::{Config as WebSocketConfig, WebSocketSender};
 
 /// Interval between polling the eth1 node for genesis information.
@@ -260,6 +266,7 @@ where
         mut self,
         client_config: &ClientConfig,
         eth2_config: &Eth2Config,
+        events: Arc<Mutex<Bus<SignedBeaconBlockHash>>>,
     ) -> Result<Self, String> {
         let beacon_chain = self
             .beacon_chain
@@ -284,6 +291,7 @@ where
             network_chan: network_send,
         };
 
+        let log = context.log.clone();
         let listening_addr = rest_api::start_server(
             context.executor,
             &client_config.rest_api,
@@ -296,6 +304,8 @@ where
                 .create_freezer_db_path()
                 .map_err(|_| "unable to read freezer DB dir")?,
             eth2_config.clone(),
+            log,
+            events,
         )
         .map_err(|e| format!("Failed to start HTTP API: {:?}", e))?;
 
@@ -431,6 +441,40 @@ where
         self.websocket_listen_addr = listening_addr;
 
         Ok(self)
+    }
+}
+
+impl<TStore, TStoreMigrator, TSlotClock, TEth1Backend, TEthSpec>
+    ClientBuilder<
+        Witness<
+            TStore,
+            TStoreMigrator,
+            TSlotClock,
+            TEth1Backend,
+            TEthSpec,
+            ServerSentEvents<TEthSpec>,
+        >,
+    >
+where
+    TStore: Store<TEthSpec> + 'static,
+    TStoreMigrator: Migrate<TStore, TEthSpec>,
+    TSlotClock: SlotClock + 'static,
+    TEth1Backend: Eth1ChainBackend<TEthSpec, TStore> + 'static,
+    TEthSpec: EthSpec + 'static,
+{
+    /// Specifies that the `BeaconChain` should publish events using the WebSocket server.
+    pub fn server_sent_events_event_handler(
+        mut self,
+    ) -> Result<(Self, Arc<Mutex<Bus<SignedBeaconBlockHash>>>), String> {
+        let context = self
+            .runtime_context
+            .as_ref()
+            .ok_or_else(|| "server_sent_events_event_handler requires a runtime_context")?
+            .service_context("sse".into());
+
+        let (sse, bus) = ServerSentEvents::new(context.log.clone());
+        self.event_handler = Some(sse);
+        Ok((self, bus))
     }
 }
 

--- a/beacon_node/rest_api/Cargo.toml
+++ b/beacon_node/rest_api/Cargo.toml
@@ -37,6 +37,8 @@ futures = "0.3.5"
 operation_pool = { path = "../operation_pool" }
 rayon = "1.3.0"
 environment = { path = "../../lighthouse/environment" }
+uhttp_sse = "0.5.1"
+bus = "2.2.3"
 
 [dev-dependencies]
 assert_matches = "1.3.0"

--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -3,16 +3,20 @@ use crate::response_builder::ResponseBuilder;
 use crate::validator::get_state_for_epoch;
 use crate::{ApiError, ApiResult, UrlQuery};
 use beacon_chain::{BeaconChain, BeaconChainTypes, StateSkipConfig};
-use hyper::{Body, Request};
+use hyper::{Body, Request, Chunk, Response};
+use bus::BusReader;
 use rest_types::{
     BlockResponse, CanonicalHeadResponse, Committee, HeadBeaconBlock, StateResponse,
     ValidatorRequest, ValidatorResponse,
 };
+use std::io::Write;
 use std::sync::Arc;
 use store::Store;
+
+use slog::{error, Logger};
 use types::{
     AttesterSlashing, BeaconState, EthSpec, Hash256, ProposerSlashing, PublicKeyBytes,
-    RelativeEpoch, Slot,
+    RelativeEpoch, SignedBeaconBlockHash, Slot,
 };
 
 /// HTTP handler to return a `BeaconBlock` at a given `root` or `slot`.
@@ -120,6 +124,48 @@ pub fn get_block_root<T: BeaconChainTypes>(
     })?;
 
     ResponseBuilder::new(&req)?.body(&root)
+}
+
+fn make_sse_response_chunk(new_head_hash: SignedBeaconBlockHash) -> std::io::Result<Chunk> {
+    let mut buffer = Vec::new();
+    {
+        let mut sse_message = uhttp_sse::SseMessage::new(&mut buffer);
+        let untyped_hash: Hash256 = new_head_hash.into();
+        write!(sse_message.data()?, "{:?}", untyped_hash)?;
+    }
+    let chunk: Chunk = buffer.into();
+    Ok(chunk)
+}
+
+pub fn stream_forks<T: BeaconChainTypes>(
+    log: Logger,
+    mut events: BusReader<SignedBeaconBlockHash>,
+) -> ApiResult {
+    let (mut sender, body) = Body::channel();
+    std::thread::spawn(move || {
+        while let Ok(new_head_hash) = events.recv() {
+            let chunk = match make_sse_response_chunk(new_head_hash) {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    error!(log, "Failed to make SSE chunk"; "error" => e.to_string());
+                    sender.abort();
+                    break;
+                }
+            };
+            if let Err(chunk) = sender.send_data(chunk) {
+                error!(log, "Couldn't stream chunk {:?}", chunk);
+            }
+        }
+    });
+    let response = Response::builder()
+        .status(200)
+        .header("Content-Type", "text/event-stream")
+        .header("Connection", "Keep-Alive")
+        .header("Cache-Control", "no-cache")
+        .header("Access-Control-Allow-Origin", "*")
+        .body(body)
+        .map_err(|e| ApiError::ServerError(format!("Failed to build response: {:?}", e)))?;
+    Ok(response)
 }
 
 /// HTTP handler to return the `Fork` of the current head.

--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -3,8 +3,10 @@ use crate::response_builder::ResponseBuilder;
 use crate::validator::get_state_for_epoch;
 use crate::{ApiError, ApiResult, UrlQuery};
 use beacon_chain::{BeaconChain, BeaconChainTypes, StateSkipConfig};
-use hyper::{Body, Request, Chunk, Response};
 use bus::BusReader;
+use futures::executor::block_on;
+use hyper::body::Bytes;
+use hyper::{Body, Request, Response};
 use rest_types::{
     BlockResponse, CanonicalHeadResponse, Committee, HeadBeaconBlock, StateResponse,
     ValidatorRequest, ValidatorResponse,
@@ -126,15 +128,15 @@ pub fn get_block_root<T: BeaconChainTypes>(
     ResponseBuilder::new(&req)?.body(&root)
 }
 
-fn make_sse_response_chunk(new_head_hash: SignedBeaconBlockHash) -> std::io::Result<Chunk> {
+fn make_sse_response_chunk(new_head_hash: SignedBeaconBlockHash) -> std::io::Result<Bytes> {
     let mut buffer = Vec::new();
     {
         let mut sse_message = uhttp_sse::SseMessage::new(&mut buffer);
         let untyped_hash: Hash256 = new_head_hash.into();
         write!(sse_message.data()?, "{:?}", untyped_hash)?;
     }
-    let chunk: Chunk = buffer.into();
-    Ok(chunk)
+    let bytes: Bytes = buffer.into();
+    Ok(bytes)
 }
 
 pub fn stream_forks<T: BeaconChainTypes>(
@@ -152,8 +154,8 @@ pub fn stream_forks<T: BeaconChainTypes>(
                     break;
                 }
             };
-            if let Err(chunk) = sender.send_data(chunk) {
-                error!(log, "Couldn't stream chunk {:?}", chunk);
+            if let Err(bytes) = block_on(sender.send_data(chunk)) {
+                error!(log, "Couldn't stream piece {:?}", bytes);
             }
         }
     });

--- a/beacon_node/rest_api/src/error.rs
+++ b/beacon_node/rest_api/src/error.rs
@@ -71,6 +71,12 @@ impl From<hyper::error::Error> for ApiError {
     }
 }
 
+impl From<std::io::Error> for ApiError {
+    fn from(e: std::io::Error) -> ApiError {
+        ApiError::ServerError(format!("IO error: {:?}", e))
+    }
+}
+
 impl StdError for ApiError {
     fn cause(&self) -> Option<&dyn StdError> {
         None

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -60,7 +60,6 @@ pub fn start_server<T: BeaconChainTypes>(
     db_path: PathBuf,
     freezer_db_path: PathBuf,
     eth2_config: Eth2Config,
-    log: slog::Logger,
     events: Arc<Mutex<Bus<SignedBeaconBlockHash>>>,
 ) -> Result<SocketAddr, hyper::Error> {
     let log = executor.log();

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -21,6 +21,7 @@ mod url_query;
 mod validator;
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
+use bus::Bus;
 use client_network::NetworkMessage;
 pub use config::ApiEncodingFormat;
 use error::{ApiError, ApiResult};
@@ -29,13 +30,14 @@ use eth2_libp2p::NetworkGlobals;
 use futures::future::TryFutureExt;
 use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Server};
+use hyper::{Body, Request, Response, Server};
+use parking_lot::Mutex;
 use slog::{info, warn};
 use std::net::SocketAddr;
-use std::ops::Deref;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use types::SignedBeaconBlockHash;
 use url_query::UrlQuery;
 
 pub use crate::helpers::parse_pubkey_bytes;
@@ -58,6 +60,8 @@ pub fn start_server<T: BeaconChainTypes>(
     db_path: PathBuf,
     freezer_db_path: PathBuf,
     eth2_config: Eth2Config,
+    log: slog::Logger,
+    events: Arc<Mutex<Bus<SignedBeaconBlockHash>>>,
 ) -> Result<SocketAddr, hyper::Error> {
     let log = executor.log();
     let inner_log = log.clone();
@@ -72,6 +76,7 @@ pub fn start_server<T: BeaconChainTypes>(
         let network_channel = network_info.network_chan.clone();
         let db_path = db_path.clone();
         let freezer_db_path = freezer_db_path.clone();
+        let events = events.clone();
 
         async move {
             Ok::<_, hyper::Error>(service_fn(move |req: Request<Body>| {
@@ -84,6 +89,7 @@ pub fn start_server<T: BeaconChainTypes>(
                     log.clone(),
                     db_path.clone(),
                     freezer_db_path.clone(),
+                    events.clone(),
                 )
             }))
         }
@@ -130,15 +136,4 @@ pub fn start_server<T: BeaconChainTypes>(
     executor.spawn_without_exit(server_future, "http");
 
     Ok(actual_listen_addr)
-}
-
-#[derive(Clone)]
-pub struct DBPath(PathBuf);
-
-impl Deref for DBPath {
-    type Target = PathBuf;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
 }

--- a/beacon_node/rest_api/src/lib.rs
+++ b/beacon_node/rest_api/src/lib.rs
@@ -30,7 +30,7 @@ use eth2_libp2p::NetworkGlobals;
 use futures::future::TryFutureExt;
 use hyper::server::conn::AddrStream;
 use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Request, Response, Server};
+use hyper::{Body, Request, Server};
 use parking_lot::Mutex;
 use slog::{info, warn};
 use std::net::SocketAddr;

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -10,10 +10,10 @@ pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
 pub use config::{get_data_dir, get_eth2_testnet_config, get_testnet_dir};
 pub use eth2_config::Eth2Config;
 
+use beacon_chain::events::ServerSentEvents;
 use beacon_chain::migrate::{BackgroundMigrator, HotColdDB};
 use beacon_chain::{
-    builder::Witness, eth1_chain::CachingEth1Backend, events::WebSocketSender,
-    slot_clock::SystemTimeSlotClock,
+    builder::Witness, eth1_chain::CachingEth1Backend, slot_clock::SystemTimeSlotClock,
 };
 use clap::ArgMatches;
 use config::get_config;
@@ -30,7 +30,7 @@ pub type ProductionClient<E> = Client<
         SystemTimeSlotClock,
         CachingEth1Backend<E, HotColdDB<E>>,
         E,
-        WebSocketSender<E>,
+        ServerSentEvents<E>,
     >,
 >;
 
@@ -113,15 +113,17 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
             builder.no_eth1_backend()?
         };
 
-        let builder = builder
+        let (builder, events) = builder
             .system_time_slot_clock()?
-            .websocket_event_handler(client_config.websocket_server.clone())?
+            .server_sent_events_event_handler()?;
+
+        let builder = builder
             .build_beacon_chain()?
             .network(&mut client_config.network)?
             .notifier()?;
 
         let builder = if client_config.rest_api.enabled {
-            builder.http_server(&client_config, &http_eth2_config)?
+            builder.http_server(&client_config, &http_eth2_config, events)?
         } else {
             builder
         };

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -10,8 +10,8 @@ pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
 pub use config::{get_data_dir, get_eth2_testnet_config, get_testnet_dir};
 pub use eth2_config::Eth2Config;
 
-use beacon_chain::migrate::{BackgroundMigrator, HotColdDB};
 use beacon_chain::events::TeeEventHandler;
+use beacon_chain::migrate::{BackgroundMigrator, HotColdDB};
 use beacon_chain::{
     builder::Witness, eth1_chain::CachingEth1Backend, slot_clock::SystemTimeSlotClock,
 };

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -10,8 +10,8 @@ pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
 pub use config::{get_data_dir, get_eth2_testnet_config, get_testnet_dir};
 pub use eth2_config::Eth2Config;
 
-use beacon_chain::events::ServerSentEvents;
 use beacon_chain::migrate::{BackgroundMigrator, HotColdDB};
+use beacon_chain::events::TeeEventHandler;
 use beacon_chain::{
     builder::Witness, eth1_chain::CachingEth1Backend, slot_clock::SystemTimeSlotClock,
 };
@@ -30,7 +30,7 @@ pub type ProductionClient<E> = Client<
         SystemTimeSlotClock,
         CachingEth1Backend<E, HotColdDB<E>>,
         E,
-        ServerSentEvents<E>,
+        TeeEventHandler<E>,
     >,
 >;
 
@@ -115,7 +115,7 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
 
         let (builder, events) = builder
             .system_time_slot_clock()?
-            .server_sent_events_event_handler()?;
+            .tee_event_handler(client_config.websocket_server.clone())?;
 
         let builder = builder
             .build_beacon_chain()?


### PR DESCRIPTION
## Proposed Changes

 * Implements [forks streaming](https://ethereum.github.io/eth2.0-APIs/#/Beacon/get_beacon_fork_stream) via [Server Sent Events mechanism](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events), based on the Hyper library.  Other streaming endpoints to follow.

 * First head seen by the validator client is the one beacon node saw changed first *after* the connection to `/beacon/fork/stream` was made.

 * ~~(!) Disables the current WebSockets endpoint.  I.e. it no longer publishes events.  This is not final.  I'm gonna need a decision here what to do with it: whether to try to maintain both, or to ditch WebSockets completely.~~

 * Uses a thread per connection.  This may sound expensive but I don't anticipate more than 1-2 clients connected.  In any case, it can be optimized later quite easily.

 * In case the stream consumer is extremely slow, new events are simply dropped on the floor so as to avoid blocking beacon chain block processing.  This is by design.

 * I think the current implementation of events handling can be simplified considerably by getting rid of the `EventHandler` trait and using `Bus` directly as an explicit synchronization mechanism.