### PR TITLE
Use schlesi as default testnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2397,6 +2397,7 @@ dependencies = [
  "clap_utils 0.1.0",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "environment 0.2.0",
+ "eth2_testnet_config 0.2.0",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "logging 0.2.0",
  "slog 2.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/eth2/utils/eth2_testnet_config/.gitignore
+++ b/eth2/utils/eth2_testnet_config/.gitignore
@@ -1,1 +1,2 @@
 testnet*
+schlesi-*

--- a/eth2/utils/eth2_testnet_config/build.rs
+++ b/eth2/utils/eth2_testnet_config/build.rs
@@ -1,11 +1,12 @@
-/// Pulls down the latest Lighthouse testnet from https://github.com/eth2-clients/eth2-testnets
+//! Downloads a testnet configuration from Github.
+
 use reqwest;
 use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-const TESTNET_ID: &str = "testnet5";
+const TESTNET_ID: &str = "schlesi-v0-11";
 
 fn main() {
     if !base_dir().exists() {
@@ -37,16 +38,18 @@ pub fn get_all_files() -> Result<(), String> {
 
 pub fn get_file(filename: &str) -> Result<(), String> {
     let url = format!(
-        "https://raw.githubusercontent.com/eth2-clients/eth2-testnets/master/lighthouse/{}/{}",
-        TESTNET_ID, filename
+        "https://raw.githubusercontent.com/goerli/schlesi/839866fe29a1b4df3a87bfe2ff1257c8a58671c9/light/{}",
+        filename
     );
 
     let path = base_dir().join(filename);
     let mut file =
         File::create(path).map_err(|e| format!("Failed to create {}: {:?}", filename, e))?;
 
-    let mut response =
-        reqwest::get(&url).map_err(|e| format!("Failed to download {}: {}", filename, e))?;
+    let mut response = reqwest::get(&url)
+        .map_err(|e| format!("Failed to download {}: {}", filename, e))?
+        .error_for_status()
+        .map_err(|e| format!("Error downloading {}: {}", filename, e))?;
     let mut contents: Vec<u8> = vec![];
     response
         .copy_to(&mut contents)

--- a/eth2/utils/eth2_testnet_config/src/lib.rs
+++ b/eth2/utils/eth2_testnet_config/src/lib.rs
@@ -20,11 +20,14 @@ pub const BOOT_ENR_FILE: &str = "boot_enr.yaml";
 pub const GENESIS_STATE_FILE: &str = "genesis.ssz";
 pub const YAML_CONFIG_FILE: &str = "config.yaml";
 
-pub const HARDCODED_YAML_CONFIG: &[u8] = include_bytes!("../testnet5/config.yaml");
-pub const HARDCODED_DEPLOY_BLOCK: &[u8] = include_bytes!("../testnet5/deploy_block.txt");
-pub const HARDCODED_DEPOSIT_CONTRACT: &[u8] = include_bytes!("../testnet5/deposit_contract.txt");
-pub const HARDCODED_GENESIS_STATE: &[u8] = include_bytes!("../testnet5/genesis.ssz");
-pub const HARDCODED_BOOT_ENR: &[u8] = include_bytes!("../testnet5/boot_enr.yaml");
+pub const HARDCODED_TESTNET: &str = "schlesi-v0-11";
+
+pub const HARDCODED_YAML_CONFIG: &[u8] = include_bytes!("../schlesi-v0-11/config.yaml");
+pub const HARDCODED_DEPLOY_BLOCK: &[u8] = include_bytes!("../schlesi-v0-11/deploy_block.txt");
+pub const HARDCODED_DEPOSIT_CONTRACT: &[u8] =
+    include_bytes!("../schlesi-v0-11/deposit_contract.txt");
+pub const HARDCODED_GENESIS_STATE: &[u8] = include_bytes!("../schlesi-v0-11/genesis.ssz");
+pub const HARDCODED_BOOT_ENR: &[u8] = include_bytes!("../schlesi-v0-11/boot_enr.yaml");
 
 /// Specifies an Eth2 testnet.
 ///

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -23,3 +23,4 @@ futures = "0.1.25"
 validator_client = { "path" = "../validator_client" }
 account_manager = { "path" = "../account_manager" }
 clap_utils = { path = "../eth2/utils/clap_utils" }
+eth2_testnet_config = { path = "../eth2/utils/eth2_testnet_config" }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -6,6 +6,7 @@ use clap::{App, Arg, ArgMatches};
 use clap_utils;
 use env_logger::{Builder, Env};
 use environment::EnvironmentBuilder;
+use eth2_testnet_config::HARDCODED_TESTNET;
 use slog::{crit, info, warn};
 use std::path::PathBuf;
 use std::process::exit;
@@ -155,6 +156,14 @@ fn run<E: EthSpec>(
         log,
         "Ethereum 2.0 is pre-release. This software is experimental."
     );
+
+    if !matches.is_present("testnet-dir") {
+        info!(
+            log,
+            "Using default testnet";
+            "default" => HARDCODED_TESTNET
+        )
+    }
 
     // Note: the current code technically allows for starting a beacon node _and_ a validator
     // client at the same time.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

"Bakes in" the [schlesi](https://github.com/goerli/schlesi/tree/master/light) testnet by @q9f as the default testnet in lighthouse. This means that connecting to schlesi is achieved simply with:

```
lighthouse bn

May 06 10:06:09.451 WARN Ethereum 2.0 is pre-release. This software is experimental.
May 06 10:06:09.451 INFO Using default testnet                   default: schlesi-v0-11
...
```
