### PR TITLE
Adds counter of received chunks to an OutboundSubstream. Ends the str…

### DIFF
--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -834,10 +834,18 @@ where
                                         remaining_number_of_chunks_for_this_stream
                                             .map(|count| count.saturating_sub(1))
                                             .unwrap_or_else(|| 0);
-                                    if remaining_number_of_chunks_after_this_chunk == 0 {
-                                        // close the stream if all expected chunks have been received
+                                    if remaining_number_of_chunks_for_this_stream == Some(0) {
                                         substream_entry.0 =
                                             OutboundSubstreamState::Closing(substream);
+                                        return Poll::Ready(ProtocolsHandlerEvent::Custom(
+                                            RPCEvent::Response(
+                                                request_id,
+                                                RPCCodedResponse::StreamTermination(
+                                                    request.stream_termination(),
+                                                ),
+                                            ),
+                                        ));
+                                    // close the stream if all expected chunks have been received
                                     } else {
                                         // If the response chunk was expected update the remaining number of chunks expected and reset the Timeout
                                         substream_entry.0 =

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -370,14 +370,15 @@ where
                 .outbound_substreams_delay
                 .insert(id, Duration::from_secs(RESPONSE_TIMEOUT));
             let protocol = request.protocol();
-            let awaiting_stream = OutboundSubstreamState::RequestPendingResponse {
-                substream: out,
-                request,
-            };
+            let request_copy = request.clone();
             let response_chunk_count: Option<u64> = match request {
                 RPCRequest::BlocksByRange(req) => Some(req.count),
                 RPCRequest::BlocksByRoot(req) => Some(req.block_roots.len() as u64),
                 _ => None,
+            };
+            let awaiting_stream = OutboundSubstreamState::RequestPendingResponse {
+                substream: out,
+                request: request_copy,
             };
             if let Some(_) = self.outbound_substreams.insert(
                 id,

--- a/beacon_node/eth2-libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2-libp2p/src/rpc/handler.rs
@@ -372,15 +372,14 @@ where
                 .outbound_substreams_delay
                 .insert(id, Duration::from_secs(RESPONSE_TIMEOUT));
             let protocol = request.protocol();
-            let request_copy = request.clone();
-            let response_chunk_count: Option<u64> = match request {
-                RPCRequest::BlocksByRange(req) => Some(req.count),
-                RPCRequest::BlocksByRoot(req) => Some(req.block_roots.len() as u64),
-                _ => None,
+            let response_chunk_count = match request {
+                RPCRequest::BlocksByRange(ref req) => Some(req.count),
+                RPCRequest::BlocksByRoot(ref req) => Some(req.block_roots.len() as u64),
+                _ => None, // Other requests do not have a known response chunk length,
             };
             let awaiting_stream = OutboundSubstreamState::RequestPendingResponse {
                 substream: out,
-                request: request_copy,
+                request: request,
             };
             if let Some(_) = self.outbound_substreams.insert(
                 id,

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -617,6 +617,152 @@ async fn test_blocks_by_root_chunked_rpc() {
 }
 
 #[tokio::test]
+// Tests a streamed, chunked BlocksByRoot RPC Message terminates when all expected reponses have been received
+async fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
+    // set up the logging. The level and enabled logging or not
+    let log_level = Level::Debug;
+    let enable_logging = false;
+
+    let messages_to_send: u64 = 10;
+    let extra_messages_to_send: u64 = 10;
+
+    let log = common::build_log(log_level, enable_logging);
+    let spec = E::default_spec();
+
+    // get sender/receiver
+    let (mut sender, mut receiver) = common::build_node_pair(&log).await;
+
+    // BlocksByRoot Request
+    let rpc_request = RPCRequest::BlocksByRoot(BlocksByRootRequest {
+        block_roots: vec![
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+        ],
+    });
+
+    // BlocksByRoot Response
+    let full_block = BeaconBlock::full(&spec);
+    let signed_full_block = SignedBeaconBlock {
+        message: full_block,
+        signature: Signature::empty_signature(),
+    };
+    let rpc_response = RPCResponse::BlocksByRoot(Box::new(signed_full_block));
+
+    // keep count of the number of messages received
+    let mut messages_received = 0;
+    // build the sender future
+    let sender_future = async {
+        loop {
+            match sender.next_event().await {
+                Libp2pEvent::PeerConnected { peer_id, .. } => {
+                    // Send a STATUS message
+                    debug!(log, "Sending RPC");
+                    sender
+                        .swarm
+                        .send_rpc(peer_id, RPCEvent::Request(10, rpc_request.clone()));
+                }
+                Libp2pEvent::Behaviour(BehaviourEvent::RPC(_, event)) => match event {
+                    // Should receive the RPC response
+                    RPCEvent::Response(id, response) => {
+                        if id == 10 {
+                            debug!(log, "Sender received a response");
+                            match response {
+                                RPCCodedResponse::Success(res) => {
+                                    assert_eq!(res, rpc_response.clone());
+                                    messages_received += 1;
+                                    debug!(log, "Chunk received");
+                                }
+                                RPCCodedResponse::StreamTermination(_) => {
+                                    // should be exactly messages_to_send
+                                    assert_eq!(messages_received, messages_to_send);
+                                    // end the test
+                                    return;
+                                }
+                                _ => {} // Ignore other RPC messages
+                            }
+                        }
+                    }
+                    _ => {} // Ignore other RPC messages
+                },
+                _ => {} // Ignore other behaviour events
+            }
+        }
+    };
+
+    // determine messages to send (PeerId, RequestId). If some, indicates we still need to send
+    // messages
+    let mut message_info = None;
+    // the number of messages we've sent
+    let mut messages_sent = 0;
+    let receiver_future = async {
+        loop {
+            // this future either drives the sending/receiving or times out allowing messages to be
+            // sent in the timeout
+            match futures::future::select(
+                Box::pin(receiver.next_event()),
+                tokio::time::delay_for(Duration::from_millis(50)),
+            )
+            .await
+            {
+                futures::future::Either::Left((
+                    Libp2pEvent::Behaviour(BehaviourEvent::RPC(peer_id, event)),
+                    _,
+                )) => {
+                    match event {
+                        // Should receive sent RPC request
+                        RPCEvent::Request(id, request) => {
+                            if request == rpc_request {
+                                // send the response
+                                warn!(log, "Receiver got request");
+                                message_info = Some((peer_id, id));
+                            } else {
+                                continue;
+                            }
+                        }
+                        _ => continue, // Ignore other events, don't send messages until ready
+                    }
+                }
+                futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
+                _ => continue,
+            }
+
+            // if we need to send messages send them here. This will happen after a delay
+            if message_info.is_some() {
+                messages_sent += 1;
+                receiver.swarm.send_rpc(
+                    message_info.as_ref().unwrap().0.clone(),
+                    RPCEvent::Response(
+                        message_info.as_ref().unwrap().1.clone(),
+                        RPCCodedResponse::Success(rpc_response.clone()),
+                    ),
+                );
+                debug!(log, "Sending message {}", messages_sent);
+                if messages_sent == messages_to_send + extra_messages_to_send {
+                    // stop sending messages
+                    return;
+                }
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = sender_future => {}
+        _ = receiver_future => {}
+        _ = delay_for(Duration::from_millis(1000)) => {
+            panic!("Future timed out");
+        }
+    }
+}
+
+#[tokio::test]
 // Tests a Goodbye RPC message
 async fn test_goodbye_rpc() {
     // set up the logging. The level and enabled logging or not

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -509,7 +509,11 @@ async fn test_blocks_by_root_chunked_rpc() {
 
     // BlocksByRoot Request
     let rpc_request = RPCRequest::BlocksByRoot(BlocksByRootRequest {
-        block_roots: vec![Hash256::from_low_u64_be(0), Hash256::from_low_u64_be(0)],
+        block_roots: vec![
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+            Hash256::from_low_u64_be(0),
+        ],
     });
 
     // BlocksByRoot Response

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -289,13 +289,19 @@ async fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
                                     messages_received += 1;
                                     warn!(log, "Chunk received");
                                 }
+                                RPCCodedResponse::StreamTermination(_) => {
+                                    // should be exactly 10 messages, as requested
+                                    assert_eq!(messages_received, messages_to_send);
+                                }
                                 _ => panic!("Invalid RPC received"),
                             }
                         }
                     }
+                    // TODO: can the error be checked here?
                     RPCEvent::Error(id, protocol, error) => {
                         if id == 10 {
                             assert_eq!(messages_received, messages_to_send);
+                            // end the test
                             return;
                         }
                     }

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -114,9 +114,15 @@ async fn test_status_rpc() {
     }
 }
 
+<<<<<<< HEAD
 #[tokio::test]
 // Tests a streamed BlocksByRange RPC Message
 async fn test_blocks_by_range_chunked_rpc() {
+=======
+#[test]
+// Tests a streamed BlocksByRange RPC Message that terminates when all chunks have been received
+fn test_blocks_by_range_chunked_rpc() {
+>>>>>>> 58c994bf... WIP test, waiting for stable-futures to land in master
     // set up the logging. The level and enabled logging or not
     let log_level = Level::Trace;
     let enable_logging = false;
@@ -188,6 +194,7 @@ async fn test_blocks_by_range_chunked_rpc() {
     // build the receiver future
     let receiver_future = async {
         loop {
+<<<<<<< HEAD
             match receiver.next_event().await {
                 Libp2pEvent::Behaviour(BehaviourEvent::RPC(peer_id, event)) => {
                     match event {
@@ -207,6 +214,17 @@ async fn test_blocks_by_range_chunked_rpc() {
                                     );
                                 }
                                 // send the stream termination
+=======
+            match receiver.poll().unwrap() {
+                Async::Ready(Some(BehaviourEvent::RPC(peer_id, event))) => match event {
+                    // Should receive the sent RPC request
+                    RPCEvent::Request(id, request) => {
+                        if request == rpc_request {
+                            // send the response
+                            warn!(log, "Receiver got request");
+
+                            for _ in 1..=messages_to_send + 1 {
+>>>>>>> 58c994bf... WIP test, waiting for stable-futures to land in master
                                 receiver.swarm.send_rpc(
                                     peer_id,
                                     RPCEvent::Response(

--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -114,15 +114,9 @@ async fn test_status_rpc() {
     }
 }
 
-<<<<<<< HEAD
 #[tokio::test]
 // Tests a streamed BlocksByRange RPC Message
 async fn test_blocks_by_range_chunked_rpc() {
-=======
-#[test]
-// Tests a streamed BlocksByRange RPC Message that terminates when all chunks have been received
-fn test_blocks_by_range_chunked_rpc() {
->>>>>>> 58c994bf... WIP test, waiting for stable-futures to land in master
     // set up the logging. The level and enabled logging or not
     let log_level = Level::Trace;
     let enable_logging = false;
@@ -194,7 +188,6 @@ fn test_blocks_by_range_chunked_rpc() {
     // build the receiver future
     let receiver_future = async {
         loop {
-<<<<<<< HEAD
             match receiver.next_event().await {
                 Libp2pEvent::Behaviour(BehaviourEvent::RPC(peer_id, event)) => {
                     match event {
@@ -214,17 +207,6 @@ fn test_blocks_by_range_chunked_rpc() {
                                     );
                                 }
                                 // send the stream termination
-=======
-            match receiver.poll().unwrap() {
-                Async::Ready(Some(BehaviourEvent::RPC(peer_id, event))) => match event {
-                    // Should receive the sent RPC request
-                    RPCEvent::Request(id, request) => {
-                        if request == rpc_request {
-                            // send the response
-                            warn!(log, "Receiver got request");
-
-                            for _ in 1..=messages_to_send + 1 {
->>>>>>> 58c994bf... WIP test, waiting for stable-futures to land in master
                                 receiver.swarm.send_rpc(
                                     peer_id,
                                     RPCEvent::Response(


### PR DESCRIPTION
…eam when the counter reaches the desired amount of chunks that where specified in a Request.

## Issue Addressed
https://github.com/sigp/lighthouse/issues/754

## Proposed Changes

- Add counter to `OutboundSubstream`
- in response handler, end the stream if the counter matches the requested amount of chunks


