### PR TITLE
Switch to ring for hkdf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ version = "0.1.0"
 dependencies = [
  "hex 0.3.2",
  "num-bigint-dig",
+ "ring",
  "rust-crypto",
  "zeroize 1.1.0",
 ]

--- a/eth2/utils/eth2_key_derivation/Cargo.toml
+++ b/eth2/utils/eth2_key_derivation/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 rust-crypto = "0.2.36"
 zeroize = { version = "1.0.0", features = ["zeroize_derive"] }
 num-bigint-dig = { version = "0.6.0", features = ["zeroize"] }
+ring = "0.16.9"
 
 [dev-dependencies]
 hex = "0.3"

--- a/eth2/utils/eth2_key_derivation/src/derived_key.rs
+++ b/eth2/utils/eth2_key_derivation/src/derived_key.rs
@@ -3,6 +3,7 @@ use crate::{
 };
 use crypto::{digest::Digest, sha2::Sha256};
 use num_bigint_dig::BigUint;
+use ring::hkdf::{KeyType, Prk, Salt, HKDF_SHA256};
 use zeroize::Zeroize;
 
 /// The byte size of a SHA256 hash.
@@ -83,7 +84,7 @@ fn derive_child_sk(parent_sk: &[u8], index: u32) -> SecretHash {
 /// Equivalent to `HKDF_mod_r` in EIP-2333.
 fn hkdf_mod_r(ikm: &[u8]) -> SecretHash {
     let prk = hkdf_extract("BLS-SIG-KEYGEN-SALT-".as_bytes(), ikm);
-    let okm = &hkdf_expand(prk.as_bytes(), MOD_R_L);
+    let okm = &hkdf_expand(prk, MOD_R_L);
     mod_r(okm.as_bytes())
 }
 
@@ -144,25 +145,39 @@ fn parent_sk_to_lamport_pk(ikm: &[u8], index: u32) -> SecretHash {
 /// Equivalent to `IKM_to_lamport_SK` in EIP-2333.
 fn ikm_to_lamport_sk(salt: &[u8], ikm: &[u8]) -> LamportSecretKey {
     let prk = hkdf_extract(salt, ikm);
-    let okm = hkdf_expand(prk.as_bytes(), HASH_SIZE * LAMPORT_ARRAY_SIZE as usize);
+    let okm = hkdf_expand(prk, HASH_SIZE * LAMPORT_ARRAY_SIZE as usize);
     LamportSecretKey::from_bytes(okm.as_bytes())
 }
 
 /// Peforms a `HKDF-Extract` on the `ikm` (initial key material) based up on the `salt`.
 ///
 /// Defined in [RFC5869](https://tools.ietf.org/html/rfc5869).
-fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> SecretHash {
+fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> Prk {
+    Salt::new(HKDF_SHA256, salt).extract(ikm)
+    /*
     let mut prk = SecretHash::zero();
     crypto::hkdf::hkdf_extract(Sha256::new(), salt, ikm, prk.as_mut_bytes());
     prk
+    */
 }
 
 /// Peforms a `HKDF-Expand` on the `pkr` (pseudo-random key), returning `l` bytes.
 ///
 /// Defined in [RFC5869](https://tools.ietf.org/html/rfc5869).
-fn hkdf_expand(prk: &[u8], l: usize) -> SecretBytes {
+fn hkdf_expand(prk: Prk, l: usize) -> SecretBytes {
+    struct ExpandLen(usize);
+
+    impl KeyType for ExpandLen {
+        fn len(&self) -> usize {
+            self.0
+        }
+    }
+
     let mut okm = SecretBytes::zero(l);
-    crypto::hkdf::hkdf_expand(Sha256::new(), prk, &[], okm.as_mut_bytes());
+    prk.expand(&[], ExpandLen(l))
+        .expect("expand len is constant and cannot be too large")
+        .fill(okm.as_mut_bytes())
+        .expect("fill len is constant and cannot be too large");
     okm
 }
 

--- a/eth2/utils/eth2_key_derivation/src/derived_key.rs
+++ b/eth2/utils/eth2_key_derivation/src/derived_key.rs
@@ -154,11 +154,6 @@ fn ikm_to_lamport_sk(salt: &[u8], ikm: &[u8]) -> LamportSecretKey {
 /// Defined in [RFC5869](https://tools.ietf.org/html/rfc5869).
 fn hkdf_extract(salt: &[u8], ikm: &[u8]) -> Prk {
     Salt::new(HKDF_SHA256, salt).extract(ikm)
-    /*
-    let mut prk = SecretHash::zero();
-    crypto::hkdf::hkdf_extract(Sha256::new(), salt, ikm, prk.as_mut_bytes());
-    prk
-    */
 }
 
 /// Peforms a `HKDF-Expand` on the `pkr` (pseudo-random key), returning `l` bytes.

--- a/eth2/utils/eth2_keystore/tests/eip2335_vectors.rs
+++ b/eth2/utils/eth2_keystore/tests/eip2335_vectors.rs
@@ -3,6 +3,7 @@
 //! https://eips.ethereum.org/EIPS/eip-2335
 
 #![cfg(test)]
+#![cfg(not(debug_assertions))]
 
 use eth2_keystore::{Keystore, Uuid};
 

--- a/eth2/utils/eth2_keystore/tests/json.rs
+++ b/eth2/utils/eth2_keystore/tests/json.rs
@@ -340,6 +340,7 @@ fn bad_version() {
 }
 
 #[test]
+#[cfg(not(debug_assertions))]
 fn json_bad_checksum() {
     let vector = r#"
             {

--- a/eth2/utils/eth2_keystore/tests/tests.rs
+++ b/eth2/utils/eth2_keystore/tests/tests.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![cfg(not(debug_assertions))]
 
 use bls::Keypair;
 use eth2_keystore::{Error, Keystore, KeystoreBuilder};


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

As pointed out by @kirk-baird, `rust_crypto` says that its hdkf expand/extract [must not be used for password hashing](https://docs.rs/rust-crypto/0.2.36/crypto/hkdf/index.html).

This PR uses [ring::hkdf](https://briansmith.org/rustdoc/ring/hkdf/index.html) instead.
