### PR TITLE
Small fix: remove duplicated assignment

### DIFF
--- a/tests/node_test_rig/src/lib.rs
+++ b/tests/node_test_rig/src/lib.rs
@@ -86,8 +86,6 @@ pub fn testing_client_config() -> ClientConfig {
         genesis_time: now,
     };
 
-    client_config.dummy_eth1_backend = true;
-
     client_config
 }
 


### PR DESCRIPTION
## Issue Addressed

`client.dummy_eth1_backend` has been assigned a value, in [the above line](https://github.com/ackintosh/lighthouse/blob/a310d0672e1939cb0f2a9456f14989e963f33db5/tests/node_test_rig/src/lib.rs#L77) already. 😃 