### PR TITLE
Move long-running atestation tests to release

### DIFF
--- a/beacon_node/beacon_chain/src/observed_attestations.rs
+++ b/beacon_node/beacon_chain/src/observed_attestations.rs
@@ -242,6 +242,7 @@ impl<E: EthSpec> ObservedAttestations<E> {
 }
 
 #[cfg(test)]
+#[cfg(not(debug_assertions))]
 mod tests {
     use super::*;
     use tree_hash::TreeHash;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Moves some long-running tests over to debug.

I'm confident that running the tests in debug is not required to catch overflows.