### PR TITLE
Tiny improvement: assertions

### DIFF
--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -365,7 +365,7 @@ mod tests {
         let different_root = Hash256::from_low_u64_be(1337);
         unset_bit(&mut a_different, 0);
         sign(&mut a_different, 2, genesis_validators_root);
-        assert!(a_different.data.beacon_block_root != different_root);
+        assert_ne!(a_different.data.beacon_block_root, different_root);
         a_different.data.beacon_block_root = different_root;
 
         assert_eq!(

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -687,7 +687,7 @@ where
             AttestationStrategy::SomeValidators(faulty_validators.to_vec()),
         );
 
-        assert!(honest_head != faulty_head, "forks should be distinct");
+        assert_ne!(honest_head, faulty_head, "forks should be distinct");
 
         (honest_head, faulty_head)
     }

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -368,7 +368,7 @@ fn delete_blocks_and_states() {
         fork_blocks as usize,
     );
 
-    assert!(honest_head != faulty_head, "forks should be distinct");
+    assert_ne!(honest_head, faulty_head, "forks should be distinct");
     let head_info = harness.chain.head_info().expect("should get head");
     assert_eq!(head_info.slot, unforked_blocks + fork_blocks);
 

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -159,7 +159,7 @@ fn chooses_fork() {
         faulty_fork_blocks,
     );
 
-    assert!(honest_head != faulty_head, "forks should be distinct");
+    assert_ne!(honest_head, faulty_head, "forks should be distinct");
 
     let state = &harness.chain.head().expect("should get head").beacon_state;
 

--- a/beacon_node/rest_api/tests/test.rs
+++ b/beacon_node/rest_api/tests/test.rs
@@ -382,8 +382,8 @@ fn check_duties<T: BeaconChainTypes>(
                     let slot_proposer = state
                         .get_beacon_proposer_index(slot, spec)
                         .expect("should know proposer");
-                    assert!(
-                        slot_proposer != validator_index,
+                    assert_ne!(
+                        slot_proposer, validator_index,
                         "validator should not have proposal slot in this epoch"
                     )
                 })


### PR DESCRIPTION
## Issue Addressed

`assert_ne!` is preferred as it prints the values of expressions on panic. 😃 