### PR TITLE
Move wallet tests to release only

### DIFF
--- a/eth2/utils/eth2_wallet/tests/tests.rs
+++ b/eth2/utils/eth2_wallet/tests/tests.rs
@@ -1,3 +1,5 @@
+#![cfg(not(debug_assertions))]
+
 use eth2_wallet::{
     bip39::{Language, Mnemonic, Seed},
     recover_validator_secret, DerivedKey, Error, KeyType, KeystoreError, Wallet, WalletBuilder,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Moves some long-running wallet tests over to release-only testing. They take several minutes on debug.