### PR TITLE
Stable futures: Vc sync

### DIFF
--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -127,6 +127,12 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .duration_to_next_slot()
             .ok_or_else(|| "Unable to determine duration to next slot".to_string())?;
 
+        info!(
+            log,
+            "Attestation production service started";
+            "next_update_millis" => duration_to_next_slot.as_millis()
+        );
+
         let mut interval = {
             // Note: `interval_at` panics if `slot_duration` is 0
             interval_at(

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -475,7 +475,9 @@ impl<T: SlotClock + 'static, E: EthSpec> DutiesService<T, E> {
     async fn do_update(self) -> Result<(), ()> {
         let log = &self.context.log;
 
-        if !is_synced(&self.beacon_node, None).await && !self.allow_unsynced_beacon_node {
+        if !is_synced(&self.beacon_node, &self.slot_clock, None).await
+            && !self.allow_unsynced_beacon_node
+        {
             return Ok(());
         }
 

--- a/validator_client/src/is_synced.rs
+++ b/validator_client/src/is_synced.rs
@@ -1,0 +1,59 @@
+use remote_beacon_node::RemoteBeaconNode;
+use rest_types::SyncingResponse;
+use slog::{debug, error, Logger};
+use types::EthSpec;
+
+const SYNC_TOLERANCE: u64 = 4;
+
+pub async fn is_synced<E: EthSpec>(
+    beacon_node: &RemoteBeaconNode<E>,
+    log_opt: Option<&Logger>,
+) -> bool {
+    let resp = match beacon_node.http.node().syncing_status().await {
+        Ok(resp) => resp,
+        Err(e) => {
+            if let Some(log) = log_opt {
+                error!(
+                    log,
+                    "Unable connect to beacon node";
+                    "error" => format!("{:?}", e)
+                )
+            }
+
+            return false;
+        }
+    };
+
+    match &resp {
+        SyncingResponse {
+            is_syncing: false, ..
+        } => true,
+        SyncingResponse {
+            is_syncing: true,
+            sync_status,
+        } => {
+            if let Some(log) = log_opt {
+                debug!(
+                    log,
+                    "Beacon node sync status";
+                    "status" => format!("{:?}", resp),
+                );
+            }
+
+            if sync_status.current_slot + SYNC_TOLERANCE >= sync_status.highest_slot {
+                true
+            } else {
+                if let Some(log) = log_opt {
+                    error!(
+                        log,
+                        "Beacon node is syncing";
+                        "msg" => "not receiving new duties",
+                        "target_slot" => sync_status.highest_slot.as_u64(),
+                        "current_slot" => sync_status.current_slot.as_u64(),
+                    );
+                }
+                false
+            }
+        }
+    }
+}

--- a/validator_client/src/is_synced.rs
+++ b/validator_client/src/is_synced.rs
@@ -3,8 +3,19 @@ use rest_types::SyncingResponse;
 use slog::{debug, error, Logger};
 use types::EthSpec;
 
+/// A distance in slots.
 const SYNC_TOLERANCE: u64 = 4;
 
+/// Returns `true` if the beacon node is synced and ready for action.
+///
+/// Returns `false` if:
+///
+///  - The beacon node is unreachable.
+///  - The beacon node indicates that it is syncing **AND** it is more than `SYNC_TOLERANCE` behind
+///  the highest known slot.
+///
+///  The second condition means the even if the beacon node thinks that it's syncing, we'll still
+///  try to use it if it's close enough to the head.
 pub async fn is_synced<E: EthSpec>(
     beacon_node: &RemoteBeaconNode<E>,
     log_opt: Option<&Logger>,

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -4,6 +4,7 @@ mod cli;
 mod config;
 mod duties_service;
 mod fork_service;
+mod is_synced;
 mod notifier;
 mod validator_store;
 
@@ -42,6 +43,7 @@ pub struct ProductionValidatorClient<T: EthSpec> {
     block_service: BlockService<SystemTimeSlotClock, T>,
     attestation_service: AttestationService<SystemTimeSlotClock, T>,
     exit_signals: Vec<Signal>,
+    config: Config,
 }
 
 impl<T: EthSpec> ProductionValidatorClient<T> {
@@ -217,6 +219,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             block_service,
             attestation_service,
             exit_signals: vec![],
+            config,
         })
     }
 

--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -1,4 +1,4 @@
-use crate::ProductionValidatorClient;
+use crate::{is_synced::is_synced, ProductionValidatorClient};
 use exit_future::Signal;
 use futures::{FutureExt, StreamExt};
 use slog::{error, info};
@@ -12,6 +12,8 @@ pub fn spawn_notifier<T: EthSpec>(client: &ProductionValidatorClient<T>) -> Resu
     let runtime_handle = context.runtime_handle.clone();
     let log = context.log.clone();
     let duties_service = client.duties_service.clone();
+    let beacon_node = duties_service.beacon_node.clone();
+    let allow_unsynced_beacon_node = client.config.allow_unsynced_beacon_node;
 
     let slot_duration = Duration::from_millis(context.eth2_config.spec.milliseconds_per_slot);
     let duration_to_next_slot = client
@@ -28,6 +30,10 @@ pub fn spawn_notifier<T: EthSpec>(client: &ProductionValidatorClient<T>) -> Resu
         let log = &context.log;
 
         while interval.next().await.is_some() {
+            if !is_synced(&beacon_node, Some(&log)).await && !allow_unsynced_beacon_node {
+                continue;
+            }
+
             if let Some(slot) = duties_service.slot_clock.now() {
                 let epoch = slot.epoch(T::slots_per_epoch());
 

--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -12,12 +12,10 @@ pub fn spawn_notifier<T: EthSpec>(client: &ProductionValidatorClient<T>) -> Resu
     let runtime_handle = context.runtime_handle.clone();
     let log = context.log.clone();
     let duties_service = client.duties_service.clone();
-    let beacon_node = duties_service.beacon_node.clone();
     let allow_unsynced_beacon_node = client.config.allow_unsynced_beacon_node;
 
     let slot_duration = Duration::from_millis(context.eth2_config.spec.milliseconds_per_slot);
-    let duration_to_next_slot = client
-        .duties_service
+    let duration_to_next_slot = duties_service
         .slot_clock
         .duration_to_next_slot()
         .ok_or_else(|| "slot_notifier unable to determine time to next slot")?;
@@ -30,7 +28,14 @@ pub fn spawn_notifier<T: EthSpec>(client: &ProductionValidatorClient<T>) -> Resu
         let log = &context.log;
 
         while interval.next().await.is_some() {
-            if !is_synced(&beacon_node, Some(&log)).await && !allow_unsynced_beacon_node {
+            if !is_synced(
+                &duties_service.beacon_node,
+                &duties_service.slot_clock,
+                Some(&log),
+            )
+            .await
+                && !allow_unsynced_beacon_node
+            {
                 continue;
             }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Upgrade VC to use the new BN syncing endpoint. This allows it to have a much better notion of when it should/shouldn't request duties.

Note: any existing block/attestation production duties will still happen regardless of sync status.
