### PR TITLE
Fix `remove_peer` in sync

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -31,6 +31,7 @@ const BATCH_BUFFER_SIZE: u8 = 5;
 /// be downvoted.
 const INVALID_BATCH_LOOKUP_ATTEMPTS: u8 = 3;
 
+#[derive(PartialEq)]
 /// A return type for functions that act on a `Chain` which informs the caller whether the chain
 /// has been completed and should be removed or to be kept if further processing is
 /// required.

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -47,7 +47,7 @@ pub type ChainId = u64;
 /// chain.
 pub struct SyncingChain<T: BeaconChainTypes> {
     /// A random id used to identify this chain.
-    id: ChainId,
+    pub id: ChainId,
 
     /// The original start slot when this chain was initialised.
     pub start_epoch: Epoch,

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -47,7 +47,7 @@ pub type ChainId = u64;
 /// chain.
 pub struct SyncingChain<T: BeaconChainTypes> {
     /// A random id used to identify this chain.
-    pub id: ChainId,
+    id: ChainId,
 
     /// The original start slot when this chain was initialised.
     pub start_epoch: Epoch,

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -370,12 +370,10 @@ impl<T: BeaconChainTypes> RangeSync<T> {
     /// for this peer. If so we mark the batch as failed. The batch may then hit it's maximum
     /// retries. In this case, we need to remove the chain and re-status all the peers.
     fn remove_peer(&mut self, network: &mut SyncNetworkContext<T::EthSpec>, peer_id: &PeerId) {
-        let log = self.log.clone();
         while let Some((index, ProcessingResult::RemoveChain)) = self
             .chains
             .head_finalized_request_all(|chain| {
                 if chain.peer_pool.remove(peer_id) {
-                    debug!(log, "Removed peer from chain id"; "id" => chain.id);
                     // this chain contained the peer
                     while let Some(batch) = chain.pending_batches.remove_batch_by_peer(peer_id) {
                         if let ProcessingResult::RemoveChain = chain.failed_batch(network, batch) {

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -370,9 +370,12 @@ impl<T: BeaconChainTypes> RangeSync<T> {
     /// for this peer. If so we mark the batch as failed. The batch may then hit it's maximum
     /// retries. In this case, we need to remove the chain and re-status all the peers.
     fn remove_peer(&mut self, network: &mut SyncNetworkContext<T::EthSpec>, peer_id: &PeerId) {
-        if let Some((index, ProcessingResult::RemoveChain)) =
-            self.chains.head_finalized_request(|chain| {
+        let log = self.log.clone();
+        while let Some((index, ProcessingResult::RemoveChain)) = self
+            .chains
+            .head_finalized_request_all(|chain| {
                 if chain.peer_pool.remove(peer_id) {
+                    debug!(log, "Removed peer from chain id"; "id" => chain.id);
                     // this chain contained the peer
                     while let Some(batch) = chain.pending_batches.remove_batch_by_peer(peer_id) {
                         if let ProcessingResult::RemoveChain = chain.failed_batch(network, batch) {
@@ -386,10 +389,12 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     None
                 }
             })
+            .iter()
+            .next()
         {
             // the chain needed to be removed
             debug!(self.log, "Chain being removed due to failed batch");
-            self.chains.remove_chain(network, index);
+            self.chains.remove_chain(network, *index);
         }
     }
 

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -370,29 +370,26 @@ impl<T: BeaconChainTypes> RangeSync<T> {
     /// for this peer. If so we mark the batch as failed. The batch may then hit it's maximum
     /// retries. In this case, we need to remove the chain and re-status all the peers.
     fn remove_peer(&mut self, network: &mut SyncNetworkContext<T::EthSpec>, peer_id: &PeerId) {
-        while let Some((index, ProcessingResult::RemoveChain)) = self
-            .chains
-            .head_finalized_request_all(|chain| {
-                if chain.peer_pool.remove(peer_id) {
-                    // this chain contained the peer
-                    while let Some(batch) = chain.pending_batches.remove_batch_by_peer(peer_id) {
-                        if let ProcessingResult::RemoveChain = chain.failed_batch(network, batch) {
-                            // a single batch failed, remove the chain
-                            return Some(ProcessingResult::RemoveChain);
-                        }
+        for (index, result) in self.chains.head_finalized_request_all(|chain| {
+            if chain.peer_pool.remove(peer_id) {
+                // this chain contained the peer
+                while let Some(batch) = chain.pending_batches.remove_batch_by_peer(peer_id) {
+                    if let ProcessingResult::RemoveChain = chain.failed_batch(network, batch) {
+                        // a single batch failed, remove the chain
+                        return Some(ProcessingResult::RemoveChain);
                     }
-                    // peer removed from chain, no batch failed
-                    Some(ProcessingResult::KeepChain)
-                } else {
-                    None
                 }
-            })
-            .iter()
-            .next()
-        {
-            // the chain needed to be removed
-            debug!(self.log, "Chain being removed due to failed batch");
-            self.chains.remove_chain(network, *index);
+                // peer removed from chain, no batch failed
+                Some(ProcessingResult::KeepChain)
+            } else {
+                None
+            }
+        }) {
+            if result == ProcessingResult::RemoveChain {
+                // the chain needed to be removed
+                debug!(self.log, "Chain being removed due to failed batch");
+                self.chains.remove_chain(network, index);
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

`remove_peer` in sync was removing the peer from the `peer_pool` of the first chain it finds. This caused issues where the removed peer from chain1 wasn't removed from chain2 and we ended up making requests to the disconnected peer which caused stalled syncs.
This PR modifies `remove_peer` to remove the peer from all existing head and finalised chains.

## Additional info

Tested this out while syncing Schlesi and don't see the sync stalling anymore.