### PR TITLE
Stable futures: Fix VC bug, update agg pool, add more metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,7 @@ dependencies = [
  "hashset_delay",
  "hex 0.4.2",
  "lazy_static",
+ "lighthouse_metrics",
  "matches",
  "parking_lot 0.10.2",
  "rand 0.7.3",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com
 edition = "2018"
 
 [features]
+default = ["participation_metrics"]
 write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
+participation_metrics = []  # Exposes validator participation metrics to Prometheus.
 
 [dependencies]
 eth2_config = { path = "../../eth2/utils/eth2_config" }

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -847,7 +847,7 @@ where
             // The state roots are not useful for the shuffling, so there's no need to
             // compute them.
             per_slot_processing(&mut state, Some(Hash256::zero()), &chain.spec)
-                .map_err(|e| BeaconChainError::from(e))?
+                .map_err(|e| BeaconChainError::from(e))?;
         }
 
         metrics::stop_timer(state_skip_timer);

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -863,7 +863,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         attestation: Attestation<T::EthSpec>,
     ) -> Result<VerifiedUnaggregatedAttestation<T>, AttestationError> {
-        VerifiedUnaggregatedAttestation::verify(attestation, self)
+        metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_REQUESTS);
+
+        VerifiedUnaggregatedAttestation::verify(attestation, self).map(|v| {
+            metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
+            v
+        })
     }
 
     /// Accepts some `SignedAggregateAndProof` from the network and attempts to verify it,
@@ -872,7 +877,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         signed_aggregate: SignedAggregateAndProof<T::EthSpec>,
     ) -> Result<VerifiedAggregatedAttestation<T>, AttestationError> {
-        VerifiedAggregatedAttestation::verify(signed_aggregate, self)
+        metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_REQUESTS);
+
+        VerifiedAggregatedAttestation::verify(signed_aggregate, self).map(|v| {
+            metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
+            v
+        })
     }
 
     /// Accepts some attestation-type object and attempts to verify it in the context of fork

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -864,6 +864,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         attestation: Attestation<T::EthSpec>,
     ) -> Result<VerifiedUnaggregatedAttestation<T>, AttestationError> {
         metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_REQUESTS);
+        let _timer =
+            metrics::start_timer(&metrics::UNAGGREGATED_ATTESTATION_GOSSIP_VERIFICATION_TIMES);
 
         VerifiedUnaggregatedAttestation::verify(attestation, self).map(|v| {
             metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
@@ -878,6 +880,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         signed_aggregate: SignedAggregateAndProof<T::EthSpec>,
     ) -> Result<VerifiedAggregatedAttestation<T>, AttestationError> {
         metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_REQUESTS);
+        let _timer =
+            metrics::start_timer(&metrics::AGGREGATED_ATTESTATION_GOSSIP_VERIFICATION_TIMES);
 
         VerifiedAggregatedAttestation::verify(signed_aggregate, self).map(|v| {
             metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
@@ -897,6 +901,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         unverified_attestation: &'a impl IntoForkChoiceVerifiedAttestation<'a, T>,
     ) -> Result<ForkChoiceVerifiedAttestation<'a, T>, AttestationError> {
+        let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_APPLY_TO_FORK_CHOICE);
+
         let verified = unverified_attestation.into_fork_choice_verified_attestation(self)?;
         let indexed_attestation = verified.indexed_attestation();
         self.fork_choice
@@ -917,6 +923,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         unaggregated_attestation: VerifiedUnaggregatedAttestation<T>,
     ) -> Result<VerifiedUnaggregatedAttestation<T>, AttestationError> {
+        let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_APPLY_TO_AGG_POOL);
+
         let attestation = unaggregated_attestation.attestation();
 
         match self.naive_aggregation_pool.insert(attestation) {
@@ -960,6 +968,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         signed_aggregate: VerifiedAggregatedAttestation<T>,
     ) -> Result<VerifiedAggregatedAttestation<T>, AttestationError> {
+        let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_APPLY_TO_OP_POOL);
+
         // If there's no eth1 chain then it's impossible to produce blocks and therefore
         // useless to put things in the op pool.
         if self.eth1_chain.is_some() {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -553,7 +553,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     // Note: supplying some `state_root` when it is known would be a cheap and easy
                     // optimization.
                     match per_slot_processing(&mut state, skip_state_root, &self.spec) {
-                        Ok(()) => (),
+                        Ok(_) => (),
                         Err(e) => {
                             warn!(
                                 self.log,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -924,8 +924,8 @@ fn expose_participation_metrics(summaries: &[EpochProcessingSummary]) {
 }
 
 fn participation_ratio(section: u64, total: u64) -> Option<f64> {
-    // Reduce the precision to 1/1,000th of an ETH (instead of 1/1,000,000,000 th).
-    const PRECISION: u64 = 1_000_000;
+    // Reduce the precision to help ensure we fit inside a u32.
+    const PRECISION: u64 = 100_000_000;
 
     let section: f64 = u32::try_from(section / PRECISION).ok()?.into();
     let total: f64 = u32::try_from(total / PRECISION).ok()?.into();

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -924,8 +924,11 @@ fn expose_participation_metrics(summaries: &[EpochProcessingSummary]) {
 }
 
 fn participation_ratio(section: u64, total: u64) -> Option<f64> {
-    let section: f64 = u32::try_from(section).ok()?.into();
-    let total: f64 = u32::try_from(total).ok()?.into();
+    // Reduce the precision to 1/1,000th of an ETH (instead of 1/1,000,000,000 th).
+    const PRECISION: u64 = 1_000_000;
+
+    let section: f64 = u32::try_from(section / PRECISION).ok()?.into();
+    let total: f64 = u32::try_from(total / PRECISION).ok()?.into();
 
     if total > 0_f64 {
         Some(section / total)

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -906,27 +906,32 @@ fn expose_participation_metrics(summaries: &[EpochProcessingSummary]) {
     for summary in summaries {
         let b = &summary.total_balances;
 
-        metrics::maybe_set_gauge(
+        metrics::maybe_set_float_gauge(
             &metrics::PARTICIPATION_PREV_EPOCH_ATTESTER,
             participation_ratio(b.previous_epoch_attesters(), b.previous_epoch()),
         );
 
-        metrics::maybe_set_gauge(
+        metrics::maybe_set_float_gauge(
             &metrics::PARTICIPATION_PREV_EPOCH_TARGET_ATTESTER,
             participation_ratio(b.previous_epoch_target_attesters(), b.previous_epoch()),
         );
 
-        metrics::maybe_set_gauge(
+        metrics::maybe_set_float_gauge(
             &metrics::PARTICIPATION_PREV_EPOCH_HEAD_ATTESTER,
             participation_ratio(b.previous_epoch_head_attesters(), b.previous_epoch()),
         );
     }
 }
 
-fn participation_ratio(section: u64, total: u64) -> Option<i64> {
-    let section = i64::try_from(section).ok()?;
-    let total = i64::try_from(total).ok()?;
-    section.checked_div(total)
+fn participation_ratio(section: u64, total: u64) -> Option<f64> {
+    let section: f64 = u32::try_from(section).ok()?.into();
+    let total: f64 = u32::try_from(total).ok()?.into();
+
+    if total > 0_f64 {
+        Some(section / total)
+    } else {
+        None
+    }
 }
 
 fn write_state<T: EthSpec>(prefix: &str, state: &BeaconState<T>, log: &Logger) {

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -139,6 +139,10 @@ lazy_static! {
         "beacon_attestation_processing_agg_pool_aggregation",
         "Time spent doing signature aggregation when adding to the agg poll"
     );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_CREATE_MAP: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_create_map",
+        "Time spent for creating a map for a new slot"
+    );
     pub static ref ATTESTATION_PROCESSING_APPLY_TO_OP_POOL: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_apply_to_op_pool",
         "Time spent applying an attestation to the block inclusion pool"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -123,6 +123,10 @@ lazy_static! {
         "beacon_attestation_processing_apply_to_agg_pool",
         "Time spent applying an attestation to the naive aggregation pool"
     );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_AGGREGATION: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_aggregation",
+        "Time spent doing signature aggregation when adding to the agg poll"
+    );
     pub static ref ATTESTATION_PROCESSING_APPLY_TO_OP_POOL: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_apply_to_op_pool",
         "Time spent applying an attestation to the block inclusion pool"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -123,6 +123,10 @@ lazy_static! {
         "beacon_attestation_processing_apply_to_agg_pool",
         "Time spent applying an attestation to the naive aggregation pool"
     );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_MAPS_WRITE_LOCK: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_maps_write_lock",
+        "Time spent waiting for the maps write lock when adding to the agg poll"
+    );
     pub static ref ATTESTATION_PROCESSING_AGG_POOL_AGGREGATION: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_agg_pool_aggregation",
         "Time spent doing signature aggregation when adding to the agg poll"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -255,15 +255,15 @@ lazy_static! {
     /*
      * Participation Metrics
      */
-    pub static ref PARTICIPATION_PREV_EPOCH_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+    pub static ref PARTICIPATION_PREV_EPOCH_ATTESTER: Result<Gauge> = try_create_float_gauge(
         "beacon_participation_prev_epoch_attester",
         "Ratio of attesting balances to total balances"
     );
-    pub static ref PARTICIPATION_PREV_EPOCH_TARGET_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+    pub static ref PARTICIPATION_PREV_EPOCH_TARGET_ATTESTER: Result<Gauge> = try_create_float_gauge(
         "beacon_participation_prev_epoch_target_attester",
         "Ratio of target-attesting balances to total balances"
     );
-    pub static ref PARTICIPATION_PREV_EPOCH_HEAD_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+    pub static ref PARTICIPATION_PREV_EPOCH_HEAD_ATTESTER: Result<Gauge> = try_create_float_gauge(
         "beacon_participation_prev_epoch_head_attester",
         "Ratio of head-attesting balances to total balances"
     );

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -131,6 +131,10 @@ lazy_static! {
         "beacon_attestation_processing_agg_pool_prune",
         "Time spent for the agg pool to prune"
     );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_INSERT: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_insert",
+        "Time spent for the outer pool.insert() function of agg pool"
+    );
     pub static ref ATTESTATION_PROCESSING_AGG_POOL_CORE_INSERT: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_agg_pool_core_insert",
         "Time spent for the core map.insert() function of agg pool"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -127,6 +127,14 @@ lazy_static! {
         "beacon_attestation_processing_agg_pool_maps_write_lock",
         "Time spent waiting for the maps write lock when adding to the agg poll"
     );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_PRUNE: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_prune",
+        "Time spent for the agg pool to prune"
+    );
+    pub static ref ATTESTATION_PROCESSING_AGG_POOL_CORE_INSERT: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_agg_pool_core_insert",
+        "Time spent for the core map.insert() function of agg pool"
+    );
     pub static ref ATTESTATION_PROCESSING_AGG_POOL_AGGREGATION: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_agg_pool_aggregation",
         "Time spent doing signature aggregation when adding to the agg poll"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -83,13 +83,21 @@ lazy_static! {
     /*
      * Attestation Processing
      */
-    pub static ref ATTESTATION_PROCESSING_REQUESTS: Result<IntCounter> = try_create_int_counter(
-        "beacon_attestation_processing_requests_total",
-        "Count of all attestations submitted for processing"
+    pub static ref UNAGGREGATED_ATTESTATION_PROCESSING_REQUESTS: Result<IntCounter> = try_create_int_counter(
+        "beacon_unaggregated_attestation_processing_requests_total",
+        "Count of all unaggregated attestations submitted for processing"
     );
-    pub static ref ATTESTATION_PROCESSING_SUCCESSES: Result<IntCounter> = try_create_int_counter(
-        "beacon_attestation_processing_successes_total",
-        "total_attestation_processing_successes"
+    pub static ref UNAGGREGATED_ATTESTATION_PROCESSING_SUCCESSES: Result<IntCounter> = try_create_int_counter(
+        "beacon_unaggregated_attestation_processing_successes_total",
+        "Number of unaggregated attestations verified for gossip"
+    );
+    pub static ref AGGREGATED_ATTESTATION_PROCESSING_REQUESTS: Result<IntCounter> = try_create_int_counter(
+        "beacon_aggregated_attestation_processing_requests_total",
+        "Count of all aggregated attestations submitted for processing"
+    );
+    pub static ref AGGREGATED_ATTESTATION_PROCESSING_SUCCESSES: Result<IntCounter> = try_create_int_counter(
+        "beacon_aggregated_attestation_processing_successes_total",
+        "Number of aggregated attestations verified for gossip"
     );
     pub static ref ATTESTATION_PROCESSING_TIMES: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_seconds",
@@ -278,7 +286,7 @@ lazy_static! {
     );
     pub static ref ATTN_OBSERVATION_PREV_EPOCH_AGGREGATORS: Result<IntGauge> = try_create_int_gauge(
         "beacon_attn_observation_epoch_aggregators",
-        "Count of attesters that have been seen by the beacon chain in the previous epoch"
+        "Count of aggregators that have been seen by the beacon chain in the previous epoch"
     );
 }
 

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -81,7 +81,7 @@ lazy_static! {
     );
 
     /*
-     * Attestation Processing
+     * Unaggregated Attestation Verification
      */
     pub static ref UNAGGREGATED_ATTESTATION_PROCESSING_REQUESTS: Result<IntCounter> = try_create_int_counter(
         "beacon_unaggregated_attestation_processing_requests_total",
@@ -91,6 +91,14 @@ lazy_static! {
         "beacon_unaggregated_attestation_processing_successes_total",
         "Number of unaggregated attestations verified for gossip"
     );
+    pub static ref UNAGGREGATED_ATTESTATION_GOSSIP_VERIFICATION_TIMES: Result<Histogram> = try_create_histogram(
+        "beacon_unaggregated_attestation_gossip_verification_seconds",
+        "Full runtime of aggregated attestation gossip verification"
+    );
+
+    /*
+     * Aggregated Attestation Verification
+     */
     pub static ref AGGREGATED_ATTESTATION_PROCESSING_REQUESTS: Result<IntCounter> = try_create_int_counter(
         "beacon_aggregated_attestation_processing_requests_total",
         "Count of all aggregated attestations submitted for processing"
@@ -99,14 +107,30 @@ lazy_static! {
         "beacon_aggregated_attestation_processing_successes_total",
         "Number of aggregated attestations verified for gossip"
     );
-    pub static ref ATTESTATION_PROCESSING_TIMES: Result<Histogram> = try_create_histogram(
-        "beacon_attestation_processing_seconds",
-        "Full runtime of attestation processing"
+    pub static ref AGGREGATED_ATTESTATION_GOSSIP_VERIFICATION_TIMES: Result<Histogram> = try_create_histogram(
+        "beacon_aggregated_attestation_gossip_verification_seconds",
+        "Full runtime of aggregated attestation gossip verification"
     );
-    pub static ref ATTESTATION_PROCESSING_INITIAL_VALIDATION_TIMES: Result<Histogram> = try_create_histogram(
-        "beacon_attestation_processing_initial_validation_seconds",
-        "Time spent on the initial_validation of attestation processing"
+
+    /*
+     * General Attestation Processing
+     */
+    pub static ref ATTESTATION_PROCESSING_APPLY_TO_FORK_CHOICE: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_apply_to_fork_choice",
+        "Time spent applying an attestation to fork choice"
     );
+    pub static ref ATTESTATION_PROCESSING_APPLY_TO_AGG_POOL: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_apply_to_agg_pool",
+        "Time spent applying an attestation to the naive aggregation pool"
+    );
+    pub static ref ATTESTATION_PROCESSING_APPLY_TO_OP_POOL: Result<Histogram> = try_create_histogram(
+        "beacon_attestation_processing_apply_to_op_pool",
+        "Time spent applying an attestation to the block inclusion pool"
+    );
+
+    /*
+     * Attestation Processing
+     */
     pub static ref ATTESTATION_PROCESSING_SHUFFLING_CACHE_WAIT_TIMES: Result<Histogram> = try_create_histogram(
         "beacon_attestation_processing_shuffling_cache_wait_seconds",
         "Time spent on waiting for the shuffling cache lock during attestation processing"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -251,6 +251,22 @@ lazy_static! {
         try_create_int_gauge("beacon_op_pool_proposer_slashings_total", "Count of proposer slashings in the op pool");
     pub static ref OP_POOL_NUM_VOLUNTARY_EXITS: Result<IntGauge> =
         try_create_int_gauge("beacon_op_pool_voluntary_exits_total", "Count of voluntary exits in the op pool");
+
+    /*
+     * Participation Metrics
+     */
+    pub static ref PARTICIPATION_PREV_EPOCH_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+        "beacon_participation_prev_epoch_attester",
+        "Ratio of attesting balances to total balances"
+    );
+    pub static ref PARTICIPATION_PREV_EPOCH_TARGET_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+        "beacon_participation_prev_epoch_target_attester",
+        "Ratio of target-attesting balances to total balances"
+    );
+    pub static ref PARTICIPATION_PREV_EPOCH_HEAD_ATTESTER: Result<IntGauge> = try_create_int_gauge(
+        "beacon_participation_prev_epoch_head_attester",
+        "Ratio of head-attesting balances to total balances"
+    );
 }
 
 /// Scrape the `beacon_chain` for metrics that are not constantly updated (e.g., the present slot,

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -1,3 +1,4 @@
+use crate::metrics;
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use types::{Attestation, AttestationData, EthSpec, Slot};
@@ -93,6 +94,8 @@ impl<E: EthSpec> AggregatedAttestationMap<E> {
             {
                 Ok(InsertOutcome::SignatureAlreadyKnown { committee_index })
             } else {
+                let _timer =
+                    metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_AGGREGATION);
                 existing_attestation.aggregate(a);
                 Ok(InsertOutcome::SignatureAggregated { committee_index })
             }

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -187,6 +187,7 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
         let outcome = if let Some(map) = maps.get_mut(&slot) {
             map.insert(attestation)
         } else {
+            let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_CREATE_MAP);
             // To avoid re-allocations, try and determine a rough initial capacity for the new item
             // by obtaining the mean size of all items in earlier epoch.
             let (count, sum) = maps

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -231,6 +231,12 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
 
         // Taking advantage of saturating subtraction on `Slot`.
         let lowest_permissible_slot = current_slot - Slot::from(SLOTS_RETAINED);
+
+        // No need to prune if the lowest permissible slot has not changed.
+        if *self.lowest_permissible_slot.write() == lowest_permissible_slot {
+            return;
+        }
+
         *self.lowest_permissible_slot.write() = lowest_permissible_slot;
         let mut maps = self.maps.write();
 

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -69,6 +69,8 @@ impl<E: EthSpec> AggregatedAttestationMap<E> {
     ///
     /// The given attestation (`a`) must only have one signature.
     pub fn insert(&mut self, a: &Attestation<E>) -> Result<InsertOutcome, Error> {
+        let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_CORE_INSERT);
+
         let set_bits = a
             .aggregation_bits
             .iter()
@@ -226,6 +228,8 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
     /// Removes any attestations with a slot lower than `current_slot` and bars any future
     /// attestations with a slot lower than `current_slot - SLOTS_RETAINED`.
     pub fn prune(&self, current_slot: Slot) {
+        let _timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_PRUNE);
+
         // Taking advantage of saturating subtraction on `Slot`.
         let lowest_permissible_slot = current_slot - Slot::from(SLOTS_RETAINED);
         *self.lowest_permissible_slot.write() = lowest_permissible_slot;

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -178,7 +178,11 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
             });
         }
 
-        let mut maps = self.maps.write();
+        let mut maps = {
+            let _timer =
+                metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_MAPS_WRITE_LOCK);
+            self.maps.write()
+        };
 
         let outcome = if let Some(map) = maps.get_mut(&slot) {
             map.insert(attestation)

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -180,11 +180,9 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
             });
         }
 
-        let mut maps = {
-            let _timer =
-                metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_MAPS_WRITE_LOCK);
-            self.maps.write()
-        };
+        let timer = metrics::start_timer(&metrics::ATTESTATION_PROCESSING_AGG_POOL_MAPS_WRITE_LOCK);
+        let mut maps = self.maps.write();
+        drop(timer);
 
         let outcome = if let Some(map) = maps.get_mut(&slot) {
             map.insert(attestation)

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -234,8 +234,11 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
         // Taking advantage of saturating subtraction on `Slot`.
         let lowest_permissible_slot = current_slot - Slot::from(SLOTS_RETAINED);
 
-        // No need to prune if the lowest permissible slot has not changed.
-        if *self.lowest_permissible_slot.read() == lowest_permissible_slot {
+        // No need to prune if the lowest permissible slot has not changed and the queue length is
+        // less than the maximum
+        if *self.lowest_permissible_slot.read() == lowest_permissible_slot
+            && self.maps.read().len() <= SLOTS_RETAINED
+        {
             return;
         }
 

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -233,7 +233,7 @@ impl<E: EthSpec> NaiveAggregationPool<E> {
         let lowest_permissible_slot = current_slot - Slot::from(SLOTS_RETAINED);
 
         // No need to prune if the lowest permissible slot has not changed.
-        if *self.lowest_permissible_slot.write() == lowest_permissible_slot {
+        if *self.lowest_permissible_slot.read() == lowest_permissible_slot {
             return;
         }
 

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -32,3 +32,5 @@ smallvec = "1.4.0"
 rand = "0.7.3"
 fnv = "1.0.6"
 rlp = "0.4.5"
+lazy_static = "1.4.0"
+lighthouse_metrics = { path = "../../eth2/utils/lighthouse_metrics" }

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -1,8 +1,12 @@
+#[macro_use]
+extern crate lazy_static;
+
 /// This crate provides the network server for Lighthouse.
 pub mod error;
 pub mod service;
 
 mod attestation_service;
+mod metrics;
 mod persisted_dht;
 mod router;
 mod sync;

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -2,7 +2,7 @@ pub use lighthouse_metrics::*;
 
 lazy_static! {
     /*
-     * Gossip
+     * Gossip Rx
      */
     pub static ref GOSSIP_BLOCKS_RX: Result<IntCounter> = try_create_int_counter(
         "network_gossip_blocks_rx_total",
@@ -15,5 +15,21 @@ lazy_static! {
     pub static ref GOSSIP_AGGREGATED_ATTESTATIONS_RX: Result<IntCounter> = try_create_int_counter(
         "network_gossip_aggregated_attestations_rx_total",
         "Count of gossip aggregated attestations received"
+    );
+
+    /*
+     * Gossip Tx
+     */
+    pub static ref GOSSIP_BLOCKS_TX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_blocks_tx_total",
+        "Count of gossip blocks transmitted"
+    );
+    pub static ref GOSSIP_UNAGGREGATED_ATTESTATIONS_TX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_unaggregated_attestations_tx_total",
+        "Count of gossip unaggregated attestations transmitted"
+    );
+    pub static ref GOSSIP_AGGREGATED_ATTESTATIONS_TX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_aggregated_attestations_tx_total",
+        "Count of gossip aggregated attestations transmitted"
     );
 }

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -1,0 +1,19 @@
+pub use lighthouse_metrics::*;
+
+lazy_static! {
+    /*
+     * Gossip
+     */
+    pub static ref GOSSIP_BLOCKS_RX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_blocks_rx_total",
+        "Count of gossip blocks received"
+    );
+    pub static ref GOSSIP_UNAGGREGATED_ATTESTATIONS_RX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_unaggregated_attestations_rx_total",
+        "Count of gossip unaggregated attestations received"
+    );
+    pub static ref GOSSIP_AGGREGATED_ATTESTATIONS_RX: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_aggregated_attestations_rx_total",
+        "Count of gossip aggregated attestations received"
+    );
+}

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -12,6 +12,10 @@ lazy_static! {
         "network_gossip_unaggregated_attestations_rx_total",
         "Count of gossip unaggregated attestations received"
     );
+    pub static ref GOSSIP_UNAGGREGATED_ATTESTATIONS_IGNORED: Result<IntCounter> = try_create_int_counter(
+        "network_gossip_unaggregated_attestations_ignored_total",
+        "Count of gossip unaggregated attestations ignored by attestation service"
+    );
     pub static ref GOSSIP_AGGREGATED_ATTESTATIONS_RX: Result<IntCounter> = try_create_int_counter(
         "network_gossip_aggregated_attestations_rx_total",
         "Count of gossip aggregated attestations received"

--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -7,7 +7,6 @@
 pub mod processor;
 
 use crate::error;
-use crate::metrics;
 use crate::service::NetworkMessage;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError};
 use eth2_libp2p::{
@@ -251,7 +250,6 @@ impl<T: BeaconChainTypes> Router<T> {
         match gossip_message {
             // Attestations should never reach the router.
             PubsubMessage::AggregateAndProofAttestation(aggregate_and_proof) => {
-                metrics::inc_counter(&metrics::GOSSIP_AGGREGATED_ATTESTATIONS_RX);
                 if let Some(gossip_verified) =
                     self.processor.verify_aggregated_attestation_for_gossip(
                         peer_id.clone(),
@@ -264,7 +262,6 @@ impl<T: BeaconChainTypes> Router<T> {
                 }
             }
             PubsubMessage::Attestation(subnet_attestation) => {
-                metrics::inc_counter(&metrics::GOSSIP_UNAGGREGATED_ATTESTATIONS_RX);
                 if let Some(gossip_verified) =
                     self.processor.verify_unaggregated_attestation_for_gossip(
                         peer_id.clone(),
@@ -277,7 +274,6 @@ impl<T: BeaconChainTypes> Router<T> {
                 }
             }
             PubsubMessage::BeaconBlock(block) => {
-                metrics::inc_counter(&metrics::GOSSIP_BLOCKS_RX);
                 match self.processor.should_forward_block(&peer_id, block) {
                     Ok(verified_block) => {
                         info!(self.log, "New block received"; "slot" => verified_block.block.slot(), "hash" => verified_block.block_root.to_string());

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -1,10 +1,10 @@
-use crate::error;
 use crate::persisted_dht::{load_dht, persist_dht};
 use crate::router::{Router, RouterMessage};
 use crate::{
     attestation_service::{AttServiceMessage, AttestationService},
     NetworkConfig,
 };
+use crate::{error, metrics};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::Service as LibP2PService;
 use eth2_libp2p::{rpc::RPCRequest, BehaviourEvent, Enr, MessageId, NetworkGlobals, PeerId};
@@ -208,7 +208,13 @@ fn spawn_service<T: BeaconChainTypes>(
                                         topic_kinds.push(message.kind());
                                     }
                                 }
-                                debug!(service.log, "Sending pubsub messages"; "count" => messages.len(), "topics" => format!("{:?}", topic_kinds));
+                                debug!(
+                                    service.log,
+                                    "Sending pubsub messages";
+                                    "count" => messages.len(),
+                                    "topics" => format!("{:?}", topic_kinds)
+                                );
+                                expose_publish_metrics(&messages);
                                 service.libp2p.swarm.publish(messages);
                             }
                         }
@@ -386,4 +392,20 @@ pub enum NetworkMessage<T: EthSpec> {
     },
     /// Disconnect and bans a peer id.
     Disconnect { peer_id: PeerId },
+}
+
+/// Inspects the `messages` that were being sent to the network and updates Prometheus metrics.
+fn expose_publish_metrics<T: EthSpec>(messages: &[PubsubMessage<T>]) {
+    for message in messages {
+        match message {
+            PubsubMessage::BeaconBlock(_) => metrics::inc_counter(&metrics::GOSSIP_BLOCKS_TX),
+            PubsubMessage::Attestation(_) => {
+                metrics::inc_counter(&metrics::GOSSIP_UNAGGREGATED_ATTESTATIONS_TX)
+            }
+            PubsubMessage::AggregateAndProofAttestation(_) => {
+                metrics::inc_counter(&metrics::GOSSIP_AGGREGATED_ATTESTATIONS_TX)
+            }
+            _ => {}
+        }
+    }
 }

--- a/eth2/state_processing/src/per_epoch_processing.rs
+++ b/eth2/state_processing/src/per_epoch_processing.rs
@@ -15,8 +15,9 @@ pub use process_slashings::process_slashings;
 pub use registry_updates::process_registry_updates;
 pub use validator_statuses::{TotalBalances, ValidatorStatus, ValidatorStatuses};
 
+/// Provides a summary of validator participation during the epoch.
 pub struct EpochProcessingSummary {
-    pub validator_statuses: ValidatorStatuses,
+    pub total_balances: TotalBalances,
 }
 
 /// Performs per-epoch processing on some BeaconState.
@@ -62,7 +63,9 @@ pub fn per_epoch_processing<T: EthSpec>(
     // Rotate the epoch caches to suit the epoch transition.
     state.advance_caches();
 
-    Ok(EpochProcessingSummary { validator_statuses })
+    Ok(EpochProcessingSummary {
+        total_balances: validator_statuses.total_balances,
+    })
 }
 
 /// Update the following fields on the `BeaconState`:

--- a/eth2/state_processing/src/per_epoch_processing.rs
+++ b/eth2/state_processing/src/per_epoch_processing.rs
@@ -15,6 +15,10 @@ pub use process_slashings::process_slashings;
 pub use registry_updates::process_registry_updates;
 pub use validator_statuses::{TotalBalances, ValidatorStatus, ValidatorStatuses};
 
+pub struct EpochProcessingSummary {
+    pub validator_statuses: ValidatorStatuses,
+}
+
 /// Performs per-epoch processing on some BeaconState.
 ///
 /// Mutates the given `BeaconState`, returning early if an error is encountered. If an error is
@@ -24,7 +28,7 @@ pub use validator_statuses::{TotalBalances, ValidatorStatus, ValidatorStatuses};
 pub fn per_epoch_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,
-) -> Result<(), Error> {
+) -> Result<EpochProcessingSummary, Error> {
     // Ensure the committee caches are built.
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
@@ -58,7 +62,7 @@ pub fn per_epoch_processing<T: EthSpec>(
     // Rotate the epoch caches to suit the epoch transition.
     state.advance_caches();
 
-    Ok(())
+    Ok(EpochProcessingSummary { validator_statuses })
 }
 
 /// Update the following fields on the `BeaconState`:

--- a/eth2/state_processing/src/per_slot_processing.rs
+++ b/eth2/state_processing/src/per_slot_processing.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{per_epoch_processing::EpochProcessingSummary, *};
 use types::*;
 
 #[derive(Debug, PartialEq)]
@@ -18,16 +18,18 @@ pub fn per_slot_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     state_root: Option<Hash256>,
     spec: &ChainSpec,
-) -> Result<(), Error> {
+) -> Result<Vec<EpochProcessingSummary>, Error> {
     cache_state(state, state_root)?;
 
+    let mut summaries = vec![];
+
     if state.slot > spec.genesis_slot && (state.slot + 1) % T::slots_per_epoch() == 0 {
-        per_epoch_processing(state, spec)?;
+        summaries.push(per_epoch_processing(state, spec)?);
     }
 
     state.slot += 1;
 
-    Ok(())
+    Ok(summaries)
 }
 
 fn cache_state<T: EthSpec>(

--- a/eth2/state_processing/src/per_slot_processing.rs
+++ b/eth2/state_processing/src/per_slot_processing.rs
@@ -18,18 +18,18 @@ pub fn per_slot_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     state_root: Option<Hash256>,
     spec: &ChainSpec,
-) -> Result<Vec<EpochProcessingSummary>, Error> {
+) -> Result<Option<EpochProcessingSummary>, Error> {
     cache_state(state, state_root)?;
 
-    let mut summaries = vec![];
+    let mut summary = None;
 
     if state.slot > spec.genesis_slot && (state.slot + 1) % T::slots_per_epoch() == 0 {
-        summaries.push(per_epoch_processing(state, spec)?);
+        summary = Some(per_epoch_processing(state, spec)?);
     }
 
     state.slot += 1;
 
-    Ok(summaries)
+    Ok(summary)
 }
 
 fn cache_state<T: EthSpec>(

--- a/eth2/utils/lighthouse_metrics/src/lib.rs
+++ b/eth2/utils/lighthouse_metrics/src/lib.rs
@@ -124,6 +124,12 @@ pub fn set_gauge(gauge: &Result<IntGauge>, value: i64) {
     }
 }
 
+pub fn maybe_set_gauge(gauge: &Result<IntGauge>, value_opt: Option<i64>) {
+    if let Some(value) = value_opt {
+        set_gauge(gauge, value)
+    }
+}
+
 /// Sets the value of a `Histogram` manually.
 pub fn observe(histogram: &Result<Histogram>, value: f64) {
     if let Ok(histogram) = histogram {

--- a/eth2/utils/lighthouse_metrics/src/lib.rs
+++ b/eth2/utils/lighthouse_metrics/src/lib.rs
@@ -56,7 +56,7 @@
 
 use prometheus::{HistogramOpts, HistogramTimer, Opts};
 
-pub use prometheus::{Encoder, Histogram, IntCounter, IntGauge, Result, TextEncoder};
+pub use prometheus::{Encoder, Gauge, Histogram, IntCounter, IntGauge, Result, TextEncoder};
 
 /// Collect all the metrics for reporting.
 pub fn gather() -> Vec<prometheus::proto::MetricFamily> {
@@ -77,6 +77,15 @@ pub fn try_create_int_counter(name: &str, help: &str) -> Result<IntCounter> {
 pub fn try_create_int_gauge(name: &str, help: &str) -> Result<IntGauge> {
     let opts = Opts::new(name, help);
     let gauge = IntGauge::with_opts(opts)?;
+    prometheus::register(Box::new(gauge.clone()))?;
+    Ok(gauge)
+}
+
+/// Attempts to crate a `Gauge`, returning `Err` if the registry does not accept the counter
+/// (potentially due to naming conflict).
+pub fn try_create_float_gauge(name: &str, help: &str) -> Result<Gauge> {
+    let opts = Opts::new(name, help);
+    let gauge = Gauge::with_opts(opts)?;
     prometheus::register(Box::new(gauge.clone()))?;
     Ok(gauge)
 }
@@ -127,6 +136,18 @@ pub fn set_gauge(gauge: &Result<IntGauge>, value: i64) {
 pub fn maybe_set_gauge(gauge: &Result<IntGauge>, value_opt: Option<i64>) {
     if let Some(value) = value_opt {
         set_gauge(gauge, value)
+    }
+}
+
+pub fn set_float_gauge(gauge: &Result<Gauge>, value: f64) {
+    if let Ok(gauge) = gauge {
+        gauge.set(value);
+    }
+}
+
+pub fn maybe_set_float_gauge(gauge: &Result<Gauge>, value_opt: Option<f64>) {
+    if let Some(value) = value_opt {
+        set_float_gauge(gauge, value)
     }
 }
 

--- a/tests/ef_tests/src/cases/sanity_slots.rs
+++ b/tests/ef_tests/src/cases/sanity_slots.rs
@@ -66,7 +66,7 @@ impl<E: EthSpec> Case for SanitySlots<E> {
         state.build_all_caches(spec).unwrap();
 
         let mut result = (0..self.slots)
-            .try_for_each(|_| per_slot_processing(&mut state, None, spec))
+            .try_for_each(|_| per_slot_processing(&mut state, None, spec).map(|_| ()))
             .map(|_| state);
 
         compare_beacon_state_results_without_caches(&mut result, &mut expected)


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Fix a bug where the VC wasn't indicating when it is an aggregator.
- Make some changes to `NaiveAggregationPool` to make it less read-lock greedy.
- Makes `per_epoch_processing` return the `TotalBalances` struct
  - @michaelsproul it would be great if you could check [this commit](https://github.com/sigp/lighthouse/pull/1151/commits/087cc6c9ec2b32c301bc7ae70c4d4a76ecc764a2) retrospectively, but it's non-substantive.
- Exposes many new metrics to Prometheus.
- Clean up some old unused metrics.

## Additional Info

- I have not checked to see if this aligns with other clients metrics; I need this quicky and it can be aligned later. 
- These metrics will get a bit messy in the event of forking, but I don't see any way to keep this clean during forks.
- ~~Tests are failing on the upstream branch so they'll fail here too.~~
