### PR TITLE
Update work-flow for pull_request

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,6 +1,6 @@
 name: test-suite
 
-on: [push]
+on: [pull_request]
 
 jobs:
   cargo-fmt:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,6 +1,10 @@
 name: test-suite
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   cargo-fmt:


### PR DESCRIPTION
Updates lighthouse's CI workflow to trigger on pull requests. 

As no-one is committing directly to master it makes sense we trigger on pull requests such that extern-contributors PR's have CI run on them and they are aware if their PR's are passing CI or not