### PR TITLE
Fix Schlesi-splitting penalty bug

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
+++ b/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
@@ -225,7 +225,9 @@ fn get_attestation_delta<T: EthSpec>(
         delta.penalize(spec.base_rewards_per_epoch.safe_mul(base_reward)?)?;
 
         // Additionally, all validators whose FFG target didn't match are penalized extra
-        if !validator.is_previous_epoch_target_attester {
+        // This condition is equivalent to this condition from the spec:
+        // `index not in get_unslashed_attesting_indices(state, matching_target_attestations)`
+        if validator.is_slashed || !validator.is_previous_epoch_target_attester {
             delta.penalize(
                 validator
                     .current_epoch_effective_balance

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -56,6 +56,8 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq {
 
     fn default_spec() -> ChainSpec;
 
+    fn spec_name() -> &'static str;
+
     fn genesis_epoch() -> Epoch {
         Epoch::new(Self::GenesisEpoch::to_u64())
     }
@@ -159,6 +161,10 @@ impl EthSpec for MainnetEthSpec {
     fn default_spec() -> ChainSpec {
         ChainSpec::mainnet()
     }
+
+    fn spec_name() -> &'static str {
+        "mainnet"
+    }
 }
 
 pub type FoundationBeaconState = BeaconState<MainnetEthSpec>;
@@ -196,6 +202,10 @@ impl EthSpec for MinimalEthSpec {
     fn default_spec() -> ChainSpec {
         ChainSpec::minimal()
     }
+
+    fn spec_name() -> &'static str {
+        "minimal"
+    }
 }
 
 pub type MinimalBeaconState = BeaconState<MinimalEthSpec>;
@@ -230,6 +240,10 @@ impl EthSpec for InteropEthSpec {
 
     fn default_spec() -> ChainSpec {
         ChainSpec::interop()
+    }
+
+    fn spec_name() -> &'static str {
+        "interop"
     }
 }
 

--- a/lcli/src/parse_hex.rs
+++ b/lcli/src/parse_hex.rs
@@ -18,7 +18,7 @@ pub fn run_parse_hex<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
 
     let hex = hex::decode(&hex).map_err(|e| format!("Failed to parse hex: {:?}", e))?;
 
-    info!("Using minimal spec");
+    info!("Using {} spec", T::spec_name());
     info!("Type: {:?}", type_str);
 
     match type_str {

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -26,7 +26,7 @@ pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
         .parse::<PathBuf>()
         .map_err(|e| format!("Failed to parse output path: {}", e))?;
 
-    info!("Using minimal spec");
+    info!("Using {} spec", T::spec_name());
     info!("Pre-state path: {:?}", pre_state_path);
     info!("Slots: {:?}", slots);
 

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -25,7 +25,7 @@ pub fn run_transition_blocks<T: EthSpec>(matches: &ArgMatches) -> Result<(), Str
         .parse::<PathBuf>()
         .map_err(|e| format!("Failed to parse output path: {}", e))?;
 
-    info!("Using minimal spec");
+    info!("Using {} spec", T::spec_name());
     info!("Pre-state path: {:?}", pre_state_path);
     info!("Block path: {:?}", block_path);
 


### PR DESCRIPTION
This PR fixes a bug in the calculation of rewards and penalties that was identified when the Schlesi testnet split on May 18th 2020.

The new code correctly produces a state with root `0xd2e0f469565e14d2eaa331d6d359062ce9162ffbb93d551c2428ef8489092f9b` when applying `block.ssz` from slot 150496 to the state `lh-pre.ssz`, downloadable here:

https://discord.com/channels/595666850260713488/707233122097299496/711935902468931595

This state root matches the pyspec and Teku, as per:

* https://discord.com/channels/595666850260713488/707233122097299496/711938830164295740
* https://discord.com/channels/595666850260713488/707233122097299496/711999231270977596

The root cause of the bug was an incorrect implementation of penalties for slashed validators who also targeted the correct root with their attestations:

```python
matching_target_attesting_indices = get_unslashed_attesting_indices(state, matching_target_attestations)
for index in eligible_validator_indices:
    penalties[index] += Gwei(BASE_REWARDS_PER_EPOCH * get_base_reward(state, index))
    if index not in matching_target_attesting_indices:
        effective_balance = state.validators[index].effective_balance
        penalties[index] += Gwei(effective_balance * finality_delay // INACTIVITY_PENALTY_QUOTIENT)
```

The check:

```python
index not in get_unslashed_attesting_indices(state, matching_target_attestations)
```

should be translated to

```rust
!(!validator.slashed && validator.is_previous_epoch_target_attester)
```

i.e.

```rust
validator.slashed || !validator_is_previous_epoch_target_attester
```

The `validator.slashed` disjunct was missed, because me from 13 months ago didn't read the logic carefully enough!

Spec at time of writing: v0.11.3