### PR TITLE
Remove v0.1.2 install instructions

### DIFF
--- a/book/src/become-a-validator-source.md
+++ b/book/src/become-a-validator-source.md
@@ -12,7 +12,6 @@ Once you have Rust installed, you can install Lighthouse with the following comm
 
 1.  `git clone https://github.com/sigp/lighthouse.git`
 2.  `cd lighthouse`
-3.  `git checkout v0.1.2`
 4.  `make`
 
 You may need to open a new terminal window before running `make`.

--- a/book/src/installation.md
+++ b/book/src/installation.md
@@ -5,7 +5,6 @@ fact, if you already have Rust installed all you need is:
 
 - `git clone https://github.com/sigp/lighthouse.git`
 - `cd lighthouse`
-- `git checkout v0.1.2`
 - `make`
 
 If this doesn't work or is not clear enough, see the [Detailed Instructions](#detailed-instructions). If you have further issues, see [Troubleshooting](#troubleshooting). If you'd prefer to use Docker, see the [Docker Guide](./docker.md).


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Now that Schlesi has passed away (RIP) we don't need to maintain compat. with the old validator keys. This PR removes the instruction for users to install via the `v0.1.2` tag. 
