### PR TITLE
Relax PartialEq constraint on error enums

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -62,7 +62,7 @@ use types::{
 ///   other than `BeaconChainError`).
 /// - The application encountered an internal error whilst attempting to determine validity
 ///   (the `BeaconChainError` variant)
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     /// The attestation is from a slot that is later than the current slot (with respect to the
     /// gossip clock disparity).

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -86,7 +86,7 @@ const WRITE_BLOCK_PROCESSING_SSZ: bool = cfg!(feature = "write_ssz_files");
 ///
 /// - The block is malformed/invalid (indicated by all results other than `BeaconChainError`.
 /// - We encountered an error whilst trying to verify the block (a `BeaconChainError`).
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum BlockError {
     /// The parent block was unknown.
     ParentUnknown(Hash256),

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -26,7 +26,7 @@ macro_rules! easy_from_to {
     };
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum BeaconChainError {
     InsufficientValidators,
     UnableToReadSlot,
@@ -87,7 +87,7 @@ easy_from_to!(ObservedBlockProducersError, BeaconChainError);
 easy_from_to!(BlockSignatureVerifierError, BeaconChainError);
 easy_from_to!(ArithError, BeaconChainError);
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum BlockProductionError {
     UnableToGetBlockRootFromState,
     UnableToReadSlot,

--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -19,7 +19,7 @@ use types::{
 type BlockNumber = u64;
 type Eth1DataVoteCount = HashMap<(Eth1Data, BlockNumber), u64>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     /// Unable to return an Eth1Data for the given epoch.
     EpochUnavailable,

--- a/beacon_node/beacon_chain/src/fork_choice.rs
+++ b/beacon_node/beacon_chain/src/fork_choice.rs
@@ -13,7 +13,7 @@ use types::{BeaconBlock, BeaconState, BeaconStateError, Epoch, Hash256, IndexedA
 
 type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     MissingBlock(Hash256),
     MissingState(Hash256),

--- a/beacon_node/beacon_chain/tests/persistence_tests.rs
+++ b/beacon_node/beacon_chain/tests/persistence_tests.rs
@@ -143,7 +143,11 @@ fn finalizes_after_resuming_from_db() {
 fn assert_chains_pretty_much_the_same<T: BeaconChainTypes>(a: &BeaconChain<T>, b: &BeaconChain<T>) {
     assert_eq!(a.spec, b.spec, "spec should be equal");
     assert_eq!(a.op_pool, b.op_pool, "op_pool should be equal");
-    assert_eq!(a.head(), b.head(), "head() should be equal");
+    assert_eq!(
+        a.head().unwrap(),
+        b.head().unwrap(),
+        "head() should be equal"
+    );
     assert_eq!(a.heads(), b.heads(), "heads() should be equal");
     assert_eq!(
         a.genesis_block_root, b.genesis_block_root,

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -3,7 +3,7 @@ use crate::hot_cold_store::HotColdDBError;
 use ssz::DecodeError;
 use types::{BeaconStateError, Hash256};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     SszDecodeError(DecodeError),
     VectorChunkError(ChunkError),

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -337,20 +337,20 @@ mod tests {
         let key = Hash256::random();
         let item = StorableThing { a: 1, b: 42 };
 
-        assert_eq!(store.exists::<StorableThing>(&key), Ok(false));
+        assert_eq!(store.exists::<StorableThing>(&key).unwrap(), false);
 
         store.put(&key, &item).unwrap();
 
-        assert_eq!(store.exists::<StorableThing>(&key), Ok(true));
+        assert_eq!(store.exists::<StorableThing>(&key).unwrap(), true);
 
         let retrieved = store.get(&key).unwrap().unwrap();
         assert_eq!(item, retrieved);
 
         store.delete::<StorableThing>(&key).unwrap();
 
-        assert_eq!(store.exists::<StorableThing>(&key), Ok(false));
+        assert_eq!(store.exists::<StorableThing>(&key).unwrap(), false);
 
-        assert_eq!(store.get::<StorableThing>(&key), Ok(None));
+        assert_eq!(store.get::<StorableThing>(&key).unwrap(), None);
     }
 
     #[test]


### PR DESCRIPTION
This has been salvaged from the [failed attempt at replacing MemoryStore with plain LevelDB](https://github.com/sigp/lighthouse/issues/1139#issuecomment-630976898).

The reason why reliance on `PartialEq` with error types is risky is that some error types are merely *tokens* for actual errors and can't capture the complete context the error values represents as it lies partially in the OS ([std::io::Error](https://doc.rust-lang.org/std/io/struct.Error.html) for instance).  If the error value doesn't capture the entire context, `==` on it isn't well defined.  It's therefore safer to *match* against specific `Err(...)`, rather the `==` the value assuming it implements `PartialEq`, and this is what this PR changes.

In addition to he above, the requirement on error type to be `PartialEq` precludes inclusion of error types (e.g. std::io::Error) that aren't `PartialEq`, as  error`enum` variants, which leads to all kinds of hacks like converting it to `String` just to make it satisfy `PartialEq`.