### PR TITLE
Add tests for REST API `/validator/attestation`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
+
+[[package]]
 name = "async-tls"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3689,6 +3695,7 @@ dependencies = [
 name = "rest_api"
 version = "0.1.2"
 dependencies = [
+ "assert_matches",
  "beacon_chain",
  "bls",
  "eth2-libp2p",

--- a/beacon_node/rest_api/Cargo.toml
+++ b/beacon_node/rest_api/Cargo.toml
@@ -38,6 +38,7 @@ operation_pool = { path = "../operation_pool" }
 rayon = "1.3.0"
 
 [dev-dependencies]
+assert_matches = "1.3.0"
 remote_beacon_node = { path = "../../common/remote_beacon_node" }
 node_test_rig = { path = "../../testing/node_test_rig" }
 tree_hash = "0.1.0"


### PR DESCRIPTION
## Issue Addressed

This is the first PR for #914.

I've added tests that ensures `/validator/attestation` returns `400 Bad Rquest` if the required query parameters are missing in the request.

