### PR TITLE
Drop runtime after task completion

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -241,5 +241,9 @@ fn run<E: EthSpec>(
     drop(validator_client);
 
     // Shutdown the environment once all tasks have completed.
-    Ok(environment.shutdown_on_idle())
+    // Due to a bug in tokio: https://github.com/tokio-rs/tokio/issues/2314
+    // the shutdown on idle wait until the timeout. For the time-being, we shutdown as soon as all
+    // threads have completed, by dropping the runtime.
+    //Ok(environment.shutdown_on_idle())
+    Ok(())
 }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -242,7 +242,7 @@ fn run<E: EthSpec>(
 
     // Shutdown the environment once all tasks have completed.
     // Due to a bug in tokio: https://github.com/tokio-rs/tokio/issues/2314
-    // the shutdown on idle wait until the timeout. For the time-being, we shutdown as soon as all
+    // the `shutdown_on_idle()` will wait until the entire timeout. For the time-being, we shutdown as soon as all
     // threads have completed, by dropping the runtime.
     //Ok(environment.shutdown_on_idle())
     Ok(())


### PR DESCRIPTION
This is a temporary work around for ending lighthouse, once all tasks are complete.

The original behaviour was to wait until all tasks have been completed before ending the client. This was upgraded to waiting a maximum period of time for tasks to complete before forcing a shutdown. This upgraded behaviour does not work as expected due to a bug in tokio. 
I've reverted to the old behaviour, as a temporary work-around.

This speeds up lighthouse's shutdown time making it super fast (as it should be). We will revert to having a maximum wait time once the bug in tokio is fixed. For now, this should be good for public use. 