### PR TITLE
Revert runtime drop

### DIFF
--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -276,7 +276,7 @@ impl<E: EthSpec> Environment<E> {
     /// Shutdown the `tokio` runtime when all tasks are idle.
     pub fn shutdown_on_idle(self) {
         self.runtime
-            .shutdown_timeout(std::time::Duration::from_secs(5))
+            .shutdown_timeout(std::time::Duration::from_secs(2))
     }
 
     /// Sets the logger (and all child loggers) to log to a file.

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -241,9 +241,5 @@ fn run<E: EthSpec>(
     drop(validator_client);
 
     // Shutdown the environment once all tasks have completed.
-    // Due to a bug in tokio: https://github.com/tokio-rs/tokio/issues/2314
-    // the `shutdown_on_idle()` will wait until the entire timeout. For the time-being, we shutdown as soon as all
-    // threads have completed, by dropping the runtime.
-    //Ok(environment.shutdown_on_idle())
-    Ok(())
+    Ok(environment.shutdown_on_idle())
 }


### PR DESCRIPTION
## Issue Addressed

This reverts #1196. 

Although #1196 worked in some cases (including my test runs) it does not work in general. I've shortened the wait time to 2 seconds, but again this is not ideal. We will have to wait for an upstream fix for this to be corrected properly.
