### PR TITLE
Strip off newline chars from password

### DIFF
--- a/account_manager/src/common.rs
+++ b/account_manager/src/common.rs
@@ -10,6 +10,8 @@ use std::path::{Path, PathBuf};
 /// 62**48 is greater than 255**32, therefore this password has more bits of entropy than a byte
 /// array of length 32.
 const DEFAULT_PASSWORD_LEN: usize = 48;
+const NEWLINE_SLASH_N: u8 = 10;
+const NEWLINE_SLASH_R: u8 = 13;
 
 pub fn random_password() -> PlainText {
     rand::thread_rng()
@@ -36,4 +38,62 @@ pub fn base_wallet_dir(matches: &ArgMatches, arg: &'static str) -> Result<PathBu
         arg,
         PathBuf::new().join(".lighthouse").join("wallets"),
     )
+}
+
+pub fn strip_off_newline_codes(bytes: &mut Vec<u8>) -> Vec<u8> {
+    let mut strip_off = 0;
+    for (i, byte) in bytes.iter().rev().enumerate() {
+        if *byte == NEWLINE_SLASH_N || *byte == NEWLINE_SLASH_R {
+            strip_off = i + 1;
+        } else {
+            break;
+        }
+    }
+    bytes.resize(bytes.len() - strip_off, 0);
+
+    bytes.to_vec()
+}
+
+#[cfg(test)]
+mod test {
+    use super::strip_off_newline_codes;
+
+    #[test]
+    fn test_strip_off() {
+        let expected_bytes: Vec<u8> = vec![108, 105, 103, 104, 116, 104, 111, 117, 115, 101];
+
+        let mut bytes: Vec<u8> = vec![108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 10];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![
+            108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 10, 10, 10, 10,
+        ];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 13];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![
+            108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 13, 13, 13, 13, 13, 13,
+        ];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 13, 10];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![
+            108, 105, 103, 104, 116, 104, 111, 117, 115, 101, 13, 10, 13, 10, 13, 10,
+        ];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+
+        let mut bytes: Vec<u8> = vec![108, 105, 103, 104, 116, 104, 111, 117, 115, 101];
+        bytes = strip_off_newline_codes(&mut bytes);
+        assert_eq!(bytes, expected_bytes);
+    }
 }

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -1,4 +1,7 @@
-use crate::{common::random_password, BASE_DIR_FLAG};
+use crate::{
+    common::{random_password, strip_off_newline_codes},
+    BASE_DIR_FLAG,
+};
 use clap::{App, Arg, ArgMatches};
 use eth2_wallet::{
     bip39::{Language, Mnemonic, MnemonicType},
@@ -104,7 +107,10 @@ pub fn cli_run(matches: &ArgMatches, base_dir: PathBuf) -> Result<(), String> {
 
     let wallet_password = fs::read(&wallet_password_path)
         .map_err(|e| format!("Unable to read {:?}: {:?}", wallet_password_path, e))
-        .map(|bytes| PlainText::from(bytes))?;
+        .map(|mut bytes| {
+            bytes = strip_off_newline_codes(&mut bytes);
+            PlainText::from(bytes)
+        })?;
 
     let wallet = mgr
         .create_wallet(name, wallet_type, &mnemonic, wallet_password.as_bytes())

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{random_password, strip_off_newline_codes},
+    common::{random_password, strip_off_newlines},
     BASE_DIR_FLAG,
 };
 use clap::{App, Arg, ArgMatches};
@@ -107,8 +107,8 @@ pub fn cli_run(matches: &ArgMatches, base_dir: PathBuf) -> Result<(), String> {
 
     let wallet_password = fs::read(&wallet_password_path)
         .map_err(|e| format!("Unable to read {:?}: {:?}", wallet_password_path, e))
-        .map(|mut bytes| {
-            bytes = strip_off_newline_codes(&mut bytes);
+        .map(|bytes| {
+            let bytes = strip_off_newlines(bytes);
             PlainText::from(bytes)
         })?;
 


### PR DESCRIPTION
## Issue Addressed

Issue #1175 

## Proposed Changes

* Add a function to `src/common.rs` that strips off newline chars (`\n` and `\r`)
    * Characters are stripped off from the end until the first non-newline character is found
    * This newly added function is tested in `src/common.rs` 
* Use this function before parsing bytes as `PlainText` in `src/wallet/create.rs`

## Additional Info

The mutability of read bytes is changed to `mut` to be able to strip off the characters.
