### PR TITLE
allows passwords to only be UTF-8 encoded

### DIFF
--- a/account_manager/src/common.rs
+++ b/account_manager/src/common.rs
@@ -38,18 +38,13 @@ pub fn base_wallet_dir(matches: &ArgMatches, arg: &'static str) -> Result<PathBu
     )
 }
 
-/// Remove any number of newline or carriage returns from the end of a vector of bytes.
-pub fn strip_off_newlines(mut bytes: Vec<u8>) -> Vec<u8> {
-    let mut strip_off = 0;
-    for (i, byte) in bytes.iter().rev().enumerate() {
-        if *byte == b'\n' || *byte == b'\r' {
-            strip_off = i + 1;
-        } else {
-            break;
-        }
-    }
-    bytes.truncate(bytes.len() - strip_off);
-    bytes
+/// Remove any number of newline or carriage returns from the end of a string slice
+/// and return a vector of bytes
+pub fn strip_off_newlines(value: &str) -> Vec<u8> {
+    value
+        .trim_end_matches(|c| c == '\r' || c == '\n')
+        .as_bytes()
+        .to_vec()
 }
 
 #[cfg(test)]
@@ -60,33 +55,12 @@ mod test {
     fn test_strip_off() {
         let expected = "hello world".as_bytes().to_vec();
 
-        assert_eq!(
-            strip_off_newlines("hello world\n".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world\n\n\n\n".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world\r".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world\r\r\r\r\r".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world\r\n".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world\r\n\r\n".as_bytes().to_vec()),
-            expected
-        );
-        assert_eq!(
-            strip_off_newlines("hello world".as_bytes().to_vec()),
-            expected
-        );
+        assert_eq!(strip_off_newlines("hello world\n"), expected);
+        assert_eq!(strip_off_newlines("hello world\n\n\n\n"), expected);
+        assert_eq!(strip_off_newlines("hello world\r"), expected);
+        assert_eq!(strip_off_newlines("hello world\r\r\r\r\r"), expected);
+        assert_eq!(strip_off_newlines("hello world\r\n"), expected);
+        assert_eq!(strip_off_newlines("hello world\r\n\r\n"), expected);
+        assert_eq!(strip_off_newlines("hello world"), expected);
     }
 }

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -153,9 +153,9 @@ pub fn cli_run<T: EthSpec>(
         return Ok(());
     }
 
-    let wallet_password = fs::read(&wallet_password_path)
+    let wallet_password = fs::read_to_string(&wallet_password_path)
         .map_err(|e| format!("Unable to read {:?}: {:?}", wallet_password_path, e))
-        .map(|bytes| PlainText::from(strip_off_newlines(bytes)))?;
+        .map(|password| PlainText::from(strip_off_newlines(password.as_str())))?;
 
     let mgr = WalletManager::open(&wallet_base_dir)
         .map_err(|e| format!("Unable to open --{}: {:?}", BASE_DIR_FLAG, e))?;

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -105,9 +105,9 @@ pub fn cli_run(matches: &ArgMatches, base_dir: PathBuf) -> Result<(), String> {
             .map_err(|e| format!("Unable to write to {:?}: {:?}", wallet_password_path, e))?;
     }
 
-    let wallet_password = fs::read(&wallet_password_path)
+    let wallet_password = fs::read_to_string(&wallet_password_path)
         .map_err(|e| format!("Unable to read {:?}: {:?}", wallet_password_path, e))
-        .map(|bytes| PlainText::from(strip_off_newlines(bytes)))?;
+        .map(|password| PlainText::from(strip_off_newlines(password.as_str())))?;
 
     let wallet = mgr
         .create_wallet(name, wallet_type, &mnemonic, wallet_password.as_bytes())


### PR DESCRIPTION
## Issue Addressed

Issue #1205 

## Proposed Changes

* Use `fs::read_to_string` instead of `fs::read`
    * Reading to a `String` enforces the content to be UTF-8 encoded
* Changes due to the above change, and as suggested in the issue description

## Additional Info

NA
