### PR TITLE
Fix create validator example to include required param --count

### DIFF
--- a/book/src/key-managment.md
+++ b/book/src/key-managment.md
@@ -37,12 +37,12 @@ keypairs. Creating a single validator looks like this:
 1. Create a **wallet** and record the **mnemonic**:
     - `lighthouse account wallet create --name wally --passphrase-file wally.pass`
 1. Create the voting and withdrawal **keystores** for one validator:
-	- `lighthouse account validator create --wallet-name wally --wallet-passphrase wally.pass`
+	- `lighthouse account validator create --wallet-name wally --wallet-passphrase wally.pass --count 1`
 
 
 In step (1), we created a wallet in `~/.lighthouse/wallets` with the name
 `mywallet`. We encrypted this using a pre-defined password in the
-`mywallet.pass` file. Then, in step (2), we created a new validator in the
+`mywallet.pass` file. Then, in step (2), we created one new validator in the
 `~/.lighthouse/validators` directory using `mywallet` (unlocking it with
 `mywallet.pass`) and storing the passwords to the validators voting key in
 `~/.lighthouse/secrets`.


### PR DESCRIPTION
The current example fails with v0.1.2 fails with "Must supply either --count or --at-most"  This change proposes passing count=1, esp'ly since "Creating another validator is easy" a couple of paragraphs down.

## Issue Addressed
Minor doc correction

## Proposed Changes
Update validator creation example to fix error msg


## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
