### PR TITLE
beacon_node, consensus: fix possible deadlocks when comparing with itself

### DIFF
--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -20,6 +20,7 @@ use state_processing::per_block_processing::{
 };
 use std::collections::{hash_map, HashMap, HashSet};
 use std::marker::PhantomData;
+use std::ptr;
 use types::{
     typenum::Unsigned, Attestation, AttesterSlashing, BeaconState, BeaconStateError, ChainSpec,
     EthSpec, Fork, Hash256, ProposerSlashing, RelativeEpoch, SignedVoluntaryExit, Validator,
@@ -408,6 +409,9 @@ fn prune_validator_hash_map<T, F, E: EthSpec>(
 /// Compare two operation pools.
 impl<T: EthSpec + Default> PartialEq for OperationPool<T> {
     fn eq(&self, other: &Self) -> bool {
+        if ptr::eq(self, other) {
+            return true;
+        }
         *self.attestations.read() == *other.attestations.read()
             && *self.attester_slashings.read() == *other.attester_slashings.read()
             && *self.proposer_slashings.read() == *other.proposer_slashings.read()

--- a/consensus/proto_array_fork_choice/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array_fork_choice/src/proto_array_fork_choice.rs
@@ -5,6 +5,7 @@ use parking_lot::{RwLock, RwLockReadGuard};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::collections::HashMap;
+use std::ptr;
 use types::{Epoch, Hash256, Slot};
 
 pub const DEFAULT_PRUNE_THRESHOLD: usize = 256;
@@ -51,6 +52,9 @@ pub struct ProtoArrayForkChoice {
 
 impl PartialEq for ProtoArrayForkChoice {
     fn eq(&self, other: &Self) -> bool {
+        if ptr::eq(self, other) {
+            return true;
+        }
         *self.proto_array.read() == *other.proto_array.read()
             && *self.votes.read() == *other.votes.read()
             && *self.balances.read() == *other.balances.read()


### PR DESCRIPTION
## Proposed Changes
This PR fixes possible deadlock bugs in beacon_node/operation_pool and consensus/proto_array_fork_choice.
Both are in fn `eq(&self, other: &Self)`.
When `self` and `other` refers to the same obj, (i.e. comparing with itself),
the first Read lock is not released before calling the second Read lock. 
The lock is a `parking_lot::RwLock`.
According to the doc of `parking_lot::RwLock`:
[“readers trying to acquire the lock will block even if the lock is unlocked when there are writers waiting to acquire the lock.”
“attempts to recursively acquire a read lock within a single thread may result in a deadlock.”](https://amanieu.github.io/parking_lot/parking_lot/struct.RwLock.html)
Therefore, a deadlock may happen when a write lock interleaves the two read locks.

This PR compares the ptr addresses first to avoid comparing with itself. 
