### PR TITLE
Use npm --unsafe-perms for MacOS in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
-      run: sudo npm install -g ganache-cli
+      run: sudo npm install -g --unsafe-perm ganache-cli
     - name: Run tests in release
       run: make test-release
     - name: Install Lighthouse


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Attempts to resolve an issue with `npm` when running CI on MacOS runners.

~~Failed test: https://github.com/sigp/lighthouse/pull/1227/checks?check_run_id=733447872~~

Error:

```
/usr/local/bin/ganache-cli -> /usr/local/lib/node_modules/ganache-cli/cli.js

> keccak@1.4.0 install /usr/local/lib/node_modules/ganache-cli/node_modules/keccak
> npm run rebuild || echo "Keccak bindings compilation fail. Pure JS implementation will be used."


> keccak@1.4.0 rebuild /usr/local/lib/node_modules/ganache-cli/node_modules/keccak
> node-gyp rebuild

gyp ERR! clean error 
gyp ERR! stack Error: EACCES: permission denied, rmdir 'build'
gyp ERR! System Darwin 19.4.0
gyp ERR! command "/usr/local/Cellar/node@12/12.16.3/bin/node" "/usr/local/Cellar/node@12/12.16.3/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /usr/local/lib/node_modules/ganache-cli/node_modules/keccak
gyp ERR! node -v v12.16.3
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok 
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! keccak@1.4.0 rebuild: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
```

Where I found the solution: https://github.com/nodejs/node-gyp/issues/1547#issuecomment-428345362
