### PR TITLE
Increase RPC test timeouts

### DIFF
--- a/beacon_node/eth2-libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2-libp2p/tests/rpc_tests.rs
@@ -94,7 +94,7 @@ async fn test_status_rpc() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }
@@ -204,7 +204,7 @@ async fn test_blocks_by_range_chunked_rpc() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }
@@ -291,7 +291,7 @@ async fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
             // sent in the timeout
             match futures::future::select(
                 Box::pin(receiver.next_event()),
-                tokio::time::delay_for(Duration::from_millis(50)),
+                tokio::time::delay_for(Duration::from_secs(1)),
             )
             .await
             {
@@ -334,7 +334,7 @@ async fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }
@@ -441,7 +441,7 @@ async fn test_blocks_by_range_single_empty_rpc() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(800)) => {
+        _ = delay_for(Duration::from_secs(20)) => {
             panic!("Future timed out");
         }
     }
@@ -555,7 +555,7 @@ async fn test_blocks_by_root_chunked_rpc() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }
@@ -651,7 +651,7 @@ async fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
             // sent in the timeout
             match futures::future::select(
                 Box::pin(receiver.next_event()),
-                tokio::time::delay_for(Duration::from_millis(50)),
+                tokio::time::delay_for(Duration::from_millis(1000)),
             )
             .await
             {
@@ -694,7 +694,7 @@ async fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }
@@ -752,7 +752,7 @@ async fn test_goodbye_rpc() {
     tokio::select! {
         _ = sender_future => {}
         _ = receiver_future => {}
-        _ = delay_for(Duration::from_millis(2000)) => {
+        _ = delay_for(Duration::from_secs(30)) => {
             panic!("Future timed out");
         }
     }


### PR DESCRIPTION
Increase timeouts in RPC tests to handle slow CI
