### PR TITLE
Check for unused deps in CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -121,3 +121,14 @@ jobs:
    - uses: actions/checkout@v1
    - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
      run:  make audit
+  cargo-udeps:
+   runs-on: ubuntu-latest
+   needs: cargo-fmt
+   steps:
+   - uses: actions/checkout@v1
+   - name: Get latest version of nightly Rust
+     run: rustup update nightly
+   - name: Install cargo-udeps
+     run: cargo install cargo-udeps --locked
+   - name: Run cargo udeps to identify unused crates in the dependency graph
+     run: make udeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,8 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "tempdir",
  "tokio 0.2.21",
  "types",
- "validator_client",
  "validator_dir",
  "web3",
 ]
@@ -179,12 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_approx_eq"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
-
-[[package]]
 name = "assert_matches"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +319,6 @@ dependencies = [
  "client",
  "ctrlc",
  "dirs",
- "env_logger",
  "environment",
  "eth2-libp2p",
  "eth2_config",
@@ -348,16 +339,6 @@ dependencies = [
  "toml",
  "types",
  "version",
-]
-
-[[package]]
-name = "bincode"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
-dependencies = [
- "byteorder",
- "serde",
 ]
 
 [[package]]
@@ -451,7 +432,6 @@ dependencies = [
  "arbitrary",
  "eth2_hashing",
  "eth2_ssz",
- "eth2_ssz_types",
  "hex 0.4.2",
  "milagro_bls",
  "rand 0.7.3",
@@ -998,17 +978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb582b60359da160a9477ee80f15c8d784c477e69c217ef2cdd4169c24ea380f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,7 +1106,6 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
- "walkdir",
 ]
 
 [[package]]
@@ -1191,10 +1159,7 @@ dependencies = [
 name = "environment"
 version = "0.1.2"
 dependencies = [
- "beacon_node",
- "clap",
  "ctrlc",
- "env_logger",
  "eth2_config",
  "eth2_testnet_config",
  "exit-future",
@@ -1396,7 +1361,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_hex",
- "serde_yaml",
  "tree_hash",
  "tree_hash_derive",
  "typenum",
@@ -2274,7 +2238,6 @@ dependencies = [
  "deposit_contract",
  "dirs",
  "environment",
- "eth1_test_rig",
  "eth2-libp2p",
  "eth2_keystore",
  "eth2_ssz",
@@ -2983,7 +2946,6 @@ dependencies = [
 name = "network"
 version = "0.1.2"
 dependencies = [
- "assert_approx_eq",
  "beacon_chain",
  "environment",
  "error-chain",
@@ -3507,7 +3469,6 @@ version = "0.2.0"
 dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
- "itertools 0.9.0",
  "parking_lot 0.10.2",
  "serde",
  "serde_derive",
@@ -4578,7 +4539,6 @@ name = "state_processing"
 version = "0.2.0"
 dependencies = [
  "arbitrary",
- "beacon_chain",
  "bls",
  "criterion",
  "env_logger",
@@ -4596,7 +4556,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "store",
  "tree_hash",
  "tree_hash_derive",
  "types",
@@ -4684,7 +4643,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "slog",
- "sloggers",
  "state_processing",
  "tempfile",
  "tree_hash",
@@ -4734,8 +4692,6 @@ dependencies = [
  "criterion",
  "eth2_hashing",
  "ethereum-types",
- "hex 0.4.2",
- "yaml-rust",
 ]
 
 [[package]]
@@ -5389,9 +5345,7 @@ dependencies = [
  "compare_fields",
  "compare_fields_derive",
  "criterion",
- "derivative",
  "dirs",
- "env_logger",
  "eth2_hashing",
  "eth2_interop_keypairs",
  "eth2_ssz",
@@ -5559,14 +5513,12 @@ dependencies = [
 name = "validator_client"
 version = "0.1.2"
 dependencies = [
- "bincode",
  "bls",
  "clap",
  "clap_utils",
  "deposit_contract",
  "dirs",
  "environment",
- "error-chain",
  "eth2_config",
  "eth2_interop_keypairs",
  "eth2_ssz",
@@ -5593,7 +5545,6 @@ dependencies = [
  "tree_hash",
  "types",
  "validator_dir",
- "web3",
 ]
 
 [[package]]
@@ -5603,7 +5554,6 @@ dependencies = [
  "bls",
  "deposit_contract",
  "eth2_keystore",
- "eth2_wallet",
  "hex 0.4.2",
  "rand 0.7.3",
  "rayon",

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,10 @@ audit:
 	cargo install --force cargo-audit
 	cargo audit
 
+# Runs `cargo udeps` to check for unused dependencies
+udeps:
+	cargo +nightly udeps --tests --all-targets --release
+
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:
 	cargo clean

--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.0.1"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Luke Anderson <luke@sigmaprime.io>"]
 edition = "2018"
 
-[dev-dependencies]
-tempdir = "0.3.7"
-
 [dependencies]
 bls = { path = "../crypto/bls" }
 clap = "2.33.0"
@@ -21,7 +18,6 @@ libc = "0.2.65"
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
 hex = "0.4.2"
-validator_client = { path = "../validator_client" }
 rayon = "1.3.0"
 eth2_testnet_config = { path = "../common/eth2_testnet_config" }
 web3 = "0.11.0"

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -29,7 +29,6 @@ slog-async = "2.5.0"
 ctrlc = { version = "3.1.4", features = ["termination"] }
 tokio = { version = "0.2.21", features = ["time"] }
 exit-future = "0.2.0"
-env_logger = "0.7.1"
 dirs = "2.0.2"
 logging = { path = "../common/logging" }
 futures = "0.3.5"

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -11,7 +11,6 @@ lazy_static = "1.4.0"
 matches = "0.1.8"
 tempfile = "3.1.0"
 exit-future = "0.2.0"
-assert_approx_eq = "1.1.0"
 
 [dependencies]
 beacon_chain =  { path = "../beacon_chain" }

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -10,7 +10,6 @@ harness = false
 
 [dev-dependencies]
 tempfile = "3.1.0"
-sloggers = "1.0.0"
 criterion = "0.3.2"
 rayon = "1.3.0"
 

--- a/common/compare_fields/Cargo.toml
+++ b/common/compare_fields/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2018"
 [dev-dependencies]
 compare_fields_derive = { path = "../compare_fields_derive" }
 
-[dependencies]
+[package.metadata.cargo-udeps.ignore]
+development = ["compare_fields_derive"] # used in doc-tests

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -11,7 +11,6 @@ insecure_keys = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eth2_wallet = { path = "../../crypto/eth2_wallet" }
 bls = { path = "../../crypto/bls" }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 types = { path = "../../consensus/types" }

--- a/consensus/proto_array_fork_choice/Cargo.toml
+++ b/consensus/proto_array_fork_choice/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/bin.rs"
 [dependencies]
 parking_lot = "0.10.2"
 types = { path = "../types" }
-itertools = "0.9.0"
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
 serde = "1.0.110"

--- a/consensus/ssz_types/Cargo.toml
+++ b/consensus/ssz_types/Cargo.toml
@@ -17,5 +17,4 @@ typenum = "1.12.0"
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 
 [dev-dependencies]
-serde_yaml = "0.8.11"
 tree_hash_derive = "0.2.0"

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -15,8 +15,6 @@ serde = "1.0.110"
 serde_derive = "1.0.110"
 lazy_static = "1.4.0"
 serde_yaml = "0.8.11"
-beacon_chain = { path = "../../beacon_node/beacon_chain" }
-store = { path = "../../beacon_node/store" }
 
 [dependencies]
 bls = { path = "../../crypto/bls" }

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -10,8 +10,6 @@ harness = false
 
 [dev-dependencies]
 criterion = "0.3.2"
-yaml-rust = "0.4.3"
-hex = "0.4.2"
 
 [dependencies]
 eth2_hashing = "0.1.0"

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -13,7 +13,6 @@ bls = { path = "../../crypto/bls" }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 dirs = "2.0.2"
-derivative = "2.1.1"
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 ethereum-types = "0.9.1"
 eth2_hashing = "0.1.0"
@@ -42,7 +41,6 @@ rusqlite = { version = "0.23.1", features = ["bundled"], optional = true }
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 
 [dev-dependencies]
-env_logger = "0.7.1"
 serde_json = "1.0.52"
 criterion = "0.3.2"
 

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -13,7 +13,6 @@ serde = "1.0.110"
 serde_derive = "1.0.110"
 serde_hex = { path = "../../consensus/serde_hex" }
 eth2_ssz = "0.1.2"
-eth2_ssz_types = { path = "../../consensus/ssz_types" }
 tree_hash = "0.1.0"
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 zeroize = { version = "1.0.0", features = ["zeroize_derive"] }

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -18,7 +18,6 @@ types = { path = "../consensus/types" }
 state_processing = { path = "../consensus/state_processing" }
 eth2_ssz = "0.1.2"
 regex = "1.3.7"
-eth1_test_rig = { path = "../testing/eth1_test_rig" }
 futures = { version = "0.3.5", features = ["compat"] }
 environment = { path = "../lighthouse/environment" }
 web3 = "0.11.0"

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -5,14 +5,12 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-clap = "2.33.0"
 tokio = "0.2.21"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.0"
 types = { "path" = "../../consensus/types" }
 eth2_config = { "path" = "../../common/eth2_config" }
 eth2_testnet_config = { path = "../../common/eth2_testnet_config" }
-env_logger = "0.7.1"
 logging = { path = "../../common/logging" }
 slog-term = "2.5.0"
 slog-async = "2.5.0"
@@ -23,6 +21,3 @@ slog-json = "2.3.0"
 exit-future = "0.2.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-
-[dev-dependencies]
-beacon_node = { path = "../../beacon_node" }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -27,4 +27,3 @@ cached_tree_hash = { path = "../../consensus/cached_tree_hash" }
 state_processing = { path = "../../consensus/state_processing" }
 swap_or_not_shuffle = { path = "../../consensus/swap_or_not_shuffle" }
 types = { path = "../../consensus/types" }
-walkdir = "2.3.1"

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -28,8 +28,6 @@ slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_tr
 slog-async = "2.5.0"
 slog-term = "2.5.0"
 tokio = { version = "0.2.21", features = ["time"] }
-error-chain = "0.12.2"
-bincode = "1.2.1"
 futures = { version = "0.3.5", features = ["compat"] }
 dirs = "2.0.2"
 logging = { path = "../common/logging" }
@@ -44,6 +42,5 @@ bls = { path = "../crypto/bls" }
 remote_beacon_node = { path = "../common/remote_beacon_node" }
 tempdir = "0.3.7"
 rayon = "1.3.0"
-web3 = "0.11.0"
 validator_dir = { path = "../common/validator_dir" }
 clap_utils = { path = "../common/clap_utils" }

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -11,7 +11,7 @@ tree_hash = { path = "../../consensus/tree_hash" }
 rusqlite = { version = "0.23.1", features = ["bundled"] }
 r2d2 = "0.8.8"
 r2d2_sqlite = "0.16.0"
-parking_lot = "0.9.0"
+parking_lot = "0.10.2"
 
 [dev-dependencies]
 rayon = "1.3.0"


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

Remove unused crates from the dependency graph, and run `cargo udeps` on CI so that we keep Lighthouse as light as possible!
