### PR TITLE
Avoid pruning when there are no forks

### DIFF
--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -42,6 +42,11 @@ pub trait Migrate<E: EthSpec>: Send + Sync + 'static {
         new_finalized_block_hash: SignedBeaconBlockHash,
         new_finalized_slot: Slot,
     ) -> Result<(), BeaconChainError> {
+        // There will never be any blocks to prune if there is only a single head in the chain.
+        if head_tracker.heads().len() == 1 {
+            return Ok(());
+        }
+
         let old_finalized_slot = store
             .get_block(&old_finalized_block_hash.into())?
             .ok_or_else(|| BeaconChainError::MissingBeaconBlock(old_finalized_block_hash.into()))?


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Bypass pruning finalized blocks/states if there is only a single head in the chain. 

## Additional Info

When running `heaptrack` during a Witti sync I noticed a significant amount of allocations 5.5GB in ~1 minute (12.8% of total allocations) due to trying to prune a single head:

[![pruning.png](https://i.postimg.cc/jdt1YP8y/pruning.png)](https://postimg.cc/jC3czwYj)

It's rebuilding the `TreeHashCache` due to needing to replay blocks that's actually doing all the allocation. Ideally it would be good to be able to access non-boundary hot states without doing a tree-hash, but that's non-trivial. Even if we had that, I think this change would still be worth it.

After this change I can't even see anything related to pruning on the flamegraph, so I assume it is effective.