### PR TITLE
Bump all spec tags to v0.12.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Like all Ethereum 2.0 clients, Lighthouse is a work-in-progress.
 
 Current development overview:
 
-- Specification `v0.11.1` implemented, optimized and passing test vectors.
+- Specification `v0.12.1` implemented, optimized and passing test vectors.
 - Rust-native libp2p with Gossipsub and Discv5.
 - RESTful JSON API via HTTP server.
 - Events via WebSocket.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -88,9 +88,9 @@ pub enum ChainSegmentResult {
     },
 }
 
-/// The accepted clock drift for nodes gossiping blocks and attestations (spec v0.11.0). See:
+/// The accepted clock drift for nodes gossiping blocks and attestations. See:
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/p2p-interface.md#configuration
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#configuration
 pub const MAXIMUM_GOSSIP_CLOCK_DISPARITY: Duration = Duration::from_millis(500);
 
 #[derive(Debug, PartialEq)]

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -232,7 +232,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following two tests ensure:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * aggregate.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (with a
      * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. aggregate.data.slot +
@@ -277,7 +277,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The block being voted for (aggregate.data.beacon_block_root) passes validation.
      */
@@ -299,7 +299,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The attestation has participants.
      */
@@ -320,7 +320,7 @@ fn aggregated_gossip_verification() {
     /*
      * This test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The aggregator signature, signed_aggregate_and_proof.signature, is valid.
      */
@@ -340,7 +340,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The aggregate_and_proof.selection_proof is a valid signature of the aggregate.data.slot by
      * the validator with index aggregate_and_proof.aggregator_index.
@@ -387,7 +387,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The signature of aggregate is valid.
      */
@@ -421,7 +421,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The aggregator's validator index is within the committee -- i.e.
      * aggregate_and_proof.aggregator_index in get_beacon_committee(state, aggregate.data.slot,
@@ -450,7 +450,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * aggregate_and_proof.selection_proof selects the validator as an aggregator for the slot --
      * i.e. is_aggregator(state, aggregate.data.slot, aggregate.data.index,
@@ -491,7 +491,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The valid aggregate attestation defined by hash_tree_root(aggregate) has not already been
      * seen (via aggregate gossip, within a block, or through the creation of an equivalent
@@ -508,7 +508,7 @@ fn aggregated_gossip_verification() {
     /*
      * The following test ensures:
      *
-     * Spec v0.12.0
+     * Spec v0.12.1
      *
      * The aggregate is the first valid aggregate received for the aggregator with index
      * aggregate_and_proof.aggregator_index for the epoch aggregate.data.target.epoch.
@@ -605,7 +605,7 @@ fn unaggregated_gossip_verification() {
     /*
      * The following two tests ensure:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * attestation.data.slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots (within a
      * MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) -- i.e. attestation.data.slot +
@@ -654,7 +654,7 @@ fn unaggregated_gossip_verification() {
     /*
      * The following two tests ensure:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The attestation is unaggregated -- that is, it has exactly one participating validator
      * (len([bit for bit in attestation.aggregation_bits if bit == 0b1]) == 1).
@@ -694,7 +694,7 @@ fn unaggregated_gossip_verification() {
     /*
      * The following test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The block being voted for (attestation.data.beacon_block_root) passes validation.
      */
@@ -717,7 +717,7 @@ fn unaggregated_gossip_verification() {
     /*
      * The following test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The signature of attestation is valid.
      */
@@ -748,7 +748,7 @@ fn unaggregated_gossip_verification() {
     /*
      * The following test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      *
      * There has been no other valid attestation seen on an attestation subnet that has an

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -558,7 +558,7 @@ fn block_gossip_verification() {
     /*
      * This test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The block is not from a future slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance) --
      * i.e. validate that signed_beacon_block.message.slot <= current_slot (a client MAY queue
@@ -583,7 +583,7 @@ fn block_gossip_verification() {
     /*
      * This test ensure that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The block is from a slot greater than the latest finalized slot -- i.e. validate that
      * signed_beacon_block.message.slot >
@@ -616,7 +616,7 @@ fn block_gossip_verification() {
     /*
      * This test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The proposer signature, signed_beacon_block.signature, is valid with respect to the
      * proposer_index pubkey.
@@ -635,7 +635,7 @@ fn block_gossip_verification() {
     /*
      * This test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The block is proposed by the expected proposer_index for the block's slot in the context of
      * the current shuffling (defined by parent_root/slot). If the proposer_index cannot
@@ -689,7 +689,7 @@ fn block_gossip_verification() {
     /*
      * This test ensures that:
      *
-     * Spec v0.11.2
+     * Spec v0.12.1
      *
      * The block is the first block with valid signature received for the proposer for the slot,
      * signed_beacon_block.message.slot.

--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -11,7 +11,7 @@ use types::*;
 ///
 /// Utilises lazy-loading from separate storage for its vector fields.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[derive(Debug, PartialEq, Clone, Encode, Decode)]
 pub struct PartialBeaconState<T>
 where

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -19,7 +19,7 @@ validators must listen to event logs from the deposit contract. Since the
 latest blocks of the Eth1 chain are vulnerable to re-orgs due to minor network
 partitions, beacon nodes follow the Eth1 chain at a distance of 1,024 blocks
 (~4 hours) (see
-[`ETH1_FOLLOW_DISTANCE`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#misc)).
+[`ETH1_FOLLOW_DISTANCE`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#misc)).
 This follow distance protects the beacon chain from on-boarding validators that
 are likely to be removed due to an Eth1 re-org.
 
@@ -27,13 +27,13 @@ Now we know there's a 4 hours delay before the beacon nodes even _consider_ an
 Eth1 block. Once they _are_ considering these blocks, there's a voting period
 where beacon validators vote on which Eth1 to include in the beacon chain. This
 period is defined as 32 epochs (~3.4 hours, see
-[`ETH1_VOTING_PERIOD`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#time-parameters)).
+[`ETH1_VOTING_PERIOD`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#time-parameters)).
 During this voting period, each beacon block producer includes an
-[`Eth1Data`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#eth1data)
+[`Eth1Data`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#eth1data)
 in their block which counts as a vote towards what that validator considers to
 be the head of the Eth1 chain at the start of the voting period (with respect
 to `ETH1_FOLLOW_DISTANCE`, of course). You can see the exact voting logic
-[here](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/validator.md#eth1-data).
+[here](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#eth1-data).
 
 These two delays combined represent the time between an Eth1 deposit being
 included in an Eth1 data vote and that validator appearing in the beacon chain.
@@ -57,17 +57,17 @@ They will simply be forgotten by the beacon chain! But, if those parameters were
 correct, once the Eth1 delays have elapsed and the validator appears in the
 beacon chain, there's _another_ delay before the validator becomes "active"
 (canonical definition
-[here](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#is_active_validator)) and can start producing blocks and attestations.
+[here](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#is_active_validator)) and can start producing blocks and attestations.
 
 Firstly, the validator won't become active until their beacon chain balance is
 equal to or greater than
-[`MAX_EFFECTIVE_BALANCE`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#gwei-values)
+[`MAX_EFFECTIVE_BALANCE`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#gwei-values)
 (32 ETH on mainnet, usually 3.2 ETH on testnets). Once this balance is reached,
 the validator must wait until the start of the next epoch (up to 6.4 minutes)
 for the
-[`process_registry_updates`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#registry-updates)
+[`process_registry_updates`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#registry-updates)
 routine to run. This routine activates validators with respect to a [churn
-limit](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#get_validator_churn_limit);
+limit](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#get_validator_churn_limit);
 it will only allow the number of validators to increase (churn) by a certain
 amount. Up until there are about 330,000 validators this churn limit is set to
 4 and it starts to very slowly increase as the number of validators increases

--- a/book/src/http/beacon.md
+++ b/book/src/http/beacon.md
@@ -259,7 +259,7 @@ Typical Responses | 200
 
 ### Returns
 
-Returns an object containing the [`Fork`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#fork) of the current head.
+Returns an object containing the [`Fork`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#fork) of the current head.
 
 ### Example Response
 
@@ -478,7 +478,7 @@ canonical chain.
 ### Returns
 
 Returns an object containing a single
-[`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconstate)
+[`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#beaconstate)
 and its tree hash root.
 
 ### Example Response
@@ -540,7 +540,7 @@ Typical Responses | 200
 ### Returns
 
 Returns an object containing the genesis
-[`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#beaconstate).
+[`BeaconState`](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#beaconstate).
 
 ### Example Response
 

--- a/common/deposit_contract/build.rs
+++ b/common/deposit_contract/build.rs
@@ -9,9 +9,9 @@ use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-const TAG: &str = "v0.11.1";
+const TAG: &str = "v0.12.1";
 // NOTE: the version of the unsafe contract lags the main tag, but the v0.9.2.1 code is compatible
-// with the unmodified v0.11.1 contract
+// with the unmodified v0.12.1 contract
 const UNSAFE_TAG: &str = "v0.9.2.1";
 
 fn spec_url() -> String {

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -23,15 +23,15 @@ impl From<ethabi::Error> for DecodeError {
 
 pub const CONTRACT_DEPLOY_GAS: usize = 4_000_000;
 pub const DEPOSIT_GAS: usize = 400_000;
-pub const ABI: &[u8] = include_bytes!("../contracts/v0.11.1_validator_registration.json");
-pub const BYTECODE: &[u8] = include_bytes!("../contracts/v0.11.1_validator_registration.bytecode");
+pub const ABI: &[u8] = include_bytes!("../contracts/v0.12.1_validator_registration.json");
+pub const BYTECODE: &[u8] = include_bytes!("../contracts/v0.12.1_validator_registration.bytecode");
 pub const DEPOSIT_DATA_LEN: usize = 420; // lol
 
 pub mod testnet {
     pub const ABI: &[u8] =
-        include_bytes!("../contracts/v0.11.1_testnet_validator_registration.json");
+        include_bytes!("../contracts/v0.12.1_testnet_validator_registration.json");
     pub const BYTECODE: &[u8] =
-        include_bytes!("../contracts/v0.11.1_testnet_validator_registration.bytecode");
+        include_bytes!("../contracts/v0.12.1_testnet_validator_registration.bytecode");
 }
 
 pub fn encode_eth1_tx_data(deposit_data: &DepositData) -> Result<Vec<u8>, Error> {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -8,7 +8,7 @@ use types::{
 
 /// Defined here:
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#configuration
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#configuration
 pub const SAFE_SLOTS_TO_UPDATE_JUSTIFIED: u64 = 8;
 
 #[derive(Debug)]
@@ -103,7 +103,7 @@ impl<T> From<String> for Error<T> {
 ///
 /// Equivalent to:
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#compute_slots_since_epoch_start
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#compute_slots_since_epoch_start
 pub fn compute_slots_since_epoch_start<E: EthSpec>(slot: Slot) -> Slot {
     slot - slot
         .epoch(E::slots_per_epoch())
@@ -116,7 +116,7 @@ pub fn compute_slots_since_epoch_start<E: EthSpec>(slot: Slot) -> Slot {
 ///
 /// Equivalent to:
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_start_slot_at_epoch
 fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
     epoch.start_slot(E::slots_per_epoch())
 }
@@ -127,7 +127,7 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
 ///
 /// Equivalent to:
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#on_tick
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#on_tick
 fn on_tick<T, E>(store: &mut T, time: Slot) -> Result<(), Error<T::Error>>
 where
     T: ForkChoiceStore<E>,
@@ -198,7 +198,7 @@ fn dequeue_attestations(
 
 /// Provides an implementation of "Ethereum 2.0 Phase 0 -- Beacon Chain Fork Choice":
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#ethereum-20-phase-0----beacon-chain-fork-choice
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#ethereum-20-phase-0----beacon-chain-fork-choice
 ///
 /// ## Detail
 ///
@@ -285,7 +285,7 @@ where
     ///
     /// Equivalent to:
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#get_ancestor
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#get_ancestor
     fn get_ancestor(
         &self,
         block_root: Hash256,
@@ -324,7 +324,7 @@ where
     ///
     /// Is equivalent to:
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#get_head
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#get_head
     pub fn get_head(&mut self, current_slot: Slot) -> Result<Hash256, Error<T::Error>> {
         self.update_time(current_slot)?;
 
@@ -350,7 +350,7 @@ where
     ///
     /// Is equivalent to:
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#should_update_justified_checkpoint
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#should_update_justified_checkpoint
     fn should_update_justified_checkpoint(
         &mut self,
         current_slot: Slot,
@@ -403,7 +403,7 @@ where
     ///
     /// Approximates:
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#on_block
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#on_block
     ///
     /// It only approximates the specification since it does not run the `state_transition` check.
     /// That should have already been called upstream and it's too expensive to call again.
@@ -633,7 +633,7 @@ where
     ///
     /// Approximates:
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#on_attestation
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#on_attestation
     ///
     /// It only approximates the specification since it does not perform
     /// `is_valid_indexed_attestation` since that should already have been called upstream and it's

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -2,7 +2,7 @@ use types::{BeaconBlock, BeaconState, Checkpoint, EthSpec, Hash256, Slot};
 
 /// Approximates the `Store` in "Ethereum 2.0 Phase 0 -- Beacon Chain Fork Choice":
 ///
-/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.0/specs/phase0/fork-choice.md#store
+/// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/fork-choice.md#store
 ///
 /// ## Detail
 ///

--- a/consensus/ssz/src/lib.rs
+++ b/consensus/ssz/src/lib.rs
@@ -2,8 +2,8 @@
 //! format designed for use in Ethereum 2.0.
 //!
 //! Adheres to the Ethereum 2.0 [SSZ
-//! specification](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/ssz/simple-serialize.md)
-//! at v0.11.1.
+//! specification](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/ssz/simple-serialize.md)
+//! at v0.12.1.
 //!
 //! ## Example
 //!

--- a/consensus/ssz_types/src/lib.rs
+++ b/consensus/ssz_types/src/lib.rs
@@ -9,8 +9,8 @@
 //! for padding and verification.
 //!
 //! Adheres to the Ethereum 2.0 [SSZ
-//! specification](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/ssz/simple-serialize.md)
-//! at v0.11.1.
+//! specification](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/ssz/simple-serialize.md)
+//! at v0.12.1.
 //!
 //! ## Example
 //! ```

--- a/consensus/state_processing/src/common/get_attesting_indices.rs
+++ b/consensus/state_processing/src/common/get_attesting_indices.rs
@@ -2,7 +2,7 @@ use types::*;
 
 /// Returns validator indices which participated in the attestation, sorted by increasing index.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_attesting_indices<T: EthSpec>(
     committee: &[usize],
     bitlist: &BitList<T::MaxValidatorsPerCommittee>,

--- a/consensus/state_processing/src/common/get_base_reward.rs
+++ b/consensus/state_processing/src/common/get_base_reward.rs
@@ -4,7 +4,7 @@ use types::*;
 
 /// Returns the base reward for some validator.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_base_reward<T: EthSpec>(
     state: &BeaconState<T>,
     index: usize,

--- a/consensus/state_processing/src/common/get_indexed_attestation.rs
+++ b/consensus/state_processing/src/common/get_indexed_attestation.rs
@@ -6,7 +6,7 @@ type Result<T> = std::result::Result<T, BlockOperationError<Invalid>>;
 
 /// Convert `attestation` to (almost) indexed-verifiable form.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_indexed_attestation<T: EthSpec>(
     committee: &[usize],
     attestation: &Attestation<T>,

--- a/consensus/state_processing/src/common/initiate_validator_exit.rs
+++ b/consensus/state_processing/src/common/initiate_validator_exit.rs
@@ -3,7 +3,7 @@ use types::{BeaconStateError as Error, *};
 
 /// Initiate the exit of the validator of the given `index`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn initiate_validator_exit<T: EthSpec>(
     state: &mut BeaconState<T>,
     index: usize,

--- a/consensus/state_processing/src/common/mod.rs
+++ b/consensus/state_processing/src/common/mod.rs
@@ -17,7 +17,7 @@ use types::{BeaconState, EthSpec};
 
 /// Increase the balance of a validator, erroring upon overflow, as per the spec.
 ///
-/// Spec v0.11.2
+/// Spec v0.12.1
 pub fn increase_balance<E: EthSpec>(
     state: &mut BeaconState<E>,
     index: usize,
@@ -28,7 +28,7 @@ pub fn increase_balance<E: EthSpec>(
 
 /// Decrease the balance of a validator, saturating upon overflow, as per the spec.
 ///
-/// Spec v0.11.2
+/// Spec v0.12.1
 pub fn decrease_balance<E: EthSpec>(state: &mut BeaconState<E>, index: usize, delta: u64) {
     state.balances[index] = state.balances[index].saturating_sub(delta);
 }

--- a/consensus/state_processing/src/common/slash_validator.rs
+++ b/consensus/state_processing/src/common/slash_validator.rs
@@ -5,7 +5,7 @@ use types::{BeaconStateError as Error, *};
 
 /// Slash the validator with index ``index``.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn slash_validator<T: EthSpec>(
     state: &mut BeaconState<T>,
     slashed_index: usize,

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -7,7 +7,7 @@ use types::*;
 
 /// Initialize a `BeaconState` from genesis data.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 // TODO: this is quite inefficient and we probably want to rethink how we do this
 pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
     eth1_block_hash: Hash256,
@@ -50,7 +50,7 @@ pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
 
 /// Determine whether a candidate genesis state is suitable for starting the chain.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn is_valid_genesis_state<T: EthSpec>(state: &BeaconState<T>, spec: &ChainSpec) -> bool {
     state.genesis_time >= spec.min_genesis_time
         && state.get_active_validator_indices(T::genesis_epoch()).len() as u64
@@ -59,7 +59,7 @@ pub fn is_valid_genesis_state<T: EthSpec>(state: &BeaconState<T>, spec: &ChainSp
 
 /// Activate genesis validators, if their balance is acceptable.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_activations<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,
@@ -82,7 +82,7 @@ pub fn process_activations<T: EthSpec>(
 ///
 /// Does _not_ ensure that the time is greater than `MIN_GENESIS_TIME`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn eth2_genesis_time(eth1_timestamp: u64, spec: &ChainSpec) -> Result<u64, ArithError> {
     eth1_timestamp.safe_add(spec.genesis_delay)
 }

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -76,7 +76,7 @@ impl VerifySignatures {
 /// tree hash root of the block, NOT the signing root of the block. This function takes
 /// care of mixing in the domain.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn per_block_processing<T: EthSpec>(
     mut state: &mut BeaconState<T>,
     signed_block: &SignedBeaconBlock<T>,
@@ -148,7 +148,7 @@ pub fn per_block_processing<T: EthSpec>(
 
 /// Processes the block header.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_block_header<T: EthSpec>(
     state: &mut BeaconState<T>,
     block: &BeaconBlock<T>,
@@ -200,7 +200,7 @@ pub fn process_block_header<T: EthSpec>(
 
 /// Verifies the signature of a block.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_block_signature<T: EthSpec>(
     state: &BeaconState<T>,
     block: &SignedBeaconBlock<T>,
@@ -225,7 +225,7 @@ pub fn verify_block_signature<T: EthSpec>(
 /// Verifies the `randao_reveal` against the block's proposer pubkey and updates
 /// `state.latest_randao_mixes`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_randao<T: EthSpec>(
     state: &mut BeaconState<T>,
     block: &BeaconBlock<T>,
@@ -249,7 +249,7 @@ pub fn process_randao<T: EthSpec>(
 
 /// Update the `state.eth1_data_votes` based upon the `eth1_data` provided.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_eth1_data<T: EthSpec>(
     state: &mut BeaconState<T>,
     eth1_data: &Eth1Data,
@@ -266,7 +266,7 @@ pub fn process_eth1_data<T: EthSpec>(
 /// Returns `Ok(Some(eth1_data))` if adding the given `eth1_data` to `state.eth1_data_votes` would
 /// result in a change to `state.eth1_data`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_new_eth1_data<T: EthSpec>(
     state: &BeaconState<T>,
     eth1_data: &Eth1Data,
@@ -290,7 +290,7 @@ pub fn get_new_eth1_data<T: EthSpec>(
 /// Returns `Ok(())` if the validation and state updates completed successfully, otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_proposer_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     proposer_slashings: &[ProposerSlashing],
@@ -323,7 +323,7 @@ pub fn process_proposer_slashings<T: EthSpec>(
 /// Returns `Ok(())` if the validation and state updates completed successfully, otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_attester_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     attester_slashings: &[AttesterSlashing<T>],
@@ -350,7 +350,7 @@ pub fn process_attester_slashings<T: EthSpec>(
 /// Returns `Ok(())` if the validation and state updates completed successfully, otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_attestations<T: EthSpec>(
     state: &mut BeaconState<T>,
     attestations: &[Attestation<T>],
@@ -391,7 +391,7 @@ pub fn process_attestations<T: EthSpec>(
 /// Returns `Ok(())` if the validation and state updates completed successfully, otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_deposits<T: EthSpec>(
     state: &mut BeaconState<T>,
     deposits: &[Deposit],
@@ -433,7 +433,7 @@ pub fn process_deposits<T: EthSpec>(
 
 /// Process a single deposit, optionally verifying its merkle proof.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_deposit<T: EthSpec>(
     state: &mut BeaconState<T>,
     deposit: &Deposit,
@@ -499,7 +499,7 @@ pub fn process_deposit<T: EthSpec>(
 /// Returns `Ok(())` if the validation and state updates completed successfully, otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_exits<T: EthSpec>(
     state: &mut BeaconState<T>,
     voluntary_exits: &[SignedVoluntaryExit],

--- a/consensus/state_processing/src/per_block_processing/is_valid_indexed_attestation.rs
+++ b/consensus/state_processing/src/per_block_processing/is_valid_indexed_attestation.rs
@@ -11,7 +11,7 @@ fn error(reason: Invalid) -> BlockOperationError<Invalid> {
 
 /// Verify an `IndexedAttestation`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn is_valid_indexed_attestation<T: EthSpec>(
     state: &BeaconState<T>,
     indexed_attestation: &IndexedAttestation<T>,

--- a/consensus/state_processing/src/per_block_processing/verify_attestation.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_attestation.rs
@@ -15,7 +15,7 @@ fn error(reason: Invalid) -> BlockOperationError<Invalid> {
 ///
 /// Optionally verifies the aggregate signature, depending on `verify_signatures`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_attestation_for_block_inclusion<T: EthSpec>(
     state: &BeaconState<T>,
     attestation: &Attestation<T>,
@@ -49,7 +49,7 @@ pub fn verify_attestation_for_block_inclusion<T: EthSpec>(
 /// Returns a descriptive `Err` if the attestation is malformed or does not accurately reflect the
 /// prior blocks in `state`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_attestation_for_state<T: EthSpec>(
     state: &BeaconState<T>,
     attestation: &Attestation<T>,
@@ -76,7 +76,7 @@ pub fn verify_attestation_for_state<T: EthSpec>(
 
 /// Check target epoch and source checkpoint.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 fn verify_casper_ffg_vote<T: EthSpec>(
     attestation: &Attestation<T>,
     state: &BeaconState<T>,

--- a/consensus/state_processing/src/per_block_processing/verify_attester_slashing.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_attester_slashing.rs
@@ -16,7 +16,7 @@ fn error(reason: Invalid) -> BlockOperationError<Invalid> {
 /// Returns `Ok(())` if the `AttesterSlashing` is valid, otherwise indicates the reason for
 /// invalidity.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_attester_slashing<T: EthSpec>(
     state: &BeaconState<T>,
     attester_slashing: &AttesterSlashing<T>,
@@ -45,7 +45,7 @@ pub fn verify_attester_slashing<T: EthSpec>(
 ///
 /// Returns Ok(indices) if `indices.len() > 0`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_slashable_indices<T: EthSpec>(
     state: &BeaconState<T>,
     attester_slashing: &AttesterSlashing<T>,

--- a/consensus/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_deposit.rs
@@ -15,7 +15,7 @@ fn error(reason: DepositInvalid) -> BlockOperationError<DepositInvalid> {
 
 /// Verify `Deposit.pubkey` signed `Deposit.signature`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_deposit_signature(deposit_data: &DepositData, spec: &ChainSpec) -> Result<()> {
     let deposit_signature_message = deposit_pubkey_signature_message(&deposit_data, spec)
         .ok_or_else(|| error(DepositInvalid::BadBlsBytes))?;
@@ -47,7 +47,7 @@ pub fn get_existing_validator_index<T: EthSpec>(
 /// The deposit index is provided as a parameter so we can check proofs
 /// before they're due to be processed, and in parallel.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_deposit_merkle_proof<T: EthSpec>(
     state: &BeaconState<T>,
     deposit: &Deposit,

--- a/consensus/state_processing/src/per_block_processing/verify_exit.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_exit.rs
@@ -16,7 +16,7 @@ fn error(reason: ExitInvalid) -> BlockOperationError<ExitInvalid> {
 ///
 /// Returns `Ok(())` if the `Exit` is valid, otherwise indicates the reason for invalidity.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_exit<T: EthSpec>(
     state: &BeaconState<T>,
     exit: &SignedVoluntaryExit,
@@ -28,7 +28,7 @@ pub fn verify_exit<T: EthSpec>(
 
 /// Like `verify_exit` but doesn't run checks which may become true in future states.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_exit_time_independent_only<T: EthSpec>(
     state: &BeaconState<T>,
     exit: &SignedVoluntaryExit,
@@ -40,7 +40,7 @@ pub fn verify_exit_time_independent_only<T: EthSpec>(
 
 /// Parametric version of `verify_exit` that skips some checks if `time_independent_only` is true.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 fn verify_exit_parametric<T: EthSpec>(
     state: &BeaconState<T>,
     signed_exit: &SignedVoluntaryExit,

--- a/consensus/state_processing/src/per_block_processing/verify_proposer_slashing.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_proposer_slashing.rs
@@ -14,7 +14,7 @@ fn error(reason: Invalid) -> BlockOperationError<Invalid> {
 ///
 /// Returns `Ok(())` if the `ProposerSlashing` is valid, otherwise indicates the reason for invalidity.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn verify_proposer_slashing<T: EthSpec>(
     proposer_slashing: &ProposerSlashing,
     state: &BeaconState<T>,

--- a/consensus/state_processing/src/per_epoch_processing.rs
+++ b/consensus/state_processing/src/per_epoch_processing.rs
@@ -25,7 +25,7 @@ pub struct EpochProcessingSummary {
 /// Mutates the given `BeaconState`, returning early if an error is encountered. If an error is
 /// returned, a state might be "half-processed" and therefore in an invalid state.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn per_epoch_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,
@@ -78,7 +78,7 @@ pub fn per_epoch_processing<T: EthSpec>(
 /// - `finalized_epoch`
 /// - `finalized_root`
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[allow(clippy::if_same_then_else)] // For readability and consistency with spec.
 pub fn process_justification_and_finalization<T: EthSpec>(
     state: &mut BeaconState<T>,
@@ -154,7 +154,7 @@ pub fn process_justification_and_finalization<T: EthSpec>(
 
 /// Finish up an epoch update.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_final_updates<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,

--- a/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
+++ b/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
@@ -34,7 +34,7 @@ impl Delta {
 
 /// Apply attester and proposer rewards.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_rewards_and_penalties<T: EthSpec>(
     state: &mut BeaconState<T>,
     validator_statuses: &mut ValidatorStatuses,
@@ -65,7 +65,7 @@ pub fn process_rewards_and_penalties<T: EthSpec>(
 
 /// Apply rewards for participation in attestations during the previous epoch.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 fn get_attestation_deltas<T: EthSpec>(
     state: &BeaconState<T>,
     validator_statuses: &ValidatorStatuses,
@@ -269,7 +269,7 @@ fn get_proposer_reward(base_reward: u64, spec: &ChainSpec) -> Result<u64, Error>
 
 /// Is the validator eligible for penalties and rewards at the current epoch?
 ///
-/// Spec: v0.12.0
+/// Spec: v0.12.1
 fn is_eligible_validator(validator: &ValidatorStatus) -> bool {
     validator.is_active_in_previous_epoch
         || (validator.is_slashed && !validator.is_withdrawable_in_current_epoch)

--- a/consensus/state_processing/src/per_epoch_processing/process_slashings.rs
+++ b/consensus/state_processing/src/per_epoch_processing/process_slashings.rs
@@ -3,7 +3,7 @@ use types::{BeaconStateError as Error, *};
 
 /// Process slashings.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     total_balance: u64,

--- a/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -5,7 +5,7 @@ use types::*;
 
 /// Performs a validator registry update, if required.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn process_registry_updates<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,

--- a/consensus/state_processing/src/per_epoch_processing/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/validator_statuses.rs
@@ -187,7 +187,7 @@ impl ValidatorStatuses {
     /// - Active validators
     /// - Total balances for the current and previous epochs.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn new<T: EthSpec>(
         state: &BeaconState<T>,
         spec: &ChainSpec,
@@ -231,7 +231,7 @@ impl ValidatorStatuses {
     /// Process some attestations from the given `state` updating the `statuses` and
     /// `total_balances` fields.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn process_attestations<T: EthSpec>(
         &mut self,
         state: &BeaconState<T>,
@@ -322,7 +322,7 @@ impl ValidatorStatuses {
 /// Returns `true` if the attestation's FFG target is equal to the hash of the `state`'s first
 /// beacon block in the given `epoch`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 fn target_matches_epoch_start_block<T: EthSpec>(
     a: &PendingAttestation<T>,
     state: &BeaconState<T>,
@@ -337,7 +337,7 @@ fn target_matches_epoch_start_block<T: EthSpec>(
 /// Returns `true` if a `PendingAttestation` and `BeaconState` share the same beacon block hash for
 /// the current slot of the `PendingAttestation`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 fn has_common_beacon_block_root<T: EthSpec>(
     a: &PendingAttestation<T>,
     state: &BeaconState<T>,

--- a/consensus/state_processing/src/per_slot_processing.rs
+++ b/consensus/state_processing/src/per_slot_processing.rs
@@ -13,7 +13,7 @@ pub enum Error {
 /// `state_root` is `None`, the root of `state` will be computed using a cached tree hash.
 /// Providing the `state_root` makes this function several orders of magniude faster.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn per_slot_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     state_root: Option<Hash256>,

--- a/consensus/swap_or_not_shuffle/src/lib.rs
+++ b/consensus/swap_or_not_shuffle/src/lib.rs
@@ -1,7 +1,7 @@
 //! Provides list-shuffling functions matching the Ethereum 2.0 specification.
 //!
 //! See
-//! [compute_shuffled_index](https://github.com/ethereum/eth2.0-specs/blob/v0.11.1/specs/phase0/beacon-chain.md#compute_shuffled_index)
+//! [compute_shuffled_index](https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/beacon-chain.md#compute_shuffled_index)
 //! for specifications.
 //!
 //! There are two functions exported by this crate:

--- a/consensus/types/src/aggregate_and_proof.rs
+++ b/consensus/types/src/aggregate_and_proof.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 
 /// A Validators aggregate attestation and selection proof.
 ///
-/// Spec v0.10.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
 #[serde(bound = "T: EthSpec")]

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -18,7 +18,7 @@ pub enum Error {
 
 /// Details an attestation that can be slashable.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 #[serde(bound = "T: EthSpec")]

--- a/consensus/types/src/attestation_data.rs
+++ b/consensus/types/src/attestation_data.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// The data upon which an attestation is based.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug,

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// Two conflicting attestations.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Derivative,

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 
 /// A block of the `BeaconChain`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 #[serde(bound = "T: EthSpec")]
@@ -27,7 +27,7 @@ impl<T: EthSpec> SignedRoot for BeaconBlock<T> {}
 impl<T: EthSpec> BeaconBlock<T> {
     /// Returns an empty block to be used during genesis.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn empty(spec: &ChainSpec) -> Self {
         BeaconBlock {
             slot: spec.genesis_slot,
@@ -152,7 +152,7 @@ impl<T: EthSpec> BeaconBlock<T> {
 
     /// Returns the `tree_hash_root` of the block.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn canonical_root(&self) -> Hash256 {
         Hash256::from_slice(&self.tree_hash_root()[..])
     }
@@ -164,7 +164,7 @@ impl<T: EthSpec> BeaconBlock<T> {
     ///
     /// Note: performs a full tree-hash of `self.body`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn block_header(&self) -> BeaconBlockHeader {
         BeaconBlockHeader {
             slot: self.slot,
@@ -177,7 +177,7 @@ impl<T: EthSpec> BeaconBlock<T> {
 
     /// Returns a "temporary" header, where the `state_root` is `Hash256::zero()`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn temporary_block_header(&self) -> BeaconBlockHeader {
         BeaconBlockHeader {
             state_root: Hash256::zero(),

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 
 /// The body of a `BeaconChain` block, containing operations.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 #[serde(bound = "T: EthSpec")]

--- a/consensus/types/src/beacon_block_header.rs
+++ b/consensus/types/src/beacon_block_header.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// A header of a `BeaconBlock`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct BeaconBlockHeader {
@@ -25,14 +25,14 @@ impl SignedRoot for BeaconBlockHeader {}
 impl BeaconBlockHeader {
     /// Returns the `tree_hash_root` of the header.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn canonical_root(&self) -> Hash256 {
         Hash256::from_slice(&self.tree_hash_root()[..])
     }
 
     /// Given a `body`, consumes `self` and returns a complete `BeaconBlock`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn into_block<T: EthSpec>(self, body: BeaconBlockBody<T>) -> BeaconBlock<T> {
         BeaconBlock {
             slot: self.slot,

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -133,7 +133,7 @@ impl From<BeaconStateHash> for Hash256 {
 
 /// The state of the `BeaconChain` at some slot.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[derive(
     Debug,
     PartialEq,
@@ -225,7 +225,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Not a complete genesis state, see `initialize_beacon_state_from_eth1`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn new(genesis_time: u64, eth1_data: Eth1Data, spec: &ChainSpec) -> Self {
         BeaconState {
             // Versioning
@@ -283,7 +283,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Returns the `tree_hash_root` of the state.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn canonical_root(&self) -> Hash256 {
         Hash256::from_slice(&self.tree_hash_root()[..])
     }
@@ -312,7 +312,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// The epoch corresponding to `self.slot`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn current_epoch(&self) -> Epoch {
         self.slot.epoch(T::slots_per_epoch())
     }
@@ -321,7 +321,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// If the current epoch is the genesis epoch, the genesis_epoch is returned.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn previous_epoch(&self) -> Epoch {
         let current_epoch = self.current_epoch();
         if current_epoch > T::genesis_epoch() {
@@ -333,7 +333,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// The epoch following `self.current_epoch()`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn next_epoch(&self) -> Epoch {
         self.current_epoch() + 1
     }
@@ -342,7 +342,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Makes use of the committee cache and will fail if no cache exists for the slot's epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_committee_count_at_slot(&self, slot: Slot) -> Result<u64, Error> {
         let cache = self.committee_cache_at_slot(slot)?;
         Ok(cache.committees_per_slot() as u64)
@@ -350,7 +350,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Compute the number of committees in an entire epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_epoch_committee_count(&self, relative_epoch: RelativeEpoch) -> Result<u64, Error> {
         let cache = self.committee_cache(relative_epoch)?;
         Ok(cache.epoch_committee_count() as u64)
@@ -374,7 +374,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Does not utilize the cache, performs a full iteration over the validator registry.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_active_validator_indices(&self, epoch: Epoch) -> Vec<usize> {
         // FIXME(sproul): put a bounds check on here based on the maximum lookahead
         get_active_validator_indices(&self.validators, epoch)
@@ -395,7 +395,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Utilises the committee cache.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_beacon_committee(
         &self,
         slot: Slot,
@@ -414,7 +414,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Utilises the committee cache.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_beacon_committees_at_slot(&self, slot: Slot) -> Result<Vec<BeaconCommittee>, Error> {
         let cache = self.committee_cache_at_slot(slot)?;
         cache.get_beacon_committees_at_slot(slot)
@@ -424,7 +424,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Utilises the committee cache.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_beacon_committees_at_epoch(
         &self,
         relative_epoch: RelativeEpoch,
@@ -435,7 +435,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Compute the proposer (not necessarily for the Beacon chain) from a list of indices.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     // NOTE: be sure to test this bad boy.
     pub fn compute_proposer_index(
         &self,
@@ -476,7 +476,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return `true` if the validator who produced `slot_signature` is eligible to aggregate.
     ///
-    /// Spec v0.10.1
+    /// Spec v0.12.1
     pub fn is_aggregator(
         &self,
         slot: Slot,
@@ -501,7 +501,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Returns the beacon proposer index for the `slot` in the given `relative_epoch`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_beacon_proposer_index(&self, slot: Slot, spec: &ChainSpec) -> Result<usize, Error> {
         let epoch = slot.epoch(T::slots_per_epoch());
         let seed = self.get_beacon_proposer_seed(slot, spec)?;
@@ -512,7 +512,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Compute the seed to use for the beacon proposer selection at the given `slot`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_beacon_proposer_seed(&self, slot: Slot, spec: &ChainSpec) -> Result<Vec<u8>, Error> {
         let epoch = slot.epoch(T::slots_per_epoch());
         let mut preimage = self
@@ -527,7 +527,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// It needs filling in on all slots where there isn't a skip.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_latest_block_root(&self, current_state_root: Hash256) -> Hash256 {
         if self.latest_block_header.state_root.is_zero() {
             let mut latest_block_header = self.latest_block_header.clone();
@@ -540,7 +540,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Safely obtains the index for latest block roots, given some `slot`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_latest_block_roots_index(&self, slot: Slot) -> Result<usize, Error> {
         if slot < self.slot && self.slot <= slot + self.block_roots.len() as u64 {
             Ok(slot.as_usize().safe_rem(self.block_roots.len())?)
@@ -551,7 +551,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return the block root at a recent `slot`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_block_root(&self, slot: Slot) -> Result<&Hash256, BeaconStateError> {
         let i = self.get_latest_block_roots_index(slot)?;
         Ok(&self.block_roots[i])
@@ -559,7 +559,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return the block root at a recent `epoch`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     // NOTE: the spec calls this get_block_root
     pub fn get_block_root_at_epoch(&self, epoch: Epoch) -> Result<&Hash256, BeaconStateError> {
         self.get_block_root(epoch.start_slot(T::slots_per_epoch()))
@@ -567,7 +567,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Sets the block root for some given slot.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn set_block_root(
         &mut self,
         slot: Slot,
@@ -585,7 +585,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Safely obtains the index for `randao_mixes`
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_randao_mix_index(
         &self,
         epoch: Epoch,
@@ -607,7 +607,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// See `Self::get_randao_mix`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn update_randao_mix(&mut self, epoch: Epoch, signature: &Signature) -> Result<(), Error> {
         let i = epoch
             .as_usize()
@@ -622,7 +622,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return the randao mix at a recent ``epoch``.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_randao_mix(&self, epoch: Epoch) -> Result<&Hash256, Error> {
         let i = self.get_randao_mix_index(epoch, AllowNextEpoch::False)?;
         Ok(&self.randao_mixes[i])
@@ -630,7 +630,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Set the randao mix at a recent ``epoch``.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn set_randao_mix(&mut self, epoch: Epoch, mix: Hash256) -> Result<(), Error> {
         let i = self.get_randao_mix_index(epoch, AllowNextEpoch::True)?;
         self.randao_mixes[i] = mix;
@@ -639,7 +639,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Safely obtains the index for latest state roots, given some `slot`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_latest_state_roots_index(&self, slot: Slot) -> Result<usize, Error> {
         if slot < self.slot && self.slot <= slot + self.state_roots.len() as u64 {
             Ok(slot.as_usize().safe_rem(self.state_roots.len())?)
@@ -650,7 +650,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Gets the state root for some slot.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_state_root(&self, slot: Slot) -> Result<&Hash256, Error> {
         let i = self.get_latest_state_roots_index(slot)?;
         Ok(&self.state_roots[i])
@@ -658,7 +658,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Gets the oldest (earliest slot) state root.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_oldest_state_root(&self) -> Result<&Hash256, Error> {
         let i =
             self.get_latest_state_roots_index(self.slot - Slot::from(self.state_roots.len()))?;
@@ -667,7 +667,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Gets the oldest (earliest slot) block root.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_oldest_block_root(&self) -> Result<&Hash256, Error> {
         let i = self.get_latest_block_roots_index(self.slot - self.block_roots.len() as u64)?;
         Ok(&self.block_roots[i])
@@ -683,7 +683,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Sets the latest state root for slot.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn set_state_root(&mut self, slot: Slot, state_root: Hash256) -> Result<(), Error> {
         let i = self.get_latest_state_roots_index(slot)?;
         self.state_roots[i] = state_root;
@@ -692,7 +692,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Safely obtain the index for `slashings`, given some `epoch`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_slashings_index(
         &self,
         epoch: Epoch,
@@ -714,14 +714,14 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Get a reference to the entire `slashings` vector.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_all_slashings(&self) -> &[u64] {
         &self.slashings
     }
 
     /// Get the total slashed balances for some epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_slashings(&self, epoch: Epoch) -> Result<u64, Error> {
         let i = self.get_slashings_index(epoch, AllowNextEpoch::False)?;
         Ok(self.slashings[i])
@@ -729,7 +729,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Set the total slashed balances for some epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn set_slashings(&mut self, epoch: Epoch, value: u64) -> Result<(), Error> {
         let i = self.get_slashings_index(epoch, AllowNextEpoch::True)?;
         self.slashings[i] = value;
@@ -738,7 +738,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Get the attestations from the current or previous epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_matching_source_attestations(
         &self,
         epoch: Epoch,
@@ -754,7 +754,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Generate a seed for the given `epoch`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_seed(
         &self,
         epoch: Epoch,
@@ -785,7 +785,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return the effective balance (also known as "balance at stake") for a validator with the given ``index``.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_effective_balance(
         &self,
         validator_index: usize,
@@ -799,7 +799,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     ///  Return the epoch at which an activation or exit triggered in ``epoch`` takes effect.
     ///
-    ///  Spec v0.11.1
+    ///  Spec v0.12.1
     pub fn compute_activation_exit_epoch(&self, epoch: Epoch, spec: &ChainSpec) -> Epoch {
         epoch + 1 + spec.max_seed_lookahead
     }
@@ -808,7 +808,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Uses the epoch cache, and will error if it isn't initialized.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_churn_limit(&self, spec: &ChainSpec) -> Result<u64, Error> {
         Ok(std::cmp::max(
             spec.min_per_epoch_churn_limit,
@@ -824,7 +824,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Note: Utilizes the cache and will fail if the appropriate cache is not initialized.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_attestation_duties(
         &self,
         validator_index: usize,
@@ -837,7 +837,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Return the combined effective balance of an array of validators.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_total_balance(
         &self,
         validator_indices: &[usize],

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -24,7 +24,7 @@ pub struct CommitteeCache {
 impl CommitteeCache {
     /// Return a new, fully initialized cache.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn initialized<T: EthSpec>(
         state: &BeaconState<T>,
         epoch: Epoch,
@@ -89,7 +89,7 @@ impl CommitteeCache {
     ///
     /// Always returns `&[]` for a non-initialized epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn active_validator_indices(&self) -> &[usize] {
         &self.shuffling
     }
@@ -98,7 +98,7 @@ impl CommitteeCache {
     ///
     /// Always returns `&[]` for a non-initialized epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn shuffling(&self) -> &[usize] {
         &self.shuffling
     }
@@ -204,7 +204,7 @@ impl CommitteeCache {
     ///
     /// Always returns `usize::default()` for a non-initialized epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn active_validator_count(&self) -> usize {
         self.shuffling.len()
     }
@@ -213,7 +213,7 @@ impl CommitteeCache {
     ///
     /// Always returns `usize::default()` for a non-initialized epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn epoch_committee_count(&self) -> usize {
         self.committees_per_slot as usize * self.slots_per_epoch as usize
     }
@@ -225,7 +225,7 @@ impl CommitteeCache {
 
     /// Returns a slice of `self.shuffling` that represents the `index`'th committee in the epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn compute_committee(&self, index: usize) -> Option<&[usize]> {
         Some(&self.shuffling[self.compute_committee_range(index)?])
     }
@@ -236,7 +236,7 @@ impl CommitteeCache {
     ///
     /// Will also return `None` if the index is out of bounds.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn compute_committee_range(&self, index: usize) -> Option<Range<usize>> {
         let count = self.epoch_committee_count();
         if count == 0 || index >= count {
@@ -263,7 +263,7 @@ impl CommitteeCache {
 /// Returns a list of all `validators` indices where the validator is active at the given
 /// `epoch`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 pub fn get_active_validator_indices(validators: &[Validator], epoch: Epoch) -> Vec<usize> {
     let mut active = Vec::with_capacity(validators.len());
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -11,7 +11,7 @@ use utils::{
 
 /// Each of the BLS signature domains.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Domain {
     BeaconProposer,
@@ -25,7 +25,7 @@ pub enum Domain {
 
 /// Holds all the "constants" for a BeaconChain.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -154,7 +154,7 @@ impl ChainSpec {
 
     /// Get the domain number, unmodified by the fork.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_domain_constant(&self, domain: Domain) -> u32 {
         match domain {
             Domain::BeaconProposer => self.domain_beacon_proposer,
@@ -169,7 +169,7 @@ impl ChainSpec {
 
     /// Get the domain that represents the fork meta and signature domain.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_domain(
         &self,
         epoch: Epoch,
@@ -186,7 +186,7 @@ impl ChainSpec {
     /// Deposits are valid across forks, thus the deposit domain is computed
     /// with the genesis fork version.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_deposit_domain(&self) -> Hash256 {
         self.compute_domain(Domain::Deposit, self.genesis_fork_version, Hash256::zero())
     }
@@ -195,7 +195,7 @@ impl ChainSpec {
     ///
     /// This is used primarily in signature domains to avoid collisions across forks/chains.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn compute_fork_data_root(
         current_version: [u8; 4],
         genesis_validators_root: Hash256,
@@ -223,7 +223,7 @@ impl ChainSpec {
 
     /// Compute a domain by applying the given `fork_version`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn compute_domain(
         &self,
         domain: Domain,
@@ -243,7 +243,7 @@ impl ChainSpec {
 
     /// Returns a `ChainSpec` compatible with the Ethereum Foundation specification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn mainnet() -> Self {
         Self {
             /*
@@ -341,7 +341,7 @@ impl ChainSpec {
 
     /// Ethereum Foundation minimal spec, as defined in the eth2.0-specs repo.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn minimal() -> Self {
         // Note: bootnodes to be updated when static nodes exist.
         let boot_nodes = vec![];
@@ -442,7 +442,7 @@ mod tests {
 ///
 /// Doesn't include fields of the YAML that we don't need yet (e.g. Phase 1 stuff).
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 // Yaml Config is declared here in order to access domain fields of ChainSpec which are private.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "UPPERCASE")]
@@ -560,7 +560,7 @@ impl Default for YamlConfig {
     }
 }
 
-/// Spec v0.11.1
+/// Spec v0.12.1
 impl YamlConfig {
     #[allow(clippy::integer_arithmetic)]
     pub fn from_spec<T: EthSpec>(spec: &ChainSpec) -> Self {

--- a/consensus/types/src/checkpoint.rs
+++ b/consensus/types/src/checkpoint.rs
@@ -7,7 +7,7 @@ use tree_hash_derive::TreeHash;
 
 /// Casper FFG checkpoint, used in attestations.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug,

--- a/consensus/types/src/deposit.rs
+++ b/consensus/types/src/deposit.rs
@@ -10,7 +10,7 @@ pub const DEPOSIT_TREE_DEPTH: usize = 32;
 
 /// A deposit to potentially become a beacon chain validator.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct Deposit {

--- a/consensus/types/src/deposit_data.rs
+++ b/consensus/types/src/deposit_data.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// The data supplied by the user to the deposit contract.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct DepositData {
@@ -22,7 +22,7 @@ pub struct DepositData {
 impl DepositData {
     /// Create a `DepositMessage` corresponding to this `DepositData`, for signature verification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn as_deposit_message(&self) -> DepositMessage {
         DepositMessage {
             pubkey: self.pubkey.clone(),
@@ -33,7 +33,7 @@ impl DepositData {
 
     /// Generate the signature for a given DepositData details.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn create_signature(&self, secret_key: &SecretKey, spec: &ChainSpec) -> SignatureBytes {
         let domain = spec.get_deposit_domain();
         let msg = self.as_deposit_message().signing_root(domain);

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// The data supplied by the user to the deposit contract.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct DepositMessage {

--- a/consensus/types/src/eth1_data.rs
+++ b/consensus/types/src/eth1_data.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// Contains data obtained from the Eth1 chain.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug,

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -67,7 +67,7 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq +
     /// Note: the number of committees per slot is constant in each epoch, and depends only on
     /// the `active_validator_count` during the slot's epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn get_committee_count_per_slot(
         active_validator_count: usize,
         spec: &ChainSpec,
@@ -96,28 +96,28 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq +
 
     /// Returns the `SLOTS_PER_EPOCH` constant for this specification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn slots_per_epoch() -> u64 {
         Self::SlotsPerEpoch::to_u64()
     }
 
     /// Returns the `SLOTS_PER_HISTORICAL_ROOT` constant for this specification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn slots_per_historical_root() -> usize {
         Self::SlotsPerHistoricalRoot::to_usize()
     }
 
     /// Returns the `EPOCHS_PER_HISTORICAL_VECTOR` constant for this specification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn epochs_per_historical_vector() -> usize {
         Self::EpochsPerHistoricalVector::to_usize()
     }
 
     /// Returns the `SLOTS_PER_ETH1_VOTING_PERIOD` constant for this specification.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     fn slots_per_eth1_voting_period() -> usize {
         Self::SlotsPerEth1VotingPeriod::to_usize()
     }
@@ -133,7 +133,7 @@ macro_rules! params_from_eth_spec {
 
 /// Ethereum Foundation specifications.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub struct MainnetEthSpec;
@@ -171,7 +171,7 @@ pub type FoundationBeaconState = BeaconState<MainnetEthSpec>;
 
 /// Ethereum Foundation minimal spec, as defined in the eth2.0-specs repo.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
 pub struct MinimalEthSpec;

--- a/consensus/types/src/fork.rs
+++ b/consensus/types/src/fork.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug,
@@ -41,7 +41,7 @@ pub struct Fork {
 impl Fork {
     /// Return the fork version of the given ``epoch``.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn get_fork_version(&self, epoch: Epoch) -> [u8; 4] {
         if epoch < self.epoch {
             return self.previous_version;

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,

--- a/consensus/types/src/historical_batch.rs
+++ b/consensus/types/src/historical_batch.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// Historical block and state roots.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct HistoricalBatch<T: EthSpec> {

--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 ///
 /// To be included in an `AttesterSlashing`.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
@@ -26,14 +26,14 @@ pub struct IndexedAttestation<T: EthSpec> {
 impl<T: EthSpec> IndexedAttestation<T> {
     /// Check if ``attestation_data_1`` and ``attestation_data_2`` have the same target.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn is_double_vote(&self, other: &Self) -> bool {
         self.data.target.epoch == other.data.target.epoch && self.data != other.data
     }
 
     /// Check if ``attestation_data_1`` surrounds ``attestation_data_2``.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn is_surround_vote(&self, other: &Self) -> bool {
         self.data.source.epoch < other.data.source.epoch
             && other.data.target.epoch < self.data.target.epoch

--- a/consensus/types/src/pending_attestation.rs
+++ b/consensus/types/src/pending_attestation.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// An attestation that has been included in the state but not yet fully processed.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct PendingAttestation<T: EthSpec> {
     pub aggregation_bits: BitList<T::MaxValidatorsPerCommittee>,

--- a/consensus/types/src/proposer_slashing.rs
+++ b/consensus/types/src/proposer_slashing.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// Two conflicting proposals from the same proposer (validator).
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct ProposerSlashing {

--- a/consensus/types/src/relative_epoch.rs
+++ b/consensus/types/src/relative_epoch.rs
@@ -12,7 +12,7 @@ use arbitrary::Arbitrary;
 /// Defines the epochs relative to some epoch. Most useful when referring to the committees prior
 /// to and following some epoch.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum RelativeEpoch {
@@ -27,7 +27,7 @@ pub enum RelativeEpoch {
 impl RelativeEpoch {
     /// Returns the `epoch` that `self` refers to, with respect to the `base` epoch.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn into_epoch(self, base: Epoch) -> Epoch {
         match self {
             // Due to saturating nature of epoch, check for current first.
@@ -44,7 +44,7 @@ impl RelativeEpoch {
     /// - `EpochTooLow` when `other` is more than 1 prior to `base`.
     /// - `EpochTooHigh` when `other` is more than 1 after `base`.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn from_epoch(base: Epoch, other: Epoch) -> Result<Self, Error> {
         // Due to saturating nature of epoch, check for current first.
         if other == base {

--- a/consensus/types/src/signed_aggregate_and_proof.rs
+++ b/consensus/types/src/signed_aggregate_and_proof.rs
@@ -11,7 +11,7 @@ use tree_hash_derive::TreeHash;
 /// A Validators signed aggregate proof to publish on the `beacon_aggregate_and_proof`
 /// gossipsub topic.
 ///
-/// Spec v0.10.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
 #[serde(bound = "T: EthSpec")]

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -39,7 +39,7 @@ impl From<SignedBeaconBlockHash> for Hash256 {
 
 /// A `BeaconBlock` and a signature from its proposer.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TestRandom)]
 #[serde(bound = "E: EthSpec")]
@@ -98,7 +98,7 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
 
     /// Returns the `tree_hash_root` of the block.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn canonical_root(&self) -> Hash256 {
         Hash256::from_slice(&self.message.tree_hash_root()[..])
     }

--- a/consensus/types/src/signed_beacon_block_header.rs
+++ b/consensus/types/src/signed_beacon_block_header.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct SignedBeaconBlockHeader {

--- a/consensus/types/src/signed_voluntary_exit.rs
+++ b/consensus/types/src/signed_voluntary_exit.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct SignedVoluntaryExit {

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 /// Information about a `BeaconChain` validator.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
 pub struct Validator {
@@ -45,7 +45,7 @@ impl Validator {
 
     /// Returns `true` if the validator is eligible to join the activation queue.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn is_eligible_for_activation_queue(&self, spec: &ChainSpec) -> bool {
         self.activation_eligibility_epoch == spec.far_future_epoch
             && self.effective_balance == spec.max_effective_balance
@@ -53,7 +53,7 @@ impl Validator {
 
     /// Returns `true` if the validator is eligible to be activated.
     ///
-    /// Spec v0.11.1
+    /// Spec v0.12.1
     pub fn is_eligible_for_activation<E: EthSpec>(
         &self,
         state: &BeaconState<E>,

--- a/consensus/types/src/voluntary_exit.rs
+++ b/consensus/types/src/voluntary_exit.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
-/// Spec v0.11.1
+/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct VoluntaryExit {

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -121,7 +121,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // validator = state.validators[voluntary_exit.validator_index]
@@ -139,7 +139,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify exit has not been initiated
@@ -159,7 +159,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify the validator is active
@@ -179,7 +179,7 @@ vectors_and_tests!(
     },
     // Also tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify the validator is active
@@ -211,7 +211,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Exits must specify an epoch when they become valid; they are not
@@ -232,7 +232,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify the validator has been active long enough
@@ -253,7 +253,7 @@ vectors_and_tests!(
     },
     // Also tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify the validator has been active long enough
@@ -274,7 +274,7 @@ vectors_and_tests!(
     },
     // Tests the following line of the spec:
     //
-    // v0.11.2
+    // Spec v0.12.1
     //
     // ```ignore
     // # Verify signature

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -222,7 +222,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
     /// Performs the first step of the attesting process: downloading `Attestation` objects,
     /// signing them and returning them to the validator.
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/validator.md#attesting
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#attesting
     ///
     /// ## Detail
     ///
@@ -291,7 +291,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
     /// Performs the first step of the attesting process: downloading `Attestation` objects,
     /// signing them and returning them to the validator.
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/validator.md#attesting
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#attesting
     ///
     /// ## Detail
     ///
@@ -441,7 +441,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
     /// Performs the second step of the attesting process: downloading an aggregated `Attestation`,
     /// converting it into a `SignedAggregateAndProof` and returning it to the BN.
     ///
-    /// https://github.com/ethereum/eth2.0-specs/blob/v0.11.0/specs/phase0/validator.md#broadcast-aggregate
+    /// https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/validator.md#broadcast-aggregate
     ///
     /// ## Detail
     ///


### PR DESCRIPTION
## Issue Addressed

The last part of #1182! :tada: 

## Proposed Changes

Bump all the version references to v0.12.1

## Additional Info

I'm starting to doubt the usefulness of the `Spec v0.12.1` tags, when typically they just get bumped en-masse like this... but we can come back to the idea of deleting them as we get closer to `1.0`
