### PR TITLE
Optional Discovery

### DIFF
--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -37,6 +37,5 @@ genesis = { path = "genesis" }
 eth2_testnet_config = { path = "../common/eth2_testnet_config" }
 eth2_libp2p = { path = "./eth2_libp2p" }
 eth2_ssz = "0.1.2"
-toml = "0.5.6"
 serde = "1.0.110"
 clap_utils = { path = "../common/clap_utils" }

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -56,6 +56,9 @@ pub struct Config {
     /// Client version
     pub client_version: String,
 
+    /// Disables the discovery protocol from starting.
+    pub disable_discovery: bool,
+
     /// List of extra topics to initially subscribe to as strings.
     pub topics: Vec<GossipKind>,
 }
@@ -104,7 +107,7 @@ impl Default for Config {
             .request_retries(2)
             .enr_peer_update_min(2) // prevents NAT's should be raised for mainnet
             .query_parallelism(5)
-            .query_timeout(Duration::from_secs(60))
+            .query_timeout(Duration::from_secs(30))
             .query_peer_timeout(Duration::from_secs(2))
             .ip_limit() // limits /24 IP's in buckets.
             .ping_interval(Duration::from_secs(300))
@@ -125,6 +128,7 @@ impl Default for Config {
             boot_nodes: vec![],
             libp2p_nodes: vec![],
             client_version: version::version(),
+            disable_discovery: false,
             topics,
         }
     }

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -110,7 +110,12 @@ impl<TSpec: EthSpec> Service<TSpec> {
         ));
 
         info!(log, "Libp2p Service"; "peer_id" => format!("{:?}", enr.peer_id()));
-        debug!(log, "Attempting to open listening ports"; "address" => format!("{}", config.listen_address), "tcp_port" => config.libp2p_port, "udp_port" => config.discovery_port);
+        let discovery_string = if config.disable_discovery {
+            "None".into()
+        } else {
+            config.discovery_port.to_string()
+        };
+        debug!(log, "Attempting to open listening ports"; "address" => format!("{}", config.listen_address), "tcp_port" => config.libp2p_port, "udp_port" => discovery_string);
 
         let mut swarm = {
             // Set up the transport - tcp/ws with noise/secio and mplex/yamux

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -61,7 +61,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("max_peers")
+            Arg::with_name("max-peers")
                 .long("max-peers")
                 .help("The maximum number of peers.")
                 .default_value("50")
@@ -125,6 +125,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        without an ENR.")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("disable-discovery")
+                .long("disable-discovery")
+                .help("Disables the discv5 discovery protocol. The node will not search for new peers or participate in the discovery protocol.")
+                .takes_value(false),
+        )
+
         /* REST API related arguments */
         .arg(
             Arg::with_name("http")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -195,6 +195,11 @@ pub fn get_config<E: EthSpec>(
         client_config.network.discv5_config.enr_update = false;
     }
 
+    if cli_args.is_present("disable-discovery") {
+        client_config.network.disable_discovery = true;
+        slog::warn!(log, "Discovery is disabled. New peers will not be found");
+    }
+
     /*
      * Http server
      */

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -7,14 +7,11 @@ use eth2_testnet_config::Eth2TestnetConfig;
 use slog::{crit, info, Logger};
 use ssz::Encode;
 use std::fs;
-use std::fs::File;
-use std::io::prelude::*;
 use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::net::{TcpListener, UdpSocket};
 use std::path::PathBuf;
 use types::{ChainSpec, EthSpec};
 
-pub const CLIENT_CONFIG_FILENAME: &str = "beacon-node.toml";
 pub const BEACON_NODE_DIR: &str = "beacon";
 pub const NETWORK_DIR: &str = "network";
 
@@ -72,17 +69,7 @@ pub fn get_config<E: EthSpec>(
     log_dir.pop();
     info!(log, "Data directory initialised"; "datadir" => format!("{}",log_dir.into_os_string().into_string().expect("Datadir should be a valid os string")));
 
-    // Load the client config, if it exists .
-    let config_file_path = client_config.data_dir.join(CLIENT_CONFIG_FILENAME);
-    let config_file_existed = config_file_path.exists();
-    if config_file_existed {
-        client_config = read_from_file(config_file_path.clone())
-            .map_err(|e| format!("Unable to parse {:?} file: {:?}", config_file_path, e))?
-            .ok_or_else(|| format!("{:?} file does not exist", config_file_path))?;
-    } else {
-        client_config.spec_constants = spec_constants.into();
-    }
-
+    client_config.spec_constants = spec_constants.into();
     client_config.testnet_dir = get_testnet_dir(cli_args);
 
     /*
@@ -351,10 +338,6 @@ pub fn get_config<E: EthSpec>(
         client_config.genesis = ClientGenesis::DepositContract;
     }
 
-    if !config_file_existed {
-        write_to_file(config_file_path, &client_config)?;
-    }
-
     Ok(client_config)
 }
 
@@ -434,43 +417,4 @@ pub fn unused_port(transport: &str) -> Result<u16, String> {
         _ => return Err("Invalid transport to find unused port".into()),
     };
     Ok(local_addr.port())
-}
-
-/// Write a configuration to file.
-pub fn write_to_file<T>(path: PathBuf, config: &T) -> Result<(), String>
-where
-    T: Default + serde::de::DeserializeOwned + serde::Serialize,
-{
-    if let Ok(mut file) = File::create(path.clone()) {
-        let toml_encoded = toml::to_string(&config).map_err(|e| {
-            format!(
-                "Failed to write configuration to {:?}. Error: {:?}",
-                path, e
-            )
-        })?;
-        file.write_all(toml_encoded.as_bytes())
-            .unwrap_or_else(|_| panic!("Unable to write to {:?}", path));
-    }
-
-    Ok(())
-}
-
-/// Loads a `ClientConfig` from file. If unable to load from file, generates a default
-/// configuration and saves that as a sample file.
-pub fn read_from_file<T>(path: PathBuf) -> Result<Option<T>, String>
-where
-    T: Default + serde::de::DeserializeOwned + serde::Serialize,
-{
-    if let Ok(mut file) = File::open(path.clone()) {
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)
-            .map_err(|e| format!("Unable to read {:?}. Error: {:?}", path, e))?;
-
-        let config = toml::from_str(&contents)
-            .map_err(|e| format!("Unable to parse {:?}: {:?}", path, e))?;
-
-        Ok(Some(config))
-    } else {
-        Ok(None)
-    }
 }


### PR DESCRIPTION
## Description

Make the discovery service optional. Useful for managing and strictly controlling the peers connected to lighthouse. 
