### PR TITLE
LevelDB CMake hotfix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,8 +2299,7 @@ dependencies = [
 [[package]]
 name = "leveldb-sys"
 version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4abc211bb716f076618bca48aaae128f6feb326195608f40f41a9cdbedc502"
+source = "git+https://github.com/michaelsproul/leveldb-sys?branch=v2.0.6-cmake#e784dba085921bad187ff74b3418c539914a02ff"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,4 @@ eth2_ssz = { path = "consensus/ssz" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_hashing = { path = "crypto/eth2_hashing" }
+leveldb-sys = { git = "https://github.com/michaelsproul/leveldb-sys", branch = "v2.0.6-cmake" }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Switches to a different `leveldb` that searches `lib64` directories for shared libraries.