### PR TITLE
Fix BlockByRootRequest ssz type

### DIFF
--- a/beacon_node/eth2_libp2p/src/rpc/codec/ssz.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/codec/ssz.rs
@@ -9,7 +9,6 @@ use crate::rpc::{
 use crate::rpc::{RPCCodedResponse, RPCRequest, RPCResponse};
 use libp2p::bytes::{BufMut, Bytes, BytesMut};
 use ssz::{Decode, Encode};
-use ssz_types::VariableList;
 use std::marker::PhantomData;
 use tokio_util::codec::{Decoder, Encoder};
 use types::{EthSpec, SignedBeaconBlock};
@@ -124,9 +123,9 @@ impl<TSpec: EthSpec> Decoder for SSZInboundCodec<TSpec> {
                         if packet.len() >= *BLOCKS_BY_ROOT_REQUEST_MIN
                             && packet.len() <= *BLOCKS_BY_ROOT_REQUEST_MAX
                         {
-                            Ok(Some(RPCRequest::BlocksByRoot(BlocksByRootRequest {
-                                block_roots: VariableList::from_ssz_bytes(&packet)?,
-                            })))
+                            Ok(Some(RPCRequest::BlocksByRoot(
+                                BlocksByRootRequest::from_ssz_bytes(&packet)?,
+                            )))
                         } else {
                             Err(RPCError::InvalidData)
                         }
@@ -192,7 +191,7 @@ impl<TSpec: EthSpec> Encoder<RPCRequest<TSpec>> for SSZOutboundCodec<TSpec> {
             RPCRequest::Status(req) => req.as_ssz_bytes(),
             RPCRequest::Goodbye(req) => req.as_ssz_bytes(),
             RPCRequest::BlocksByRange(req) => req.as_ssz_bytes(),
-            RPCRequest::BlocksByRoot(req) => req.block_roots.as_ssz_bytes(),
+            RPCRequest::BlocksByRoot(req) => req.as_ssz_bytes(),
             RPCRequest::Ping(req) => req.as_ssz_bytes(),
             RPCRequest::MetaData(_) => return Ok(()), // no metadata to encode
         };

--- a/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
@@ -11,7 +11,6 @@ use libp2p::bytes::BytesMut;
 use snap::read::FrameDecoder;
 use snap::write::FrameEncoder;
 use ssz::{Decode, Encode};
-use ssz_types::VariableList;
 use std::io::Cursor;
 use std::io::ErrorKind;
 use std::io::{Read, Write};
@@ -165,9 +164,9 @@ impl<TSpec: EthSpec> Decoder for SSZSnappyInboundCodec<TSpec> {
                             if decoded_buffer.len() >= *BLOCKS_BY_ROOT_REQUEST_MIN
                                 && decoded_buffer.len() <= *BLOCKS_BY_ROOT_REQUEST_MAX
                             {
-                                Ok(Some(RPCRequest::BlocksByRoot(BlocksByRootRequest {
-                                    block_roots: VariableList::from_ssz_bytes(&decoded_buffer)?,
-                                })))
+                                Ok(Some(RPCRequest::BlocksByRoot(
+                                    BlocksByRootRequest::from_ssz_bytes(&decoded_buffer)?,
+                                )))
                             } else {
                                 Err(RPCError::InvalidData)
                             }
@@ -242,7 +241,7 @@ impl<TSpec: EthSpec> Encoder<RPCRequest<TSpec>> for SSZSnappyOutboundCodec<TSpec
             RPCRequest::Status(req) => req.as_ssz_bytes(),
             RPCRequest::Goodbye(req) => req.as_ssz_bytes(),
             RPCRequest::BlocksByRange(req) => req.as_ssz_bytes(),
-            RPCRequest::BlocksByRoot(req) => req.block_roots.as_ssz_bytes(),
+            RPCRequest::BlocksByRoot(req) => req.as_ssz_bytes(),
             RPCRequest::Ping(req) => req.as_ssz_bytes(),
             RPCRequest::MetaData(_) => return Ok(()), // no metadata to encode
         };

--- a/beacon_node/eth2_libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/methods.rs
@@ -188,11 +188,7 @@ pub struct BlocksByRangeRequest {
 }
 
 /// Request a number of beacon block bodies from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
-pub struct BlocksByRootRequest {
-    /// The list of beacon block bodies being requested.
-    pub block_roots: VariableList<Hash256, MaxRequestBlocks>,
-}
+pub type BlocksByRootRequest = VariableList<Hash256, MaxRequestBlocks>;
 
 /* RPC Handling and Grouping */
 // Collection of enums and structs used by the Codecs to encode/decode RPC messages

--- a/beacon_node/eth2_libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/protocol.rs
@@ -43,18 +43,14 @@ lazy_static! {
     }
     .as_ssz_bytes()
     .len();
-    pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize = BlocksByRootRequest {
-        block_roots: VariableList::<Hash256, MaxRequestBlocks>::from(Vec::<Hash256>::new())
-    }
+    pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize = BlocksByRootRequest::from(Vec::<Hash256>::new())
     .as_ssz_bytes()
     .len();
-    pub static ref BLOCKS_BY_ROOT_REQUEST_MAX: usize = BlocksByRootRequest {
-        block_roots: VariableList::<Hash256, MaxRequestBlocks>::from(vec![
+    pub static ref BLOCKS_BY_ROOT_REQUEST_MAX: usize = BlocksByRootRequest::from(vec![
             Hash256::zero();
             MAX_REQUEST_BLOCKS
                 as usize
         ])
-    }
     .as_ssz_bytes()
     .len();
 }
@@ -330,7 +326,7 @@ impl<TSpec: EthSpec> RPCRequest<TSpec> {
             RPCRequest::Status(_) => 1,
             RPCRequest::Goodbye(_) => 0,
             RPCRequest::BlocksByRange(req) => req.count as usize,
-            RPCRequest::BlocksByRoot(req) => req.block_roots.len(),
+            RPCRequest::BlocksByRoot(req) => req.len(),
             RPCRequest::Ping(_) => 1,
             RPCRequest::MetaData(_) => 1,
         }

--- a/beacon_node/eth2_libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/protocol.rs
@@ -9,14 +9,13 @@ use crate::rpc::{
         InboundCodec, OutboundCodec,
     },
     methods::ResponseTermination,
-    MaxRequestBlocks, MAX_REQUEST_BLOCKS,
+    MAX_REQUEST_BLOCKS,
 };
 use futures::future::Ready;
 use futures::prelude::*;
 use futures::prelude::{AsyncRead, AsyncWrite};
 use libp2p::core::{InboundUpgrade, OutboundUpgrade, ProtocolName, UpgradeInfo};
 use ssz::Encode;
-use ssz_types::VariableList;
 use std::io;
 use std::marker::PhantomData;
 use std::pin::Pin;

--- a/beacon_node/eth2_libp2p/tests/rpc_tests.rs
+++ b/beacon_node/eth2_libp2p/tests/rpc_tests.rs
@@ -467,13 +467,11 @@ async fn test_blocks_by_root_chunked_rpc() {
     let (mut sender, mut receiver) = common::build_node_pair(&log).await;
 
     // BlocksByRoot Request
-    let rpc_request = Request::BlocksByRoot(BlocksByRootRequest {
-        block_roots: VariableList::from(vec![
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-        ]),
-    });
+    let rpc_request = Request::BlocksByRoot(VariableList::from(vec![
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+    ]));
 
     // BlocksByRoot Response
     let full_block = BeaconBlock::full(&spec);
@@ -579,20 +577,18 @@ async fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
     let (mut sender, mut receiver) = common::build_node_pair(&log).await;
 
     // BlocksByRoot Request
-    let rpc_request = Request::BlocksByRoot(BlocksByRootRequest {
-        block_roots: VariableList::from(vec![
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-            Hash256::from_low_u64_be(0),
-        ]),
-    });
+    let rpc_request = Request::BlocksByRoot(BlocksByRootRequest::from(vec![
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+        Hash256::from_low_u64_be(0),
+    ]));
 
     // BlocksByRoot Response
     let full_block = BeaconBlock::full(&spec);

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -290,7 +290,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         request: BlocksByRootRequest,
     ) {
         let mut send_block_count = 0;
-        for root in request.block_roots.iter() {
+        for root in request.iter() {
             if let Ok(Some(block)) = self.chain.store.get_block(root) {
                 self.network.send_response(
                     peer_id.clone(),
@@ -311,7 +311,7 @@ impl<T: BeaconChainTypes> Processor<T> {
             self.log,
             "Received BlocksByRoot Request";
             "peer" => format!("{:?}", peer_id),
-            "requested" => request.block_roots.len(),
+            "requested" => request.len(),
             "returned" => send_block_count,
         );
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -46,7 +46,6 @@ use eth2_libp2p::PeerId;
 use fnv::FnvHashMap;
 use slog::{crit, debug, error, info, trace, warn, Logger};
 use smallvec::SmallVec;
-use ssz_types::VariableList;
 use std::boxed::Box;
 use std::ops::Sub;
 use std::sync::Arc;
@@ -501,9 +500,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             return;
         }
 
-        let request = BlocksByRootRequest {
-            block_roots: VariableList::from(vec![block_hash]),
-        };
+        let request = BlocksByRootRequest::from(vec![block_hash]);
 
         if let Ok(request_id) = self.network.blocks_by_root_request(peer_id, request) {
             self.single_block_lookups
@@ -719,9 +716,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             return;
         };
 
-        let request = BlocksByRootRequest {
-            block_roots: VariableList::from(vec![parent_hash]),
-        };
+        let request = BlocksByRootRequest::from(vec![parent_hash]);
 
         // We continue to search for the chain of blocks from the same peer. Other peers are not
         // guaranteed to have this chain of blocks.

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -95,7 +95,7 @@ impl<T: EthSpec> SyncNetworkContext<T> {
             self.log,
             "Sending BlocksByRoot Request";
             "method" => "BlocksByRoot",
-            "count" => request.block_roots.len(),
+            "count" => request.len(),
             "peer" => format!("{:?}", peer_id)
         );
         self.send_rpc_request(peer_id, Request::BlocksByRoot(request))


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes
Fix `BlocksByRootRequest`  so that it is encoded/decoded directly and not in an ssz container.


