### PR TITLE
Fix BlocksByRootRequest min/max bounds calculation

### DIFF
--- a/beacon_node/eth2_libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/methods.rs
@@ -188,7 +188,7 @@ pub struct BlocksByRangeRequest {
 }
 
 /// Request a number of beacon block bodies from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlocksByRootRequest {
     /// The list of beacon block bodies being requested.
     pub block_roots: VariableList<Hash256, MaxRequestBlocks>,

--- a/beacon_node/eth2_libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/protocol.rs
@@ -43,18 +43,16 @@ lazy_static! {
     }
     .as_ssz_bytes()
     .len();
-    pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize = BlocksByRootRequest {
-        block_roots: VariableList::<Hash256, MaxRequestBlocks>::from(Vec::<Hash256>::new())
-    }
+    pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize =
+        VariableList::<Hash256, MaxRequestBlocks>::from(Vec::<Hash256>::new())
     .as_ssz_bytes()
     .len();
-    pub static ref BLOCKS_BY_ROOT_REQUEST_MAX: usize = BlocksByRootRequest {
-        block_roots: VariableList::<Hash256, MaxRequestBlocks>::from(vec![
+    pub static ref BLOCKS_BY_ROOT_REQUEST_MAX: usize =
+        VariableList::<Hash256, MaxRequestBlocks>::from(vec![
             Hash256::zero();
             MAX_REQUEST_BLOCKS
                 as usize
         ])
-    }
     .as_ssz_bytes()
     .len();
 }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The ssz bounds were being calculated incorrectly for `BlocksByRootRequest` as we were counting the size of the ssz container as well. Fixes that to calculate bounds directly on the `VariableList` type.
