### PR TITLE
Add metrics for validator subscriptions

### DIFF
--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -2,6 +2,7 @@
 //! given time. It schedules subscriptions to shard subnets, requests peer discoveries and
 //! determines whether attestations should be aggregated and/or passed to the beacon node.
 
+use crate::metrics;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::{types::GossipKind, NetworkGlobals};
 use futures::prelude::*;
@@ -191,6 +192,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
         subscriptions: Vec<ValidatorSubscription>,
     ) -> Result<(), String> {
         for subscription in subscriptions {
+            metrics::inc_counter(&metrics::SUBNET_SUBSCRIPTION_REQUESTS);
             //NOTE: We assume all subscriptions have been verified before reaching this service
 
             // Registers the validator with the attestation service.
@@ -237,6 +239,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
             // TODO: Implement
 
             if subscription.is_aggregator {
+                metrics::inc_counter(&metrics::SUBNET_SUBSCRIPTION_AGGREGATOR_REQUESTS);
                 // set the subscription timer to subscribe to the next subnet if required
                 if let Err(e) = self.subscribe_to_subnet(exact_subnet.clone()) {
                     warn!(self.log,

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -36,4 +36,16 @@ lazy_static! {
         "network_gossip_aggregated_attestations_tx_total",
         "Count of gossip aggregated attestations transmitted"
     );
+
+    /*
+     * Attestation subnet subscriptions
+     */
+    pub static ref SUBNET_SUBSCRIPTION_REQUESTS: Result<IntCounter> = try_create_int_counter(
+        "network_subnet_subscriptions_total",
+        "Count of validator subscription requests."
+    );
+    pub static ref SUBNET_SUBSCRIPTION_AGGREGATOR_REQUESTS: Result<IntCounter> = try_create_int_counter(
+        "network_subnet_subscriptions_aggregator_total",
+        "Count of validator subscription requests where the subscriber is an aggregator."
+    );
 }


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

This is helpful for some debugging I'm doing; I can't see any unaggregrated attestations coming and I want to know if there are any subscriptions reaching the BN.
