### PR TITLE
Fix a retry limit condition

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -369,7 +369,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
     /// updates the min_ttl field.
     fn add_subnet_query(&mut self, subnet_id: SubnetId, min_ttl: Option<Instant>, retries: usize) {
         // remove the entry and complete the query if greater than the maximum search count
-        if retries >= MAX_DISCOVERY_RETRY {
+        if retries > MAX_DISCOVERY_RETRY {
             debug!(
                 self.log,
                 "Subnet peer discovery did not find sufficient peers. Reached max retry limit"


### PR DESCRIPTION
## Issue Addressed

This PR fixes the comparison operators issue. 

Let's say we don't allow retrying (`MAX_DISCOVERY_RETRY`: 0): the first querying (retry: 0) should be allowed and the first retry (retry: 1) should not be allowed.
