### PR TITLE
Add account_manager command for moving validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "bls",
  "clap",
  "clap_utils",
+ "copy_dir",
  "deposit_contract",
  "dirs",
  "environment",
@@ -710,6 +711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "copy_dir"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
+dependencies = [
+ "walkdir 0.1.8",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,7 +766,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "walkdir",
+ "walkdir 2.3.1",
 ]
 
 [[package]]
@@ -5554,6 +5564,16 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "walkdir"

--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -29,3 +29,4 @@ rand = "0.7.2"
 validator_dir = { path = "../common/validator_dir", features = ["unencrypted_keys"] }
 tokio = { version = "0.2.21", features = ["full"] }
 eth2_keystore = { path = "../crypto/eth2_keystore" }
+copy_dir = "0.1.2"

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -1,6 +1,6 @@
 use crate::{
-    common::{ensure_dir_exists, random_password, strip_off_newlines},
-    SECRETS_DIR_FLAG, VALIDATOR_DIR_FLAG,
+    common::{base_wallet_dir, ensure_dir_exists, random_password, strip_off_newlines},
+    BASE_DIR_FLAG, SECRETS_DIR_FLAG, VALIDATOR_DIR_FLAG,
 };
 use clap::{App, Arg, ArgMatches};
 use environment::Environment;
@@ -12,7 +12,6 @@ use types::EthSpec;
 use validator_dir::Builder as ValidatorDirBuilder;
 
 pub const CMD: &str = "create";
-pub const BASE_DIR_FLAG: &str = "base-dir";
 pub const WALLET_NAME_FLAG: &str = "wallet-name";
 pub const WALLET_PASSPHRASE_FLAG: &str = "wallet-passphrase";
 pub const DEPOSIT_GWEI_FLAG: &str = "deposit-gwei";
@@ -25,6 +24,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .about(
             "Creates new validators from an existing EIP-2386 wallet using the EIP-2333 HD key \
             derivation scheme.",
+        )
+        .arg(
+            Arg::with_name(BASE_DIR_FLAG)
+                .long(BASE_DIR_FLAG)
+                .value_name("BASE_DIRECTORY")
+                .help("A path containing Eth2 EIP-2386 wallets. Defaults to ~/.lighthouse/wallets")
+                .takes_value(true),
         )
         .arg(
             Arg::with_name(WALLET_NAME_FLAG)
@@ -102,11 +108,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         )
 }
 
-pub fn cli_run<T: EthSpec>(
-    matches: &ArgMatches,
-    mut env: Environment<T>,
-    wallet_base_dir: PathBuf,
-) -> Result<(), String> {
+pub fn cli_run<T: EthSpec>(matches: &ArgMatches, mut env: Environment<T>) -> Result<(), String> {
+    let wallet_base_dir = base_wallet_dir(matches, BASE_DIR_FLAG)?;
     let spec = env.core_context().eth2_config.spec;
 
     let name: String = clap_utils::parse_required(matches, WALLET_NAME_FLAG)?;

--- a/account_manager/src/validator/mod.rs
+++ b/account_manager/src/validator/mod.rs
@@ -1,8 +1,8 @@
 pub mod create;
 pub mod deposit;
+pub mod mv; // Not called `move` since it is a reserved keyword.
 
-use crate::common::base_wallet_dir;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, ArgMatches};
 use environment::Environment;
 use types::EthSpec;
 
@@ -11,23 +11,16 @@ pub const CMD: &str = "validator";
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new(CMD)
         .about("Provides commands for managing Eth2 validators.")
-        .arg(
-            Arg::with_name("base-dir")
-                .long("base-dir")
-                .value_name("BASE_DIRECTORY")
-                .help("A path containing Eth2 EIP-2386 wallets. Defaults to ~/.lighthouse/wallets")
-                .takes_value(true),
-        )
         .subcommand(create::cli_app())
         .subcommand(deposit::cli_app())
+        .subcommand(mv::cli_app())
 }
 
 pub fn cli_run<T: EthSpec>(matches: &ArgMatches, env: Environment<T>) -> Result<(), String> {
-    let base_wallet_dir = base_wallet_dir(matches, "base-dir")?;
-
     match matches.subcommand() {
-        (create::CMD, Some(matches)) => create::cli_run::<T>(matches, env, base_wallet_dir),
+        (create::CMD, Some(matches)) => create::cli_run::<T>(matches, env),
         (deposit::CMD, Some(matches)) => deposit::cli_run::<T>(matches, env),
+        (mv::CMD, Some(matches)) => mv::cli_run::<T>(matches),
         (unknown, _) => {
             return Err(format!(
                 "{} does not have a {} command. See --help",

--- a/account_manager/src/validator/mv.rs
+++ b/account_manager/src/validator/mv.rs
@@ -1,0 +1,208 @@
+use clap::{App, Arg, ArgMatches};
+use clap_utils;
+use copy_dir::copy_dir;
+use std::fmt::Debug;
+use std::fs;
+use std::path::{Path, PathBuf};
+use types::EthSpec;
+use validator_dir::{Error as ValidatorError, Manager as ValidatorManager};
+
+pub const CMD: &str = "move";
+pub const SRC_VALIDATORS_FLAG: &str = "src-validators";
+pub const SRC_SECRETS_FLAG: &str = "src-secrets";
+pub const DST_VALIDATORS_FLAG: &str = "dst-validators";
+pub const DST_SECRETS_FLAG: &str = "dst-secrets";
+pub const COUNT_FLAG: &str = "count";
+
+pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
+    App::new("move")
+        .visible_aliases(&["mv", CMD])
+        .about(
+            "Moves one or more validators from one directory into another. \
+            It is recommended to use this command instead of manual file-system
+            commands since it ensures no files are left behind and respects
+            lockfiles.",
+        )
+        .arg(
+            Arg::with_name(SRC_VALIDATORS_FLAG)
+                .long(SRC_VALIDATORS_FLAG)
+                .value_name("DIRECTORY")
+                .help("The source validators directory (e.g., ~/.lighthouse/validators)")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(SRC_SECRETS_FLAG)
+                .long(SRC_SECRETS_FLAG)
+                .value_name("DIRECTORY")
+                .help("The source secrets directory (e.g., ~/.lighthouse/secrets)")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(DST_VALIDATORS_FLAG)
+                .long(DST_VALIDATORS_FLAG)
+                .value_name("DIRECTORY")
+                .help("The destination validators directory (e.g., ~/.lighthouse-2/validators)")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(DST_SECRETS_FLAG)
+                .long(DST_SECRETS_FLAG)
+                .value_name("DIRECTORY")
+                .help("The destination secrets directory (e.g., ~/.lighthouse-2/secrets)")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(COUNT_FLAG)
+                .long(COUNT_FLAG)
+                .value_name("VALIDATOR_COUNT")
+                .help("The first VALIDATOR_COUNT unlocked validators will be moved.")
+                .takes_value(true)
+                .required(true),
+        )
+}
+
+struct ValidatorPaths {
+    validator_dir: PathBuf,
+    voting_password: PathBuf,
+    withdrawal_password: Option<PathBuf>,
+}
+
+impl ValidatorPaths {
+    pub fn moved_paths<P: AsRef<Path>>(
+        &self,
+        dst_validators_dir: P,
+        dst_secrets_dir: P,
+    ) -> Result<Self, String> {
+        Ok(ValidatorPaths {
+            validator_dir: moved_path(&self.validator_dir, &dst_validators_dir)?,
+            voting_password: moved_path(&self.voting_password, &dst_secrets_dir)?,
+            withdrawal_password: self
+                .withdrawal_password
+                .as_ref()
+                .map(|src| moved_path(src, dst_secrets_dir))
+                .transpose()?,
+        })
+    }
+}
+
+fn moved_path<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<PathBuf, String> {
+    let file_name = src
+        .as_ref()
+        .file_name()
+        .ok_or_else(|| format!("Invalid path: {:?}", src.as_ref()))?;
+    Ok(dst.as_ref().join(file_name))
+}
+
+fn log_failed_to_remove<P: AsRef<Path>, E: Debug>(src: P, e: E) {
+    eprintln!(
+        "Failed to remove {:?} due to {:?}, continuing to avoid leaving an inconsistent state. \
+        It is strongly advise to manually ensure {:?} does not exist!",
+        src.as_ref(),
+        e,
+        src.as_ref(),
+    );
+}
+
+fn move_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<(), String> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+
+    match copy_dir(&src, &dst) {
+        Ok(_) => {
+            if let Err(e) = fs::remove_dir_all(&src) {
+                log_failed_to_remove(src, e);
+            } else {
+                eprintln!("Moved {:?} to {:?}", src, dst);
+            }
+        }
+        Err(e) => {
+            // Ignore the error if we're unable to delete the dst dir, we're just doing our
+            // best to clean up after an unexpected error.
+            let _ = fs::remove_dir_all(&dst);
+            return Err(format!("Failed to move {:?} to {:?}: {:?}", src, dst, e));
+        }
+    }
+
+    Ok(())
+}
+
+fn move_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> Result<(), String> {
+    let (src, dst) = (src.as_ref(), dst.as_ref());
+
+    match fs::copy(&src, &dst) {
+        Ok(_) => {
+            if let Err(e) = fs::remove_file(&src) {
+                log_failed_to_remove(src, e);
+            } else {
+                eprintln!("Moved {:?} to {:?}", src, dst);
+            }
+        }
+        Err(e) => {
+            // Ignore the error if we're unable to delete the dst file, we're just doing our
+            // best to clean up after an unexpected error.
+            let _ = fs::remove_file(&dst);
+            return Err(format!("Failed to move {:?} to {:?}: {:?}", src, dst, e));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn cli_run<T: EthSpec>(matches: &ArgMatches<'_>) -> Result<(), String> {
+    let src_validators_dir: PathBuf = clap_utils::parse_required(matches, SRC_VALIDATORS_FLAG)?;
+    let src_secrets_dir: PathBuf = clap_utils::parse_required(matches, SRC_SECRETS_FLAG)?;
+    let dst_validators_dir: PathBuf = clap_utils::parse_required(matches, DST_VALIDATORS_FLAG)?;
+    let dst_secrets_dir: PathBuf = clap_utils::parse_required(matches, DST_SECRETS_FLAG)?;
+    let count: usize = clap_utils::parse_required(matches, COUNT_FLAG)?;
+
+    fs::create_dir_all(&dst_validators_dir)
+        .map_err(|e| format!("Unable to create {:?}: {:?}", dst_validators_dir, e))?;
+    fs::create_dir_all(&dst_secrets_dir)
+        .map_err(|e| format!("Unable to create {:?}: {:?}", dst_secrets_dir, e))?;
+
+    let manager = ValidatorManager::open(&src_validators_dir)
+        .map_err(|e| format!("Unable to read --{}: {:?}", SRC_VALIDATORS_FLAG, e))?;
+
+    let to_move = manager
+        .directory_names()
+        .map_err(|e| format!("Unable to iterate --{}: {:?}", SRC_VALIDATORS_FLAG, e))?
+        .into_iter()
+        .take(count)
+        .filter_map(|(_, path)| manager.open_validator(path).ok())
+        .map(|v| {
+            Ok(ValidatorPaths {
+                validator_dir: v.dir().into(),
+                voting_password: v.voting_keypair_password_path(&src_secrets_dir)?,
+                withdrawal_password: v.withdrawal_keypair_password_path(&src_secrets_dir).ok(),
+            })
+        })
+        .collect::<Result<Vec<_>, ValidatorError>>()
+        .map_err(|e| format!("Unable to collect validator passwords: {:?}", e))?;
+
+    if to_move.len() != count {
+        return Err(format!(
+            "Unable to collect {} unlocked validators, only {}",
+            count,
+            to_move.len()
+        ));
+    }
+
+    for src in to_move {
+        let dst = src.moved_paths(&dst_validators_dir, &dst_secrets_dir)?;
+
+        move_dir(&src.validator_dir, dst.validator_dir)?;
+        move_file(&src.voting_password, &dst.voting_password)?;
+        if let Some(src) = src.withdrawal_password {
+            let dst = dst
+                .withdrawal_password
+                .as_ref()
+                .ok_or_else(|| "Internal error: withdrawal_password should be Some")?;
+            move_file(&src, &dst)?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds the `lighthouse account validator mv` command which makes it easy to split one validator directory into multiple.

### Example:

```
lighthouse am validator mv --src-validators grouped/validators --src-secrets grouped/secrets --dst-validators split/validators --dst-secrets split/secrets --count 1
Moved "grouped/validators/0x97f0e58ca586a6b1d04eb470de9b8641b730f529a4806f6eade0355e1a777c95409a7ac735b697369957633ba3aecb80" to "split/validators/0x97f0e58ca586a6b1d04eb470de9b8641b730f529a4806f6eade0355e1a777c95409a7ac735b697369957633ba3aecb80"
Moved "grouped/secrets/0x97f0e58ca586a6b1d04eb470de9b8641b730f529a4806f6eade0355e1a777c95409a7ac735b697369957633ba3aecb80" to "split/secrets/0x97f0e58ca586a6b1d04eb470de9b8641b730f529a4806f6eade0355e1a777c95409a7ac735b697369957633ba3aecb80"
```

## TODO

- [ ] Add tests
