### PR TITLE
Loosen VC lockfile and slashing protection registers

### DIFF
--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -34,8 +34,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        enabling the same signing key on multiple validator clients WILL lead to \
                        that validator getting slashed. Only use this flag the first time you run \
                        the validator client, or if you're certain there are no other \
-                       nodes using the same key.",
+                       nodes using the same key. Automatically enabled unless `--strict` is specified",
         ))
+        .arg(
+            Arg::with_name("strict")
+            .long("strict")
+            .help(
+                "If present, require that validator keypairs are unlocked and that auto-register \
+                is explicit before new validators are allowed to be used."
+            )
+        )
         .arg(
             Arg::with_name("allow-unsynced")
                 .long("allow-unsynced")

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -23,6 +23,8 @@ pub struct Config {
     /// If true, the validator client will still poll for duties and produce blocks even if the
     /// beacon node is not synced at startup.
     pub allow_unsynced_beacon_node: bool,
+    /// If true, we will be strict about concurrency and validator registration.
+    pub strict: bool,
     /// If true, register new validator keys with the slashing protection database.
     pub auto_register: bool,
 }
@@ -42,6 +44,7 @@ impl Default for Config {
             http_server: DEFAULT_HTTP_SERVER.to_string(),
             allow_unsynced_beacon_node: false,
             auto_register: false,
+            strict: false,
         }
     }
 }
@@ -71,6 +74,12 @@ impl Config {
 
         config.allow_unsynced_beacon_node = cli_args.is_present("allow-unsynced");
         config.auto_register = cli_args.is_present("auto-register");
+        config.strict = cli_args.is_present("strict");
+
+        if !config.strict {
+            // Do not require an explicit `--auto-register` if `--strict` is disabled.
+            config.auto_register = true
+        }
 
         if let Some(secrets_dir) = parse_optional(cli_args, "secrets-dir")? {
             config.secrets_dir = secrets_dir;

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -76,9 +76,16 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             );
         }
 
-        let validators = ValidatorManager::open(&config.data_dir)
-            .map_err(|e| format!("unable to read data_dir: {:?}", e))?
-            .decrypt_all_validators(config.secrets_dir.clone(), Some(&log))
+        let validator_manager = ValidatorManager::open(&config.data_dir)
+            .map_err(|e| format!("unable to read data_dir: {:?}", e))?;
+
+        let validators_result = if config.strict {
+            validator_manager.decrypt_all_validators(config.secrets_dir.clone(), Some(&log))
+        } else {
+            validator_manager.force_decrypt_all_validators(config.secrets_dir.clone(), Some(&log))
+        };
+
+        let validators = validators_result
             .map_err(|e| format!("unable to decrypt all validator directories: {:?}", e))?;
 
         info!(


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Adds a `--strict` flag which, when present:
  - Requires that validator directories do not have lockfiles present.
  - Requires the `--auto-register` command to add new validators to the slashing DB.

In effect, what we currently do (without this PR) is the same as using `--strict`. So, this PR loosens those restrictions by default.

This is fundamentally a temporary workaround for #1313, with the `--auto-register` change thrown-in for good measure. 
