### PR TITLE
Add latest commit info to git version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
+name = "git-version"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
+dependencies = [
+ "git-version-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2744,6 +2766,7 @@ dependencies = [
  "environment",
  "eth2_testnet_config",
  "futures 0.3.5",
+ "git-version",
  "logging",
  "slog",
  "slog-async",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.43.1 AS builder
-RUN apt-get update && apt-get install -y cmake git
-RUN git clone https://github.com/sigp/lighthouse
-RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf
+RUN apt-get update && apt-get install -y cmake
+COPY . lighthouse
 RUN cd lighthouse && make
 RUN cd lighthouse && cargo install --path lcli --locked
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.43.1 AS builder
-RUN apt-get update && apt-get install -y cmake
-COPY . lighthouse
+RUN apt-get update && apt-get install -y cmake git
+RUN git clone https://github.com/sigp/lighthouse
+RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf
 RUN cd lighthouse && make
 RUN cd lighthouse && cargo install --path lcli --locked
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -25,6 +25,7 @@ validator_client = { "path" = "../validator_client" }
 account_manager = { "path" = "../account_manager" }
 clap_utils = { path = "../common/clap_utils" }
 eth2_testnet_config = { path = "../common/eth2_testnet_config" }
+git-version = "0.3.4"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -17,7 +17,7 @@ use validator_client::ProductionValidatorClient;
 pub const VERSION: &str = git_version!(
     args = ["--always", "--dirty=(modified)"],
     prefix = concat!(crate_version!(), "-"),
-    fallback = "unknown"
+    fallback = crate_version!()
 );
 pub const DEFAULT_DATA_DIR: &str = ".lighthouse";
 pub const CLIENT_CONFIG_FILENAME: &str = "beacon-node.toml";

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -7,23 +7,26 @@ use clap_utils;
 use env_logger::{Builder, Env};
 use environment::EnvironmentBuilder;
 use eth2_testnet_config::HARDCODED_TESTNET;
-use git_version::git_describe;
+use git_version::git_version;
 use slog::{crit, info, warn};
 use std::path::PathBuf;
 use std::process::exit;
 use types::EthSpec;
 use validator_client::ProductionValidatorClient;
 
-pub const GIT_LATEST_COMMIT: &str = git_describe!("--always", "--dirty=-modified");
+pub const VERSION: &str = git_version!(
+    args = ["--always", "--dirty=(modified)"],
+    prefix = concat!(crate_version!(), "-"),
+    fallback = "unknown"
+);
 pub const DEFAULT_DATA_DIR: &str = ".lighthouse";
 pub const CLIENT_CONFIG_FILENAME: &str = "beacon-node.toml";
 pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 
 fn main() {
     // Parse the CLI parameters.
-    let version = format!("{} commit {}", crate_version!(), GIT_LATEST_COMMIT);
     let matches = App::new("Lighthouse")
-        .version(version.as_str())
+        .version(VERSION)
         .author("Sigma Prime <contact@sigmaprime.io>")
         .setting(clap::AppSettings::ColoredHelp)
         .about(

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -7,20 +7,23 @@ use clap_utils;
 use env_logger::{Builder, Env};
 use environment::EnvironmentBuilder;
 use eth2_testnet_config::HARDCODED_TESTNET;
+use git_version::git_describe;
 use slog::{crit, info, warn};
 use std::path::PathBuf;
 use std::process::exit;
 use types::EthSpec;
 use validator_client::ProductionValidatorClient;
 
+pub const GIT_LATEST_COMMIT: &str = git_describe!("--always", "--dirty=-modified");
 pub const DEFAULT_DATA_DIR: &str = ".lighthouse";
 pub const CLIENT_CONFIG_FILENAME: &str = "beacon-node.toml";
 pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 
 fn main() {
     // Parse the CLI parameters.
+    let version = format!("{} commit {}", crate_version!(), GIT_LATEST_COMMIT);
     let matches = App::new("Lighthouse")
-        .version(crate_version!())
+        .version(version.as_str())
         .author("Sigma Prime <contact@sigmaprime.io>")
         .setting(clap::AppSettings::ColoredHelp)
         .about(


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Modifies the Lighthouse binary --version to include the latest commit info.
For e.g. 
```sh
$ lighthouse --version
Lighthouse 0.1.2-265234b85(modified)
```
The "modified" indicates that the binary is compiled with further modifications on top of the commit.
I think this is minimal and would be useful for debugging issues. Can include more info if needed :)

## Additional info
In case the .git folder or git is not available, version is just the crate_version (`Lighthouse 0.1.2`). 
This will happen in the docker build as well since the resulting docker image contains the commit source as metadata anyway. 
If we want the commit info in the docker image version as well, would have to change the Dockerfile to "git clone" the repo instead of COPY. Not sure if we want that.