### PR TITLE
[Merged by Bors] - Refactor inbound substream logic with async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602d785912f476e480434627e8732e6766b760c045bbf897d9dfaa9f4fbd399c"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
  "gimli",
 ]
@@ -53,22 +53,22 @@ checksum = "567b077b825e468cc974f0020d4082ee6e03132512f207ef1a02fd5d00d1f32d"
 
 [[package]]
 name = "aead"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.14.2",
 ]
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
- "block-cipher-trait",
+ "aes-soft 0.4.0",
+ "aesni 0.7.0",
+ "block-cipher",
 ]
 
 [[package]]
@@ -97,16 +97,15 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834a6bda386024dbb7c8fc51322856c10ffe69559f972261c868485f5759c638"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
  "aead",
  "aes",
- "block-cipher-trait",
+ "block-cipher",
  "ghash",
  "subtle 2.2.3",
- "zeroize",
 ]
 
 [[package]]
@@ -290,14 +289,14 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.49"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05100821de9e028f12ae3d189176b41ee198341eb8f369956407fea2f5cc666c"
+checksum = "46254cf2fdcdf1badb5934448c1bcbe046a56537b3987d96c51a7afc5d03f293"
 dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide 0.3.7",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -353,7 +352,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "log 0.4.8",
- "lru 0.5.2",
+ "lru 0.5.3",
  "merkle_proof",
  "operation_pool",
  "parking_lot 0.11.0",
@@ -434,13 +433,14 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
+checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
  "byte-tools",
- "crypto-mac 0.7.0",
- "digest 0.8.1",
+ "byteorder",
+ "crypto-mac 0.8.0",
+ "digest 0.9.0",
  "opaque-debug 0.2.3",
 ]
 
@@ -668,24 +668,24 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a7ae4c498f8447d86baef0fa0831909333f558866fabcb21600625ac5a31c7"
+checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
- "stream-cipher 0.3.2",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48901293601228db2131606f741db33561f7576b5d19c99cd66222380a7dc863"
+checksum = "18b0c90556d8e3fec7cf18d84a2f53d27b21288f2fe481b830fadcf809e48205"
 dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher 0.3.2",
+ "stream-cipher 0.4.1",
  "zeroize",
 ]
 
@@ -1507,7 +1507,7 @@ dependencies = [
  "lazy_static",
  "libp2p",
  "lighthouse_metrics",
- "lru 0.5.2",
+ "lru 0.5.3",
  "parking_lot 0.11.0",
  "serde",
  "serde_derive",
@@ -1717,7 +1717,7 @@ dependencies = [
  "crc32fast",
  "libc",
  "libz-sys",
- "miniz_oxide 0.4.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2006,18 +2006,18 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
  "polyval",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "git-version"
@@ -2326,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.5",
  "hyper 0.13.6",
@@ -3019,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297efb9401445cf7b6986a583d7ac194023334b46b294ff7da0d36662c1251c2"
+checksum = "35c456c123957de3a220cd03786e0d86aa542a88b46029973b542f426da6ef34"
 dependencies = [
  "hashbrown",
 ]
@@ -3124,15 +3124,6 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime 0.3.16",
  "unicase 2.6.0",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
 ]
 
 [[package]]
@@ -3757,18 +3748,18 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5829f50f48e9ddb79f3f7c3097029d0caee30f8286accb241416df603b080b8"
+checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
 dependencies = [
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -4214,7 +4205,7 @@ dependencies = [
  "http 0.2.1",
  "http-body 0.3.1",
  "hyper 0.13.6",
- "hyper-tls 0.4.1",
+ "hyper-tls 0.4.3",
  "js-sys",
  "lazy_static",
  "log 0.4.8",
@@ -4898,15 +4889,15 @@ dependencies = [
 
 [[package]]
 name = "snap"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fb9b0bb877b35a1cc1474a3b43d9c226a2625311760cdda2cbccbc0c7a8376"
+checksum = "da73c8f77aebc0e40c300b93f0a5f1bece7a248a36eee287d4e095f35c7b7d6e"
 
 [[package]]
 name = "snow"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0f91be479494dd92e69d9971bd23ed27037dd1c94fcf558f6c6e74e6afa654"
+checksum = "32bf8474159a95551661246cda4976e89356999e3cbfef36f493dacc3fae1e8e"
 dependencies = [
  "aes-gcm",
  "blake2",
@@ -4915,7 +4906,7 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "subtle 2.2.3",
  "x25519-dalek",
 ]
@@ -5066,7 +5057,7 @@ dependencies = [
  "lazy_static",
  "leveldb",
  "lighthouse_metrics",
- "lru 0.5.2",
+ "lru 0.5.3",
  "parking_lot 0.11.0",
  "rayon",
  "serde",
@@ -5901,11 +5892,11 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.14.2",
  "subtle 2.2.3",
 ]
 

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -254,11 +254,8 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         error: RPCResponseErrorCode,
         reason: String,
     ) {
-        self.eth2_rpc.send_response(
-            peer_id,
-            id,
-            RPCCodedResponse::from_error_code(error, reason),
-        )
+        self.eth2_rpc
+            .send_response(peer_id, id, RPCCodedResponse::Error(error, reason.into()))
     }
 
     /* Peer management functions */

--- a/beacon_node/eth2_libp2p/src/rpc/codec/ssz.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/codec/ssz.rs
@@ -56,9 +56,7 @@ impl<TSpec: EthSpec> Encoder<RPCCodedResponse<TSpec>> for SSZInboundCodec<TSpec>
                 RPCResponse::Pong(res) => res.data.as_ssz_bytes(),
                 RPCResponse::MetaData(res) => res.as_ssz_bytes(),
             },
-            RPCCodedResponse::InvalidRequest(err) => err.as_ssz_bytes(),
-            RPCCodedResponse::ServerError(err) => err.as_ssz_bytes(),
-            RPCCodedResponse::Unknown(err) => err.as_ssz_bytes(),
+            RPCCodedResponse::Error(_, err) => err.as_ssz_bytes(),
             RPCCodedResponse::StreamTermination(_) => {
                 unreachable!("Code error - attempting to encode a stream termination")
             }

--- a/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
@@ -64,9 +64,7 @@ impl<TSpec: EthSpec> Encoder<RPCCodedResponse<TSpec>> for SSZSnappyInboundCodec<
                 RPCResponse::Pong(res) => res.data.as_ssz_bytes(),
                 RPCResponse::MetaData(res) => res.as_ssz_bytes(),
             },
-            RPCCodedResponse::InvalidRequest(err) => err.as_ssz_bytes(),
-            RPCCodedResponse::ServerError(err) => err.as_ssz_bytes(),
-            RPCCodedResponse::Unknown(err) => err.as_ssz_bytes(),
+            RPCCodedResponse::Error(_, err) => err.as_ssz_bytes(),
             RPCCodedResponse::StreamTermination(_) => {
                 unreachable!("Code error - attempting to encode a stream termination")
             }

--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::cognitive_complexity)]
 
-use super::methods::{RPCCodedResponse, RequestId, ResponseTermination};
+use super::methods::{RPCCodedResponse, RPCResponseErrorCode, RequestId, ResponseTermination};
 use super::protocol::{Protocol, RPCError, RPCProtocol, RPCRequest};
 use super::{RPCReceived, RPCSend};
 use crate::rpc::protocol::{InboundFramed, OutboundFramed};
@@ -14,7 +14,7 @@ use libp2p::swarm::protocols_handler::{
     KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,
 };
 use libp2p::swarm::NegotiatedSubstream;
-use slog::{crit, debug, error, trace, warn};
+use slog::{crit, debug, warn};
 use smallvec::SmallVec;
 use std::{
     collections::hash_map::Entry,
@@ -39,6 +39,16 @@ const SHUTDOWN_TIMEOUT_SECS: u8 = 15;
 /// Identifier of inbound and outbound substreams from the handler's perspective.
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct SubstreamId(usize);
+
+type InboundSubstream<TSpec> = InboundFramed<NegotiatedSubstream, TSpec>;
+
+/// Output of the future handling the send of responses to a peer's request.
+type InboundProcessingOutput<TSpec> = (
+    InboundSubstream<TSpec>, /* substream */
+    Vec<RPCError>,           /* Errors sending messages if any */
+    bool,                    /* whether to remove the stream afterwards */
+    u64,                     /* Chunks remaining to be sent after this processing finishes */
+);
 
 /// An error encountered by the handler.
 pub enum HandlerErr {
@@ -73,7 +83,7 @@ where
     /// The upgrade for inbound substreams.
     listen_protocol: SubstreamProtocol<RPCProtocol<TSpec>>,
 
-    /// Errors ocurring on outbound and inbound connections queued for reporting back.
+    /// Errors occurring on outbound and inbound connections queued for reporting back.
     pending_errors: Vec<HandlerErr>,
 
     /// Queue of events to produce in `poll()`.
@@ -86,14 +96,7 @@ where
     dial_negotiated: u32,
 
     /// Current inbound substreams awaiting processing.
-    inbound_substreams: FnvHashMap<
-        SubstreamId,
-        (
-            InboundSubstreamState<TSpec>,
-            Option<delay_queue::Key>,
-            Protocol,
-        ),
-    >,
+    inbound_substreams: FnvHashMap<SubstreamId, InboundInfo<TSpec>>,
 
     /// Inbound substream `DelayQueue` which keeps track of when an inbound substream will timeout.
     inbound_substreams_delay: DelayQueue<SubstreamId>,
@@ -103,9 +106,6 @@ where
 
     /// Inbound substream `DelayQueue` which keeps track of when an inbound substream will timeout.
     outbound_substreams_delay: DelayQueue<SubstreamId>,
-
-    /// Map of outbound items that are queued as the stream processes them.
-    queued_outbound_items: FnvHashMap<SubstreamId, Vec<RPCCodedResponse<TSpec>>>,
 
     /// Sequential ID for waiting substreams. For inbound substreams, this is also the inbound request ID.
     current_inbound_substream_id: SubstreamId,
@@ -143,6 +143,20 @@ enum HandlerState {
     Deactivated,
 }
 
+/// Contains the information the handler keeps on established inbound substreams.
+struct InboundInfo<TSpec: EthSpec> {
+    /// State of the substream.
+    state: InboundState<TSpec>,
+    /// Responses queued for sending.
+    pending_items: Vec<RPCCodedResponse<TSpec>>,
+    /// Protocol of the original request we received from the peer.
+    protocol: Protocol,
+    /// Responses that the peer is still expecting from us.
+    remaining_chunks: u64,
+    /// Key to keep track of the substream's timeout via `self.inbound_substreams_delay`.
+    delay_key: Option<delay_queue::Key>,
+}
+
 /// Contains the information the handler keeps on established outbound substreams.
 struct OutboundInfo<TSpec: EthSpec> {
     /// State of the substream.
@@ -154,43 +168,44 @@ struct OutboundInfo<TSpec: EthSpec> {
     /// Number of chunks to be seen from the peer's response.
     // TODO: removing the option could allow clossing the streams after the number of
     // expected responses is met for all protocols.
-    // TODO: the type of this is  wrong
-    remaining_chunks: Option<usize>,
-    /// RequestId as given by the application that sent the request.
+    remaining_chunks: Option<u64>,
+    /// `RequestId` as given by the application that sent the request.
     req_id: RequestId,
 }
 
-pub enum InboundSubstreamState<TSpec>
-where
-    TSpec: EthSpec,
-{
-    /// A response has been sent, pending writing.
-    ResponsePendingSend {
-        /// The substream used to send the response
-        substream: Box<InboundFramed<NegotiatedSubstream, TSpec>>,
-        /// The message that is attempting to be sent.
-        message: RPCCodedResponse<TSpec>,
-        /// Whether a stream termination is requested. If true the stream will be closed after
-        /// this send. Otherwise it will transition to an idle state until a stream termination is
-        /// requested or a timeout is reached.
-        closing: bool,
-    },
-    /// A response has been sent, pending flush.
-    ResponsePendingFlush {
-        /// The substream used to send the response
-        substream: Box<InboundFramed<NegotiatedSubstream, TSpec>>,
-        /// Whether a stream termination is requested. If true the stream will be closed after
-        /// this send. Otherwise it will transition to an idle state until a stream termination is
-        /// requested or a timeout is reached.
-        closing: bool,
-    },
-    /// The response stream is idle and awaiting input from the application to send more chunked
-    /// responses.
-    ResponseIdle(Box<InboundFramed<NegotiatedSubstream, TSpec>>),
-    /// The substream is attempting to shutdown.
-    Closing(Box<InboundFramed<NegotiatedSubstream, TSpec>>),
+/// State of an inbound substream connection.
+enum InboundState<TSpec: EthSpec> {
+    /// The underlying substream is not being used.
+    Idle(InboundSubstream<TSpec>),
+    /// The underlying substream is processing responses.
+    Busy(Pin<Box<dyn Future<Output = InboundProcessingOutput<TSpec>> + Send>>),
     /// Temporary state during processing
     Poisoned,
+}
+
+impl<TSpec: EthSpec> InboundState<TSpec> {
+    /// Sends the given items over the underlying substream, if the state allows it, and returns the
+    /// final state.
+    fn send_items(
+        self,
+        pending_items: &mut Vec<RPCCodedResponse<TSpec>>,
+        remaining_chunks: u64,
+    ) -> Self {
+        if let InboundState::Idle(substream) = self {
+            // only send on Idle
+            if !pending_items.is_empty() {
+                // take the items that we need to send
+                let to_send = std::mem::replace(pending_items, vec![]);
+                let fut = process_inbound_substream(substream, remaining_chunks, to_send).boxed();
+                InboundState::Busy(Box::pin(fut))
+            } else {
+                // nothing to do, keep waiting for responses
+                InboundState::Idle(substream)
+            }
+        } else {
+            self
+        }
+    }
 }
 
 /// State of an outbound substream. Either waiting for a response, or in the process of sending.
@@ -209,69 +224,6 @@ pub enum OutboundSubstreamState<TSpec: EthSpec> {
     Poisoned,
 }
 
-impl<TSpec> InboundSubstreamState<TSpec>
-where
-    TSpec: EthSpec,
-{
-    /// Moves the substream state to closing and informs the connected peer. The
-    /// `queued_outbound_items` must be given as a parameter to add stream termination messages to
-    /// the outbound queue.
-    pub fn close(&mut self, outbound_queue: &mut Vec<RPCCodedResponse<TSpec>>) {
-        // When terminating a stream, report the stream termination to the requesting user via
-        // an RPC error
-        let error = RPCCodedResponse::ServerError("Request timed out".into());
-
-        // The stream termination type is irrelevant, this will terminate the
-        // stream
-        let stream_termination =
-            RPCCodedResponse::StreamTermination(ResponseTermination::BlocksByRange);
-
-        match std::mem::replace(self, InboundSubstreamState::Poisoned) {
-            // if we are busy awaiting a send/flush add the termination to the queue
-            InboundSubstreamState::ResponsePendingSend {
-                substream,
-                message,
-                closing,
-            } => {
-                if !closing {
-                    outbound_queue.push(error);
-                    outbound_queue.push(stream_termination);
-                }
-                // if the stream is closing after the send, allow it to finish
-
-                *self = InboundSubstreamState::ResponsePendingSend {
-                    substream,
-                    message,
-                    closing,
-                }
-            }
-            // if we are busy awaiting a send/flush add the termination to the queue
-            InboundSubstreamState::ResponsePendingFlush { substream, closing } => {
-                if !closing {
-                    outbound_queue.push(error);
-                    outbound_queue.push(stream_termination);
-                }
-                // if the stream is closing after the send, allow it to finish
-                *self = InboundSubstreamState::ResponsePendingFlush { substream, closing }
-            }
-            InboundSubstreamState::ResponseIdle(substream) => {
-                *self = InboundSubstreamState::ResponsePendingSend {
-                    substream,
-                    message: error,
-                    closing: true,
-                };
-            }
-            InboundSubstreamState::Closing(substream) => {
-                // let the stream close
-                *self = InboundSubstreamState::Closing(substream);
-            }
-            InboundSubstreamState::Poisoned => {
-                unreachable!("Coding error: Timeout poisoned substream")
-            }
-        };
-    }
-}
-
 impl<TSpec> RPCHandler<TSpec>
 where
     TSpec: EthSpec,
@@ -283,7 +235,6 @@ where
             events_out: SmallVec::new(),
             dial_queue: SmallVec::new(),
             dial_negotiated: 0,
-            queued_outbound_items: FnvHashMap::default(),
             inbound_substreams: FnvHashMap::default(),
             outbound_substreams: FnvHashMap::default(),
             inbound_substreams_delay: DelayQueue::new(),
@@ -360,32 +311,21 @@ where
     // NOTE: If the substream has closed due to inactivity, or the substream is in the
     // wrong state a response will fail silently.
     fn send_response(&mut self, inbound_id: SubstreamId, response: RPCCodedResponse<TSpec>) {
-        // Variables indicating if the response is an error response or a multi-part
-        // response
-        let res_is_error = response.is_error();
-        let res_is_multiple = response.multiple_responses();
-
         // check if the stream matching the response still exists
-        let (substream_state, protocol) = match self.inbound_substreams.get_mut(&inbound_id) {
-            Some((substream_state, _, protocol)) => (substream_state, protocol),
-            None => {
-                warn!(self.log, "Stream has expired. Response not sent";
-                    "response" => response.to_string(), "id" => inbound_id);
-                return;
-            }
+        let inbound_info = if let Some(info) = self.inbound_substreams.get_mut(&inbound_id) {
+            info
+        } else {
+            warn!(self.log, "Stream has expired. Response not sent";
+                "response" => response.to_string(), "id" => inbound_id);
+            return;
         };
 
         // If the response we are sending is an error, report back for handling
         match response {
-            RPCCodedResponse::InvalidRequest(ref reason)
-            | RPCCodedResponse::ServerError(ref reason)
-            | RPCCodedResponse::Unknown(ref reason) => {
-                let code = &response
-                    .error_code()
-                    .expect("Error response should map to an error code");
+            RPCCodedResponse::Error(ref code, ref reason) => {
                 let err = HandlerErr::Inbound {
                     id: inbound_id,
-                    proto: *protocol,
+                    proto: inbound_info.protocol,
                     error: RPCError::ErrorResponse(*code, reason.to_string()),
                 };
                 self.pending_errors.push(err);
@@ -399,85 +339,7 @@ where
                 "response" => response.to_string(), "id" => inbound_id);
             return;
         }
-
-        match std::mem::replace(substream_state, InboundSubstreamState::Poisoned) {
-            InboundSubstreamState::ResponseIdle(substream) => {
-                // close the stream if there is no response
-                if let RPCCodedResponse::StreamTermination(_) = response {
-                    *substream_state = InboundSubstreamState::Closing(substream);
-                } else {
-                    // send the response
-                    // if it's a single rpc request or an error close the stream after.
-                    *substream_state = InboundSubstreamState::ResponsePendingSend {
-                        substream,
-                        message: response,
-                        closing: !res_is_multiple | res_is_error,
-                    }
-                }
-            }
-            InboundSubstreamState::ResponsePendingSend {
-                substream,
-                message,
-                closing,
-            } if res_is_multiple => {
-                // the stream is in use, add the request to a pending queue if active
-                self.queued_outbound_items
-                    .entry(inbound_id)
-                    .or_insert_with(Vec::new)
-                    .push(response);
-
-                // return the state
-                *substream_state = InboundSubstreamState::ResponsePendingSend {
-                    substream,
-                    message,
-                    closing,
-                };
-            }
-            InboundSubstreamState::ResponsePendingFlush { substream, closing }
-                if res_is_multiple =>
-            {
-                // the stream is in use, add the request to a pending queue
-                self.queued_outbound_items
-                    .entry(inbound_id)
-                    .or_insert_with(Vec::new)
-                    .push(response);
-
-                // return the state
-                *substream_state =
-                    InboundSubstreamState::ResponsePendingFlush { substream, closing };
-            }
-            InboundSubstreamState::Closing(substream) => {
-                *substream_state = InboundSubstreamState::Closing(substream);
-                debug!(self.log, "Response not sent. Stream is closing"; "response" => response.to_string());
-            }
-            InboundSubstreamState::ResponsePendingSend {
-                substream, message, ..
-            } => {
-                *substream_state = InboundSubstreamState::ResponsePendingSend {
-                    substream,
-                    message,
-                    closing: true,
-                };
-                error!(
-                    self.log,
-                    "Attempted sending multiple responses to a single response request"
-                );
-            }
-            InboundSubstreamState::ResponsePendingFlush { substream, .. } => {
-                *substream_state = InboundSubstreamState::ResponsePendingFlush {
-                    substream,
-                    closing: true,
-                };
-                error!(
-                    self.log,
-                    "Attempted sending multiple responses to a single response request"
-                );
-            }
-            InboundSubstreamState::Poisoned => {
-                crit!(self.log, "Poisoned inbound substream");
-                unreachable!("Coding error: Poisoned substream");
-            }
-        }
+        inbound_info.pending_items.push(response);
     }
 
     /// Updates the `KeepAlive` returned by `connection_keep_alive`.
@@ -538,18 +400,25 @@ where
         }
 
         let (req, substream) = substream;
+        let expected_responses = req.expected_responses();
 
         // store requests that expect responses
-        if req.expected_responses() > 0 {
+        if expected_responses > 0 {
             // Store the stream and tag the output.
             let delay_key = self.inbound_substreams_delay.insert(
                 self.current_inbound_substream_id,
                 Duration::from_secs(RESPONSE_TIMEOUT),
             );
-            let awaiting_stream = InboundSubstreamState::ResponseIdle(Box::new(substream));
+            let awaiting_stream = InboundState::Idle(substream);
             self.inbound_substreams.insert(
                 self.current_inbound_substream_id,
-                (awaiting_stream, Some(delay_key), req.protocol()),
+                InboundInfo {
+                    state: awaiting_stream,
+                    pending_items: vec![],
+                    delay_key: Some(delay_key),
+                    protocol: req.protocol(),
+                    remaining_chunks: expected_responses,
+                },
             );
         }
 
@@ -709,13 +578,6 @@ where
             if delay.is_elapsed() {
                 self.state = HandlerState::Deactivated;
                 debug!(self.log, "Handler deactivated");
-                // Drain queued responses
-                for (inbound_id, queued_responses) in self.queued_outbound_items.drain() {
-                    for response in queued_responses {
-                        debug!(self.log, "Response not sent. Deactivated handler";
-                            "response" => response.to_string(), "id" => inbound_id);
-                    }
-                }
             }
         }
 
@@ -724,23 +586,22 @@ where
             match self.inbound_substreams_delay.poll_next_unpin(cx) {
                 Poll::Ready(Some(Ok(inbound_id))) => {
                     // handle a stream timeout for various states
-                    if let Some((substream_state, delay_key, protocol)) =
-                        self.inbound_substreams.get_mut(inbound_id.get_ref())
-                    {
+                    if let Some(info) = self.inbound_substreams.get_mut(inbound_id.get_ref()) {
                         // the delay has been removed
-                        *delay_key = None;
-
+                        info.delay_key = None;
                         self.pending_errors.push(HandlerErr::Inbound {
                             id: *inbound_id.get_ref(),
-                            proto: *protocol,
+                            proto: info.protocol,
                             error: RPCError::StreamTimeout,
                         });
 
-                        let outbound_queue = self
-                            .queued_outbound_items
-                            .entry(inbound_id.into_inner())
-                            .or_insert_with(Vec::new);
-                        substream_state.close(outbound_queue);
+                        if info.pending_items.last().map(|l| l.close_after()) == Some(false) {
+                            // if the last chunk does not close the stream, append an error
+                            info.pending_items.push(RPCCodedResponse::Error(
+                                RPCResponseErrorCode::ServerError,
+                                "Request timed out".into(),
+                            ));
+                        }
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
@@ -788,204 +649,80 @@ where
         let deactivated = matches!(self.state, HandlerState::Deactivated);
 
         // drive inbound streams that need to be processed
-        for request_id in self.inbound_substreams.keys().copied().collect::<Vec<_>>() {
-            // Drain all queued items until all messages have been processed for this stream
-            // TODO Improve this code logic
-            let mut drive_stream_further = true;
-            while drive_stream_further {
-                drive_stream_further = false;
-                match self.inbound_substreams.entry(request_id) {
-                    Entry::Occupied(mut entry) => {
-                        match std::mem::replace(
-                            &mut entry.get_mut().0,
-                            InboundSubstreamState::Poisoned,
-                        ) {
-                            InboundSubstreamState::ResponsePendingSend {
-                                mut substream,
-                                message,
-                                closing,
-                            } => {
-                                if deactivated {
-                                    if !closing {
-                                        // inform back to cancel this request's processing
-                                        self.pending_errors.push(HandlerErr::Inbound {
-                                            id: request_id,
-                                            proto: entry.get().2,
-                                            error: RPCError::HandlerRejected,
-                                        });
-                                    }
-                                    entry.get_mut().0 = InboundSubstreamState::Closing(substream);
-                                    drive_stream_further = true;
-                                } else {
-                                    match Sink::poll_ready(Pin::new(&mut substream), cx) {
-                                        Poll::Ready(Ok(())) => {
-                                            // stream is ready to send data
-                                            match Sink::start_send(
-                                                Pin::new(&mut substream),
-                                                message,
-                                            ) {
-                                                Ok(()) => {
-                                                    // await flush
-                                                    entry.get_mut().0 =
-                                                    InboundSubstreamState::ResponsePendingFlush {
-                                                        substream,
-                                                        closing,
-                                                    };
-                                                    drive_stream_further = true;
-                                                }
-                                                Err(e) => {
-                                                    // error with sending in the codec
-                                                    warn!(self.log, "Error sending RPC message"; "error" => e.to_string());
-                                                    // keep connection with the peer and return the
-                                                    // stream to awaiting response if this message
-                                                    // wasn't closing the stream
-                                                    if closing {
-                                                        entry.get_mut().0 =
-                                                            InboundSubstreamState::Closing(
-                                                                substream,
-                                                            );
-                                                        drive_stream_further = true;
-                                                    } else {
-                                                        // check for queued chunks and update the stream
-                                                        entry.get_mut().0 = apply_queued_responses(
-                                                            *substream,
-                                                            &mut self
-                                                                .queued_outbound_items
-                                                                .get_mut(&request_id),
-                                                            &mut drive_stream_further,
-                                                        );
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        Poll::Ready(Err(e)) => {
-                                            error!(
-                                                self.log,
-                                                "Outbound substream error while sending RPC message: {:?}",
-                                                e
-                                            );
-                                            entry.remove();
-                                            self.update_keep_alive();
-                                            return Poll::Ready(ProtocolsHandlerEvent::Close(e));
-                                        }
-                                        Poll::Pending => {
-                                            // the stream is not yet ready, continue waiting
-                                            entry.get_mut().0 =
-                                                InboundSubstreamState::ResponsePendingSend {
-                                                    substream,
-                                                    message,
-                                                    closing,
-                                                };
-                                        }
-                                    }
-                                }
+        let mut substreams_to_remove = Vec::new(); // Closed substreams that need to be removed
+        for (id, info) in self.inbound_substreams.iter_mut() {
+            match std::mem::replace(&mut info.state, InboundState::Poisoned) {
+                state @ InboundState::Idle(..) if !deactivated => {
+                    info.state = state.send_items(&mut info.pending_items, info.remaining_chunks);
+                }
+                InboundState::Idle(mut substream) => {
+                    // handler is deactivated, close the stream and mark it for removal
+                    match substream.close().poll_unpin(cx) {
+                        // if we can't close right now, put the substream back and try again later
+                        Poll::Pending => info.state = InboundState::Idle(substream),
+                        Poll::Ready(res) => {
+                            substreams_to_remove.push(id.clone());
+                            if let Some(ref delay_key) = info.delay_key {
+                                self.inbound_substreams_delay.remove(delay_key);
                             }
-                            InboundSubstreamState::ResponsePendingFlush {
-                                mut substream,
-                                closing,
-                            } => {
-                                match Sink::poll_flush(Pin::new(&mut substream), cx) {
-                                    Poll::Ready(Ok(())) => {
-                                        // finished flushing
-                                        // TODO: Duplicate code
-                                        if closing | deactivated {
-                                            if !closing {
-                                                // inform back to cancel this request's processing
-                                                self.pending_errors.push(HandlerErr::Inbound {
-                                                    id: request_id,
-                                                    proto: entry.get().2,
-                                                    error: RPCError::HandlerRejected,
-                                                });
-                                            }
-                                            entry.get_mut().0 =
-                                                InboundSubstreamState::Closing(substream);
-                                            drive_stream_further = true;
-                                        } else {
-                                            // check for queued chunks and update the stream
-                                            entry.get_mut().0 = apply_queued_responses(
-                                                *substream,
-                                                &mut self
-                                                    .queued_outbound_items
-                                                    .get_mut(&request_id),
-                                                &mut drive_stream_further,
-                                            );
-                                        }
-                                    }
-                                    Poll::Ready(Err(e)) => {
-                                        // error during flush
-                                        trace!(self.log, "Error sending flushing RPC message"; "error" => e.to_string());
-                                        // we drop the stream on error and inform the user, remove
-                                        // any pending requests
-                                        // TODO: Duplicate code
-                                        if let Some(delay_key) = &entry.get().1 {
-                                            self.inbound_substreams_delay.remove(delay_key);
-                                        }
-                                        self.queued_outbound_items.remove(&request_id);
-                                        entry.remove();
-
-                                        self.update_keep_alive();
-                                    }
-                                    Poll::Pending => {
-                                        entry.get_mut().0 =
-                                            InboundSubstreamState::ResponsePendingFlush {
-                                                substream,
-                                                closing,
-                                            };
-                                    }
-                                }
+                            if let Err(error) = res {
+                                self.pending_errors.push(HandlerErr::Inbound {
+                                    id: id.clone(),
+                                    error,
+                                    proto: info.protocol,
+                                });
                             }
-                            InboundSubstreamState::ResponseIdle(substream) => {
-                                if !deactivated {
-                                    entry.get_mut().0 = apply_queued_responses(
-                                        *substream,
-                                        &mut self.queued_outbound_items.get_mut(&request_id),
-                                        &mut drive_stream_further,
-                                    );
-                                } else {
-                                    entry.get_mut().0 = InboundSubstreamState::Closing(substream);
-                                    drive_stream_further = true;
-                                }
-                            }
-                            InboundSubstreamState::Closing(mut substream) => {
-                                match Sink::poll_close(Pin::new(&mut substream), cx) {
-                                    Poll::Ready(Ok(())) => {
-                                        if let Some(delay_key) = &entry.get().1 {
-                                            self.inbound_substreams_delay.remove(delay_key);
-                                        }
-                                        self.queued_outbound_items.remove(&request_id);
-                                        entry.remove();
-
-                                        self.update_keep_alive();
-                                    } // drop the stream
-                                    Poll::Ready(Err(e)) => {
-                                        error!(self.log, "Error closing inbound stream"; "error" => e.to_string());
-                                        // drop the stream anyway
-                                        // TODO: Duplicate code
-                                        if let Some(delay_key) = &entry.get().1 {
-                                            self.inbound_substreams_delay.remove(delay_key);
-                                        }
-                                        self.queued_outbound_items.remove(&request_id);
-                                        entry.remove();
-
-                                        self.update_keep_alive();
-                                    }
-                                    Poll::Pending => {
-                                        entry.get_mut().0 =
-                                            InboundSubstreamState::Closing(substream);
-                                    }
-                                }
-                            }
-                            InboundSubstreamState::Poisoned => {
-                                crit!(self.log, "Poisoned outbound substream");
-                                unreachable!("Coding Error: Inbound Substream is poisoned");
+                            if info.pending_items.last().map(|l| l.close_after()) == Some(false) {
+                                // if the request was still active, report back to cancel it
+                                self.pending_errors.push(HandlerErr::Inbound {
+                                    id: *id,
+                                    proto: info.protocol,
+                                    error: RPCError::HandlerRejected,
+                                });
                             }
                         }
                     }
-                    Entry::Vacant(_) => unreachable!(),
                 }
+                InboundState::Busy(mut fut) => {
+                    // first check if sending finished
+                    let state = match fut.poll_unpin(cx) {
+                        Poll::Ready((substream, errors, remove, new_remaining_chunks)) => {
+                            info.remaining_chunks = new_remaining_chunks;
+                            // report any error
+                            for error in errors {
+                                self.pending_errors.push(HandlerErr::Inbound {
+                                    id: *id,
+                                    error,
+                                    proto: info.protocol,
+                                })
+                            }
+                            if remove {
+                                substreams_to_remove.push(id.clone());
+                                if let Some(ref delay_key) = info.delay_key {
+                                    self.inbound_substreams_delay.remove(delay_key);
+                                }
+                            }
+                            InboundState::Idle(substream)
+                        }
+                        Poll::Pending => InboundState::Busy(fut),
+                    };
+                    info.state = if !deactivated {
+                        // if the last batch finished, send more.
+                        state.send_items(&mut info.pending_items, info.remaining_chunks)
+                    } else {
+                        state
+                    };
+                }
+                InboundState::Poisoned => unreachable!("Poisoned inbound substream"),
             }
         }
 
+        // remove closed substreams
+        for inbound_id in substreams_to_remove {
+            self.inbound_substreams.remove(&inbound_id);
+        }
+
+        self.update_keep_alive();
         // drive outbound streams that need to be processed
         for outbound_id in self.outbound_substreams.keys().copied().collect::<Vec<_>>() {
             // get the state and mark it as poisoned
@@ -1018,7 +755,7 @@ where
                     request,
                 } => match substream.poll_next_unpin(cx) {
                     Poll::Ready(Some(Ok(response))) => {
-                        if request.expected_responses() > 1 && !response.is_error() {
+                        if request.expected_responses() > 1 && !response.close_after() {
                             let substream_entry = entry.get_mut();
                             let delay_key = &substream_entry.delay_key;
                             // chunks left after this one
@@ -1041,8 +778,8 @@ where
                                     .reset(delay_key, Duration::from_secs(RESPONSE_TIMEOUT));
                             }
                         } else {
-                            // either this is a single response request or we received an
-                            // error only expect a single response, close the stream
+                            // either this is a single response request or this response closes the
+                            // stream
                             entry.get_mut().state = OutboundSubstreamState::Closing(substream);
                         }
 
@@ -1055,18 +792,11 @@ where
                                 Ok(RPCReceived::EndOfStream(id, t))
                             }
                             RPCCodedResponse::Success(resp) => Ok(RPCReceived::Response(id, resp)),
-                            RPCCodedResponse::InvalidRequest(ref r)
-                            | RPCCodedResponse::ServerError(ref r)
-                            | RPCCodedResponse::Unknown(ref r) => {
-                                let code = response.error_code().expect(
-                                    "Response indicating and error should map to an error code",
-                                );
-                                Err(HandlerErr::Outbound {
-                                    id,
-                                    proto,
-                                    error: RPCError::ErrorResponse(code, r.to_string()),
-                                })
-                            }
+                            RPCCodedResponse::Error(ref code, ref r) => Err(HandlerErr::Outbound {
+                                id,
+                                proto,
+                                error: RPCError::ErrorResponse(*code, r.to_string()),
+                            }),
                         };
 
                         return Poll::Ready(ProtocolsHandlerEvent::Custom(received));
@@ -1172,35 +902,6 @@ where
     }
 }
 
-// Check for new items to send to the peer and update the underlying stream
-fn apply_queued_responses<TSpec: EthSpec>(
-    substream: InboundFramed<NegotiatedSubstream, TSpec>,
-    queued_outbound_items: &mut Option<&mut Vec<RPCCodedResponse<TSpec>>>,
-    new_items_to_send: &mut bool,
-) -> InboundSubstreamState<TSpec> {
-    match queued_outbound_items {
-        Some(ref mut queue) if !queue.is_empty() => {
-            *new_items_to_send = true;
-            // we have queued items
-            match queue.remove(0) {
-                RPCCodedResponse::StreamTermination(_) => {
-                    // close the stream if this is a stream termination
-                    InboundSubstreamState::Closing(Box::new(substream))
-                }
-                chunk => InboundSubstreamState::ResponsePendingSend {
-                    substream: Box::new(substream),
-                    message: chunk,
-                    closing: false,
-                },
-            }
-        }
-        _ => {
-            // no items queued set to idle
-            InboundSubstreamState::ResponseIdle(Box::new(substream))
-        }
-    }
-}
-
 impl slog::Value for SubstreamId {
     fn serialize(
         &self,
@@ -1210,4 +911,44 @@ impl slog::Value for SubstreamId {
     ) -> slog::Result {
         slog::Value::serialize(&self.0, record, key, serializer)
     }
+}
+
+/// Sends the queued items to the peer.
+async fn process_inbound_substream<TSpec: EthSpec>(
+    mut substream: InboundSubstream<TSpec>,
+    mut remaining_chunks: u64,
+    pending_items: Vec<RPCCodedResponse<TSpec>>,
+) -> InboundProcessingOutput<TSpec> {
+    let mut errors = Vec::new();
+    let mut substream_closed = false;
+
+    for item in pending_items {
+        if !substream_closed {
+            if matches!(item, RPCCodedResponse::StreamTermination(_)) {
+                substream.close().await.unwrap_or_else(|e| errors.push(e));
+                substream_closed = true;
+            } else {
+                remaining_chunks = remaining_chunks.saturating_sub(1);
+                // chunks that are not stream terminations get sent, and the stream is closed if
+                // the response is an error
+                let is_error = matches!(item, RPCCodedResponse::Error(..));
+
+                substream
+                    .send(item)
+                    .await
+                    .unwrap_or_else(|e| errors.push(e));
+
+                if remaining_chunks == 0 || is_error {
+                    substream.close().await.unwrap_or_else(|e| errors.push(e));
+                    substream_closed = true;
+                }
+            }
+        } else {
+            // we have more items after a closed substream, report those as errors
+            errors.push(RPCError::InternalError(
+                "Sending responses to closed inbound substream",
+            ));
+        }
+    }
+    (substream, errors, substream_closed, remaining_chunks)
 }

--- a/beacon_node/eth2_libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/protocol.rs
@@ -323,12 +323,12 @@ impl<TSpec: EthSpec> RPCRequest<TSpec> {
     /* These functions are used in the handler for stream management */
 
     /// Number of responses expected for this request.
-    pub fn expected_responses(&self) -> usize {
+    pub fn expected_responses(&self) -> u64 {
         match self {
             RPCRequest::Status(_) => 1,
             RPCRequest::Goodbye(_) => 0,
-            RPCRequest::BlocksByRange(req) => req.count as usize,
-            RPCRequest::BlocksByRoot(req) => req.block_roots.len(),
+            RPCRequest::BlocksByRange(req) => req.count,
+            RPCRequest::BlocksByRoot(req) => req.block_roots.len() as u64,
             RPCRequest::Ping(_) => 1,
             RPCRequest::MetaData(_) => 1,
         }


### PR DESCRIPTION
## Issue Addressed
#1112 

The logic is slightly different but still valid wrt to error handling.
- Inbound state is either Busy with a future that return the subtream (and info about the processing)
- The state machine works as follows:
  - `Idle` with pending responses => `Busy`
  - `Busy` => finished ? if so and there are new pending responses then `Busy`, if not then `Idle`
               => not finished remains `Busy`
- Add an `InboundInfo` for readability
- Other stuff:
  - Close inbound substreams when all expected responses are sent
  - Remove the error variants from `RPCCodedResponse` and use the codes instead
  - Fix various spelling mistakes because I got sloppy last time

Sorry for the delay