### PR TITLE
Timeouts for github downloads via build scripts

### DIFF
--- a/common/eth2_testnet_config/build.rs
+++ b/common/eth2_testnet_config/build.rs
@@ -5,8 +5,11 @@ use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::time::Duration;
 
 const TESTNET_ID: &str = "altona-v3";
+
+const HTTP_REQUEST_TIMEOUT_SECONDS: Duration = Duration::from_secs(60 * 5);
 
 fn main() {
     if !base_dir().exists() {
@@ -48,6 +51,7 @@ pub fn get_file(filename: &str) -> Result<(), String> {
         File::create(path).map_err(|e| format!("Failed to create {}: {:?}", filename, e))?;
 
     let request = reqwest::blocking::Client::builder()
+        .timeout(Some(HTTP_REQUEST_TIMEOUT_SECONDS))
         .build()
         .map_err(|_| "Could not build request client".to_string())?
         .get(&url)


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

There have been reports that users behind the GFW (China) get ~10kbs download speeds from Github when downloading the genesis file during the `build.rs` of the `eth2_testnet_config` crate.

This PR adds a very long timeout (5 minutes). I'm just making this as a hot-patch for now, but I think we should look at being able to modify this value, since it may(?) cause a 5 min wait for users that are not connected to the internet.

## TODO

- [ ] Review default timeout, potentially make accessible via env var.
