### PR TITLE
Update smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
  "slog-term",
  "sloggers",
  "slot_clock",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "state_processing",
  "store",
  "tempfile",
@@ -641,7 +641,7 @@ dependencies = [
  "ethereum-types",
  "quickcheck",
  "quickcheck_macros",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "tree_hash",
 ]
 
@@ -1243,7 +1243,7 @@ dependencies = [
  "rand 0.7.3",
  "rlp",
  "sha2 0.8.2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "tokio 0.2.21",
  "uint",
  "zeroize",
@@ -1516,7 +1516,7 @@ dependencies = [
  "slog-async",
  "slog-stdlog",
  "slog-term",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "snap",
  "tempdir",
  "tiny-keccak 2.0.2",
@@ -1535,7 +1535,7 @@ version = "0.1.2"
 dependencies = [
  "eth2_ssz_derive",
  "ethereum-types",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
 ]
 
 [[package]]
@@ -2619,7 +2619,7 @@ dependencies = [
  "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=95e27446ca4371e41fc0035b187f60daa19b4b86)",
  "parking_lot 0.10.2",
  "pin-project",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2649,7 +2649,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2683,7 +2683,7 @@ dependencies = [
  "ring",
  "rw-stream-sink",
  "sha2 0.8.2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "thiserror",
  "unsigned-varint 0.4.0",
  "void",
@@ -2728,7 +2728,7 @@ dependencies = [
  "prost-build",
  "rand 0.7.3",
  "sha2 0.8.2",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
  "wasm-timer",
 ]
@@ -2744,7 +2744,7 @@ dependencies = [
  "log 0.4.8",
  "prost",
  "prost-build",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "wasm-timer",
 ]
 
@@ -2821,7 +2821,7 @@ dependencies = [
  "libp2p-core 0.19.2 (git+https://github.com/sigp/rust-libp2p?rev=95e27446ca4371e41fc0035b187f60daa19b4b86)",
  "log 0.4.8",
  "rand 0.7.3",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "void",
  "wasm-timer",
 ]
@@ -3250,7 +3250,7 @@ dependencies = [
  "futures 0.3.5",
  "log 0.4.8",
  "pin-project",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
 ]
 
@@ -3264,7 +3264,7 @@ dependencies = [
  "futures 0.3.5",
  "log 0.4.8",
  "pin-project",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "unsigned-varint 0.4.0",
 ]
 
@@ -3324,7 +3324,7 @@ dependencies = [
  "slog",
  "sloggers",
  "slot_clock",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "state_processing",
  "store",
  "tempfile",
@@ -3403,7 +3403,7 @@ dependencies = [
  "num-traits",
  "rand 0.7.3",
  "serde",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "zeroize",
 ]
 
@@ -3639,7 +3639,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -3654,7 +3654,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "winapi 0.3.9",
 ]
 
@@ -4338,7 +4338,7 @@ dependencies = [
  "libsqlite3-sys",
  "lru-cache",
  "memchr",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "time 0.1.43",
 ]
 
@@ -4871,9 +4871,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "snafu"
@@ -5739,7 +5739,7 @@ dependencies = [
  "ethereum-types",
  "lazy_static",
  "rand 0.7.3",
- "smallvec 1.4.0",
+ "smallvec 1.4.1",
  "tree_hash_derive",
  "types",
 ]

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -15,7 +15,7 @@ merkle_proof = { path = "../../consensus/merkle_proof" }
 store = { path = "../store" }
 parking_lot = "0.11.0"
 lazy_static = "1.4.0"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 log = "0.4.8"
 operation_pool = { path = "../operation_pool" }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -23,7 +23,7 @@ fnv = "1.0.7"
 unsigned-varint = { git = "https://github.com/sigp/unsigned-varint", branch = "latest-codecs", features = ["codec"] }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 lru = "0.5.1"
 parking_lot = "0.11.0"
 sha2 = "0.9.1"

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -19,7 +19,7 @@ use libp2p::{
     },
     PeerId,
 };
-use slog::{crit, debug, o};
+use slog::{crit, debug, o, trace};
 use std::{
     collections::VecDeque,
     marker::PhantomData,
@@ -355,7 +355,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         let ping = crate::rpc::Ping {
             data: self.meta_data.seq_number,
         };
-        debug!(self.log, "Sending Ping"; "request_id" => id, "peer_id" => peer_id.to_string());
+        trace!(self.log, "Sending Ping"; "request_id" => id, "peer_id" => peer_id.to_string());
 
         self.eth2_rpc
             .send_request(peer_id, id, RPCRequest::Ping(ping));
@@ -366,7 +366,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         let ping = crate::rpc::Ping {
             data: self.meta_data.seq_number,
         };
-        debug!(self.log, "Sending Pong"; "request_id" => id.1, "peer_id" => peer_id.to_string());
+        trace!(self.log, "Sending Pong"; "request_id" => id.1, "peer_id" => peer_id.to_string());
         let event = RPCCodedResponse::Success(RPCResponse::Pong(ping));
         self.eth2_rpc.send_response(peer_id, id, event);
     }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -30,7 +30,7 @@ futures = "0.3.5"
 error-chain = "0.12.2"
 tokio = { version = "0.2.21", features = ["full"] }
 parking_lot = "0.11.0"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 # TODO: Remove rand crate for mainnet
 rand = "0.7.3"
 fnv = "1.0.6"

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -11,7 +11,7 @@ eth2_hashing = "0.1.0"
 eth2_ssz_derive = "0.1.0"
 eth2_ssz = "0.1.2"
 tree_hash = "0.1.0"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -14,7 +14,7 @@ eth2_ssz_derive = "0.1.0"
 
 [dependencies]
 ethereum-types = "0.9.1"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 [dependencies]
 ethereum-types = "0.9.1"
 eth2_hashing = "0.1.0"
-smallvec = "1.4.0"
+smallvec = "1.4.1"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]


### PR DESCRIPTION
The version of smallvec we are using has been yanked from crates.io

This PR updates smallvec to the latest version.