### PR TITLE
[Merged by Bors] - Tune CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - trying
+      - 'pr/*'
   pull_request:
 
 jobs:


### PR DESCRIPTION
`pr/*` branches now trigger CI before creating a PR to avoid submitting PR with failing tests.

Details in the commit messages.