### PR TITLE
Fix query expiry computation

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -75,7 +75,7 @@ impl QueryType {
             Self::FindPeers => false,
             Self::Subnet { min_ttl, .. } => {
                 if let Some(ttl) = min_ttl {
-                    ttl > &Instant::now()
+                    ttl < &Instant::now()
                 } else {
                     true
                 }
@@ -471,7 +471,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
             .count();
 
         if peers_on_subnet > TARGET_SUBNET_PEERS {
-            trace!(self.log, "Discovery ignored";
+            debug!(self.log, "Discovery ignored";
                 "reason" => "Already connected to desired peers",
                 "connected_peers_on_subnet" => peers_on_subnet,
                 "target_subnet_peers" => TARGET_SUBNET_PEERS,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes
In some cases, validators were missing attestations on the Altona testnet. This could be one of the reasons why we are missing attestations.
On receiving an attestation duty, the beacon node should ensure that it has some minimum sufficient peers. If not it should make a discovery query for peers in that subnet.

Before making the discovery subnet query, we check if the query has expired and retain only ones that are still valid here:
https://github.com/sigp/lighthouse/blob/559b7c8faa839d218d464479861010a21e38465e/beacon_node/eth2_libp2p/src/discovery/mod.rs#L420

This PR fixes a bug in the query expiry calculation because of which the discovery queries would not have been made even if we didn't have sufficient peers in that subnet.

Note: Most of the times, we end up not having to make this discovery query as we are connected to enough nodes who are subscribed to multiple subnets. Currently running a node with a single validator with this fix on Altona. Haven't hit this case yet. Will check again tomorrow. 
