### PR TITLE
Fix condition for resubscription

### DIFF
--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -285,7 +285,7 @@ impl DutiesStore {
                     duties.compute_selection_proof(validator_store)?;
 
                     // Determine if a re-subscription is required.
-                    let should_resubscribe = duties.subscription_eq(known_duties);
+                    let should_resubscribe = !duties.subscription_eq(known_duties);
 
                     // Replace the existing duties.
                     *known_duties = duties;


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

This PR fixes an edge case I hit while running altona where the VC didn't resubscribe after a change in duties due to a chain reorg.
After the duties change, we should have ideally received `InsertOutcome::Replaced {should_resubscribe: true}` and subscribed to the updated duty here:
https://github.com/sigp/lighthouse/blob/e8d5d37bc15f0e5a19248f564fba687f2d1f126f/validator_client/src/duties_service.rs#L645
but we received `should_resubscribe` as `false`.



