### PR TITLE
[Merged by Bors] - Correct environment compiling

### DIFF
--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = "0.2.21"
+tokio = { version = "0.2.21", features = ["macros"] }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.0"
 types = { "path" = "../../consensus/types" }


### PR DESCRIPTION
Adds the macro feature to tokio to allow the environment crate to compile independently