### PR TITLE
[Merged by Bors] - Return 32-bit architecture error earlier

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -156,6 +156,13 @@ fn run<E: EthSpec>(
     environment_builder: EnvironmentBuilder<E>,
     matches: &ArgMatches,
 ) -> Result<(), String> {
+    if std::mem::size_of::<usize>() != 8 {
+        return Err(format!(
+            "{}bit architecture is not supported (64bit only).",
+            std::mem::size_of::<usize>() * 8
+        ));
+    }
+
     let debug_level = matches
         .value_of("debug-level")
         .ok_or_else(|| "Expected --debug-level flag".to_string())?;
@@ -178,15 +185,6 @@ fn run<E: EthSpec>(
             .parse::<PathBuf>()
             .map_err(|e| format!("Failed to parse log path: {:?}", e))?;
         environment.log_to_json_file(path, debug_level, log_format)?;
-    }
-
-    if std::mem::size_of::<usize>() != 8 {
-        crit!(
-            log,
-            "Lighthouse only supports 64bit CPUs";
-            "detected" => format!("{}bit", std::mem::size_of::<usize>() * 8)
-        );
-        return Err("Invalid CPU architecture".into());
     }
 
     // Note: the current code technically allows for starting a beacon node _and_ a validator


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Exits *earlier* when system is 32-bit. Previously we were trying (and failing) to parse the genesis SSZ first. This made for a bad user experience.

## Additional Info

NA
