### PR TITLE
Fix attestation propagation

### DIFF
--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -271,7 +271,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
     /// Checks if we have subscribed aggregate validators for the subnet. If not, checks the gossip
     /// verification, re-propagates and returns false.
     pub fn should_process_attestation(
-        &mut self,
+        &self,
         subnet: SubnetId,
         attestation: &Attestation<T::EthSpec>,
     ) -> bool {

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -12,10 +12,6 @@ lazy_static! {
         "network_gossip_unaggregated_attestations_rx_total",
         "Count of gossip unaggregated attestations received"
     );
-    pub static ref GOSSIP_UNAGGREGATED_ATTESTATIONS_IGNORED: Result<IntCounter> = try_create_int_counter(
-        "network_gossip_unaggregated_attestations_ignored_total",
-        "Count of gossip unaggregated attestations ignored by attestation service"
-    );
     pub static ref GOSSIP_AGGREGATED_ATTESTATIONS_RX: Result<IntCounter> = try_create_int_counter(
         "network_gossip_aggregated_attestations_rx_total",
         "Count of gossip aggregated attestations received"

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -344,8 +344,8 @@ fn spawn_service<T: BeaconChainTypes>(
                                     PubsubMessage::Attestation(ref subnet_and_attestation) => {
                                         let subnet = subnet_and_attestation.0;
                                         let attestation = &subnet_and_attestation.1;
-                                        // checks if we have an aggregator for the slot. If so, we process
-                                        // the attestation
+                                        // checks if we have an aggregator for the slot. If so, we should process
+                                        // the attestation, else we just just propagate the Attestation.
                                         let should_process = service.attestation_service.should_process_attestation(
                                             subnet,
                                             attestation,

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -346,25 +346,22 @@ fn spawn_service<T: BeaconChainTypes>(
                                         let attestation = &subnet_and_attestation.1;
                                         // checks if we have an aggregator for the slot. If so, we process
                                         // the attestation
-                                        if service.attestation_service.should_process_attestation(
+                                        let should_process = service.attestation_service.should_process_attestation(
                                             subnet,
                                             attestation,
-                                        ) {
-                                            let _ = service
-                                                .router_send
-                                                .send(RouterMessage::PubsubMessage(id, source, message))
-                                                .map_err(|_| {
-                                                    debug!(service.log, "Failed to send pubsub message to router");
-                                                });
-                                        } else {
-                                            metrics::inc_counter(&metrics::GOSSIP_UNAGGREGATED_ATTESTATIONS_IGNORED)
-                                        }
+                                        );
+                                        let _ = service
+                                            .router_send
+                                            .send(RouterMessage::PubsubMessage(id, source, message, should_process))
+                                            .map_err(|_| {
+                                                debug!(service.log, "Failed to send pubsub message to router");
+                                            });
                                     }
                                     _ => {
                                         // all else is sent to the router
                                         let _ = service
                                             .router_send
-                                            .send(RouterMessage::PubsubMessage(id, source, message))
+                                            .send(RouterMessage::PubsubMessage(id, source, message, true))
                                             .map_err(|_| {
                                                 debug!(service.log, "Failed to send pubsub message to router");
                                             });


### PR DESCRIPTION
## Issue Addressed


Ideally, on receiving an unaggregated attestation, we should forward the attestation to gossip if the attestation verification passes. Not doing so might lead to missed attestation in the following scenario:
- We are scheduled to attest on some slot `X` of an epoch
- We are connected to `n` peers on that subnet. All `n` are Lighthouse peers who are **not** aggregators for slot `X`. Hence, when they receive our attestation, they don't forward it to their gossip peers who might be aggregators:
https://github.com/sigp/lighthouse/blob/fc5e6cbbb0f5c7ef139aeb76662ff21d995eeff5/beacon_node/network/src/service.rs#L349-L352
Hence, our attestation doesn't reach an aggregator and we miss the attestation for the slot.

## Proposed Changes

Adds a `bool` field to the `RouterMessage::PubsubMessage` variant which indicates if the `Attestation` should be processed by the beacon chain after successful verification. 
If the bool is `false`, we just propagate the attestation on successful verification, else we propagate and process the attestation for aggregation.

Also removes the `GOSSIP_UNAGGREGATED_ATTESTATIONS_IGNORED` metric.

## Additional info

The `should_process` boolean is useful only for `PubsubMessage::Attestation` and not for any other variant. I couldn't think of a better way of only propagating if we aren't aggregators for a slot without some significant refactoring of the network service. Please let me know if there's a better way :)