### PR TITLE
[Merged by Bors] - Small improvement: encapsulate a public field

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -586,10 +586,7 @@ where
         let backend =
             CachingEth1Backend::new(Eth1Config::default(), log.clone(), self.spec.clone());
 
-        let mut eth1_chain = Eth1Chain::new(backend);
-        eth1_chain.use_dummy_backend = true;
-
-        self.eth1_chain = Some(eth1_chain);
+        self.eth1_chain = Some(Eth1Chain::new_dummy(backend));
 
         Ok(self)
     }

--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -82,7 +82,7 @@ where
     backend: T,
     /// When `true`, the backend will be ignored and dummy data from the 2019 Canada interop method
     /// will be used instead.
-    pub use_dummy_backend: bool,
+    use_dummy_backend: bool,
     _phantom: PhantomData<E>,
 }
 
@@ -96,6 +96,13 @@ where
             backend,
             use_dummy_backend: false,
             _phantom: PhantomData,
+        }
+    }
+
+    pub fn new_dummy(backend: T) -> Self {
+        Self {
+            use_dummy_backend: true,
+            ..Self::new(backend)
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

This PR makes the `Eth1Chain::use_dummy_backend` field private. I believe this could be good to ensure the consistency  of a Eth1Chain instance. 💡 
