### PR TITLE
Close outbound rpc stream after sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "exit-future",
  "futures 0.3.5",
  "genesis",
- "hyper 0.13.6",
+ "hyper 0.13.7",
  "logging",
  "node_test_rig",
  "rand 0.7.3",

--- a/beacon_node/eth2_libp2p/src/rpc/protocol.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/protocol.rs
@@ -395,7 +395,11 @@ where
 
         let mut socket = Framed::new(socket, codec);
 
-        let future = async { socket.send(self).await.map(|_| socket) };
+        let future = async {
+            socket.send(self).await?;
+            socket.close().await?;
+            Ok(socket)
+        };
         Box::pin(future)
     }
 }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

For rpc requests, the spec requires that 
>The requester MUST close the write side of the stream once it finishes writing the request message.

which we weren't doing. Tested this fix on altona and onyx and it is working fine. Able to peer with Teku peers as well.