### PR TITLE
Discv5 update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1209,9 +1209,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.1.0-alpha.6"
+version = "0.1.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98b6912fcca9a6491fc1addcd4d205323005d922d65cb67bfed8748bc8a89b6"
+checksum = "d7083584562c5b36f929dbe621437a911eef4f8ac73bab1b1c64c8f556212943"
 dependencies = [
  "arrayvec",
  "digest 0.8.1",
@@ -1228,7 +1228,7 @@ dependencies = [
  "multihash",
  "net2",
  "openssl",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.0",
  "rand 0.7.3",
  "rlp",
  "sha2 0.8.2",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -32,7 +32,7 @@ snap = "1.0.0"
 void = "1.0.2"
 tokio-io-timeout = "0.4.0"
 tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
-discv5 = { version = "0.1.0-alpha.6", features = ["libp2p"] }
+discv5 = { version = "0.1.0-alpha.7", features = ["libp2p"] }
 tiny-keccak = "2.0.2"
 environment = { path = "../../lighthouse/environment" }
 

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -104,8 +104,8 @@ impl Default for Config {
             .enable_packet_filter()
             .session_cache_capacity(1000)
             .request_timeout(Duration::from_secs(4))
-            .request_retries(2)
-            .enr_peer_update_min(2) // prevents NAT's should be raised for mainnet
+            .request_retries(1)
+            .enr_peer_update_min(10)
             .query_parallelism(5)
             .query_timeout(Duration::from_secs(30))
             .query_peer_timeout(Duration::from_secs(2))

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -21,4 +21,4 @@ slog-json = "2.3.0"
 exit-future = "0.2.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-discv5 = "0.1.0-alpha.6"
+discv5 = "0.1.0-alpha.7"


### PR DESCRIPTION
## Description

There was a bug in discv5 which could lead to a panic. This appeared to be exasperated by performing re-requests of discovery packets. 

This PR updates discv5 to a version which addresses the panic and removes retries from the discovery protocol. 

It also updates the minimum number of peers before our local ENR gets updated to 10, to prevent the chance of non-contactable addresses being added to the DHT.
