### PR TITLE
[Merged by Bors] - Prefer viable nightly Rust builds for CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -145,8 +145,8 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
-    - name: Get latest version of nightly Rust
-      run: rustup update nightly
+    - name: Install a nightly compiler with rustfmt, as a kind of quality control
+      run: rustup toolchain install --component=rustfmt nightly
     - name: Install cargo-udeps
       run: cargo install cargo-udeps --locked
     - name: Run cargo udeps to identify unused crates in the dependency graph


### PR DESCRIPTION
## Proposed Changes

CI is failing on PRs because of a regression in nightly Rust. This change forces `rustup` to install a version of the nightly compiler that can at least build `rustfmt`, which should reduce the frequency of this happening.

## Additional Info

Example failing run: https://github.com/sigp/lighthouse/runs/896694659

Alternatively, we could allow CI to succeed even when `cargo-udeps` fails, but I think we should avoid doing that unless we really have to.
