### PR TITLE
[Merged by Bors] - Fix early return from DepositLog parsing

### DIFF
--- a/beacon_node/eth1/src/deposit_log.rs
+++ b/beacon_node/eth1/src/deposit_log.rs
@@ -63,9 +63,8 @@ impl DepositLog {
                 .map_err(|e| format!("Invalid signature ssz: {:?}", e))?,
         };
 
-        let deposit_signature_message = deposit_pubkey_signature_message(&deposit_data, spec)
-            .ok_or_else(|| "Unable to prepare deposit signature verification".to_string())?;
-        let signature_is_valid = deposit_signature_set(&deposit_signature_message).is_valid();
+        let signature_is_valid = deposit_pubkey_signature_message(&deposit_data, spec)
+            .map_or(false, |msg| deposit_signature_set(&msg).is_valid());
 
         Ok(DepositLog {
             deposit_data,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

When parsing deposit logs, we were returning an error in case `PublicKeyBytes` or `SignatureBytes` didn't convert to valid bls `PublicKey` or `Signature` types. This would stall our import of deposit logs. 
Fixes this by returning `signature_is_valid` as `false` in `DepositLog` if the bytes are invalid `PublicKey/Signature` types.

Tested this fix on the Onyx deposit contract where the bug was observed and it works correctly as expected. 