### PR TITLE
Replace max_peers cli argument by target_peers and use excess peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1509,6 +1509,7 @@ dependencies = [
  "lighthouse_metrics",
  "lru 0.5.3",
  "parking_lot 0.11.0",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "sha2 0.9.1",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -35,6 +35,8 @@ tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
 discv5 = { version = "0.1.0-alpha.7", features = ["libp2p"] }
 tiny-keccak = "2.0.2"
 environment = { path = "../../lighthouse/environment" }
+# TODO: Remove rand crate for mainnet
+rand = "0.7.3"
 
 [dependencies.libp2p]
 #version = "0.19.1"

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -37,7 +37,7 @@ pub struct Config {
     pub enr_tcp_port: Option<u16>,
 
     /// Target number of connected peers.
-    pub max_peers: usize,
+    pub target_peers: usize,
 
     /// Gossipsub configuration parameters.
     #[serde(skip)]
@@ -122,7 +122,7 @@ impl Default for Config {
             enr_address: None,
             enr_udp_port: None,
             enr_tcp_port: None,
-            max_peers: 50,
+            target_peers: 50,
             gs_config,
             discv5_config,
             boot_nodes: vec![],

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -63,6 +63,11 @@ impl<T: EthSpec> PeerInfo<T> {
         }
         false
     }
+
+    /// Reports if this peer has some future validator duty in which case it is valuable to keep it.
+    pub fn has_future_duty(&self) -> bool {
+        self.min_ttl.map_or(false, |i| i >= Instant::now())
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -67,9 +67,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("max-peers")
-                .long("max-peers")
-                .help("The maximum number of peers.")
+            Arg::with_name("target-peers")
+                .long("target-peers")
+                .help("The target number of peers.")
                 .default_value("50")
                 .takes_value(true),
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -90,10 +90,10 @@ pub fn get_config<E: EthSpec>(
         client_config.network.listen_address = listen_address;
     }
 
-    if let Some(max_peers_str) = cli_args.value_of("max-peers") {
-        client_config.network.max_peers = max_peers_str
+    if let Some(target_peers_str) = cli_args.value_of("target-peers") {
+        client_config.network.target_peers = target_peers_str
             .parse::<usize>()
-            .map_err(|_| format!("Invalid number of max peers: {}", max_peers_str))?;
+            .map_err(|_| format!("Invalid number of target peers: {}", target_peers_str))?;
     }
 
     if let Some(port_str) = cli_args.value_of("port") {


### PR DESCRIPTION
## Issue Addressed

#1374 

## Proposed Changes

We replace the `max_peers` cli argument by `target_peers`. Furthermore a `PEER_EXCESS_FACTOR` gets introduced that is a relative excess limit for the number of peers above `target_peers`. If more peers than target_peers are connected we disconnect the ones with the worst scores in regular intervals (`PeerManager` heartbeat).