### PR TITLE
[Merged by Bors] - Add info about valid deposit count to logs

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -227,6 +227,15 @@ impl Service {
             .get_valid_signature_count(self.highest_safe_block()?)
     }
 
+    /// Returns the number of deposits with valid signatures that have been observed, without
+    /// respecting the `highest_safe_block`.
+    pub fn get_raw_valid_signature_count(&self) -> Option<usize> {
+        let deposits = self.deposits().read();
+        deposits
+            .cache
+            .get_valid_signature_count(deposits.cache.latest_block_number()?)
+    }
+
     /// Returns the number of deposits with valid signatures that have been observed up to and
     /// including the block at `block_number`.
     ///

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -146,6 +146,7 @@ impl Eth1GenesisService {
                         "Waiting for more deposits";
                         "min_genesis_active_validators" => spec.min_genesis_active_validator_count,
                         "total_deposits" => eth1_service.deposit_cache_len(),
+                        "valid_deposits" => eth1_service.get_raw_valid_signature_count(),
                     );
 
                     delay_for(update_interval).await;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a `valid_deposits` field to the logs whilst waiting for genesis:

```
Jul 25 11:02:25.631 INFO Waiting for more deposits               valid_deposits: 3085, total_deposits: 3188, min_genesis_active_validators: 16384, service: beacon
```

In this example we can see there are `3188` deposits, but only `3085` have valid signatures.

## Additional Info

NA
