### PR TITLE
[Merged by Bors] - Update to EF tests v0.12.2

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v0.12.1
+TESTS_TAG := v0.12.2
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -207,6 +207,25 @@ impl<E: EthSpec + TypeName, T: EpochTransition<E>> Handler for EpochProcessingHa
     }
 }
 
+pub struct FinalityHandler<E>(PhantomData<E>);
+
+impl<E: EthSpec + TypeName> Handler for FinalityHandler<E> {
+    // Reuse the blocks case runner.
+    type Case = cases::SanityBlocks<E>;
+
+    fn config_name() -> &'static str {
+        E::name()
+    }
+
+    fn runner_name() -> &'static str {
+        "finality"
+    }
+
+    fn handler_name() -> String {
+        "finality".into()
+    }
+}
+
 pub struct GenesisValidityHandler<E>(PhantomData<E>);
 
 impl<E: EthSpec + TypeName> Handler for GenesisValidityHandler<E> {

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -10,7 +10,8 @@ fn config_test<E: EthSpec + TypeName>() {
         .join("eth2.0-spec-tests")
         .join("tests")
         .join(E::name())
-        .join("config.yaml");
+        .join("config")
+        .join("phase0.yaml");
     let yaml_config = YamlConfig::from_file(&config_path).expect("config file loads OK");
     let spec = E::default_spec();
     let yaml_from_spec = YamlConfig::from_spec::<E>(&spec);
@@ -233,8 +234,14 @@ fn epoch_processing_slashings() {
 
 #[test]
 fn epoch_processing_final_updates() {
+    EpochProcessingHandler::<MinimalEthSpec, FinalUpdates>::run();
     EpochProcessingHandler::<MainnetEthSpec, FinalUpdates>::run();
-    EpochProcessingHandler::<MainnetEthSpec, FinalUpdates>::run();
+}
+
+#[test]
+fn finality() {
+    FinalityHandler::<MinimalEthSpec>::run();
+    FinalityHandler::<MainnetEthSpec>::run();
 }
 
 #[test]


### PR DESCRIPTION
Update the EF test vectors to v0.12.2 so that they include the new finality tests. Also, correct a typo that caused the epoch processing final update tests not to run on the minimal spec.
