### PR TITLE
[Merged by Bors] - Fix clippy lints rpc

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -593,11 +593,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             info!(self.log, "Sync state updated"; "old_state" => format!("{}", old_state), "new_state" => format!("{}",new_state));
         }
     }
+
     /* Processing State Functions */
     // These functions are called in the main poll function to transition the state of the sync
     // manager
 
-    #[allow(clippy::needless_return)]
     /// A new block has been received for a parent lookup query, process it.
     fn process_parent_request(&mut self, mut parent_request: ParentRequests<T::EthSpec>) {
         // verify the last added block is the parent of the last requested block
@@ -658,7 +658,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     // add the block back to the queue and continue the search
                     parent_request.downloaded_blocks.push(newest_block);
                     self.request_parent(parent_request);
-                    return;
                 }
                 Ok(_) | Err(BlockError::BlockIsAlreadyKnown { .. }) => {
                     spawn_block_processor(
@@ -685,7 +684,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         parent_request.last_submitted_peer,
                         PeerAction::MidToleranceError,
                     );
-                    return;
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed
#1388 partially (eth2_libp2p & network)

## Proposed Changes 
TLDR at the end
- *Complex types* are 3 on the handlers/Behaviours but the types are `Poll<ComplexType>` where `ComplexType` comes from the traits of libp2p. Those, I don't thing are worth an alias. A couple more were from using tokio combinators and were removed writing things the async way and using [`BoxFuture`](https://docs.rs/futures/0.3.5/futures/future/type.BoxFuture.html)
- The *cognitive complexity*.. I tried to address those before (they come from the poll functions too) and tbh they are cognitively simpler to understand the way they are now. Moving separate parts to functions doesn't add much since that code is not repeated and they all do early returns. If moved those returns would now need to be wrapped in an Option, probably, and checked to be returned again. I would leave them like that but that's just preference.
- *Too many arguments*: They are not easily put together in a wrapping struct since the parameters don't relate semantically (Ex: fn new with a log, a reference to the chain, a peer, etc) but some may differ.
- *Needless returns* were indeed needless

## Additional Info
TLDR: removed needless return, used BoxFuture and async, left the rest untouched since those lgtm
