### PR TITLE
[Merged by Bors] - Improve account manager CLI

### DIFF
--- a/account_manager/src/validator/deposit.rs
+++ b/account_manager/src/validator/deposit.rs
@@ -50,7 +50,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long(VALIDATOR_DIR_FLAG)
                 .value_name("VALIDATOR_DIRECTORY")
                 .help(
-                    "The path the validator client data directory. \
+                    "The path to the validator client data directory. \
                     Defaults to ~/.lighthouse/validators",
                 )
                 .takes_value(true),

--- a/account_manager/src/validator/list.rs
+++ b/account_manager/src/validator/list.rs
@@ -1,12 +1,23 @@
 use crate::VALIDATOR_DIR_FLAG;
-use clap::{App, ArgMatches};
+use clap::{App, Arg, ArgMatches};
 use std::path::PathBuf;
 use validator_dir::Manager as ValidatorManager;
 
 pub const CMD: &str = "list";
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
-    App::new(CMD).about("Lists the names of all validators.")
+    App::new(CMD)
+        .arg(
+            Arg::with_name(VALIDATOR_DIR_FLAG)
+                .long(VALIDATOR_DIR_FLAG)
+                .value_name("VALIDATOR_DIRECTORY")
+                .help(
+                    "The path to search for validator directories. \
+                    Defaults to ~/.lighthouse/validators",
+                )
+                .takes_value(true),
+        )
+        .about("Lists the names of all validators.")
 }
 
 pub fn cli_run(matches: &ArgMatches<'_>) -> Result<(), String> {

--- a/account_manager/src/wallet/mod.rs
+++ b/account_manager/src/wallet/mod.rs
@@ -11,7 +11,7 @@ pub const CMD: &str = "wallet";
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new(CMD)
-        .about("TODO")
+        .about("Manage wallets, from which validator keys can be derived.")
         .arg(
             Arg::with_name(BASE_DIR_FLAG)
                 .long(BASE_DIR_FLAG)

--- a/common/validator_dir/src/manager.rs
+++ b/common/validator_dir/src/manager.rs
@@ -2,7 +2,7 @@ use crate::{Error as ValidatorDirError, ValidatorDir};
 use bls::Keypair;
 use rayon::prelude::*;
 use slog::{info, warn, Logger};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::read_dir;
 use std::io;
 use std::iter::FromIterator;
@@ -163,13 +163,13 @@ impl Manager {
     /// ## Errors
     ///
     /// Returns an error if a directory is unable to be read.
-    pub fn directory_names(&self) -> Result<HashMap<String, PathBuf>, Error> {
-        Ok(HashMap::from_iter(self.iter_dir()?.into_iter().filter_map(
-            |path| {
+    pub fn directory_names(&self) -> Result<BTreeMap<String, PathBuf>, Error> {
+        Ok(BTreeMap::from_iter(
+            self.iter_dir()?.into_iter().filter_map(|path| {
                 path.file_name()
                     .and_then(|os_string| os_string.to_str().map(|s| s.to_string()))
                     .map(|filename| (filename, path))
-            },
-        )))
+            }),
+        ))
     }
 }


### PR DESCRIPTION
## Proposed Changes

Fixes some sharp edges on the new `lighthouse account validator list` command, and the account manager CLI.

* Validator names/keys are always printed in the same order due to the use of a sorted `BTreeMap`
* The `validator list` subcommand now respects the `--validator-dir` flag, instead of always looking in `~/.lighthouse/validators`
* The `--help` now shows a description for the `wallet` subcommand instead of just `TODO`
