### PR TITLE
[Merged by Bors] - Sync update

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -158,7 +158,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             info.score.apply_peer_action(action);
             if previous_state != info.score.state() {
                 match info.score.state() {
-                    ScoreState::Ban => {
+                    ScoreState::Banned => {
                         debug!(self.log, "Peer has been banned"; "peer_id" => peer_id.to_string(), "score" => info.score.to_string());
                         ban_peer = Some(peer_id.clone());
                         if info.connection_status.is_connected_or_dialing() {
@@ -168,7 +168,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                             ));
                         }
                     }
-                    ScoreState::Disconnect => {
+                    ScoreState::Disconnected => {
                         debug!(self.log, "Peer transitioned to disconnect state"; "peer_id" => peer_id.to_string(), "score" => info.score.to_string(), "past_state" => previous_state.to_string());
                         // disconnect the peer if it's currently connected or dialing
                         unban_peer = Some(peer_id.clone());
@@ -502,7 +502,11 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     .peers
                     .read()
                     .is_connected_or_dialing(&peer_id)
-                && !self.network_globals.peers.read().is_banned(&peer_id)
+                && !self
+                    .network_globals
+                    .peers
+                    .read()
+                    .is_banned_or_disconnected(&peer_id)
             {
                 // TODO: Update output
                 // This should be updated with the peer dialing. In fact created once the peer is
@@ -630,7 +634,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             // handle score transitions
             if previous_state != info.score.state() {
                 match info.score.state() {
-                    ScoreState::Ban => {
+                    ScoreState::Banned => {
                         debug!(self.log, "Peer has been banned"; "peer_id" => peer_id.to_string(), "score" => info.score.to_string());
                         to_ban_peers.push(peer_id.clone());
                         if info.connection_status.is_connected_or_dialing() {
@@ -640,7 +644,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                             ));
                         }
                     }
-                    ScoreState::Disconnect => {
+                    ScoreState::Disconnected => {
                         debug!(self.log, "Peer transitioned to disconnect state"; "peer_id" => peer_id.to_string(), "score" => info.score.to_string(), "past_state" => previous_state.to_string());
                         // disconnect the peer if it's currently connected or dialing
                         to_unban_peers.push(peer_id.clone());

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -1,6 +1,6 @@
 use super::peer_info::{PeerConnectionStatus, PeerInfo};
 use super::peer_sync_status::PeerSyncStatus;
-use super::score::Score;
+use super::score::{Score, ScoreState};
 use crate::rpc::methods::MetaData;
 use crate::PeerId;
 use rand::seq::SliceRandom;
@@ -99,9 +99,17 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
 
     /// Returns true if the Peer is banned.
     pub fn is_banned(&self, peer_id: &PeerId) -> bool {
-        match self.peers.get(peer_id).map(|info| &info.connection_status) {
-            Some(status) => status.is_banned(),
-            None => false,
+        match self.peers.get(peer_id).map(|info| info.score.state()) {
+            Some(ScoreState::Banned) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the Peer is either banned or in the disconnected state.
+    pub fn is_banned_or_disconnected(&self, peer_id: &PeerId) -> bool {
+        match self.peers.get(peer_id).map(|info| info.score.state()) {
+            Some(ScoreState::Banned) | Some(ScoreState::Disconnected) => true,
+            _ => false,
         }
     }
 

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -60,10 +60,10 @@ pub(crate) enum ScoreState {
     /// We are content with the peers performance. We permit connections and messages.
     Healthy,
     /// The peer should be disconnected. We allow re-connections if the peer is persistent.
-    Disconnect,
+    Disconnected,
     /// The peer is banned. We disallow new connections until it's score has decayed into a
     /// tolerable threshold.
-    Ban,
+    Banned,
 }
 
 /// A peer's score (perceived potential usefulness).
@@ -138,8 +138,8 @@ impl std::fmt::Display for ScoreState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ScoreState::Healthy => write!(f, "Healthy"),
-            ScoreState::Ban => write!(f, "Ban"),
-            ScoreState::Disconnect => write!(f, "Disconnect"),
+            ScoreState::Banned => write!(f, "Banned"),
+            ScoreState::Disconnected => write!(f, "Disconnected"),
         }
     }
 }
@@ -164,8 +164,8 @@ impl Score {
     /// Returns the expected state of the peer given it's score.
     pub(crate) fn state(&self) -> ScoreState {
         match self.score {
-            x if x <= MIN_SCORE_BEFORE_BAN => ScoreState::Ban,
-            x if x <= MIN_SCORE_BEFORE_DISCONNECT => ScoreState::Disconnect,
+            x if x <= MIN_SCORE_BEFORE_BAN => ScoreState::Banned,
+            x if x <= MIN_SCORE_BEFORE_DISCONNECT => ScoreState::Disconnected,
             _ => ScoreState::Healthy,
         }
     }

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -39,21 +39,31 @@ pub struct Batch<T: EthSpec> {
     pub id: BatchId,
     /// The requested start slot of the batch, inclusive.
     pub start_slot: Slot,
-    /// The requested end slot of batch, inclusive.
+    /// The requested end slot of batch, exlcusive.
     pub end_slot: Slot,
-    /// The peer that was originally assigned to the batch.
-    pub original_peer: PeerId,
+    /// The `Attempts` that have been made to send us this batch.
+    pub attempts: Vec<Attempt>,
     /// The peer that is currently assigned to the batch.
     pub current_peer: PeerId,
     /// The number of retries this batch has undergone due to a failed request.
+    /// This occurs when peers do not respond or we get an RPC error.
     pub retries: u8,
     /// The number of times this batch has attempted to be re-downloaded and re-processed. This
     /// occurs when a batch has been received but cannot be processed.
     pub reprocess_retries: u8,
-    /// Marks the batch as undergoing a re-process, with a hash of the original blocks it received.
-    pub original_hash: Option<u64>,
     /// The blocks that have been downloaded.
     pub downloaded_blocks: Vec<SignedBeaconBlock<T>>,
+}
+
+/// Represents a peer's attempt and providing the result for this batch.
+///
+/// Invalid attempts will downscore a peer.
+#[derive(PartialEq, Debug)]
+pub struct Attempt {
+    /// The peer that made the attempt.
+    pub peer_id: PeerId,
+    /// The hash of the blocks of the attempt.
+    pub hash: u64,
 }
 
 impl<T: EthSpec> Eq for Batch<T> {}
@@ -64,11 +74,10 @@ impl<T: EthSpec> Batch<T> {
             id,
             start_slot,
             end_slot,
-            original_peer: peer_id.clone(),
+            attempts: Vec::new(),
             current_peer: peer_id,
             retries: 0,
             reprocess_retries: 0,
-            original_hash: None,
             downloaded_blocks: Vec::new(),
         }
     }

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -39,7 +39,7 @@ pub struct Batch<T: EthSpec> {
     pub id: BatchId,
     /// The requested start slot of the batch, inclusive.
     pub start_slot: Slot,
-    /// The requested end slot of batch, exclusive.
+    /// The requested end slot of batch, inclusive.
     pub end_slot: Slot,
     /// The peer that was originally assigned to the batch.
     pub original_peer: PeerId,

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -549,7 +549,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         debug!(self.log, "Re-requesting batch";
             "chain_id" => self.id,
             "start_slot" => batch.start_slot,
-            "end_slot" => batch.end_slot - 1, // The -1 shows invlusive
+            "end_slot" => batch.end_slot -1, // The -1 shows inclusive blocks
             "id" => *batch.id,
             "peer" => format!("{}", batch.current_peer),
             "retries" => batch.retries,
@@ -685,7 +685,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             debug!(self.log, "Re-Requesting batch";
                 "chain_id" => self.id,
                 "start_slot" => batch.start_slot,
-                "end_slot" => batch.end_slot -1,
+                "end_slot" => batch.end_slot -1, // The -1 shows inclusive blocks
+
                 "id" => *batch.id,
                 "peer" => format!("{:?}", batch.current_peer));
             self.send_batch(network, batch);
@@ -710,7 +711,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 debug!(self.log, "Requesting batch";
                     "chain_id" => self.id,
                     "start_slot" => batch.start_slot,
-                    "end_slot" => batch.end_slot - 1,
+                    "end_slot" => batch.end_slot -1, // The -1 shows inclusive blocks 
                     "id" => *batch.id,
                     "peer" => format!("{}", batch.current_peer));
                 // send the batch
@@ -748,8 +749,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     ///
     ///
     /// Epoch boundary |                                   |
-    /// | 30 | 31 | 32 | 33 | 34 | ... | 61 | 62 | 63 | 64 | 65 |
-    ///  Batch 1       |           Batch 2                 |  Batch 3
+    ///  ... | 30 | 31 | 32 | 33 | 34 | ... | 61 | 62 | 63 | 64 | 65 |
+    ///       Batch 1       |              Batch 2              |  Batch 3
     fn get_next_batch(&mut self, peer_id: PeerId) -> Option<Batch<T::EthSpec>> {
         let slots_per_epoch = T::EthSpec::slots_per_epoch();
         let blocks_per_batch = slots_per_epoch * EPOCHS_PER_BATCH;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -746,11 +746,10 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     ///
     /// For example:
     ///
-    /// ```
+    ///
     /// Epoch boundary |                                   |
     /// | 30 | 31 | 32 | 33 | 34 | ... | 61 | 62 | 63 | 64 | 65 |
     ///  Batch 1       |           Batch 2                 |  Batch 3
-    ///  ```
     fn get_next_batch(&mut self, peer_id: PeerId) -> Option<Batch<T::EthSpec>> {
         let slots_per_epoch = T::EthSpec::slots_per_epoch();
         let blocks_per_batch = slots_per_epoch * EPOCHS_PER_BATCH;


### PR DESCRIPTION
## Issue Addressed

Recurring sync loop and invalid batch downloading

## Proposed Changes

Shifts the batches to include the first slot of each epoch. This ensures the finalized is always downloaded once a chain has completed syncing. 

Also add in logic to prevent re-dialing disconnected peers. Non-performant peers get disconnected during sync, this prevents re-connection to these during sync. 

## Additional Info

N/A
