### PR TITLE
[Merged by Bors] - Limit incoming connection requests

### DIFF
--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -103,6 +103,9 @@ impl<TSpec: EthSpec> Service<TSpec> {
                 }
             }
             SwarmBuilder::new(transport, behaviour, local_peer_id.clone())
+                .notify_handler_buffer_size(std::num::NonZeroUsize::new(32).expect("Not zero"))
+                .connection_event_buffer_size(64)
+                .incoming_connection_limit(10)
                 .peer_connection_limit(MAX_CONNECTIONS_PER_PEER)
                 .executor(Box::new(Executor(executor)))
                 .build()


### PR DESCRIPTION
## Issue Addressed

Limits the number of incoming connections and adjusts the buffer sizes in libp2p