### PR TITLE
[Merged by Bors] - Check deposit signatures when submitting via CLI

### DIFF
--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -11,6 +11,7 @@ slog = "2.5.2"
 slog-term = "2.5.0"
 slog-async = "2.5.0"
 types = { path = "../consensus/types" }
+state_processing = { path = "../consensus/state_processing" }
 dirs = "2.0.2"
 environment = { path = "../lighthouse/environment" }
 deposit_contract = { path = "../common/deposit_contract" }


### PR DESCRIPTION
## Proposed Changes

Having been bitten by submitting deposits with invalid signatures (for the wrong testnet), I'm proposing we check the signatures of deposits when submitting them via `lighthouse account validator deposit`.

The impact on performance is likely to be minimal because waiting for an Eth1 transaction confirmation takes a lot longer than verifying a single signature.

It would be great to have the same protection in the deposit web UI in the Lighthouse Book, but I imagine that will be obsoleted by the validator web UI work.