### PR TITLE
Allow docker to target generic CPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rust:1.44.1 AS builder
 RUN apt-get update && apt-get install -y cmake
 COPY . lighthouse
+RUN export RUSTFLAGS="-C target-cpu=generic"
 RUN cd lighthouse && make
 RUN cd lighthouse && cargo install --path lcli --locked
 


### PR DESCRIPTION
## Issue Addressed

#1395 

## Proposed Changes

When docker compiles the lighthouse binary it does it for a specific CPU architecture. This PR modifies the docker build to use a generic CPU architecture so that docker images may run on a variety of machines.

## Additional Info
