### PR TITLE
Downgrade sync and rpc warn logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,13 +2657,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "libp2p"
 version = "0.22.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-gossipsub",
@@ -2676,7 +2676,7 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multihash",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.1",
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2699,8 +2699,8 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.11",
  "multihash",
- "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2752,8 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+version = "0.20.2"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "quote",
  "syn",
@@ -2762,17 +2762,17 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
 ]
 
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
@@ -2781,7 +2781,7 @@ dependencies = [
  "futures 0.3.5",
  "futures_codec",
  "hex_fmt",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "libp2p-swarm",
  "log 0.4.11",
  "lru_time_cache",
@@ -2797,10 +2797,10 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "libp2p-swarm",
  "log 0.4.11",
  "prost",
@@ -2812,13 +2812,13 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
@@ -2827,13 +2827,13 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.21.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "prost",
  "prost-build",
@@ -2848,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "aes-ctr 0.3.0",
  "ctr 0.3.2",
@@ -2856,7 +2856,7 @@ dependencies = [
  "hmac 0.7.1",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "parity-send-wrapper",
  "pin-project",
@@ -2877,10 +2877,10 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.1",
@@ -2891,13 +2891,13 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "futures 0.3.5",
  "futures-timer",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "socket2",
  "tokio 0.2.22",
@@ -2906,12 +2906,12 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.21.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "async-tls",
  "either",
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "log 0.4.11",
  "quicksink",
  "rustls",
@@ -2925,10 +2925,10 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3284,7 +3284,7 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.8.2"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
@@ -3572,7 +3572,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8211054ddd6576d3f1cc317ecb207f1b47308c22#8211054ddd6576d3f1cc317ecb207f1b47308c22"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
 dependencies = [
  "arrayref",
  "bs58",

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -307,7 +307,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn handle_rpc_error(&mut self, peer_id: &PeerId, protocol: Protocol, err: &RPCError) {
         let client = self.network_globals.client(peer_id);
         let score = self.network_globals.peers.read().score(peer_id);
-        warn!(self.log, "RPC Error"; "protocol" => protocol.to_string(), "err" => err.to_string(), "client" => client.to_string(), "peer_id" => peer_id.to_string(), "score" => score.to_string());
+        debug!(self.log, "RPC Error"; "protocol" => protocol.to_string(), "err" => err.to_string(), "client" => client.to_string(), "peer_id" => peer_id.to_string(), "score" => score.to_string());
 
         // Map this error to a `PeerAction` (if any)
         let peer_action = match err {

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -10,7 +10,7 @@ use futures::Stream;
 use hashset_delay::HashSetDelay;
 use libp2p::core::multiaddr::Protocol as MProtocol;
 use libp2p::identify::IdentifyInfo;
-use slog::{crit, debug, error, warn};
+use slog::{crit, debug, error};
 use smallvec::SmallVec;
 use std::{
     net::SocketAddr,

--- a/beacon_node/network/src/sync/block_processor.rs
+++ b/beacon_node/network/src/sync/block_processor.rs
@@ -60,12 +60,12 @@ pub fn spawn_block_processor<T: BeaconChainTypes>(
                         BatchProcessResult::Success
                     }
                     (imported_blocks, Err(e)) if imported_blocks > 0 => {
-                        warn!(log, "Batch processing failed but imported some blocks";
+                        debug!(log, "Batch processing failed but imported some blocks";
                             "id" => *batch_id, "error" => e, "imported_blocks"=> imported_blocks);
                         BatchProcessResult::Partial
                     }
                     (_, Err(e)) => {
-                        warn!(log, "Batch processing failed"; "id" => *batch_id, "error" => e);
+                        debug!(log, "Batch processing failed"; "id" => *batch_id, "error" => e);
                         BatchProcessResult::Failed
                     }
                 };
@@ -237,7 +237,7 @@ fn handle_failed_chain_segment(error: BlockError, log: &slog::Logger) -> Result<
             Err(format!("Internal error whilst processing block: {:?}", e))
         }
         other => {
-            warn!(
+            debug!(
                 log, "Invalid block received";
                 "msg" => "peer sent invalid block",
                 "outcome" => format!("{:?}", other),

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -644,7 +644,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         request_id: RequestId,
     ) -> Option<ProcessingResult> {
         if let Some(batch) = self.pending_batches.remove(request_id) {
-            warn!(self.log, "Batch failed. RPC Error";
+            debug!(self.log, "Batch failed. RPC Error";
                 "chain_id" => self.id,
                 "id" => *batch.id,
                 "retries" => batch.retries,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Downgrade the WARN logs from the RPC and sync (which are primarily for debugging) which pollute a normal terminal with warnings. 


## Additional Info

