### PR TITLE
[Merged by Bors] - Add top-level feature to enable Milagro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.1.1"
+source = "git+https://github.com/sigp/blst.git?rev=dad1ad0cd22861e5773bee177bee4e1684792605#dad1ad0cd22861e5773bee177bee4e1684792605"
 dependencies = [
  "cc",
  "glob",

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 write_ssz_files = ["beacon_node/write_ssz_files"]
 # Compiles the BLS crypto code so that the binary is portable across machines.
 portable = ["bls/supranational-portable"]
+# Uses the slower Milagro BLS library, which is written in native Rust.
+milagro = ["bls/milagro"]
 
 [dependencies]
 beacon_node = { "path" = "../beacon_node" }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -21,6 +21,16 @@ pub const VERSION: &str = git_version!(
 pub const DEFAULT_DATA_DIR: &str = ".lighthouse";
 pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 
+fn bls_library_name() -> &'static str {
+    if cfg!(feature = "portable") {
+        "blst-portable"
+    } else if cfg!(feature = "milagro") {
+        "milagro"
+    } else {
+        "blst"
+    }
+}
+
 fn main() {
     // Parse the CLI parameters.
     let matches = App::new("Lighthouse")
@@ -30,6 +40,13 @@ fn main() {
         .about(
             "Ethereum 2.0 client by Sigma Prime. Provides a full-featured beacon \
              node, a validator client and utilities for managing validator accounts.",
+        )
+        .long_version(
+            format!(
+                "{}\n\
+                 BLS Library: {}",
+                 VERSION, bls_library_name()
+            ).as_str()
         )
         .arg(
             Arg::with_name("spec")


### PR DESCRIPTION
## Proposed Changes

In the continuing war against unportable binaries I figured we should have an option to enable building the Lighthouse binary itself with Milagro. This PR adds a `milagro` feature that can be used with `cargo install --path lighthouse --features milagro --force --locked`. The BLS library in-use will also show up under `lighthouse --version` like this:

```
Lighthouse 0.1.2-7d8acc20a(modified)
BLS Library: milagro
```

Future work: add other cool stuff like the compiler version and CPU target to `--version`.