### PR TITLE
[Merged by Bors] - Add Medalla genesis state, more boot enr

### DIFF
--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -118,9 +118,9 @@ define_net!(
     medalla,
     include_medalla_file,
     "medalla",
-    "b21fef76ddf472c6cea62d5c98b678033a9b195a",
+    "2c0cd6c380fa83b65e199216e132b416bcf5a7a1",
     "https://raw.githubusercontent.com/sigp/witti/{{ commit }}/medalla/{{ file }}",
-    false
+    true
 );
 
 #[cfg(test)]

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -118,7 +118,7 @@ define_net!(
     medalla,
     include_medalla_file,
     "medalla",
-    "2c0cd6c380fa83b65e199216e132b416bcf5a7a1",
+    "09bbf2c9d108944ac934f94ec6a1d0684ca062a5",
     "https://raw.githubusercontent.com/sigp/witti/{{ commit }}/medalla/{{ file }}",
     true
 );


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Include the Medalla `genesis.ssz` file.
- Adds the boot nodes from here: https://github.com/goerli/medalla/blob/27e7e7cc878c5484867cbef78b7a83d74238aced/medalla/bootnodes.txt

## Additional Info

NA
