### PR TITLE
Update score decay behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
+ "state_processing",
  "tokio 0.2.22",
  "types",
  "validator_dir",
@@ -2658,13 +2659,13 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "libp2p"
 version = "0.22.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-gossipsub",
@@ -2677,7 +2678,7 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multihash",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.1",
@@ -2687,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2700,8 +2701,8 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.11",
  "multihash",
- "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2754,7 +2755,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.20.2"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "quote",
  "syn",
@@ -2763,17 +2764,17 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
 ]
 
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
@@ -2782,7 +2783,7 @@ dependencies = [
  "futures 0.3.5",
  "futures_codec",
  "hex_fmt",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "libp2p-swarm",
  "log 0.4.11",
  "lru_time_cache",
@@ -2798,10 +2799,10 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "libp2p-swarm",
  "log 0.4.11",
  "prost",
@@ -2813,13 +2814,13 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
@@ -2828,13 +2829,13 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.21.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "prost",
  "prost-build",
@@ -2849,7 +2850,7 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "aes-ctr 0.3.0",
  "ctr 0.3.2",
@@ -2857,7 +2858,7 @@ dependencies = [
  "hmac 0.7.1",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "parity-send-wrapper",
  "pin-project",
@@ -2878,10 +2879,10 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.1",
@@ -2892,13 +2893,13 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "futures 0.3.5",
  "futures-timer",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "socket2",
  "tokio 0.2.22",
@@ -2907,12 +2908,12 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.21.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "async-tls",
  "either",
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "log 0.4.11",
  "quicksink",
  "rustls",
@@ -2926,10 +2927,10 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822)",
+ "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3286,7 +3287,7 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 [[package]]
 name = "multistream-select"
 version = "0.8.2"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
@@ -3574,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8e9e35994e63716c6eb0a05b9702133d113b3822#8e9e35994e63716c6eb0a05b9702133d113b3822"
+source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
 dependencies = [
  "arrayref",
  "bs58",

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -199,6 +199,8 @@ impl Score {
                 <= Some(BANNED_BEFORE_DECAY)
         {
             // The peer is banned and still within the ban timeout. Do not update it's score.
+            // Update last_updated so that the decay begins correctly when ready.
+            self.last_updated = now;
             return;
         }
 


### PR DESCRIPTION
## Issue Addressed

Banned peer's scores would decay rapidly once the banning timeout expired. 

## Proposed Changes

Update the decay logic for banned peers to start once the banned peer timeout expires.

