### PR TITLE
[Merged by Bors] - Track gossip subscriptions as a metric

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -406,9 +406,23 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
                 }
             }
             GossipsubEvent::Subscribed { peer_id, topic } => {
+                if let Some(topic_metric) = metrics::get_int_gauge(
+                    &metrics::GOSSIPSUB_SUBSCRIBED_PEERS_COUNT,
+                    &[topic.as_str()],
+                ) {
+                    topic_metric.inc()
+                }
+
                 self.add_event(BehaviourEvent::PeerSubscribed(peer_id, topic));
             }
-            GossipsubEvent::Unsubscribed { .. } => {}
+            GossipsubEvent::Unsubscribed { peer_id: _, topic } => {
+                if let Some(topic_metric) = metrics::get_int_gauge(
+                    &metrics::GOSSIPSUB_SUBSCRIBED_PEERS_COUNT,
+                    &[topic.as_str()],
+                ) {
+                    topic_metric.dec()
+                }
+            }
         }
     }
 

--- a/beacon_node/eth2_libp2p/src/metrics.rs
+++ b/beacon_node/eth2_libp2p/src/metrics.rs
@@ -34,6 +34,11 @@ lazy_static! {
         "Unsolicited discovery requests per ip per second",
         &["Addresses"]
     );
+    pub static ref GOSSIPSUB_SUBSCRIBED_PEERS_COUNT: Result<IntGaugeVec> = try_create_int_gauge_vec(
+        "gossipsub_peers_per_topic_count",
+        "Peers subscribed per topic",
+        &["topic_hash"]
+    );
 }
 
 pub fn scrape_discovery_metrics() {


### PR DESCRIPTION
## Issue Addressed
#1399 

## Proposed Changes
Set an Int gauge per topic and inc/dec when peers subscribe/unsubscribe