### PR TITLE
[Merged by Bors] - Add reason to invalid attestation log

### DIFF
--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -596,6 +596,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         debug!(
             self.log,
             "Invalid attestation from network";
+            "reason" => format!("{:?}", error),
             "block" => format!("{}", beacon_block_root),
             "peer_id" => peer_id.to_string(),
             "type" => format!("{:?}", attestation_type),


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds an extra field to a debug log so we can see *why* an attestation was invalid.

## Additional Info

NA
