### PR TITLE
[Merged by Bors] - Ensure .git is copied into docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@ tests/ef_tests/eth2.0-spec-tests
 target/
 *.data
 *.tar.gz
-.git


### PR DESCRIPTION
## Issue Addressed

- Resolves #1461 

## Proposed Changes

Copy the `.git` directory across when building docker so we can get commit information.

Unfortunately this means duplicating you `.git` directory which might be quite large (mine is >100mb). Notably this directory isn't contained in the final image, just the intermediate builder image.

## Additional Info

NA
