### PR TITLE
[Merged by Bors] - Correct version string

### DIFF
--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -10,7 +10,7 @@ use target_info::Target;
 /// `Lighthouse/v0.2.0-1419501f2+`
 pub const VERSION: &str = git_version!(
     args = ["--always", "--dirty=+"],
-    prefix = "Lighthouse/v0.2.0/",
+    prefix = "Lighthouse/v0.2.0-",
     fallback = "unknown"
 );
 


### PR DESCRIPTION
Corrects the version string to expected result

i.e 
`Lighthouse/v0.2.0-0feb3cf1/aarch64-linux` 
