### PR TITLE
[Merged by Bors] - Libp2p update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,21 +86,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
- "aes-soft 0.4.0",
- "aesni 0.7.0",
+ "aes-soft",
+ "aesni",
  "block-cipher",
-]
-
-[[package]]
-name = "aes-ctr"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e5b0458ea3beae0d1d8c0f3946564f8e10f90646cf78c06b4351052058d1ee"
-dependencies = [
- "aes-soft 0.3.3",
- "aesni 0.6.0",
- "ctr 0.3.2",
- "stream-cipher 0.3.2",
 ]
 
 [[package]]
@@ -109,10 +97,10 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e60aeefd2a0243bd53a42e92444e039f67c3d7f0382c9813577696e7c10bf3"
 dependencies = [
- "aes-soft 0.4.0",
- "aesni 0.7.0",
- "ctr 0.4.0",
- "stream-cipher 0.4.1",
+ "aes-soft",
+ "aesni",
+ "ctr",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -130,17 +118,6 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
-dependencies = [
- "block-cipher-trait",
- "byteorder",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "aes-soft"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
@@ -152,24 +129,13 @@ dependencies = [
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
-dependencies = [
- "block-cipher-trait",
- "opaque-debug 0.2.3",
- "stream-cipher 0.3.2",
-]
-
-[[package]]
-name = "aesni"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
  "block-cipher",
  "opaque-debug 0.2.3",
- "stream-cipher 0.4.1",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -379,7 +345,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "log 0.4.11",
- "lru 0.5.3",
+ "lru",
  "merkle_proof",
  "operation_pool",
  "parking_lot 0.11.0",
@@ -522,15 +488,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
  "generic-array 0.14.3",
-]
-
-[[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -709,7 +666,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "086c0f07ac275808b7bf9a39f2fd013aae1498be83632814c8c4e0bd53f2dc58"
 dependencies = [
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -722,7 +679,7 @@ dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "stream-cipher 0.4.1",
+ "stream-cipher",
  "zeroize",
 ]
 
@@ -1082,21 +1039,11 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022cd691704491df67d25d006fe8eca083098253c4d43516c2206479c58c6736"
-dependencies = [
- "block-cipher-trait",
- "stream-cipher 0.3.2",
-]
-
-[[package]]
-name = "ctr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3592740fd55aaf61dd72df96756bd0d11e6037b89dcf30ae2e1895b267692be"
 dependencies = [
- "stream-cipher 0.4.1",
+ "stream-cipher",
 ]
 
 [[package]]
@@ -1260,7 +1207,7 @@ dependencies = [
  "hex 0.4.2",
  "hkdf",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.20.1",
  "libsecp256k1",
  "log 0.4.11",
  "lru_time_cache",
@@ -1508,7 +1455,7 @@ dependencies = [
 name = "eth2_keystore"
 version = "0.1.0"
 dependencies = [
- "aes-ctr 0.4.0",
+ "aes-ctr",
  "bls",
  "eth2_key_derivation",
  "eth2_ssz",
@@ -1547,7 +1494,7 @@ dependencies = [
  "libp2p",
  "lighthouse_metrics",
  "lighthouse_version",
- "lru 0.5.3",
+ "lru",
  "parking_lot 0.11.0",
  "rand 0.7.3",
  "serde",
@@ -2192,6 +2139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
 name = "hkdf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,27 +2607,25 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 [[package]]
 name = "libp2p"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ebb6c031584a5af181fe3a1e4b074af5d0b1a3b31663200f0251f4bcff6b5c"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-mplex",
  "libp2p-noise",
- "libp2p-secio",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-websocket",
  "libp2p-yamux",
  "multihash",
- "parity-multiaddr",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef)",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.1",
@@ -2698,8 +2649,41 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.11",
  "multihash",
- "multistream-select",
- "parity-multiaddr",
+ "multistream-select 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-multiaddr 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.10.2",
+ "pin-project",
+ "prost",
+ "prost-build",
+ "rand 0.7.3",
+ "ring",
+ "rw-stream-sink",
+ "sha2 0.8.2",
+ "smallvec 1.4.1",
+ "thiserror",
+ "unsigned-varint 0.4.0",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
+dependencies = [
+ "asn1_der",
+ "bs58",
+ "ed25519-dalek",
+ "either",
+ "fnv",
+ "futures 0.3.5",
+ "futures-timer",
+ "lazy_static",
+ "libsecp256k1",
+ "log 0.4.11",
+ "multihash",
+ "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef)",
+ "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef)",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2718,8 +2702,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "quote",
  "syn",
@@ -2727,20 +2710,18 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751924b6b98e350005e0b87a822beb246792a3fb878c684e088f866158120ac"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
 ]
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70f76b6c53ae9c97c234498c799802e43f91766bcf4a2a1f94f9339617d713b"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
@@ -2748,10 +2729,11 @@ dependencies = [
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "libp2p-core",
+ "hex_fmt",
+ "libp2p-core 0.21.0",
  "libp2p-swarm",
  "log 0.4.11",
- "lru 0.4.3",
+ "lru_time_cache",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2763,12 +2745,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912c00a7bf67e0e765daf0cc37e08f675ea26aba3d6d1fbfaee81f19a4c23049"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "libp2p-swarm",
  "log 0.4.11",
  "prost",
@@ -2779,15 +2760,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ae0ffacd30f073f96cd518b2c9cd2cb18ac27c3d136a4b23cf1af99f33e541"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
@@ -2795,15 +2775,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e594f2de0c23c2b7ad14802c991a2e68e95315c6a6c7715e53801506f20135d"
+version = "0.23.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
  "prost",
  "prost-build",
@@ -2816,43 +2795,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-secio"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff43513c383f7cdab2736eb98465fc4c5dd5d1988df89749dc8a68950349d56"
-dependencies = [
- "aes-ctr 0.3.0",
- "ctr 0.3.2",
- "futures 0.3.5",
- "hmac 0.7.1",
- "js-sys",
- "lazy_static",
- "libp2p-core",
- "log 0.4.11",
- "parity-send-wrapper",
- "pin-project",
- "prost",
- "prost-build",
- "quicksink",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.8.2",
- "static_assertions",
- "twofish",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "libp2p-swarm"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88d5e2a090a2aadf042cd33484e2f015c6dab212567406a59deece5dedbd133"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.1",
@@ -2862,15 +2810,14 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1fa2bbad054020cb875546a577a66a65a5bf42eff55ed5265f92ffee3cc052"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "futures 0.3.5",
  "futures-timer",
  "get_if_addrs",
  "ipnet",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
  "socket2",
  "tokio 0.2.22",
@@ -2878,14 +2825,13 @@ dependencies = [
 
 [[package]]
 name = "libp2p-websocket"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046a5201f6e471f22b22b394e4d084269ed1e28cf7300f7b49874385db84c7bd"
+version = "0.22.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "async-tls",
  "either",
  "futures 0.3.5",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "log 0.4.11",
  "quicksink",
  "rustls",
@@ -2898,12 +2844,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ae9bf2f7d8a4be9c7e9b61df9de9dc1bd66419d669098f22f81f8d9571029a"
+version = "0.21.0"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core",
+ "libp2p-core 0.21.0",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -3042,15 +2987,6 @@ dependencies = [
  "lighthouse_metrics",
  "slog",
  "slog-term",
-]
-
-[[package]]
-name = "lru"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
-dependencies = [
- "hashbrown 0.6.3",
 ]
 
 [[package]]
@@ -3273,6 +3209,19 @@ name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+
+[[package]]
+name = "multistream-select"
+version = "0.8.2"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
+dependencies = [
+ "bytes 0.5.6",
+ "futures 0.3.5",
+ "log 0.4.11",
+ "pin-project",
+ "smallvec 1.4.1",
+ "unsigned-varint 0.4.0",
+]
 
 [[package]]
 name = "multistream-select"
@@ -3552,6 +3501,23 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.1"
+source = "git+https://github.com/sigp/rust-libp2p?rev=5139ec3ace4ad52506f217d790f0a9425274caef#5139ec3ace4ad52506f217d790f0a9425274caef"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash",
+ "percent-encoding 2.1.0",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.4.0",
+ "url 2.1.1",
+]
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc20af3143a62c16e7c9e92ea5c6ae49f7d271d97d4d8fe73afc28f0514a3d0f"
 dependencies = [
@@ -3578,12 +3544,6 @@ dependencies = [
  "byte-slice-cast",
  "serde",
 ]
-
-[[package]]
-name = "parity-send-wrapper"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
 
 [[package]]
 name = "parking_lot"
@@ -5129,7 +5089,7 @@ dependencies = [
  "lazy_static",
  "leveldb",
  "lighthouse_metrics",
- "lru 0.5.3",
+ "lru",
  "parking_lot 0.11.0",
  "rayon",
  "serde",
@@ -5140,15 +5100,6 @@ dependencies = [
  "tempfile",
  "tree_hash",
  "types",
-]
-
-[[package]]
-name = "stream-cipher"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
-dependencies = [
- "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -5849,17 +5800,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "twofish"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
-dependencies = [
- "block-cipher-trait",
- "byteorder",
- "opaque-debug 0.2.3",
-]
 
 [[package]]
 name = "typeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "log 0.4.11",
- "lru",
+ "lru 0.5.3",
  "merkle_proof",
  "operation_pool",
  "parking_lot 0.11.0",
@@ -1260,7 +1260,7 @@ dependencies = [
  "hex 0.4.2",
  "hkdf",
  "lazy_static",
- "libp2p-core 0.20.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libp2p-core",
  "libsecp256k1",
  "log 0.4.11",
  "lru_time_cache",
@@ -1547,7 +1547,7 @@ dependencies = [
  "libp2p",
  "lighthouse_metrics",
  "lighthouse_version",
- "lru",
+ "lru 0.5.3",
  "parking_lot 0.11.0",
  "rand 0.7.3",
  "serde",
@@ -2192,12 +2192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
-name = "hex_fmt"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
-
-[[package]]
 name = "hkdf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,7 +2570,7 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "lcli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bls",
  "clap",
@@ -2659,14 +2653,15 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.22.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1ebb6c031584a5af181fe3a1e4b074af5d0b1a3b31663200f0251f4bcff6b5c"
 dependencies = [
  "atomic",
  "bytes 0.5.6",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "libp2p-core-derive",
  "libp2p-dns",
  "libp2p-gossipsub",
@@ -2679,44 +2674,11 @@ dependencies = [
  "libp2p-websocket",
  "libp2p-yamux",
  "multihash",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.1",
  "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-core"
-version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
-dependencies = [
- "asn1_der",
- "bs58",
- "ed25519-dalek",
- "either",
- "fnv",
- "futures 0.3.5",
- "futures-timer",
- "lazy_static",
- "libsecp256k1",
- "log 0.4.11",
- "multihash",
- "multistream-select 0.8.2 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
- "parity-multiaddr 0.9.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
- "parking_lot 0.10.2",
- "pin-project",
- "prost",
- "prost-build",
- "rand 0.7.3",
- "ring",
- "rw-stream-sink",
- "sha2 0.8.2",
- "smallvec 1.4.1",
- "thiserror",
- "unsigned-varint 0.4.0",
- "void",
- "zeroize",
 ]
 
 [[package]]
@@ -2736,8 +2698,8 @@ dependencies = [
  "libsecp256k1",
  "log 0.4.11",
  "multihash",
- "multistream-select 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "parity-multiaddr 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "multistream-select",
+ "parity-multiaddr",
  "parking_lot 0.10.2",
  "pin-project",
  "prost",
@@ -2756,7 +2718,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.20.2"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
 dependencies = [
  "quote",
  "syn",
@@ -2765,17 +2728,19 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751924b6b98e350005e0b87a822beb246792a3fb878c684e088f866158120ac"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
 ]
 
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70f76b6c53ae9c97c234498c799802e43f91766bcf4a2a1f94f9339617d713b"
 dependencies = [
  "base64 0.11.0",
  "byteorder",
@@ -2783,11 +2748,10 @@ dependencies = [
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "hex_fmt",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "libp2p-swarm",
  "log 0.4.11",
- "lru_time_cache",
+ "lru 0.4.3",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -2800,10 +2764,11 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "912c00a7bf67e0e765daf0cc37e08f675ea26aba3d6d1fbfaee81f19a4c23049"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "libp2p-swarm",
  "log 0.4.11",
  "prost",
@@ -2815,13 +2780,14 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ae0ffacd30f073f96cd518b2c9cd2cb18ac27c3d136a4b23cf1af99f33e541"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
  "futures 0.3.5",
  "futures_codec",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "parking_lot 0.10.2",
  "unsigned-varint 0.4.0",
@@ -2829,14 +2795,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-noise"
-version = "0.21.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e594f2de0c23c2b7ad14802c991a2e68e95315c6a6c7715e53801506f20135d"
 dependencies = [
  "bytes 0.5.6",
  "curve25519-dalek",
  "futures 0.3.5",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "prost",
  "prost-build",
@@ -2851,7 +2818,8 @@ dependencies = [
 [[package]]
 name = "libp2p-secio"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ff43513c383f7cdab2736eb98465fc4c5dd5d1988df89749dc8a68950349d56"
 dependencies = [
  "aes-ctr 0.3.0",
  "ctr 0.3.2",
@@ -2859,7 +2827,7 @@ dependencies = [
  "hmac 0.7.1",
  "js-sys",
  "lazy_static",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "parity-send-wrapper",
  "pin-project",
@@ -2880,10 +2848,11 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.20.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88d5e2a090a2aadf042cd33484e2f015c6dab212567406a59deece5dedbd133"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "rand 0.7.3",
  "smallvec 1.4.1",
@@ -2894,13 +2863,14 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1fa2bbad054020cb875546a577a66a65a5bf42eff55ed5265f92ffee3cc052"
 dependencies = [
  "futures 0.3.5",
  "futures-timer",
  "get_if_addrs",
  "ipnet",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "socket2",
  "tokio 0.2.22",
@@ -2909,12 +2879,13 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.21.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046a5201f6e471f22b22b394e4d084269ed1e28cf7300f7b49874385db84c7bd"
 dependencies = [
  "async-tls",
  "either",
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "log 0.4.11",
  "quicksink",
  "rustls",
@@ -2928,10 +2899,11 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.20.0"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46ae9bf2f7d8a4be9c7e9b61df9de9dc1bd66419d669098f22f81f8d9571029a"
 dependencies = [
  "futures 0.3.5",
- "libp2p-core 0.20.1 (git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16)",
+ "libp2p-core",
  "parking_lot 0.10.2",
  "thiserror",
  "yamux",
@@ -2978,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "account_manager",
  "account_utils",
@@ -3070,6 +3042,15 @@ dependencies = [
  "lighthouse_metrics",
  "slog",
  "slog-term",
+]
+
+[[package]]
+name = "lru"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
+dependencies = [
+ "hashbrown 0.6.3",
 ]
 
 [[package]]
@@ -3292,19 +3273,6 @@ name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
-
-[[package]]
-name = "multistream-select"
-version = "0.8.2"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.5",
- "log 0.4.11",
- "pin-project",
- "smallvec 1.4.1",
- "unsigned-varint 0.4.0",
-]
 
 [[package]]
 name = "multistream-select"
@@ -3579,23 +3547,6 @@ dependencies = [
  "state_processing",
  "store",
  "types",
-]
-
-[[package]]
-name = "parity-multiaddr"
-version = "0.9.1"
-source = "git+https://github.com/sigp/rust-libp2p?rev=f1b660a1a96c1b6198cd62062e75d357893faf16#f1b660a1a96c1b6198cd62062e75d357893faf16"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash",
- "percent-encoding 2.1.0",
- "serde",
- "static_assertions",
- "unsigned-varint 0.4.0",
- "url 2.1.1",
 ]
 
 [[package]]
@@ -5178,7 +5129,7 @@ dependencies = [
  "lazy_static",
  "leveldb",
  "lighthouse_metrics",
- "lru",
+ "lru 0.5.3",
  "parking_lot 0.11.0",
  "rayon",
  "serde",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -39,9 +39,9 @@ environment = { path = "../../lighthouse/environment" }
 rand = "0.7.3"
 
 [dependencies.libp2p]
-#version = "0.19.1"
-git = "https://github.com/sigp/rust-libp2p"
-rev = "f1b660a1a96c1b6198cd62062e75d357893faf16"
+version = "0.23.0"
+#git = "https://github.com/sigp/rust-libp2p"
+#rev = "f1b660a1a96c1b6198cd62062e75d357893faf16"
 default-features = false
 features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns", "secio", "tcp-tokio"]
 

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -39,11 +39,11 @@ environment = { path = "../../lighthouse/environment" }
 rand = "0.7.3"
 
 [dependencies.libp2p]
-version = "0.23.0"
-#git = "https://github.com/sigp/rust-libp2p"
-#rev = "f1b660a1a96c1b6198cd62062e75d357893faf16"
+#version = "0.23.0"
+git = "https://github.com/sigp/rust-libp2p"
+rev = "5139ec3ace4ad52506f217d790f0a9425274caef"
 default-features = false
-features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns", "secio", "tcp-tokio"]
+features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns", "tcp-tokio"]
 
 [dev-dependencies]
 tokio = { version = "0.2.21", features = ["full"] }


### PR DESCRIPTION
Updates to latest libp2p master. 

This now has native noise support. 

This PR
- Removes secio support
- Prioritises mplex over yamux