### PR TITLE
[Merged by Bors] - Log to file without json format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "lcli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bls",
  "clap",
@@ -2978,7 +2978,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -4,6 +4,7 @@ extern crate lazy_static;
 use lighthouse_metrics::{
     inc_counter, try_create_int_counter, IntCounter, Result as MetricsResult,
 };
+use slog_term::Decorator;
 use std::io::{Result, Write};
 
 pub const MAX_MESSAGE_WIDTH: usize = 40;
@@ -19,13 +20,13 @@ lazy_static! {
         try_create_int_counter("crit_total", "Count of crits logged");
 }
 
-pub struct AlignedTermDecorator {
-    wrapped: slog_term::TermDecorator,
+pub struct AlignedTermDecorator<D: Decorator> {
+    wrapped: D,
     message_width: usize,
 }
 
-impl AlignedTermDecorator {
-    pub fn new(decorator: slog_term::TermDecorator, message_width: usize) -> AlignedTermDecorator {
+impl<D: Decorator> AlignedTermDecorator<D> {
+    pub fn new(decorator: D, message_width: usize) -> Self {
         AlignedTermDecorator {
             wrapped: decorator,
             message_width,
@@ -33,7 +34,7 @@ impl AlignedTermDecorator {
     }
 }
 
-impl slog_term::Decorator for AlignedTermDecorator {
+impl<D: Decorator> Decorator for AlignedTermDecorator<D> {
     fn with_record<F>(
         &self,
         record: &slog::Record,

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -63,7 +63,7 @@ fn main() {
                 .long("logfile")
                 .value_name("FILE")
                 .help(
-                    "File path where output will be written. Default file logging format is JSON.",
+                    "File path where output will be written.",
                 )
                 .takes_value(true),
         )

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -197,20 +197,21 @@ fn run<E: EthSpec>(
         optional_testnet_config = clap_utils::parse_testnet_dir(matches, "testnet-dir")?;
     };
 
-    let mut environment = environment_builder
-        .async_logger(debug_level, log_format)?
+    let builder = if let Some(log_path) = matches.value_of("logfile") {
+        let path = log_path
+            .parse::<PathBuf>()
+            .map_err(|e| format!("Failed to parse log path: {:?}", e))?;
+        environment_builder.log_to_file(path, debug_level, log_format)?
+    } else {
+        environment_builder.async_logger(debug_level, log_format)?
+    };
+
+    let mut environment = builder
         .multi_threaded_tokio_runtime()?
         .optional_eth2_testnet_config(optional_testnet_config)?
         .build()?;
 
     let log = environment.core_context().log().clone();
-
-    if let Some(log_path) = matches.value_of("logfile") {
-        let path = log_path
-            .parse::<PathBuf>()
-            .map_err(|e| format!("Failed to parse log path: {:?}", e))?;
-        environment.log_to_json_file(path, debug_level, log_format)?;
-    }
 
     // Note: the current code technically allows for starting a beacon node _and_ a validator
     // client at the same time.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Earlier, to log to a file, the only options were to redirect stdout/stderr to a file or use json logging. 
Redirecting to stdout/stderr works well but causes issues with mistakenly overwriting the file instead of appending which has resulted in loss of precious logs on multiple occasions for me.

Json logging creates a timestamped backup of the file if it already exists, but the json format itself is hugely annoying.

This PR modifies the `--logfile` option to log as it does in the terminal to a logfile.