### PR TITLE
[Merged by Bors] - Upgrade logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,9 +1195,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7083584562c5b36f929dbe621437a911eef4f8ac73bab1b1c64c8f556212943"
+checksum = "90782d49541b01f9b7e34e6af5d80d01396bf7b1a81505a0035da224134b8d73"
 dependencies = [
  "arrayvec",
  "digest 0.8.1",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -32,7 +32,7 @@ snap = "1.0.0"
 void = "1.0.2"
 tokio-io-timeout = "0.4.0"
 tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
-discv5 = { version = "0.1.0-alpha.7", features = ["libp2p"] }
+discv5 = { version = "0.1.0-alpha.8", features = ["libp2p"] }
 tiny-keccak = "2.0.2"
 environment = { path = "../../lighthouse/environment" }
 # TODO: Remove rand crate for mainnet

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -210,7 +210,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
 
         // Start the discv5 service and obtain an event stream
         let event_stream = if !config.disable_discovery {
-            discv5.start(listen_socket);
+            discv5.start(listen_socket).map_err(|e| e.to_string())?;
             debug!(log, "Discovery service started");
             EventStream::Awaiting(Box::pin(discv5.event_stream()))
         } else {

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -271,10 +271,10 @@ impl<TSpec: EthSpec> Service<TSpec> {
                     debug!(self.log, "Listen address expired"; "multiaddr" => multiaddr.to_string())
                 }
                 SwarmEvent::ListenerClosed { addresses, reason } => {
-                    debug!(self.log, "Listener closed"; "addresses" => format!("{:?}", addresses), "reason" => format!("{:?}", reason))
+                    crit!(self.log, "Listener closed"; "addresses" => format!("{:?}", addresses), "reason" => format!("{:?}", reason))
                 }
                 SwarmEvent::ListenerError { error } => {
-                    debug!(self.log, "Listener error"; "error" => format!("{:?}", error.to_string()))
+                    warn!(self.log, "Listener error"; "error" => format!("{:?}", error.to_string()))
                 }
                 SwarmEvent::Dialing(peer_id) => {
                     debug!(self.log, "Dialing peer"; "peer_id" => peer_id.to_string());

--- a/boot_node/src/server.rs
+++ b/boot_node/src/server.rs
@@ -43,7 +43,10 @@ pub async fn run(config: BootNodeConfig, log: slog::Logger) {
     }
 
     // start the server
-    discv5.start(config.listen_socket);
+    if let Err(e) = discv5.start(config.listen_socket) {
+        slog::crit!(log, "Could not start discv5 server"; "error" => e.to_string());
+        return;
+    }
 
     // if there are peers in the local routing table, establish a session by running a query
     if !discv5.table_entries_id().is_empty() {

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -21,4 +21,4 @@ slog-json = "2.3.0"
 exit-future = "0.2.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-discv5 = "0.1.0-alpha.7"
+discv5 = "0.1.0-alpha.8"


### PR DESCRIPTION
## Issue Addressed

#1483 

## Proposed Changes

Upgrades the log to a critical if a listener fails. We are able to listen on many interfaces so a single instance is not critical. We should however gracefully shutdown the client if we have no listeners, although the client can still function solely on outgoing connections.

For now a critical is raised and I leave #1494 for more sophisticated handling of this. 

This also updates discv5 to handle errors of binding to a UDP socket such that lighthouse is now able to handle them. 
