### PR TITLE
[Merged by Bors] - Update key-management.md

### DIFF
--- a/book/src/key-management.md
+++ b/book/src/key-management.md
@@ -41,9 +41,9 @@ keypairs. Creating a single validator looks like this:
 
 
 In step (1), we created a wallet in `~/.lighthouse/wallets` with the name
-`mywallet`. We encrypted this using a pre-defined password in the
+`wally`. We encrypted this using a pre-defined password in the
 `mywallet.pass` file. Then, in step (2), we created one new validator in the
-`~/.lighthouse/validators` directory using `mywallet` (unlocking it with
+`~/.lighthouse/validators` directory using `wally` (unlocking it with
 `mywallet.pass`) and storing the passwords to the validators voting key in
 `~/.lighthouse/secrets`.
 


### PR DESCRIPTION
## Issue Addressed

minor documentation changes in order to have identical command prompts and description below

## Proposed Changes

adjust description "wally" to align with command prompt

## Additional Info

devs might give it a thought whether command line should be "mywallet"
I personally prefer "wally" for minimization reasons =)
