### PR TITLE
[Merged by Bors] - Persist metadata and enr across restarts

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -112,7 +112,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             network_globals,
             enr_fork_id,
             waker: None,
-            network_dir: PathBuf::from(net_conf.network_dir.clone()),
+            network_dir: net_conf.network_dir.clone(),
             log: behaviour_log,
         })
     }
@@ -1049,7 +1049,7 @@ fn load_or_build_metadata<E: EthSpec>(network_dir: &PathBuf, log: &slog::Logger)
     let metadata_path = network_dir.join(METADATA_FILENAME);
     if let Ok(mut metadata_file) = File::open(metadata_path) {
         let mut metadata_ssz = Vec::new();
-        if let Ok(_) = metadata_file.read_to_end(&mut metadata_ssz) {
+        if metadata_file.read_to_end(&mut metadata_ssz).is_ok() {
             match MetaData::<E>::from_ssz_bytes(&metadata_ssz) {
                 Ok(persisted_metadata) => {
                     meta_data.seq_number = persisted_metadata.seq_number;

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -92,7 +92,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             .expect("Local ENR must have subnet bitfield");
 
         let meta_data = MetaData {
-            seq_number: 1,
+            seq_number: 0,
             attnets,
         };
 

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1,6 +1,6 @@
 use crate::peer_manager::{score::PeerAction, PeerManager, PeerManagerEvent};
 use crate::rpc::*;
-use crate::types::{GossipEncoding, GossipKind, GossipTopic};
+use crate::types::{EnrBitfield, GossipEncoding, GossipKind, GossipTopic};
 use crate::Eth2Enr;
 use crate::{error, metrics, Enr, NetworkConfig, NetworkGlobals, PubsubMessage, TopicHash};
 use futures::prelude::*;
@@ -19,7 +19,11 @@ use libp2p::{
     },
     PeerId,
 };
-use slog::{crit, debug, o, trace};
+use slog::{crit, debug, o, trace, warn};
+use ssz::{Decode, Encode};
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
 use std::{
     collections::VecDeque,
     marker::PhantomData,
@@ -32,6 +36,7 @@ use types::{EnrForkId, EthSpec, SignedBeaconBlock, SubnetId};
 mod handler;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
+const METADATA_FILENAME: &str = "metadata";
 
 /// Builds the network behaviour that manages the core protocols of eth2.
 /// This core behaviour is managed by `Behaviour` which adds peer management to all core
@@ -61,6 +66,8 @@ pub struct Behaviour<TSpec: EthSpec> {
     enr_fork_id: EnrForkId,
     /// The waker for the current thread.
     waker: Option<std::task::Waker>,
+    /// Directory where metadata is stored
+    network_dir: PathBuf,
     /// Logger for behaviour actions.
     log: slog::Logger,
 }
@@ -91,10 +98,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             .bitfield::<TSpec>()
             .expect("Local ENR must have subnet bitfield");
 
-        let meta_data = MetaData {
-            seq_number: 0,
-            attnets,
-        };
+        let meta_data = load_or_build_metadata(&net_conf.network_dir, &log);
 
         // TODO: Until other clients support no author, we will use a 0 peer_id as our author.
         let message_author = PeerId::from_bytes(vec![0, 1, 0]).expect("Valid peer id");
@@ -113,6 +117,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             network_globals,
             enr_fork_id,
             waker: None,
+            network_dir: PathBuf::from(net_conf.network_dir.clone()),
             log: behaviour_log,
         })
     }
@@ -345,6 +350,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             .local_enr()
             .bitfield::<TSpec>()
             .expect("Local discovery must have bitfield");
+        save_metadata_to_disk(&self.network_dir, self.meta_data.clone(), &self.log);
     }
 
     /// Sends a Ping request to the peer.
@@ -1034,4 +1040,57 @@ pub enum BehaviourEvent<TSpec: EthSpec> {
     PeerSubscribed(PeerId, TopicHash),
     /// Inform the network to send a Status to this peer.
     StatusPeer(PeerId),
+}
+
+/// Load metadata from persisted file. Return default metadata if loading fails.
+fn load_or_build_metadata<E: EthSpec>(network_dir: &PathBuf, log: &slog::Logger) -> MetaData<E> {
+    // Default metadata
+    let mut meta_data = MetaData {
+        seq_number: 0,
+        attnets: EnrBitfield::<E>::default(),
+    };
+    // Read metadata from persisted file if available
+    let metadata_path = network_dir.join(METADATA_FILENAME);
+    if let Ok(mut metadata_file) = File::open(metadata_path) {
+        let mut metadata_ssz = Vec::new();
+        if let Ok(_) = metadata_file.read_to_end(&mut metadata_ssz) {
+            match MetaData::<E>::from_ssz_bytes(&metadata_ssz) {
+                Ok(persisted_metadata) => {
+                    meta_data.seq_number = persisted_metadata.seq_number;
+                    debug!(log, "Loaded metadata seq number from disk");
+                }
+                Err(e) => {
+                    debug!(
+                        log,
+                        "Metadata from file could not be decoded";
+                        "error" => format!("{:?}", e),
+                    );
+                }
+            }
+        }
+    };
+
+    debug!(log, "Metadata sequence number"; "seq_num" => meta_data.seq_number);
+    save_metadata_to_disk(network_dir, meta_data.clone(), &log);
+    meta_data
+}
+
+/// Persist metadata to disk
+fn save_metadata_to_disk<E: EthSpec>(dir: &PathBuf, metadata: MetaData<E>, log: &slog::Logger) {
+    let _ = std::fs::create_dir_all(&dir);
+    match File::create(dir.join(METADATA_FILENAME))
+        .and_then(|mut f| f.write_all(&metadata.as_ssz_bytes()))
+    {
+        Ok(_) => {
+            debug!(log, "Metadata written to disk");
+        }
+        Err(e) => {
+            warn!(
+                log,
+                "Could not write metadata to disk";
+                "file" => format!("{:?}{:?}",dir, METADATA_FILENAME),
+                "error" => format!("{}", e)
+            );
+        }
+    }
 }

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1053,7 +1053,11 @@ fn load_or_build_metadata<E: EthSpec>(network_dir: &PathBuf, log: &slog::Logger)
             match MetaData::<E>::from_ssz_bytes(&metadata_ssz) {
                 Ok(persisted_metadata) => {
                     meta_data.seq_number = persisted_metadata.seq_number;
-                    debug!(log, "Loaded metadata seq number from disk");
+                    // Increment seq number if persisted attnet is not default
+                    if persisted_metadata.attnets != meta_data.attnets {
+                        meta_data.seq_number += 1;
+                    }
+                    debug!(log, "Loaded metadata from disk");
                 }
                 Err(e) => {
                     debug!(

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -93,11 +93,6 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             .eth2()
             .expect("Local ENR must have a fork id");
 
-        let attnets = network_globals
-            .local_enr()
-            .bitfield::<TSpec>()
-            .expect("Local ENR must have subnet bitfield");
-
         let meta_data = load_or_build_metadata(&net_conf.network_dir, &log);
 
         // TODO: Until other clients support no author, we will use a 0 peer_id as our author.
@@ -350,6 +345,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
             .local_enr()
             .bitfield::<TSpec>()
             .expect("Local discovery must have bitfield");
+        // Save the updated metadata to disk
         save_metadata_to_disk(&self.network_dir, self.meta_data.clone(), &self.log);
     }
 

--- a/beacon_node/eth2_libp2p/src/discovery/enr.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/enr.rs
@@ -82,6 +82,8 @@ pub fn build_or_load_enr<T: EthSpec>(
                             }
 
                             // same node id, different configuration - update the sequence number
+                            // Note: local_enr is generated with default(0) attnets value,
+                            // so a non default value in persisted enr will also update sequence number.
                             let new_seq_no = disk_enr.seq().checked_add(1).ok_or_else(|| "ENR sequence number on file is too large. Remove it to generate a new NodeId")?;
                             local_enr.set_seq(new_seq_no, &enr_key).map_err(|e| {
                                 format!("Could not update ENR sequence number: {:?}", e)

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -335,6 +335,9 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
 
         // replace the global version
         *self.network_globals.local_enr.write() = self.discv5.local_enr();
+
+        // persist modified enr to disk
+        enr::save_enr_to_disk(Path::new(&self.enr_dir), &self.local_enr(), &self.log);
         Ok(())
     }
 
@@ -367,6 +370,9 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
 
         // replace the global version with discovery version
         *self.network_globals.local_enr.write() = self.discv5.local_enr();
+
+        // persist modified enr to disk
+        enr::save_enr_to_disk(Path::new(&self.enr_dir), &self.local_enr(), &self.log);
     }
 
     /* Internal Functions */

--- a/beacon_node/eth2_libp2p/src/types/globals.rs
+++ b/beacon_node/eth2_libp2p/src/types/globals.rs
@@ -1,10 +1,9 @@
 //! A collection of variables that are accessible outside of the network thread itself.
 use crate::peer_manager::PeerDB;
-use crate::rpc::methods::MetaData;
 use crate::types::SyncState;
 use crate::Client;
 use crate::EnrExt;
-use crate::{Enr, Eth2Enr, GossipTopic, Multiaddr, PeerId};
+use crate::{Enr, GossipTopic, Multiaddr, PeerId};
 use parking_lot::RwLock;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicU16, Ordering};
@@ -13,8 +12,6 @@ use types::EthSpec;
 pub struct NetworkGlobals<TSpec: EthSpec> {
     /// The current local ENR.
     pub local_enr: RwLock<Enr>,
-    /// The current node's meta-data.
-    pub meta_data: RwLock<MetaData<TSpec>>,
     /// The local peer_id.
     pub peer_id: RwLock<PeerId>,
     /// Listening multiaddrs.
@@ -33,17 +30,8 @@ pub struct NetworkGlobals<TSpec: EthSpec> {
 
 impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
     pub fn new(enr: Enr, tcp_port: u16, udp_port: u16, log: &slog::Logger) -> Self {
-        // set up the local meta data of the node
-        let meta_data = RwLock::new(MetaData {
-            seq_number: 0,
-            attnets: enr
-                .bitfield::<TSpec>()
-                .expect("Local ENR must have a bitfield specified"),
-        });
-
         NetworkGlobals {
             local_enr: RwLock::new(enr.clone()),
-            meta_data,
             peer_id: RwLock::new(enr.peer_id()),
             listen_multiaddrs: RwLock::new(Vec::new()),
             listen_port_tcp: AtomicU16::new(tcp_port),


### PR DESCRIPTION
## Issue Addressed

Resolves #1489 

## Proposed Changes

- Change starting metadata seq num to 0 according to the [spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#metadata).
- Remove metadata field from `NetworkGlobals`
- Persist metadata to disk on every update
- Load metadata seq number from disk on restart
- Persist enr to disk on update to ensure enr sequence number increments are persisted as well.

## Additional info

Since we modified starting metadata seq num to 0 from 1, we might still see `Invalid Sequence number provided` like in #1489  from prysm nodes if they have our metadata cached.