### PR TITLE
[Merged by Bors] - Wind down the SSE thread when the client disconnects

### DIFF
--- a/beacon_node/rest_api/src/beacon.rs
+++ b/beacon_node/rest_api/src/beacon.rs
@@ -155,8 +155,10 @@ pub fn stream_forks<T: BeaconChainTypes>(
                     break;
                 }
             };
-            if let Err(bytes) = block_on(sender.send_data(chunk)) {
-                error!(log, "Couldn't stream piece {:?}", bytes);
+            match block_on(sender.send_data(chunk)) {
+                Err(e) if e.is_closed() => break,
+                Err(e) => error!(log, "Couldn't stream piece {:?}", e),
+                Ok(_) => (),
             }
         }
     });


### PR DESCRIPTION
These started to appear when I `^C` `curl -N http://localhost:5052/beacon/fork/stream`: `Aug 12 13:00:01.539 ERRO Couldn't stream piece hyper::Error(ChannelClosed), service: http`

Something must have changed in hyper since SSE has been implemented because I'm sure I haven't seen those errors before.

This PR properly detects a closed SSE stream and cleans up.