### PR TITLE
[Merged by Bors] - Update discv5 to alpha.9

### DIFF
--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -32,7 +32,7 @@ snap = "1.0.0"
 void = "1.0.2"
 tokio-io-timeout = "0.4.0"
 tokio-util = { version = "0.3.1", features = ["codec", "compat"] }
-discv5 = { version = "0.1.0-alpha.8", features = ["libp2p"] }
+discv5 = { version = "0.1.0-alpha.9", features = ["libp2p"] }
 tiny-keccak = "2.0.2"
 environment = { path = "../../lighthouse/environment" }
 # TODO: Remove rand crate for mainnet

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -21,4 +21,4 @@ slog-json = "2.3.0"
 exit-future = "0.2.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-discv5 = "0.1.0-alpha.8"
+discv5 = "0.1.0-alpha.9"


### PR DESCRIPTION
## Discovery v5 update

In this update we remove the openssl dependency in favour of rust-crypto. 

The update also removes a series of unnecessary async functions which may improve some of the issues we have been experiencing. 
