### PR TITLE
reuse beacon_node methods for initializing network configs in boot_node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "account_manager"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "account_utils",
  "bls",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -530,8 +530,9 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
+ "beacon_node",
  "clap",
  "discv5",
  "eth2_libp2p",
@@ -2894,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "account_manager",
  "account_utils",
@@ -6022,7 +6023,7 @@ dependencies = [
 
 [[package]]
 name = "validator_client"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "account_utils",
  "bls",

--- a/beacon_node/eth2_libp2p/src/discovery/enr.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/enr.rs
@@ -6,6 +6,7 @@ use super::enr_ext::CombinedKeyExt;
 use super::ENR_FILENAME;
 use crate::types::{Enr, EnrBitfield};
 use crate::NetworkConfig;
+use discv5::enr::EnrKey;
 use libp2p::core::identity::Keypair;
 use slog::{debug, warn};
 use ssz::{Decode, Encode};
@@ -48,6 +49,54 @@ impl Eth2Enr for Enr {
     }
 }
 
+/// Either use the given enr or load an ENR from file if it exists and meatches the current NodeId
+/// and sequence number.
+/// If an ENR exists, with the same NodeId, this function checks to see if the loaded ENR from
+/// disk is suitable to use, otherwise we increment the given ENR's sequence number.
+pub fn use_or_load_enr(
+    enr_key: &CombinedKey,
+    local_enr: &mut Enr,
+    config: &NetworkConfig,
+    log: &slog::Logger,
+) -> Result<(), String> {
+    let enr_f = config.network_dir.join(ENR_FILENAME);
+    if let Ok(mut enr_file) = File::open(enr_f.clone()) {
+        let mut enr_string = String::new();
+        match enr_file.read_to_string(&mut enr_string) {
+            Err(_) => debug!(log, "Could not read ENR from file"),
+            Ok(_) => {
+                match Enr::from_str(&enr_string) {
+                    Ok(disk_enr) => {
+                        // if the same node id, then we may need to update our sequence number
+                        if local_enr.node_id() == disk_enr.node_id() {
+                            if compare_enr(&local_enr, &disk_enr) {
+                                debug!(log, "ENR loaded from disk"; "file" => format!("{:?}", enr_f));
+                                // the stored ENR has the same configuration, use it
+                                *local_enr = disk_enr;
+                                return Ok(());
+                            }
+
+                            // same node id, different configuration - update the sequence number
+                            let new_seq_no = disk_enr.seq().checked_add(1).ok_or_else(|| "ENR sequence number on file is too large. Remove it to generate a new NodeId")?;
+                            local_enr.set_seq(new_seq_no, enr_key).map_err(|e| {
+                                format!("Could not update ENR sequence number: {:?}", e)
+                            })?;
+                            debug!(log, "ENR sequence number increased"; "seq" =>  new_seq_no);
+                        }
+                    }
+                    Err(e) => {
+                        warn!(log, "ENR from file could not be decoded"; "error" => format!("{:?}", e));
+                    }
+                }
+            }
+        }
+    }
+
+    save_enr_to_disk(&config.network_dir, &local_enr, log);
+
+    Ok(())
+}
+
 /// Loads an ENR from file if it exists and matches the current NodeId and sequence number. If none
 /// exists, generates a new one.
 ///
@@ -65,49 +114,11 @@ pub fn build_or_load_enr<T: EthSpec>(
     let enr_key = CombinedKey::from_libp2p(&local_key)?;
     let mut local_enr = build_enr::<T>(&enr_key, config, enr_fork_id)?;
 
-    let enr_f = config.network_dir.join(ENR_FILENAME);
-    if let Ok(mut enr_file) = File::open(enr_f.clone()) {
-        let mut enr_string = String::new();
-        match enr_file.read_to_string(&mut enr_string) {
-            Err(_) => debug!(log, "Could not read ENR from file"),
-            Ok(_) => {
-                match Enr::from_str(&enr_string) {
-                    Ok(disk_enr) => {
-                        // if the same node id, then we may need to update our sequence number
-                        if local_enr.node_id() == disk_enr.node_id() {
-                            if compare_enr(&local_enr, &disk_enr) {
-                                debug!(log, "ENR loaded from disk"; "file" => format!("{:?}", enr_f));
-                                // the stored ENR has the same configuration, use it
-                                return Ok(disk_enr);
-                            }
-
-                            // same node id, different configuration - update the sequence number
-                            let new_seq_no = disk_enr.seq().checked_add(1).ok_or_else(|| "ENR sequence number on file is too large. Remove it to generate a new NodeId")?;
-                            local_enr.set_seq(new_seq_no, &enr_key).map_err(|e| {
-                                format!("Could not update ENR sequence number: {:?}", e)
-                            })?;
-                            debug!(log, "ENR sequence number increased"; "seq" =>  new_seq_no);
-                        }
-                    }
-                    Err(e) => {
-                        warn!(log, "ENR from file could not be decoded"; "error" => format!("{:?}", e));
-                    }
-                }
-            }
-        }
-    }
-
-    save_enr_to_disk(&config.network_dir, &local_enr, log);
-
+    use_or_load_enr(&enr_key, &mut local_enr, config, log)?;
     Ok(local_enr)
 }
 
-/// Builds a lighthouse ENR given a `NetworkConfig`.
-pub fn build_enr<T: EthSpec>(
-    enr_key: &CombinedKey,
-    config: &NetworkConfig,
-    enr_fork_id: EnrForkId,
-) -> Result<Enr, String> {
+pub fn create_enr_builder_from_config<T: EnrKey>(config: &NetworkConfig) -> EnrBuilder<T> {
     let mut builder = EnrBuilder::new("v4");
     if let Some(enr_address) = config.enr_address {
         builder.ip(enr_address);
@@ -118,7 +129,17 @@ pub fn build_enr<T: EthSpec>(
     // we always give it our listening tcp port
     // TODO: Add uPnP support to map udp and tcp ports
     let tcp_port = config.enr_tcp_port.unwrap_or_else(|| config.libp2p_port);
-    builder.tcp(tcp_port);
+    builder.tcp(tcp_port).tcp(config.libp2p_port);
+    builder
+}
+
+/// Builds a lighthouse ENR given a `NetworkConfig`.
+pub fn build_enr<T: EthSpec>(
+    enr_key: &CombinedKey,
+    config: &NetworkConfig,
+    enr_fork_id: EnrForkId,
+) -> Result<Enr, String> {
+    let mut builder = create_enr_builder_from_config(config);
 
     // set the `eth2` field on our ENR
     builder.add_value(ETH2_ENR_KEY.into(), enr_fork_id.as_ssz_bytes());
@@ -129,7 +150,6 @@ pub fn build_enr<T: EthSpec>(
     builder.add_value(BITFIELD_ENR_KEY.into(), bitfield.as_ssz_bytes());
 
     builder
-        .tcp(config.libp2p_port)
         .build(enr_key)
         .map_err(|e| format!("Could not build Local ENR: {:?}", e))
 }

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod enr;
 pub mod enr_ext;
 
 // Allow external use of the lighthouse ENR builder
-pub use enr::{build_enr, CombinedKey, Eth2Enr};
+pub use enr::{build_enr, create_enr_builder_from_config, use_or_load_enr, CombinedKey, Eth2Enr};
 pub use enr_ext::{CombinedKeyExt, EnrExt};
 pub use libp2p::core::identity::Keypair;
 

--- a/beacon_node/eth2_libp2p/src/lib.rs
+++ b/beacon_node/eth2_libp2p/src/lib.rs
@@ -26,4 +26,4 @@ pub use metrics::scrape_discovery_metrics;
 pub use peer_manager::{
     client::Client, score::PeerAction, PeerDB, PeerInfo, PeerSyncStatus, SyncInfo,
 };
-pub use service::{Libp2pEvent, Service, NETWORK_KEY_FILENAME};
+pub use service::{load_private_key, Libp2pEvent, Service, NETWORK_KEY_FILENAME};

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -340,7 +340,7 @@ fn keypair_from_bytes(mut bytes: Vec<u8>) -> error::Result<Keypair> {
 /// generated and is then saved to disk.
 ///
 /// Currently only secp256k1 keys are allowed, as these are the only keys supported by discv5.
-fn load_private_key(config: &NetworkConfig, log: &slog::Logger) -> Keypair {
+pub fn load_private_key(config: &NetworkConfig, log: &slog::Logger) -> Keypair {
     // check for key from disk
     let network_key_f = config.network_dir.join(NETWORK_KEY_FILENAME);
     if let Ok(mut network_key_file) = File::open(network_key_f.clone()) {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -2,7 +2,7 @@ use beacon_chain::builder::PUBKEY_CACHE_FILENAME;
 use clap::ArgMatches;
 use clap_utils::BAD_TESTNET_DIR_MESSAGE;
 use client::{config::DEFAULT_DATADIR, ClientConfig, ClientGenesis};
-use eth2_libp2p::{Enr, Multiaddr};
+use eth2_libp2p::{Enr, Multiaddr, NetworkConfig};
 use eth2_testnet_config::Eth2TestnetConfig;
 use slog::{crit, info, Logger};
 use ssz::Encode;
@@ -75,130 +75,13 @@ pub fn get_config<E: EthSpec>(
     /*
      * Networking
      */
-    // If a network dir has been specified, override the `datadir` definition.
-    if let Some(dir) = cli_args.value_of("network-dir") {
-        client_config.network.network_dir = PathBuf::from(dir);
-    } else {
-        client_config.network.network_dir = client_config.data_dir.join(NETWORK_DIR);
-    };
-
-    if let Some(listen_address_str) = cli_args.value_of("listen-address") {
-        let listen_address = listen_address_str
-            .parse()
-            .map_err(|_| format!("Invalid listen address: {:?}", listen_address_str))?;
-        client_config.network.listen_address = listen_address;
-    }
-
-    if let Some(target_peers_str) = cli_args.value_of("target-peers") {
-        client_config.network.target_peers = target_peers_str
-            .parse::<usize>()
-            .map_err(|_| format!("Invalid number of target peers: {}", target_peers_str))?;
-    }
-
-    if let Some(port_str) = cli_args.value_of("port") {
-        let port = port_str
-            .parse::<u16>()
-            .map_err(|_| format!("Invalid port: {}", port_str))?;
-        client_config.network.libp2p_port = port;
-        client_config.network.discovery_port = port;
-    }
-
-    if let Some(port_str) = cli_args.value_of("discovery-port") {
-        let port = port_str
-            .parse::<u16>()
-            .map_err(|_| format!("Invalid port: {}", port_str))?;
-        client_config.network.discovery_port = port;
-    }
-
-    if let Some(boot_enr_str) = cli_args.value_of("boot-nodes") {
-        client_config.network.boot_nodes = boot_enr_str
-            .split(',')
-            .map(|enr| enr.parse().map_err(|_| format!("Invalid ENR: {}", enr)))
-            .collect::<Result<Vec<Enr>, _>>()?;
-    }
-
-    if let Some(libp2p_addresses_str) = cli_args.value_of("libp2p-addresses") {
-        client_config.network.libp2p_nodes = libp2p_addresses_str
-            .split(',')
-            .map(|multiaddr| {
-                multiaddr
-                    .parse()
-                    .map_err(|_| format!("Invalid Multiaddr: {}", multiaddr))
-            })
-            .collect::<Result<Vec<Multiaddr>, _>>()?;
-    }
-
-    if let Some(enr_udp_port_str) = cli_args.value_of("enr-udp-port") {
-        client_config.network.enr_udp_port = Some(
-            enr_udp_port_str
-                .parse::<u16>()
-                .map_err(|_| format!("Invalid discovery port: {}", enr_udp_port_str))?,
-        );
-    }
-
-    if let Some(enr_tcp_port_str) = cli_args.value_of("enr-tcp-port") {
-        client_config.network.enr_tcp_port = Some(
-            enr_tcp_port_str
-                .parse::<u16>()
-                .map_err(|_| format!("Invalid ENR TCP port: {}", enr_tcp_port_str))?,
-        );
-    }
-
-    if cli_args.is_present("enr-match") {
-        // set the enr address to localhost if the address is 0.0.0.0
-        if client_config.network.listen_address
-            == "0.0.0.0".parse::<IpAddr>().expect("valid ip addr")
-        {
-            client_config.network.enr_address =
-                Some("127.0.0.1".parse::<IpAddr>().expect("valid ip addr"));
-        } else {
-            client_config.network.enr_address = Some(client_config.network.listen_address);
-        }
-        client_config.network.enr_udp_port = Some(client_config.network.discovery_port);
-    }
-
-    if let Some(enr_address) = cli_args.value_of("enr-address") {
-        let resolved_addr = match enr_address.parse::<IpAddr>() {
-            Ok(addr) => addr, // // Input is an IpAddr
-            Err(_) => {
-                let mut addr = enr_address.to_string();
-                // Appending enr-port to the dns hostname to appease `to_socket_addrs()` parsing.
-                // Since enr-update is disabled with a dns address, not setting the enr-udp-port
-                // will make the node undiscoverable.
-                if let Some(enr_udp_port) = client_config.network.enr_udp_port {
-                    addr.push_str(&format!(":{}", enr_udp_port.to_string()));
-                } else {
-                    return Err(
-                        "enr-udp-port must be set for node to be discoverable with dns address"
-                            .into(),
-                    );
-                }
-                // `to_socket_addr()` does the dns resolution
-                // Note: `to_socket_addrs()` is a blocking call
-                let resolved_addr = if let Ok(mut resolved_addrs) = addr.to_socket_addrs() {
-                    // Pick the first ip from the list of resolved addresses
-                    resolved_addrs
-                        .next()
-                        .map(|a| a.ip())
-                        .ok_or_else(|| "Resolved dns addr contains no entries".to_string())?
-                } else {
-                    return Err(format!("Failed to parse enr-address: {}", enr_address));
-                };
-                client_config.network.discv5_config.enr_update = false;
-                resolved_addr
-            }
-        };
-        client_config.network.enr_address = Some(resolved_addr);
-    }
-
-    if cli_args.is_present("disable_enr_auto_update") {
-        client_config.network.discv5_config.enr_update = false;
-    }
-
-    if cli_args.is_present("disable-discovery") {
-        client_config.network.disable_discovery = true;
-        slog::warn!(log, "Discovery is disabled. New peers will not be found");
-    }
+    set_network_config(
+        &mut client_config.network,
+        cli_args,
+        &client_config.data_dir,
+        &log,
+        false,
+    )?;
 
     /*
      * Http server
@@ -369,6 +252,145 @@ pub fn get_config<E: EthSpec>(
         .copy_from_slice(&raw_graffiti[..trimmed_graffiti_len]);
 
     Ok(client_config)
+}
+
+/// Sets the network config from the command line arguments
+pub fn set_network_config(
+    config: &mut NetworkConfig,
+    cli_args: &ArgMatches,
+    data_dir: &PathBuf,
+    log: &Logger,
+    use_listening_port_as_enr_port_by_default: bool,
+) -> Result<(), String> {
+    // If a network dir has been specified, override the `datadir` definition.
+    if let Some(dir) = cli_args.value_of("network-dir") {
+        config.network_dir = PathBuf::from(dir);
+    } else {
+        config.network_dir = data_dir.join(NETWORK_DIR);
+    };
+
+    if let Some(listen_address_str) = cli_args.value_of("listen-address") {
+        let listen_address = listen_address_str
+            .parse()
+            .map_err(|_| format!("Invalid listen address: {:?}", listen_address_str))?;
+        config.listen_address = listen_address;
+    }
+
+    if let Some(target_peers_str) = cli_args.value_of("target-peers") {
+        config.target_peers = target_peers_str
+            .parse::<usize>()
+            .map_err(|_| format!("Invalid number of target peers: {}", target_peers_str))?;
+    }
+
+    if let Some(port_str) = cli_args.value_of("port") {
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid port: {}", port_str))?;
+        config.libp2p_port = port;
+        config.discovery_port = port;
+    }
+
+    if let Some(port_str) = cli_args.value_of("discovery-port") {
+        let port = port_str
+            .parse::<u16>()
+            .map_err(|_| format!("Invalid port: {}", port_str))?;
+        config.discovery_port = port;
+    }
+
+    if let Some(boot_enr_str) = cli_args.value_of("boot-nodes") {
+        config.boot_nodes = boot_enr_str
+            .split(',')
+            .map(|enr| enr.parse().map_err(|_| format!("Invalid ENR: {}", enr)))
+            .collect::<Result<Vec<Enr>, _>>()?;
+    }
+
+    if let Some(libp2p_addresses_str) = cli_args.value_of("libp2p-addresses") {
+        config.libp2p_nodes = libp2p_addresses_str
+            .split(',')
+            .map(|multiaddr| {
+                multiaddr
+                    .parse()
+                    .map_err(|_| format!("Invalid Multiaddr: {}", multiaddr))
+            })
+            .collect::<Result<Vec<Multiaddr>, _>>()?;
+    }
+
+    if let Some(enr_udp_port_str) = cli_args.value_of("enr-udp-port") {
+        config.enr_udp_port = Some(
+            enr_udp_port_str
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid discovery port: {}", enr_udp_port_str))?,
+        );
+    }
+
+    if let Some(enr_tcp_port_str) = cli_args.value_of("enr-tcp-port") {
+        config.enr_tcp_port = Some(
+            enr_tcp_port_str
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid ENR TCP port: {}", enr_tcp_port_str))?,
+        );
+    }
+
+    if cli_args.is_present("enr-match") {
+        // set the enr address to localhost if the address is 0.0.0.0
+        if config.listen_address == "0.0.0.0".parse::<IpAddr>().expect("valid ip addr") {
+            config.enr_address = Some("127.0.0.1".parse::<IpAddr>().expect("valid ip addr"));
+        } else {
+            config.enr_address = Some(config.listen_address);
+        }
+        config.enr_udp_port = Some(config.discovery_port);
+    }
+
+    if let Some(enr_address) = cli_args.value_of("enr-address") {
+        let resolved_addr = match enr_address.parse::<IpAddr>() {
+            Ok(addr) => addr, // // Input is an IpAddr
+            Err(_) => {
+                let mut addr = enr_address.to_string();
+                // Appending enr-port to the dns hostname to appease `to_socket_addrs()` parsing.
+                // Since enr-update is disabled with a dns address, not setting the enr-udp-port
+                // will make the node undiscoverable.
+                if let Some(enr_udp_port) = config.enr_udp_port.or_else(|| {
+                    if use_listening_port_as_enr_port_by_default {
+                        Some(config.discovery_port)
+                    } else {
+                        None
+                    }
+                }) {
+                    addr.push_str(&format!(":{}", enr_udp_port.to_string()));
+                } else {
+                    return Err(
+                        "enr-udp-port must be set for node to be discoverable with dns address"
+                            .into(),
+                    );
+                }
+                // `to_socket_addr()` does the dns resolution
+                // Note: `to_socket_addrs()` is a blocking call
+                let resolved_addr = if let Ok(mut resolved_addrs) = addr.to_socket_addrs() {
+                    // Pick the first ip from the list of resolved addresses
+                    resolved_addrs
+                        .next()
+                        .map(|a| a.ip())
+                        .ok_or_else(|| "Resolved dns addr contains no entries".to_string())?
+                } else {
+                    return Err(format!("Failed to parse enr-address: {}", enr_address));
+                };
+                config.discv5_config.enr_update = false;
+                resolved_addr
+            }
+        };
+        config.enr_address = Some(resolved_addr);
+    }
+
+    if cli_args.is_present("disable_enr_auto_update") {
+        config.discv5_config.enr_update = false;
+    }
+
+    if cli_args.is_present("disable-discovery") {
+        config.disable_discovery = true;
+        slog::warn!(log, "Discovery is disabled. New peers will not be found");
+    }
+
+    Ok(())
 }
 
 /// Gets the datadir which should be used.

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -7,7 +7,7 @@ mod config;
 pub use beacon_chain;
 pub use cli::cli_app;
 pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
-pub use config::{get_data_dir, get_eth2_testnet_config};
+pub use config::{get_data_dir, get_eth2_testnet_config, set_network_config};
 pub use eth2_config::Eth2Config;
 
 use beacon_chain::events::TeeEventHandler;

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
+beacon_node = { path = "../beacon_node" }
 clap = "2.33.0"
 eth2_libp2p = { path = "../beacon_node/eth2_libp2p" } 
 slog = "2.5.2"

--- a/boot_node/src/cli.rs
+++ b/boot_node/src/cli.rs
@@ -12,7 +12,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         surface compared to a full beacon node.")
         .settings(&[clap::AppSettings::ColoredHelp])
         .arg(
-            Arg::with_name("boot-node-enr-address")
+            Arg::with_name("enr-address")
                 .value_name("IP-ADDRESS")
                 .help("The external IP address/ DNS address to broadcast to other peers on how to reach this node. \
                 If a DNS address is provided, the enr-address is set to the IP address it resolves to and \
@@ -44,7 +44,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("enr-port")
+            Arg::with_name("enr-udp-port")
                 .long("enr-port")
                 .value_name("PORT")
                 .help("The UDP port of the boot node's ENR. This is the port that external peers will dial to reach this boot node. Set this only if the external port differs from the listening port.")

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -1,7 +1,12 @@
+use beacon_node::{get_data_dir, set_network_config};
 use clap::ArgMatches;
 use discv5::{enr::CombinedKey, Enr};
+use eth2_libp2p::{
+    discovery::{create_enr_builder_from_config, use_or_load_enr},
+    load_private_key, CombinedKeyExt, NetworkConfig,
+};
 use std::convert::TryFrom;
-use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 
 /// A set of configuration parameters for the bootnode, established from CLI arguments.
 pub struct BootNodeConfig {
@@ -17,17 +22,22 @@ impl TryFrom<&ArgMatches<'_>> for BootNodeConfig {
     type Error = String;
 
     fn try_from(matches: &ArgMatches<'_>) -> Result<Self, Self::Error> {
-        let listen_address = matches
-            .value_of("listen-address")
-            .expect("required parameter")
-            .parse::<IpAddr>()
-            .map_err(|_| "Invalid listening address".to_string())?;
+        let data_dir = get_data_dir(matches);
 
-        let listen_port = matches
-            .value_of("port")
-            .expect("required parameter")
-            .parse::<u16>()
-            .map_err(|_| "Invalid listening port".to_string())?;
+        let mut network_config = NetworkConfig::default();
+
+        let logger = slog_scope::logger();
+
+        set_network_config(&mut network_config, matches, &data_dir, &logger, true)?;
+
+        let private_key = load_private_key(&network_config, &logger);
+        let local_key = CombinedKey::from_libp2p(&private_key)?;
+
+        let mut local_enr = create_enr_builder_from_config(&network_config)
+            .build(&local_key)
+            .map_err(|e| format!("Failed to build ENR: {:?}", e))?;
+
+        use_or_load_enr(&local_key, &mut local_enr, &network_config, &logger)?;
 
         let boot_nodes = {
             if let Some(boot_nodes) = matches.value_of("boot-nodes") {
@@ -40,34 +50,11 @@ impl TryFrom<&ArgMatches<'_>> for BootNodeConfig {
             }
         };
 
-        let enr_port = {
-            if let Some(port) = matches.value_of("boot-node-enr-port") {
-                port.parse::<u16>()
-                    .map_err(|_| "Invalid ENR port".to_string())?
-            } else {
-                listen_port
-            }
-        };
-
-        let enr_address = {
-            let address_string = matches
-                .value_of("boot-node-enr-address")
-                .expect("required parameter");
-            resolve_address(address_string.into(), enr_port)?
-        };
-
         let auto_update = matches.is_present("enable-enr_auto_update");
 
         // the address to listen on
-        let listen_socket = SocketAddr::new(listen_address, enr_port);
-
-        // Generate a new key and build a new ENR
-        let local_key = CombinedKey::generate_secp256k1();
-        let local_enr = discv5::enr::EnrBuilder::new("v4")
-            .ip(enr_address)
-            .udp(enr_port)
-            .build(&local_key)
-            .map_err(|e| format!("Failed to build ENR: {:?}", e))?;
+        let listen_socket =
+            SocketAddr::new(network_config.listen_address, network_config.discovery_port);
 
         Ok(BootNodeConfig {
             listen_socket,
@@ -76,27 +63,5 @@ impl TryFrom<&ArgMatches<'_>> for BootNodeConfig {
             local_key,
             auto_update,
         })
-    }
-}
-
-/// Resolves an IP/DNS string to an IpAddr.
-fn resolve_address(address_string: String, port: u16) -> Result<IpAddr, String> {
-    match address_string.parse::<IpAddr>() {
-        Ok(addr) => Ok(addr), // valid IpAddr
-        Err(_) => {
-            let mut addr = address_string.clone();
-            // Appending enr-port to the dns hostname to appease `to_socket_addrs()` parsing.
-            addr.push_str(&format!(":{}", port.to_string()));
-            // `to_socket_addr()` does the dns resolution
-            // Note: `to_socket_addrs()` is a blocking call
-            addr.to_socket_addrs()
-                .map(|mut resolved_addrs|
-                    // Pick the first ip from the list of resolved addresses
-                    resolved_addrs
-                        .next()
-                        .map(|a| a.ip())
-                        .ok_or_else(|| "Resolved dns addr contains no entries".to_string()))
-                .map_err(|_| format!("Failed to parse enr-address: {}", address_string))?
-        }
     }
 }


### PR DESCRIPTION
## Issue Addressed

#1378

## Proposed Changes

Boot node reuses code from beacon_node to initialize network config. This also enables using the network directory to store/load the enr and the private key.

## Additional Info

Note that before this PR the port cli arguments were off (the argument was named `enr-port` but used as `boot-node-enr-port`).
Therefore as port always the cli port argument was used (for both enr and listening). Now the enr-port argument can be used to overwrite the listening port as the public port others should connect to.

Last but not least note, that this restructuring reuses `ethlibp2p::NetworkConfig` that has many more options than the ones used in the boot node. For example the network config has an own `discv5_config` field that gets never used in the boot node and instead another `Discv5Config` gets created later in the boot node process.