### PR TITLE
[Merged by Bors] - Commit Cargo.lock changes, add build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 flamegraph.svg
 perf.data*
 *.tar.gz
+bin/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "account_manager"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "account_utils",
  "bls",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "0.1.0"
+version = "0.2.3"
 dependencies = [
  "clap",
  "discv5",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "account_manager",
  "account_utils",
@@ -6022,7 +6022,7 @@ dependencies = [
 
 [[package]]
 name = "validator_client"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "account_utils",
  "bls",

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ endef
 # The current git tag will be used as the version in the output file names. You
 # will likely need to use `git tag` and create a semver tag (e.g., `v0.2.3`).
 build-release-tarballs:
-	echo "Using git tag $(GIT_TAG) as the version for tarball filenames."
 	[ -d $(BIN_DIR) ] || mkdir -p $(BIN_DIR)
 	$(MAKE) build-x86_64
 	$(call tarball_release_binary,$(BUILD_PATH_X86_64),$(X86_64_TAG),"")

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@
 
 EF_TESTS = "testing/ef_tests"
 STATE_TRANSITION_VECTORS = "testing/state_transition_vectors"
+GIT_TAG := $(shell git describe --tags --candidates 1)
+BIN_DIR = "bin"
+
+X86_64_TAG = "x86_64-unknown-linux-gnu"
+BUILD_PATH_X86_64 = "target/$(X86_64_TAG)/release"
+AARCH64_TAG = "aarch64-unknown-linux-gnu"
+BUILD_PATH_AARCH64 = "target/$(AARCH64_TAG)/release"
 
 # Builds the Lighthouse binary in release (optimized).
 #
@@ -42,6 +49,32 @@ build-aarch64:
 	cross build --release --manifest-path lighthouse/Cargo.toml --target aarch64-unknown-linux-gnu
 build-aarch64-portable:
 	cross build --release --manifest-path lighthouse/Cargo.toml --target aarch64-unknown-linux-gnu --features portable
+
+# Create a `.tar.gz` containing a binary for a specific target.
+define tarball_release_binary
+	cp $(1)/lighthouse $(BIN_DIR)/lighthouse
+	cd $(BIN_DIR) && \
+		tar -czf lighthouse-$(GIT_TAG)-$(2)$(3).tar.gz lighthouse && \
+		rm lighthouse
+endef
+
+# Create a series of `.tar.gz` files in the BIN_DIR directory, each containing
+# a `lighthouse` binary for a different target.
+#
+# The current git tag will be used as the version in the output file names. You
+# will likely need to use `git tag` and create a semver tag (e.g., `v0.2.3`).
+build-release-tarballs:
+	echo "Using git tag $(GIT_TAG) as the version for tarball filenames."
+	[ -d $(BIN_DIR) ] || mkdir -p $(BIN_DIR)
+	$(MAKE) build-x86_64
+	$(call tarball_release_binary,$(BUILD_PATH_X86_64),$(X86_64_TAG),"")
+	$(MAKE) build-x86_64-portable
+	$(call tarball_release_binary,$(BUILD_PATH_X86_64),$(X86_64_TAG),"-portable")
+	$(MAKE) build-aarch64
+	$(call tarball_release_binary,$(BUILD_PATH_AARCH64),$(AARCH64_TAG),"")
+	$(MAKE) build-aarch64-portable
+	$(call tarball_release_binary,$(BUILD_PATH_AARCH64),$(AARCH64_TAG),"-portable")
+
 
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR commits the `Cargo.lock` file so it does not indicate a dirty git tree in the version tag. This code should be used for the `v0.2.3` release.

Also, adds a `Makefile` command to produce tarballs for upload on release.

## Additional Info

NA
