### PR TITLE
[Merged by Bors] - Memory usage reduction

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -775,7 +775,12 @@ where
             metrics::start_timer(&metrics::ATTESTATION_PROCESSING_STATE_READ_TIMES);
 
         let mut state = chain
-            .get_state(&target_block.state_root, Some(target_block.slot))?
+            .store
+            .get_inconsistent_state_for_attestation_verification_only(
+                &target_block.state_root,
+                Some(target_block.slot),
+            )
+            .map_err(BeaconChainError::from)?
             .ok_or_else(|| BeaconChainError::MissingBeaconState(target_block.state_root))?;
 
         metrics::stop_timer(state_read_timer);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -397,6 +397,11 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
         // Check if the block is already known. We know it is post-finalization, so it is
         // sufficient to check the fork choice.
+        //
+        // In normal operation this isn't necessary, however it is useful immediately after a
+        // reboot if the `observed_block_producers` cache is empty. In that case, without this
+        // check, we will load the parent and state from disk only to find out later that we
+        // already know this block.
         if chain.fork_choice.read().contains_block(&block_root) {
             return Err(BlockError::BlockIsAlreadyKnown);
         }

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -686,7 +686,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                 let op = if state.slot % T::EthSpec::slots_per_epoch() == 0 {
                     StoreOp::PutState(
                         state_root.into(),
-                        Cow::Owned(state.clone_with(CloneConfig::none())),
+                        Cow::Owned(state.clone_with(CloneConfig::committee_caches_only())),
                     )
                 } else {
                     StoreOp::PutStateSummary(

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -672,7 +672,10 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                 let state_root = state.update_tree_hash_cache()?;
 
                 let op = if state.slot % T::EthSpec::slots_per_epoch() == 0 {
-                    StoreOp::PutState(state_root.into(), Cow::Owned(state.clone()))
+                    StoreOp::PutState(
+                        state_root.into(),
+                        Cow::Owned(state.clone_with(CloneConfig::none())),
+                    )
                 } else {
                     StoreOp::PutStateSummary(
                         state_root.into(),

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -251,7 +251,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     /// Fetch a state from the store, but don't compute all of the values when replaying blocks
-    /// upon that state (e.g., state roots). Additionally, only state from the hot store are
+    /// upon that state (e.g., state roots). Additionally, only states from the hot store are
     /// returned.
     ///
     /// See `Self::get_state` for information about `slot`.

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -30,9 +30,13 @@ use types::*;
 /// 32-byte key for accessing the `split` of the freezer DB.
 pub const SPLIT_DB_KEY: &str = "FREEZERDBSPLITFREEZERDBSPLITFREE";
 
+/// Defines how blocks should be replayed on states.
 #[derive(PartialEq)]
 pub enum BlockReplay {
+    /// Perform all transitions faithfully to the specification.
     Accurate,
+    /// Don't compute state roots, eventually computing an invalid beacon state that can only be
+    /// used for obtaining shuffling.
     InconsistentStateRoots,
 }
 
@@ -246,6 +250,16 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
     }
 
+    /// Fetch a state from the store, but don't compute all of the values when replaying blocks
+    /// upon that state (e.g., state roots). Additionally, only state from the hot store are
+    /// returned.
+    ///
+    /// See `Self::get_state` for information about `slot`.
+    ///
+    /// ## Warning
+    ///
+    /// The returned state **is not a valid beacon state**, it can only be used for obtaining
+    /// shuffling to process attestations.
     pub fn get_inconsistent_state_for_attestation_verification_only(
         &self,
         state_root: &Hash256,

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -292,7 +292,7 @@ impl ValidatorsListTreeHashCache {
         let leaves = self.values.leaves(validators)?;
         let num_leaves = leaves.iter().map(|arena| arena.len()).sum();
 
-        let leaves_iter = ForcedLengthIterator {
+        let leaves_iter = ForcedExactSizeIterator {
             iter: leaves.into_iter().flatten().map(|h| h.to_fixed_bytes()),
             len: num_leaves,
         };
@@ -311,12 +311,12 @@ impl ValidatorsListTreeHashCache {
 /// programmer but not the compiler. This allows use of `ExactSizeIterator` in some occasions.
 ///
 /// Care should be taken to ensure `len` is accurate.
-struct ForcedLengthIterator<I> {
+struct ForcedExactSizeIterator<I> {
     iter: I,
     len: usize,
 }
 
-impl<V, I: Iterator<Item = V>> Iterator for ForcedLengthIterator<I> {
+impl<V, I: Iterator<Item = V>> Iterator for ForcedExactSizeIterator<I> {
     type Item = V;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -324,7 +324,7 @@ impl<V, I: Iterator<Item = V>> Iterator for ForcedLengthIterator<I> {
     }
 }
 
-impl<V, I: Iterator<Item = V>> ExactSizeIterator for ForcedLengthIterator<I> {
+impl<V, I: Iterator<Item = V>> ExactSizeIterator for ForcedExactSizeIterator<I> {
     fn len(&self) -> usize {
         self.len
     }

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use std::cmp::Ordering;
+use std::iter::ExactSizeIterator;
 use tree_hash::{mix_in_length, MerkleHasher, TreeHash};
 
 /// The number of fields on a beacon state.
@@ -288,21 +289,44 @@ impl ValidatorsListTreeHashCache {
     fn recalculate_tree_hash_root(&mut self, validators: &[Validator]) -> Result<Hash256, Error> {
         let mut list_arena = std::mem::take(&mut self.list_arena);
 
-        let leaves = self
-            .values
-            .leaves(validators)?
-            .into_iter()
-            .flatten()
-            .map(|h| h.to_fixed_bytes())
-            .collect::<Vec<_>>();
+        let leaves = self.values.leaves(validators)?;
+        let num_leaves = leaves.iter().map(|arena| arena.len()).sum();
+
+        let leaves_iter = ForcedLengthIterator {
+            iter: leaves.into_iter().flatten().map(|h| h.to_fixed_bytes()),
+            len: num_leaves,
+        };
 
         let list_root = self
             .list_cache
-            .recalculate_merkle_root(&mut list_arena, leaves.into_iter())?;
+            .recalculate_merkle_root(&mut list_arena, leaves_iter)?;
 
         self.list_arena = list_arena;
 
         Ok(mix_in_length(&list_root, validators.len()))
+    }
+}
+
+/// Provides a wrapper around some `iter` if the number of items in the iterator is known to the
+/// programmer but not the compiler. This allows use of `ExactSizeIterator` in some occasions.
+///
+/// Care should be taken to ensure `len` is accurate.
+struct ForcedLengthIterator<I> {
+    iter: I,
+    len: usize,
+}
+
+impl<V, I: Iterator<Item = V>> Iterator for ForcedLengthIterator<I> {
+    type Item = V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+impl<V, I: Iterator<Item = V>> ExactSizeIterator for ForcedLengthIterator<I> {
+    fn len(&self) -> usize {
+        self.len
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Adds a new function to allow getting a state with a bad state root history for attestation verification. This reduces unnecessary tree hashing during attestation processing, which accounted for 23% of memory allocations (by bytes) in a recent `heaptrack` observation.
- Don't clone caches on intermediate epoch-boundary states during block processing.
- Reject blocks that are known to fork choice earlier during gossip processing, instead of waiting until after state has been loaded (this only happens in edge-case).
- Avoid multiple re-allocations by creating a "forced" exact size iterator.

## Additional Info

NA