### PR TITLE
[Merged by Bors] - Update gossipsub duplicate cache

### DIFF
--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -41,7 +41,7 @@ rand = "0.7.3"
 [dependencies.libp2p]
 #version = "0.23.0"
 git = "https://github.com/sigp/rust-libp2p"
-rev = "3096cb6b89b2883a79ce5ffcb03d41778a09b695"
+rev = "bbf0cfbaff2f733b3ae7bfed3caba8b7ee542803"
 default-features = false
 features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns", "tcp-tokio"]
 


### PR DESCRIPTION
This potentially handles memory leak issues by preventing adding references to already seen gossipsub messages.