### PR TITLE
[Merged by Bors] - Limit parallelism of head chain sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,9 +1195,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90782d49541b01f9b7e34e6af5d80d01396bf7b1a81505a0035da224134b8d73"
+checksum = "98bc715508160877f74d828b94238c156c50f0ca80f51271bca9a855be94c488"
 dependencies = [
  "arrayvec",
  "digest 0.8.1",
@@ -1213,10 +1213,10 @@ dependencies = [
  "lru_time_cache",
  "multihash",
  "net2",
- "openssl",
  "parking_lot 0.11.0",
  "rand 0.7.3",
  "rlp",
+ "rust-crypto",
  "sha2 0.8.2",
  "smallvec 1.4.1",
  "tokio 0.2.22",
@@ -4022,6 +4022,16 @@ checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -4382,6 +4392,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-crypto"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
+dependencies = [
+ "gcc",
+ "libc",
+ "rand 0.3.23",
+ "rustc-serialize",
+ "time 0.1.43",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,6 +4421,12 @@ name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustc_version"

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -694,6 +694,14 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         }
     }
 
+    /// Returns true if this chain is currently syncing.
+    pub fn is_syncing(&self) -> bool {
+        match self.state {
+            ChainSyncingState::Syncing => true,
+            ChainSyncingState::Stopped => false,
+        }
+    }
+
     /// Attempts to request the next required batches from the peer pool if the chain is syncing. It will exhaust the peer
     /// pool and left over batches until the batch buffer is reached or all peers are exhausted.
     fn request_batches(&mut self, network: &mut SyncNetworkContext<T::EthSpec>) {

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -260,12 +260,13 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         let downloaded_blocks = std::mem::replace(&mut batch.downloaded_blocks, Vec::new());
         let process_id = ProcessId::RangeBatchId(self.id, batch.id);
         self.current_processing_batch = Some(batch);
+        let log = self.log.new(slog::o!("service"=> "sync"));
         spawn_block_processor(
             Arc::downgrade(&self.chain.clone()),
             process_id,
             downloaded_blocks,
             self.sync_send.clone(),
-            self.log.clone(),
+            log,
         );
     }
 

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -330,7 +330,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             currently_syncing = self
                 .head_chains
                 .iter()
-                .filter(|chain| !chain.is_syncing())
+                .filter(|chain| chain.is_syncing())
                 .count();
             not_syncing = self.head_chains.len() - currently_syncing;
         }

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -307,7 +307,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         let mut currently_syncing = self
             .head_chains
             .iter()
-            .filter(|chain| !chain.is_syncing())
+            .filter(|chain| chain.is_syncing())
             .count();
         let mut not_syncing = self.head_chains.len() - currently_syncing;
 

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -15,6 +15,9 @@ use tokio::sync::mpsc;
 use types::EthSpec;
 use types::{Epoch, Hash256, Slot};
 
+/// The number of head syncing chains to sync at a time.
+const PARALLEL_HEAD_CHAINS: usize = 2;
+
 /// The state of the long range/batch sync.
 #[derive(Clone)]
 pub enum RangeSyncState {
@@ -205,8 +208,9 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     /// Updates the state of the chain collection.
     ///
     /// This removes any out-dated chains, swaps to any higher priority finalized chains and
-    /// updates the state of the collection.
-    pub fn update_finalized(&mut self, network: &mut SyncNetworkContext<T::EthSpec>) {
+    /// updates the state of the collection. This starts head chains syncing if any are required to
+    /// do so.
+    pub fn update(&mut self, network: &mut SyncNetworkContext<T::EthSpec>) {
         let local_epoch = {
             let local = match PeerSyncInfo::from_chain(&self.beacon_chain) {
                 Some(local) => local,
@@ -222,9 +226,25 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             local.finalized_epoch
         };
 
-        // Remove any outdated finalized chains
+        // Remove any outdated finalized/head chains
         self.purge_outdated_chains(network);
 
+        // Choose the best finalized chain if one needs to be selected.
+        self.update_finalized_chains(network, local_epoch);
+
+        if self.finalized_syncing_index().is_none() {
+            // Handle head syncing chains if there are no finalized chains left.
+            self.update_head_chains(network, local_epoch);
+        }
+    }
+
+    /// This looks at all current finalized chains and decides if a new chain should be prioritised
+    /// or not.
+    fn update_finalized_chains(
+        &mut self,
+        network: &mut SyncNetworkContext<T::EthSpec>,
+        local_epoch: Epoch,
+    ) {
         // Check if any chains become the new syncing chain
         if let Some(index) = self.finalized_syncing_index() {
             // There is a current finalized chain syncing
@@ -269,30 +289,74 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                 head_root: chain.target_head_root,
             };
             self.state = state;
-        } else {
-            // There are no finalized chains, update the state.
-            if self.head_chains.is_empty() {
-                self.state = RangeSyncState::Idle;
-            } else {
-                // for the syncing API, we find the minimal start_slot and the maximum
-                // target_slot of all head chains to report back.
-
-                let (min_epoch, max_slot) = self.head_chains.iter().fold(
-                    (Epoch::from(0u64), Slot::from(0u64)),
-                    |(min, max), chain| {
-                        (
-                            std::cmp::min(min, chain.start_epoch),
-                            std::cmp::max(max, chain.target_head_slot),
-                        )
-                    },
-                );
-                let head_state = RangeSyncState::Head {
-                    start_slot: min_epoch.start_slot(T::EthSpec::slots_per_epoch()),
-                    head_slot: max_slot,
-                };
-                self.state = head_state;
-            }
         }
+    }
+
+    /// Start syncing any head chains if required.
+    fn update_head_chains(
+        &mut self,
+        network: &mut SyncNetworkContext<T::EthSpec>,
+        local_epoch: Epoch,
+    ) {
+        // There are no finalized chains, update the state.
+        if self.head_chains.is_empty() {
+            self.state = RangeSyncState::Idle;
+            return;
+        }
+
+        let mut currently_syncing = self
+            .head_chains
+            .iter()
+            .filter(|chain| !chain.is_syncing())
+            .count();
+        let mut not_syncing = self.head_chains.len() - currently_syncing;
+
+        // Find all head chains that are not currently syncing ordered by peer count.
+        while currently_syncing <= PARALLEL_HEAD_CHAINS && not_syncing > 0 {
+            // Find the chain with the most peers and start syncing
+            if let Some((_index, chain)) = self
+                .head_chains
+                .iter_mut()
+                .filter(|chain| !chain.is_syncing())
+                .enumerate()
+                .max_by_key(|(_index, chain)| chain.peer_pool.len())
+            {
+                // start syncing this chain
+                debug!(self.log, "New head chain started syncing"; "new_target_root" => format!("{}", chain.target_head_root), "new_end_slot" => chain.target_head_slot, "new_start_epoch"=> chain.start_epoch);
+                chain.start_syncing(network, local_epoch);
+            }
+
+            // update variables
+            currently_syncing = self
+                .head_chains
+                .iter()
+                .filter(|chain| !chain.is_syncing())
+                .count();
+            not_syncing = self.head_chains.len() - currently_syncing;
+        }
+
+        // Start
+        // for the syncing API, we find the minimal start_slot and the maximum
+        // target_slot of all head chains to report back.
+
+        let (min_epoch, max_slot) = self
+            .head_chains
+            .iter()
+            .filter(|chain| chain.is_syncing())
+            .fold(
+                (Epoch::from(0u64), Slot::from(0u64)),
+                |(min, max), chain| {
+                    (
+                        std::cmp::min(min, chain.start_epoch),
+                        std::cmp::max(max, chain.target_head_slot),
+                    )
+                },
+            );
+        let head_state = RangeSyncState::Head {
+            start_slot: min_epoch.start_slot(T::EthSpec::slots_per_epoch()),
+            head_slot: max_slot,
+        };
+        self.state = head_state;
     }
 
     /// Add a new finalized chain to the collection.
@@ -321,7 +385,6 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     #[allow(clippy::too_many_arguments)]
     pub fn new_head_chain(
         &mut self,
-        network: &mut SyncNetworkContext<T::EthSpec>,
         remote_finalized_epoch: Epoch,
         target_head: Hash256,
         target_slot: Slot,
@@ -336,7 +399,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         self.head_chains.retain(|chain| !chain.peer_pool.is_empty());
 
         let chain_id = rand::random();
-        let mut new_head_chain = SyncingChain::new(
+        let new_head_chain = SyncingChain::new(
             chain_id,
             remote_finalized_epoch,
             target_slot,
@@ -346,8 +409,6 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             self.beacon_chain.clone(),
             self.log.clone(),
         );
-        // All head chains can sync simultaneously
-        new_head_chain.start_syncing(network, remote_finalized_epoch);
         self.head_chains.push(new_head_chain);
     }
 
@@ -511,7 +572,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         debug!(self.log, "Chain was removed"; "start_epoch" => chain.start_epoch, "end_slot" => chain.target_head_slot);
 
         // update the state
-        self.update_finalized(network);
+        self.update(network);
     }
 
     /// Returns the index of finalized chain that is currently syncing. Returns `None` if no

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -168,7 +168,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     chain.add_peer(network, peer_id);
 
                     // check if the new peer's addition will favour a new syncing chain.
-                    self.chains.update_finalized(network);
+                    self.chains.update(network);
                     // update the global sync state if necessary
                     self.chains.update_sync_state();
                 } else {
@@ -183,7 +183,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                         peer_id,
                         self.sync_send.clone(),
                     );
-                    self.chains.update_finalized(network);
+                    self.chains.update(network);
                     // update the global sync state
                     self.chains.update_sync_state();
                 }
@@ -223,7 +223,6 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                     debug!(self.log, "Creating a new syncing head chain"; "head_root" => format!("{}",remote_info.head_root), "start_epoch" => start_epoch, "head_slot" => remote_info.head_slot, "peer_id" => format!("{:?}", peer_id));
 
                     self.chains.new_head_chain(
-                        network,
                         start_epoch,
                         remote_info.head_root,
                         remote_info.head_slot,
@@ -231,7 +230,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                         self.sync_send.clone(),
                     );
                 }
-                self.chains.update_finalized(network);
+                self.chains.update(network);
                 self.chains.update_sync_state();
             }
         }
@@ -292,7 +291,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                 let chain = self.chains.remove_finalized_chain(index);
                 debug!(self.log, "Finalized chain removed"; "start_epoch" => chain.start_epoch, "end_slot" => chain.target_head_slot);
                 // update the state of the collection
-                self.chains.update_finalized(network);
+                self.chains.update(network);
 
                 // the chain is complete, re-status it's peers
                 chain.status_peers(network);
@@ -332,7 +331,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
                         chain.status_peers(network);
 
                         // update the state of the collection
-                        self.chains.update_finalized(network);
+                        self.chains.update(network);
                         // update the global state and log any change
                         self.chains.update_sync_state();
                     }
@@ -361,7 +360,7 @@ impl<T: BeaconChainTypes> RangeSync<T> {
         self.remove_peer(network, peer_id);
 
         // update the state of the collection
-        self.chains.update_finalized(network);
+        self.chains.update(network);
         // update the global state and inform the user
         self.chains.update_sync_state();
     }


### PR DESCRIPTION
## Description

Currently lighthouse load-balances across peers a single finalized chain. The chain is selected via the most peers. Once synced to the latest finalized epoch Lighthouse creates chains amongst its peers and syncs them all in parallel amongst each peer (grouped by their current head block). 

This is typically fast and relatively efficient under normal operations. However if the chain has not finalized in a long time, the head chains can grow quite long. Peer's head chains will update every slot as new blocks are added to the head. Syncing all head chains in parallel is a bottleneck and highly inefficient in block duplication leads to RPC timeouts when attempting to handle all new heads chains at once. 

This PR limits the parallelism of head syncing chains to 2. We now sync at most two head chains at a time. This allows for the possiblity of sync progressing alongside a peer being slow and holding up one chain via RPC timeouts.


