### PR TITLE
[Merged by Bors] - Do not reset batch ids & redownload out of range batches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "account_manager"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "account_utils",
  "bls",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "clap",
  "discv5",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "account_manager",
  "account_utils",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "validator_client"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "account_utils",
  "bls",

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -35,7 +35,7 @@
 
 use super::network_context::SyncNetworkContext;
 use super::peer_sync_info::{PeerSyncInfo, PeerSyncType};
-use super::range_sync::{BatchId, ChainId, RangeSync, EPOCHS_PER_BATCH};
+use super::range_sync::{ChainId, RangeSync, EPOCHS_PER_BATCH};
 use super::RequestId;
 use crate::beacon_processor::{ProcessId, WorkEvent as BeaconWorkEvent};
 use crate::service::NetworkMessage;
@@ -51,7 +51,7 @@ use std::boxed::Box;
 use std::ops::Sub;
 use std::sync::Arc;
 use tokio::sync::mpsc;
-use types::{EthSpec, Hash256, SignedBeaconBlock, Slot};
+use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
 
 /// The number of slots ahead of us that is allowed before requesting a long-range (batch)  Sync
 /// from a peer. If a peer is within this tolerance (forwards or backwards), it is treated as a
@@ -100,7 +100,7 @@ pub enum SyncMessage<T: EthSpec> {
     /// A batch has been processed by the block processor thread.
     BatchProcessed {
         chain_id: ChainId,
-        batch_id: BatchId,
+        epoch: Epoch,
         downloaded_blocks: Vec<SignedBeaconBlock<T>>,
         result: BatchProcessResult,
     },
@@ -842,14 +842,14 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     }
                     SyncMessage::BatchProcessed {
                         chain_id,
-                        batch_id,
+                        epoch,
                         downloaded_blocks,
                         result,
                     } => {
                         self.range_sync.handle_block_process_result(
                             &mut self.network,
                             chain_id,
-                            batch_id,
+                            epoch,
                             downloaded_blocks,
                             result,
                         );

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -8,7 +8,7 @@ mod range_sync;
 
 pub use manager::{BatchProcessResult, SyncMessage};
 pub use peer_sync_info::PeerSyncInfo;
-pub use range_sync::{BatchId, ChainId};
+pub use range_sync::ChainId;
 
 /// Type of id of rpc requests sent by sync
 pub type RequestId = usize;

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -9,37 +9,14 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::ops::Sub;
-use types::{EthSpec, SignedBeaconBlock, Slot};
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct BatchId(pub u64);
-
-impl std::ops::Deref for BatchId {
-    type Target = u64;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-impl std::ops::DerefMut for BatchId {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl std::convert::From<u64> for BatchId {
-    fn from(id: u64) -> Self {
-        BatchId(id)
-    }
-}
+use types::{Epoch, EthSpec, SignedBeaconBlock, Slot};
 
 /// A collection of sequential blocks that are requested from peers in a single RPC request.
 #[derive(PartialEq, Debug)]
 pub struct Batch<T: EthSpec> {
-    /// The ID of the batch, these are sequential.
-    pub id: BatchId,
-    /// The requested start slot of the batch, inclusive.
-    pub start_slot: Slot,
-    /// The requested end slot of batch, exlcusive.
+    /// The requested start epoch of the batch.
+    pub start_epoch: Epoch,
+    /// The requested end slot of batch, exclusive.
     pub end_slot: Slot,
     /// The `Attempts` that have been made to send us this batch.
     pub attempts: Vec<Attempt>,
@@ -69,10 +46,9 @@ pub struct Attempt {
 impl<T: EthSpec> Eq for Batch<T> {}
 
 impl<T: EthSpec> Batch<T> {
-    pub fn new(id: BatchId, start_slot: Slot, end_slot: Slot, peer_id: PeerId) -> Self {
+    pub fn new(start_epoch: Epoch, end_slot: Slot, peer_id: PeerId) -> Self {
         Batch {
-            id,
-            start_slot,
+            start_epoch,
             end_slot,
             attempts: Vec::new(),
             current_peer: peer_id,
@@ -82,12 +58,21 @@ impl<T: EthSpec> Batch<T> {
         }
     }
 
+    pub fn start_slot(&self) -> Slot {
+        // batches are shifted by 1
+        self.start_epoch.start_slot(T::slots_per_epoch()) + 1
+    }
+
+    pub fn end_slot(&self) -> Slot {
+        self.end_slot
+    }
     pub fn to_blocks_by_range_request(&self) -> BlocksByRangeRequest {
+        let start_slot = self.start_slot();
         BlocksByRangeRequest {
-            start_slot: self.start_slot.into(),
+            start_slot: start_slot.into(),
             count: min(
                 T::slots_per_epoch() * EPOCHS_PER_BATCH,
-                self.end_slot.sub(self.start_slot).into(),
+                self.end_slot.sub(start_slot).into(),
             ),
             step: 1,
         }
@@ -105,7 +90,7 @@ impl<T: EthSpec> Batch<T> {
 
 impl<T: EthSpec> Ord for Batch<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.id.0.cmp(&other.id.0)
+        self.start_epoch.cmp(&other.start_epoch)
     }
 }
 

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -9,7 +9,7 @@ use crate::sync::network_context::SyncNetworkContext;
 use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::{types::SyncState, NetworkGlobals, PeerId};
-use slog::{debug, error, info};
+use slog::{debug, error, info, o};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use types::EthSpec;
@@ -313,7 +313,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             peer_id,
             beacon_processor_send,
             self.beacon_chain.clone(),
-            self.log.clone(),
+            self.log.new(o!("chain" => chain_id)),
         ));
     }
 

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -8,6 +8,5 @@ mod range;
 mod sync_type;
 
 pub use batch::Batch;
-pub use batch::BatchId;
 pub use chain::{ChainId, EPOCHS_PER_BATCH};
 pub use range::RangeSync;


### PR DESCRIPTION
The changes are somewhat simple but should solve two issues:
- When quickly changing between chains once and a second time back again, batchIds would collide and cause havoc. 
- If we got an out of range response from a peer, sync would remain in syncing but without advancing

Changes:
- remove the batch id. Identify each batch (inside a chain) by its starting epoch. Target epochs for downloading and processing now advance by EPOCHS_PER_BATCH
- for the same reason, move the "to_be_downloaded_id" to be an epoch
- remove a sneaky line that dropped an out of range batch without downloading it
- bonus: put the chain_id in the log given to the chain. This is why explicitly logging the chain_id is removed