### PR TITLE
[Merged by Bors] - Ensure RUSTFLAGS is passed through on cross compile

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+    "RUSTFLAGS",
+]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Tells `cross` (used for cross-compiling) to read the `RUSTFLAGS`env and pass it through during build. This allows us to use `-g` and get debug info. 

## Additional Info

NA
