### PR TITLE
[Merged by Bors] - Set default max skips to 700

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -1,6 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 
-pub const DEFAULT_IMPORT_BLOCK_MAX_SKIP_SLOTS: u64 = 10 * 32;
+/// There is a 693 block skip in the current canonical Medalla chain, we use 700 to be safe.
+pub const DEFAULT_IMPORT_BLOCK_MAX_SKIP_SLOTS: u64 = 700;
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct ChainConfig {

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -260,6 +260,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 )
                 .value_name("NUM_SLOTS")
                 .takes_value(true)
-                .default_value("320")
+                .default_value("700")
         )
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Sets the default max skips to 700 so that it can cover the 693 slot skip from `80894 - 80201`.

## Additional Info

NA
