### PR TITLE
[Merged by Bors] - Docs: Fix reference to incorrect password file.

### DIFF
--- a/book/src/key-management.md
+++ b/book/src/key-management.md
@@ -44,7 +44,7 @@ In step (1), we created a wallet in `~/.lighthouse/wallets` with the name
 `wally`. We encrypted this using a pre-defined password in the
 `wally.pass` file. Then, in step (2), we created one new validator in the
 `~/.lighthouse/validators` directory using `wally` (unlocking it with
-`mywallet.pass`) and storing the passwords to the validators voting key in
+`wally.pass`) and storing the passwords to the validators voting key in
 `~/.lighthouse/secrets`.
 
 Thanks to the hierarchical key derivation scheme, we can delete all of the


### PR DESCRIPTION
Leftover "mywallet.pass" -> "wally.pass"

Thanks @pecurliarly (from Discord)!