### PR TITLE
[Merged by Bors] - Fix order of testnet config load

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -189,13 +189,16 @@ fn run<E: EthSpec>(
 
     // Parse testnet config from the `testnet` and `testnet-dir` flag in that order
     // else, use the default
-    let mut optional_testnet_config = Eth2TestnetConfig::hard_coded_default()?;
+    let mut optional_testnet_config = None;
     if matches.is_present("testnet") {
         optional_testnet_config = clap_utils::parse_hardcoded_network(matches, "testnet")?;
     };
     if matches.is_present("testnet-dir") {
         optional_testnet_config = clap_utils::parse_testnet_dir(matches, "testnet-dir")?;
     };
+    if optional_testnet_config.is_none() {
+        optional_testnet_config = Eth2TestnetConfig::hard_coded_default()?;
+    }
 
     let builder = if let Some(log_path) = matches.value_of("logfile") {
         let path = log_path


### PR DESCRIPTION
## Issue Addressed

Fixes #1552 

## Proposed Changes

Earlier, we were always loading the hardcoded default testnet config which is a mainnet spec. So running lighthouse with `--spec` option anything other than mainnet gave errors because we tried loading a mainnet genesis spec with `minimal`/`interop` flags.

This PR fixes the order of loading such that we load the hardcoded default spec only if neither `--testnet` and `--testnet-dir` flags are present.
