### PR TITLE
[Merged by Bors] - Check Cargo.lock freshness on CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -123,6 +123,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Lint code for quality and style with Clippy
       run: make lint
+    - name: Certify Cargo.lock freshness
+      run: git diff --exit-code Cargo.lock
   arbitrary-check:
     name: arbitrary-check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "account_manager"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "account_utils",
  "bls",
@@ -373,7 +373,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -530,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "beacon_node",
  "clap",
@@ -2537,7 +2537,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "bls",
  "clap",
@@ -2894,7 +2894,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "account_manager",
  "account_utils",
@@ -6036,7 +6036,7 @@ dependencies = [
 
 [[package]]
 name = "validator_client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "account_utils",
  "bls",


### PR DESCRIPTION
Check that `Cargo.lock` is up-to-date on CI so we're not having to push messy lockfile fix ups after releases.
