### PR TITLE
[Merged by Bors] - add a github action for build multi-arch docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,33 @@
+name: docker
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build-docker-image:
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@master
+
+            - name: Dockerhub login
+              env:
+                  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+                  DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+              run: |
+                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+
+            - name: Set up Docker Buildx
+              id: buildx
+              uses: crazy-max/ghaction-docker-buildx@v1
+              with:
+                  buildx-version: latest
+
+            - name: Build dockerfile (with push)
+              run: |
+                  docker buildx build \
+                      --platform=linux/amd64,linux/arm64 \
+                      --output "type=image,push=true" \
+                      --file ./Dockerfile . \
+                      --tag sigp/lighthouse:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,11 +18,20 @@ jobs:
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-            - name: Set up Docker Buildx
-              id: buildx
-              uses: crazy-max/ghaction-docker-buildx@v1
-              with:
-                  buildx-version: latest
+            - name: Build Docker Buildx
+              run: |
+                  export DOCKER_BUILDKIT=1;
+                  docker build --platform=local -o . git://github.com/docker/buildx;
+                  mkdir -p ~/.docker/cli-plugins;
+                  mv buildx ~/.docker/cli-plugins/docker-buildx;
+
+            - name: Create Docker Builder
+              run: |
+                  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes;
+                  docker context create node-amd64;
+                  docker context create node-arm64;
+                  docker buildx create --use --name lighthouse node-amd64;
+                  docker buildx create --append --name lighthouse node-arm64;
 
             - name: Build dockerfile (with push)
               run: |


### PR DESCRIPTION
## Issue Addressed

#1512

## Proposed Changes

Use Github Actions to automate the Docker image build, so that we can make a multi-arch image.  

## Additional Info

This change will require adding the DOCKER_USERNAME and DOCKER_PASSWORD secrets in Github. It will also require disabling the Docker Hub automated build. 
