### PR TITLE
[Merged by Bors] - Don't quote slot and epoch, for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5892,7 +5892,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_utils",
  "serde_yaml",
  "slog",
  "swap_or_not_shuffle",

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -25,7 +25,6 @@ rand = "0.7.3"
 safe_arith = { path = "../safe_arith" }
 serde = "1.0.110"
 serde_derive = "1.0.110"
-serde_utils = { path = "../serde_utils" }
 slog = "2.5.2"
 eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -25,12 +25,12 @@ use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssi
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Eq, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Slot(#[serde(with = "serde_utils::quoted_u64")] u64);
+pub struct Slot(u64);
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(Eq, Clone, Copy, Default, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Epoch(#[serde(with = "serde_utils::quoted_u64")] u64);
+pub struct Epoch(u64);
 
 impl_common!(Slot);
 impl_common!(Epoch);


### PR DESCRIPTION
Fixes a breaking change to our API that was unnecessary and can wait until #1569 is merged
