### PR TITLE
[Merged by Bors] - Remove references to rust-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An open-source Ethereum 2.0 client, written in Rust and maintained by Sigma Prime.
 
-[![Build Status]][Build Link] [![Book Status]][Book Link] [![RustDoc Status]][RustDoc Link] [![Chat Badge]][Chat Link]
+[![Build Status]][Build Link] [![Book Status]][Book Link] [![Chat Badge]][Chat Link]
 
 [Build Status]: https://github.com/sigp/lighthouse/workflows/test-suite/badge.svg?branch=master
 [Build Link]: https://github.com/sigp/lighthouse/actions
@@ -10,8 +10,6 @@ An open-source Ethereum 2.0 client, written in Rust and maintained by Sigma Prim
 [Chat Link]: https://discord.gg/cyAszAh
 [Book Status]:https://img.shields.io/badge/user--docs-master-informational
 [Book Link]: http://lighthouse-book.sigmaprime.io/
-[RustDoc Status]:https://img.shields.io/badge/code--docs-master-orange
-[RustDoc Link]: http://lighthouse-docs.sigmaprime.io/
 
 [Documentation](http://lighthouse-book.sigmaprime.io/)
 
@@ -58,9 +56,6 @@ Current development overview:
 
 The [Lighthouse Book](http://lighthouse-book.sigmaprime.io/) contains information
 for testnet users and developers.
-
-Code documentation is generated via `cargo doc` and hosted at
-[lighthouse-docs.sigmaprime.io](http://lighthouse-docs.sigmaprime.io/).
 
 If you'd like some background on Sigma Prime, please see the [Lighthouse Update
 \#00](https://lighthouse.sigmaprime.io/update-00.html) blog post or

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -2,12 +2,10 @@
 
 _Documentation for Lighthouse users and developers._
 
-[![Doc Status]][Doc Link] [![Chat Badge]][Chat Link]
+[![Chat Badge]][Chat Link]
 
 [Chat Badge]: https://img.shields.io/badge/chat-discord-%237289da
 [Chat Link]: https://discord.gg/cyAszAh
-[Doc Status]:https://img.shields.io/badge/rust--docs-master-orange
-[Doc Link]: http://lighthouse-docs.sigmaprime.io/
 
 Lighthouse is an **Ethereum 2.0 client** that connects to other Ethereum 2.0
 clients to form a resilient and decentralized proof-of-stake blockchain.
@@ -24,7 +22,6 @@ You may read this book from start to finish, or jump to some of these topics:
 - Utilize the whole stack by starting a [local testnet](./local-testnets.md).
 - Query the [RESTful HTTP API](./http.md) using `curl`.
 - Listen to events with the [JSON WebSocket API](./websockets.md).
-- View the [Rust code docs](http://lighthouse-docs.sigmaprime.io/).
 
 
 Prospective contributors can read the [Contributing](./contributing.md) section


### PR DESCRIPTION
## Issue Addressed

- Resolves #897
- Resolves #821

## Proposed Changes

Removes references to the rust docs that we're no long maintaining.

## Additional Info

NA