### PR TITLE
[Merged by Bors] - Prevent printing binary in RPC errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,6 +1521,7 @@ dependencies = [
  "lru",
  "parking_lot 0.11.0",
  "rand 0.7.3",
+ "regex",
  "serde",
  "serde_derive",
  "sha2 0.9.1",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -37,6 +37,7 @@ tiny-keccak = "2.0.2"
 environment = { path = "../../lighthouse/environment" }
 # TODO: Remove rand crate for mainnet
 rand = "0.7.3"
+regex = "1.3.9"
 
 [dependencies.libp2p]
 #version = "0.23.0"

--- a/beacon_node/eth2_libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/methods.rs
@@ -42,10 +42,7 @@ impl Deref for ErrorType {
 
 impl ToString for ErrorType {
     fn to_string(&self) -> String {
-        match std::str::from_utf8(self.0.deref()) {
-            Ok(s) => s.to_string(),
-            Err(_) => format!("{:?}", self.0.deref()), // Display raw bytes if not a UTF-8 string
-        }
+        String::from_utf8_lossy(self.0.deref()).into_owned()
     }
 }
 

--- a/beacon_node/eth2_libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/methods.rs
@@ -1,6 +1,7 @@
 //! Available RPC methods types and ids.
 
 use crate::types::EnrBitfield;
+use regex::bytes::Regex;
 use serde::Serialize;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
@@ -42,7 +43,9 @@ impl Deref for ErrorType {
 
 impl ToString for ErrorType {
     fn to_string(&self) -> String {
-        String::from_utf8_lossy(self.0.deref()).into_owned()
+        #[allow(clippy::invalid_regex)]
+        let re = Regex::new("\\p{C}").expect("Regex is valid");
+        String::from_utf8_lossy(&re.replace_all(self.0.deref(), &b""[..])).to_string()
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

#1566 

## Proposed Changes

Prevents printing binary characters in the RPC error response from peers.
