### PR TITLE
[Merged by Bors] - Gossipsub message id to shortened bytes

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -85,9 +85,9 @@ impl Default for Config {
         ];
 
         // The function used to generate a gossipsub message id
-        // We use the first 20 bytes of SHA256(data) for content addressing
+        // We use the first 8 bytes of SHA256(data) for content addressing
         let gossip_message_id =
-            |message: &GossipsubMessage| MessageId::from(&Sha256::digest(&message.data)[..20]);
+            |message: &GossipsubMessage| MessageId::from(&Sha256::digest(&message.data)[..8]);
 
         // gossipsub configuration
         // Note: The topics by default are sent as plain strings. Hashes are an optional

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -85,13 +85,9 @@ impl Default for Config {
         ];
 
         // The function used to generate a gossipsub message id
-        // We use base64(SHA256(data)) for content addressing
-        let gossip_message_id = |message: &GossipsubMessage| {
-            MessageId::from(base64::encode_config(
-                &Sha256::digest(&message.data),
-                base64::URL_SAFE_NO_PAD,
-            ))
-        };
+        // We use the first 20 bytes of SHA256(data) for content addressing
+        let gossip_message_id =
+            |message: &GossipsubMessage| MessageId::from(&Sha256::digest(&message.data)[..20]);
 
         // gossipsub configuration
         // Note: The topics by default are sent as plain strings. Hashes are an optional


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/eth2.0-specs/pull/2044

## Proposed Changes

Shifts the gossipsub message id to use the first 8 bytes of the SHA256 hash of the gossipsub message data field.

## Additional Info

We should merge this in once the spec has been decided on. It will cause issues with gossipsub scoring and gossipsub propagation rates (as we won't receive IWANT) messages from clients that also haven't made this update. 
