### PR TITLE
[Merged by Bors] - ignore too early / too late attestations instead of penalizing them

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker.rs
+++ b/beacon_node/network/src/beacon_processor/worker.rs
@@ -564,7 +564,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                  */
                 trace!(
                     self.log,
-                    "Attestation is not within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots ";
+                    "Attestation is not within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots";
                     "peer_id" => peer_id.to_string(),
                     "block" => format!("{}", beacon_block_root),
                     "type" => format!("{:?}", attestation_type),

--- a/beacon_node/network/src/beacon_processor/worker.rs
+++ b/beacon_node/network/src/beacon_processor/worker.rs
@@ -562,12 +562,18 @@ impl<T: BeaconChainTypes> Worker<T> {
                  *
                  * The peer has published an invalid consensus message, _only_ if we trust our own clock.
                  */
+                trace!(
+                    self.log,
+                    "Attestation is not within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots ";
+                    "peer_id" => peer_id.to_string(),
+                    "block" => format!("{}", beacon_block_root),
+                    "type" => format!("{:?}", attestation_type),
+                );
                 self.propagate_validation_result(
                     message_id,
                     peer_id.clone(),
-                    MessageAcceptance::Reject,
+                    MessageAcceptance::Ignore,
                 );
-                self.penalize_peer(peer_id.clone(), PeerAction::LowToleranceError);
             }
             AttnError::InvalidSelectionProof { .. } | AttnError::InvalidSignature => {
                 /*


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This ignores attestations that are too early or too late as it is specified in the spec (see https://github.com/ethereum/eth2.0-specs/blob/v0.12.1/specs/phase0/p2p-interface.md#global-topics first subpoint of `beacon_aggregate_and_proof`)
