### PR TITLE
[Merged by Bors] - Remove redundant decompression in process_deposit

### DIFF
--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -450,10 +450,6 @@ pub fn process_deposit<T: EthSpec>(
     // depositing validator already exists in the registry.
     state.update_pubkey_cache()?;
 
-    let pubkey: PublicKey = match deposit.data.pubkey.decompress() {
-        Err(_) => return Ok(()), //bad public key => return early
-        Ok(k) => k,
-    };
     // Get an `Option<u64>` where `u64` is the validator index if this deposit public key
     // already exists in the beacon_state.
     let validator_index = get_existing_validator_index(state, &deposit.data.pubkey)
@@ -473,7 +469,7 @@ pub fn process_deposit<T: EthSpec>(
 
         // Create a new validator.
         let validator = Validator {
-            pubkey: pubkey.into(),
+            pubkey: deposit.data.pubkey.clone(),
             withdrawal_credentials: deposit.data.withdrawal_credentials,
             activation_eligibility_epoch: spec.far_future_epoch,
             activation_epoch: spec.far_future_epoch,


### PR DESCRIPTION
## Issue Addressed

Closes #1076

## Proposed Changes

Remove an extra unnecessary decompression of the deposit public key from `process_deposit`. The key is decompressed and used to verify the signature in `verify_deposit_signature`, making this initial decompression redundant.

## Additional Info

This is _not_ a consensus-breaking change because keys which previously failed the early decompression check will not be found in the pubkey cache (they are invalid), and will be checked and rejected as part of `verify_deposit_signature`.
