### PR TITLE
[Merged by Bors] - minimize the number of places we are calling `update_pubkey_cache`

### DIFF
--- a/beacon_node/rest_api/src/consensus.rs
+++ b/beacon_node/rest_api/src/consensus.rs
@@ -92,10 +92,6 @@ pub fn post_individual_votes<T: BeaconChainTypes>(
             let mut validator_statuses = ValidatorStatuses::new(&state, spec)?;
             validator_statuses.process_attestations(&state, spec)?;
 
-            state.update_pubkey_cache().map_err(|e| {
-                ApiError::ServerError(format!("Unable to build pubkey cache: {:?}", e))
-            })?;
-
             body.pubkeys
                 .into_iter()
                 .map(|pubkey| {

--- a/beacon_node/rest_api/src/validator.rs
+++ b/beacon_node/rest_api/src/validator.rs
@@ -156,9 +156,6 @@ fn return_validator_duties<T: BeaconChainTypes>(
     state
         .build_committee_cache(relative_epoch, &beacon_chain.spec)
         .map_err(|e| ApiError::ServerError(format!("Unable to build committee cache: {:?}", e)))?;
-    state
-        .update_pubkey_cache()
-        .map_err(|e| ApiError::ServerError(format!("Unable to build pubkey cache: {:?}", e)))?;
 
     // Get a list of all validators for this epoch.
     //

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -446,10 +446,6 @@ pub fn process_deposit<T: EthSpec>(
 
     state.eth1_deposit_index.increment()?;
 
-    // Ensure the state's pubkey cache is fully up-to-date, it will be used to check to see if the
-    // depositing validator already exists in the registry.
-    state.update_pubkey_cache()?;
-
     // Get an `Option<u64>` where `u64` is the validator index if this deposit public key
     // already exists in the beacon_state.
     let validator_index = get_existing_validator_index(state, &deposit.data.pubkey)

--- a/consensus/state_processing/src/per_block_processing/verify_deposit.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_deposit.rs
@@ -35,7 +35,7 @@ pub fn verify_deposit_signature(deposit_data: &DepositData, spec: &ChainSpec) ->
 ///
 /// Errors if the state's `pubkey_cache` is not current.
 pub fn get_existing_validator_index<T: EthSpec>(
-    state: &BeaconState<T>,
+    state: &mut BeaconState<T>,
     pub_key: &PublicKeyBytes,
 ) -> Result<Option<u64>> {
     let validator_index = state.get_validator_index(pub_key)?;

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -300,22 +300,12 @@ impl<T: EthSpec> BeaconState<T> {
         }
     }
 
-    /// If a validator pubkey exists in the validator registry, returns `Some(i)`, otherwise
-    /// returns `None`.
-    ///
-    /// Requires a fully up-to-date `pubkey_cache`, returns an error if this is not the case.
+    /// This method ensures the state's pubkey cache is fully up-to-date before checking if the validator
+    /// exists in the registry. If a validator pubkey exists in the validator registry, returns `Some(i)`,
+    /// otherwise returns `None`.
     pub fn get_validator_index(&mut self, pubkey: &PublicKeyBytes) -> Result<Option<usize>, Error> {
-        // Ensure the state's pubkey cache is fully up-to-date, it will be used to check to see if the
-        // depositing validator already exists in the registry.
         self.update_pubkey_cache()?;
-        if self.pubkey_cache.len() == self.validators.len() {
-            Ok(self.pubkey_cache.get(pubkey))
-        } else {
-            Err(Error::PubkeyCacheIncomplete {
-                cache_len: self.pubkey_cache.len(),
-                registry_len: self.validators.len(),
-            })
-        }
+        Ok(self.pubkey_cache.get(pubkey))
     }
 
     /// The epoch corresponding to `self.slot`.

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -304,7 +304,10 @@ impl<T: EthSpec> BeaconState<T> {
     /// returns `None`.
     ///
     /// Requires a fully up-to-date `pubkey_cache`, returns an error if this is not the case.
-    pub fn get_validator_index(&self, pubkey: &PublicKeyBytes) -> Result<Option<usize>, Error> {
+    pub fn get_validator_index(&mut self, pubkey: &PublicKeyBytes) -> Result<Option<usize>, Error> {
+        // Ensure the state's pubkey cache is fully up-to-date, it will be used to check to see if the
+        // depositing validator already exists in the registry.
+        self.update_pubkey_cache()?;
         if self.pubkey_cache.len() == self.validators.len() {
             Ok(self.pubkey_cache.get(pubkey))
         } else {


### PR DESCRIPTION
## Issue Addressed

- Resolves #1080

## Proposed Changes

- Call `update_pubkey_cache` only in the `build_all_caches` method and `get_validator_index` method. 

## Additional Info

This does reduce the number of places the cache is updated, making it simpler. But the `get_validator_index` method is used a couple times when we are iterating through the entire validator registry (or set of active validators). Before, we would only call `update_pubkey_cache` once before iterating through all validators.  So I'm not _totally_ sure this change is worth it. 