### PR TITLE
[Merged by Bors] - Update LevelDB to v0.8.6, removing patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,9 +2585,9 @@ dependencies = [
 
 [[package]]
 name = "leveldb"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a2fa830c44ac4762564389a7efe22688a469c8d7b71dd11da2e35c33ae96c2"
+checksum = "32651baaaa5596b3a6e0bee625e73fd0334c167db0ea5ac68750ef9a629a2d6a"
 dependencies = [
  "db-key",
  "leveldb-sys",
@@ -2596,8 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "leveldb-sys"
-version = "2.0.6"
-source = "git+https://github.com/michaelsproul/leveldb-sys?branch=v2.0.6-cmake#e784dba085921bad187ff74b3418c539914a02ff"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c44b9b785ca705d58190ebd432a4e7edb900eadf236ff966d7d1307e482e87"
 dependencies = [
  "cmake",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,4 +79,3 @@ eth2_ssz = { path = "consensus/ssz" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_hashing = { path = "crypto/eth2_hashing" }
-leveldb-sys = { git = "https://github.com/michaelsproul/leveldb-sys", branch = "v2.0.6-cmake" }

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.3.0"
 
 [dependencies]
 db-key = "0.0.5"
-leveldb = "0.8.5"
+leveldb = "0.8.6"
 parking_lot = "0.11.0"
 itertools = "0.9.0"
 eth2_ssz = "0.1.2"


### PR DESCRIPTION
Removes our dependency on a fork of LevelDB now that https://github.com/skade/leveldb-sys/pull/17 is merged
