### PR TITLE
Tidy hotfix for inconsistent head

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -69,7 +69,6 @@ pub const VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT: Duration = Duration::from_secs(1)
 pub const BEACON_CHAIN_DB_KEY: [u8; 32] = [0; 32];
 pub const OP_POOL_DB_KEY: [u8; 32] = [0; 32];
 pub const ETH1_CACHE_DB_KEY: [u8; 32] = [0; 32];
-pub const FORK_CHOICE_DB_KEY: [u8; 32] = [0; 32];
 
 /// The result of a chain segment processing.
 pub enum ChainSegmentResult<T: EthSpec> {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -97,6 +97,7 @@ pub struct BeaconChainBuilder<T: BeaconChainTypes> {
     store_migrator: Option<T::StoreMigrator>,
     pub canonical_head: Option<BeaconSnapshot<T::EthSpec>>,
     genesis_block_root: Option<Hash256>,
+    #[allow(clippy::type_complexity)]
     fork_choice: Option<
         ForkChoice<BeaconForkChoiceStore<T::EthSpec, T::HotStore, T::ColdStore>, T::EthSpec>,
     >,
@@ -404,7 +405,7 @@ where
             beacon_state,
         };
 
-        let fc_store = BeaconForkChoiceStore::get_forkchoice_store(store.clone(), &head);
+        let fc_store = BeaconForkChoiceStore::get_forkchoice_store(store, &head);
 
         self.fork_choice = Some(
             ForkChoice::from_genesis(fc_store, &head.beacon_block.message)

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -244,8 +244,6 @@ lazy_static! {
         try_create_histogram("beacon_persist_op_pool", "Time taken to persist the operations pool");
     pub static ref PERSIST_ETH1_CACHE: Result<Histogram> =
         try_create_histogram("beacon_persist_eth1_cache", "Time taken to persist the eth1 caches");
-    pub static ref PERSIST_FORK_CHOICE: Result<Histogram> =
-        try_create_histogram("beacon_persist_fork_choice", "Time taken to persist the fork choice struct");
 
     /*
      * Eth1

--- a/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
@@ -1,14 +1,17 @@
+use crate::beacon_fork_choice_store::PersistedForkChoiceStore as ForkChoiceStore;
 use crate::head_tracker::SszHeadTracker;
+use fork_choice::PersistedForkChoice as ForkChoice;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use store::{DBColumn, Error as StoreError, StoreItem};
 use types::Hash256;
 
-#[derive(Clone, Encode, Decode)]
+#[derive(Encode, Decode)]
 pub struct PersistedBeaconChain {
-    pub canonical_head_block_root: Hash256,
+    pub genesis_time: u64,
     pub genesis_block_root: Hash256,
     pub ssz_head_tracker: SszHeadTracker,
+    pub persisted_fork_choice: PersistedForkChoice,
 }
 
 impl StoreItem for PersistedBeaconChain {
@@ -21,6 +24,26 @@ impl StoreItem for PersistedBeaconChain {
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {
+        Self::from_ssz_bytes(bytes).map_err(Into::into)
+    }
+}
+
+#[derive(Encode, Decode)]
+pub struct PersistedForkChoice {
+    pub fork_choice: ForkChoice,
+    pub fork_choice_store: ForkChoiceStore,
+}
+
+impl StoreItem for PersistedForkChoice {
+    fn db_column() -> DBColumn {
+        DBColumn::ForkChoice
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> std::result::Result<Self, StoreError> {
         Self::from_ssz_bytes(bytes).map_err(Into::into)
     }
 }

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1,6 +1,4 @@
-pub use crate::beacon_chain::{
-    BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, FORK_CHOICE_DB_KEY, OP_POOL_DB_KEY,
-};
+pub use crate::beacon_chain::{BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY};
 use crate::migrate::{BlockingMigrator, Migrate, NullMigrator};
 pub use crate::persisted_beacon_chain::PersistedBeaconChain;
 use crate::slog::Drain;

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -713,9 +713,9 @@ where
             .ok_or_else(|| "system_time_slot_clock requires a beacon_chain_builder")?;
 
         let genesis_time = beacon_chain_builder
-            .finalized_snapshot
+            .canonical_head
             .as_ref()
-            .ok_or_else(|| "system_time_slot_clock requires an initialized beacon state")?
+            .ok_or_else(|| "system_time_slot_clock requires a canonical head")?
             .beacon_state
             .genesis_time;
 

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -52,6 +52,9 @@ pub trait SlotClock: Send + Sync + Sized {
     /// Returns the first slot to be returned at the genesis time.
     fn genesis_slot(&self) -> Slot;
 
+    /// Returns the genesis time, as a duration since UNIX epoch.
+    fn genesis_duration(&self) -> Duration;
+
     /// Returns the slot if the internal clock were advanced by `duration`.
     fn now_with_future_tolerance(&self, tolerance: Duration) -> Option<Slot> {
         self.slot_of(self.now_duration()?.checked_add(tolerance)?)

--- a/common/slot_clock/src/manual_slot_clock.rs
+++ b/common/slot_clock/src/manual_slot_clock.rs
@@ -41,10 +41,6 @@ impl ManualSlotClock {
         self.set_slot(self.now().unwrap().as_u64() + 1)
     }
 
-    pub fn genesis_duration(&self) -> &Duration {
-        &self.genesis_duration
-    }
-
     /// Returns the duration between UNIX epoch and the start of `slot`.
     pub fn start_of(&self, slot: Slot) -> Option<Duration> {
         let slot = slot
@@ -141,6 +137,10 @@ impl SlotClock for ManualSlotClock {
 
     fn slot_duration(&self) -> Duration {
         self.slot_duration
+    }
+
+    fn genesis_duration(&self) -> Duration {
+        self.genesis_duration
     }
 
     fn duration_to_slot(&self, slot: Slot) -> Option<Duration> {

--- a/common/slot_clock/src/system_time_slot_clock.rs
+++ b/common/slot_clock/src/system_time_slot_clock.rs
@@ -24,7 +24,7 @@ impl SlotClock for SystemTimeSlotClock {
 
     fn is_prior_to_genesis(&self) -> Option<bool> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?;
-        Some(now < *self.clock.genesis_duration())
+        Some(now < self.clock.genesis_duration())
     }
 
     fn now_duration(&self) -> Option<Duration> {
@@ -47,6 +47,10 @@ impl SlotClock for SystemTimeSlotClock {
 
     fn slot_duration(&self) -> Duration {
         self.clock.slot_duration()
+    }
+
+    fn genesis_duration(&self) -> Duration {
+        self.clock.genesis_duration()
     }
 
     fn duration_to_slot(&self, slot: Slot) -> Option<Duration> {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -3,7 +3,8 @@ use std::marker::PhantomData;
 use proto_array::{Block as ProtoBlock, ProtoArrayForkChoice};
 use ssz_derive::{Decode, Encode};
 use types::{
-    BeaconBlock, BeaconState, BeaconStateError, Epoch, EthSpec, Hash256, IndexedAttestation, Slot,
+    BeaconBlock, BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, Hash256,
+    IndexedAttestation, Slot,
 };
 
 use crate::ForkChoiceStore;
@@ -756,6 +757,11 @@ where
     pub fn is_descendant_of_finalized(&self, block_root: Hash256) -> bool {
         self.proto_array
             .is_descendant(self.fc_store.finalized_checkpoint().root, block_root)
+    }
+
+    /// Return the current finalized checkpoint.
+    pub fn finalized_checkpoint(&self) -> Checkpoint {
+        *self.fc_store.finalized_checkpoint()
     }
 
     /// Returns the latest message for a given validator, if any.


### PR DESCRIPTION
## Issue Addressed

- Cleans up after #1639, but causes a DB schema change.

## Proposed Changes

- Instead of persisting the root of `chain.canonical_head`, derive it again on startup using the persisted `fork_choice`. This avoids a race condition that was potentially causing #1616 where the persisted fork choice can be more recent than the persisted canonical head.
- Store the `PersistedForkChoiceStore` in the `PersistedBeaconChain` struct since there's no need for them to be separate.
- In block verification, use the more sophisticated `check_block_is_finalized_descendant` function instead of `fork_choice.contains_block`. This allows for differentiating between `ParentUnknown` and `WouldRevertFinalizedSlot`.
- Remove the `finalized_snapshot` field of `BeaconChainBuilder` as it is redundant.
- Don't allow the `BeaconChainBuilder` to silently instantiate new objects if they are unable to be retrieved from the database. Fail loudly instead.

## Additional Info

- Blocked on #1639
