### PR TITLE
[Merged by Bors] - Remove saturating arith from state_processing

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -115,6 +115,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: Typecheck benchmark code without running it
       run: make check-benches
+  check-consensus:
+    name: check-consensus
+    runs-on: ubuntu-latest
+    needs: cargo-fmt
+    steps:
+    - uses: actions/checkout@v1
+    - name: Typecheck consensus code in strict mode
+      run: make check-consensus
   clippy:
     name: clippy
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,10 @@ cargo-fmt:
 check-benches:
 	cargo check --all --benches
 
+# Typechecks consensus code *without* allowing deprecated legacy arithmetic
+check-consensus:
+	cargo check --manifest-path=consensus/state_processing/Cargo.toml --no-default-features
+
 # Runs only the ef-test vectors.
 run-ef-tests:
 	cargo test --release --manifest-path=$(EF_TESTS)/Cargo.toml --features "ef_tests"

--- a/consensus/safe_arith/src/lib.rs
+++ b/consensus/safe_arith/src/lib.rs
@@ -7,7 +7,7 @@ pub enum ArithError {
     DivisionByZero,
 }
 
-type Result<T> = std::result::Result<T, ArithError>;
+pub type Result<T> = std::result::Result<T, ArithError>;
 
 macro_rules! assign_method {
     ($name:ident, $op:ident, $doc_op:expr) => {
@@ -25,24 +25,24 @@ macro_rules! assign_method {
 }
 
 /// Trait providing safe arithmetic operations for built-in types.
-pub trait SafeArith: Sized + Copy {
+pub trait SafeArith<Rhs = Self>: Sized + Copy {
     const ZERO: Self;
     const ONE: Self;
 
     /// Safe variant of `+` that guards against overflow.
-    fn safe_add(&self, other: Self) -> Result<Self>;
+    fn safe_add(&self, other: Rhs) -> Result<Self>;
 
     /// Safe variant of `-` that guards against overflow.
-    fn safe_sub(&self, other: Self) -> Result<Self>;
+    fn safe_sub(&self, other: Rhs) -> Result<Self>;
 
     /// Safe variant of `*` that guards against overflow.
-    fn safe_mul(&self, other: Self) -> Result<Self>;
+    fn safe_mul(&self, other: Rhs) -> Result<Self>;
 
     /// Safe variant of `/` that guards against division by 0.
-    fn safe_div(&self, other: Self) -> Result<Self>;
+    fn safe_div(&self, other: Rhs) -> Result<Self>;
 
     /// Safe variant of `%` that guards against division by 0.
-    fn safe_rem(&self, other: Self) -> Result<Self>;
+    fn safe_rem(&self, other: Rhs) -> Result<Self>;
 
     /// Safe variant of `<<` that guards against overflow.
     fn safe_shl(&self, other: u32) -> Result<Self>;
@@ -50,18 +50,13 @@ pub trait SafeArith: Sized + Copy {
     /// Safe variant of `>>` that guards against overflow.
     fn safe_shr(&self, other: u32) -> Result<Self>;
 
-    assign_method!(safe_add_assign, safe_add, "+=");
-    assign_method!(safe_sub_assign, safe_sub, "-=");
-    assign_method!(safe_mul_assign, safe_mul, "*=");
-    assign_method!(safe_div_assign, safe_div, "/=");
-    assign_method!(safe_rem_assign, safe_rem, "%=");
+    assign_method!(safe_add_assign, safe_add, Rhs, "+=");
+    assign_method!(safe_sub_assign, safe_sub, Rhs, "-=");
+    assign_method!(safe_mul_assign, safe_mul, Rhs, "*=");
+    assign_method!(safe_div_assign, safe_div, Rhs, "/=");
+    assign_method!(safe_rem_assign, safe_rem, Rhs, "%=");
     assign_method!(safe_shl_assign, safe_shl, u32, "<<=");
     assign_method!(safe_shr_assign, safe_shr, u32, ">>=");
-
-    /// Mutate `self` by adding 1, erroring on overflow.
-    fn increment(&mut self) -> Result<()> {
-        self.safe_add_assign(Self::ONE)
-    }
 }
 
 macro_rules! impl_safe_arith {
@@ -133,8 +128,7 @@ mod test {
     #[test]
     fn mutate() {
         let mut x = 0u8;
-        x.increment().unwrap();
-        x.increment().unwrap();
+        x.safe_add_assign(2).unwrap();
         assert_eq!(x, 2);
         x.safe_sub_assign(1).unwrap();
         assert_eq!(x, 1);

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -27,14 +27,16 @@ log = "0.4.8"
 safe_arith = { path = "../safe_arith" }
 tree_hash = "0.1.0"
 tree_hash_derive = "0.2.0"
-types = { path = "../types" }
+types = { path = "../types", default-features = false }
 rayon = "1.3.0"
 eth2_hashing = "0.1.0"
 int_to_bytes = { path = "../int_to_bytes" }
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 
 [features]
+default = ["legacy-arith"]
 fake_crypto = ["bls/fake_crypto"]
+legacy-arith = ["types/legacy-arith"]
 arbitrary-fuzz = [
   "arbitrary",
   "types/arbitrary-fuzz",

--- a/consensus/state_processing/src/common/deposit_data_tree.rs
+++ b/consensus/state_processing/src/common/deposit_data_tree.rs
@@ -47,7 +47,7 @@ impl DepositDataTree {
     /// Add a deposit to the merkle tree.
     pub fn push_leaf(&mut self, leaf: Hash256) -> Result<(), MerkleTreeError> {
         self.tree.push_leaf(leaf, self.depth)?;
-        self.mix_in_length.increment()?;
+        self.mix_in_length.safe_add_assign(1)?;
         Ok(())
     }
 }

--- a/consensus/state_processing/src/common/initiate_validator_exit.rs
+++ b/consensus/state_processing/src/common/initiate_validator_exit.rs
@@ -1,3 +1,4 @@
+use safe_arith::SafeArith;
 use std::cmp::max;
 use types::{BeaconStateError as Error, *};
 
@@ -22,7 +23,7 @@ pub fn initiate_validator_exit<T: EthSpec>(
     state.exit_cache.build(&state.validators, spec)?;
 
     // Compute exit queue epoch
-    let delayed_epoch = state.compute_activation_exit_epoch(state.current_epoch(), spec);
+    let delayed_epoch = state.compute_activation_exit_epoch(state.current_epoch(), spec)?;
     let mut exit_queue_epoch = state
         .exit_cache
         .max_epoch()?
@@ -30,13 +31,13 @@ pub fn initiate_validator_exit<T: EthSpec>(
     let exit_queue_churn = state.exit_cache.get_churn_at(exit_queue_epoch)?;
 
     if exit_queue_churn >= state.get_churn_limit(spec)? {
-        exit_queue_epoch += 1;
+        exit_queue_epoch.safe_add_assign(1)?;
     }
 
     state.exit_cache.record_validator_exit(exit_queue_epoch)?;
     state.validators[index].exit_epoch = exit_queue_epoch;
     state.validators[index].withdrawable_epoch =
-        exit_queue_epoch + spec.min_validator_withdrawability_delay;
+        exit_queue_epoch.safe_add(spec.min_validator_withdrawability_delay)?;
 
     Ok(())
 }

--- a/consensus/state_processing/src/common/slash_validator.rs
+++ b/consensus/state_processing/src/common/slash_validator.rs
@@ -23,7 +23,7 @@ pub fn slash_validator<T: EthSpec>(
     state.validators[slashed_index].slashed = true;
     state.validators[slashed_index].withdrawable_epoch = cmp::max(
         state.validators[slashed_index].withdrawable_epoch,
-        epoch + Epoch::from(T::EpochsPerSlashingsVector::to_u64()),
+        epoch.safe_add(T::EpochsPerSlashingsVector::to_u64())?,
     );
     let validator_effective_balance = state.get_effective_balance(slashed_index, spec)?;
     state.set_slashings(

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -368,7 +368,7 @@ pub fn process_attestations<T: EthSpec>(
         let pending_attestation = PendingAttestation {
             aggregation_bits: attestation.aggregation_bits.clone(),
             data: attestation.data.clone(),
-            inclusion_delay: (state.slot - attestation.data.slot).as_u64(),
+            inclusion_delay: state.slot.safe_sub(attestation.data.slot)?.as_u64(),
             proposer_index,
         };
 
@@ -444,7 +444,7 @@ pub fn process_deposit<T: EthSpec>(
             .map_err(|e| e.into_with_index(deposit_index))?;
     }
 
-    state.eth1_deposit_index.increment()?;
+    state.eth1_deposit_index.safe_add_assign(1)?;
 
     // Ensure the state's pubkey cache is fully up-to-date, it will be used to check to see if the
     // depositing validator already exists in the registry.

--- a/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
+++ b/consensus/state_processing/src/per_epoch_processing/apply_rewards.rs
@@ -71,7 +71,10 @@ fn get_attestation_deltas<T: EthSpec>(
     validator_statuses: &ValidatorStatuses,
     spec: &ChainSpec,
 ) -> Result<Vec<Delta>, Error> {
-    let finality_delay = (state.previous_epoch() - state.finalized_checkpoint.epoch).as_u64();
+    let finality_delay = state
+        .previous_epoch()
+        .safe_sub(state.finalized_checkpoint.epoch)?
+        .as_u64();
 
     let mut deltas = vec![Delta::default(); state.validators.len()];
 

--- a/consensus/state_processing/src/per_epoch_processing/process_slashings.rs
+++ b/consensus/state_processing/src/per_epoch_processing/process_slashings.rs
@@ -14,7 +14,7 @@ pub fn process_slashings<T: EthSpec>(
 
     for (index, validator) in state.validators.iter().enumerate() {
         if validator.slashed
-            && epoch + T::EpochsPerSlashingsVector::to_u64().safe_div(2)?
+            && epoch.safe_add(T::EpochsPerSlashingsVector::to_u64().safe_div(2)?)?
                 == validator.withdrawable_epoch
         {
             let increment = spec.effective_balance_increment;

--- a/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -1,6 +1,6 @@
-use super::super::common::initiate_validator_exit;
-use super::Error;
+use crate::{common::initiate_validator_exit, per_epoch_processing::Error};
 use itertools::Itertools;
+use safe_arith::SafeArith;
 use types::*;
 
 /// Performs a validator registry update, if required.
@@ -31,7 +31,7 @@ pub fn process_registry_updates<T: EthSpec>(
 
     for index in indices_to_update {
         if state.validators[index].is_eligible_for_activation_queue(spec) {
-            state.validators[index].activation_eligibility_epoch = current_epoch + 1;
+            state.validators[index].activation_eligibility_epoch = current_epoch.safe_add(1)?;
         }
         if is_ejectable(&state.validators[index]) {
             initiate_validator_exit(state, index, spec)?;
@@ -50,7 +50,7 @@ pub fn process_registry_updates<T: EthSpec>(
 
     // Dequeue validators for activation up to churn limit
     let churn_limit = state.get_churn_limit(spec)? as usize;
-    let delayed_activation_epoch = state.compute_activation_exit_epoch(current_epoch, spec);
+    let delayed_activation_epoch = state.compute_activation_exit_epoch(current_epoch, spec)?;
     for index in activation_queue.into_iter().take(churn_limit) {
         let validator = &mut state.validators[index];
         validator.activation_epoch = delayed_activation_epoch;

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -46,7 +46,9 @@ serde_json = "1.0.52"
 criterion = "0.3.2"
 
 [features]
-default = ["sqlite"]
+default = ["sqlite", "legacy-arith"]
+# Allow saturating arithmetic on slots and epochs. Enabled by default, but deprecated.
+legacy-arith = []
 sqlite = ["rusqlite"]
 arbitrary-fuzz = [
   "arbitrary",

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -100,10 +100,10 @@ enum AllowNextEpoch {
 }
 
 impl AllowNextEpoch {
-    fn upper_bound_of(self, current_epoch: Epoch) -> Epoch {
+    fn upper_bound_of(self, current_epoch: Epoch) -> Result<Epoch, Error> {
         match self {
-            AllowNextEpoch::True => current_epoch + 1,
-            AllowNextEpoch::False => current_epoch,
+            AllowNextEpoch::True => Ok(current_epoch.safe_add(1)?),
+            AllowNextEpoch::False => Ok(current_epoch),
         }
     }
 }
@@ -330,7 +330,9 @@ impl<T: EthSpec> BeaconState<T> {
     pub fn previous_epoch(&self) -> Epoch {
         let current_epoch = self.current_epoch();
         if current_epoch > T::genesis_epoch() {
-            current_epoch - 1
+            current_epoch
+                .safe_sub(1)
+                .expect("current epoch greater than genesis implies greater than 0")
         } else {
             current_epoch
         }
@@ -339,8 +341,8 @@ impl<T: EthSpec> BeaconState<T> {
     /// The epoch following `self.current_epoch()`.
     ///
     /// Spec v0.12.1
-    pub fn next_epoch(&self) -> Epoch {
-        self.current_epoch() + 1
+    pub fn next_epoch(&self) -> Result<Epoch, Error> {
+        Ok(self.current_epoch().safe_add(1)?)
     }
 
     /// Compute the number of committees at `slot`.
@@ -385,7 +387,7 @@ impl<T: EthSpec> BeaconState<T> {
         epoch: Epoch,
         spec: &ChainSpec,
     ) -> Result<Vec<usize>, Error> {
-        if epoch >= self.compute_activation_exit_epoch(self.current_epoch(), spec) {
+        if epoch >= self.compute_activation_exit_epoch(self.current_epoch(), spec)? {
             Err(BeaconStateError::EpochOutOfBounds)
         } else {
             Ok(get_active_validator_indices(&self.validators, epoch))
@@ -482,7 +484,7 @@ impl<T: EthSpec> BeaconState<T> {
             {
                 return Ok(candidate_index);
             }
-            i.increment()?;
+            i.safe_add_assign(1)?;
         }
     }
 
@@ -560,7 +562,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Spec v0.12.1
     fn get_latest_block_roots_index(&self, slot: Slot) -> Result<usize, Error> {
-        if slot < self.slot && self.slot <= slot + self.block_roots.len() as u64 {
+        if slot < self.slot && self.slot <= slot.safe_add(self.block_roots.len() as u64)? {
             Ok(slot.as_usize().safe_rem(self.block_roots.len())?)
         } else {
             Err(BeaconStateError::SlotOutOfBounds)
@@ -612,7 +614,9 @@ impl<T: EthSpec> BeaconState<T> {
         let current_epoch = self.current_epoch();
         let len = T::EpochsPerHistoricalVector::to_u64();
 
-        if current_epoch < epoch + len && epoch <= allow_next_epoch.upper_bound_of(current_epoch) {
+        if current_epoch < epoch.safe_add(len)?
+            && epoch <= allow_next_epoch.upper_bound_of(current_epoch)?
+        {
             Ok(epoch.as_usize().safe_rem(len as usize)?)
         } else {
             Err(Error::EpochOutOfBounds)
@@ -659,7 +663,7 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Spec v0.12.1
     fn get_latest_state_roots_index(&self, slot: Slot) -> Result<usize, Error> {
-        if slot < self.slot && self.slot <= slot + self.state_roots.len() as u64 {
+        if slot < self.slot && self.slot <= slot.safe_add(self.state_roots.len() as u64)? {
             Ok(slot.as_usize().safe_rem(self.state_roots.len())?)
         } else {
             Err(BeaconStateError::SlotOutOfBounds)
@@ -679,7 +683,7 @@ impl<T: EthSpec> BeaconState<T> {
     /// Spec v0.12.1
     pub fn get_oldest_state_root(&self) -> Result<&Hash256, Error> {
         let i =
-            self.get_latest_state_roots_index(self.slot - Slot::from(self.state_roots.len()))?;
+            self.get_latest_state_roots_index(self.slot.saturating_sub(self.state_roots.len()))?;
         Ok(&self.state_roots[i])
     }
 
@@ -687,7 +691,9 @@ impl<T: EthSpec> BeaconState<T> {
     ///
     /// Spec v0.12.1
     pub fn get_oldest_block_root(&self) -> Result<&Hash256, Error> {
-        let i = self.get_latest_block_roots_index(self.slot - self.block_roots.len() as u64)?;
+        let i = self.get_latest_block_roots_index(
+            self.slot.saturating_sub(self.block_roots.len() as u64),
+        )?;
         Ok(&self.block_roots[i])
     }
 
@@ -719,8 +725,8 @@ impl<T: EthSpec> BeaconState<T> {
         // We allow the slashings vector to be accessed at any cached epoch at or before
         // the current epoch, or the next epoch if `AllowNextEpoch::True` is passed.
         let current_epoch = self.current_epoch();
-        if current_epoch < epoch + T::EpochsPerSlashingsVector::to_u64()
-            && epoch <= allow_next_epoch.upper_bound_of(current_epoch)
+        if current_epoch < epoch.safe_add(T::EpochsPerSlashingsVector::to_u64())?
+            && epoch <= allow_next_epoch.upper_bound_of(current_epoch)?
         {
             Ok(epoch
                 .as_usize()
@@ -782,7 +788,10 @@ impl<T: EthSpec> BeaconState<T> {
         // Bypass the safe getter for RANDAO so we can gracefully handle the scenario where `epoch
         // == 0`.
         let mix = {
-            let i = epoch + T::EpochsPerHistoricalVector::to_u64() - spec.min_seed_lookahead - 1;
+            let i = epoch
+                .safe_add(T::EpochsPerHistoricalVector::to_u64())?
+                .safe_sub(spec.min_seed_lookahead)?
+                .safe_sub(1)?;
             self.randao_mixes[i.as_usize().safe_rem(self.randao_mixes.len())?]
         };
         let domain_bytes = int_to_bytes4(spec.get_domain_constant(domain_type));
@@ -818,8 +827,12 @@ impl<T: EthSpec> BeaconState<T> {
     ///  Return the epoch at which an activation or exit triggered in ``epoch`` takes effect.
     ///
     ///  Spec v0.12.1
-    pub fn compute_activation_exit_epoch(&self, epoch: Epoch, spec: &ChainSpec) -> Epoch {
-        epoch + 1 + spec.max_seed_lookahead
+    pub fn compute_activation_exit_epoch(
+        &self,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> Result<Epoch, Error> {
+        Ok(epoch.safe_add(1)?.safe_add(spec.max_seed_lookahead)?)
     }
 
     /// Return the churn limit for the current epoch (number of validators who can leave per epoch).

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -3,6 +3,7 @@
 use super::BeaconState;
 use crate::*;
 use core::num::NonZeroUsize;
+use safe_arith::SafeArith;
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use std::ops::Range;
@@ -197,7 +198,7 @@ impl CommitteeCache {
         let epoch_start_slot = self.initialized_epoch?.start_slot(self.slots_per_epoch);
         let slot_offset = global_committee_index / self.committees_per_slot;
         let index = global_committee_index % self.committees_per_slot;
-        Some((epoch_start_slot + slot_offset, index))
+        Some((epoch_start_slot.safe_add(slot_offset).ok()?, index))
     }
 
     /// Returns the number of active validators in the initialized epoch.

--- a/consensus/types/src/beacon_state/committee_cache/tests.rs
+++ b/consensus/types/src/beacon_state/committee_cache/tests.rs
@@ -53,8 +53,8 @@ fn initializes_with_the_right_epoch() {
     let cache = CommitteeCache::initialized(&state, state.previous_epoch(), &spec).unwrap();
     assert_eq!(cache.initialized_epoch, Some(state.previous_epoch()));
 
-    let cache = CommitteeCache::initialized(&state, state.next_epoch(), &spec).unwrap();
-    assert_eq!(cache.initialized_epoch, Some(state.next_epoch()));
+    let cache = CommitteeCache::initialized(&state, state.next_epoch().unwrap(), &spec).unwrap();
+    assert_eq!(cache.initialized_epoch, Some(state.next_epoch().unwrap()));
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn shuffles_for_the_right_epoch() {
         .get_seed(state.current_epoch(), Domain::BeaconAttester, spec)
         .unwrap();
     let next_seed = state
-        .get_seed(state.next_epoch(), Domain::BeaconAttester, spec)
+        .get_seed(state.next_epoch().unwrap(), Domain::BeaconAttester, spec)
         .unwrap();
 
     assert!((previous_seed != current_seed) && (current_seed != next_seed));
@@ -114,7 +114,7 @@ fn shuffles_for_the_right_epoch() {
     assert_eq!(cache.shuffling, shuffling_with_seed(previous_seed));
     assert_shuffling_positions_accurate(&cache);
 
-    let cache = CommitteeCache::initialized(&state, state.next_epoch(), spec).unwrap();
+    let cache = CommitteeCache::initialized(&state, state.next_epoch().unwrap(), spec).unwrap();
     assert_eq!(cache.shuffling, shuffling_with_seed(next_seed));
     assert_shuffling_positions_accurate(&cache);
 }

--- a/consensus/types/src/beacon_state/exit_cache.rs
+++ b/consensus/types/src/beacon_state/exit_cache.rs
@@ -44,7 +44,7 @@ impl ExitCache {
         self.exit_epoch_counts
             .entry(exit_epoch)
             .or_insert(0)
-            .increment()?;
+            .safe_add_assign(1)?;
         Ok(())
     }
 

--- a/consensus/types/src/test_utils/builders/testing_beacon_state_builder.rs
+++ b/consensus/types/src/test_utils/builders/testing_beacon_state_builder.rs
@@ -143,11 +143,11 @@ impl<T: EthSpec> TestingBeaconStateBuilder<T> {
 
         state.slot = slot;
 
-        state.previous_justified_checkpoint.epoch = epoch - 3;
-        state.current_justified_checkpoint.epoch = epoch - 2;
+        state.previous_justified_checkpoint.epoch = epoch.saturating_sub(3u64);
+        state.current_justified_checkpoint.epoch = epoch.saturating_sub(2u64);
         state.justification_bits = BitVector::from_bytes(vec![0b0000_1111]).unwrap();
 
-        state.finalized_checkpoint.epoch = epoch - 3;
+        state.finalized_checkpoint.epoch = state.previous_justified_checkpoint.epoch;
     }
 
     /// Creates a full set of attestations for the `BeaconState`. Each attestation has full


### PR DESCRIPTION
## Issue Addressed

Resolves #1100

## Proposed Changes

* Implement the `SafeArith` trait for `Slot` and `Epoch`, so that methods like `safe_add` become available.
* Tweak the `SafeArith` trait to allow a different `Rhs` type (analagous to `std::ops::Add`, etc).
* Add a `legacy-arith` feature to `types` and `state_processing` that conditionally enables implementations of
  the `std` ops with saturating semantics.
* Check compilation of `types` and `state_processing` _without_ `legacy-arith` on CI,
  thus guaranteeing that they only use the `SafeArith` primitives :tada:

## Additional Info

The `legacy-arith` feature gets turned on by all higher-level crates that depend on `state_processing` or `types`, thus allowing the beacon chain, networking, and other components to continue to rely on the availability of ops like `+`, `-`, `*`, etc.

**This is a consensus-breaking change**, but brings us in line with the spec, and our incompatibilities shouldn't have been reachable with any valid configuration of Eth2 parameters.
