### PR TITLE
[Merged by Bors] - Revert "Update BLST, add force-adx support (#1595)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,7 +525,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.1.1"
-source = "git+https://github.com/supranational/blst.git?rev=a8398ed284b0d78858302ad1ceb25a80e7bbe535#a8398ed284b0d78858302ad1ceb25a80e7bbe535"
+source = "git+https://github.com/sigp/blst.git?rev=284f7059642851c760a09fb1708bcb59c7ca323c#284f7059642851c760a09fb1708bcb59c7ca323c"
 dependencies = [
  "cc",
  "glob",

--- a/book/src/cross-compiling.md
+++ b/book/src/cross-compiling.md
@@ -18,15 +18,17 @@ project.
 
 The `Makefile` in the project contains four targets for cross-compiling:
 
-- `build-x86_64`: builds an optimized version for x86_64 processors (suitable for most users).
-  Supports Intel Broadwell (2014) and newer, and AMD Ryzen (2017) and newer.
-- `build-x86_64-portable`: builds a version for x86_64 processors which avoids using some modern CPU
-  instructions that are incompatible with older CPUs. Suitable for pre-Broadwell/Ryzen CPUs.
-- `build-aarch64`: builds an optimized version for 64-bit ARM processors
+- `build-x86_64`: builds an optimized version for x86_64 processors (suitable
+	for most users).
+- `build-x86_64-portable`: builds a version x86_64 processors which avoids
+	using some modern CPU instructions that might cause an "illegal
+	instruction" error on older CPUs.
+- `build-aarch64`: builds an optimized version for 64bit ARM processors
 	(suitable for Raspberry Pi 4).
-- `build-aarch64-portable`: builds a version for 64-bit ARM processors which avoids using some
-  modern CPU instructions. In practice, very few ARM processors lack the instructions necessary to
-  run the faster non-portable build.
+- `build-aarch64-portable`: builds a version 64 bit ARM processors which avoids
+	using some modern CPU instructions that might cause an "illegal
+	instruction" error on older CPUs.
+
 
 ### Example
 

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -17,7 +17,7 @@ eth2_hashing = "0.1.0"
 ethereum-types = "0.9.1"
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 zeroize = { version = "1.0.0", features = ["zeroize_derive"] }
-blst = { git = "https://github.com/supranational/blst.git", rev = "a8398ed284b0d78858302ad1ceb25a80e7bbe535" }
+blst = { git = "https://github.com/sigp/blst.git", rev = "284f7059642851c760a09fb1708bcb59c7ca323c" }
 
 [features]
 default = ["supranational"]
@@ -25,4 +25,3 @@ fake_crypto = []
 milagro = []
 supranational = []
 supranational-portable = ["supranational", "blst/portable"]
-supranational-force-adx = ["supranational", "blst/force-adx"]

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -9,9 +9,6 @@ edition = "2018"
 write_ssz_files = ["beacon_node/write_ssz_files"]
 # Compiles the BLS crypto code so that the binary is portable across machines.
 portable = ["bls/supranational-portable"]
-# Compiles BLST so that it always uses ADX instructions.
-# Compatible with processors from 2013 onwards.
-modern = ["bls/supranational-force-adx"]
 # Uses the slower Milagro BLS library, which is written in native Rust.
 milagro = ["bls/milagro"]
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -16,8 +16,6 @@ pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 fn bls_library_name() -> &'static str {
     if cfg!(feature = "portable") {
         "blst-portable"
-    } else if cfg!(feature = "modern") {
-        "blst-modern"
     } else if cfg!(feature = "milagro") {
         "milagro"
     } else {
@@ -180,13 +178,6 @@ fn run<E: EthSpec>(
         return Err(format!(
             "{}bit architecture is not supported (64bit only).",
             std::mem::size_of::<usize>() * 8
-        ));
-    }
-
-    #[cfg(all(feature = "modern", target_arch = "x86_64"))]
-    if !std::is_x86_feature_detected!("adx") {
-        return Err(format!(
-            "CPU incompatible with optimized binary, please try Lighthouse portable build"
         ));
     }
 


### PR DESCRIPTION
This reverts commit 4fca3063974084a5e83ac06dc0823748614b9762.

Something in the BLST update is causing SIGILLs on aarch64 non-portable builds. While we debug the issue, I think it's best if we just revert the update.
