### PR TITLE
[Merged by Bors] - Beacon node does not quit on eth1 errors

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -598,24 +598,6 @@ where
             .clone()
             .ok_or_else(|| "caching_eth1_backend requires a chain spec".to_string())?;
 
-        // Check if the eth1 endpoint we connect to is on the correct network id.
-        // Note: This check also effectively checks the eth1 http connection before the beacon chain
-        // is completely started and fails loudly if there is an issue.
-        let network_id =
-            eth1::http::check_eth1_endpoint(&config.endpoint, Duration::from_millis(15_000))
-                .await
-                .map_err(|_| "Error connecting to eth1 node.\n\
-                    Please ensure that you have an eth1 http server running locally on localhost:8545 \
-                    or pass an external endpoint using `--eth1-endpoint <SERVER-ADDRESS>`.\n\
-                    Also ensure that `eth` and `net` apis are enabled on the eth1 http server.".to_string())?;
-
-        if network_id != config.network_id {
-            return Err(format!(
-                "Invalid eth1 network id. Expected {:?}, got {:?}",
-                config.network_id, network_id
-            ));
-        }
-
         let backend = if let Some(eth1_service_from_genesis) = self.eth1_service {
             eth1_service_from_genesis.update_config(config)?;
 

--- a/beacon_node/eth1/src/http.rs
+++ b/beacon_node/eth1/src/http.rs
@@ -55,19 +55,6 @@ impl FromStr for Eth1NetworkId {
     }
 }
 
-/// Checks that the provided eth1 node has all the relevant api endpoints open
-/// and returns the network id.
-pub async fn check_eth1_endpoint(
-    endpoint: &str,
-    timeout: Duration,
-) -> Result<Eth1NetworkId, String> {
-    // Checks that the "eth" api works as expected.
-    let _block_number = get_block_number(endpoint, timeout).await?;
-    // Checks that the "net" api works as expected.
-    let network_id = get_network_id(endpoint, timeout).await?;
-    Ok(network_id)
-}
-
 /// Get the eth1 network id of the given endpoint.
 pub async fn get_network_id(endpoint: &str, timeout: Duration) -> Result<Eth1NetworkId, String> {
     let response_body = send_rpc_request(endpoint, "net_version", json!([]), timeout).await?;


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Log critical errors instead of quitting if eth1 node cannot be reached or is on wrong network id.
