### PR TITLE
[Merged by Bors] - Add gossip conditions from spec v0.12.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,11 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit
+	# TODO: we should address this --ignore.
+	#
+	# Tracking issue:
+	# https://github.com/sigp/lighthouse/issues/1669
+	cargo audit --ignore RUSTSEC-2020-0043
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -759,7 +759,7 @@ pub fn obtain_indexed_attestation_and_committees_per_slot<T: BeaconChainTypes>(
     map_attestation_committee(chain, attestation, |(committee, committees_per_slot)| {
         get_indexed_attestation(committee.committee, &attestation)
             .map(|attestation| (attestation, committees_per_slot))
-            .map_err(|e| BeaconChainError::from(e).into())
+            .map_err(Error::Invalid)
     })
 }
 

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -478,6 +478,9 @@ impl<T: BeaconChainTypes> VerifiedUnaggregatedAttestation<T> {
             //
             // Whilst this seems clearly invalid in the "spirit of the protocol", there is nothing
             // in the specification to prevent these messages from propagating.
+            //
+            // Reference:
+            // https://github.com/ethereum/eth2.0-specs/pull/2001#issuecomment-699246659
         } else {
             let target_root = if head_block_epoch == attestation_epoch {
                 // If the block is in the same epoch as the attestation, then use the target root

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -233,7 +233,7 @@ pub enum Error {
     ///
     /// The peer has sent an invalid message.
     InvalidTargetEpoch { slot: Slot, epoch: Epoch },
-    /// The attestation has pointed to a target root from a different chain to its head.
+    /// The attestation references an invalid target block.
     ///
     /// ## Peer scoring
     ///

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -11,13 +11,15 @@ use beacon_chain::{
     BeaconChain, BeaconChainTypes,
 };
 use int_to_bytes::int_to_bytes32;
-use state_processing::per_slot_processing;
+use state_processing::{
+    per_block_processing::errors::AttestationValidationError, per_slot_processing,
+};
 use store::config::StoreConfig;
 use tree_hash::TreeHash;
 use types::{
-    test_utils::generate_deterministic_keypair, AggregateSignature, Attestation, BitList, EthSpec,
-    Hash256, Keypair, MainnetEthSpec, SecretKey, SelectionProof, SignedAggregateAndProof,
-    SignedBeaconBlock, SubnetId, Unsigned,
+    test_utils::generate_deterministic_keypair, AggregateSignature, Attestation, BeaconStateError,
+    BitList, EthSpec, Hash256, Keypair, MainnetEthSpec, SecretKey, SelectionProof,
+    SignedAggregateAndProof, SignedBeaconBlock, SubnetId, Unsigned,
 };
 
 pub type E = MainnetEthSpec;
@@ -590,19 +592,22 @@ fn unaggregated_gossip_verification() {
      * The committee index is within the expected range -- i.e. `data.index <
      * get_committee_count_per_slot(state, data.target.epoch)`.
      */
-    let mut a = valid_attestation.clone();
-    a.data.index = harness
-        .chain
-        .head()
-        .unwrap()
-        .beacon_state
-        .get_committee_count_at_slot(a.data.slot)
-        .unwrap();
-    harness
-        .chain
-        .verify_unaggregated_attestation_for_gossip(a, subnet_id)
-        .err()
-        .expect("invalid index");
+    assert_invalid!(
+        "attestation with invalid committee index",
+        {
+            let mut a = valid_attestation.clone();
+            a.data.index = harness
+                .chain
+                .head()
+                .unwrap()
+                .beacon_state
+                .get_committee_count_at_slot(a.data.slot)
+                .unwrap();
+            a
+        },
+        subnet_id,
+        AttnError::NoCommitteeForSlotAndIndex { .. }
+    );
 
     /*
      * The following test ensures:
@@ -747,17 +752,22 @@ fn unaggregated_gossip_verification() {
      *   `len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot,
      *   data.index))`.
      */
-    let mut a = valid_attestation.clone();
-    let bits = a.aggregation_bits.iter().collect::<Vec<_>>();
-    a.aggregation_bits = BitList::with_capacity(bits.len() + 1).unwrap();
-    for (i, bit) in bits.into_iter().enumerate() {
-        a.aggregation_bits.set(i, bit).unwrap();
-    }
-    harness
-        .chain
-        .verify_unaggregated_attestation_for_gossip(a, subnet_id)
-        .err()
-        .expect("invalid committee length");
+    assert_invalid!(
+        "attestation with invalid bitfield",
+        {
+            let mut a = valid_attestation.clone();
+            let bits = a.aggregation_bits.iter().collect::<Vec<_>>();
+            a.aggregation_bits = BitList::with_capacity(bits.len() + 1).unwrap();
+            for (i, bit) in bits.into_iter().enumerate() {
+                a.aggregation_bits.set(i, bit).unwrap();
+            }
+            a
+        },
+        subnet_id,
+        AttnError::Invalid(AttestationValidationError::BeaconStateError(
+            BeaconStateError::InvalidBitfield
+        ))
+    );
 
     /*
      * The following test ensures that:

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -693,7 +693,7 @@ fn unaggregated_gossip_verification() {
      */
 
     assert_invalid!(
-        "attestation without invalid target epoch",
+        "attestation with invalid target epoch",
         {
             let mut a = valid_attestation.clone();
             a.data.target.epoch += 1;

--- a/beacon_node/network/src/beacon_processor/worker.rs
+++ b/beacon_node/network/src/beacon_processor/worker.rs
@@ -847,6 +847,32 @@ impl<T: BeaconChainTypes> Worker<T> {
                 );
                 self.penalize_peer(peer_id.clone(), PeerAction::LowToleranceError);
             }
+            AttnError::InvalidTargetEpoch { .. } => {
+                /*
+                 * The attestation is malformed.
+                 *
+                 * The peer has published an invalid consensus message.
+                 */
+                self.propagate_validation_result(
+                    message_id,
+                    peer_id.clone(),
+                    MessageAcceptance::Reject,
+                );
+                self.penalize_peer(peer_id.clone(), PeerAction::LowToleranceError);
+            }
+            AttnError::InvalidTargetRoot { .. } => {
+                /*
+                 * The attestation is malformed.
+                 *
+                 * The peer has published an invalid consensus message.
+                 */
+                self.propagate_validation_result(
+                    message_id,
+                    peer_id.clone(),
+                    MessageAcceptance::Reject,
+                );
+                self.penalize_peer(peer_id.clone(), PeerAction::LowToleranceError);
+            }
             AttnError::TooManySkippedSlots {
                 head_block_slot,
                 attestation_slot,

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -244,7 +244,9 @@ lazy_static! {
         "beacon_processor_aggregated_attestation_imported_total",
         "Total number of aggregated attestations imported to fork choice, etc."
     );
+}
 
+lazy_static! {
     /*
      * Attestation Errors
      */
@@ -336,6 +338,14 @@ lazy_static! {
         "gossipsub_attestation_error_invalid_too_many_skipped_slots",
         "Count of a specific error type (see metric name)"
     );
+    pub static ref GOSSIP_ATTESTATION_ERROR_INVALID_TARGET_ROOT: Result<IntCounter> = try_create_int_counter(
+        "gossip_attestation_error_invalid_target_root",
+        "Count of a specific error type (see metric name)"
+    );
+    pub static ref GOSSIP_ATTESTATION_ERROR_INVALID_TARGET_EPOCH: Result<IntCounter> = try_create_int_counter(
+        "gossip_attestation_error_invalid_target_epoch",
+        "Count of a specific error type (see metric name)"
+    );
     pub static ref GOSSIP_ATTESTATION_ERROR_BEACON_CHAIN_ERROR: Result<IntCounter> = try_create_int_counter(
         "gossipsub_attestation_error_beacon_chain_error",
         "Count of a specific error type (see metric name)"
@@ -393,6 +403,12 @@ pub fn register_attestation_error(error: &AttnError) {
             inc_counter(&GOSSIP_ATTESTATION_ERROR_INVALID_SUBNET_ID)
         }
         AttnError::Invalid(_) => inc_counter(&GOSSIP_ATTESTATION_ERROR_INVALID_STATE_PROCESSING),
+        AttnError::InvalidTargetRoot { .. } => {
+            inc_counter(&GOSSIP_ATTESTATION_ERROR_INVALID_TARGET_ROOT)
+        }
+        AttnError::InvalidTargetEpoch { .. } => {
+            inc_counter(&GOSSIP_ATTESTATION_ERROR_INVALID_TARGET_EPOCH)
+        }
         AttnError::TooManySkippedSlots { .. } => {
             inc_counter(&GOSSIP_ATTESTATION_ERROR_INVALID_TOO_MANY_SKIPPED_SLOTS)
         }

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -18,6 +18,7 @@ pub struct VoteTracker {
 /// A block that is to be applied to the fork choice.
 ///
 /// A simplified version of `types::BeaconBlock`.
+#[derive(Clone, Debug, PartialEq)]
 pub struct Block {
     pub slot: Slot,
     pub root: Hash256,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

There are four new conditions introduced in v0.12.3:

 1. _[REJECT]_ The attestation's epoch matches its target -- i.e. `attestation.data.target.epoch ==
  compute_epoch_at_slot(attestation.data.slot)`
1. _[REJECT]_ The attestation's target block is an ancestor of the block named in the LMD vote -- i.e.
  `get_ancestor(store, attestation.data.beacon_block_root, compute_start_slot_at_epoch(attestation.data.target.epoch)) == attestation.data.target.root`
1. _[REJECT]_ The committee index is within the expected range -- i.e. `data.index < get_committee_count_per_slot(state, data.target.epoch)`.
1. _[REJECT]_ The number of aggregation bits matches the committee size -- i.e.
  `len(attestation.aggregation_bits) == len(get_beacon_committee(state, data.slot, data.index))`.

This PR implements new logic to suit (1) and (2). Tests are added for (3) and (4), although they were already implicitly enforced.

## Additional Info

- There's a bit of edge-case with target root verification that I raised here: https://github.com/ethereum/eth2.0-specs/pull/2001#issuecomment-699246659
- I've had to add an `--ignore` to `cargo audit` to get CI to pass. See https://github.com/sigp/lighthouse/issues/1669
