### PR TITLE
[Merged by Bors] - Remove macos tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -33,20 +33,6 @@ jobs:
       run: sudo npm install -g ganache-cli
     - name: Run tests in release
       run: make test-release
-  release-tests-and-install-macos:
-    name: release-tests-and-install-macos
-    runs-on: macos-latest
-    needs: cargo-fmt
-    steps:
-    - uses: actions/checkout@v1
-    - name: Get latest version of stable Rust
-      run: rustup update stable
-    - name: Install ganache-cli
-      run: sudo npm install -g ganache-cli
-    - name: Run tests in release
-      run: make test-release
-    - name: Install Lighthouse
-      run: make
   debug-tests-ubuntu:
     name: debug-tests-ubuntu
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,19 @@
-status = ["cargo-fmt", "release-tests-ubuntu", "release-tests-and-install-macos", "debug-tests-ubuntu", "state-transition-vectors-ubuntu", "ef-tests-ubuntu", "dockerfile-ubuntu", "eth1-simulator-ubuntu", "no-eth1-simulator-ubuntu", "check-benchmarks", "clippy", "arbitrary-check", "cargo-audit", "cargo-udeps"]
+status = [
+    "cargo-fmt",
+    "release-tests-ubuntu",
+    "debug-tests-ubuntu",
+    "state-transition-vectors-ubuntu",
+    "ef-tests-ubuntu",
+    "dockerfile-ubuntu",
+    "eth1-simulator-ubuntu",
+    "no-eth1-simulator-ubuntu",
+    "check-benchmarks",
+    "check-consensus",
+    "clippy",
+    "arbitrary-check",
+    "cargo-audit",
+    "cargo-udeps"
+]
 use_squash_merge = true
 timeout_sec = 7200
 pr_status = ["license/cla"]


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Remove the MacOs tests. They routinely fail, causing bors to retry and slowing down the whole merge process.

## Additional Info

N/A
