### PR TITLE
[Merged by Bors] - Add database schema versioning

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -229,7 +229,7 @@ where
             .ok_or_else(|| "get_persisted_eth1_backend requires a store.".to_string())?;
 
         store
-            .get_item::<SszEth1>(&Hash256::from_slice(&ETH1_CACHE_DB_KEY))
+            .get_item::<SszEth1>(&ETH1_CACHE_DB_KEY)
             .map_err(|e| format!("DB error whilst reading eth1 cache: {:?}", e))
     }
 
@@ -241,7 +241,7 @@ where
             .ok_or_else(|| "store_contains_beacon_chain requires a store.".to_string())?;
 
         Ok(store
-            .get_item::<PersistedBeaconChain>(&Hash256::from_slice(&BEACON_CHAIN_DB_KEY))
+            .get_item::<PersistedBeaconChain>(&BEACON_CHAIN_DB_KEY)
             .map_err(|e| format!("DB error when reading persisted beacon chain: {:?}", e))?
             .is_some())
     }
@@ -272,7 +272,7 @@ where
             .ok_or_else(|| "resume_from_db requires a store.".to_string())?;
 
         let chain = store
-            .get_item::<PersistedBeaconChain>(&Hash256::from_slice(&BEACON_CHAIN_DB_KEY))
+            .get_item::<PersistedBeaconChain>(&BEACON_CHAIN_DB_KEY)
             .map_err(|e| format!("DB error when reading persisted beacon chain: {:?}", e))?
             .ok_or_else(|| {
                 "No persisted beacon chain found in store. Try purging the beacon chain database."
@@ -280,7 +280,7 @@ where
             })?;
 
         let persisted_fork_choice = store
-            .get_item::<PersistedForkChoice>(&Hash256::from_slice(&FORK_CHOICE_DB_KEY))
+            .get_item::<PersistedForkChoice>(&FORK_CHOICE_DB_KEY)
             .map_err(|e| format!("DB error when reading persisted fork choice: {:?}", e))?
             .ok_or_else(|| "No persisted fork choice present in database.".to_string())?;
 
@@ -307,7 +307,7 @@ where
 
         self.op_pool = Some(
             store
-                .get_item::<PersistedOperationPool<TEthSpec>>(&Hash256::from_slice(&OP_POOL_DB_KEY))
+                .get_item::<PersistedOperationPool<TEthSpec>>(&OP_POOL_DB_KEY)
                 .map_err(|e| format!("DB error whilst reading persisted op pool: {:?}", e))?
                 .map(PersistedOperationPool::into_operation_pool)
                 .unwrap_or_else(OperationPool::new),

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -357,11 +357,10 @@ fn roundtrip_operation_pool() {
         .persist_op_pool()
         .expect("should persist op pool");
 
-    let key = Hash256::from_slice(&OP_POOL_DB_KEY);
     let restored_op_pool = harness
         .chain
         .store
-        .get_item::<PersistedOperationPool<MinimalEthSpec>>(&key)
+        .get_item::<PersistedOperationPool<MinimalEthSpec>>(&OP_POOL_DB_KEY)
         .expect("should read db")
         .expect("should find op pool")
         .into_operation_pool();

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -3,15 +3,14 @@ use std::sync::Arc;
 use store::{DBColumn, Error as StoreError, HotColdDB, ItemStore, StoreItem};
 use types::{EthSpec, Hash256};
 
-/// 32-byte key for accessing the `DhtEnrs`.
-pub const DHT_DB_KEY: &str = "PERSISTEDDHTPERSISTEDDHTPERSISTE";
+/// 32-byte key for accessing the `DhtEnrs`. All zero because `DhtEnrs` has its own column.
+pub const DHT_DB_KEY: Hash256 = Hash256::zero();
 
 pub fn load_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
 ) -> Vec<Enr> {
     // Load DHT from store
-    let key = Hash256::from_slice(&DHT_DB_KEY.as_bytes());
-    match store.get_item(&key) {
+    match store.get_item(&DHT_DB_KEY) {
         Ok(Some(p)) => {
             let p: PersistedDht = p;
             p.enrs
@@ -25,9 +24,7 @@ pub fn persist_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
     store: Arc<HotColdDB<E, Hot, Cold>>,
     enrs: Vec<Enr>,
 ) -> Result<(), store::Error> {
-    let key = Hash256::from_slice(&DHT_DB_KEY.as_bytes());
-    store.put_item(&key, &PersistedDht { enrs })?;
-    Ok(())
+    store.put_item(&DHT_DB_KEY, &PersistedDht { enrs })
 }
 
 /// Wrapper around DHT for persistence to disk.
@@ -61,7 +58,7 @@ mod tests {
     use std::str::FromStr;
     use store::config::StoreConfig;
     use store::{HotColdDB, MemoryStore};
-    use types::{ChainSpec, Hash256, MinimalEthSpec};
+    use types::{ChainSpec, MinimalEthSpec};
     #[test]
     fn test_persisted_dht() {
         let log = NullLoggerBuilder.build().unwrap();
@@ -71,11 +68,10 @@ mod tests {
             MemoryStore<MinimalEthSpec>,
         > = HotColdDB::open_ephemeral(StoreConfig::default(), ChainSpec::minimal(), log).unwrap();
         let enrs = vec![Enr::from_str("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8").unwrap()];
-        let key = Hash256::from_slice(&DHT_DB_KEY.as_bytes());
         store
-            .put_item(&key, &PersistedDht { enrs: enrs.clone() })
+            .put_item(&DHT_DB_KEY, &PersistedDht { enrs: enrs.clone() })
             .unwrap();
-        let dht: PersistedDht = store.get_item(&key).unwrap().unwrap();
+        let dht: PersistedDht = store.get_item(&DHT_DB_KEY).unwrap().unwrap();
         assert_eq!(dht.enrs, enrs);
     }
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -267,7 +267,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("slots-per-restore-point")
                 .value_name("SLOT_COUNT")
                 .help("Specifies how often a freezer DB restore point should be stored. \
-                       DO NOT DECREASE AFTER INITIALIZATION. [default: 2048 (mainnet) or 64 (minimal)]")
+                       Cannot be changed after initialization. \
+                       [default: 2048 (mainnet) or 64 (minimal)]")
                 .takes_value(true)
         )
         .arg(

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -1,16 +1,24 @@
+use crate::{DBColumn, Error, StoreItem};
 use serde_derive::{Deserialize, Serialize};
+use ssz::{Decode, Encode};
+use ssz_derive::{Decode, Encode};
 use types::{EthSpec, MinimalEthSpec};
 
 pub const DEFAULT_SLOTS_PER_RESTORE_POINT: u64 = 2048;
 pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5;
 
 /// Database configuration parameters.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
 pub struct StoreConfig {
     /// Number of slots to wait between storing restore points in the freezer database.
     pub slots_per_restore_point: u64,
     /// Maximum number of blocks to store in the in-memory block cache.
     pub block_cache_size: usize,
+}
+
+#[derive(Debug, Clone)]
+pub enum StoreConfigError {
+    MismatchedSlotsPerRestorePoint { config: u64, on_disk: u64 },
 }
 
 impl Default for StoreConfig {
@@ -20,5 +28,31 @@ impl Default for StoreConfig {
             slots_per_restore_point: MinimalEthSpec::slots_per_historical_root() as u64,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
         }
+    }
+}
+
+impl StoreConfig {
+    pub fn check_compatibility(&self, on_disk_config: &Self) -> Result<(), StoreConfigError> {
+        if self.slots_per_restore_point != on_disk_config.slots_per_restore_point {
+            return Err(StoreConfigError::MismatchedSlotsPerRestorePoint {
+                config: self.slots_per_restore_point,
+                on_disk: on_disk_config.slots_per_restore_point,
+            });
+        }
+        Ok(())
+    }
+}
+
+impl StoreItem for StoreConfig {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconMeta
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(Self::from_ssz_bytes(bytes)?)
     }
 }

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -1,4 +1,5 @@
 use crate::chunked_vector::ChunkError;
+use crate::config::StoreConfigError;
 use crate::hot_cold_store::HotColdDBError;
 use ssz::DecodeError;
 use types::{BeaconStateError, Hash256, Slot};
@@ -17,6 +18,7 @@ pub enum Error {
     BlockNotFound(Hash256),
     NoContinuationData,
     SplitPointModified(Slot, Slot),
+    ConfigError(StoreConfigError),
 }
 
 impl From<DecodeError> for Error {
@@ -46,6 +48,12 @@ impl From<BeaconStateError> for Error {
 impl From<DBError> for Error {
     fn from(e: DBError) -> Error {
         Error::DBError { message: e.message }
+    }
+}
+
+impl From<StoreConfigError> for Error {
+    fn from(e: StoreConfigError) -> Error {
+        Error::ConfigError(e)
     }
 }
 

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -154,7 +154,7 @@ pub enum DBColumn {
 }
 
 impl Into<&'static str> for DBColumn {
-    /// Returns a `&str` that can be used for keying a key-value data base.
+    /// Returns a `&str` prefix to be added to keys before they hit the key-value database.
     fn into(self) -> &'static str {
         match self {
             DBColumn::BeaconMeta => "bma",

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -19,6 +19,7 @@ pub mod hot_cold_store;
 mod impls;
 mod leveldb_store;
 mod memory_store;
+mod metadata;
 mod metrics;
 mod partial_beacon_state;
 

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -1,0 +1,29 @@
+use crate::{DBColumn, Error, StoreItem};
+use ssz::{Decode, Encode};
+use types::Hash256;
+
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(1);
+
+// All the keys that get stored under the `BeaconMeta` column.
+//
+// We use `repeat_byte` because it's a const fn.
+pub const SCHEMA_VERSION_KEY: Hash256 = Hash256::repeat_byte(0);
+pub const CONFIG_KEY: Hash256 = Hash256::repeat_byte(1);
+pub const SPLIT_KEY: Hash256 = Hash256::repeat_byte(2);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemaVersion(pub u64);
+
+impl StoreItem for SchemaVersion {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconMeta
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(SchemaVersion(u64::from_ssz_bytes(bytes)?))
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Closes #673

## Proposed Changes

Store a schema version in the database so that future releases can check they're running against a compatible database version. This would also enable automatic migration on breaking database changes, but that's left as future work.

The database config is also stored in the database so that the `slots_per_restore_point` value can be checked for consistency, which closes #673
