### PR TITLE
MacOS compatibility with the health endpoint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,7 +153,7 @@ version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
- "memchr",
+ "memchr 2.3.3",
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
- "memchr",
+ "memchr 2.3.3",
  "regex-automata",
  "serde",
 ]
@@ -622,6 +622,12 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytesize"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
 
 [[package]]
 name = "bzip2"
@@ -1066,7 +1072,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
- "memchr",
+ "memchr 2.3.3",
 ]
 
 [[package]]
@@ -1122,7 +1128,7 @@ checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
 dependencies = [
  "darwin-libproc-sys",
  "libc",
- "memchr",
+ "memchr 2.3.3",
 ]
 
 [[package]]
@@ -1923,7 +1929,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
+ "memchr 2.3.3",
  "pin-project",
  "pin-utils",
  "proc-macro-hack",
@@ -1939,7 +1945,7 @@ checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
  "bytes 0.5.6",
  "futures 0.3.5",
- "memchr",
+ "memchr 2.3.3",
  "pin-project",
 ]
 
@@ -3065,6 +3071,15 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -3364,6 +3379,15 @@ name = "nom"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+dependencies = [
+ "memchr 1.0.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -3820,7 +3844,7 @@ checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
 dependencies = [
  "byteorder",
  "libc",
- "nom",
+ "nom 2.2.1",
  "rustc_version",
 ]
 
@@ -4151,7 +4175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
- "memchr",
+ "memchr 2.3.3",
  "regex-syntax",
  "thread_local",
 ]
@@ -4296,6 +4320,7 @@ dependencies = [
  "serde_yaml",
  "state_processing",
  "store",
+ "systemstat",
  "tokio 0.2.22",
  "tree_hash",
  "types",
@@ -4352,7 +4377,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "libsqlite3-sys",
  "lru-cache",
- "memchr",
+ "memchr 2.3.3",
  "smallvec 1.4.2",
  "time 0.1.44",
 ]
@@ -5186,6 +5211,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "systemstat"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2078da8d09c6202bffd5e075946e65bfad5ce2cfa161edb15c5f014a8440adee"
+dependencies = [
+ "bytesize",
+ "chrono",
+ "lazy_static",
+ "libc",
+ "nom 3.2.1",
+ "time 0.1.44",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5444,7 +5484,7 @@ dependencies = [
  "iovec",
  "lazy_static",
  "libc",
- "memchr",
+ "memchr 2.3.3",
  "mio",
  "mio-named-pipes",
  "mio-uds",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,12 +3376,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-
-[[package]]
-name = "nom"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
@@ -3834,18 +3828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
-]
-
-[[package]]
-name = "procinfo"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
-dependencies = [
- "byteorder",
- "libc",
- "nom 2.2.1",
- "rustc_version",
 ]
 
 [[package]]
@@ -4312,7 +4294,6 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "hyper 0.13.7",
- "procinfo",
  "psutil",
  "rayon",
  "serde",
@@ -5220,7 +5201,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "libc",
- "nom 3.2.1",
+ "nom",
  "time 0.1.44",
  "winapi 0.3.9",
 ]

--- a/beacon_node/rest_api/src/metrics.rs
+++ b/beacon_node/rest_api/src/metrics.rs
@@ -33,10 +33,6 @@ lazy_static! {
         "http_server_request_duration_seconds",
         "Time taken to build a response to a HTTP request"
     );
-    pub static ref PROCESS_NUM_THREADS: Result<IntGauge> = try_create_int_gauge(
-        "process_num_threads",
-        "Number of threads used by the current process"
-    );
     pub static ref PROCESS_RES_MEM: Result<IntGauge> = try_create_int_gauge(
         "process_resident_memory_bytes",
         "Resident memory used by the current process"
@@ -102,7 +98,6 @@ pub fn get_prometheus<T: BeaconChainTypes>(
     // This will silently fail if we are unable to observe the health. This is desired behaviour
     // since we don't support `Health` for all platforms.
     if let Ok(health) = Health::observe() {
-        set_gauge(&PROCESS_NUM_THREADS, health.pid_num_threads as i64);
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
         set_gauge(&SYSTEM_VIRT_MEM_TOTAL, health.sys_virt_mem_total as i64);

--- a/book/src/http/node.md
+++ b/book/src/http/node.md
@@ -76,7 +76,6 @@ Typical Responses | 200
 ```json
 {
     "pid": 96160,
-    "pid_num_threads": 30,
     "pid_mem_resident_set_size": 55476224,
     "pid_mem_virtual_memory_size": 2081382400,
     "sys_virt_mem_total": 16721076224,

--- a/common/rest_types/Cargo.toml
+++ b/common/rest_types/Cargo.toml
@@ -24,7 +24,6 @@ serde_yaml = "0.8.11"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 psutil = "3.1.0"
-procinfo = "0.4.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 systemstat = "0.1.5"

--- a/common/rest_types/Cargo.toml
+++ b/common/rest_types/Cargo.toml
@@ -25,3 +25,7 @@ serde_yaml = "0.8.11"
 [target.'cfg(target_os = "linux")'.dependencies]
 psutil = "3.1.0"
 procinfo = "0.4.2"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+systemstat = "0.1.5"
+psutil = "3.1.0"

--- a/common/rest_types/src/node.rs
+++ b/common/rest_types/src/node.rs
@@ -4,7 +4,7 @@ use ssz_derive::{Decode, Encode};
 use types::Slot;
 
 #[cfg(target_os = "linux")]
-use {procinfo::pid, psutil::process::Process};
+use {psutil::process::Process};
 
 #[cfg(target_os = "macos")]
 use {
@@ -45,8 +45,6 @@ pub struct SyncingResponse {
 pub struct Health {
     /// The pid of this process.
     pub pid: u32,
-    /// The number of threads used by this pid.
-    pub pid_num_threads: i32,
     /// The total resident memory used by this pid.
     pub pid_mem_resident_set_size: u64,
     /// The total virtual memory used by this pid.
@@ -90,8 +88,6 @@ impl Health {
 
         Ok(Self {
             pid: process.pid() as u32,
-            //TODO: figure out how to get threads for a PID on mac
-            pid_num_threads: 0,
             pid_mem_resident_set_size: process_mem.rss(),
             pid_mem_virtual_memory_size: process_mem.vms(),
             sys_virt_mem_total: vm.total(),
@@ -114,8 +110,6 @@ impl Health {
             .memory_info()
             .map_err(|e| format!("Unable to get process memory info: {:?}", e))?;
 
-        let stat = pid::stat_self().map_err(|e| format!("Unable to get stat: {:?}", e))?;
-
         let vm = psutil::memory::virtual_memory()
             .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
         let loadavg =
@@ -123,7 +117,6 @@ impl Health {
 
         Ok(Self {
             pid: process.pid(),
-            pid_num_threads: stat.num_threads,
             pid_mem_resident_set_size: process_mem.rss(),
             pid_mem_virtual_memory_size: process_mem.vms(),
             sys_virt_mem_total: vm.total(),


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add MacOS compatibility for the `/node/health` endpoint.

## Additional Info

Couldn't find a library with a `num_threads` metric implemented for Mac.
