### PR TITLE
[Merged by Bors] - Update tiny-bip39 dependency to one implementing zeroize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5353,8 +5353,7 @@ dependencies = [
 [[package]]
 name = "tiny-bip39"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0165e045cc2ae1660270ca65e1676dbaab60feb0f91b10f7d0665e9b47e31f2"
+source = "git+https://github.com/sigp/tiny-bip39.git?rev=1137c32da91bd5e75db4305a84ddd15255423f7f#1137c32da91bd5e75db4305a84ddd15255423f7f"
 dependencies = [
  "failure",
  "hmac 0.7.1",
@@ -5364,6 +5363,7 @@ dependencies = [
  "rustc-hash",
  "sha2 0.8.2",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]

--- a/crypto/eth2_wallet/Cargo.toml
+++ b/crypto/eth2_wallet/Cargo.toml
@@ -14,7 +14,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 rand = "0.7.2"
 eth2_keystore = { path = "../eth2_keystore" }
 eth2_key_derivation = { path = "../eth2_key_derivation" }
-tiny-bip39 = "0.7.3"
+tiny-bip39 = { git = "https://github.com/sigp/tiny-bip39.git", rev = "1137c32da91bd5e75db4305a84ddd15255423f7f" }
 
 [dev-dependencies]
 hex = "0.4.2"


### PR DESCRIPTION
## Issue Addressed

Resolves #1130

## Proposed Changes

Use the sigp fork of tiny-bip39, which includes `Zeroize` for `Mnemonic` and `Seed`

## Additional Info
N/A
