### PR TITLE
Update BLST, add force-adx support (take II)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,12 +160,8 @@ dependencies = [
 
 [[package]]
 name = "amcl"
-version = "0.2.0"
-source = "git+https://github.com/sigp/milagro_bls?branch=paulh#7662690845f3f2594e46cfe71b6b0bb91d5e1f82"
-dependencies = [
- "hex 0.3.2",
- "lazy_static",
-]
+version = "0.3.0"
+source = "git+https://github.com/sigp/milagro_bls?tag=v1.2.0#515201c5d165f1e08bca93e24cad4044eeed6e21"
 
 [[package]]
 name = "ansi_term"
@@ -3225,8 +3221,8 @@ dependencies = [
 
 [[package]]
 name = "milagro_bls"
-version = "1.1.0"
-source = "git+https://github.com/sigp/milagro_bls?branch=paulh#7662690845f3f2594e46cfe71b6b0bb91d5e1f82"
+version = "1.2.0"
+source = "git+https://github.com/sigp/milagro_bls?tag=v1.2.0#515201c5d165f1e08bca93e24cad4044eeed6e21"
 dependencies = [
  "amcl",
  "hex 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
 [[package]]
 name = "blst"
 version = "0.1.1"
-source = "git+https://github.com/sigp/blst.git?rev=284f7059642851c760a09fb1708bcb59c7ca323c#284f7059642851c760a09fb1708bcb59c7ca323c"
+source = "git+https://github.com/supranational/blst.git?rev=893d0bcf58dce17604efed6dac0c688aacc1edf7#893d0bcf58dce17604efed6dac0c688aacc1edf7"
 dependencies = [
  "cc",
  "glob",

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 # optimized CPU functions that may not be available on some systems. This
 # results in a more portable binary with ~20% slower BLS verification.
 build-x86_64:
-	cross build --release --manifest-path lighthouse/Cargo.toml --target x86_64-unknown-linux-gnu
+	cross build --release --manifest-path lighthouse/Cargo.toml --target x86_64-unknown-linux-gnu --features modern
 build-x86_64-portable:
 	cross build --release --manifest-path lighthouse/Cargo.toml --target x86_64-unknown-linux-gnu --features portable
 build-aarch64:

--- a/book/src/cross-compiling.md
+++ b/book/src/cross-compiling.md
@@ -18,17 +18,15 @@ project.
 
 The `Makefile` in the project contains four targets for cross-compiling:
 
-- `build-x86_64`: builds an optimized version for x86_64 processors (suitable
-	for most users).
-- `build-x86_64-portable`: builds a version x86_64 processors which avoids
-	using some modern CPU instructions that might cause an "illegal
-	instruction" error on older CPUs.
-- `build-aarch64`: builds an optimized version for 64bit ARM processors
+- `build-x86_64`: builds an optimized version for x86_64 processors (suitable for most users).
+  Supports Intel Broadwell (2014) and newer, and AMD Ryzen (2017) and newer.
+- `build-x86_64-portable`: builds a version for x86_64 processors which avoids using some modern CPU
+  instructions that are incompatible with older CPUs. Suitable for pre-Broadwell/Ryzen CPUs.
+- `build-aarch64`: builds an optimized version for 64-bit ARM processors
 	(suitable for Raspberry Pi 4).
-- `build-aarch64-portable`: builds a version 64 bit ARM processors which avoids
-	using some modern CPU instructions that might cause an "illegal
-	instruction" error on older CPUs.
-
+- `build-aarch64-portable`: builds a version for 64-bit ARM processors which avoids using some
+  modern CPU instructions. In practice, very few ARM processors lack the instructions necessary to
+  run the faster non-portable build.
 
 ### Example
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -262,7 +262,6 @@ impl ChainSpec {
             hysteresis_quotient: 4,
             hysteresis_downward_multiplier: 1,
             hysteresis_upward_multiplier: 5,
-            proportional_slashing_multiplier: 3,
 
             /*
              *  Gwei values
@@ -281,7 +280,7 @@ impl ChainSpec {
             /*
              * Time parameters
              */
-            genesis_delay: 172800, // 2 days
+            genesis_delay: 604800, // 7 days
             milliseconds_per_slot: 12_000,
             min_attestation_inclusion_delay: 1,
             min_seed_lookahead: Epoch::new(1),
@@ -296,8 +295,9 @@ impl ChainSpec {
             base_reward_factor: 64,
             whistleblower_reward_quotient: 512,
             proposer_reward_quotient: 8,
-            inactivity_penalty_quotient: u64::pow(2, 24),
-            min_slashing_penalty_quotient: 32,
+            inactivity_penalty_quotient: u64::pow(2, 26),
+            min_slashing_penalty_quotient: 128,
+            proportional_slashing_multiplier: 1,
 
             /*
              * Signature domains
@@ -318,7 +318,7 @@ impl ChainSpec {
             /*
              * Eth1
              */
-            eth1_follow_distance: 1_024,
+            eth1_follow_distance: 2048,
             seconds_per_eth1_block: 14,
             deposit_contract_address: "1234567890123456789012345678901234567890"
                 .parse()
@@ -355,6 +355,9 @@ impl ChainSpec {
             shard_committee_period: 64,
             genesis_delay: 300,
             milliseconds_per_slot: 6_000,
+            inactivity_penalty_quotient: u64::pow(2, 25),
+            min_slashing_penalty_quotient: 64,
+            proportional_slashing_multiplier: 2,
             safe_slots_to_update_justified: 2,
             network_id: 2, // lighthouse testnet network id
             boot_nodes,
@@ -475,10 +478,6 @@ pub struct YamlConfig {
     hysteresis_downward_multiplier: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     hysteresis_upward_multiplier: u64,
-    // Proportional slashing multiplier defaults to 3 for compatibility with Altona and Medalla.
-    #[serde(default = "default_proportional_slashing_multiplier")]
-    #[serde(with = "serde_utils::quoted_u64")]
-    proportional_slashing_multiplier: u64,
     #[serde(with = "serde_utils::bytes_4_hex")]
     genesis_fork_version: [u8; 4],
     #[serde(with = "serde_utils::u8_hex")]
@@ -507,6 +506,10 @@ pub struct YamlConfig {
     inactivity_penalty_quotient: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     min_slashing_penalty_quotient: u64,
+    // Proportional slashing multiplier defaults to 3 for compatibility with Altona and Medalla.
+    #[serde(default = "default_proportional_slashing_multiplier")]
+    #[serde(with = "serde_utils::quoted_u64")]
+    proportional_slashing_multiplier: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     safe_slots_to_update_justified: u64,
 

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -144,7 +144,7 @@ impl EthSpec for MainnetEthSpec {
     type MaxValidatorsPerCommittee = U2048;
     type GenesisEpoch = U0;
     type SlotsPerEpoch = U32;
-    type EpochsPerEth1VotingPeriod = U32;
+    type EpochsPerEth1VotingPeriod = U64;
     type SlotsPerHistoricalRoot = U8192;
     type EpochsPerHistoricalVector = U65536;
     type EpochsPerSlashingsVector = U8192;
@@ -156,7 +156,7 @@ impl EthSpec for MainnetEthSpec {
     type MaxDeposits = U16;
     type MaxVoluntaryExits = U16;
     type MaxPendingAttestations = U4096; // 128 max attestations * 32 slots per epoch
-    type SlotsPerEth1VotingPeriod = U1024; // 32 epochs * 32 slots per epoch
+    type SlotsPerEth1VotingPeriod = U2048; // 64 epochs * 32 slots per epoch
 
     fn default_spec() -> ChainSpec {
         ChainSpec::mainnet()

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -17,7 +17,7 @@ eth2_hashing = "0.1.0"
 ethereum-types = "0.9.1"
 arbitrary = { version = "0.4.4", features = ["derive"], optional = true }
 zeroize = { version = "1.0.0", features = ["zeroize_derive"] }
-blst = { git = "https://github.com/sigp/blst.git", rev = "284f7059642851c760a09fb1708bcb59c7ca323c" }
+blst = { git = "https://github.com/supranational/blst.git", rev = "893d0bcf58dce17604efed6dac0c688aacc1edf7" }
 
 [features]
 default = ["supranational"]
@@ -25,3 +25,4 @@ fake_crypto = []
 milagro = []
 supranational = []
 supranational-portable = ["supranational", "blst/portable"]
+supranational-force-adx = ["supranational", "blst/force-adx"]

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 eth2_ssz = "0.1.2"
 tree_hash = "0.1.0"
-milagro_bls = { git = "https://github.com/sigp/milagro_bls", branch = "paulh" }
+milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.2.0" }
 rand = "0.7.2"
 serde = "1.0.102"
 serde_derive = "1.0.102"

--- a/crypto/bls/src/generic_aggregate_signature.rs
+++ b/crypto/bls/src/generic_aggregate_signature.rs
@@ -183,13 +183,6 @@ where
             return false;
         }
 
-        if self.is_infinity
-            && pubkeys.len() == 1
-            && pubkeys.first().map_or(false, |pk| pk.is_infinity)
-        {
-            return true;
-        }
-
         match self.point.as_ref() {
             Some(point) => point.fast_aggregate_verify(msg, pubkeys),
             None => false,
@@ -205,13 +198,6 @@ where
     pub fn aggregate_verify(&self, msgs: &[Hash256], pubkeys: &[&GenericPublicKey<Pub>]) -> bool {
         if msgs.is_empty() || msgs.len() != pubkeys.len() {
             return false;
-        }
-
-        if self.is_infinity
-            && pubkeys.len() == 1
-            && pubkeys.first().map_or(false, |pk| pk.is_infinity)
-        {
-            return true;
         }
 
         match self.point.as_ref() {

--- a/crypto/bls/src/generic_public_key.rs
+++ b/crypto/bls/src/generic_public_key.rs
@@ -33,8 +33,6 @@ pub trait TPublicKey: Sized + Clone {
 pub struct GenericPublicKey<Pub> {
     /// The underlying point which performs *actual* cryptographic operations.
     point: Pub,
-    /// True if this point is equal to the `INFINITY_PUBLIC_KEY`.
-    pub(crate) is_infinity: bool,
 }
 
 impl<Pub> GenericPublicKey<Pub>
@@ -42,8 +40,8 @@ where
     Pub: TPublicKey,
 {
     /// Instantiates `Self` from a `point`.
-    pub(crate) fn from_point(point: Pub, is_infinity: bool) -> Self {
-        Self { point, is_infinity }
+    pub(crate) fn from_point(point: Pub) -> Self {
+        Self { point }
     }
 
     /// Returns a reference to the underlying BLS point.
@@ -63,10 +61,13 @@ where
 
     /// Deserialize `self` from compressed bytes.
     pub fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        Ok(Self {
-            point: Pub::deserialize(bytes)?,
-            is_infinity: bytes == &INFINITY_PUBLIC_KEY[..],
-        })
+        if bytes == &INFINITY_PUBLIC_KEY[..] {
+            Err(Error::InvalidInfinityPublicKey)
+        } else {
+            Ok(Self {
+                point: Pub::deserialize(bytes)?,
+            })
+        }
     }
 }
 

--- a/crypto/bls/src/generic_public_key_bytes.rs
+++ b/crypto/bls/src/generic_public_key_bytes.rs
@@ -1,6 +1,6 @@
 use crate::{
     generic_public_key::{GenericPublicKey, TPublicKey},
-    Error, INFINITY_PUBLIC_KEY, PUBLIC_KEY_BYTES_LEN,
+    Error, PUBLIC_KEY_BYTES_LEN,
 };
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
@@ -32,8 +32,7 @@ where
     ///
     /// May fail if the bytes are invalid.
     pub fn decompress(&self) -> Result<GenericPublicKey<Pub>, Error> {
-        let is_infinity = self.bytes[..] == INFINITY_PUBLIC_KEY[..];
-        Pub::deserialize(&self.bytes).map(|point| GenericPublicKey::from_point(point, is_infinity))
+        GenericPublicKey::deserialize(&self.bytes)
     }
 }
 

--- a/crypto/bls/src/generic_secret_key.rs
+++ b/crypto/bls/src/generic_secret_key.rs
@@ -58,8 +58,7 @@ where
 
     /// Returns the public key that corresponds to self.
     pub fn public_key(&self) -> GenericPublicKey<Pub> {
-        let is_infinity = false;
-        GenericPublicKey::from_point(self.point.public_key(), is_infinity)
+        GenericPublicKey::from_point(self.point.public_key())
     }
 
     /// Serialize `self` as compressed bytes.

--- a/crypto/bls/src/generic_signature.rs
+++ b/crypto/bls/src/generic_signature.rs
@@ -125,10 +125,6 @@ where
 {
     /// Returns `true` if `self` is a signature across `msg` by `pubkey`.
     pub fn verify(&self, pubkey: &GenericPublicKey<Pub>, msg: Hash256) -> bool {
-        if self.is_infinity && pubkey.is_infinity {
-            return true;
-        }
-
         if let Some(point) = &self.point {
             point.verify(pubkey.point(), msg)
         } else {

--- a/crypto/bls/src/impls/blst.rs
+++ b/crypto/bls/src/impls/blst.rs
@@ -50,15 +50,6 @@ pub fn verify_signature_sets<'a>(
     let mut pks = Vec::with_capacity(sets.len());
 
     for set in &sets {
-        // If this set is simply an infinity signature and infinity pubkey then skip verification.
-        // This has the effect of always declaring that this sig/pubkey combination is valid.
-        if set.signature.is_infinity
-            && set.signing_keys.len() == 1
-            && set.signing_keys.first().map_or(false, |pk| pk.is_infinity)
-        {
-            continue;
-        }
-
         // Generate random scalars.
         let mut vals = [0u64; 4];
         vals[0] = rng.gen();

--- a/crypto/bls/src/lib.rs
+++ b/crypto/bls/src/lib.rs
@@ -56,6 +56,8 @@ pub enum Error {
     InvalidByteLength { got: usize, expected: usize },
     /// The provided secret key bytes were an incorrect length.
     InvalidSecretKeyLength { got: usize, expected: usize },
+    /// The public key represents the point at infinity, which is invalid.
+    InvalidInfinityPublicKey,
 }
 
 impl From<AmclError> for Error {

--- a/crypto/bls/tests/tests.rs
+++ b/crypto/bls/tests/tests.rs
@@ -1,4 +1,4 @@
-use bls::{Hash256, INFINITY_PUBLIC_KEY, INFINITY_SIGNATURE};
+use bls::{Hash256, INFINITY_SIGNATURE};
 use ssz::{Decode, Encode};
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -131,11 +131,6 @@ macro_rules! test_suite {
                 self
             }
 
-            pub fn infinity_pubkey(mut self) -> Self {
-                self.pubkey = PublicKey::deserialize(&INFINITY_PUBLIC_KEY[..]).unwrap();
-                self
-            }
-
             pub fn assert_verify(self, is_valid: bool) {
                 assert_eq!(self.sig.verify(&self.pubkey, self.msg), is_valid);
 
@@ -154,24 +149,9 @@ macro_rules! test_suite {
         }
 
         #[test]
-        fn infinity_signature_is_valid_with_infinity_pubkey() {
-            SignatureTester::default()
-                .infinity_sig()
-                .infinity_pubkey()
-                .assert_verify(true)
-        }
-
-        #[test]
         fn infinity_signature_is_invalid_with_standard_pubkey() {
             SignatureTester::default()
                 .infinity_sig()
-                .assert_verify(false)
-        }
-
-        #[test]
-        fn standard_signature_is_invalid_with_infinity_pubkey() {
-            SignatureTester::default()
-                .infinity_pubkey()
                 .assert_verify(false)
         }
 
@@ -234,17 +214,6 @@ macro_rules! test_suite {
                 self
             }
 
-            pub fn single_infinity_pubkey(mut self) -> Self {
-                self.pubkeys = vec![PublicKey::deserialize(&INFINITY_PUBLIC_KEY[..]).unwrap()];
-                self
-            }
-
-            pub fn push_infinity_pubkey(mut self) -> Self {
-                self.pubkeys
-                    .push(PublicKey::deserialize(&INFINITY_PUBLIC_KEY[..]).unwrap());
-                self
-            }
-
             pub fn assert_single_message_verify(self, is_valid: bool) {
                 assert!(self.msgs.len() == 1);
                 let msg = self.msgs.first().unwrap();
@@ -304,15 +273,6 @@ macro_rules! test_suite {
                 .assert_single_message_verify(false)
         }
 
-        /// The infinity signature and one infinity pubkey should verify.
-        #[test]
-        fn fast_aggregate_verify_infinity_signature_with_one_infinity_pubkey() {
-            AggregateSignatureTester::new_with_single_msg(1)
-                .infinity_sig()
-                .single_infinity_pubkey()
-                .assert_single_message_verify(true)
-        }
-
         /// Adding a infinity signature (without an infinity pubkey) should verify.
         #[test]
         fn fast_aggregate_verify_with_one_aggregated_infinity_sig() {
@@ -329,34 +289,6 @@ macro_rules! test_suite {
                 .aggregate_infinity_sig()
                 .aggregate_infinity_sig()
                 .aggregate_infinity_sig()
-                .assert_single_message_verify(true)
-        }
-
-        /// Adding a infinity pubkey and an infinity signature should verify.
-        #[test]
-        fn fast_aggregate_verify_with_one_additional_infinity_pubkey_and_matching_sig() {
-            AggregateSignatureTester::new_with_single_msg(1)
-                .aggregate_infinity_sig()
-                .push_infinity_pubkey()
-                .assert_single_message_verify(true)
-        }
-
-        /// Adding a single infinity pubkey **without** updating the signature **should verify**.
-        #[test]
-        fn fast_aggregate_verify_with_one_additional_infinity_pubkey() {
-            AggregateSignatureTester::new_with_single_msg(1)
-                .push_infinity_pubkey()
-                .assert_single_message_verify(true)
-        }
-
-        /// Adding multiple infinity pubkeys **without** updating the signature **should verify**.
-        #[test]
-        fn fast_aggregate_verify_with_four_additional_infinity_pubkeys() {
-            AggregateSignatureTester::new_with_single_msg(1)
-                .push_infinity_pubkey()
-                .push_infinity_pubkey()
-                .push_infinity_pubkey()
-                .push_infinity_pubkey()
                 .assert_single_message_verify(true)
         }
 
@@ -463,34 +395,12 @@ macro_rules! test_suite {
                 self
             }
 
-            pub fn push_invalid_sig_infinity_set(mut self) -> Self {
-                let mut signature = AggregateSignature::infinity();
-                signature.add_assign(&secret_from_u64(42).sign(Hash256::zero()));
-                self.owned_sets.push(OwnedSignatureSet {
-                    signature,
-                    signing_keys: vec![PublicKey::deserialize(&INFINITY_PUBLIC_KEY).unwrap()],
-                    message: Hash256::zero(),
-                    should_be_valid: false,
-                });
-                self
-            }
-
             pub fn push_invalid_pubkey_infinity_set(mut self) -> Self {
                 self.owned_sets.push(OwnedSignatureSet {
                     signature: AggregateSignature::deserialize(&INFINITY_SIGNATURE).unwrap(),
                     signing_keys: vec![secret_from_u64(42).public_key()],
                     message: Hash256::zero(),
                     should_be_valid: false,
-                });
-                self
-            }
-
-            pub fn push_valid_infinity_set(mut self) -> Self {
-                self.owned_sets.push(OwnedSignatureSet {
-                    signature: AggregateSignature::deserialize(&INFINITY_SIGNATURE).unwrap(),
-                    signing_keys: vec![PublicKey::deserialize(&INFINITY_PUBLIC_KEY).unwrap()],
-                    message: Hash256::zero(),
-                    should_be_valid: true,
                 });
                 self
             }
@@ -569,35 +479,10 @@ macro_rules! test_suite {
         }
 
         #[test]
-        fn signature_set_1_valid_set_with_1_infinity_set() {
-            SignatureSetTester::default()
-                .push_valid_infinity_set()
-                .run_checks()
-        }
-
-        #[test]
-        fn signature_set_3_sets_with_one_valid_infinity_set() {
-            SignatureSetTester::default()
-                .push_valid_set(2)
-                .push_valid_infinity_set()
-                .push_valid_set(2)
-                .run_checks()
-        }
-
-        #[test]
         fn signature_set_3_sets_with_one_invalid_pubkey_infinity_set() {
             SignatureSetTester::default()
                 .push_valid_set(2)
                 .push_invalid_pubkey_infinity_set()
-                .push_valid_set(2)
-                .run_checks()
-        }
-
-        #[test]
-        fn signature_set_3_sets_with_one_invalid_sig_infinity_set() {
-            SignatureSetTester::default()
-                .push_valid_set(2)
-                .push_invalid_sig_infinity_set()
                 .push_valid_set(2)
                 .run_checks()
         }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 write_ssz_files = ["beacon_node/write_ssz_files"]
 # Compiles the BLS crypto code so that the binary is portable across machines.
 portable = ["bls/supranational-portable"]
+# Compiles BLST so that it always uses ADX instructions.
+modern = ["bls/supranational-force-adx"]
 # Uses the slower Milagro BLS library, which is written in native Rust.
 milagro = ["bls/milagro"]
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -15,6 +15,8 @@ pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 fn bls_library_name() -> &'static str {
     if cfg!(feature = "portable") {
         "blst-portable"
+    } else if cfg!(feature = "modern") {
+        "blst-modern"
     } else if cfg!(feature = "milagro") {
         "milagro"
     } else {
@@ -180,6 +182,13 @@ fn run<E: EthSpec>(
         return Err(format!(
             "{}bit architecture is not supported (64bit only).",
             std::mem::size_of::<usize>() * 8
+        ));
+    }
+
+    #[cfg(all(feature = "modern", target_arch = "x86_64"))]
+    if !std::is_x86_feature_detected!("adx") {
+        return Err(format!(
+            "CPU incompatible with optimized binary, please try Lighthouse portable build"
         ));
     }
 

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v0.12.3
+TESTS_TAG := v1.0.0-rc.0
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 


### PR DESCRIPTION
## Issue Addressed

Revival of #1595 after it was reverted in #1649 

## Proposed Changes

Update BLST to the latest commit at time of writing, which includes a fix for https://github.com/supranational/blst/issues/31 which was causing illegal instruction errors on Raspberry Pi 4.

The BLST fix is contained in this commit: https://github.com/supranational/blst/commit/bf7f1e6b5f1297005f99b6ba44d7c517f6f36ffb

Also update Milagro to a compatible version so that the tests are consistent between the two implementations.
