### PR TITLE
[Merged by Bors] - Tidy some TODOs

### DIFF
--- a/crypto/bls/src/impls/blst.rs
+++ b/crypto/bls/src/impls/blst.rs
@@ -66,7 +66,7 @@ pub fn verify_signature_sets<'a>(
 
         // TODO: remove this `unsafe` code-block once we get a safe option from `blst`.
         //
-        // See https://github.com/supranational/blst/issues/13
+        // https://github.com/sigp/lighthouse/issues/1720
         unsafe {
             blst::blst_scalar_from_uint64(rand_i.as_mut_ptr(), vals.as_ptr());
             rands.push(rand_i.assume_init());

--- a/crypto/eth2_wallet/src/json_wallet/mod.rs
+++ b/crypto/eth2_wallet/src/json_wallet/mod.rs
@@ -13,11 +13,6 @@ pub use uuid::Uuid;
 pub struct JsonWallet {
     pub crypto: Crypto,
     pub name: String,
-    // TODO: confirm if this field is optional or not.
-    //
-    // Reference:
-    //
-    // https://github.com/sigp/lighthouse/pull/1117#discussion_r422892396
     pub nextaccount: u32,
     pub uuid: Uuid,
     pub version: Version,

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -66,7 +66,6 @@ impl<'a> WalletBuilder<'a> {
         password: &'a [u8],
         name: String,
     ) -> Result<Self, Error> {
-        // TODO: `bip39` does not use zeroize. Perhaps we should make a PR upstream?
         let seed = Bip39Seed::new(mnemonic, "");
 
         Self::from_seed_bytes(seed.as_bytes(), password, name)

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -163,7 +163,6 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
     }
 
     pub fn randao_reveal(&self, validator_pubkey: &PublicKey, epoch: Epoch) -> Option<Signature> {
-        // TODO: check this against the slot clock to make sure it's not an early reveal?
         self.validators
             .read()
             .voting_keypair(validator_pubkey)


### PR DESCRIPTION
## Issue Addressed

- Resolves #1705

## Proposed Changes

Cleans up some of my TODOs in the code base.

- Adds link to issue in this repo for BLST `unsafe` block.
- Confirms that the `nextaccount` field *is* required on an EIP-2386 wallet.
    - Reference: https://github.com/mcdee/EIPs/blob/master/EIPS/eip-2386.md#json-schema
- Removes TODO about Zeroize on bip39 that was resolved in #1701 
- Removes a TODO about an early randao reveal since we use the slot clock to generate the reveal: https://github.com/sigp/lighthouse/blob/c4bd9c86e6bf23dd66bde150ef85e08caa5e4826/validator_client/src/block_service.rs#L212-L220

## Additional Info

NA
