### PR TITLE
[Merged by Bors] - Increase content-id length

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -84,7 +84,7 @@ impl Default for Config {
         // The function used to generate a gossipsub message id
         // We use the first 8 bytes of SHA256(data) for content addressing
         let gossip_message_id =
-            |message: &GossipsubMessage| MessageId::from(&Sha256::digest(&message.data)[..8]);
+            |message: &GossipsubMessage| MessageId::from(&Sha256::digest(&message.data)[..]);
 
         // gossipsub configuration
         // Note: The topics by default are sent as plain strings. Hashes are an optional


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Increase gossipsub's content-id length to the full 32 byte hash. 

## Additional Info

N/A
