### PR TITLE
[Merged by Bors] - Validator dir creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,7 @@ dependencies = [
 name = "account_utils"
 version = "0.1.0"
 dependencies = [
+ "directory",
  "eth2_keystore",
  "eth2_wallet",
  "rand 0.7.3",

--- a/account_manager/src/validator/mod.rs
+++ b/account_manager/src/validator/mod.rs
@@ -26,7 +26,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     Defaults to ~/.lighthouse/{testnet}/validators",
                 )
                 .takes_value(true)
-                .global(true)
                 .conflicts_with("datadir"),
         )
         .subcommand(create::cli_app())

--- a/account_manager/src/wallet/mod.rs
+++ b/account_manager/src/wallet/mod.rs
@@ -18,7 +18,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("WALLETS_DIRECTORY")
                 .help("A path containing Eth2 EIP-2386 wallets. Defaults to ~/.lighthouse/{testnet}/wallets")
                 .takes_value(true)
-                .global(true)
                 .conflicts_with("datadir"),
         )
         .subcommand(create::cli_app())

--- a/common/account_utils/Cargo.toml
+++ b/common/account_utils/Cargo.toml
@@ -19,3 +19,4 @@ types = { path = "../../consensus/types" }
 validator_dir = { path = "../validator_dir" }
 regex = "1.3.9"
 rpassword = "5.0.0"
+directory = { path = "../directory" }

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -37,7 +37,7 @@ pub enum Error {
     /// The keystore was unable to be opened.
     UnableToOpenKeystore(eth2_keystore::Error),
     /// The validator directory could not be created.
-    UnableToCreateValidatorDir,
+    UnableToCreateValidatorDir(PathBuf),
 }
 
 /// Defines how the validator client should attempt to sign messages for this validator.
@@ -111,8 +111,9 @@ pub struct ValidatorDefinitions(Vec<ValidatorDefinition>);
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
-        ensure_dir_exists(validators_dir.as_ref())
-            .map_err(|_| Error::UnableToCreateValidatorDir)?;
+        ensure_dir_exists(validators_dir.as_ref()).map_err(|_| {
+            Error::UnableToCreateValidatorDir(PathBuf::from(validators_dir.as_ref()))
+        })?;
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         if !config_path.exists() {
             let this = Self::default();

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -36,6 +36,8 @@ pub enum Error {
     InvalidKeystorePubkey,
     /// The keystore was unable to be opened.
     UnableToOpenKeystore(eth2_keystore::Error),
+    /// The validator directory could not be created.
+    UnableToCreateValidatorDir,
 }
 
 /// Defines how the validator client should attempt to sign messages for this validator.
@@ -109,7 +111,7 @@ pub struct ValidatorDefinitions(Vec<ValidatorDefinition>);
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
-        ensure_dir_exists(validators_dir.as_ref());
+        ensure_dir_exists(validators_dir.as_ref()).map_err(Error::UnableToCreateValidatorDir)?;
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         if !config_path.exists() {
             let this = Self::default();

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -111,7 +111,8 @@ pub struct ValidatorDefinitions(Vec<ValidatorDefinition>);
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
-        ensure_dir_exists(validators_dir.as_ref()).map_err(Error::UnableToCreateValidatorDir)?;
+        ensure_dir_exists(validators_dir.as_ref())
+            .map_err(|_| Error::UnableToCreateValidatorDir)?;
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         if !config_path.exists() {
             let this = Self::default();

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -108,6 +108,10 @@ pub struct ValidatorDefinitions(Vec<ValidatorDefinition>);
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
+        if !validator_dir.exists() {
+            fs::create_dir_all(&validator_dir)
+                .map_err(|e| format!("Unable to create {}: {:?}", validator_dir.display(), e))?;
+        }
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         if !config_path.exists() {
             let this = Self::default();

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -4,6 +4,7 @@
 //! attempt) to load into the `crate::intialized_validators::InitializedValidators` struct.
 
 use crate::{create_with_600_perms, default_keystore_password_path, ZeroizeString};
+use directory::ensure_dir_exists;
 use eth2_keystore::Keystore;
 use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
@@ -108,10 +109,7 @@ pub struct ValidatorDefinitions(Vec<ValidatorDefinition>);
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
-        if !validator_dir.exists() {
-            fs::create_dir_all(&validator_dir)
-                .map_err(|e| format!("Unable to create {}: {:?}", validator_dir.display(), e))?;
-        }
+        ensure_dir_exists(validators_dir.as_ref());
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
         if !config_path.exists() {
             let this = Self::default();


### PR DESCRIPTION
## Issue Addressed

Resolves #1744

## Proposed Changes

- Add `directory::ensure_dir_exists` to the `ValidatorDefinition::open_or_create` method 
- As @pawanjay176 suggested, making the `--validator-dir` non-global so users are forced to include the flag after the `validator` subcommand. Current behavior seems to be ignoring the flag if it comes after something like `validator import`

## Additional Info
N/A
