### PR TITLE
[Merged by Bors] - Simulator and attestation service fixes

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/subnet_predicate.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/subnet_predicate.rs
@@ -1,6 +1,6 @@
 ///! The subnet predicate used for searching for a particular subnet.
 use super::*;
-use slog::{debug, trace};
+use slog::trace;
 use std::ops::Deref;
 
 /// Returns the predicate for a given subnet.
@@ -38,7 +38,7 @@ where
                 );
                 return false;
             } else {
-                debug!(
+                trace!(
                    log_clone,
                    "Peer found on desired subnet(s)";
                    "peer_id" => format!("{}", enr.peer_id()),

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -250,7 +250,9 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             .collect();
 
         // request the subnet query from discovery
-        self.discovery.discover_subnet_peers(filtered);
+        if !filtered.is_empty() {
+            self.discovery.discover_subnet_peers(filtered);
+        }
     }
 
     /// A STATUS message has been received from a peer. This resets the status timer.

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -354,11 +354,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
         // unsubscriptions immediately after the subscription. We also want to minimize
         // subscription churn and maintain a consecutive subnet subscriptions.
         self.unsubscriptions.retain(|subnet| {
-            if subnet.subnet_id == exact_subnet.subnet_id && subnet.slot <= exact_subnet.slot {
-                false
-            } else {
-                true
-            }
+            !(subnet.subnet_id == exact_subnet.subnet_id && subnet.slot <= exact_subnet.slot)
         });
         // add an unsubscription event to remove ourselves from the subnet once completed
         self.unsubscriptions

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -353,11 +353,13 @@ impl<T: BeaconChainTypes> AttestationService<T> {
         // if there is an unsubscription event for the slot prior, we remove it to prevent
         // unsubscriptions immediately after the subscription. We also want to minimize
         // subscription churn and maintain a consecutive subnet subscriptions.
-        let to_remove_subnet = ExactSubnet {
-            subnet_id: exact_subnet.subnet_id,
-            slot: exact_subnet.slot.saturating_sub(1u64),
-        };
-        self.unsubscriptions.remove(&to_remove_subnet);
+        self.unsubscriptions.retain(|subnet| {
+            if subnet.subnet_id == exact_subnet.subnet_id && subnet.slot <= exact_subnet.slot {
+                false
+            } else {
+                true
+            }
+        });
         // add an unsubscription event to remove ourselves from the subnet once completed
         self.unsubscriptions
             .insert_at(exact_subnet, expected_end_subscription_duration);
@@ -429,6 +431,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
             // if we are not already subscribed, then subscribe
             if !self.subscriptions.contains(&subnet_id) {
                 self.subscriptions.insert(subnet_id);
+                debug!(self.log, "Subscribing to random subnet"; "subnet_id" => ?subnet_id);
                 self.events
                     .push_back(AttServiceMessage::Subscribe(subnet_id));
             }
@@ -504,17 +507,23 @@ impl<T: BeaconChainTypes> AttestationService<T> {
             self.random_subnets.insert(subnet_id);
             return;
         }
+        // If there are no unsubscription events for `subnet_id`, we unsubscribe immediately.
+        if self
+            .unsubscriptions
+            .keys()
+            .find(|s| s.subnet_id == subnet_id)
+            .is_none()
+        {
+            // we are not at capacity, unsubscribe from the current subnet.
+            debug!(self.log, "Unsubscribing from random subnet"; "subnet_id" => *subnet_id);
+            self.events
+                .push_back(AttServiceMessage::Unsubscribe(subnet_id));
+        }
 
-        // we are not at capacity, unsubscribe from the current subnet, remove the ENR bitfield bit and choose a new random one
-        // from the available subnets
-        // Note: This should not occur during a required subnet as subscriptions update the timeout
-        // to last as long as they are needed.
-
-        debug!(self.log, "Unsubscribing from random subnet"; "subnet_id" => *subnet_id);
-        self.events
-            .push_back(AttServiceMessage::Unsubscribe(subnet_id));
+        // Remove the ENR bitfield bit and choose a new random on from the available subnets
         self.events
             .push_back(AttServiceMessage::EnrRemove(subnet_id));
+        // Subscribe to a new random subnet
         self.subscribe_to_random_subnets(1);
     }
 

--- a/beacon_node/network/src/attestation_service/tests/mod.rs
+++ b/beacon_node/network/src/attestation_service/tests/mod.rs
@@ -20,7 +20,7 @@ mod tests {
     use tempfile::tempdir;
     use types::{CommitteeIndex, EthSpec, MinimalEthSpec};
 
-    const SLOT_DURATION_MILLIS: u64 = 200;
+    const SLOT_DURATION_MILLIS: u64 = 400;
 
     type TestBeaconChainType = Witness<
         NullMigrator,

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -93,6 +93,11 @@ impl<E: EthSpec> LocalNetwork<E> {
                     .enr()
                     .expect("bootnode must have a network"),
             );
+            let count = self.beacon_node_count() as u16;
+            beacon_config.network.discovery_port = BOOTNODE_PORT + count;
+            beacon_config.network.libp2p_port = BOOTNODE_PORT + count;
+            beacon_config.network.enr_udp_port = Some(BOOTNODE_PORT + count);
+            beacon_config.network.enr_tcp_port = Some(BOOTNODE_PORT + count);
         }
 
         let index = self.beacon_nodes.read().len();


### PR DESCRIPTION
## Issue Addressed

#1729 #1730 

Which issue # does this PR address?

## Proposed Changes

1. Fixes a bug in the simulator where nodes can't find each other due to 0 udp ports in their enr.
2. Fixes bugs in attestation service where we are unsubscribing from a subnet prematurely.

More testing is needed for attestation service fixes.