### PR TITLE
[Merged by Bors] - Fixed cross-compiling by replacing wget with curl

### DIFF
--- a/validator_client/slashing_protection/Makefile
+++ b/validator_client/slashing_protection/Makefile
@@ -10,7 +10,7 @@ $(OUTPUT_DIR): $(TARBALL)
 	tar --strip-components=1 -xzf $^ -C $@
 
 $(TARBALL):
-	wget $(ARCHIVE_URL) -O $@
+	curl -L -o $@ $(ARCHIVE_URL)
 
 clean-test-files:
 	rm -rf $(OUTPUT_DIR)


### PR DESCRIPTION
It looks like the default docker image used by cross doesn't have
wget installed. This causes builds to fail. This can be fixed by
switching to curl.

## Issue Addressed
cross-compiling was broken (at least for build-aarch64)

## Proposed Changes
swap wget for curl
