### PR TITLE
[Merged by Bors] - add direction information to PeerInfo

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -298,28 +298,6 @@ impl PeerConnectionStatus {
         }
     }
 
-    /// Modifies the status to Connected and increases the number of ingoing
-    /// connections by one
-    pub fn connect_ingoing(&mut self) {
-        match self {
-            Connected { n_in, .. } => *n_in += 1,
-            Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                *self = Connected { n_in: 1, n_out: 0 }
-            }
-        }
-    }
-
-    /// Modifies the status to Connected and increases the number of outgoing
-    /// connections by one
-    pub fn connect_outgoing(&mut self) {
-        match self {
-            Connected { n_out, .. } => *n_out += 1,
-            Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                *self = Connected { n_in: 0, n_out: 1 }
-            }
-        }
-    }
-
     /// Modifies the status to Disconnected and sets the last seen instant to now
     pub fn disconnect(&mut self) {
         *self = Disconnected {

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -61,7 +61,7 @@ impl<TSpec: EthSpec> Default for PeerInfo<TSpec> {
             meta_data: None,
             min_ttl: None,
             is_trusted: false,
-            connection_direction: None
+            connection_direction: None,
         }
     }
 }
@@ -122,10 +122,7 @@ impl<T: EthSpec> PeerInfo<T> {
         match &mut self.connection_status {
             Connected { n_in, .. } => *n_in += 1,
             Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                self.connection_status = Connected {
-                    n_in: 1,
-                    n_out: 0,
-                };
+                self.connection_status = Connected { n_in: 1, n_out: 0 };
                 self.connection_direction = Some(ConnectionDirection::Incoming);
             }
         }
@@ -137,10 +134,7 @@ impl<T: EthSpec> PeerInfo<T> {
         match &mut self.connection_status {
             Connected { n_out, .. } => *n_out += 1,
             Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                self.connection_status = Connected {
-                    n_in: 0,
-                    n_out: 1,
-                };
+                self.connection_status = Connected { n_in: 0, n_out: 1 };
                 self.connection_direction = Some(ConnectionDirection::Outgoing);
             }
         }
@@ -310,10 +304,7 @@ impl PeerConnectionStatus {
         match self {
             Connected { n_in, .. } => *n_in += 1,
             Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                *self = Connected {
-                    n_in: 1,
-                    n_out: 0,
-                }
+                *self = Connected { n_in: 1, n_out: 0 }
             }
         }
     }
@@ -324,10 +315,7 @@ impl PeerConnectionStatus {
         match self {
             Connected { n_out, .. } => *n_out += 1,
             Disconnected { .. } | Banned { .. } | Dialing { .. } | Unknown => {
-                *self = Connected {
-                    n_in: 0,
-                    n_out: 1,
-                }
+                *self = Connected { n_in: 0, n_out: 1 }
             }
         }
     }

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -207,7 +207,7 @@ impl Serialize for PeerConnectionStatus {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut s = serializer.serialize_struct("connection_status", 5)?;
         match self {
-            Connected { n_in, n_out, .. } => {
+            Connected { n_in, n_out } => {
                 s.serialize_field("status", "connected")?;
                 s.serialize_field("connections_in", n_in)?;
                 s.serialize_field("connections_out", n_out)?;
@@ -322,7 +322,7 @@ impl PeerConnectionStatus {
 
     pub fn connections(&self) -> (u8, u8) {
         match self {
-            Connected { n_in, n_out, .. } => (*n_in, *n_out),
+            Connected { n_in, n_out } => (*n_in, *n_out),
             _ => (0, 0),
         }
     }

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -369,7 +369,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         }
         self.banned_peers_count
             .remove_banned_peer(&info.connection_status);
-        info.connection_status.connect_ingoing();
+        info.connect_ingoing();
 
         // Add the seen ip address to the peer's info
         if let Some(ip_addr) = multiaddr.iter().find_map(|p| match p {
@@ -390,7 +390,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         }
         self.banned_peers_count
             .remove_banned_peer(&info.connection_status);
-        info.connection_status.connect_outgoing();
+        info.connect_outgoing();
 
         // Add the seen ip address to the peer's info
         if let Some(ip_addr) = multiaddr.iter().find_map(|p| match p {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a direction field to `PeerConnectionStatus` that can be accessed by calling `is_outgoing` which will return `true` iff the peer is connected and the first connection was an outgoing one.