### PR TITLE
Ensure passwords are UTF-8 encoded

### DIFF
--- a/account_manager/src/common.rs
+++ b/account_manager/src/common.rs
@@ -15,10 +15,10 @@ pub fn read_mnemonic_from_cli(
     stdin_inputs: bool,
 ) -> Result<Mnemonic, String> {
     let mnemonic = match mnemonic_path {
-        Some(path) => fs::read(&path)
+        Some(path) => fs::read_to_string(&path)
             .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-            .and_then(|bytes| {
-                let bytes_no_newlines: PlainText = strip_off_newlines(bytes).into();
+            .and_then(|password| {
+                let bytes_no_newlines: PlainText = strip_off_newlines(password.as_str()).into();
                 let phrase = from_utf8(&bytes_no_newlines.as_ref())
                     .map_err(|e| format!("Unable to derive mnemonic: {:?}", e))?;
                 Mnemonic::from_phrase(phrase, Language::English).map_err(|e| {

--- a/account_manager/src/common.rs
+++ b/account_manager/src/common.rs
@@ -1,9 +1,8 @@
+use account_utils::read_input_from_user;
 use account_utils::PlainText;
-use account_utils::{read_input_from_user, strip_off_newlines};
 use eth2_wallet::bip39::{Language, Mnemonic};
 use std::fs;
 use std::path::PathBuf;
-use std::str::from_utf8;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -18,9 +17,8 @@ pub fn read_mnemonic_from_cli(
         Some(path) => fs::read_to_string(&path)
             .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
             .and_then(|password| {
-                let bytes_no_newlines: PlainText = strip_off_newlines(password.as_str()).into();
-                let phrase = from_utf8(&bytes_no_newlines.as_ref())
-                    .map_err(|e| format!("Unable to derive mnemonic: {:?}", e))?;
+                let bytes_no_newlines: PlainText = password.into();
+                let phrase = bytes_no_newlines.as_str();
                 Mnemonic::from_phrase(phrase, Language::English).map_err(|e| {
                     format!(
                         "Unable to derive mnemonic from string {:?}: {:?}",

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -260,9 +260,9 @@ pub fn read_wallet_password_from_cli(
     stdin_inputs: bool,
 ) -> Result<PlainText, String> {
     match password_file_path {
-        Some(path) => fs::read(&path)
+        Some(path) => fs::read_to_string(&path)
             .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-            .map(|bytes| strip_off_newlines(bytes).into()),
+            .map(|password| strip_off_newlines(password.as_str()).into()),
         None => {
             eprintln!("");
             eprintln!("{}", WALLET_PASSWORD_PROMPT);

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -1,9 +1,7 @@
 use crate::common::read_wallet_name_from_cli;
 use crate::wallet::create::STDIN_INPUTS_FLAG;
 use crate::{SECRETS_DIR_FLAG, WALLETS_DIR_FLAG};
-use account_utils::{
-    random_password, read_password_from_user, strip_off_newlines, validator_definitions, PlainText,
-};
+use account_utils::{random_password, read_password_from_user, validator_definitions, PlainText};
 use clap::{App, Arg, ArgMatches};
 use directory::{
     ensure_dir_exists, parse_path_or_default_with_flag, DEFAULT_SECRET_DIR, DEFAULT_WALLET_DIR,
@@ -220,8 +218,8 @@ pub fn cli_run<T: EthSpec>(
 
         ValidatorDirBuilder::new(validator_dir.clone())
             .password_dir(secrets_dir.clone())
-            .voting_keystore(keystores.voting, voting_password.as_bytes())
-            .withdrawal_keystore(keystores.withdrawal, withdrawal_password.as_bytes())
+            .voting_keystore(keystores.voting, voting_password)
+            .withdrawal_keystore(keystores.withdrawal, withdrawal_password)
             .create_eth1_tx_data(deposit_gwei, &spec)
             .store_withdrawal_keystore(matches.is_present(STORE_WITHDRAW_FLAG))
             .build()
@@ -262,12 +260,11 @@ pub fn read_wallet_password_from_cli(
     match password_file_path {
         Some(path) => fs::read_to_string(&path)
             .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-            .map(|password| strip_off_newlines(password.as_str()).into()),
+            .map(|password| PlainText::from(password).without_newlines()),
         None => {
             eprintln!("");
             eprintln!("{}", WALLET_PASSWORD_PROMPT);
-            let password =
-                PlainText::from(read_password_from_user(stdin_inputs)?.as_ref().to_vec());
+            let password = PlainText::from(read_password_from_user(stdin_inputs)?.as_str());
             Ok(password)
         }
     }

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -126,8 +126,8 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
 
         ValidatorDirBuilder::new(validator_dir.clone())
             .password_dir(secrets_dir.clone())
-            .voting_keystore(keystores.voting, voting_password.as_bytes())
-            .withdrawal_keystore(keystores.withdrawal, withdrawal_password.as_bytes())
+            .voting_keystore(keystores.voting, voting_password)
+            .withdrawal_keystore(keystores.withdrawal, withdrawal_password)
             .store_withdrawal_keystore(matches.is_present(STORE_WITHDRAW_FLAG))
             .build()
             .map_err(|e| format!("Unable to build validator directory: {:?}", e))?;

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -1,8 +1,6 @@
 use crate::common::read_wallet_name_from_cli;
 use crate::WALLETS_DIR_FLAG;
-use account_utils::{
-    is_password_sufficiently_complex, random_password, read_password_from_user, strip_off_newlines,
-};
+use account_utils::{is_password_sufficiently_complex, random_password, read_password_from_user};
 use clap::{App, Arg, ArgMatches};
 use eth2_wallet::{
     bip39::{Language, Mnemonic, MnemonicType},
@@ -208,7 +206,7 @@ pub fn read_new_wallet_password_from_cli(
         Some(path) => {
             let password: PlainText = fs::read_to_string(&path)
                 .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-                .map(|password| strip_off_newlines(password.as_str()).into())?;
+                .map(|password| PlainText::from(password).without_newlines())?;
 
             // Ensure the password meets the minimum requirements.
             is_password_sufficiently_complex(password.as_bytes())?;
@@ -217,15 +215,14 @@ pub fn read_new_wallet_password_from_cli(
         None => loop {
             eprintln!("");
             eprintln!("{}", NEW_WALLET_PASSWORD_PROMPT);
-            let password =
-                PlainText::from(read_password_from_user(stdin_inputs)?.as_ref().to_vec());
+            let password = PlainText::from(read_password_from_user(stdin_inputs)?.as_str());
 
             // Ensure the password meets the minimum requirements.
             match is_password_sufficiently_complex(password.as_bytes()) {
                 Ok(_) => {
                     eprintln!("{}", RETYPE_PASSWORD_PROMPT);
                     let retyped_password =
-                        PlainText::from(read_password_from_user(stdin_inputs)?.as_ref().to_vec());
+                        PlainText::from(read_password_from_user(stdin_inputs)?.as_str());
                     if retyped_password == password {
                         break Ok(password);
                     } else {

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -206,9 +206,9 @@ pub fn read_new_wallet_password_from_cli(
 ) -> Result<PlainText, String> {
     match password_file_path {
         Some(path) => {
-            let password: PlainText = fs::read(&path)
+            let password: PlainText = fs::read_to_string(&path)
                 .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-                .map(|bytes| strip_off_newlines(bytes).into())?;
+                .map(|password| strip_off_newlines(password.as_str()).into())?;
 
             // Ensure the password meets the minimum requirements.
             is_password_sufficiently_complex(password.as_bytes())?;

--- a/common/validator_dir/src/builder.rs
+++ b/common/validator_dir/src/builder.rs
@@ -81,16 +81,16 @@ impl<'a> Builder<'a> {
     /// Build the `ValidatorDir` use the given `keystore` which can be unlocked with `password`.
     ///
     /// The builder will not necessarily check that `password` can unlock `keystore`.
-    pub fn voting_keystore(mut self, keystore: Keystore, password: &[u8]) -> Self {
-        self.voting_keystore = Some((keystore, password.to_vec().into()));
+    pub fn voting_keystore(mut self, keystore: Keystore, password: PlainText) -> Self {
+        self.voting_keystore = Some((keystore, password));
         self
     }
 
     /// Build the `ValidatorDir` use the given `keystore` which can be unlocked with `password`.
     ///
     /// The builder will not necessarily check that `password` can unlock `keystore`.
-    pub fn withdrawal_keystore(mut self, keystore: Keystore, password: &[u8]) -> Self {
-        self.withdrawal_keystore = Some((keystore, password.to_vec().into()));
+    pub fn withdrawal_keystore(mut self, keystore: Keystore, password: PlainText) -> Self {
+        self.withdrawal_keystore = Some((keystore, password));
         self
     }
 
@@ -307,7 +307,6 @@ fn random_keystore() -> Result<(Keystore, PlainText), Error> {
         .sample_iter(&Alphanumeric)
         .take(DEFAULT_PASSWORD_LEN)
         .collect::<String>()
-        .into_bytes()
         .into();
 
     let keystore = KeystoreBuilder::new(&keypair, password.as_bytes(), "".into())?.build()?;

--- a/common/validator_dir/src/insecure_keys.rs
+++ b/common/validator_dir/src/insecure_keys.rs
@@ -44,7 +44,11 @@ pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainText)
         .build()
         .map_err(|e| format!("Unable to build keystore: {:?}", e))?;
 
-    Ok((keystore, INSECURE_PASSWORD.to_vec().into()))
+    let password = std::str::from_utf8(INSECURE_PASSWORD)
+        .map_err(|_| format!("The insecure password is not valid UTF-8"))?
+        .into();
+
+    Ok((keystore, password))
 }
 
 /// Returns an INSECURE key derivation function.

--- a/common/validator_dir/src/insecure_keys.rs
+++ b/common/validator_dir/src/insecure_keys.rs
@@ -45,7 +45,7 @@ pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainText)
         .map_err(|e| format!("Unable to build keystore: {:?}", e))?;
 
     let password = std::str::from_utf8(INSECURE_PASSWORD)
-        .map_err(|_| format!("The insecure password is not valid UTF-8"))?
+        .map_err(|e| format!("The insecure password is not valid: {:?}", e))?
         .into();
 
     Ok((keystore, password))

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -4,7 +4,7 @@ use crate::builder::{
 };
 use deposit_contract::decode_eth1_tx_data;
 use eth2_keystore::{Error as KeystoreError, Keystore, PlainText};
-use std::fs::{read, remove_file, write, OpenOptions};
+use std::fs::{read, read_to_string, remove_file, write, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use tree_hash::TreeHash;
@@ -268,7 +268,7 @@ fn unlock_keypair<P: AsRef<Path>>(
     let password_path = password_dir
         .as_ref()
         .join(format!("0x{}", keystore.pubkey()));
-    let password: PlainText = read(&password_path)
+    let password: PlainText = read_to_string(&password_path)
         .map_err(|_| Error::UnableToReadPassword(password_path))?
         .into();
 

--- a/common/validator_dir/tests/tests.rs
+++ b/common/validator_dir/tests/tests.rs
@@ -51,7 +51,11 @@ pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainText)
         .build()
         .map_err(|e| format!("Unable to build keystore: {:?}", e))?;
 
-    Ok((keystore, INSECURE_PASSWORD.to_vec().into()))
+    let password = std::str::from_utf8(INSECURE_PASSWORD)
+        .map_err(|_| "The insecure password is not valid UTF-8")?
+        .into();
+
+    Ok((keystore, password))
 }
 
 /// A testing harness for generating validator directories.
@@ -88,14 +92,14 @@ impl Harness {
             builder.random_voting_keystore().unwrap()
         } else {
             let (keystore, password) = generate_deterministic_keystore(0).unwrap();
-            builder.voting_keystore(keystore, password.as_bytes())
+            builder.voting_keystore(keystore, password)
         };
 
         let builder = if config.random_withdrawal_keystore {
             builder.random_withdrawal_keystore().unwrap()
         } else {
             let (keystore, password) = generate_deterministic_keystore(1).unwrap();
-            builder.withdrawal_keystore(keystore, password.as_bytes())
+            builder.withdrawal_keystore(keystore, password)
         };
 
         let builder = if let Some(amount) = config.deposit_amount {

--- a/crypto/eth2_key_derivation/src/plain_text.rs
+++ b/crypto/eth2_key_derivation/src/plain_text.rs
@@ -1,45 +1,102 @@
 use zeroize::Zeroize;
 
-/// Provides wrapper around `Vec<u8>` that implements `Zeroize`.
+/// Provides wrapper around `String` that implements `Zeroize` and guarantees the underlying bytes
+/// are UTF-8.
 #[derive(Zeroize, Clone, PartialEq)]
 #[zeroize(drop)]
-pub struct PlainText(Vec<u8>);
+pub struct PlainText(String);
 
 impl PlainText {
-    /// Instantiate self with `len` zeros.
-    pub fn zero(len: usize) -> Self {
-        Self(vec![0; len])
-    }
-
     /// The byte-length of `self`
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    // NOTE: This method is not used.
     /// Checks whether `self` is empty
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Returns a reference to the underlying &str.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
     /// Returns a reference to the underlying bytes.
     pub fn as_bytes(&self) -> &[u8] {
-        &self.0
+        self.0.as_bytes()
     }
 
     /// Returns a mutable reference to the underlying bytes.
     pub fn as_mut_bytes(&mut self) -> &mut [u8] {
-        &mut self.0
+        // This will panic if the resulting bytes are not UTF-8.
+        unsafe { self.0.as_bytes_mut() }
+    }
+
+    /// Remove any number of newline or carriage returns from the end of a vector of bytes.
+    pub fn without_newlines(&self) -> PlainText {
+        let stripped_string = self.0.trim_end_matches(|c| c == '\r' || c == '\n').into();
+        Self(stripped_string)
     }
 }
 
-impl From<Vec<u8>> for PlainText {
-    fn from(vec: Vec<u8>) -> Self {
-        Self(vec)
+// TODO: Is it bettter to call to_string() or into() instead of using this helper?
+impl From<&str> for PlainText {
+    fn from(value: &str) -> Self {
+        Self(value.into())
     }
 }
 
-impl AsRef<[u8]> for PlainText {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
+impl From<String> for PlainText {
+    fn from(value: String) -> Self {
+        PlainText(value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PlainText;
+
+    #[test]
+    fn test_strip_off() {
+        let expected = "hello world";
+
+        assert_eq!(
+            PlainText::from("hello world\n").without_newlines().as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world\n\n\n\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world\r").without_newlines().as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world\r\r\r\r\r")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world\r\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world\r\n\r\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainText::from("hello world").without_newlines().as_str(),
+            expected
+        );
     }
 }

--- a/crypto/eth2_keystore/src/keystore.rs
+++ b/crypto/eth2_keystore/src/keystore.rs
@@ -59,7 +59,7 @@ pub const HASH_SIZE: usize = 32;
 pub enum Error {
     InvalidSecretKeyLen { len: usize, expected: usize },
     InvalidPassword,
-    InvalidPasswordUtf8,
+    InvalidPasswordUtf8(std::str::Utf8Error),
     InvalidSecretKeyBytes(bls::Error),
     PublicKeyMismatch,
     EmptyPassword,
@@ -368,7 +368,7 @@ pub fn decrypt(password: &[u8], crypto: &Crypto) -> Result<PlainText, Error> {
     }
 
     let mut plain_text = PlainText::from(
-        std::str::from_utf8(cipher_message.as_bytes()).map_err(|_| Error::InvalidPasswordUtf8)?,
+        std::str::from_utf8(cipher_message.as_bytes()).map_err(Error::InvalidPasswordUtf8)?,
     );
     match &crypto.cipher.params {
         Cipher::Aes128Ctr(params) => {

--- a/crypto/eth2_keystore/src/keystore.rs
+++ b/crypto/eth2_keystore/src/keystore.rs
@@ -59,6 +59,7 @@ pub const HASH_SIZE: usize = 32;
 pub enum Error {
     InvalidSecretKeyLen { len: usize, expected: usize },
     InvalidPassword,
+    InvalidPasswordUtf8,
     InvalidSecretKeyBytes(bls::Error),
     PublicKeyMismatch,
     EmptyPassword,
@@ -366,7 +367,9 @@ pub fn decrypt(password: &[u8], crypto: &Crypto) -> Result<PlainText, Error> {
         return Err(Error::InvalidPassword);
     }
 
-    let mut plain_text = PlainText::from(cipher_message.as_bytes().to_vec());
+    let mut plain_text = PlainText::from(
+        std::str::from_utf8(cipher_message.as_bytes()).map_err(|_| Error::InvalidPasswordUtf8)?,
+    );
     match &crypto.cipher.params {
         Cipher::Aes128Ctr(params) => {
             let key = GenericArray::from_slice(&derived_key.as_bytes()[0..16]);

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -24,7 +24,7 @@ pub enum Error {
     PathExhausted,
     EmptyPassword,
     EmptySeed,
-    InvalidPasswordUtf8,
+    InvalidPasswordUtf8(std::str::Utf8Error),
 }
 
 impl From<KeystoreError> for Error {
@@ -88,7 +88,7 @@ impl<'a> WalletBuilder<'a> {
 
             Ok(Self {
                 seed: std::str::from_utf8(seed)
-                    .map_err(|_| Error::InvalidPasswordUtf8)?
+                    .map_err(Error::InvalidPasswordUtf8)?
                     .into(),
                 password,
                 kdf: default_kdf(salt.to_vec()),
@@ -302,7 +302,7 @@ pub fn recover_validator_secret(
 
     let destination = path.iter_nodes().fold(master, |dk, i| dk.child(*i));
     let password = std::str::from_utf8(destination.secret())
-        .map_err(|_| Error::InvalidPasswordUtf8)?
+        .map_err(Error::InvalidPasswordUtf8)?
         .into();
 
     Ok((password, path))
@@ -321,7 +321,7 @@ pub fn recover_validator_secret_from_mnemonic(
 
     let destination = path.iter_nodes().fold(master, |dk, i| dk.child(*i));
     let password = std::str::from_utf8(destination.secret())
-        .map_err(|_| Error::InvalidPasswordUtf8)?
+        .map_err(Error::InvalidPasswordUtf8)?
         .into();
 
     Ok((password, path))

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -92,8 +92,8 @@ pub fn create_validators<P: AsRef<Path>, T: 'static + SlotClock, E: EthSpec>(
             })?;
 
         let validator_dir = ValidatorDirBuilder::new(validator_dir.as_ref().into())
-            .voting_keystore(keystores.voting, voting_password.as_bytes())
-            .withdrawal_keystore(keystores.withdrawal, withdrawal_password.as_bytes())
+            .voting_keystore(keystores.voting, voting_password)
+            .withdrawal_keystore(keystores.withdrawal, withdrawal_password)
             .create_eth1_tx_data(request.deposit_gwei, &spec)
             .store_withdrawal_keystore(false)
             .build()

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -330,7 +330,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         })?;
 
                     let validator_dir = ValidatorDirBuilder::new(validator_dir.clone())
-                        .voting_keystore(body.keystore.clone(), body.password.as_ref())
+                        .voting_keystore(body.keystore.clone(), body.password.as_str().into())
                         .store_withdrawal_keystore(false)
                         .build()
                         .map_err(|e| {

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -322,9 +322,7 @@ impl ApiTester {
         if !s.correct_password {
             let request = KeystoreValidatorsPostRequest {
                 enable: s.enabled,
-                password: String::from_utf8(random_password().as_ref().to_vec())
-                    .unwrap()
-                    .into(),
+                password: password.as_str().to_string().into(),
                 keystore,
             };
 
@@ -338,9 +336,7 @@ impl ApiTester {
 
         let request = KeystoreValidatorsPostRequest {
             enable: s.enabled,
-            password: String::from_utf8(password.as_ref().to_vec())
-                .unwrap()
-                .into(),
+            password: password.as_str().to_string().into(),
             keystore,
         };
 

--- a/validator_client/src/key_cache.rs
+++ b/validator_client/src/key_cache.rs
@@ -118,7 +118,7 @@ impl KeyCache {
             std::str::from_utf8(
                 &bincode::serialize(&secret_map).map_err(Error::UnableToSerializeKeyMap)?,
             )
-            .map_err(|_| Error::InvalidPasswordUtf8)?,
+            .map_err(Error::InvalidPasswordUtf8)?,
         );
         let (cipher_text, checksum) = encrypt(
             raw.as_bytes(),
@@ -257,7 +257,7 @@ pub enum Error {
     MissingUuidKey,
     /// Cache file is already decrypted
     AlreadyDecrypted,
-    InvalidPasswordUtf8,
+    InvalidPasswordUtf8(std::str::Utf8Error),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Issue Addressed

Issue #1205 
Feedback from PR #1217 

## Proposed Changes

1. This uses `fs::read_to_string` to enforce utf8 when dealing with passwords.
2. This changes `PlainText(Vec<u8>)` to be a `PlainText(String)` to make it impossible (I think?) to carry an invalid utf8 password.
3. Updates a few methods that were going `PlainText -> &[u8] -> PlainText`. 
4. There is a new `unsafe` and a few comments around methods that can be removed.

## Additional Info

I'm relatively new to rust so please let me know if something here isn't a best practice. I'm also not super familiar with lighthouse but wanted to contributes to some new rust projects as practice. Thanks!
