### PR TITLE
Update blst and milagro_bls subgroup checking

### DIFF
--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 eth2_ssz = "0.1.2"
 tree_hash = "0.1.1"
-milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.3.0" }
+milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.0" }
 rand = "0.7.3"
 serde = "1.0.116"
 serde_derive = "1.0.116"
@@ -17,7 +17,7 @@ eth2_hashing = "0.1.0"
 ethereum-types = "0.9.2"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
-blst = { git = "https://github.com/supranational/blst.git", rev = "414ac6b185f6b2ef2e6364d5716f915af966c465" }
+blst = { git = "https://github.com/sigp/blst.git", rev = "7cf47864627ca479cad06c2a164f30d0cbaf16ce" }
 
 [features]
 default = ["supranational"]

--- a/crypto/bls/src/generic_aggregate_public_key.rs
+++ b/crypto/bls/src/generic_aggregate_public_key.rs
@@ -1,17 +1,5 @@
-use crate::{Error, PUBLIC_KEY_BYTES_LEN};
-
 /// Implemented on some struct from a BLS library so it may be used internally in this crate.
-pub trait TAggregatePublicKey: Sized + Clone {
-    /// Initialize `Self` to the infinity value which can then have other public keys aggregated
-    /// upon it.
-    fn infinity() -> Self;
-
-    /// Serialize `self` as compressed bytes.
-    fn serialize(&self) -> [u8; PUBLIC_KEY_BYTES_LEN];
-
-    /// Deserialize `self` from compressed bytes.
-    fn deserialize(bytes: &[u8]) -> Result<Self, Error>;
-}
+pub trait TAggregatePublicKey: Sized + Clone {}
 
 /*
  * Note: there is no immediate need for a `GenericAggregatePublicKey` struct.

--- a/crypto/bls/src/impls/blst.rs
+++ b/crypto/bls/src/impls/blst.rs
@@ -119,7 +119,10 @@ impl TPublicKey for blst_core::PublicKey {
         // key_validate accepts uncompressed bytes too so enforce byte length here.
         // It also does subgroup checks, noting infinity check is done in `generic_public_key.rs`.
         if bytes.len() != PUBLIC_KEY_BYTES_LEN {
-            return Err(Error::InvalidByteLength{got: bytes.len(), expected: PUBLIC_KEY_BYTES_LEN})
+            return Err(Error::InvalidByteLength {
+                got: bytes.len(),
+                expected: PUBLIC_KEY_BYTES_LEN,
+            });
         }
         Self::key_validate(&bytes).map_err(Into::into)
     }

--- a/crypto/bls/src/impls/blst.rs
+++ b/crypto/bls/src/impls/blst.rs
@@ -4,7 +4,7 @@ use crate::{
     generic_public_key::{GenericPublicKey, TPublicKey, PUBLIC_KEY_BYTES_LEN},
     generic_secret_key::TSecretKey,
     generic_signature::{TSignature, SIGNATURE_BYTES_LEN},
-    Error, Hash256, ZeroizeHash, INFINITY_PUBLIC_KEY, INFINITY_SIGNATURE,
+    Error, Hash256, ZeroizeHash, INFINITY_SIGNATURE,
 };
 pub use blst::min_pk as blst_core;
 use blst::{blst_scalar, BLST_ERROR};
@@ -52,7 +52,10 @@ pub fn verify_signature_sets<'a>(
     for set in &sets {
         // Generate random scalars.
         let mut vals = [0u64; 4];
-        vals[0] = rng.gen();
+        while vals[0] == 0 {
+            // Do not use zero
+            vals[0] = rng.gen();
+        }
         let mut rand_i = std::mem::MaybeUninit::<blst_scalar>::uninit();
 
         // TODO: remove this `unsafe` code-block once we get a safe option from `blst`.
@@ -66,8 +69,12 @@ pub fn verify_signature_sets<'a>(
         // Grab a slice of the message, to satisfy the blst API.
         msgs_refs.push(set.message.as_bytes());
 
-        // Convert the aggregate signature into a signature.
         if let Some(point) = set.signature.point() {
+            // Subgroup check the signature
+            if !point.0.subgroup_check() {
+                return false;
+            }
+            // Convert the aggregate signature into a signature.
             sigs.push(point.0.to_signature())
         } else {
             // Any "empty" signature should cause a signature failure.
@@ -94,12 +101,6 @@ pub fn verify_signature_sets<'a>(
         pks.push(blst_core::AggregatePublicKey::aggregate(&signing_keys).to_public_key());
     }
 
-    // Due to an earlier check, the only case this can be empty is if all the sets consisted of
-    // infinity pubkeys/sigs. In such a case we wish to return `true`.
-    if msgs_refs.is_empty() {
-        return true;
-    }
-
     let (sig_refs, pks_refs): (Vec<_>, Vec<_>) = sigs.iter().zip(pks.iter()).unzip();
 
     let err = blst_core::Signature::verify_multiple_aggregate_signatures(
@@ -115,7 +116,12 @@ impl TPublicKey for blst_core::PublicKey {
     }
 
     fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        Self::uncompress(&bytes).map_err(Into::into)
+        // key_validate accepts uncompressed bytes too so enforce byte length here.
+        // It also does subgroup checks, noting infinity check is done in `generic_public_key.rs`.
+        if bytes.len() != PUBLIC_KEY_BYTES_LEN {
+            return Err(Error::InvalidByteLength{got: bytes.len(), expected: PUBLIC_KEY_BYTES_LEN})
+        }
+        Self::key_validate(&bytes).map_err(Into::into)
     }
 }
 
@@ -136,25 +142,7 @@ impl PartialEq for BlstAggregatePublicKey {
     }
 }
 
-impl TAggregatePublicKey for BlstAggregatePublicKey {
-    fn infinity() -> Self {
-        blst_core::PublicKey::from_bytes(&INFINITY_PUBLIC_KEY)
-            .map(|pk| blst_core::AggregatePublicKey::from_public_key(&pk))
-            .map(Self)
-            .expect("should decode infinity public key")
-    }
-
-    fn serialize(&self) -> [u8; PUBLIC_KEY_BYTES_LEN] {
-        self.0.to_public_key().compress()
-    }
-
-    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        blst_core::PublicKey::from_bytes(&bytes)
-            .map_err(Into::into)
-            .map(|pk| blst_core::AggregatePublicKey::from_public_key(&pk))
-            .map(Self)
-    }
-}
+impl TAggregatePublicKey for BlstAggregatePublicKey {}
 
 impl TSignature<blst_core::PublicKey> for blst_core::Signature {
     fn serialize(&self) -> [u8; SIGNATURE_BYTES_LEN] {
@@ -166,6 +154,9 @@ impl TSignature<blst_core::PublicKey> for blst_core::Signature {
     }
 
     fn verify(&self, pubkey: &blst_core::PublicKey, msg: Hash256) -> bool {
+        if !self.subgroup_check() {
+            return false;
+        }
         self.verify(msg.as_bytes(), DST, &[], pubkey) == BLST_ERROR::BLST_SUCCESS
     }
 }
@@ -223,6 +214,9 @@ impl TAggregateSignature<blst_core::PublicKey, BlstAggregatePublicKey, blst_core
     ) -> bool {
         let pubkeys = pubkeys.iter().map(|pk| pk.point()).collect::<Vec<_>>();
         let signature = self.0.clone().to_signature();
+        if !signature.subgroup_check() {
+            return false;
+        }
         signature.fast_aggregate_verify(msg.as_bytes(), DST, &pubkeys) == BLST_ERROR::BLST_SUCCESS
     }
 
@@ -234,6 +228,9 @@ impl TAggregateSignature<blst_core::PublicKey, BlstAggregatePublicKey, blst_core
         let pubkeys = pubkeys.iter().map(|pk| pk.point()).collect::<Vec<_>>();
         let msgs = msgs.iter().map(|hash| hash.as_bytes()).collect::<Vec<_>>();
         let signature = self.0.clone().to_signature();
+        if !signature.subgroup_check() {
+            return false;
+        }
         signature.aggregate_verify(&msgs, DST, &pubkeys) == BLST_ERROR::BLST_SUCCESS
     }
 }

--- a/crypto/bls/src/impls/fake_crypto.rs
+++ b/crypto/bls/src/impls/fake_crypto.rs
@@ -63,25 +63,7 @@ impl PartialEq for PublicKey {
 #[derive(Clone)]
 pub struct AggregatePublicKey([u8; PUBLIC_KEY_BYTES_LEN]);
 
-impl TAggregatePublicKey for AggregatePublicKey {
-    fn infinity() -> Self {
-        Self([0; PUBLIC_KEY_BYTES_LEN])
-    }
-
-    fn serialize(&self) -> [u8; PUBLIC_KEY_BYTES_LEN] {
-        let mut bytes = [0; PUBLIC_KEY_BYTES_LEN];
-        bytes[..].copy_from_slice(&self.0);
-        bytes
-    }
-
-    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        let mut key = [0; PUBLIC_KEY_BYTES_LEN];
-
-        key[..].copy_from_slice(&bytes);
-
-        Ok(Self(key))
-    }
-}
+impl TAggregatePublicKey for AggregatePublicKey {}
 
 impl Eq for AggregatePublicKey {}
 

--- a/crypto/bls/src/impls/milagro.rs
+++ b/crypto/bls/src/impls/milagro.rs
@@ -4,7 +4,7 @@ use crate::{
     generic_public_key::{GenericPublicKey, TPublicKey, PUBLIC_KEY_BYTES_LEN},
     generic_secret_key::{TSecretKey, SECRET_KEY_BYTES_LEN},
     generic_signature::{TSignature, SIGNATURE_BYTES_LEN},
-    Error, Hash256, ZeroizeHash, INFINITY_PUBLIC_KEY,
+    Error, Hash256, ZeroizeHash,
 };
 pub use milagro_bls as milagro;
 use rand::thread_rng;
@@ -86,21 +86,7 @@ impl TPublicKey for milagro::PublicKey {
     }
 }
 
-impl TAggregatePublicKey for milagro::AggregatePublicKey {
-    fn infinity() -> Self {
-        Self::from_bytes(&INFINITY_PUBLIC_KEY).expect("should decode infinity public key")
-    }
-
-    fn serialize(&self) -> [u8; PUBLIC_KEY_BYTES_LEN] {
-        let mut bytes = [0; PUBLIC_KEY_BYTES_LEN];
-        bytes[..].copy_from_slice(&self.as_bytes());
-        bytes
-    }
-
-    fn deserialize(bytes: &[u8]) -> Result<Self, Error> {
-        Self::from_bytes(&bytes).map_err(Into::into)
-    }
-}
+impl TAggregatePublicKey for milagro::AggregatePublicKey {}
 
 impl TSignature<milagro::PublicKey> for milagro::Signature {
     fn serialize(&self) -> [u8; SIGNATURE_BYTES_LEN] {


### PR DESCRIPTION
## Issue Addressed

n/a

## Proposed Changes

Subgroup checks are added for `blst` and updated in `milagro_bls`.

Subgroup checks will now be done:
- during deserialisation for `PublicKeys`
- during verification for `Signatures`/`AggregateSignatures`

## Additional Info

We can no longer safely aggregate Signatures that have not been verified. The only place `Signature` aggregation currently occurs is during `Attestation` aggregation which will only be done if the signature is verified.

Currently we are pointing to our own fork of blst again to expose the subgroup checking function. We should update back to supranational/blst after this PR is merged https://github.com/supranational/blst/pull/35.
