### PR TITLE
[Merged by Bors] - Implement database temp states to reduce memory usage

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1630,7 +1630,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             Box::new(signed_block.clone()),
         ));
         ops.push(StoreOp::PutState(block.state_root, &state));
+        let txn_lock = self.store.hot_db.begin_rw_transaction();
         self.store.do_atomically(ops)?;
+        drop(txn_lock);
 
         // The fork choice write-lock is dropped *after* the on-disk database has been updated.
         // This prevents inconsistency between the two at the expense of concurrency.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1498,7 +1498,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let block_root = fully_verified_block.block_root;
         let mut state = fully_verified_block.state;
         let current_slot = self.slot()?;
-        let mut ops = fully_verified_block.intermediate_states;
+        let mut ops = fully_verified_block.confirmation_db_batch;
 
         let attestation_observation_timer =
             metrics::start_timer(&metrics::BLOCK_PROCESSING_ATTESTATION_OBSERVATION);
@@ -1623,12 +1623,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let db_write_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_DB_WRITE);
 
-        // Store all the states between the parent block state and this block's slot, the block and state.
-        ops.push(StoreOp::PutBlock(block_root.into(), signed_block.clone()));
-        ops.push(StoreOp::PutState(
-            block.state_root.into(),
-            Cow::Borrowed(&state),
+        // Store the block and its state, and execute the confirmation batch for the intermediate
+        // states, which will delete their temporary flags.
+        ops.push(StoreOp::PutBlock(
+            block_root,
+            Box::new(signed_block.clone()),
         ));
+        ops.push(StoreOp::PutState(block.state_root, &state));
         self.store.do_atomically(ops)?;
 
         // The fork choice write-lock is dropped *after* the on-disk database has been updated.

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -363,7 +363,7 @@ pub struct FullyVerifiedBlock<'a, T: BeaconChainTypes> {
     pub block_root: Hash256,
     pub state: BeaconState<T::EthSpec>,
     pub parent_block: SignedBeaconBlock<T::EthSpec>,
-    pub intermediate_states: Vec<StoreOp<'a, T::EthSpec>>,
+    pub confirmation_db_batch: Vec<StoreOp<'a, T::EthSpec>>,
 }
 
 /// Implemented on types that can be converted into a `FullyVerifiedBlock`.
@@ -676,9 +676,9 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
 
         let catchup_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_CATCHUP_STATE);
 
-        // Keep a batch of any states that were "skipped" (block-less) in between the parent state
-        // slot and the block slot. These will be stored in the database.
-        let mut intermediate_states: Vec<StoreOp<T::EthSpec>> = Vec::new();
+        // Stage a batch of operations to be completed atomically if this block is imported
+        // successfully.
+        let mut confirmation_db_batch = vec![];
 
         // The block must have a higher slot than its parent.
         if block.slot() <= parent.beacon_state.slot {
@@ -702,18 +702,34 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                 // processing, but we get early access to it.
                 let state_root = state.update_tree_hash_cache()?;
 
-                let op = if state.slot % T::EthSpec::slots_per_epoch() == 0 {
-                    StoreOp::PutState(
-                        state_root.into(),
-                        Cow::Owned(state.clone_with(CloneConfig::committee_caches_only())),
-                    )
+                // Store the state immediately, marking it as temporary, and staging the deletion
+                // of its temporary status as part of the larger atomic operation.
+                let state_already_exists =
+                    chain.store.load_hot_state_summary(&state_root)?.is_some();
+
+                let state_batch = if state_already_exists {
+                    // If the state exists, it could be temporary or permanent, but in neither case
+                    // should we rewrite it or store a new temporary flag for it. We *will* stage
+                    // the temporary flag for deletion because it's OK to double-delete the flag,
+                    // and we don't mind if another thread gets there first.
+                    vec![]
                 } else {
-                    StoreOp::PutStateSummary(
-                        state_root.into(),
-                        HotStateSummary::new(&state_root, &state)?,
-                    )
+                    vec![
+                        if state.slot % T::EthSpec::slots_per_epoch() == 0 {
+                            StoreOp::PutState(state_root, &state)
+                        } else {
+                            StoreOp::PutStateSummary(
+                                state_root,
+                                HotStateSummary::new(&state_root, &state)?,
+                            )
+                        },
+                        StoreOp::PutStateTemporaryFlag(state_root),
+                    ]
                 };
-                intermediate_states.push(op);
+                chain.store.do_atomically(state_batch)?;
+
+                confirmation_db_batch.push(StoreOp::DeleteStateTemporaryFlag(state_root));
+
                 state_root
             };
 
@@ -801,7 +817,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
             block_root,
             state,
             parent_block: parent.beacon_block,
-            intermediate_states,
+            confirmation_db_batch,
         })
     }
 }

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -1,9 +1,6 @@
 use serde_derive::{Deserialize, Serialize};
 use types::Checkpoint;
 
-/// There is a 693 block skip in the current canonical Medalla chain, we use 700 to be safe.
-pub const DEFAULT_IMPORT_BLOCK_MAX_SKIP_SLOTS: u64 = 700;
-
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct ChainConfig {
     /// Maximum number of slots to skip when importing a consensus message (e.g., block,
@@ -20,7 +17,7 @@ pub struct ChainConfig {
 impl Default for ChainConfig {
     fn default() -> Self {
         Self {
-            import_max_skip_slots: Some(DEFAULT_IMPORT_BLOCK_MAX_SKIP_SLOTS),
+            import_max_skip_slots: None,
             weak_subjectivity_checkpoint: None,
         }
     }

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -436,11 +436,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
 
         let batch: Vec<StoreOp<E>> = abandoned_blocks
             .into_iter()
+            .map(Into::into)
             .map(StoreOp::DeleteBlock)
             .chain(
                 abandoned_states
                     .into_iter()
-                    .map(|(slot, state_hash)| StoreOp::DeleteState(state_hash, slot)),
+                    .map(|(slot, state_hash)| StoreOp::DeleteState(state_hash.into(), slot)),
             )
             .collect();
 

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -441,7 +441,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
             .chain(
                 abandoned_states
                     .into_iter()
-                    .map(|(slot, state_hash)| StoreOp::DeleteState(state_hash.into(), slot)),
+                    .map(|(slot, state_hash)| StoreOp::DeleteState(state_hash.into(), Some(slot))),
             )
             .collect();
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -730,7 +730,7 @@ where
         }
     }
 
-    fn set_current_slot(&self, slot: Slot) {
+    pub fn set_current_slot(&self, slot: Slot) {
         let current_slot = self.chain.slot().unwrap();
         let current_epoch = current_slot.epoch(E::slots_per_epoch());
         let epoch = slot.epoch(E::slots_per_epoch());

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -34,6 +34,10 @@ type E = MinimalEthSpec;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 
 fn get_store(db_path: &TempDir) -> Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>> {
+    println!(
+        "StoreOp size: {}",
+        std::mem::size_of::<store::StoreOp<types::MainnetEthSpec>>()
+    );
     let spec = MinimalEthSpec::default_spec();
     let hot_path = db_path.path().join("hot_db");
     let cold_path = db_path.path().join("cold_db");

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -312,13 +312,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("max-skip-slots")
                 .help(
                     "Refuse to skip more than this many slots when processing a block or attestation. \
-                    This prevents nodes on minority forks from wasting our time and RAM, \
-                    but might need to be raised or set to 'none' in times of extreme network \
-                    outage."
+                    This prevents nodes on minority forks from wasting our time and disk space, \
+                    but could also cause unnecessary consensus failures, so is disabled by default."
                 )
                 .value_name("NUM_SLOTS")
                 .takes_value(true)
-                .default_value("700")
         )
         .arg(
             Arg::with_name("wss-checkpoint")

--- a/beacon_node/store/src/garbage_collection.rs
+++ b/beacon_node/store/src/garbage_collection.rs
@@ -1,0 +1,36 @@
+//! Garbage collection process that runs at start-up to clean up the database.
+use crate::hot_cold_store::HotColdDB;
+use crate::{Error, LevelDB, StoreOp};
+use slog::debug;
+use types::EthSpec;
+
+impl<E> HotColdDB<E, LevelDB<E>, LevelDB<E>>
+where
+    E: EthSpec,
+{
+    pub fn remove_garbage(&self) -> Result<(), Error> {
+        self.delete_temp_states()
+    }
+
+    pub fn delete_temp_states(&self) -> Result<(), Error> {
+        let delete_ops =
+            self.iter_temporary_state_roots()
+                .try_fold(vec![], |mut ops, state_root| {
+                    let state_root = state_root?;
+                    ops.push(StoreOp::DeleteState(state_root, None));
+                    ops.push(StoreOp::DeleteStateTemporaryFlag(state_root));
+                    Result::<_, Error>::Ok(ops)
+                })?;
+
+        if !delete_ops.is_empty() {
+            debug!(
+                self.log,
+                "Garbage collecting {} temporary states",
+                delete_ops.len() / 2
+            );
+            self.do_atomically(delete_ops)?;
+        }
+
+        Ok(())
+    }
+}

--- a/beacon_node/store/src/garbage_collection.rs
+++ b/beacon_node/store/src/garbage_collection.rs
@@ -8,10 +8,12 @@ impl<E> HotColdDB<E, LevelDB<E>, LevelDB<E>>
 where
     E: EthSpec,
 {
+    /// Clean up the database by performing one-off maintenance at start-up.
     pub fn remove_garbage(&self) -> Result<(), Error> {
         self.delete_temp_states()
     }
 
+    /// Delete the temporary states that were leftover by failed block imports.
     pub fn delete_temp_states(&self) -> Result<(), Error> {
         let delete_ops =
             self.iter_temporary_state_roots()

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -15,6 +15,7 @@ pub mod chunked_vector;
 pub mod config;
 pub mod errors;
 mod forwards_iter;
+mod garbage_collection;
 pub mod hot_cold_store;
 mod impls;
 mod leveldb_store;
@@ -127,7 +128,7 @@ pub enum StoreOp<'a, E: EthSpec> {
     PutStateTemporaryFlag(Hash256),
     DeleteStateTemporaryFlag(Hash256),
     DeleteBlock(Hash256),
-    DeleteState(Hash256, Slot),
+    DeleteState(Hash256, Option<Slot>),
 }
 
 /// A unique column identifier.
@@ -176,6 +177,16 @@ impl Into<&'static str> for DBColumn {
             DBColumn::BeaconRandaoMixes => "brm",
             DBColumn::DhtEnrs => "dht",
         }
+    }
+}
+
+impl DBColumn {
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+
+    pub fn as_bytes(self) -> &'static [u8] {
+        self.as_str().as_bytes()
     }
 }
 

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -22,6 +22,7 @@ mod memory_store;
 mod metadata;
 mod metrics;
 mod partial_beacon_state;
+mod schema_change;
 
 pub mod iter;
 

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::{DBColumn, Error, StoreItem};
 use ssz::{Decode, Encode};
 use types::Hash256;
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(1);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(2);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //
@@ -13,6 +13,12 @@ pub const SPLIT_KEY: Hash256 = Hash256::repeat_byte(2);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaVersion(pub u64);
+
+impl SchemaVersion {
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+}
 
 impl StoreItem for SchemaVersion {
     fn db_column() -> DBColumn {

--- a/beacon_node/store/src/schema_change.rs
+++ b/beacon_node/store/src/schema_change.rs
@@ -4,31 +4,29 @@ use crate::metadata::{SchemaVersion, CURRENT_SCHEMA_VERSION};
 use crate::{Error, ItemStore};
 use types::EthSpec;
 
-/// Migrate the database from one schema version to another, applying all requisite mutations.
-pub fn migrate_schema<E, Hot, Cold>(
-    db: &HotColdDB<E, Hot, Cold>,
-    from: SchemaVersion,
-    to: SchemaVersion,
-) -> Result<(), Error>
+impl<E, Hot, Cold> HotColdDB<E, Hot, Cold>
 where
     E: EthSpec,
     Hot: ItemStore<E>,
     Cold: ItemStore<E>,
 {
-    match (from, to) {
-        // Migration from v0.3.0 to v0.3.x, adding the temporary states column.
-        // Nothing actually needs to be done, but once a DB uses v2 it shouldn't go back.
-        (SchemaVersion(1), SchemaVersion(2)) => {
-            db.store_schema_version(to)?;
-            Ok(())
+    /// Migrate the database from one schema version to another, applying all requisite mutations.
+    pub fn migrate_schema(&self, from: SchemaVersion, to: SchemaVersion) -> Result<(), Error> {
+        match (from, to) {
+            // Migration from v0.3.0 to v0.3.x, adding the temporary states column.
+            // Nothing actually needs to be done, but once a DB uses v2 it shouldn't go back.
+            (SchemaVersion(1), SchemaVersion(2)) => {
+                self.store_schema_version(to)?;
+                Ok(())
+            }
+            // Migrating from the current schema version to iself is always OK, a no-op.
+            (_, _) if from == to && to == CURRENT_SCHEMA_VERSION => Ok(()),
+            // Anything else is an error.
+            (_, _) => Err(HotColdDBError::UnsupportedSchemaVersion {
+                target_version: to,
+                current_version: from,
+            }
+            .into()),
         }
-        // Migrating from the current schema version to iself is always OK, a no-op.
-        (_, _) if from == to && to == CURRENT_SCHEMA_VERSION => Ok(()),
-        // Anything else is an error.
-        (_, _) => Err(HotColdDBError::UnsupportedSchemaVersion {
-            target_version: to,
-            current_version: from,
-        }
-        .into()),
     }
 }

--- a/beacon_node/store/src/schema_change.rs
+++ b/beacon_node/store/src/schema_change.rs
@@ -1,0 +1,34 @@
+//! Utilities for managing database schema changes.
+use crate::hot_cold_store::{HotColdDB, HotColdDBError};
+use crate::metadata::{SchemaVersion, CURRENT_SCHEMA_VERSION};
+use crate::{Error, ItemStore};
+use types::EthSpec;
+
+/// Migrate the database from one schema version to another, applying all requisite mutations.
+pub fn migrate_schema<E, Hot, Cold>(
+    db: &HotColdDB<E, Hot, Cold>,
+    from: SchemaVersion,
+    to: SchemaVersion,
+) -> Result<(), Error>
+where
+    E: EthSpec,
+    Hot: ItemStore<E>,
+    Cold: ItemStore<E>,
+{
+    match (from, to) {
+        // Migration from v0.3.0 to v0.3.x, adding the temporary states column.
+        // Nothing actually needs to be done, but once a DB uses v2 it shouldn't go back.
+        (SchemaVersion(1), SchemaVersion(2)) => {
+            db.store_schema_version(to)?;
+            Ok(())
+        }
+        // Migrating from the current schema version to iself is always OK, a no-op.
+        (_, _) if from == to && to == CURRENT_SCHEMA_VERSION => Ok(()),
+        // Anything else is an error.
+        (_, _) => Err(HotColdDBError::UnsupportedSchemaVersion {
+            target_version: to,
+            current_version: from,
+        }
+        .into()),
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Closes #800
Closes #1713

## Proposed Changes

Implement the temporary state storage algorithm described in #800. Specifically:

* Add `DBColumn::BeaconStateTemporary`, for storing 0-length temporary marker values.
* Store intermediate states immediately as they are created, marked temporary. Delete the temporary flag if the block is processed successfully.
* Add a garbage collection process to delete leftover temporary states on start-up.
* Bump the database schema version to 2 so that a DB with temporary states can't accidentally be used with older versions of the software. The auto-migration is a no-op, but puts in place some infra that we can use for future migrations (e.g. #1784)

## Additional Info

There are two known race conditions, one potentially causing permanent faults (hopefully rare), and the other insignificant.

### Race 1: Permanent state marked temporary

EDIT: this has been fixed by the addition of a lock around the relevant critical section

There are 2 threads that are trying to store 2 different blocks that share some intermediate states (e.g. they both skip some slots from the current head). Consider this sequence of events:

1. Thread 1 checks if state `s` already exists, and seeing that it doesn't, prepares an atomic commit of `(s, s_temporary_flag)`.
2. Thread 2 does the same, but also gets as far as committing the state txn, finishing the processing of its block, and _deleting_ the temporary flag.
3. Thread 1 is (finally) scheduled again, and marks `s` as temporary with its transaction.
4.
    a) The process is killed, or thread 1's block fails verification and the temp flag is not deleted. This is a permanent failure! Any attempt to load state `s` will fail... hope it isn't on the main chain! Alternatively (4b) happens...
    b) Thread 1 finishes, and re-deletes the temporary flag. In this case the failure is transient, state `s` will disappear temporarily, but will come back once thread 1 finishes running.

I _hope_ that steps 1-3 only happen very rarely, and 4a even more rarely. It's hard to know

This once again begs the question of why we're using LevelDB (#483), when it clearly doesn't care about atomicity! A ham-fisted fix would be to wrap the hot and cold DBs in locks, which would bring us closer to how other DBs handle read-write transactions. E.g. [LMDB only allows one R/W transaction at a time](https://docs.rs/lmdb/0.8.0/lmdb/struct.Environment.html#method.begin_rw_txn).

### Race 2: Temporary state returned from `get_state`

I don't think this race really matters, but in `load_hot_state`, if another thread stores a state between when we call `load_state_temporary_flag` and when we call `load_hot_state_summary`, then we could end up returning that state even though it's only a temporary state. I can't think of any case where this would be relevant, and I suspect if it did come up, it would be safe/recoverable (having data is safer than _not_ having data).

This could be fixed by using a LevelDB read snapshot, but that would require substantial changes to how we read all our values, so I don't think it's worth it right now.