### PR TITLE
[Merged by Bors] - use head slot instead of the target slot for the not_while_syncing fi…

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -290,7 +290,9 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(
             |network_globals: Arc<NetworkGlobals<T::EthSpec>>, chain: Arc<BeaconChain<T>>| async move {
                 match *network_globals.sync_state.read() {
-                    SyncState::SyncingFinalized { target_slot, .. } => {
+                    SyncState::SyncingFinalized { .. } => {
+                        let head_slot = chain.slot().map_err(warp_utils::reject::beacon_chain_error)?;
+
                         let current_slot = chain
                             .slot_clock
                             .now_or_genesis()
@@ -302,12 +304,12 @@ pub fn serve<T: BeaconChainTypes>(
 
                         let tolerance = SYNC_TOLERANCE_EPOCHS * T::EthSpec::slots_per_epoch();
 
-                        if target_slot + tolerance >= current_slot {
+                        if head_slot + tolerance >= current_slot {
                             Ok(())
                         } else {
                             Err(warp_utils::reject::not_synced(format!(
                                 "head slot is {}, current slot is {}",
-                                target_slot, current_slot
+                                head_slot, current_slot
                             )))
                         }
                     }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -291,7 +291,7 @@ pub fn serve<T: BeaconChainTypes>(
             |network_globals: Arc<NetworkGlobals<T::EthSpec>>, chain: Arc<BeaconChain<T>>| async move {
                 match *network_globals.sync_state.read() {
                     SyncState::SyncingFinalized { .. } => {
-                        let head_slot = chain.slot().map_err(warp_utils::reject::beacon_chain_error)?;
+                        let head_slot = chain.best_slot().map_err(warp_utils::reject::beacon_chain_error)?;
 
                         let current_slot = chain
                             .slot_clock


### PR DESCRIPTION
## Issue Addressed

Resolves #1792

## Proposed Changes

Use `chain.best_slot()` instead of the sync state's target slot in the `not_while_syncing_filter`

## Additional Info

N/A
