### PR TITLE
[Merged by Bors] - Update testnet scripts

### DIFF
--- a/scripts/local_testnet/clean.sh
+++ b/scripts/local_testnet/clean.sh
@@ -6,4 +6,6 @@
 
 source ./vars.env
 
-rm -r $DATADIR
+if [ -d $DATADIR ]; then
+  rm -r $DATADIR
+fi

--- a/scripts/local_testnet/setup.sh
+++ b/scripts/local_testnet/setup.sh
@@ -10,7 +10,7 @@ source ./vars.env
 lcli \
 	--spec mainnet \
 	new-testnet \
-	--deposit-contract-address 0000000000000000000000000000000000000000 \
+	--deposit-contract-address 1234567890123456789012345678901234567890 \
 	--testnet-dir $TESTNET_DIR \
 	--min-genesis-active-validator-count $VALIDATOR_COUNT \
 	--force


### PR DESCRIPTION
## Proposed Changes

A couple of minor fixes to the testnet scripts.

First, `clean.sh` only attempts to remove the directory if it exists.  This ensures a good exit code even if the directory is not present.

Second, `setup.sh` uses an updated deposit contract address to match that in the generated spec to allow the chain to start.
