### PR TITLE
[Merged by Bors] - Increase UPnP logging and decrease batch sizes

### DIFF
--- a/beacon_node/network/src/nat.rs
+++ b/beacon_node/network/src/nat.rs
@@ -41,7 +41,6 @@ pub fn construct_upnp_mappings<T: EthSpec>(
         Err(e) => info!(log, "UPnP not available"; "error" => %e),
         Ok(gateway) => {
             // Need to find the local listening address matched with the router subnet
-            let mut local_ip = None;
             let interfaces = match get_if_addrs() {
                 Ok(v) => v,
                 Err(e) => {
@@ -49,19 +48,27 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                     return;
                 }
             };
-            for interface in interfaces {
-                // Just use the first IP of the first interface that is not a loopback
+            let local_ip = interfaces.iter().find_map(|interface| {
+                // Just use the first IP of the first interface that is not a loopback and not an
+                // ipv6 address.
                 if !interface.is_loopback() {
-                    local_ip = Some(interface.ip());
+                    if let IpAddr::V4(_) = interface.ip() {
+                        Some(interface.ip())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
                 }
-            }
+            });
 
-            if local_ip.is_none() {
-                info!(log, "UPnP failed to find local IP address");
-                return;
-            }
-
-            let local_ip = local_ip.expect("IP exists");
+            let local_ip = match local_ip {
+                None => {
+                    info!(log, "UPnP failed to find local IP address");
+                    return;
+                }
+                Some(v) => v,
+            };
 
             match local_ip {
                 IpAddr::V4(address) => {
@@ -79,7 +86,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                         "lighthouse-tcp",
                     ) {
                         Err(e) => {
-                            info!(log, "UPnP could not construct libp2p port route"; "error" => %e);
+                            info!(log, "UPnP TCP route not set"; "error" => %e);
                             None
                         }
                         Ok(_) => {
@@ -101,7 +108,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                             "lighthouse-udp",
                         ) {
                             Err(e) => {
-                                info!(log, "UPnP could not construct discovery port route"; "error" => %e);
+                                info!(log, "UPnP UDP route not set"; "error" => %e);
                                 None
                             }
                             Ok(_) => {

--- a/beacon_node/network/src/nat.rs
+++ b/beacon_node/network/src/nat.rs
@@ -36,16 +36,16 @@ pub fn construct_upnp_mappings<T: EthSpec>(
     network_send: mpsc::UnboundedSender<NetworkMessage<T>>,
     log: slog::Logger,
 ) {
-    debug!(log, "UPnP Initialising routes");
+    info!(log, "UPnP Attempting to initialise routes");
     match igd::search_gateway(Default::default()) {
-        Err(e) => debug!(log, "UPnP not available"; "error" => %e),
+        Err(e) => info!(log, "UPnP not available"; "error" => %e),
         Ok(gateway) => {
             // Need to find the local listening address matched with the router subnet
             let mut local_ip = None;
             let interfaces = match get_if_addrs() {
                 Ok(v) => v,
                 Err(e) => {
-                    debug!(log, "UPnP failed to get local interfaces"; "error" => %e);
+                    info!(log, "UPnP failed to get local interfaces"; "error" => %e);
                     return;
                 }
             };
@@ -57,7 +57,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
             }
 
             if local_ip.is_none() {
-                debug!(log, "UPnP failed to find local IP address");
+                info!(log, "UPnP failed to find local IP address");
                 return;
             }
 
@@ -79,7 +79,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                         "lighthouse-tcp",
                     ) {
                         Err(e) => {
-                            debug!(log, "UPnP could not construct libp2p port route"; "error" => %e);
+                            info!(log, "UPnP could not construct libp2p port route"; "error" => %e);
                             None
                         }
                         Ok(_) => {
@@ -101,7 +101,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                             "lighthouse-udp",
                         ) {
                             Err(e) => {
-                                debug!(log, "UPnP could not construct discovery port route"; "error" => %e);
+                                info!(log, "UPnP could not construct discovery port route"; "error" => %e);
                                 None
                             }
                             Ok(_) => {

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -18,7 +18,7 @@ use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
 /// we will negatively report peers with poor bandwidth. This can be set arbitrarily high, in which
 /// case the responder will fill the response up to the max request size, assuming they have the
 /// bandwidth to do so.
-pub const EPOCHS_PER_BATCH: u64 = 8;
+pub const EPOCHS_PER_BATCH: u64 = 2;
 
 /// The maximum number of batches to queue before requesting more.
 const BATCH_BUFFER_SIZE: u8 = 5;


### PR DESCRIPTION
## Description

This increases the logging of the underlying UPnP tasks to inform the user of UPnP error/success. 

This also decreases the batch syncing size to two epochs per batch. 
