### PR TITLE
[Merged by Bors] - Update slashing protection interchange to v5

### DIFF
--- a/book/src/slashing-protection.md
+++ b/book/src/slashing-protection.md
@@ -60,11 +60,12 @@ Examples where it is **ineffective** are:
 
 ## Import and Export
 
-Lighthouse supports v4 of the slashing protection interchange format described
+Lighthouse supports v5 of the slashing protection interchange format described
 [here][interchange-spec]. An interchange file is a record of all blocks and attestations
 signing by a set of validator keys – basically a portable slashing protection database!
 
-You can import a `.json` interchange file from another client using this command:
+With your validator client stopped, you can import a `.json` interchange file from another client
+using this command:
 
 ```bash
 lighthouse account validator slashing-protection import <my_interchange.json>
@@ -84,6 +85,8 @@ You can export Lighthouse's database for use with another client with this comma
 ```
 lighthouse account validator slashing-protection export <lighthouse_interchange.json>
 ```
+
+The validator client needs to be stopped in order to export.
 
 [interchange-spec]: https://hackmd.io/@sproul/Bk0Y0qdGD
 

--- a/validator_client/slashing_protection/Makefile
+++ b/validator_client/slashing_protection/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := ac393b815b356c95569c028c215232b512df583d
+TESTS_TAG := 359085be9da6e5e19644977aa45947bcec5d99de
 GENERATE_DIR := generated-tests
 OUTPUT_DIR := interchange-tests
 TARBALL := $(OUTPUT_DIR)-$(TESTS_TAG).tar.gz

--- a/validator_client/slashing_protection/src/interchange.rs
+++ b/validator_client/slashing_protection/src/interchange.rs
@@ -3,16 +3,9 @@ use std::collections::HashSet;
 use std::iter::FromIterator;
 use types::{Epoch, Hash256, PublicKey, Slot};
 
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum InterchangeFormat {
-    Complete,
-}
-
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct InterchangeMetadata {
-    pub interchange_format: InterchangeFormat,
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub interchange_format_version: u64,
     pub genesis_validators_root: Hash256,
@@ -20,7 +13,7 @@ pub struct InterchangeMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct CompleteInterchangeData {
+pub struct InterchangeData {
     pub pubkey: PublicKey,
     pub signed_blocks: Vec<SignedBlock>,
     pub signed_attestations: Vec<SignedAttestation>,
@@ -49,7 +42,7 @@ pub struct SignedAttestation {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Interchange {
     pub metadata: InterchangeMetadata,
-    pub data: Vec<CompleteInterchangeData>,
+    pub data: Vec<InterchangeData>,
 }
 
 impl Interchange {

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -1,6 +1,6 @@
 use crate::interchange::{
-    CompleteInterchangeData, Interchange, InterchangeFormat, InterchangeMetadata,
-    SignedAttestation as InterchangeAttestation, SignedBlock as InterchangeBlock,
+    Interchange, InterchangeData, InterchangeMetadata, SignedAttestation as InterchangeAttestation,
+    SignedBlock as InterchangeBlock,
 };
 use crate::signed_attestation::InvalidAttestation;
 use crate::signed_block::InvalidBlock;
@@ -25,7 +25,7 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Supported version of the interchange format.
-pub const SUPPORTED_INTERCHANGE_FORMAT_VERSION: u64 = 4;
+pub const SUPPORTED_INTERCHANGE_FORMAT_VERSION: u64 = 5;
 
 #[derive(Debug, Clone)]
 pub struct SlashingDatabase {
@@ -673,7 +673,6 @@ impl SlashingDatabase {
         .collect::<Result<_, InterchangeError>>()?;
 
         let metadata = InterchangeMetadata {
-            interchange_format: InterchangeFormat::Complete,
             interchange_format_version: SUPPORTED_INTERCHANGE_FORMAT_VERSION,
             genesis_validators_root,
         };
@@ -681,7 +680,7 @@ impl SlashingDatabase {
         let data = data
             .into_iter()
             .map(|(pubkey, (signed_blocks, signed_attestations))| {
-                Ok(CompleteInterchangeData {
+                Ok(InterchangeData {
                     pubkey: pubkey.parse().map_err(InterchangeError::InvalidPubkey)?,
                     signed_blocks,
                     signed_attestations,


### PR DESCRIPTION
## Proposed Changes

Update the slashing protection interchange format to v5 in preparation for finalisation as part of an EIP.

Also, add some more tests and update the commit hash for https://github.com/eth2-clients/slashing-protection-interchange-tests to include the new generated tests.
