### PR TITLE
[Merged by Bors] - Call unban only when necessary 

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -675,7 +675,9 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     ScoreState::Disconnected => {
                         debug!(self.log, "Peer transitioned to disconnect state"; "peer_id" => peer_id.to_string(), "score" => info.score().to_string(), "past_state" => previous_state.to_string());
                         // disconnect the peer if it's currently connected or dialing
-                        to_unban_peers.push(peer_id.clone());
+                        if info.is_banned() {
+                            to_unban_peers.push(peer_id.clone());
+                        }
                         if info.is_connected_or_dialing() {
                             // Change the state to inform that we are disconnecting the peer.
                             info.disconnecting(false);

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -179,13 +179,16 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                                     GoodbyeReason::BadScore,
                                 ));
                                 peer_db.notify_disconnecting(peer_id);
+                            } else if info.is_banned() {
+                                unban_peer = Some(peer_id);
                             }
-                            unban_peer = Some(peer_id);
                         }
                         ScoreState::Healthy => {
                             debug!(self.log, "Peer transitioned to healthy state"; "peer_id" => peer_id.to_string(), "score" => info.score().to_string(), "past_state" => previous_state.to_string());
                             // unban the peer if it was previously banned.
-                            unban_peer = Some(peer_id);
+                            if info.is_banned() {
+                                unban_peer = Some(peer_id);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
This PR prevents a user-facing error. 

It prevents optimistically unbanning a peer and instead checks the state of the peer before requesting the peers state to be unbanned.
