### PR TITLE
[Merged by Bors] - Prevent unbanning of disconnected peers

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -678,9 +678,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     ScoreState::Disconnected => {
                         debug!(self.log, "Peer transitioned to disconnect state"; "peer_id" => peer_id.to_string(), "score" => info.score().to_string(), "past_state" => previous_state.to_string());
                         // disconnect the peer if it's currently connected or dialing
-                        if info.is_banned() {
-                            to_unban_peers.push(peer_id.clone());
-                        }
                         if info.is_connected_or_dialing() {
                             // Change the state to inform that we are disconnecting the peer.
                             info.disconnecting(false);
@@ -688,12 +685,16 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                                 peer_id.clone(),
                                 GoodbyeReason::BadScore,
                             ));
+                        } else if info.is_banned() {
+                            to_unban_peers.push(peer_id.clone());
                         }
                     }
                     ScoreState::Healthy => {
                         debug!(self.log, "Peer transitioned to healthy state"; "peer_id" => peer_id.to_string(), "score" => info.score().to_string(), "past_state" => previous_state.to_string());
                         // unban the peer if it was previously banned.
-                        to_unban_peers.push(peer_id.clone());
+                        if info.is_banned() {
+                            to_unban_peers.push(peer_id.clone());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Issue Addressed

Further testing revealed another edge case where we attempt to unban a peer that can be in a disconnected start. Although this causes no real issue, it does log an error to the user. 

This PR adds a check to prevent this edge case and prevents the error being logged to the user. 
