### PR TITLE
[Merged by Bors] - Only run http_api tests in release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,8 +1375,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595cf0600428cea17ce274cc11bb2fa8247a900a76fde1bbce2b81a39f335c02"
+source = "git+https://github.com/sigp/discv5?rev=fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0#fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0"
 dependencies = [
  "aes-ctr",
  "aes-gcm",
@@ -1408,7 +1407,8 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.1"
-source = "git+https://github.com/sigp/discv5?rev=fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0#fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595cf0600428cea17ce274cc11bb2fa8247a900a76fde1bbce2b81a39f335c02"
 dependencies = [
  "aes-ctr",
  "aes-gcm",
@@ -3987,8 +3987,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8c6ce6eb1228de568568f6cd72fb134dea5f9669#8c6ce6eb1228de568568f6cd72fb134dea5f9669"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4005,7 +4004,8 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.3"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8c6ce6eb1228de568568f6cd72fb134dea5f9669#8c6ce6eb1228de568568f6cd72fb134dea5f9669"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
 dependencies = [
  "arrayref",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,8 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.1"
-source = "git+https://github.com/sigp/discv5?rev=fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0#fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595cf0600428cea17ce274cc11bb2fa8247a900a76fde1bbce2b81a39f335c02"
 dependencies = [
  "aes-ctr",
  "aes-gcm",
@@ -1407,8 +1408,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595cf0600428cea17ce274cc11bb2fa8247a900a76fde1bbce2b81a39f335c02"
+source = "git+https://github.com/sigp/discv5?rev=fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0#fba7ceb5cfebd219ebbad6ffdb5d8c31dc8e4bc0"
 dependencies = [
  "aes-ctr",
  "aes-gcm",
@@ -3987,7 +3987,8 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.3"
-source = "git+https://github.com/sigp/rust-libp2p?rev=8c6ce6eb1228de568568f6cd72fb134dea5f9669#8c6ce6eb1228de568568f6cd72fb134dea5f9669"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
 dependencies = [
  "arrayref",
  "bs58",
@@ -4004,8 +4005,7 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7ad66970bbab360c97179b60906e2dc4aef1f7fca8ab4e5c5db8c97b16814a"
+source = "git+https://github.com/sigp/rust-libp2p?rev=8c6ce6eb1228de568568f6cd72fb134dea5f9669#8c6ce6eb1228de568568f6cd72fb134dea5f9669"
 dependencies = [
  "arrayref",
  "bs58",

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1,4 +1,5 @@
-#[cfg(not(debug_assertions))] // Tests are too slow in debug.
+#![cfg(not(debug_assertions))] // Tests are too slow in debug.
+
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
     BeaconChain, StateSkipConfig,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1,3 +1,4 @@
+#[cfg(not(debug_assertions))] // Tests are too slow in debug.
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
     BeaconChain, StateSkipConfig,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1593,59 +1593,42 @@ impl ApiTester {
 }
 
 #[tokio::test(core_threads = 2)]
-async fn beacon_genesis() {
-    ApiTester::new().test_beacon_genesis().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_root() {
-    ApiTester::new().test_beacon_states_root().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_fork() {
-    ApiTester::new().test_beacon_states_fork().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_finality_checkpoints() {
+async fn beacon_get() {
     ApiTester::new()
+        .test_beacon_genesis()
+        .await
+        .test_beacon_states_root()
+        .await
+        .test_beacon_states_fork()
+        .await
         .test_beacon_states_finality_checkpoints()
-        .await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_validators() {
-    ApiTester::new().test_beacon_states_validators().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_committees() {
-    ApiTester::new().test_beacon_states_committees().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_states_validator_id() {
-    ApiTester::new().test_beacon_states_validator_id().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_headers() {
-    ApiTester::new()
+        .await
+        .test_beacon_states_validators()
+        .await
+        .test_beacon_states_committees()
+        .await
+        .test_beacon_states_validator_id()
+        .await
         .test_beacon_headers_all_slots()
         .await
         .test_beacon_headers_all_parents()
+        .await
+        .test_beacon_headers_block_id()
+        .await
+        .test_beacon_blocks()
+        .await
+        .test_beacon_blocks_attestations()
+        .await
+        .test_beacon_blocks_root()
+        .await
+        .test_get_beacon_pool_attestations()
+        .await
+        .test_get_beacon_pool_attester_slashings()
+        .await
+        .test_get_beacon_pool_proposer_slashings()
+        .await
+        .test_get_beacon_pool_voluntary_exits()
         .await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_headers_block_id() {
-    ApiTester::new().test_beacon_headers_block_id().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_blocks() {
-    ApiTester::new().test_beacon_blocks().await;
 }
 
 #[tokio::test(core_threads = 2)]
@@ -1656,29 +1639,6 @@ async fn post_beacon_blocks_valid() {
 #[tokio::test(core_threads = 2)]
 async fn post_beacon_blocks_invalid() {
     ApiTester::new().test_post_beacon_blocks_invalid().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_blocks_root() {
-    ApiTester::new().test_beacon_blocks_root().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_blocks_attestations() {
-    ApiTester::new().test_beacon_blocks_attestations().await;
-}
-
-#[tokio::test(core_threads = 2)]
-async fn beacon_pools_get() {
-    ApiTester::new()
-        .test_get_beacon_pool_attestations()
-        .await
-        .test_get_beacon_pool_attester_slashings()
-        .await
-        .test_get_beacon_pool_proposer_slashings()
-        .await
-        .test_get_beacon_pool_voluntary_exits()
-        .await;
 }
 
 #[tokio::test(core_threads = 2)]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

As raised by @hermanjunge in a DM, the `http_api` tests have been observed taking 100+ minutes on debug. This PR:

- Moves the `http_api` tests to only run in release.
- Groups some `http_api` tests to reduce test-setup overhead.

## Additional Info

NA
