### PR TITLE
[Merged by Bors] - Ensure eth1 deposit/chain IDs are used from YamlConfig

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -370,7 +370,7 @@ impl Service {
                     crit!(
                         self.log,
                         "Invalid eth1 network. Please switch to correct network";
-                        "expected" => format!("{:?}",DEFAULT_NETWORK_ID),
+                        "expected" => format!("{:?}",config_network),
                         "received" => format!("{:?}",network_id),
                         "warning" => WARNING_MSG,
                     );

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -780,8 +780,8 @@ impl YamlConfig {
             genesis_slot: chain_spec.genesis_slot,
             far_future_epoch: chain_spec.far_future_epoch,
             base_rewards_per_epoch: chain_spec.base_rewards_per_epoch,
-            deposit_chain_id: chain_spec.deposit_chain_id,
-            deposit_network_id: chain_spec.deposit_network_id,
+            deposit_chain_id: self.deposit_chain_id,
+            deposit_network_id: self.deposit_network_id,
             deposit_contract_tree_depth: chain_spec.deposit_contract_tree_depth,
         })
     }

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -718,6 +718,8 @@ impl YamlConfig {
             random_subnets_per_validator: self.random_subnets_per_validator,
             epochs_per_random_subnet_subscription: self.epochs_per_random_subnet_subscription,
             seconds_per_eth1_block: self.seconds_per_eth1_block,
+            deposit_chain_id: self.deposit_chain_id,
+            deposit_network_id: self.deposit_network_id,
             deposit_contract_address: self.deposit_contract_address,
             /*
              * Gwei values
@@ -780,8 +782,6 @@ impl YamlConfig {
             genesis_slot: chain_spec.genesis_slot,
             far_future_epoch: chain_spec.far_future_epoch,
             base_rewards_per_epoch: chain_spec.base_rewards_per_epoch,
-            deposit_chain_id: self.deposit_chain_id,
-            deposit_network_id: self.deposit_network_id,
             deposit_contract_tree_depth: chain_spec.deposit_contract_tree_depth,
         })
     }

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -846,6 +846,8 @@ mod yaml_tests {
 
         // modifying the original spec
         spec.max_committees_per_slot += 1;
+        spec.deposit_chain_id += 1;
+        spec.deposit_network_id += 1;
         // Applying a yaml config with incorrect EthSpec should fail
         let res = yamlconfig.apply_to_chain_spec::<MainnetEthSpec>(&spec);
         assert_eq!(res, None);


### PR DESCRIPTION
## Issue Addressed

 NA

## Proposed Changes

Fixes a bug which causes the node to reject valid eth1 nodes.

- Fix core bug: failure to apply `YamlConfig` values to `ChainSpec`.
- Add a test to prevent regression in this specific case.
- Fix an invalid log message

## Additional Info

NA