### PR TITLE
[Merged by Bors] - Remove mention of OpenSSL from documentation

### DIFF
--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -50,14 +50,14 @@ Several dependencies may be required to compile Lighthouse. The following
 packages may be required in addition a base Ubuntu Server installation:
 
 ```bash
-sudo apt install -y git gcc g++ make cmake pkg-config libssl-dev
+sudo apt install -y git gcc g++ make cmake pkg-config
 ```
 
 #### macOS
 
 You will need `cmake`. You can install via homebrew:
 
-    brew install openssl cmake
+    brew install cmake
 
 ### Command is not found
 
@@ -70,13 +70,5 @@ See ["Configuring the `PATH` environment variable"
 ### Compilation error
 
 Make sure you are running the latest version of Rust. If you have installed Rust using rustup, simply type `$ rustup update`.
-
-### OpenSSL
-
-If you get a build failure relating to OpenSSL, try installing `openssl-dev` or
-`libssl-dev` using your OS package manager.
-
-- Ubuntu: `$ apt-get install libssl-dev`.
-- Amazon Linux: `$ yum install openssl-devel`.
 
 [WSL]: https://docs.microsoft.com/en-us/windows/wsl/about


### PR DESCRIPTION
If I'm not mistaken, openssl is no longer a dependency of lighthouse, so it can no longer cause build issues.