### PR TITLE
[Merged by Bors] - Downgrade ADX check to a warning

### DIFF
--- a/book/src/installation-binaries.md
+++ b/book/src/installation-binaries.md
@@ -36,3 +36,17 @@ Each binary is contained in a `.tar.gz` archive. For this example, lets use the
 1. Test the binary with `./lighthouse --version` (it should print the version).
 1. (Optional) Move the `lighthouse` binary to a location in your `PATH`, so the `lighthouse` command can be called from anywhere.
     - E.g., `cp lighthouse /usr/bin`
+
+## Troubleshooting
+
+If you get a SIGILL (exit code 132), then your CPU is incompatible with the optimized build
+of Lighthouse and you should switch to the `-portable` build. In this case, you will see a
+warning like this on start-up:
+
+```
+WARN CPU seems incompatible with optimized Lighthouse build, advice: If you get a SIGILL, please try Lighthouse portable build
+```
+
+On some VPS providers, the virtualization can make it appear as if CPU features are not available,
+even when they are. In this case you might see the warning above, but so long as the client
+continues to function it's nothing to worry about.

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -196,13 +196,6 @@ fn run<E: EthSpec>(
         ));
     }
 
-    #[cfg(all(feature = "modern", target_arch = "x86_64"))]
-    if !std::is_x86_feature_detected!("adx") {
-        return Err(format!(
-            "CPU incompatible with optimized binary, please try Lighthouse portable build"
-        ));
-    }
-
     let debug_level = matches
         .value_of("debug-level")
         .ok_or_else(|| "Expected --debug-level flag".to_string())?;
@@ -229,6 +222,15 @@ fn run<E: EthSpec>(
         warn!(
             log,
             "The --spec flag is deprecated and will be removed in a future release"
+        );
+    }
+
+    #[cfg(all(feature = "modern", target_arch = "x86_64"))]
+    if !std::is_x86_feature_detected!("adx") {
+        warn!(
+            log,
+            "CPU seems incompatible with optimized Lighthouse build";
+            "advice" => "If you get a SIGILL, please try Lighthouse portable build"
         );
     }
 


### PR DESCRIPTION
## Issue Addressed

Closes #1842

## Proposed Changes

Due to the lies told to us by VPS providers about what CPU features they support, we are forced to check for the availability of CPU features like ADX by just _running code and seeing if it crashes_. The prominent warning should hopefully help users who have truly incompatible CPUs work out what is going on, while not burdening users of cheap VPSs.
