### PR TITLE
[Merged by Bors] - Prevent errors for stream termination race

### DIFF
--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -913,10 +913,14 @@ async fn process_inbound_substream<TSpec: EthSpec>(
                 }
             }
         } else {
-            // we have more items after a closed substream, report those as errors
-            errors.push(RPCError::InternalError(
-                "Sending responses to closed inbound substream",
-            ));
+            if matches!(item, RPCCodedResponse::StreamTermination(_)) {
+                // The sender closed the stream before us, ignore this.
+            } else {
+                // we have more items after a closed substream, report those as errors
+                errors.push(RPCError::InternalError(
+                    "Sending responses to closed inbound substream",
+                ));
+            }
         }
     }
     (substream, errors, substream_closed, remaining_chunks)

--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -912,15 +912,13 @@ async fn process_inbound_substream<TSpec: EthSpec>(
                     substream_closed = true;
                 }
             }
+        } else if matches!(item, RPCCodedResponse::StreamTermination(_)) {
+            // The sender closed the stream before us, ignore this.
         } else {
-            if matches!(item, RPCCodedResponse::StreamTermination(_)) {
-                // The sender closed the stream before us, ignore this.
-            } else {
-                // we have more items after a closed substream, report those as errors
-                errors.push(RPCError::InternalError(
-                    "Sending responses to closed inbound substream",
-                ));
-            }
+            // we have more items after a closed substream, report those as errors
+            errors.push(RPCError::InternalError(
+                "Sending responses to closed inbound substream",
+            ));
         }
     }
     (substream, errors, substream_closed, remaining_chunks)


### PR DESCRIPTION
Prevents an error being propagated on a race condition for RPC stream termination
