### PR TITLE
[Merged by Bors] - Ignore RPC messages of disconnected peers and remove old peers based on disconnection time

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -26,7 +26,7 @@ use libp2p::{
     },
     PeerId,
 };
-use slog::{crit, debug, o, trace, warn};
+use slog::{crit, debug, info, o, trace, warn};
 use ssz::Encode;
 use std::collections::HashSet;
 use std::fs::File;
@@ -589,6 +589,17 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
 
     fn on_rpc_event(&mut self, message: RPCMessage<TSpec>) {
         let peer_id = message.peer_id;
+
+        if !self.peer_manager.is_connected(&peer_id) {
+            //ignore this event
+            info!(
+                self.log,
+                "Ignoring rpc message of disconnected peer";
+                "peer" => peer_id.to_string()
+            );
+            return;
+        }
+
         let handler_id = message.conn_id;
         // The METADATA and PING RPC responses are handled within the behaviour and not propagated
         match message.event {

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -26,7 +26,7 @@ use libp2p::{
     },
     PeerId,
 };
-use slog::{crit, debug, info, o, trace, warn};
+use slog::{crit, debug, o, trace, warn};
 use ssz::Encode;
 use std::collections::HashSet;
 use std::fs::File;
@@ -592,7 +592,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
 
         if !self.peer_manager.is_connected(&peer_id) {
             //ignore this event
-            info!(
+            debug!(
                 self.log,
                 "Ignoring rpc message of disconnected peer";
                 "peer" => peer_id.to_string()

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -315,6 +315,10 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         self.network_globals.peers.read().is_banned(peer_id)
     }
 
+    pub fn is_connected(&self, peer_id: &PeerId) -> bool {
+        self.network_globals.peers.read().is_connected(peer_id)
+    }
+
     /// Reports whether the peer limit is reached in which case we stop allowing new incoming
     /// connections.
     pub fn peer_limit_reached(&self) -> bool {

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -537,16 +537,14 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
     pub fn shrink_to_fit(&mut self) {
         // Remove excess banned peers
         while self.banned_peers_count.banned_peers() > MAX_BANNED_PEERS {
-            if let Some(to_drop) = if let Some((id, info)) = self
+            if let Some(to_drop) = if let Some((id, info, _)) = self
                 .peers
                 .iter()
-                .filter(|(_, info)| info.is_banned())
-                .min_by(|(_, info_a), (_, info_b)| {
-                    info_a
-                        .score()
-                        .partial_cmp(&info_b.score())
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                }) {
+                .filter_map(|(id, info)| match info.connection_status() {
+                    &PeerConnectionStatus::Banned { since} => Some((id, info, since)),
+                    _ => None
+                })
+                .min_by_key(|(_, _, since)| *since) {
                 self.banned_peers_count
                     .remove_banned_peer(info.seen_addresses());
                 Some(id.clone())
@@ -571,12 +569,11 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 .peers
                 .iter()
                 .filter(|(_, info)| info.is_disconnected())
-                .min_by(|(_, info_a), (_, info_b)| {
-                    info_a
-                        .score()
-                        .partial_cmp(&info_b.score())
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                .filter_map(|(id, info)| match info.connection_status() {
+                    &PeerConnectionStatus::Disconnected { since} => Some((id, since)),
+                    _ => None
                 })
+                .min_by_key(|(_, since)| *since)
                 .map(|(id, _)| id.clone())
             {
                 debug!(self.log, "Removing old disconnected peer"; "peer_id" => to_drop.to_string());

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -541,7 +541,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 .peers
                 .iter()
                 .filter_map(|(id, info)| match info.connection_status() {
-                    &PeerConnectionStatus::Banned { since } => Some((id, info, since)),
+                    PeerConnectionStatus::Banned { since } => Some((id, info, since)),
                     _ => None,
                 })
                 .min_by_key(|(_, _, since)| *since)
@@ -571,7 +571,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 .iter()
                 .filter(|(_, info)| info.is_disconnected())
                 .filter_map(|(id, info)| match info.connection_status() {
-                    &PeerConnectionStatus::Disconnected { since } => Some((id, since)),
+                    PeerConnectionStatus::Disconnected { since } => Some((id, since)),
                     _ => None,
                 })
                 .min_by_key(|(_, since)| *since)

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -541,10 +541,11 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 .peers
                 .iter()
                 .filter_map(|(id, info)| match info.connection_status() {
-                    &PeerConnectionStatus::Banned { since} => Some((id, info, since)),
-                    _ => None
+                    &PeerConnectionStatus::Banned { since } => Some((id, info, since)),
+                    _ => None,
                 })
-                .min_by_key(|(_, _, since)| *since) {
+                .min_by_key(|(_, _, since)| *since)
+            {
                 self.banned_peers_count
                     .remove_banned_peer(info.seen_addresses());
                 Some(id.clone())
@@ -570,8 +571,8 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 .iter()
                 .filter(|(_, info)| info.is_disconnected())
                 .filter_map(|(id, info)| match info.connection_status() {
-                    &PeerConnectionStatus::Disconnected { since} => Some((id, since)),
-                    _ => None
+                    &PeerConnectionStatus::Disconnected { since } => Some((id, since)),
+                    _ => None,
                 })
                 .min_by_key(|(_, since)| *since)
                 .map(|(id, _)| id.clone())


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Lets the networking behavior ignore messages of peers that are not connected. Furthermore, old peers are not removed from the peerdb based on score anymore but based on the disconnection time.