### PR TITLE
[Merged by Bors] - Compact database on finalization

### DIFF
--- a/beacon_node/store/src/garbage_collection.rs
+++ b/beacon_node/store/src/garbage_collection.rs
@@ -10,7 +10,8 @@ where
 {
     /// Clean up the database by performing one-off maintenance at start-up.
     pub fn remove_garbage(&self) -> Result<(), Error> {
-        self.delete_temp_states()
+        self.delete_temp_states()?;
+        Ok(())
     }
 
     /// Delete the temporary states that were leftover by failed block imports.

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -67,6 +67,9 @@ pub trait KeyValueStore<E: EthSpec>: Sync + Send + Sized + 'static {
     /// This doesn't prevent other threads writing to the DB unless they also use
     /// this method. In future we may implement a safer mandatory locking scheme.
     fn begin_rw_transaction(&self) -> MutexGuard<()>;
+
+    /// Compact the database, freeing space used by deleted items.
+    fn compact(&self) -> Result<(), Error>;
 }
 
 pub fn get_key_for_col(column: &str, key: &[u8]) -> Vec<u8> {

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -84,6 +84,10 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
     fn begin_rw_transaction(&self) -> MutexGuard<()> {
         self.transaction_mutex.lock()
     }
+
+    fn compact(&self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl<E: EthSpec> ItemStore<E> for MemoryStore<E> {}

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -1,6 +1,6 @@
 use crate::{DBColumn, Error, StoreItem};
 use ssz::{Decode, Encode};
-use types::Hash256;
+use types::{Checkpoint, Hash256};
 
 pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(2);
 
@@ -10,6 +10,7 @@ pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(2);
 pub const SCHEMA_VERSION_KEY: Hash256 = Hash256::repeat_byte(0);
 pub const CONFIG_KEY: Hash256 = Hash256::repeat_byte(1);
 pub const SPLIT_KEY: Hash256 = Hash256::repeat_byte(2);
+pub const PRUNING_CHECKPOINT_KEY: Hash256 = Hash256::repeat_byte(3);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaVersion(pub u64);
@@ -31,5 +32,29 @@ impl StoreItem for SchemaVersion {
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(SchemaVersion(u64::from_ssz_bytes(bytes)?))
+    }
+}
+
+/// The checkpoint used for pruning the database.
+///
+/// Updated whenever pruning is successful.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PruningCheckpoint {
+    pub checkpoint: Checkpoint,
+}
+
+impl StoreItem for PruningCheckpoint {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconMeta
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.checkpoint.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(PruningCheckpoint {
+            checkpoint: Checkpoint::from_ssz_bytes(bytes)?,
+        })
     }
 }


### PR DESCRIPTION
## Issue Addressed

Closes #1866

## Proposed Changes

* Compact the database on finalization. This removes the deleted states from disk completely. Because it happens in the background migrator, it doesn't block other database operations while it runs. On my Medalla node it took about 1 minute and shrank the database from 90GB to 9GB.
* Fix an inefficiency in the pruning algorithm where it would always use the genesis checkpoint as the `old_finalized_checkpoint` when running for the first time after start-up. This would result in loading lots of states one-at-a-time back to genesis, and storing a lot of block roots in memory. The new code stores the old finalized checkpoint on disk and only uses genesis if no checkpoint is already stored. This makes it both backwards compatible _and_ forwards compatible -- no schema change required!
* Introduce two new `INFO` logs to indicate when pruning has started and completed. Users seem to want to know this information without enabling debug logs!
