### PR TITLE
[Merged by Bors] - Update EF tests to 1.0.0

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -260,7 +260,7 @@ impl ChainSpec {
             churn_limit_quotient: 65_536,
             shuffle_round_count: 90,
             min_genesis_active_validator_count: 16_384,
-            min_genesis_time: 1_578_009_600, // Jan 3, 2020
+            min_genesis_time: 1606824000, // Dec 1, 2020
             hysteresis_quotient: 4,
             hysteresis_downward_multiplier: 1,
             hysteresis_upward_multiplier: 5,
@@ -324,7 +324,7 @@ impl ChainSpec {
             seconds_per_eth1_block: 14,
             deposit_chain_id: 1,
             deposit_network_id: 1,
-            deposit_contract_address: "1234567890123456789012345678901234567890"
+            deposit_contract_address: "00000000219ab540356cbb839cbe05303d7705fa"
                 .parse()
                 .expect("chain spec deposit contract address"),
 
@@ -354,6 +354,7 @@ impl ChainSpec {
             target_committee_size: 4,
             shuffle_round_count: 10,
             min_genesis_active_validator_count: 64,
+            min_genesis_time: 1578009600,
             eth1_follow_distance: 16,
             genesis_fork_version: [0x00, 0x00, 0x00, 0x01],
             shard_committee_period: 64,
@@ -366,6 +367,9 @@ impl ChainSpec {
             network_id: 2, // lighthouse testnet network id
             deposit_chain_id: 5,
             deposit_network_id: 5,
+            deposit_contract_address: "1234567890123456789012345678901234567890"
+                .parse()
+                .expect("minimal chain spec deposit address"),
             boot_nodes,
             ..ChainSpec::mainnet()
         }

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.0.0-rc.0
+TESTS_TAG := v1.0.0
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 


### PR DESCRIPTION
## Proposed Changes

Bump the EF tests from `1.0.0-rc.0` to `1.0.0`

## Additional Info

Builds on #1862
