### PR TITLE
[Merged by Bors] - do subnet discoveries until we have MESH_N_LOW many peers

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 pub const GOSSIP_MAX_SIZE: usize = 1_048_576;
 const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0, 0, 0, 0];
 const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [1, 0, 0, 0];
+pub const MESH_N_LOW: usize = 6;
 
 pub type GossipsubConfig = GenericGossipsubConfig<MessageData>;
 pub type GossipsubConfigBuilder = GenericGossipsubConfigBuilder<MessageData>;
@@ -130,7 +131,7 @@ impl Default for Config {
             .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_millis(700))
             .mesh_n(8)
-            .mesh_n_low(6)
+            .mesh_n_low(MESH_N_LOW)
             .mesh_n_high(12)
             .gossip_lazy(6)
             .fanout_ttl(Duration::from_secs(60))

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -7,7 +7,7 @@ pub use enr::{build_enr, create_enr_builder_from_config, use_or_load_enr, Combin
 pub use enr_ext::{peer_id_to_node_id, CombinedKeyExt, EnrExt};
 pub use libp2p::core::identity::{Keypair, PublicKey};
 
-use crate::metrics;
+use crate::{config, metrics};
 use crate::{error, Enr, NetworkConfig, NetworkGlobals, SubnetDiscovery};
 use discv5::{enr::NodeId, Discv5, Discv5Event};
 use enr::{BITFIELD_ENR_KEY, ETH2_ENR_KEY};
@@ -36,7 +36,7 @@ pub use subnet_predicate::subnet_predicate;
 /// Local ENR storage filename.
 pub const ENR_FILENAME: &str = "enr.dat";
 /// Target number of peers we'd like to have connected to a given long-lived subnet.
-pub const TARGET_SUBNET_PEERS: usize = 3;
+pub const TARGET_SUBNET_PEERS: usize = config::MESH_N_LOW;
 /// Target number of peers to search for given a grouped subnet query.
 const TARGET_PEERS_FOR_GROUPED_QUERY: usize = 6;
 /// Number of times to attempt a discovery request.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Increases the target peers for a subnet, so that subnet queries are executed until we have at least the minimum required peers for a mesh (`MESH_N_LOW`). We keep the limit of `6` target peers for aggregated subnet discovery queries, therefore the size (and the time needed) for a query doesn't change.