### PR TITLE
[Merged by Bors] - add slot validation to attestation_data endpoint

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1525,6 +1525,18 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
                 blocking_json_task(move || {
+                    let current_slot = chain
+                        .slot()
+                        .map_err(warp_utils::reject::beacon_chain_error)?;
+
+                    // allow a tolerance of one slot to account for clock skew
+                    if query.slot > current_slot + 1 {
+                        return Err(warp_utils::reject::custom_bad_request(format!(
+                            "request slot {} is more than one slot past the current slot {}",
+                            query.slot, current_slot
+                        )));
+                    }
+
                     chain
                         .produce_unaggregated_attestation(query.slot, query.committee_index)
                         .map(|attestation| attestation.data)

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1497,14 +1497,6 @@ impl ApiTester {
             assert_eq!(result, expected);
         }
 
-        // Ensure we don't allow queries for slots after current_slot + 1
-        self.client
-            .get_validator_attestation_data(slot + Slot::new(2), 0)
-            .await
-            .unwrap_err();
-
-        assert!(self.network_rx.try_recv().is_err());
-
         self
     }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1473,7 +1473,7 @@ impl ApiTester {
         self
     }
 
-    pub async fn test_get_validator_attestation_data(self) -> Self {
+    pub async fn test_get_validator_attestation_data(mut self) -> Self {
         let mut state = self.chain.head_beacon_state().unwrap();
         let slot = state.slot;
         state
@@ -1496,6 +1496,14 @@ impl ApiTester {
 
             assert_eq!(result, expected);
         }
+
+        // Ensure we don't allow queries for slots after current_slot + 1
+        self.client
+            .get_validator_attestation_data(slot + Slot::new(2), 0)
+            .await
+            .unwrap_err();
+
+        assert!(self.network_rx.try_recv().is_err());
 
         self
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1473,7 +1473,7 @@ impl ApiTester {
         self
     }
 
-    pub async fn test_get_validator_attestation_data(mut self) -> Self {
+    pub async fn test_get_validator_attestation_data(self) -> Self {
         let mut state = self.chain.head_beacon_state().unwrap();
         let slot = state.slot;
         state


### PR DESCRIPTION
## Issue Addressed

Resolves #1801

## Proposed Changes

Verify queries to `attestation_data` are for no later than `current_slot + 1`. If they are later than this, return a 400.
