### PR TITLE
[Merged by Bors] - Misc Peer sync info adjustments

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -136,7 +136,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         if let Some(info) = self.network_globals.peers.write().peer_info_mut(peer_id) {
             debug!(self.log, "Sending goodbye to peer"; "peer_id" => %peer_id, "reason" => %reason, "score" => %info.score());
             if matches!(reason, GoodbyeReason::IrrelevantNetwork) {
-                info.sync_status.update_irrelevant();
+                info.sync_status.update(PeerSyncStatus::IrrelevantPeer);
             }
 
             // Goodbye's are fatal

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -134,7 +134,11 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn goodbye_peer(&mut self, peer_id: &PeerId, reason: GoodbyeReason) {
         // get the peer info
         if let Some(info) = self.network_globals.peers.write().peer_info_mut(peer_id) {
-            debug!(self.log, "Sending goodbye to peer"; "peer_id" => peer_id.to_string(), "reason" => reason.to_string(), "score" => info.score().to_string());
+            debug!(self.log, "Sending goodbye to peer"; "peer_id" => %peer_id, "reason" => %reason, "score" => %info.score());
+            if matches!(reason, GoodbyeReason::IrrelevantNetwork) {
+                info.sync_status.update_irrelevant();
+            }
+
             // Goodbye's are fatal
             info.apply_peer_action_to_score(PeerAction::Fatal);
         }

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
@@ -62,7 +62,7 @@ impl PeerSyncStatus {
             false // state was not updated
         } else {
             *self = new_state;
-            false
+            true
         }
     }
 }

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -240,7 +240,7 @@ impl<TSpec: EthSpec> Service<TSpec> {
         self.swarm.report_peer(peer_id, action);
     }
 
-    // Disconnect and ban a peer, providing a reason.
+    /// Disconnect and ban a peer, providing a reason.
     pub fn goodbye_peer(&mut self, peer_id: &PeerId, reason: GoodbyeReason) {
         self.swarm.goodbye_peer(peer_id, reason);
     }

--- a/beacon_node/network/src/beacon_processor/chain_segment.rs
+++ b/beacon_node/network/src/beacon_processor/chain_segment.rs
@@ -1,7 +1,6 @@
 use crate::metrics;
-use crate::router::processor::FUTURE_SLOT_TOLERANCE;
 use crate::sync::manager::SyncMessage;
-use crate::sync::{BatchProcessResult, ChainId};
+use crate::sync::{peer_sync_info::FUTURE_SLOT_TOLERANCE, BatchProcessResult, ChainId};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, ChainSegmentResult};
 use eth2_libp2p::PeerId;
 use slog::{debug, error, trace, warn};

--- a/beacon_node/network/src/beacon_processor/chain_segment.rs
+++ b/beacon_node/network/src/beacon_processor/chain_segment.rs
@@ -1,6 +1,7 @@
 use crate::metrics;
+use crate::router::processor::FUTURE_SLOT_TOLERANCE;
 use crate::sync::manager::SyncMessage;
-use crate::sync::{peer_sync_info::FUTURE_SLOT_TOLERANCE, BatchProcessResult, ChainId};
+use crate::sync::{BatchProcessResult, ChainId};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, ChainSegmentResult};
 use eth2_libp2p::PeerId;
 use slog::{debug, error, trace, warn};

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -2,11 +2,11 @@ use crate::beacon_processor::{
     BeaconProcessor, WorkEvent as BeaconWorkEvent, MAX_WORK_EVENT_QUEUE_LEN,
 };
 use crate::service::NetworkMessage;
-use crate::sync::SyncMessage;
+use crate::sync::{peer_sync_info, SyncMessage};
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 use eth2_libp2p::rpc::*;
 use eth2_libp2p::{
-    MessageId, NetworkGlobals, PeerAction, PeerId, PeerRequestId, Request, Response,
+    MessageId, NetworkGlobals, PeerAction, PeerId, PeerRequestId, Request, Response, SyncInfo,
 };
 use itertools::process_results;
 use slog::{debug, error, o, trace, warn};
@@ -179,130 +179,60 @@ impl<T: BeaconChainTypes> Processor<T> {
         }
     }
 
-    /// Process a `Status` message, requesting new blocks if appropriate.
-    ///
-    /// Disconnects the peer if required.
+    /// Process a `Status` message to determine if a peer is relevant to us. Irrelevant peers are
+    /// disconnected; relevant peers are sent to the SyncManager
     fn process_status(
         &mut self,
         peer_id: PeerId,
-        status: StatusMessage,
+        remote: StatusMessage,
     ) -> Result<(), BeaconChainError> {
-        /*
-                let remote = PeerSyncInfo::from(status);
-                let local = match PeerSyncInfo::from_chain(&self.chain) {
-                    Some(local) => local,
-                    None => {
-                        error!(
-                            self.log,
-                            "Failed to get peer sync info";
-                            "msg" => "likely due to head lock contention"
-                        );
-                        return Err(BeaconChainError::CannotAttestToFutureState);
-                    }
-                };
+        let local = status_message(&self.chain)?;
+        let start_slot = |epoch: Epoch| epoch.start_slot(T::EthSpec::slots_per_epoch());
 
-                let start_slot = |epoch: Epoch| epoch.start_slot(T::EthSpec::slots_per_epoch());
+        let irrelevant_reason = if local.fork_digest != remote.fork_digest {
+            // The node is on a different network/fork
+            Some("Incompatible forks")
+        } else if remote.head_slot
+            > self
+                .chain
+                .slot()
+                .unwrap_or_else(|_| self.chain.slot_clock.genesis_slot())
+                + peer_sync_info::FUTURE_SLOT_TOLERANCE
+        {
+            // The remote's head is on a slot that is significantly ahead of what we consider the
+            // current slot. This could be because they are using a different genesis time, or that
+            // theirs or our system's clock is incorrect.
+            Some("Different system clocks or genesis time")
+        } else if remote.finalized_epoch <= local.finalized_epoch
+            && remote.finalized_root != Hash256::zero()
+            && local.finalized_root != Hash256::zero()
+            && self
+                .chain
+                .root_at_slot(start_slot(remote.finalized_epoch))
+                .map(|root_opt| root_opt != Some(remote.finalized_root))?
+        {
+            // The remote's finalized epoch is less than or equal to ours, but the block root is
+            // different to the one in our chain. Therefore, the node is on a different chain and we
+            // should not communicate with them.
+            Some("Different finalized chain")
+        } else {
+            None
+        };
 
-                if local.fork_digest != remote.fork_digest {
-                    // The node is on a different network/fork, disconnect them.
-                    debug!(
-                        self.log, "Handshake Failure";
-                        "peer_id" => peer_id.to_string(),
-                        "reason" => "incompatible forks",
-                        "our_fork" => hex::encode(local.fork_digest),
-                        "their_fork" => hex::encode(remote.fork_digest)
-                    );
+        if let Some(irrelevant_reason) = irrelevant_reason {
+            debug!(self.log, "Handshake Failure"; "peer" => %peer_id, "reason" => irrelevant_reason);
+            self.network
+                .goodbye_peer(peer_id, GoodbyeReason::IrrelevantNetwork);
+        } else {
+            let info = SyncInfo {
+                status_head_slot: remote.head_slot,
+                status_head_root: remote.head_root,
+                status_finalized_epoch: remote.finalized_epoch,
+                status_finalized_root: remote.finalized_root,
+            };
+            self.send_to_sync(SyncMessage::AddPeer(peer_id, info));
+        }
 
-                    self.network
-                        .goodbye_peer(peer_id, GoodbyeReason::IrrelevantNetwork);
-                } else if remote.head_slot
-                    > self
-                        .chain
-                        .slot()
-                        .unwrap_or_else(|_| self.chain.slot_clock.genesis_slot())
-                        + FUTURE_SLOT_TOLERANCE
-                {
-                    // Note: If the slot_clock cannot be read, this will not error. Other system
-                    // components will deal with an invalid slot clock error.
-
-                    // The remotes head is on a slot that is significantly ahead of ours. This could be
-                    // because they are using a different genesis time, or that theirs or our system
-                    // clock is incorrect.
-                    debug!(
-                        self.log, "Handshake Failure";
-                        "peer" => peer_id.to_string(),
-                        "reason" => "different system clocks or genesis time"
-                    );
-                    self.network
-                        .goodbye_peer(peer_id, GoodbyeReason::IrrelevantNetwork);
-                } else if remote.finalized_epoch <= local.finalized_epoch
-                    && remote.finalized_root != Hash256::zero()
-                    && local.finalized_root != Hash256::zero()
-                    && self
-                        .chain
-                        .root_at_slot(start_slot(remote.finalized_epoch))
-                        .map(|root_opt| root_opt != Some(remote.finalized_root))?
-                {
-                    // The remotes finalized epoch is less than or greater than ours, but the block root is
-                    // different to the one in our chain.
-                    //
-                    // Therefore, the node is on a different chain and we should not communicate with them.
-                    debug!(
-                        self.log, "Handshake Failure";
-                        "peer" => peer_id.to_string(),
-                        "reason" => "different finalized chain"
-                    );
-                    self.network
-                        .goodbye_peer(peer_id, GoodbyeReason::IrrelevantNetwork);
-                } else if remote.finalized_epoch < local.finalized_epoch {
-                    // The node has a lower finalized epoch, their chain is not useful to us. There are two
-                    // cases where a node can have a lower finalized epoch:
-                    //
-                    // ## The node is on the same chain
-                    //
-                    // If a node is on the same chain but has a lower finalized epoch, their head must be
-                    // lower than ours. Therefore, we have nothing to request from them.
-                    //
-                    // ## The node is on a fork
-                    //
-                    // If a node is on a fork that has a lower finalized epoch, switching to that fork would
-                    // cause us to revert a finalized block. This is not permitted, therefore we have no
-                    // interest in their blocks.
-                    debug!(
-                        self.log,
-                        "NaivePeer";
-                        "peer" => peer_id.to_string(),
-                        "reason" => "lower finalized epoch"
-                    );
-                } else if self
-                    .chain
-                    .store
-                    .item_exists::<SignedBeaconBlock<T::EthSpec>>(&remote.head_root)?
-                {
-                    debug!(
-                        self.log, "Peer with known chain found";
-                        "peer" => peer_id.to_string(),
-                        "remote_head_slot" => remote.head_slot,
-                        "remote_latest_finalized_epoch" => remote.finalized_epoch,
-                    );
-
-                    // If the node's best-block is already known to us and they are close to our current
-                    // head, treat them as a fully sync'd peer.
-                    self.send_to_sync(SyncMessage::AddPeer(peer_id, remote));
-                } else {
-                    // The remote node has an equal or great finalized epoch and we don't know it's head.
-                    //
-                    // Therefore, there are some blocks between the local finalized epoch and the remote
-                    // head that are worth downloading.
-                    debug!(
-                        self.log, "UsefulPeer";
-                        "peer" => peer_id.to_string(),
-                        "local_finalized_epoch" => local.finalized_epoch,
-                        "remote_latest_finalized_epoch" => remote.finalized_epoch,
-                    );
-                    self.send_to_sync(SyncMessage::AddPeer(peer_id, remote));
-                }
-        */
         Ok(())
     }
 

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -195,7 +195,11 @@ impl<T: BeaconChainTypes> Processor<T> {
 
         let irrelevant_reason = if local.fork_digest != remote.fork_digest {
             // The node is on a different network/fork
-            Some("Incompatible forks")
+            Some(format!(
+                "Incompatible forks Ours:{} Theirs:{}",
+                hex::encode(local.fork_digest),
+                hex::encode(remote.fork_digest)
+            ))
         } else if remote.head_slot
             > self
                 .chain
@@ -206,7 +210,7 @@ impl<T: BeaconChainTypes> Processor<T> {
             // The remote's head is on a slot that is significantly ahead of what we consider the
             // current slot. This could be because they are using a different genesis time, or that
             // their or our system's clock is incorrect.
-            Some("Different system clocks or genesis time")
+            Some("Different system clocks or genesis time".to_string())
         } else if remote.finalized_epoch <= local.finalized_epoch
             && remote.finalized_root != Hash256::zero()
             && local.finalized_root != Hash256::zero()
@@ -218,7 +222,7 @@ impl<T: BeaconChainTypes> Processor<T> {
             // The remote's finalized epoch is less than or equal to ours, but the block root is
             // different to the one in our chain. Therefore, the node is on a different chain and we
             // should not communicate with them.
-            Some("Different finalized chain")
+            Some("Different finalized chain".to_string())
         } else {
             None
         };

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -277,7 +277,8 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         self.update_peer_sync_state(&peer_id, &local, &remote, &sync_type);
 
         if matches!(sync_type, PeerSyncType::Advanced) {
-            self.range_sync.add_peer(&mut self.network, local, peer_id, remote);
+            self.range_sync
+                .add_peer(&mut self.network, local, peer_id, remote);
         }
 
         self.update_sync_state();

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -3,7 +3,7 @@
 //! Stores the various syncing methods for the beacon chain.
 pub mod manager;
 mod network_context;
-pub mod peer_sync_info;
+mod peer_sync_info;
 mod range_sync;
 
 pub use manager::{BatchProcessResult, SyncMessage};

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -3,11 +3,10 @@
 //! Stores the various syncing methods for the beacon chain.
 pub mod manager;
 mod network_context;
-mod peer_sync_info;
+pub mod peer_sync_info;
 mod range_sync;
 
 pub use manager::{BatchProcessResult, SyncMessage};
-pub use peer_sync_info::PeerSyncInfo;
 pub use range_sync::ChainId;
 
 /// Type of id of rpc requests sent by sync

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -63,7 +63,7 @@ impl<T: EthSpec> SyncNetworkContext<T> {
         chain: Arc<BeaconChain<U>>,
         peers: impl Iterator<Item = PeerId>,
     ) {
-        if let Some(status_message) = status_message(&chain) {
+        if let Ok(status_message) = status_message(&chain) {
             for peer_id in peers {
                 debug!(
                     self.log,

--- a/beacon_node/network/src/sync/peer_sync_info.rs
+++ b/beacon_node/network/src/sync/peer_sync_info.rs
@@ -1,21 +1,17 @@
 use super::manager::SLOT_IMPORT_TOLERANCE;
-use crate::router::processor::status_message;
-use beacon_chain::{BeaconChain, BeaconChainTypes};
-use eth2_libp2p::rpc::*;
-use eth2_libp2p::SyncInfo;
+use crate::router::processor::status_message as local_status;
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use eth2_libp2p::{rpc::StatusMessage, PeerSyncStatus, SyncInfo};
+use slot_clock::SlotClock;
 use std::ops::Sub;
 use std::sync::Arc;
-use types::{Epoch, Hash256, Slot};
+use types::{Epoch, EthSpec, Hash256, Slot};
 
-/// Keeps track of syncing information for known connected peers.
-#[derive(Clone, Copy, Debug)]
-pub struct PeerSyncInfo {
-    pub fork_digest: [u8; 4],
-    pub finalized_root: Hash256,
-    pub finalized_epoch: Epoch,
-    pub head_root: Hash256,
-    pub head_slot: Slot,
-}
+/// If a block is more than `FUTURE_SLOT_TOLERANCE` slots ahead of our slot clock, we drop it.
+/// Otherwise we queue it.
+pub(crate) const FUTURE_SLOT_TOLERANCE: u64 = 1;
+
+type IrrelevantPeerReason = String;
 
 /// The type of peer relative to our current state.
 pub enum PeerSyncType {
@@ -27,82 +23,168 @@ pub enum PeerSyncType {
     Behind,
 }
 
-impl From<StatusMessage> for PeerSyncInfo {
-    fn from(status: StatusMessage) -> PeerSyncInfo {
-        PeerSyncInfo {
-            fork_digest: status.fork_digest,
-            finalized_root: status.finalized_root,
-            finalized_epoch: status.finalized_epoch,
-            head_root: status.head_root,
-            head_slot: status.head_slot,
-        }
+pub fn remote_sync_status<T: BeaconChainTypes>(
+    chain: &BeaconChain<T>,
+    remote: StatusMessage,
+) -> Result<Result<(SyncInfo, PeerSyncType), IrrelevantPeerReason>, BeaconChainError> {
+    let local = local_status(chain)?;
+
+    if let Some(irrelevant_reason) = remote_irrelevant_reason(&local, &remote, chain)? {
+        return Ok(Err(irrelevant_reason));
+    }
+
+    let sync_type = if is_synced_peer(&local, &remote, chain)? {
+        PeerSyncType::FullySynced
+    } else if is_advanced_peer(&local, &remote)? {
+        PeerSyncType::FullySynced
+    } else {
+        PeerSyncType::Behind
+    };
+
+    let sync_info = SyncInfo {
+        status_head_slot: remote.head_slot,
+        status_head_root: remote.head_root,
+        status_finalized_epoch: remote.finalized_epoch,
+        status_finalized_root: remote.finalized_root,
+    };
+
+    Ok(Ok((sync_info, sync_type)))
+}
+
+fn remote_irrelevant_reason<T: BeaconChainTypes>(
+    local: &StatusMessage,
+    remote: &StatusMessage,
+    chain: &BeaconChain<T>,
+) -> Result<Option<IrrelevantPeerReason>, BeaconChainError> {
+    let start_slot = |epoch: Epoch| epoch.start_slot(T::EthSpec::slots_per_epoch());
+
+    let reason = if local.fork_digest != remote.fork_digest {
+        // The node is on a different network/fork
+        Some(format!(
+            "Incompatible forks: ours:{} theirs:{}",
+            hex::encode(local.fork_digest),
+            hex::encode(remote.fork_digest)
+        ))
+    } else if remote.head_slot
+        > chain
+            .slot()
+            .unwrap_or_else(|_| chain.slot_clock.genesis_slot())
+            + FUTURE_SLOT_TOLERANCE
+    {
+        // The remotes head is on a slot that is significantly ahead of what we consider the
+        // current slot. This could be because they are using a different genesis time, or that
+        // theirs or our systems' clock is incorrect.
+        Some("different system clocks or genesis time".to_string())
+    } else if remote.finalized_epoch <= local.finalized_epoch
+        && remote.finalized_root != Hash256::zero()
+        && local.finalized_root != Hash256::zero()
+        && chain
+            .root_at_slot(start_slot(remote.finalized_epoch))
+            .map(|root_opt| root_opt != Some(remote.finalized_root))?
+    {
+        // The remotes finalized epoch is less than or greater than ours, but the block root is
+        // different to the one in our chain. Therefore, the node is on a different chain and we
+        // should not communicate with them.
+        Some("different finalized chain".to_string())
+    } else {
+        None
+    };
+
+    Ok(reason)
+}
+
+fn is_synced_peer<T: BeaconChainTypes>(
+    local: &StatusMessage,
+    remote: &StatusMessage,
+    chain: &BeaconChain<T>,
+) -> Result<bool, BeaconChainError> {
+    // we consider synced a peer for which we have already synced their best slot, or that is near our head
+    if chain.fork_choice.read().contains_block(&remote.head_root) {
+        return Ok(true);
+    }
+
+    if local.finalized_epoch == remote.finalized_epoch // our finalized epoch matches
+
+
+
+        && local.finalized_root == remote.finalized_root // our finalized hash matches
+                            // And is near our head
+        && (
+            // Either we are slightly ahead of this peer
+            (local.head_slot >= remote.head_slot
+            && local.head_slot.sub(remote.head_slot
+
+                ).as_usize() <= SLOT_IMPORT_TOLERANCE)
+            // Or this peer is slightly ahead of us
+            || (local.head_slot < remote.head_slot
+                && remote.head_slot.sub(local.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
+        )
+    {
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn is_advanced_peer(
+    local_status: &StatusMessage,
+    remote_status: &StatusMessage,
+) -> Result<bool, BeaconChainError> {
+    unimplemented!()
+}
+/*
+/// Derives the peer sync information from a beacon chain.
+pub fn from_chain<T: BeaconChainTypes>(chain: &Arc<BeaconChain<T>>) -> Option<PeerSyncInfo> {
+    Some(Self::from(status_message(chain)?))
+}
+
+/// Given another peer's `PeerSyncInfo` this will determine how useful that peer is to us in
+/// regards to syncing. This returns the peer sync type that can then be handled by the
+/// `SyncManager`.
+pub fn peer_sync_type(&self, remote_peer_sync_info: &PeerSyncInfo) -> PeerSyncType {
+    // check if the peer is fully synced with our current chain
+    if self.is_fully_synced_peer(remote_peer_sync_info) {
+        PeerSyncType::FullySynced
+    }
+    // if not, check if the peer is ahead of our chain
+    else if self.is_advanced_peer(remote_peer_sync_info) {
+        PeerSyncType::Advanced
+    } else {
+        // the peer must be behind and not useful
+        PeerSyncType::Behind
     }
 }
 
-impl Into<SyncInfo> for PeerSyncInfo {
-    fn into(self) -> SyncInfo {
-        SyncInfo {
-            status_head_slot: self.head_slot,
-            status_head_root: self.head_root,
-            status_finalized_epoch: self.finalized_epoch,
-            status_finalized_root: self.finalized_root,
-        }
-    }
-}
-
-impl PeerSyncInfo {
-    /// Derives the peer sync information from a beacon chain.
-    pub fn from_chain<T: BeaconChainTypes>(chain: &Arc<BeaconChain<T>>) -> Option<PeerSyncInfo> {
-        Some(Self::from(status_message(chain)?))
-    }
-
-    /// Given another peer's `PeerSyncInfo` this will determine how useful that peer is to us in
-    /// regards to syncing. This returns the peer sync type that can then be handled by the
-    /// `SyncManager`.
-    pub fn peer_sync_type(&self, remote_peer_sync_info: &PeerSyncInfo) -> PeerSyncType {
-        // check if the peer is fully synced with our current chain
-        if self.is_fully_synced_peer(remote_peer_sync_info) {
-            PeerSyncType::FullySynced
-        }
-        // if not, check if the peer is ahead of our chain
-        else if self.is_advanced_peer(remote_peer_sync_info) {
-            PeerSyncType::Advanced
-        } else {
-            // the peer must be behind and not useful
-            PeerSyncType::Behind
-        }
-    }
-
-    /// Determines if another peer is fully synced with the current peer.
-    ///
-    /// A fully synced peer is a peer whose finalized epoch and hash match our own and their
-    /// head is within SLOT_IMPORT_TOLERANCE of our own.
-    /// In this case we ignore any batch/range syncing.
-    fn is_fully_synced_peer(&self, remote: &PeerSyncInfo) -> bool {
-        // ensure we are on the same chain, with minor differing heads
-        if remote.finalized_epoch == self.finalized_epoch
-            && remote.finalized_root == self.finalized_root
+/// Determines if another peer is fully synced with the current peer.
+///
+/// A fully synced peer is a peer whose finalized epoch and hash match our own and their
+/// head is within SLOT_IMPORT_TOLERANCE of our own.
+/// In this case we ignore any batch/range syncing.
+fn is_fully_synced_peer(&self, remote: &PeerSyncInfo) -> bool {
+    // ensure we are on the same chain, with minor differing heads
+    if remote.finalized_epoch == self.finalized_epoch
+        && remote.finalized_root == self.finalized_root
+    {
+        // that we are within SLOT_IMPORT_TOLERANCE of our two heads
+        if (self.head_slot >= remote.head_slot
+            && self.head_slot.sub(remote.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
+            || (self.head_slot < remote.head_slot
+                && remote.head_slot.sub(self.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
         {
-            // that we are within SLOT_IMPORT_TOLERANCE of our two heads
-            if (self.head_slot >= remote.head_slot
-                && self.head_slot.sub(remote.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
-                || (self.head_slot < remote.head_slot
-                    && remote.head_slot.sub(self.head_slot).as_usize() <= SLOT_IMPORT_TOLERANCE)
-            {
-                return true;
-            }
+            return true;
         }
-        false
     }
-
-    /// Determines if a peer has more knowledge about the current chain than we do.
-    ///
-    /// There are two conditions here.
-    /// 1) The peer could have a head slot that is greater
-    /// than SLOT_IMPORT_TOLERANCE of our current head.
-    /// 2) The peer has a greater finalized slot/epoch than our own.
-    fn is_advanced_peer(&self, remote: &PeerSyncInfo) -> bool {
-        remote.head_slot.sub(self.head_slot).as_usize() > SLOT_IMPORT_TOLERANCE
-            || self.finalized_epoch < remote.finalized_epoch
-    }
+    false
 }
+
+/// Determines if a peer has more knowledge about the current chain than we do.
+///
+/// There are two conditions here.
+/// 1) The peer could have a head slot that is greater
+/// than SLOT_IMPORT_TOLERANCE of our current head.
+/// 2) The peer has a greater finalized slot/epoch than our own.
+fn is_advanced_peer(&self, remote: &PeerSyncInfo) -> bool {
+    remote.head_slot.sub(self.head_slot).as_usize() > SLOT_IMPORT_TOLERANCE
+        || self.finalized_epoch < remote.finalized_epoch
+}
+*/

--- a/beacon_node/network/src/sync/peer_sync_info.rs
+++ b/beacon_node/network/src/sync/peer_sync_info.rs
@@ -71,14 +71,13 @@ pub fn remote_sync_type<T: BeaconChainTypes>(
             }
         }
         Ordering::Greater => {
-            if local.finalized_epoch + 1 == remote.finalized_epoch
+            if (local.finalized_epoch + 1 == remote.finalized_epoch
                 && near_range_start <= remote.head_slot
-                && remote.head_slot <= near_range_end
+                && remote.head_slot <= near_range_end)
+                || chain.fork_choice.read().contains_block(&remote.head_root)
             {
-                // This peer is near enough to us to be considered synced.
-                PeerSyncType::FullySynced
-            } else if chain.fork_choice.read().contains_block(&remote.head_root) {
-                // We have already synced up to this peer's head
+                // This peer is near enough to us to be considered synced, or
+                // we have already synced up to this peer's head
                 PeerSyncType::FullySynced
             } else {
                 PeerSyncType::Advanced

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -7,9 +7,9 @@ use super::chain::{ChainId, ProcessingResult, RemoveChain, SyncingChain};
 use super::sync_type::RangeSyncType;
 use crate::beacon_processor::WorkEvent as BeaconWorkEvent;
 use crate::sync::network_context::SyncNetworkContext;
-use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::PeerId;
+use eth2_libp2p::SyncInfo;
 use fnv::FnvHashMap;
 use slog::{crit, debug, error};
 use smallvec::SmallVec;
@@ -185,11 +185,12 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     pub fn update(
         &mut self,
         network: &mut SyncNetworkContext<T::EthSpec>,
-        awaiting_head_peers: &mut HashMap<PeerId, PeerSyncInfo>,
+        awaiting_head_peers: &mut HashMap<PeerId, SyncInfo>,
         beacon_processor_send: &mpsc::Sender<BeaconWorkEvent<T::EthSpec>>,
     ) {
+        /*
         let (local_finalized_epoch, local_head_epoch) =
-            match PeerSyncInfo::from_chain(&self.beacon_chain) {
+            match SyncInfo::from_chain(&self.beacon_chain) {
                 None => {
                     return error!(
                         self.log,
@@ -219,6 +220,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
                 beacon_processor_send,
             );
         }
+        */
     }
 
     pub fn state(&self) -> Result<Option<(RangeSyncType, Slot /* from */, Slot /* to */)>, String> {
@@ -329,7 +331,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         network: &mut SyncNetworkContext<T::EthSpec>,
         local_epoch: Epoch,
         local_head_epoch: Epoch,
-        awaiting_head_peers: &mut HashMap<PeerId, PeerSyncInfo>,
+        awaiting_head_peers: &mut HashMap<PeerId, SyncInfo>,
         beacon_processor_send: &mpsc::Sender<BeaconWorkEvent<T::EthSpec>>,
     ) {
         // Include the awaiting head peers
@@ -337,8 +339,8 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
             debug!(self.log, "including head peer");
             self.add_peer_or_create_chain(
                 local_epoch,
-                peer_sync_info.head_root,
-                peer_sync_info.head_slot,
+                peer_sync_info.status_head_root,
+                peer_sync_info.status_head_slot,
                 peer_id,
                 RangeSyncType::Head,
                 beacon_processor_send,
@@ -402,11 +404,9 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
     /// Removes any outdated finalized or head chains.
     /// This removes chains with no peers, or chains whose start block slot is less than our current
     /// finalized block slot. Peers that would create outdated chains are removed too.
-    pub fn purge_outdated_chains(
-        &mut self,
-        awaiting_head_peers: &mut HashMap<PeerId, PeerSyncInfo>,
-    ) {
-        let local_info = match PeerSyncInfo::from_chain(&self.beacon_chain) {
+    pub fn purge_outdated_chains(&mut self, awaiting_head_peers: &mut HashMap<PeerId, SyncInfo>) {
+        /*
+        let local_info = match SyncInfo::from_chain(&self.beacon_chain) {
             Some(local) => local,
             None => {
                 return error!(
@@ -463,6 +463,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         for (id, was_syncing) in removed_chains {
             self.on_chain_removed(&id, was_syncing);
         }
+        */
     }
 
     /// Adds a peer to a chain with the given target, or creates a new syncing chain if it doesn't

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -1,8 +1,9 @@
 //! Contains logic about identifying which Sync to perform given PeerSyncInfo of ourselves and
 //! of a remote.
 
-use crate::sync::PeerSyncInfo;
+// use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
+use eth2_libp2p::SyncInfo;
 use std::sync::Arc;
 
 /// The type of Range sync that should be done relative to our current state.
@@ -19,8 +20,8 @@ impl RangeSyncType {
     /// `PeerSyncInfo`.
     pub fn new<T: BeaconChainTypes>(
         chain: &Arc<BeaconChain<T>>,
-        local_info: &PeerSyncInfo,
-        remote_info: &PeerSyncInfo,
+        local_info: &SyncInfo,
+        remote_info: &SyncInfo,
     ) -> RangeSyncType {
         // Check for finalized chain sync
         //
@@ -28,11 +29,11 @@ impl RangeSyncType {
         // -  The remotes finalized epoch is greater than our current finalized epoch and we have
         //    not seen the finalized hash before.
 
-        if remote_info.finalized_epoch > local_info.finalized_epoch
+        if remote_info.status_finalized_epoch > local_info.status_finalized_epoch
             && !chain
                 .fork_choice
                 .read()
-                .contains_block(&remote_info.finalized_root)
+                .contains_block(&remote_info.status_finalized_root)
         {
             RangeSyncType::Finalized
         } else {

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -1,7 +1,6 @@
 //! Contains logic about identifying which Sync to perform given PeerSyncInfo of ourselves and
 //! of a remote.
 
-// use crate::sync::PeerSyncInfo;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2_libp2p::SyncInfo;
 use std::sync::Arc;

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -29,11 +29,11 @@ impl RangeSyncType {
         // -  The remotes finalized epoch is greater than our current finalized epoch and we have
         //    not seen the finalized hash before.
 
-        if remote_info.status_finalized_epoch > local_info.status_finalized_epoch
+        if remote_info.finalized_epoch > local_info.finalized_epoch
             && !chain
                 .fork_choice
                 .read()
-                .contains_block(&remote_info.status_finalized_root)
+                .contains_block(&remote_info.finalized_root)
         {
             RangeSyncType::Finalized
         } else {


### PR DESCRIPTION
## Issue Addressed
#1856 

## Proposed Changes
- For clarity, the router's processor now only decides if a peer is compatible and it disconnects it or sends it to sync accordingly. No logic here regarding how useful is the peer. 
- Update peer_sync_info's rules
- Add an `IrrelevantPeer` sync status to account for incompatible peers (maybe this should be "IncompatiblePeer" now that I think about it?) this state is update upon receiving an internal goodbye in the peer manager
- Misc code cleanups
- Reduce the need to create `StatusMessage`s (and thus, `Arc` accesses )
- Add missing calls to update the global sync state

The overall effect should be:
- More peers recognized as Behind, and less as Unknown
- Peers identified as incompatible