### PR TITLE
[Merged by Bors] - Update pool/attestations and committees endpoints

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -901,7 +901,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("pool"))
         .and(chain_filter.clone());
 
-    //TODO: fix error handling, update to accept an array
     // POST beacon/pool/attestations
     let post_beacon_pool_attestations = beacon_pool_path
         .clone()
@@ -990,72 +989,6 @@ pub fn serve<T: BeaconChainTypes>(
                 })
             },
         );
-
-    // // Verify that all messages in the post are valid before processing further
-    // for (index, aggregate) in aggregates.as_slice().iter().enumerate() {
-    //     match chain.verify_aggregated_attestation_for_gossip(aggregate.clone()) {
-    //         Ok(verified_aggregate) => {
-    //             messages.push(PubsubMessage::AggregateAndProofAttestation(Box::new(
-    //                 verified_aggregate.aggregate().clone(),
-    //             )));
-    //             verified_aggregates.push((index, verified_aggregate));
-    //         }
-    //         // If we already know the attestation, don't broadcast it or attempt to
-    //         // further verify it. Return success.
-    //         //
-    //         // It's reasonably likely that two different validators produce
-    //         // identical aggregates, especially if they're using the same beacon
-    //         // node.
-    //         Err(AttnError::AttestationAlreadyKnown(_)) => continue,
-    //         Err(e) => {
-    //             error!(log,
-    //                                 "Failure verifying aggregate and proofs";
-    //                                 "error" => format!("{:?}", e),
-    //                                 "request_index" => index,
-    //                                 "aggregator_index" => aggregate.message.aggregator_index,
-    //                                 "attestation_index" => aggregate.message.aggregate.data.index,
-    //                                 "attestation_slot" => aggregate.message.aggregate.data.slot,
-    //                             );
-    //             failures.push(api_types::Failure::new(index, format!("Verification: {:?}", e)));
-    //         },
-    //     }
-    // }
-    //
-    // // Publish aggregate attestations to the libp2p network
-    // if !messages.is_empty() {
-    //     publish_network_message(&network_tx, NetworkMessage::Publish { messages })?;
-    // }
-    //
-    // // Import aggregate attestations
-    // for (index, verified_aggregate) in verified_aggregates {
-    //     if let Err(e) = chain.apply_attestation_to_fork_choice(&verified_aggregate) {
-    //         error!(log,
-    //                                 "Failure applying verified aggregate attestation to fork choice";
-    //                                 "error" => format!("{:?}", e),
-    //                                 "request_index" => index,
-    //                                 "aggregator_index" => verified_aggregate.aggregate().message.aggregator_index,
-    //                                 "attestation_index" => verified_aggregate.attestation().data.index,
-    //                                 "attestation_slot" => verified_aggregate.attestation().data.slot,
-    //                             );
-    //         failures.push(api_types::Failure::new(index, format!("Fork choice: {:?}", e)));
-    //     }
-    //     if let Err(e) = chain.add_to_block_inclusion_pool(verified_aggregate) {
-    //         warn!(log,
-    //                                 "Could not add verified aggregate attestation to the inclusion pool";
-    //                                 "error" => format!("{:?}", e),
-    //                                 "request_index" => index,
-    //                             );
-    //         failures.push(api_types::Failure::new(index, format!("Op pool: {:?}", e)));
-    //     }
-    // }
-    //
-    // if !failures.is_empty() {
-    //     Err(warp_utils::reject::indexed_bad_request("error processing aggregate and proofs".to_string(),
-    //                                                 failures
-    //     ))
-    // } else {
-    //     Ok(())
-    // }
 
     // GET beacon/pool/attestations?committee_index,slot
     let get_beacon_pool_attestations = beacon_pool_path

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -607,7 +607,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(
             |state_id: StateId, chain: Arc<BeaconChain<T>>, query: api_types::CommitteesQuery| {
-
                 // the api spec says if the epoch is not present then the epoch of the state should be used
                 let query_state_id = query.epoch.map_or(state_id, |epoch| {
                     StateId::slot(epoch.start_slot(T::EthSpec::slots_per_epoch()))

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -954,7 +954,7 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
-    // GET beacon/pool/attestations
+    // GET beacon/pool/attestations?committee_index,slot
     let get_beacon_pool_attestations = beacon_pool_path
         .clone()
         .and(warp::path("attestations"))

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -924,7 +924,7 @@ impl ApiTester {
     pub async fn test_get_beacon_pool_attestations(self) -> Self {
         let result = self
             .client
-            .get_beacon_pool_attestations()
+            .get_beacon_pool_attestations(None, None)
             .await
             .unwrap()
             .data;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -625,9 +625,7 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let mut state_opt = self.get_state(state_id);
 
-            let epoch_opt = state_opt
-                .as_ref()
-                .map(|state| state.current_epoch());
+            let epoch_opt = state_opt.as_ref().map(|state| state.current_epoch());
             let results = self
                 .client
                 .get_beacon_states_committees(state_id, None, None, epoch_opt)

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -632,7 +632,7 @@ impl ApiTester {
 
             let results = self
                 .client
-                .get_beacon_states_committees(state_id, epoch, None, None)
+                .get_beacon_states_committees(state_id, None, None, Some(epoch))
                 .await
                 .unwrap()
                 .map(|res| res.data);

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -625,14 +625,12 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let mut state_opt = self.get_state(state_id);
 
-            let epoch = state_opt
+            let epoch_opt = state_opt
                 .as_ref()
-                .map(|state| state.current_epoch())
-                .unwrap_or_else(|| Epoch::new(0));
-
+                .map(|state| state.current_epoch());
             let results = self
                 .client
-                .get_beacon_states_committees(state_id, None, None, Some(epoch))
+                .get_beacon_states_committees(state_id, None, None, epoch_opt)
                 .await
                 .unwrap()
                 .map(|res| res.data);
@@ -642,11 +640,10 @@ impl ApiTester {
             }
 
             let state = state_opt.as_mut().expect("result should be none");
+
             state.build_all_committee_caches(&self.chain.spec).unwrap();
             let committees = state
-                .get_beacon_committees_at_epoch(
-                    RelativeEpoch::from_epoch(state.current_epoch(), epoch).unwrap(),
-                )
+                .get_beacon_committees_at_epoch(RelativeEpoch::Current)
                 .unwrap();
 
             for (i, result) in results.unwrap().into_iter().enumerate() {

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -335,6 +335,22 @@ impl<T: EthSpec> OperationPool<T> {
             .collect()
     }
 
+    /// Returns all known `Attestation` objects that pass the provided filter.
+    ///
+    /// This method may return objects that are invalid for block inclusion.
+    pub fn get_filtered_attestations<F>(&self, filter: F) -> Vec<Attestation<T>>
+    where
+        F: Fn(&Attestation<T>) -> bool,
+    {
+        self.attestations
+            .read()
+            .iter()
+            .map(|(_, attns)| attns.iter().cloned())
+            .flatten()
+            .filter(filter)
+            .collect()
+    }
+
     /// Returns all known `AttesterSlashing` objects.
     ///
     /// This method may return objects that are invalid for block inclusion.

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -497,6 +497,8 @@ impl BeaconNodeHttpClient {
     /// `GET beacon/pool/attestations`
     pub async fn get_beacon_pool_attestations<T: EthSpec>(
         &self,
+        slot: Option<Slot>,
+        committee_index: Option<u64>,
     ) -> Result<GenericResponse<Vec<Attestation<T>>>, Error> {
         let mut path = self.eth_path()?;
 
@@ -505,6 +507,16 @@ impl BeaconNodeHttpClient {
             .push("beacon")
             .push("pool")
             .push("attestations");
+
+        if let Some(slot) = slot {
+            path.query_pairs_mut()
+                .append_pair("slot", &slot.to_string());
+        }
+
+        if let Some(index) = committee_index {
+            path.query_pairs_mut()
+                .append_pair("committee_index", &index.to_string());
+        }
 
         self.get(path).await
     }

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -494,7 +494,7 @@ impl BeaconNodeHttpClient {
         Ok(())
     }
 
-    /// `GET beacon/pool/attestations`
+    /// `GET beacon/pool/attestations?slot,committee_index`
     pub async fn get_beacon_pool_attestations<T: EthSpec>(
         &self,
         slot: Option<Slot>,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -301,15 +301,15 @@ impl BeaconNodeHttpClient {
         self.get_opt(path).await
     }
 
-    /// `GET beacon/states/{state_id}/committees?slot,index`
+    /// `GET beacon/states/{state_id}/committees?slot,index,epoch`
     ///
     /// Returns `Ok(None)` on a 404 error.
     pub async fn get_beacon_states_committees(
         &self,
         state_id: StateId,
-        epoch: Epoch,
         slot: Option<Slot>,
         index: Option<u64>,
+        epoch: Option<Epoch>,
     ) -> Result<Option<GenericResponse<Vec<CommitteeData>>>, Error> {
         let mut path = self.eth_path()?;
 
@@ -318,8 +318,7 @@ impl BeaconNodeHttpClient {
             .push("beacon")
             .push("states")
             .push(&state_id.to_string())
-            .push("committees")
-            .push(&epoch.to_string());
+            .push("committees");
 
         if let Some(slot) = slot {
             path.query_pairs_mut()
@@ -329,6 +328,11 @@ impl BeaconNodeHttpClient {
         if let Some(index) = index {
             path.query_pairs_mut()
                 .append_pair("index", &index.to_string());
+        }
+
+        if let Some(epoch) = epoch {
+            path.query_pairs_mut()
+                .append_pair("epoch", &epoch.to_string());
         }
 
         self.get_opt(path).await

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -479,7 +479,7 @@ impl BeaconNodeHttpClient {
     /// `POST beacon/pool/attestations`
     pub async fn post_beacon_pool_attestations<T: EthSpec>(
         &self,
-        attestation: &Attestation<T>,
+        attestations: &[Attestation<T>],
     ) -> Result<(), Error> {
         let mut path = self.eth_path()?;
 
@@ -489,7 +489,14 @@ impl BeaconNodeHttpClient {
             .push("pool")
             .push("attestations");
 
-        self.post(path, attestation).await?;
+        let response = self
+            .client
+            .post(path)
+            .json(attestations)
+            .send()
+            .await
+            .map_err(Error::Reqwest)?;
+        ok_or_indexed_error(response).await?;
 
         Ok(())
     }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -351,6 +351,12 @@ pub struct CommitteesQuery {
     pub index: Option<u64>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct AttestationPoolQuery {
+    pub slot: Option<Slot>,
+    pub committee_index: Option<u64>,
+}
+
 #[derive(Deserialize)]
 pub struct ValidatorsQuery {
     pub id: Option<QueryVec<ValidatorId>>,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -349,6 +349,7 @@ impl fmt::Display for ValidatorStatus {
 pub struct CommitteesQuery {
     pub slot: Option<Slot>,
     pub index: Option<u64>,
+    pub epoch: Option<Epoch>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
## Issue Addressed

Catching up on a few eth2 spec updates:

## Proposed Changes

- adding query params to the `GET pool/attestations` endpoint
- allowing the `POST pool/attestations` endpoint to accept an array of attestations
    - batching attestation submission
- moving `epoch` from a path param to a query param in the `committees` endpoint

## Additional Info
