### PR TITLE
[Merged by Bors] - Update logs + do not downscore peers if WE time out

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -679,7 +679,11 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         match message.event {
             Err(handler_err) => {
                 match handler_err {
-                    HandlerErr::Inbound { id, proto, error } => {
+                    HandlerErr::Inbound {
+                        id: _,
+                        proto,
+                        error,
+                    } => {
                         if matches!(error, RPCError::HandlerRejected) {
                             // this peer's request got canceled
                         }

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1,5 +1,5 @@
 use crate::behaviour::gossipsub_scoring_parameters::PeerScoreSettings;
-use crate::peer_manager::{score::PeerAction, PeerManager, PeerManagerEvent};
+use crate::peer_manager::{score::PeerAction, ConnectionDirection, PeerManager, PeerManagerEvent};
 use crate::rpc::*;
 use crate::service::METADATA_FILENAME;
 use crate::types::{GossipEncoding, GossipKind, GossipTopic, MessageData, SubnetDiscovery};
@@ -70,8 +70,6 @@ pub enum BehaviourEvent<TSpec: EthSpec> {
         id: RequestId,
         /// The peer to which this request was sent.
         peer_id: PeerId,
-        /// The error that occurred.
-        error: RPCError,
     },
     RequestReceived {
         /// The peer that sent the request.
@@ -681,25 +679,31 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         match message.event {
             Err(handler_err) => {
                 match handler_err {
-                    HandlerErr::Inbound {
-                        id: _,
-                        proto,
-                        error,
-                    } => {
+                    HandlerErr::Inbound { id, proto, error } => {
                         if matches!(error, RPCError::HandlerRejected) {
                             // this peer's request got canceled
                         }
                         // Inform the peer manager of the error.
                         // An inbound error here means we sent an error to the peer, or the stream
                         // timed out.
-                        self.peer_manager.handle_rpc_error(&peer_id, proto, &error);
+                        self.peer_manager.handle_rpc_error(
+                            &peer_id,
+                            proto,
+                            &error,
+                            ConnectionDirection::Incoming,
+                        );
                     }
                     HandlerErr::Outbound { id, proto, error } => {
                         // Inform the peer manager that a request we sent to the peer failed
-                        self.peer_manager.handle_rpc_error(&peer_id, proto, &error);
+                        self.peer_manager.handle_rpc_error(
+                            &peer_id,
+                            proto,
+                            &error,
+                            ConnectionDirection::Outgoing,
+                        );
                         // inform failures of requests comming outside the behaviour
                         if !matches!(id, RequestId::Behaviour) {
-                            self.add_event(BehaviourEvent::RPCFailed { peer_id, id, error });
+                            self.add_event(BehaviourEvent::RPCFailed { peer_id, id });
                         }
                     }
                 }

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -354,10 +354,17 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     /// An error has occured in the RPC.
     ///
     /// This adjusts a peer's score based on the error.
-    pub fn handle_rpc_error(&mut self, peer_id: &PeerId, protocol: Protocol, err: &RPCError) {
+    pub fn handle_rpc_error(
+        &mut self,
+        peer_id: &PeerId,
+        protocol: Protocol,
+        err: &RPCError,
+        direction: ConnectionDirection,
+    ) {
         let client = self.network_globals.client(peer_id);
         let score = self.network_globals.peers.read().score(peer_id);
-        debug!(self.log, "RPC Error"; "protocol" => protocol.to_string(), "err" => err.to_string(), "client" => client.to_string(), "peer_id" => peer_id.to_string(), "score" => score.to_string());
+        debug!(self.log, "RPC Error"; "protocol" => %protocol, "err" => %err, "client" => %client,
+            "peer_id" => %peer_id, "score" => %score, "direction" => ?direction);
 
         // Map this error to a `PeerAction` (if any)
         let peer_action = match err {

--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -14,7 +14,7 @@ use libp2p::swarm::protocols_handler::{
     KeepAlive, ProtocolsHandler, ProtocolsHandlerEvent, ProtocolsHandlerUpgrErr, SubstreamProtocol,
 };
 use libp2p::swarm::NegotiatedSubstream;
-use slog::{crit, debug, warn};
+use slog::{crit, debug, trace, warn};
 use smallvec::SmallVec;
 use std::{
     collections::hash_map::Entry,
@@ -287,9 +287,8 @@ where
         } else {
             if !matches!(response, RPCCodedResponse::StreamTermination(..)) {
                 // the stream is closed after sending the expected number of responses
-                warn!(self.log, "Inbound stream has expired, response not sent";
-                    "response" => %response, "id" => inbound_id,
-                    "msg" => "Likely too many resources, reduce peer count");
+                trace!(self.log, "Inbound stream has expired, response not sent";
+                    "response" => %response, "id" => inbound_id);
             }
             return;
         };

--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -238,7 +238,9 @@ where
     /// Initiates the handler's shutdown process, sending an optional last message to the peer.
     pub fn shutdown(&mut self, final_msg: Option<(RequestId, RPCRequest<TSpec>)>) {
         if matches!(self.state, HandlerState::Active) {
-            debug!(self.log, "Starting handler shutdown"; "unsent_queued_requests" => self.dial_queue.len());
+            if !self.dial_queue.is_empty() {
+                debug!(self.log, "Starting handler shutdown"; "unsent_queued_requests" => self.dial_queue.len());
+            }
             // we now drive to completion communications already dialed/established
             while let Some((id, req)) = self.dial_queue.pop() {
                 self.pending_errors.push(HandlerErr::Outbound {
@@ -283,8 +285,12 @@ where
         let inbound_info = if let Some(info) = self.inbound_substreams.get_mut(&inbound_id) {
             info
         } else {
-            warn!(self.log, "Inbound stream has expired, response not sent";
-                "response" => response.to_string(), "id" => inbound_id, "msg" => "Likely too many resources, reduce peer count");
+            if !matches!(response, RPCCodedResponse::StreamTermination(..)) {
+                // the stream is closed after sending the expected number of responses
+                warn!(self.log, "Inbound stream has expired, response not sent";
+                    "response" => %response, "id" => inbound_id,
+                    "msg" => "Likely too many resources, reduce peer count");
+            }
             return;
         };
 

--- a/beacon_node/eth2_libp2p/src/rpc/methods.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/methods.rs
@@ -392,6 +392,22 @@ impl std::fmt::Display for BlocksByRangeRequest {
     }
 }
 
+impl slog::KV for StatusMessage {
+    fn serialize(
+        &self,
+        record: &slog::Record,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        use slog::Value;
+        serializer.emit_str("fork_digest", &format!("{:?}", self.fork_digest))?;
+        Value::serialize(&self.finalized_epoch, record, "finalized_epoch", serializer)?;
+        serializer.emit_str("finalized_root", &self.finalized_root.to_string())?;
+        Value::serialize(&self.head_slot, record, "head_slot", serializer)?;
+        serializer.emit_str("head_root", &self.head_root.to_string())?;
+        slog::Result::Ok(())
+    }
+}
+
 impl slog::Value for RequestId {
     fn serialize(
         &self,

--- a/beacon_node/network/src/beacon_processor/chain_segment.rs
+++ b/beacon_node/network/src/beacon_processor/chain_segment.rs
@@ -34,12 +34,12 @@ pub fn handle_chain_segment<T: BeaconChainTypes>(
 
             let result = match process_blocks(chain, downloaded_blocks.iter(), &log) {
                 (_, Ok(_)) => {
-                    debug!(log, "Batch processed"; "batch_epoch" => epoch, "first_block_slot" => start_slot,
+                    debug!(log, "Batch processed"; "batch_epoch" => epoch, "first_block_slot" => start_slot, "chain" => chain_id,
                         "last_block_slot" => end_slot, "processed_blocks" => sent_blocks, "service"=> "sync");
                     BatchProcessResult::Success(sent_blocks > 0)
                 }
                 (imported_blocks, Err(e)) => {
-                    debug!(log, "Batch processing failed"; "batch_epoch" => epoch, "first_block_slot" => start_slot,
+                    debug!(log, "Batch processing failed"; "batch_epoch" => epoch, "first_block_slot" => start_slot, "chain" => chain_id,
                         "last_block_slot" => end_slot, "error" => e, "imported_blocks" => imported_blocks, "service" => "sync");
                     BatchProcessResult::Failed(imported_blocks > 0)
                 }

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -129,7 +129,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         request_id: PeerRequestId,
         status: StatusMessage,
     ) {
-        debug!(self.log, "Received Status Request"; "peer_id" => %peer_id, &status, "req_id" => ?request_id);
+        debug!(self.log, "Received Status Request"; "peer_id" => %peer_id, &status);
 
         // ignore status responses if we are shutting down
         if let Ok(status_message) = status_message(&self.chain) {
@@ -248,7 +248,6 @@ impl<T: BeaconChainTypes> Processor<T> {
             "peer" => peer_id.to_string(),
             "requested" => request.block_roots.len(),
             "returned" => send_block_count,
-            "req_id" => ?request_id,
         );
 
         // send stream termination
@@ -270,7 +269,6 @@ impl<T: BeaconChainTypes> Processor<T> {
             "count" => req.count,
             "start_slot" => req.start_slot,
             "step" => req.step,
-            "req_id" => ?request_id,
         );
 
         // Should not send more than max request blocks

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -484,10 +484,10 @@ fn spawn_service<T: BeaconChainTypes>(
                                     });
 
                             }
-                            BehaviourEvent::RPCFailed{id, peer_id, error} => {
+                            BehaviourEvent::RPCFailed{id, peer_id} => {
                                 let _ = service
                                     .router_send
-                                    .send(RouterMessage::RPCFailed{ peer_id, request_id: id, error })
+                                    .send(RouterMessage::RPCFailed{ peer_id, request_id: id})
                                     .map_err(|_| {
                                         debug!(service.log, "Failed to send RPC to router");
                                     });


### PR DESCRIPTION
## Issue Addressed

- RPC Errors were being logged twice: first in the peer manager and then again in the router, so leave just the peer manager's one 
- The "reduce peer count" warn message gets thrown to the user for every missed chunk, so instead print it when the request times out and also do not include there info that is not relevant to the user
- The processor didn't have the service tag so add it
- Impl `KV` for status message
- Do not downscore peers if we are the ones that timed out

Other small improvements