### PR TITLE
[Merged by Bors] - Performance improvement for db reads

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -191,7 +191,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     &mut self.events,
                     &self.log,
                 );
-                if previous_state != info.score_state() {
+                if previous_state == info.score_state() {
                     debug!(self.log, "Peer score adjusted"; "peer_id" => peer_id.to_string(), "score" => info.score().to_string());
                 }
             }

--- a/beacon_node/eth2_libp2p/src/rpc/handler.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/handler.rs
@@ -624,6 +624,7 @@ where
                             // if we can't close right now, put the substream back and try again later
                             Poll::Pending => info.state = InboundState::Idle(substream),
                             Poll::Ready(res) => {
+                                // The substream closed, we remove it
                                 substreams_to_remove.push(*id);
                                 if let Some(ref delay_key) = info.delay_key {
                                     self.inbound_substreams_delay.remove(delay_key);
@@ -665,6 +666,15 @@ where
                                     substreams_to_remove.push(*id);
                                     if let Some(ref delay_key) = info.delay_key {
                                         self.inbound_substreams_delay.remove(delay_key);
+                                    }
+                                } else {
+                                    // If we are not removing this substream, we reset the timer.
+                                    // Each chunk is allowed RESPONSE_TIMEOUT to be sent.
+                                    if let Some(ref delay_key) = info.delay_key {
+                                        self.inbound_substreams_delay.reset(
+                                            delay_key,
+                                            Duration::from_secs(RESPONSE_TIMEOUT),
+                                        );
                                     }
                                 }
 

--- a/beacon_node/network/src/beacon_processor/worker.rs
+++ b/beacon_node/network/src/beacon_processor/worker.rs
@@ -215,7 +215,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             | Err(e @ BlockError::RepeatProposal { .. })
             | Err(e @ BlockError::NotFinalizedDescendant { .. })
             | Err(e @ BlockError::BeaconChainError(_)) => {
-                warn!(self.log, "Could not verify block for gossip, ignoring the block";
+                debug!(self.log, "Could not verify block for gossip, ignoring the block";
                             "error" => e.to_string());
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return;

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -306,8 +306,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         let log = self.log.clone();
 
         // Shift the db reads to a blocking thread.
-        self.executor.spawn_blocking(
-            move || {
+        self.executor.spawn_blocking(move || {
 
         debug!(
             log,

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -282,7 +282,7 @@ impl<T: BeaconChainTypes> Processor<T> {
         self.executor.spawn_blocking(move || {
 
             debug!(
-                self.log,
+                log,
                 "Received BlocksByRange Request";
                 "peer_id" => %peer_id,
                 "count" => req.count,


### PR DESCRIPTION
This PR adds a number of improvements:
- Downgrade a warning log when we ignore blocks for gossipsub processing
- Revert a a correction to improve logging of peer score changes
- Shift syncing DB reads off the core-executor allowing parallel processing of large sync messages
- Correct the timeout logic of RPC chunk sends, giving more time before timing out RPC outbound messages.
