### PR TITLE
[Merged by Bors] - Improve UX whilst VC is waiting for genesis

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2096,7 +2096,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::param::<StateId>())
         .and(warp::path("ssz"))
         .and(warp::path::end())
-        .and(chain_filter)
+        .and(chain_filter.clone())
         .and_then(|state_id: StateId, chain: Arc<BeaconChain<T>>| {
             blocking_task(move || {
                 let state = state_id.state(&chain)?;
@@ -2110,6 +2110,25 @@ pub fn serve<T: BeaconChainTypes>(
                             e
                         ))
                     })
+            })
+        });
+
+    // GET lighthouse/staking
+    let get_lighthouse_staking = warp::path("lighthouse")
+        .and(warp::path("staking"))
+        .and(warp::path::end())
+        .and(chain_filter)
+        .and_then(|chain: Arc<BeaconChain<T>>| {
+            blocking_json_task(move || {
+                if chain.eth1_chain.is_some() {
+                    Ok(())
+                } else {
+                    Err(warp_utils::reject::custom_not_found(
+                        "staking is not enabled, \
+                        see the --staking CLI flag"
+                            .to_string(),
+                    ))
+                }
             })
         });
 
@@ -2160,7 +2179,8 @@ pub fn serve<T: BeaconChainTypes>(
                 .or(get_lighthouse_eth1_syncing.boxed())
                 .or(get_lighthouse_eth1_block_cache.boxed())
                 .or(get_lighthouse_eth1_deposit_cache.boxed())
-                .or(get_lighthouse_beacon_states_ssz.boxed()),
+                .or(get_lighthouse_beacon_states_ssz.boxed())
+                .or(get_lighthouse_staking.boxed()),
         )
         .or(warp::post().and(
             post_beacon_blocks

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1804,6 +1804,19 @@ impl ApiTester {
 
         self
     }
+
+    pub async fn test_get_lighthouse_staking(self) -> Self {
+            let result = self
+                .client
+                .get_lighthouse_staking()
+                .await
+                .unwrap();
+
+            assert_eq!(result, false);
+        }
+
+        self
+    }
 }
 
 #[tokio::test(core_threads = 2)]
@@ -2076,5 +2089,7 @@ async fn lighthouse_endpoints() {
         .test_get_lighthouse_eth1_deposit_cache()
         .await
         .test_get_lighthouse_beacon_states_ssz()
+        .await
+        .test_get_lighthouse_staking()
         .await;
 }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1806,14 +1806,9 @@ impl ApiTester {
     }
 
     pub async fn test_get_lighthouse_staking(self) -> Self {
-            let result = self
-                .client
-                .get_lighthouse_staking()
-                .await
-                .unwrap();
+        let result = self.client.get_lighthouse_staking().await.unwrap();
 
-            assert_eq!(result, false);
-        }
+        assert_eq!(result, false);
 
         self
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1808,7 +1808,7 @@ impl ApiTester {
     pub async fn test_get_lighthouse_staking(self) -> Self {
         let result = self.client.get_lighthouse_staking().await.unwrap();
 
-        assert_eq!(result, false);
+        assert_eq!(result, self.chain.eth1_chain.is_some());
 
         self
     }

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -356,4 +356,16 @@ impl BeaconNodeHttpClient {
             .map(|bytes| BeaconState::from_ssz_bytes(&bytes).map_err(Error::InvalidSsz))
             .transpose()
     }
+
+    /// `GET lighthouse/staking`
+    pub async fn get_lighthouse_staking(&self) -> Result<bool, Error> {
+        let mut path = self.server.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("staking");
+
+        self.get_opt::<(), _>(path).await.map(|opt| opt.is_some())
+    }
 }


### PR DESCRIPTION
## Issue Addressed

- Resolves #1424

## Proposed Changes

Add a `GET lighthouse/staking` that returns 200 if the node is ready to stake (i.e., `--eth1` flag is present) or a 404 otherwise.

Whilst the VC is waiting for the genesis time to start (i.e., when the genesis state is known), check the `lighthouse/staking` endpoint and log an error if the node isn't configured for staking.

## Additional Info

NA
