### PR TITLE
[Merged by Bors] - Refine compaction

### DIFF
--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -19,7 +19,7 @@ use types::{
 };
 
 /// Compact approx every few days by default (every 1024 epochs).
-const COMPACTION_MODULO_THRESHOLD: u64 = 1024;
+const COMPACTION_PERIOD: u64 = 1024;
 
 /// The background migrator runs a thread to perform pruning and migrate state from the hot
 /// to the cold database.
@@ -216,8 +216,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         let old_finalized_epoch = old_finalized_checkpoint.epoch;
         let new_finalized_epoch = notif.finalized_checkpoint.epoch;
         if db.compact_on_prune()
-            && (new_finalized_epoch % COMPACTION_MODULO_THRESHOLD == 0
-                || new_finalized_epoch - old_finalized_epoch > COMPACTION_MODULO_THRESHOLD)
+            && old_finalized_epoch / COMPACTION_PERIOD < new_finalized_epoch / COMPACTION_PERIOD
         {
             info!(log, "Starting database compaction");
             if let Err(e) = db.compact() {

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -307,7 +307,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("compact-db")
                 .long("compact-db")
-                .help("If present, apply compaction to the database on start-up. Use with caution.")
+                .help("If present, apply compaction to the database on start-up. Use with caution. \
+                       It is generally not recommended unless auto-compaction is disabled.")
         )
         .arg(
             Arg::with_name("auto-compact-db")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -297,12 +297,24 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         )
 
         /*
-         * Purge.
+         * Database purging and compaction.
          */
         .arg(
             Arg::with_name("purge-db")
                 .long("purge-db")
                 .help("If present, the chain database will be deleted. Use with caution.")
+        )
+        .arg(
+            Arg::with_name("compact-db")
+                .long("compact-db")
+                .help("If present, apply compaction to the database on start-up. Use with caution.")
+        )
+        .arg(
+            Arg::with_name("auto-compact-db")
+                .long("auto-compact-db")
+                .help("Enable or disable automatic compaction of the database on finalization.")
+                .takes_value(true)
+                .default_value("true")
         )
 
         /*

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -218,6 +218,13 @@ pub fn get_config<E: EthSpec>(
             .map_err(|_| "block-cache-size is not a valid integer".to_string())?;
     }
 
+    client_config.store.compact_on_init = cli_args.is_present("compact-db");
+    if let Some(compact_on_prune) = cli_args.value_of("auto-compact-db") {
+        client_config.store.compact_on_prune = compact_on_prune
+            .parse()
+            .map_err(|_| "auto-compact-db takes a boolean".to_string())?;
+    }
+
     /*
      * Zero-ports
      *

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -8,12 +8,24 @@ pub const DEFAULT_SLOTS_PER_RESTORE_POINT: u64 = 2048;
 pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 5;
 
 /// Database configuration parameters.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StoreConfig {
     /// Number of slots to wait between storing restore points in the freezer database.
     pub slots_per_restore_point: u64,
     /// Maximum number of blocks to store in the in-memory block cache.
     pub block_cache_size: usize,
+    /// Whether to compact the database on initialization.
+    pub compact_on_init: bool,
+    /// Whether to compact the database during database pruning.
+    pub compact_on_prune: bool,
+}
+
+/// Variant of `StoreConfig` that gets written to disk. Contains immutable configuration params.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
+pub struct OnDiskStoreConfig {
+    pub slots_per_restore_point: u64,
+    // NOTE: redundant, see https://github.com/sigp/lighthouse/issues/1784
+    pub _block_cache_size: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -27,12 +39,24 @@ impl Default for StoreConfig {
             // Safe default for tests, shouldn't ever be read by a CLI node.
             slots_per_restore_point: MinimalEthSpec::slots_per_historical_root() as u64,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
+            compact_on_init: false,
+            compact_on_prune: true,
         }
     }
 }
 
 impl StoreConfig {
-    pub fn check_compatibility(&self, on_disk_config: &Self) -> Result<(), StoreConfigError> {
+    pub fn as_disk_config(&self) -> OnDiskStoreConfig {
+        OnDiskStoreConfig {
+            slots_per_restore_point: self.slots_per_restore_point,
+            _block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
+        }
+    }
+
+    pub fn check_compatibility(
+        &self,
+        on_disk_config: &OnDiskStoreConfig,
+    ) -> Result<(), StoreConfigError> {
         if self.slots_per_restore_point != on_disk_config.slots_per_restore_point {
             return Err(StoreConfigError::MismatchedSlotsPerRestorePoint {
                 config: self.slots_per_restore_point,
@@ -43,7 +67,7 @@ impl StoreConfig {
     }
 }
 
-impl StoreItem for StoreConfig {
+impl StoreItem for OnDiskStoreConfig {
     fn db_column() -> DBColumn {
         DBColumn::BeaconMeta
     }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -958,6 +958,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         PruningCheckpoint { checkpoint }.as_kv_store_op(PRUNING_CHECKPOINT_KEY)
     }
 
+    /// Load the timestamp of the last compaction as a `Duration` since the UNIX epoch.
     pub fn load_compaction_timestamp(&self) -> Result<Option<Duration>, Error> {
         Ok(self
             .hot_db
@@ -965,6 +966,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .map(|c: CompactionTimestamp| Duration::from_secs(c.0)))
     }
 
+    /// Store the timestamp of the last compaction as a `Duration` since the UNIX epoch.
     pub fn store_compaction_timestamp(&self, compaction_timestamp: Duration) -> Result<(), Error> {
         self.hot_db.put(
             &COMPACTION_TIMESTAMP_KEY,

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -11,6 +11,7 @@ pub const SCHEMA_VERSION_KEY: Hash256 = Hash256::repeat_byte(0);
 pub const CONFIG_KEY: Hash256 = Hash256::repeat_byte(1);
 pub const SPLIT_KEY: Hash256 = Hash256::repeat_byte(2);
 pub const PRUNING_CHECKPOINT_KEY: Hash256 = Hash256::repeat_byte(3);
+pub const COMPACTION_TIMESTAMP_KEY: Hash256 = Hash256::repeat_byte(4);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaVersion(pub u64);
@@ -56,5 +57,22 @@ impl StoreItem for PruningCheckpoint {
         Ok(PruningCheckpoint {
             checkpoint: Checkpoint::from_ssz_bytes(bytes)?,
         })
+    }
+}
+
+/// The last time the database was compacted.
+pub struct CompactionTimestamp(pub u64);
+
+impl StoreItem for CompactionTimestamp {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconMeta
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(CompactionTimestamp(u64::from_ssz_bytes(bytes)?))
     }
 }


### PR DESCRIPTION
## Proposed Changes

In an attempt to fix OOM issues and database consistency issues observed by some users after the introduction of compaction in v0.3.4, this PR makes the following changes:

* Run compaction less often: roughly every 1024 epochs, including after long periods of non-finality. I think the division check proposed by Paul is pretty solid, and ensures we don't miss any events where we should be compacting. LevelDB lacks an easy way to check the size of the DB, which would be another good trigger.
* Make it possible to disable the compaction on finalization using `--auto-compact-db=false`
* Make it possible to trigger a manual, single-threaded foreground compaction on start-up using `--compact-db`
* Downgrade the pruning log to `DEBUG`, as it's particularly noisy during sync

I would like to ship these changes to affected users ASAP, and will document them further in the Advanced Database section of the book if they prove effective.
