### PR TITLE
[Merged by Bors] - Add new flag to set blocks per eth1 query

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -280,6 +280,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("eth1-blocks-per-log-query")
+                .long("eth1-blocks-per-log-query")
+                .value_name("BLOCKS")
+                .help("Specifies the number of blocks that a deposit log query should span.")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("slots-per-restore-point")
                 .long("slots-per-restore-point")
                 .value_name("SLOT_COUNT")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -283,7 +283,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("eth1-blocks-per-log-query")
                 .long("eth1-blocks-per-log-query")
                 .value_name("BLOCKS")
-                .help("Specifies the number of blocks that a deposit log query should span.")
+                .help("Specifies the number of blocks that a deposit log query should span. \
+                    This will reduce the size of responses from the Eth1 endpoint.")
+                .default_value("1000")
                 .takes_value(true)
         )
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -197,6 +197,13 @@ pub fn get_config<E: EthSpec>(
         client_config.eth1.endpoint = val.to_string();
     }
 
+    if let Some(val) = cli_args.value_of("eth1-blocks-per-log-query") {
+        client_config.eth1.max_log_requests_per_update = Some(
+            val.parse()
+                .map_err(|_| "eth1-blocks-per-log-query is not a valid integer".to_string())?,
+        );
+    }
+
     if let Some(freezer_dir) = cli_args.value_of("freezer-dir") {
         client_config.freezer_db_path = Some(PathBuf::from(freezer_dir));
     }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -198,10 +198,9 @@ pub fn get_config<E: EthSpec>(
     }
 
     if let Some(val) = cli_args.value_of("eth1-blocks-per-log-query") {
-        client_config.eth1.max_log_requests_per_update = Some(
-            val.parse()
-                .map_err(|_| "eth1-blocks-per-log-query is not a valid integer".to_string())?,
-        );
+        client_config.eth1.blocks_per_log_query = val
+            .parse()
+            .map_err(|_| "eth1-blocks-per-log-query is not a valid integer".to_string())?;
     }
 
     if let Some(freezer_dir) = cli_args.value_of("freezer-dir") {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Users on Discord (and @protolambda) have experienced this error (or variants of it):

```
Failed to update eth1 cache: GetDepositLogsFailed("Eth1 node returned error: {\"code\":-32005,\"message\":\"query returned more than 10000 results\"}")
```

This PR allows users to reduce the span of blocks searched for deposit logs and therefore reduce the size of the return result. Hopefully experimentation with this flag can lead to finding a better default value.


## Additional Info

NA
