### PR TITLE
Add blocks-by-range metrics

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -302,6 +302,20 @@ lazy_static! {
 
 lazy_static! {
     /*
+     * Sync
+     */
+    pub static ref BLOCKS_BY_RANGE_RESPONSE_SECONDS: Result<Histogram> = try_create_histogram(
+        "blocks_by_range_response_seconds",
+        "Time taken to respond to a blocks by range request"
+    );
+    pub static ref BLOCKS_BY_RANGE_RESPONSE_BLOCK_ITER_SECONDS: Result<Histogram> = try_create_histogram(
+        "blocks_by_range_response_block_iter_seconds",
+        "Time taken to collect the block roots for a blocks by range response"
+    );
+}
+
+lazy_static! {
+    /*
      * Attestation Errors
      */
     pub static ref GOSSIP_ATTESTATION_ERROR_FUTURE_EPOCH: Result<IntCounter> = try_create_int_counter(


### PR DESCRIPTION
## Proposed Changes

Add two simple metrics for blocks by range responses to help us understand their performance characteristics, and what percentage of response time is consumed by iterating and collecting block roots.

Initial data seems to show that responses vary between 150-250ms, and iteration from 5-8ms
