### PR TITLE
[Merged by Bors] - Add flag to import all attestations

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -84,6 +84,10 @@ pub struct Config {
     /// Subscribe to all subnets for the duration of the runtime.
     pub subscribe_all_subnets: bool,
 
+    /// Import/aggregate all attestations recieved on subscribed subnets for the duration of the
+    /// runtime.
+    pub import_all_attestations: bool,
+
     /// List of extra topics to initially subscribe to as strings.
     pub topics: Vec<GossipKind>,
 }
@@ -185,6 +189,7 @@ impl Default for Config {
             disable_discovery: false,
             upnp_enabled: true,
             subscribe_all_subnets: false,
+            import_all_attestations: false,
             topics: Vec::new(),
         }
     }

--- a/beacon_node/network/src/attestation_service/mod.rs
+++ b/beacon_node/network/src/attestation_service/mod.rs
@@ -121,6 +121,9 @@ pub struct AttestationService<T: BeaconChainTypes> {
     /// We are always subscribed to all subnets.
     subscribe_all_subnets: bool,
 
+    /// We process and aggregate all attestations on subscribed subnets.
+    import_all_attestations: bool,
+
     /// The logger for the attestation service.
     log: slog::Logger,
 }
@@ -161,6 +164,7 @@ impl<T: BeaconChainTypes> AttestationService<T> {
             known_validators: HashSetDelay::new(last_seen_val_timeout),
             waker: None,
             subscribe_all_subnets: config.subscribe_all_subnets,
+            import_all_attestations: config.import_all_attestations,
             discovery_disabled: config.disable_discovery,
             log,
         }
@@ -286,6 +290,10 @@ impl<T: BeaconChainTypes> AttestationService<T> {
         subnet: SubnetId,
         attestation: &Attestation<T::EthSpec>,
     ) -> bool {
+        if self.import_all_attestations {
+            return true;
+        }
+
         let exact_subnet = ExactSubnet {
             subnet_id: subnet,
             slot: attestation.data.slot,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -38,6 +38,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("import-all-attestations")
+                .long("import-all-attestations")
+                .help("Import and aggregate all attestations, regardless of validator subscriptions. \
+                       This will only import attestations from already-subscribed subnets, use with \
+                       --subscribe-all-subnets to ensure all attestations are received for import.")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("zero-ports")
                 .long("zero-ports")
                 .short("z")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -373,6 +373,10 @@ pub fn set_network_config(
         config.subscribe_all_subnets = true;
     }
 
+    if cli_args.is_present("import-all-attestations") {
+        config.import_all_attestations = true;
+    }
+
     if let Some(listen_address_str) = cli_args.value_of("listen-address") {
         let listen_address = listen_address_str
             .parse()


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds the `--import-all-attestations` flag which tells the `network::AttestationService` to import/aggregate all attestations after verification (instead of only ones for subnets that are relevant to local validators).

This is useful for testing/debugging and also for creating back-up nodes that should be all cached up and ready for any validator.

## Additional Info

NA