### PR TITLE
[Merged by Bors] - Tweak slasher DB schema and pruning

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -371,8 +371,10 @@ pub fn get_config<E: EthSpec>(
             slasher_config.history_length = history_length;
         }
 
-        if let Some(max_db_size) = clap_utils::parse_optional(cli_args, "slasher-max-db-size")? {
-            slasher_config.max_db_size_gbs = max_db_size;
+        if let Some(max_db_size_gbs) =
+            clap_utils::parse_optional::<usize>(cli_args, "slasher-max-db-size")?
+        {
+            slasher_config.max_db_size_mbs = max_db_size_gbs * 1024;
         }
 
         if let Some(chunk_size) = clap_utils::parse_optional(cli_args, "slasher-chunk-size")? {

--- a/book/src/slasher.md
+++ b/book/src/slasher.md
@@ -74,7 +74,7 @@ either you can halve the space required.
 If you want a better estimate you can use this formula:
 
 ```
-352 * V * N + (16 * V * N)/(C * K) + 15000 * N
+360 * V * N + (16 * V * N)/(C * K) + 15000 * N
 ```
 
 where

--- a/slasher/src/config.rs
+++ b/slasher/src/config.rs
@@ -7,7 +7,7 @@ pub const DEFAULT_CHUNK_SIZE: usize = 16;
 pub const DEFAULT_VALIDATOR_CHUNK_SIZE: usize = 256;
 pub const DEFAULT_HISTORY_LENGTH: usize = 4096;
 pub const DEFAULT_UPDATE_PERIOD: u64 = 12;
-pub const DEFAULT_MAX_DB_SIZE: usize = 256;
+pub const DEFAULT_MAX_DB_SIZE: usize = 256 * 1024; // 256 GiB
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -18,8 +18,8 @@ pub struct Config {
     pub history_length: usize,
     /// Update frequency in seconds.
     pub update_period: u64,
-    /// Maximum size of the LMDB database in gigabytes.
-    pub max_db_size_gbs: usize,
+    /// Maximum size of the LMDB database in megabytes.
+    pub max_db_size_mbs: usize,
 }
 
 impl Config {
@@ -30,7 +30,7 @@ impl Config {
             validator_chunk_size: DEFAULT_VALIDATOR_CHUNK_SIZE,
             history_length: DEFAULT_HISTORY_LENGTH,
             update_period: DEFAULT_UPDATE_PERIOD,
-            max_db_size_gbs: DEFAULT_MAX_DB_SIZE,
+            max_db_size_mbs: DEFAULT_MAX_DB_SIZE,
         }
     }
 
@@ -38,7 +38,7 @@ impl Config {
         if self.chunk_size == 0
             || self.validator_chunk_size == 0
             || self.history_length == 0
-            || self.max_db_size_gbs == 0
+            || self.max_db_size_mbs == 0
         {
             Err(Error::ConfigInvalidZeroParameter {
                 config: self.clone(),

--- a/slasher/src/error.rs
+++ b/slasher/src/error.rs
@@ -41,11 +41,15 @@ pub enum Error {
     ProposerKeyCorrupt {
         length: usize,
     },
+    IndexedAttestationKeyCorrupt {
+        length: usize,
+    },
     MissingIndexedAttestation {
         root: Hash256,
     },
     MissingAttesterKey,
     MissingProposerKey,
+    MissingIndexedAttestationKey,
     AttesterRecordInconsistentRoot,
 }
 

--- a/slasher/src/utils.rs
+++ b/slasher/src/utils.rs
@@ -25,7 +25,7 @@ impl<T> TxnMapFull<T, Error> for Result<T, Error> {
         match self {
             Ok(x) => Ok(Some(x)),
             Err(Error::DatabaseError(lmdb::Error::MapFull)) => Ok(None),
-            Err(e) => Err(e.into()),
+            Err(e) => Err(e),
         }
     }
 }

--- a/slasher/src/utils.rs
+++ b/slasher/src/utils.rs
@@ -14,3 +14,18 @@ impl<T> TxnOptional<T, Error> for Result<T, lmdb::Error> {
         }
     }
 }
+
+/// Transform a transaction that would fail with a `MapFull` error into an optional result.
+pub trait TxnMapFull<T, E> {
+    fn allow_map_full(self) -> Result<Option<T>, E>;
+}
+
+impl<T> TxnMapFull<T, Error> for Result<T, Error> {
+    fn allow_map_full(self) -> Result<Option<T>, Error> {
+        match self {
+            Ok(x) => Ok(Some(x)),
+            Err(Error::DatabaseError(lmdb::Error::MapFull)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}

--- a/slasher/tests/wrap_around.rs
+++ b/slasher/tests/wrap_around.rs
@@ -1,6 +1,6 @@
 use slasher::{
     test_utils::{indexed_att, logger},
-    Config, Slasher,
+    Config, Error, Slasher,
 };
 use tempdir::TempDir;
 use types::Epoch;
@@ -36,4 +36,54 @@ fn attestation_pruning_empty_wrap_around() {
         1,
     ));
     slasher.process_queued(current_epoch).unwrap();
+}
+
+// Test that pruning can recover from a `MapFull` error
+#[test]
+fn pruning_with_map_full() {
+    let tempdir = TempDir::new("slasher").unwrap();
+    let mut config = Config::new(tempdir.path().into());
+    config.validator_chunk_size = 1;
+    config.chunk_size = 16;
+    config.history_length = 1024;
+    config.max_db_size_mbs = 1;
+
+    let slasher = Slasher::open(config.clone(), logger()).unwrap();
+
+    let v = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+
+    let mut current_epoch = Epoch::new(0);
+
+    loop {
+        slasher.accept_attestation(indexed_att(
+            v.clone(),
+            (current_epoch - 1).as_u64(),
+            current_epoch.as_u64(),
+            0,
+        ));
+        if let Err(Error::DatabaseError(lmdb::Error::MapFull)) =
+            slasher.process_queued(current_epoch)
+        {
+            break;
+        }
+        current_epoch += 1;
+    }
+
+    loop {
+        slasher.prune_database(current_epoch).unwrap();
+
+        slasher.accept_attestation(indexed_att(
+            v.clone(),
+            (current_epoch - 1).as_u64(),
+            current_epoch.as_u64(),
+            0,
+        ));
+        match slasher.process_queued(current_epoch) {
+            Ok(()) => break,
+            Err(Error::DatabaseError(lmdb::Error::MapFull)) => {
+                current_epoch += 1;
+            }
+            Err(e) => panic!("{:?}", e),
+        }
+    }
 }


### PR DESCRIPTION
## Issue Addressed

Resolves #1890

## Proposed Changes

Change the slasher database schema to key indexed attestations by `(target_epoch, indexed_attestation_root)` instead of just `indexed_attestation_root`. This allows more straight-forward pruning (linear scan), that is also "re-entrant". By re-entrant, we mean that a pruning pass that gets stuck because of a `MapFull` error can attempt to commit midway, and be resumed later without issue. The previous pruning strategy for indexed attestations did not have this property. There was also a flaw in the previous pruning that could leave "zombie" indexed attestations in the database (ones not referenced by any attester record), which could build up and contribute to bloat (although in practice I think they occur quite infrequently).

## Additional Info

During testing I noticed that a `MapFull` error can still occur during the commit of the transaction itself, which is irritating, but not unbearable. This PR should at least reduce the frequency with which users need to manually resize their DB, and if the `MapFull` on commit rears its ugly head too often we could use a dynamic strategy (temporarily increase the size of the map until the transaction commits).

The extra bytes for the epoch make the database a bit heavier, so the size estimate docs have been updated to reflect this. This is also a breaking schema change, so anyone using a v0 database from a few hours ago will need to drop it and update :sweat_smile: 
