### PR TITLE
[Merged by Bors] - check if the slashing protection database is locked before creating keys

### DIFF
--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -192,10 +192,13 @@ pub fn cli_run<T: EthSpec>(
             )
         })?;
 
-    // Create an empty transaction. Used to test if the database is locked.
-    let _ = slashing_protection
-        .test_transaction()
-        .map_err(|e| format!("Cannot create keys while the validator client is running: {:?}", e))?;
+    // Create an empty transaction and drops it. Used to test if the database is locked.
+    let _ = slashing_protection.test_transaction().map_err(|e| {
+        format!(
+            "Cannot create keys while the validator client is running: {:?}",
+            e
+        )
+    })?;
 
     for i in 0..n {
         let voting_password = random_password();

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -193,7 +193,7 @@ pub fn cli_run<T: EthSpec>(
         })?;
 
     // Create an empty transaction and drops it. Used to test if the database is locked.
-    let _ = slashing_protection.test_transaction().map_err(|e| {
+    slashing_protection.test_transaction().map_err(|e| {
         format!(
             "Cannot create keys while the validator client is running: {:?}",
             e

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -192,6 +192,11 @@ pub fn cli_run<T: EthSpec>(
             )
         })?;
 
+    // Create an empty transaction. Used to test if the database is locked.
+    let _ = slashing_protection
+        .test_transaction()
+        .map_err(|e| format!("Cannot create keys while the validator client is running: {:?}", e))?;
+
     for i in 0..n {
         let voting_password = random_password();
         let withdrawal_password = random_password();

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -87,7 +87,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
         })?;
 
     // Create an empty transaction and drop it. Used to test if the database is locked.
-    let _ = slashing_protection.test_transaction().map_err(|e| {
+    slashing_protection.test_transaction().map_err(|e| {
         format!(
             "Cannot import keys while the validator client is running: {:?}",
             e

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -86,6 +86,11 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             )
         })?;
 
+    // Create an empty transaction. Used to test if the database is locked.
+    let _ = slashing_protection
+        .test_transaction()
+        .map_err(|e| format!("Cannot import keys while the validator client is running: {:?}", e))?;
+
     eprintln!("validator-dir path: {:?}", validator_dir);
     // Collect the paths for the keystores that should be imported.
     let keystore_paths = match (keystore, keystores_dir) {

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -86,10 +86,13 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             )
         })?;
 
-    // Create an empty transaction. Used to test if the database is locked.
-    let _ = slashing_protection
-        .test_transaction()
-        .map_err(|e| format!("Cannot import keys while the validator client is running: {:?}", e))?;
+    // Create an empty transaction and drop it. Used to test if the database is locked.
+    let _ = slashing_protection.test_transaction().map_err(|e| {
+        format!(
+            "Cannot import keys while the validator client is running: {:?}",
+            e
+        )
+    })?;
 
     eprintln!("validator-dir path: {:?}", validator_dir);
     // Collect the paths for the keystores that should be imported.

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -136,6 +136,13 @@ impl SlashingDatabase {
     #[cfg(windows)]
     fn set_db_file_permissions(file: &File) -> Result<(), NotSafe> {}
 
+    /// Creates an empty transaction. Used to test whether the database is locked.
+    pub fn test_transaction(&self) -> Result<(), NotSafe> {
+        let mut conn = self.conn_pool.get()?;
+        Transaction::new(&mut conn, TransactionBehavior::Exclusive)?;
+        Ok(())
+    }
+
     /// Register a validator with the slashing protection database.
     ///
     /// This allows the validator to record their signatures in the database, and check

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -136,7 +136,7 @@ impl SlashingDatabase {
     #[cfg(windows)]
     fn set_db_file_permissions(file: &File) -> Result<(), NotSafe> {}
 
-    /// Creates an empty transaction. Used to test whether the database is locked.
+    /// Creates an empty transaction and drops it. Used to test whether the database is locked.
     pub fn test_transaction(&self) -> Result<(), NotSafe> {
         let mut conn = self.conn_pool.get()?;
         Transaction::new(&mut conn, TransactionBehavior::Exclusive)?;

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -810,4 +810,14 @@ mod tests {
         let db2 = SlashingDatabase::open(&file).unwrap();
         check(&db2);
     }
+
+    #[test]
+    fn test_transaction_failure() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("db.sqlite");
+        let _db1 = SlashingDatabase::create(&file).unwrap();
+
+        let db2 = SlashingDatabase::open(&file).unwrap();
+        db2.test_transaction().unwrap_err();
+    }
 }


### PR DESCRIPTION
## Issue Addressed

Closes #1790

## Proposed Changes

Make a new method that creates an empty transaction with `TransactionBehavior::Exclusive` to check whether the slashing protection is locked. Call this method before attempting to create or import new validator keystores.  

## Additional Info

N/A
