### PR TITLE
Ignore status from dc'd peers

### DIFF
--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -182,6 +182,10 @@ impl<T: BeaconChainTypes> Router<T> {
         // an error could have occurred.
         match response {
             Response::Status(status_message) => {
+                if !self.network_globals.peers.read().is_connected(&peer_id) {
+                    debug!(self.log, "Dropping status response of disconnected peer"; "peer_id" => %peer_id, status_message);
+                    return;
+                }
                 self.processor.on_status_response(peer_id, status_message);
             }
             Response::BlocksByRange(beacon_block) => {


### PR DESCRIPTION
## Issue Addressed

Sync stalls because it sends a request for a peer that is disconnected. Sync believes it is disconnected because we get a status response after the peer has sent a goodbye message

Now we ignore status messages if the peer is not connected