### PR TITLE
[Merged by Bors] - Update docs whenever unstable changes

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -3,7 +3,7 @@ name: mdbook
 on:
   push:
     branches:
-      - master
+      - unstable
 
 jobs:
   build-and-upload-to-s3:


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Presently `master` is stable (and will be sunsetted) which means our docs only update after a release. This PR sets the docs to build on the `unstable` branch, which is equivalent to what what we've always had. 

## Additional Info

This does raise the question of whether or not docs should target `stable` or `unstable`, but I'd prefer to maintain current functionality and merge #1966 for now. I think having two versions might be handy, one for stable and one for unstable; I don't imagine this very difficult to achieve.