### PR TITLE
[Merged by Bors] - Fix #1964: remove mainnet warnings which no longer apply

### DIFF
--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -25,8 +25,6 @@ pub const STORE_WITHDRAW_FLAG: &str = "store-withdrawal-keystore";
 pub const COUNT_FLAG: &str = "count";
 pub const AT_MOST_FLAG: &str = "at-most";
 pub const WALLET_PASSWORD_PROMPT: &str = "Enter your wallet's password:";
-pub const MAINNET_WARNING: &str = "These are *not* mainnet validators! Submitting a mainnet \
-                                    deposit for this validator will result in lost ETH.";
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new(CMD)
@@ -239,8 +237,6 @@ pub fn cli_run<T: EthSpec>(
             .map_err(|e| format!("Unable to build validator directory: {:?}", e))?;
 
         println!("{}/{}\t{}", i + 1, n, voting_pubkey.to_hex_string());
-
-        println!("{}", MAINNET_WARNING);
     }
 
     Ok(())

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -266,16 +266,9 @@ fn run<E: EthSpec>(
     info!(log, "Lighthouse started"; "version" => VERSION);
     info!(
         log,
-        "Configured for testnet";
+        "Configured for network";
         "name" => &testnet_name
     );
-
-    if testnet_name == "mainnet" {
-        warn!(
-            log,
-            "The mainnet specification is being used. This not recommended (yet)."
-        )
-    }
 
     match matches.subcommand() {
         ("beacon_node", Some(matches)) => {

--- a/lighthouse/tests/account_manager.rs
+++ b/lighthouse/tests/account_manager.rs
@@ -284,13 +284,9 @@ impl TestValidator {
         let pubkeys = stdout[..stdout.len() - 1]
             .split("\n")
             .filter_map(|line| {
-                if line.starts_with(MAINNET_WARNING) {
-                    None
-                } else {
-                    let tab = line.find("\t").expect("line must have tab");
-                    let (_, pubkey) = line.split_at(tab + 1);
-                    Some(pubkey.to_string())
-                }
+                let tab = line.find("\t").expect("line must have tab");
+                let (_, pubkey) = line.split_at(tab + 1);
+                Some(pubkey.to_string())
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Issue Addressed

#1964

## Proposed Changes

* remove two mainnet warnings
* reword `testnet` in logmessage
* update test