### PR TITLE
[Merged by Bors] - Sync metrics

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
@@ -68,25 +68,17 @@ impl PeerSyncStatus {
 
     pub fn as_str(&self) -> &'static str {
         match self {
-            PeerSyncStatus::Advanced { .. } => "advanced",
-            PeerSyncStatus::Behind { .. } => "behind",
-            PeerSyncStatus::Synced { .. } => "synced",
-            PeerSyncStatus::Unknown => "unknown",
-            PeerSyncStatus::IrrelevantPeer => "irrelevant",
+            PeerSyncStatus::Advanced { .. } => "Advanced",
+            PeerSyncStatus::Behind { .. } => "Behind",
+            PeerSyncStatus::Synced { .. } => "Synced",
+            PeerSyncStatus::Unknown => "Unknown",
+            PeerSyncStatus::IrrelevantPeer => "Irrelevant",
         }
     }
 }
 
-
 impl std::fmt::Display for PeerSyncStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let rpr = match self {
-            PeerSyncStatus::Behind { .. } => "Behind",
-            PeerSyncStatus::Advanced { .. } => "Advanced",
-            PeerSyncStatus::Synced { .. } => "Synced",
-            PeerSyncStatus::Unknown => "Unknown",
-            PeerSyncStatus::IrrelevantPeer => "IrrelevantPeer",
-        };
-        f.write_str(rpr)
+        f.write_str(self.as_str())
     }
 }

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
@@ -65,10 +65,8 @@ impl PeerSyncStatus {
             true
         }
     }
-}
 
-impl AsRef<str> for PeerSyncStatus {
-    fn as_ref(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             PeerSyncStatus::Advanced { .. } => "advanced",
             PeerSyncStatus::Behind { .. } => "behind",
@@ -78,6 +76,7 @@ impl AsRef<str> for PeerSyncStatus {
         }
     }
 }
+
 
 impl std::fmt::Display for PeerSyncStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_sync_status.rs
@@ -67,6 +67,18 @@ impl PeerSyncStatus {
     }
 }
 
+impl AsRef<str> for PeerSyncStatus {
+    fn as_ref(&self) -> &str {
+        match self {
+            PeerSyncStatus::Advanced { .. } => "advanced",
+            PeerSyncStatus::Behind { .. } => "behind",
+            PeerSyncStatus::Synced { .. } => "synced",
+            PeerSyncStatus::Unknown => "unknown",
+            PeerSyncStatus::IrrelevantPeer => "irrelevant",
+        }
+    }
+}
+
 impl std::fmt::Display for PeerSyncStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let rpr = match self {

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -406,6 +406,17 @@ lazy_static! {
     );
 }
 
+lazy_static! {
+    /*
+     * Sync related metrics
+     */
+    pub static ref PEERS_PER_SYNC_TYPE: Result<IntGaugeVec> = try_create_int_gauge_vec(
+        "sync_peers_per_type",
+        "Number of connected peers per sync status type",
+        &["sync_type"]
+    );
+}
+
 pub fn register_attestation_error(error: &AttnError) {
     match error {
         AttnError::FutureEpoch { .. } => inc_counter(&GOSSIP_ATTESTATION_ERROR_FUTURE_EPOCH),

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -411,10 +411,16 @@ lazy_static! {
      * Sync related metrics
      */
     pub static ref PEERS_PER_SYNC_TYPE: Result<IntGaugeVec> = try_create_int_gauge_vec(
-        "sync_peers_per_type",
+        "sync_peers_per_status",
         "Number of connected peers per sync status type",
-        &["sync_type"]
+        &["sync_status"]
     );
+    pub static ref SYNCING_CHAINS_COUNT: Result<IntGaugeVec> = try_create_int_gauge_vec(
+        "sync_range_chains",
+        "Number of Syncing chains in range, per range type",
+        &["range_type"]
+    );
+
 }
 
 pub fn register_attestation_error(error: &AttnError) {

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -6,7 +6,7 @@ use eth2_libp2p::SyncInfo;
 use std::sync::Arc;
 
 /// The type of Range sync that should be done relative to our current state.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum RangeSyncType {
     /// A finalized chain sync should be started with this peer.
     Finalized,
@@ -37,6 +37,14 @@ impl RangeSyncType {
             RangeSyncType::Finalized
         } else {
             RangeSyncType::Head
+        }
+    }
+
+    /// Get a `str` representation of the `RangeSyncType`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RangeSyncType::Finalized => "Finalized",
+            RangeSyncType::Head => "Head",
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed
- Add metrics to keep track of peer counts by sync type
- Add metric to keep track of the number of syncing chains in range

## Proposed Changes
Plugin to the network metrics update interval and update too the counts for peers wrt to their sync status with us

## Additional Info
For the peer counts
- By the way it is implemented the numbers won't always match to the total peer count in the `libp2p` metric.
- Updating the gauge with every change is messy because it requires to be updated on connection (in the `eth2_libp2p` crate, while metrics are defined in the `network` crate) on Goodbye sent (for an `IrrelevantPeer`) either in the `beacon_processor` or the `peer_manager`, and on disconnection. Since this is not a critical metric I think counting once every second is enough. If you think more accuracy is needed we can do it too, but it would be harder to maintain)

ATM those look like this
![image](https://user-images.githubusercontent.com/26765164/100275387-22137b00-2f60-11eb-93b9-94b0f265240c.png)
