### PR TITLE
[Merged by Bors] - Pretty-print EIP-3076 tests

### DIFF
--- a/validator_client/slashing_protection/Makefile
+++ b/validator_client/slashing_protection/Makefile
@@ -10,7 +10,7 @@ $(OUTPUT_DIR): $(TARBALL)
 	tar --strip-components=1 -xzf $^ -C $@
 
 $(TARBALL):
-	curl -L -o $@ $(ARCHIVE_URL)
+	curl --fail -L -o $@ $(ARCHIVE_URL)
 
 clean-test-files:
 	rm -rf $(OUTPUT_DIR)

--- a/validator_client/slashing_protection/Makefile
+++ b/validator_client/slashing_protection/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := b8413ca42dc92308019d0d4db52c87e9e125c4e9
+TESTS_TAG := f495032df9c26c678536cd2b7854e836ea94c217
 GENERATE_DIR := generated-tests
 OUTPUT_DIR := interchange-tests
 TARBALL := $(OUTPUT_DIR)-$(TESTS_TAG).tar.gz

--- a/validator_client/slashing_protection/build.rs
+++ b/validator_client/slashing_protection/build.rs
@@ -1,7 +1,0 @@
-fn main() {
-    let exit_status = std::process::Command::new("make")
-        .current_dir(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .status()
-        .unwrap();
-    assert!(exit_status.success());
-}

--- a/validator_client/slashing_protection/src/bin/test_generator.rs
+++ b/validator_client/slashing_protection/src/bin/test_generator.rs
@@ -5,6 +5,7 @@ use slashing_protection::interchange_test::{MultiTestCase, TestCase};
 use slashing_protection::test_utils::{pubkey, DEFAULT_GENESIS_VALIDATORS_ROOT};
 use slashing_protection::SUPPORTED_INTERCHANGE_FORMAT_VERSION;
 use std::fs::{self, File};
+use std::io::Write;
 use std::path::Path;
 use types::{Epoch, Hash256, Slot};
 
@@ -346,6 +347,7 @@ fn main() {
     for test in tests {
         test.run();
         let f = File::create(output_dir.join(format!("{}.json", test.name))).unwrap();
-        serde_json::to_writer(f, &test).unwrap();
+        serde_json::to_writer_pretty(&f, &test).unwrap();
+        writeln!(&f).unwrap();
     }
 }

--- a/validator_client/slashing_protection/tests/interop.rs
+++ b/validator_client/slashing_protection/tests/interop.rs
@@ -2,7 +2,19 @@ use slashing_protection::interchange_test::MultiTestCase;
 use std::fs::File;
 use std::path::PathBuf;
 
+fn download_tests() {
+    let make_output = std::process::Command::new("make")
+        .current_dir(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .output()
+        .expect("need `make` to succeed to download and untar slashing protection tests");
+    if !make_output.status.success() {
+        eprintln!("{}", String::from_utf8_lossy(&make_output.stderr));
+        panic!("Running `make` for slashing protection tests failed, see above");
+    }
+}
+
 fn test_root_dir() -> PathBuf {
+    download_tests();
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("interchange-tests")
         .join("tests")


### PR DESCRIPTION
## Proposed Changes

* Pretty-print the EIP-3076 tests to match https://github.com/eth2-clients/slashing-protection-interchange-tests/pull/4
* Move the `curl` invocation that downloads the tests to the test executor, removing the build script (closes #1982)
