### PR TITLE
[Merged by Bors] - Disable snappy in LevelDB to fix build issues

### DIFF
--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -15,7 +15,7 @@ rayon = "1.4.1"
 
 [dependencies]
 db-key = "0.0.5"
-leveldb = "0.8.6"
+leveldb = { version = "0.8.6", default-features = false }
 parking_lot = "0.11.0"
 itertools = "0.9.0"
 eth2_ssz = "0.1.2"


### PR DESCRIPTION
## Proposed Changes

A user on Discord reported build issues when trying to compile Lighthouse checked out to a path with spaces in it. I've fixed the issue upstream in `leveldb-sys` (https://github.com/skade/leveldb-sys/pull/22), but rather than waiting for a new release of the `leveldb` crate, we can also work around the issue by disabling Snappy in LevelDB, which we weren't using anyway.

This may also have the side-effect of slightly improving compilation times, as LevelDB+Snappy was found to be a substantial contributor to build time (although I'm not sure how much was LevelDB and how much was Snappy).
