### PR TITLE
book: fix command order

### DIFF
--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -6,8 +6,8 @@ Compilation should be easy. In fact, if you already have Rust installed all you
 need is:
 
 - `git clone https://github.com/sigp/lighthouse.git`
-- `git checkout stable`
 - `cd lighthouse`
+- `git checkout stable`
 - `make`
 
 If this doesn't work or is not clear enough, see the [Detailed


### PR DESCRIPTION
There is a typo in the build instructions, in which the user is told to checkout the `stable` branch before moving to the source code directory.

## Proposed Changes

Change the instruction order to fix the typo