### PR TITLE
[Merged by Bors] - Improve eth1 block sync

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -71,13 +71,18 @@ fn get_sync_status<T: EthSpec>(
     latest_cached_block: Option<&Eth1Block>,
     head_block: Option<&Eth1Block>,
     genesis_time: u64,
-    current_slot: Slot,
+    current_slot: Option<Slot>,
     spec: &ChainSpec,
 ) -> Option<Eth1SyncStatusData> {
-    let period = T::SlotsPerEth1VotingPeriod::to_u64();
-    // Since `period` is a "constant", we assume it is set sensibly.
-    let voting_period_start_slot = (current_slot / period) * period;
-    let voting_target_timestamp = {
+    // The voting target timestamp needs to be special-cased when we're before
+    // genesis (as defined by `current_slot == None`).
+    //
+    // For the sake of this status, when prior to genesis we want to invent some voting periods
+    // that are *before* genesis, so that we can indicate to users that we're actually adequately
+    // cached for where they are in time.
+    let voting_target_timestamp = if let Some(current_slot) = current_slot {
+        let voting_period_start_slot = (current_slot / period) * period;
+
         let period_start = slot_start_seconds::<T>(
             genesis_time,
             spec.milliseconds_per_slot,
@@ -88,6 +93,28 @@ fn get_sync_status<T: EthSpec>(
             .saturating_mul(spec.eth1_follow_distance);
 
         period_start.saturating_sub(eth1_follow_distance_seconds)
+    } else {
+        // The number of seconds in an eth1 voting period.
+        let voting_period_duration =
+            T::slots_per_eth1_voting_period() as u64 * (spec.milliseconds_per_slot / 1_000);
+
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+
+        // The number of seconds between now and genesis.
+        let seconds_till_genesis = genesis_time.saturating_sub(now);
+
+        // Determine how many voting periods are contained in distance between
+        // now and genesis, rounding up.
+        let voting_periods_past =
+            (seconds_till_genesis + voting_period_duration - 1) / voting_period_duration;
+
+        // Return the start time of the current voting period*.
+        //
+        // *: This voting period doesn't *actually* exist, we're just using it to
+        // give useful logs prior to genesis.
+        genesis_time
+            .saturating_sub(voting_periods_past * voting_period_duration)
+            .saturating_sub(spec.eth1_follow_distance * spec.seconds_per_eth1_block)
     };
 
     let latest_cached_block_number = latest_cached_block.map(|b| b.number);
@@ -232,7 +259,7 @@ where
     pub fn sync_status(
         &self,
         genesis_time: u64,
-        current_slot: Slot,
+        current_slot: Option<Slot>,
         spec: &ChainSpec,
     ) -> Option<Eth1SyncStatusData> {
         get_sync_status::<E>(

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -239,7 +239,7 @@ fn eth1_logging<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>, log: &Logger
                                 / beacon_chain.spec.seconds_per_eth1_block
                         })
                         .map(|distance| distance.to_string())
-                        .unwrap_or_else(|| "unknown".to_string());
+                        .unwrap_or_else(|| "initializing deposits".to_string());
 
                     warn!(
                         log,

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -27,14 +27,14 @@ pub const DEFAULT_NETWORK_ID: Eth1Id = Eth1Id::Goerli;
 /// Indicates the default eth1 chain id we use for the deposit contract.
 pub const DEFAULT_CHAIN_ID: Eth1Id = Eth1Id::Goerli;
 
-const STANDARD_TIMEOUT_MILLIS: u64 = 60_000;
+const STANDARD_TIMEOUT_MILLIS: u64 = 15_000;
 
 /// Timeout when doing a eth_blockNumber call.
 const BLOCK_NUMBER_TIMEOUT_MILLIS: u64 = STANDARD_TIMEOUT_MILLIS;
 /// Timeout when doing an eth_getBlockByNumber call.
 const GET_BLOCK_TIMEOUT_MILLIS: u64 = STANDARD_TIMEOUT_MILLIS;
 /// Timeout when doing an eth_getLogs to read the deposit contract logs.
-const GET_DEPOSIT_LOG_TIMEOUT_MILLIS: u64 = STANDARD_TIMEOUT_MILLIS;
+const GET_DEPOSIT_LOG_TIMEOUT_MILLIS: u64 = 60_000;
 
 const WARNING_MSG: &str = "BLOCK PROPOSALS WILL FAIL WITHOUT VALID, SYNCED ETH1 CONNECTION";
 

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -27,7 +27,7 @@ pub const DEFAULT_NETWORK_ID: Eth1Id = Eth1Id::Goerli;
 /// Indicates the default eth1 chain id we use for the deposit contract.
 pub const DEFAULT_CHAIN_ID: Eth1Id = Eth1Id::Goerli;
 
-const STANDARD_TIMEOUT_MILLIS: u64 = 15_000;
+const STANDARD_TIMEOUT_MILLIS: u64 = 60_000;
 
 /// Timeout when doing a eth_blockNumber call.
 const BLOCK_NUMBER_TIMEOUT_MILLIS: u64 = STANDARD_TIMEOUT_MILLIS;

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -1011,22 +1011,7 @@ impl Service {
         // consumes the it.
 
         let mut blocks_imported = 0;
-        let start_instant = Instant::now();
-        // Setting the maximum runtime longer than the auto update interval allows us to download
-        // more blocks without interruption.
-        //
-        // This value is a trade-off between making blocks download quickly and starving the deposit
-        // cache of updates.
-        let max_runtime = Duration::from_millis(self.config().auto_update_interval_millis * 2);
         for block_number in required_block_numbers {
-            // Avoid updates that lasts longer than the update interval.
-            //
-            // This prevents the block downloading routine for running for a very long time and
-            // starving the deposit cache updater.
-            if Instant::now().duration_since(start_instant) > max_runtime {
-                break;
-            }
-
             let eth1_block = endpoints
                 .first_success(|e| async move {
                     download_eth1_block(e, self.inner.clone(), Some(block_number)).await

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2075,9 +2075,7 @@ pub fn serve<T: BeaconChainTypes>(
                 let head_info = chain
                     .head_info()
                     .map_err(warp_utils::reject::beacon_chain_error)?;
-                let current_slot = chain
-                    .slot()
-                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                let current_slot_opt = chain.slot().ok();
 
                 chain
                     .eth1_chain
@@ -2088,7 +2086,7 @@ pub fn serve<T: BeaconChainTypes>(
                         )
                     })
                     .and_then(|eth1| {
-                        eth1.sync_status(head_info.genesis_time, current_slot, &chain.spec)
+                        eth1.sync_status(head_info.genesis_time, current_slot_opt, &chain.spec)
                             .ok_or_else(|| {
                                 warp_utils::reject::custom_server_error(
                                     "Unable to determine Eth1 sync status".to_string(),

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -6,6 +6,7 @@
 - [What should I do if I lose my slashing protection database?](#what-should-i-do-if-i-lose-my-slashing-protection-database)
 - [How do I update lighthouse?](#how-do-i-update-lighthouse)
 - [I can't compile lighthouse](#i-cant-compile-lighthouse)
+- [What is "Syncing eth1 block cache"](#what-is-syncing-eth1-block-cache)
 
 
 ### Why does it take so long for a validator to be activated?
@@ -155,3 +156,21 @@ You will just also need to make sure the code you have checked out is up to date
 ### I can't compile lighthouse
 
 See [here.](./installation-source.md#troubleshooting)
+
+### What is "Syncing eth1 block cache"
+
+```
+Nov 30 21:04:28.268 WARN Syncing eth1 block cache   est_blocks_remaining: initializing deposits, msg: sync can take longer when using remote eth1 nodes, service: slot_notifier
+```
+
+This log indicates that your beacon node is downloading blocks and deposits
+from your eth1 node. When the `est_blocks_remaining` is
+`initializing_deposits`, your node is downloading deposit logs. It may stay in
+this stage for several minutes. Once the deposits logs are finished
+downloading, the `est_blocks_remaining` value will start decreasing.
+
+It is perfectly normal to see this log when starting a node for the first time
+or after being off for more than several minutes.
+
+If this log continues appearing sporadically during operation, there may be an
+issue with your eth1 endpoint.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Log about eth1 whilst waiting for genesis.
- For the block and deposit caches, update them after each download instead of when *all* downloads are complete.
  - This prevents the case where a single timeout error can cause us to drop *all* previously download blocks/deposits.
- Set `max_log_requests_per_update` to avoid timeouts due to very large log counts in a response.
- Set `max_blocks_per_update` to prevent a single update of the block cache to download an unreasonable number of blocks.
  - This shouldn't have any affect in normal use, it's just a safe-guard against bugs.
- Increase the timeout for eth1 calls from 15s to 60s, as per @pawanjay176's experience with Infura.

## Additional Info

NA
