### PR TITLE
[Merged by Bors] - Add privacy option

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -151,11 +151,19 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
     ) -> error::Result<Self> {
         let behaviour_log = log.new(o!());
 
-        let identify = Identify::new(
-            "lighthouse/libp2p".into(),
-            lighthouse_version::version_with_platform(),
-            local_key.public(),
-        );
+        let identify = if net_conf.private {
+            Identify::new(
+                "".into(),
+                "".into(),
+                local_key.public(), // Still send legitimate public key
+            )
+        } else {
+            Identify::new(
+                "lighthouse/libp2p".into(),
+                lighthouse_version::version_with_platform(),
+                local_key.public(),
+            )
+        };
 
         let enr_fork_id = network_globals
             .local_enr()

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -88,6 +88,10 @@ pub struct Config {
     /// runtime.
     pub import_all_attestations: bool,
 
+    /// Indicates if the user has set the network to be in private mode. Currently this
+    /// prevents sending client identifying information over identify.
+    pub private: bool,
+
     /// List of extra topics to initially subscribe to as strings.
     pub topics: Vec<GossipKind>,
 }
@@ -188,6 +192,7 @@ impl Default for Config {
             client_version: lighthouse_version::version_with_platform(),
             disable_discovery: false,
             upnp_enabled: true,
+            private: false,
             subscribe_all_subnets: false,
             import_all_attestations: false,
             topics: Vec::new(),

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -98,6 +98,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("private")
+                .long("private")
+                .help("Prevents sending various client identification information.")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("enr-udp-port")
                 .long("enr-udp-port")
                 .value_name("PORT")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -305,6 +305,8 @@ pub fn get_config<E: EthSpec>(
         }
 
         graffiti.as_bytes()
+    } else if cli_args.is_present("private") {
+        "".as_bytes()
     } else {
         lighthouse_version::VERSION.as_bytes()
     };
@@ -575,6 +577,10 @@ pub fn set_network_config(
 
     if cli_args.is_present("disable-upnp") {
         config.upnp_enabled = false;
+    }
+
+    if cli_args.is_present("private") {
+        config.private = true;
     }
 
     Ok(())

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -306,7 +306,7 @@ pub fn get_config<E: EthSpec>(
 
         graffiti.as_bytes()
     } else if cli_args.is_present("private") {
-        "".as_bytes()
+        b""
     } else {
         lighthouse_version::VERSION.as_bytes()
     };


### PR DESCRIPTION
Adds a `--privacy` CLI flag to the beacon node that users may opt into. 

This does two things:
- Removes client identifying information from the identify libp2p protocol
- Changes the default graffiti to "" if no graffiti is set.