### PR TITLE
[Merged by Bors] - Add Content-Type to metrics server

### DIFF
--- a/beacon_node/http_metrics/src/lib.rs
+++ b/beacon_node/http_metrics/src/lib.rs
@@ -116,6 +116,7 @@ pub fn serve<T: BeaconChainTypes>(
                     .unwrap_or_else(|e| {
                         Response::builder()
                             .status(500)
+                            .header("Content-Type", "text/plain")
                             .body(format!("Unable to gather metrics: {:?}", e))
                             .unwrap()
                     }),

--- a/validator_client/src/http_metrics/mod.rs
+++ b/validator_client/src/http_metrics/mod.rs
@@ -123,6 +123,7 @@ pub fn serve<T: EthSpec>(
                     .unwrap_or_else(|e| {
                         Response::builder()
                             .status(500)
+                            .header("Content-Type", "text/plain")
                             .body(format!("Unable to gather metrics: {:?}", e))
                             .unwrap()
                     }),


### PR DESCRIPTION
## Issue Addressed

- Resolves #2013

## Proposed Changes

Adds the `Content-Type text/plain` header as per #2013

## Additional Info

NA
