### PR TITLE
Create non-root user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli
-RUN adduser --disabled-password --gecos "" --home /home/lighthouse lighthouse && \
-    chown lighthouse:lighthouse /home/lighthouse
+RUN adduser --disabled-password --gecos "" --home /home/lighthouse lighthouse \
+  && chown lighthouse:lighthouse /home/lighthouse
 USER lighthouse
 WORKDIR /home/lighthouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,3 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli
+RUN adduser --disabled-password --gecos "" --home /home/lighthouse lighthouse && \
+    chown lighthouse:lighthouse /home/lighthouse
+USER lighthouse
+WORKDIR /home/lighthouse

--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -67,7 +67,7 @@ $ docker run lighthouse:local lighthouse --help
 You can run a Docker beacon node with the following command:
 
 ```bash
-$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse --network mainnet beacon --http --http-address 0.0.0.0
+$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/home/lighthouse/.lighthouse sigp/lighthouse lighthouse --network mainnet beacon --http --http-address 0.0.0.0
 ```
 
 > To join the Pyrmont testnet, use `--network pyrmont` instead.
@@ -76,7 +76,7 @@ $ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/root/.lig
 
 ### Volumes
 
-Lighthouse uses the `/root/.lighthouse` directory inside the Docker image to
+Lighthouse uses the `/home/lighthouse/.lighthouse` directory inside the Docker image to
 store the configuration, database and validator keys. Users will generally want
 to create a bind-mount volume to ensure this directory persists between `docker
 run` commands.
@@ -85,7 +85,7 @@ The following example runs a beacon node with the data directory
 mapped to the users home directory:
 
 ```bash
-$ docker run -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse beacon
+$ docker run -v $HOME/.lighthouse:/home/lighthouse/.lighthouse sigp/lighthouse lighthouse beacon
 ```
 
 ### Ports

--- a/book/src/mainnet-validator.md
+++ b/book/src/mainnet-validator.md
@@ -155,14 +155,14 @@ Those using Docker images can start the processes with:
 ```bash
 $ docker run \
 	--network host \
-	-v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse \
+	-v $HOME/.lighthouse:/home/lighthouse/.lighthouse sigp/lighthouse \
 	lighthouse --network mainnet bn --staking --http-address 0.0.0.0
 ```
 
 ```bash
 $ docker run \
 	--network host \
-	-v $HOME/.lighthouse:/root/.lighthouse \
+	-v $HOME/.lighthouse:/home/lighthouse/.lighthouse \
 	sigp/lighthouse \
 	lighthouse --network mainnet vc
 ```

--- a/book/src/validator-import-launchpad.md
+++ b/book/src/validator-import-launchpad.md
@@ -98,14 +98,14 @@ in this document can be substituted with:
 
 ```bash
 docker run -it \
-	-v $HOME/.lighthouse:/root/.lighthouse \
-	-v $(pwd)/validator_keys:/root/validator_keys \
+	-v $HOME/.lighthouse:/home/lighthouse/.lighthouse \
+	-v $(pwd)/validator_keys:/home/lighthouse/validator_keys \
 	sigp/lighthouse \
-	lighthouse --network MY_NETWORK account validator import --directory /root/validator_keys
+	lighthouse --network MY_NETWORK account validator import --directory /home/lighthouse/validator_keys
 ```
 
 Here we use two `-v` volumes to attach:
 
-- `~/.lighthouse` on the host to `/root/.lighthouse` in the Docker container.
+- `~/.lighthouse` on the host to `/home/lighthouse/.lighthouse` in the Docker container.
 - The `validator_keys` directory in the present working directory of the host
-	to the `/root/validator_keys` directory of the Docker container.
+	to the `/home/lighthouse/validator_keys` directory of the Docker container.


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/1905

## Proposed Changes

Create a `lighthouse` user to run lighthouse in docker.

## Additional Info

- [lighthouse-docker](https://github.com/sigp/lighthouse-docker) will have to adapt. PR https://github.com/sigp/lighthouse-docker/pull/47 makes the needed changes.

- Users will have to change their data directory permissions (now `root` owns everything)

- Users will have to fix `voting_keystore_path`s in `validator_definitions.yml`. Need to replace `/root/.lighthouse/` with `/home/lighthouse/.lighthouse/`. The following sed for instance should do the trick:
  ```sh
  sed -i 's|voting_keystore_path: /root/.lighthouse|voting_keystore_path: /home/lighthouse/.lighthouse|g' validator_definitions.yml
  ```
