### PR TITLE
[Merged by Bors] - delete validator-dir path printing in subcommands

### DIFF
--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -140,7 +140,6 @@ pub fn cli_run<T: EthSpec>(
     ensure_dir_exists(&validator_dir)?;
     ensure_dir_exists(&secrets_dir)?;
 
-    eprintln!("validator-dir path: {:?}", validator_dir);
     eprintln!("secrets-dir path {:?}", secrets_dir);
     eprintln!("wallets-dir path {:?}", wallet_base_dir);
 

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -94,7 +94,6 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
         )
     })?;
 
-    eprintln!("validator-dir path: {:?}", validator_dir);
     // Collect the paths for the keystores that should be imported.
     let keystore_paths = match (keystore, keystores_dir) {
         (Some(keystore), None) => vec![keystore],

--- a/account_manager/src/validator/list.rs
+++ b/account_manager/src/validator/list.rs
@@ -9,7 +9,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn cli_run(validator_dir: PathBuf) -> Result<(), String> {
-    eprintln!("validator-dir path: {:?}", validator_dir);
     let validator_definitions = ValidatorDefinitions::open(&validator_dir).map_err(|e| {
         format!(
             "No validator definitions found in {:?}: {:?}",

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -88,7 +88,6 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
     let mnemonic_path: Option<PathBuf> = clap_utils::parse_optional(matches, MNEMONIC_FLAG)?;
     let stdin_inputs = matches.is_present(STDIN_INPUTS_FLAG);
 
-    eprintln!("validator-dir path: {:?}", validator_dir);
     eprintln!("secrets-dir path: {:?}", secrets_dir);
 
     ensure_dir_exists(&validator_dir)?;

--- a/account_manager/src/validator/slashing_protection.rs
+++ b/account_manager/src/validator/slashing_protection.rs
@@ -45,7 +45,6 @@ pub fn cli_run<T: EthSpec>(
     env: Environment<T>,
     validator_base_dir: PathBuf,
 ) -> Result<(), String> {
-    eprintln!("validator-dir path: {:?}", validator_base_dir);
     let slashing_protection_db_path = validator_base_dir.join(SLASHING_PROTECTION_FILENAME);
 
     let testnet_config = env


### PR DESCRIPTION
## Issue Addressed

Resolves #2004

## Proposed Changes

Only print validator dir path once

## Additional Info

N/A