### PR TITLE
[Merged by Bors] - Fingerprint new client identify agent string

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/client.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/client.rs
@@ -174,6 +174,20 @@ fn client_from_agent_version(agent_version: &str) -> (ClientKind, String, String
             }
             (kind, version, os_version)
         }
+        Some("nimbus") => {
+            let kind = ClientKind::Nimbus;
+            let mut version = String::from("unknown");
+            let mut os_version = version.clone();
+            if agent_split.next().is_some() {
+                if let Some(agent_version) = agent_split.next() {
+                    version = agent_version.into();
+                    if let Some(agent_os_version) = agent_split.next() {
+                        os_version = agent_os_version.into();
+                    }
+                }
+            }
+            (kind, version, os_version)
+        }
         Some("nim-libp2p") => {
             let kind = ClientKind::Nimbus;
             let mut version = String::from("unknown");


### PR DESCRIPTION
Nimbus have modified their identify agent string. 

This PR adds their new agent string to identify new nimbus peers. 
