### PR TITLE
[Merged by Bors] - Update blst to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbf4f6a3ffa04c41ed616749b40dd83431b69db520a18cb60f09db2b7a77c57"
+checksum = "b1f4904512207f2ac5208e5f679106c9e3aa45e4aca9774beda779eab5f522cb"
 dependencies = [
  "cc",
  "glob",

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -17,7 +17,7 @@ eth2_hashing = "0.1.0"
 ethereum-types = "0.9.2"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
-blst = "0.3.1"
+blst = "0.3.2"
 
 [features]
 default = ["supranational"]


### PR DESCRIPTION
## Issue Addressed

Should resolve `blst` build issues that previously required `cargo clean` :crossed_fingers:

## Proposed Changes

BLST cleaned up some of their validation logic: https://github.com/supranational/blst/compare/v0.3.1...v0.3.2

And included my build system PR: https://github.com/supranational/blst/pull/45