### PR TITLE
[Merged by Bors] - Add a purge-eth1-cache cli option

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -685,29 +685,27 @@ where
             eth1_service_from_genesis.drop_block_cache();
 
             CachingEth1Backend::from_service(eth1_service_from_genesis)
+        } else if config.purge_cache {
+            CachingEth1Backend::new(config, context.log().clone(), spec)
         } else {
-            if config.purge_cache {
-                CachingEth1Backend::new(config, context.log().clone(), spec.clone())
-            } else {
-                beacon_chain_builder
-                    .get_persisted_eth1_backend()?
-                    .map(|persisted| {
-                        Eth1Chain::from_ssz_container(
-                            &persisted,
-                            config.clone(),
-                            &context.log().clone(),
-                            spec.clone(),
-                        )
-                        .map(|chain| chain.into_backend())
-                    })
-                    .unwrap_or_else(|| {
-                        Ok(CachingEth1Backend::new(
-                            config,
-                            context.log().clone(),
-                            spec.clone(),
-                        ))
-                    })?
-            }
+            beacon_chain_builder
+                .get_persisted_eth1_backend()?
+                .map(|persisted| {
+                    Eth1Chain::from_ssz_container(
+                        &persisted,
+                        config.clone(),
+                        &context.log().clone(),
+                        spec.clone(),
+                    )
+                    .map(|chain| chain.into_backend())
+                })
+                .unwrap_or_else(|| {
+                    Ok(CachingEth1Backend::new(
+                        config,
+                        context.log().clone(),
+                        spec.clone(),
+                    ))
+                })?
         };
 
         self.eth1_service = Some(backend.core.clone());

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -686,24 +686,28 @@ where
 
             CachingEth1Backend::from_service(eth1_service_from_genesis)
         } else {
-            beacon_chain_builder
-                .get_persisted_eth1_backend()?
-                .map(|persisted| {
-                    Eth1Chain::from_ssz_container(
-                        &persisted,
-                        config.clone(),
-                        &context.log().clone(),
-                        spec.clone(),
-                    )
-                    .map(|chain| chain.into_backend())
-                })
-                .unwrap_or_else(|| {
-                    Ok(CachingEth1Backend::new(
-                        config,
-                        context.log().clone(),
-                        spec.clone(),
-                    ))
-                })?
+            if config.purge_cache {
+                CachingEth1Backend::new(config, context.log().clone(), spec.clone())
+            } else {
+                beacon_chain_builder
+                    .get_persisted_eth1_backend()?
+                    .map(|persisted| {
+                        Eth1Chain::from_ssz_container(
+                            &persisted,
+                            config.clone(),
+                            &context.log().clone(),
+                            spec.clone(),
+                        )
+                        .map(|chain| chain.into_backend())
+                    })
+                    .unwrap_or_else(|| {
+                        Ok(CachingEth1Backend::new(
+                            config,
+                            context.log().clone(),
+                            spec.clone(),
+                        ))
+                    })?
+            }
         };
 
         self.eth1_service = Some(backend.core.clone());

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -343,6 +343,8 @@ pub struct Config {
     pub max_log_requests_per_update: Option<usize>,
     /// The maximum number of log requests per update.
     pub max_blocks_per_update: Option<usize>,
+    /// If set to true, the eth1 caches are wiped clean when the eth1 service starts.
+    pub purge_cache: bool,
 }
 
 impl Config {
@@ -386,6 +388,7 @@ impl Default for Config {
             blocks_per_log_query: 1_000,
             max_log_requests_per_update: Some(100),
             max_blocks_per_update: Some(8_192),
+            purge_cache: false,
         }
     }
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -305,6 +305,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("eth1-purge-cache")
+                .long("eth1-purge-cache")
+                .value_name("PURGE-CACHE")
+                .help("Purges the eth1 block and deposit caches")
+                .takes_value(false)
+        )
+        .arg(
             Arg::with_name("eth1-blocks-per-log-query")
                 .long("eth1-blocks-per-log-query")
                 .value_name("BLOCKS")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -207,6 +207,10 @@ pub fn get_config<E: EthSpec>(
             .map_err(|_| "eth1-blocks-per-log-query is not a valid integer".to_string())?;
     }
 
+    if cli_args.is_present("eth1-purge-cache") {
+        client_config.eth1.purge_cache = true;
+    }
+
     if let Some(freezer_dir) = cli_args.value_of("freezer-dir") {
         client_config.freezer_db_path = Some(PathBuf::from(freezer_dir));
     }


### PR DESCRIPTION
## Issue

Some eth1 clients are missing deposit logs on mainnet for multiple reasons (not fully synced, eth1 client issues) because of which we are getting `FailedToInsertDeposit` errors.
Ideally, LH should pick up where it left off after pointing it to a nice eth1 client endpoint (which has all deposits). 

However, I have seen instances where LH keeps getting `FailedToInsertDeposit` even after switching to a good endpoint. Only deleting the beacon directory (which also wipes the eth1 cache) and resyncing the eth1 caches seems to be the solution. This wouldn't be great for mainnet if you have to sync your beacon node again as well.

## Proposed Changes

Add a `--purge-eth1-db` option which just wipes the eth1 cache and doesn't touch the rest of the beacon db. 
Still need to investigate if and why LH isn't picking up where it left off for the deposit logs sync, but I think it would be good to have an option to just delete eth1 caches regardless.

