### PR TITLE
[Merged by Bors] - Pass failed gossip blocks to the slasher

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -234,7 +234,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// Arbitrary bytes included in the blocks.
     pub(crate) graffiti: Graffiti,
     /// Optional slasher.
-    pub(crate) slasher: Option<Arc<Slasher<T::EthSpec>>>,
+    pub slasher: Option<Arc<Slasher<T::EthSpec>>>,
 }
 
 type BeaconBlockAndState<T> = (BeaconBlock<T>, BeaconState<T>);

--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -77,7 +77,7 @@ mod tests {
         });
 
         let raw_runtime = Arc::try_unwrap(runtime).unwrap();
-        raw_runtime.shutdown_timeout(tokio::time::Duration::from_secs(10));
+        raw_runtime.shutdown_timeout(tokio::time::Duration::from_secs(300));
 
         // Load the persisted dht from the store
         let persisted_enrs = load_dht(store);


### PR DESCRIPTION
## Issue Addressed

Closes #2042

## Proposed Changes

Pass blocks that fail gossip verification to the slasher. Blocks that are successfully verified are not passed immediately, but will be passed as part of full block verification.
