### PR TITLE
[Merged by Bors] - Remove audit ignore ws server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,9 +137,6 @@ arbitrary-fuzz:
 audit:
 	cargo install --force cargo-audit
 	# TODO: we should address this --ignore.
-	#
-	# Tracking issue:
-	# https://github.com/sigp/lighthouse/issues/1669
 	cargo audit --ignore RUSTSEC-2016-0002 --ignore RUSTSEC-2020-0008 --ignore RUSTSEC-2017-0002
 
 # Runs `cargo udeps` to check for unused dependencies

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ audit:
 	#
 	# Tracking issue:
 	# https://github.com/sigp/lighthouse/issues/1669
-	cargo audit --ignore RUSTSEC-2020-0043 --ignore RUSTSEC-2016-0002 --ignore RUSTSEC-2020-0008 --ignore RUSTSEC-2017-0002
+	cargo audit --ignore RUSTSEC-2016-0002 --ignore RUSTSEC-2020-0008 --ignore RUSTSEC-2017-0002
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:


### PR DESCRIPTION
## Issue Addressed

Closes #1669

## Proposed Changes

Remove cargo audit ignore for ws server related vuln now that the ws server has been removed

## Additional Info

N/A
