### PR TITLE
[Merged by Bors] - Downgrades a valid log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ dependencies = [
  "itertools 0.9.0",
  "lazy_static",
  "lighthouse_metrics",
+ "logging",
  "lru_cache",
  "matches",
  "num_cpus",

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -475,7 +475,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         match info.connection_status() {
             PeerConnectionStatus::Disconnected { .. } => {
                 // It is possible to ban a peer that has a disconnected score, if there are many
-                // events that score it poorly and are processed after has disconnected.
+                // events that score it poorly and are processed after it has disconnected.
                 debug!(log_ref, "Banning a disconnected peer"; "peer_id" => %peer_id);
                 self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
                 info.ban();

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -474,8 +474,9 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         // Check and verify all the connection states
         match info.connection_status() {
             PeerConnectionStatus::Disconnected { .. } => {
-                // It should not be possible to ban a peer that is already disconnected.
-                error!(log_ref, "Banning a disconnected peer"; "peer_id" => %peer_id);
+                // It is possible to ban a peer that has a disconnected score, if there are many
+                // events that score it poorly and are processed after has disconnected.
+                debug!(log_ref, "Banning a disconnected peer"; "peer_id" => %peer_id);
                 self.disconnected_peers = self.disconnected_peers.saturating_sub(1);
                 info.ban();
                 self.banned_peers_count

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -13,6 +13,7 @@ tempfile = "3.1.0"
 exit-future = "0.2.0"
 slog-term = "2.6.0"
 slog-async = "2.5.0"
+logging = { path = "../../common/logging" }
 
 [dependencies]
 beacon_chain =  { path = "../beacon_chain" }


### PR DESCRIPTION
## Issue Addressed

#2046 

## Proposed Changes

The log was originally intended to verify the correct logic and ordering of events when scoring peers. The queued tasks can be structured in such a way that peers can be banned after they are disconnected. Therefore the error log is now downgraded to  debug log. 