### PR TITLE
Use persistent data structures in fork choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,6 +566,7 @@ dependencies = [
  "fork_choice",
  "futures 0.3.8",
  "genesis",
+ "im",
  "int_to_bytes",
  "integer-sqrt",
  "itertools 0.9.0",
@@ -674,6 +675,15 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "bitvec"
@@ -2122,6 +2132,7 @@ version = "0.1.2"
 dependencies = [
  "eth2_ssz_derive",
  "ethereum-types",
+ "im",
  "smallvec 1.5.0",
 ]
 
@@ -2370,9 +2381,11 @@ name = "fork_choice"
 version = "0.1.0"
 dependencies = [
  "beacon_chain",
+ "derivative",
  "eth2_ssz",
  "eth2_ssz_derive",
  "hex",
+ "im",
  "proto_array",
  "slot_clock",
  "state_processing",
@@ -3293,6 +3306,21 @@ dependencies = [
  "rand 0.7.3",
  "url 2.2.0",
  "xmltree",
+]
+
+[[package]]
+name = "im"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
+dependencies = [
+ "bitmaps",
+ "rand_core 0.5.1",
+ "rand_xoshiro",
+ "serde",
+ "sized-chunks",
+ "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -5161,6 +5189,7 @@ version = "0.2.0"
 dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
+ "im",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -5476,6 +5505,15 @@ name = "rand_xorshift"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 dependencies = [
  "rand_core 0.5.1",
 ]
@@ -6182,6 +6220,16 @@ name = "siphasher"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa8f3741c7372e75519bd9346068370c9cdaabcc1f9599cbcf2a2719352286b7"
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+dependencies = [
+ "bitmaps",
+ "typenum",
+]
 
 [[package]]
 name = "slab"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -61,3 +61,4 @@ regex = "1.3.9"
 exit-future = "0.2.0"
 slasher = { path = "../../slasher" }
 eth2 = { path = "../../common/eth2" }
+im = "15.0.0"

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+derivative = "2.1.1"
+im = "15.0.0"
 types = { path = "../types" }
 proto_array = { path = "../proto_array" }
 eth2_ssz = "0.1.2"

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -16,7 +16,7 @@ use types::{BeaconBlock, BeaconState, Checkpoint, EthSpec, Hash256, Slot};
 /// The primary motivation for defining this as a trait to be implemented upstream rather than a
 /// concrete struct is to allow this crate to be free from "impure" on-disk database logic,
 /// hopefully making auditing easier.
-pub trait ForkChoiceStore<T: EthSpec>: Sized {
+pub trait ForkChoiceStore<T: EthSpec>: Sized + Clone {
     type Error;
 
     /// Returns the last value passed to `Self::update_time`.

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -9,6 +9,7 @@ use fork_choice::{
     ForkChoiceStore, InvalidAttestation, InvalidBlock, QueuedAttestation,
     SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
 };
+use im::Vector;
 use std::fmt;
 use std::sync::Mutex;
 use store::{MemoryStore, StoreConfig};
@@ -141,7 +142,7 @@ impl ForkChoiceTest {
     /// Inspect the queued attestations in fork choice.
     pub fn inspect_queued_attestations<F>(self, mut func: F) -> Self
     where
-        F: FnMut(&[QueuedAttestation]),
+        F: FnMut(&Vector<QueuedAttestation>),
     {
         self.harness
             .chain

--- a/consensus/proto_array/Cargo.toml
+++ b/consensus/proto_array/Cargo.toml
@@ -9,9 +9,10 @@ name = "proto_array"
 path = "src/bin.rs"
 
 [dependencies]
+im = { version = "15.0.0", features = ["serde"] }
 types = { path = "../types" }
-eth2_ssz = "0.1.2"
+eth2_ssz = { version = "0.1.2", features = ["arc", "im"] }
 eth2_ssz_derive = "0.1.0"
-serde = "1.0.116"
+serde = { version = "1.0.116", features = ["rc"] }
 serde_derive = "1.0.116"
 serde_yaml = "0.8.13"

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -2,19 +2,20 @@ use crate::{
     proto_array::{ProtoArray, ProtoNode},
     proto_array_fork_choice::{ElasticList, ProtoArrayForkChoice, VoteTracker},
 };
+use im::{HashMap, Vector};
 use ssz_derive::{Decode, Encode};
-use std::collections::HashMap;
 use std::iter::FromIterator;
+use std::sync::Arc;
 use types::{Epoch, Hash256};
 
 #[derive(Encode, Decode)]
 pub struct SszContainer {
-    votes: Vec<VoteTracker>,
-    balances: Vec<u64>,
+    votes: Vector<Arc<VoteTracker>>,
+    balances: Vector<u64>,
     prune_threshold: usize,
     justified_epoch: Epoch,
     finalized_epoch: Epoch,
-    nodes: Vec<ProtoNode>,
+    nodes: Vector<Arc<ProtoNode>>,
     indices: Vec<(Hash256, usize)>,
 }
 

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -14,7 +14,9 @@ eth2_ssz_derive = "0.1.0"
 
 [dependencies]
 ethereum-types = "0.9.2"
+im = { version = "15.0.0", optional = true }
 smallvec = "1.4.2"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]
+arc = []


### PR DESCRIPTION
## Issue Addressed

Closes #2028

## Proposed Changes

This PR fixes issues with fork choice becoming out of sync with the database after failed writes (the root cause of #2028). It does this using quite a drastic approach: rather than mutating fork choice directly, we take a clone of it, mutate the clone, and then atomically update the original once the database write has succeeded. In order to make the clone cheap(er), we use persistent data structures from the `im` crate.

In order to make this work, I've added SSZ implementations for `Arc` and `Vector`.

## Additional Info

I'm still assessing the performance and memory impact of this change. We should definitely test it for a substantial period of time on our Pyrmont nodes to ensure the performance penalty is tolerable.