### PR TITLE
Add new PlainTextString type to ensure all passwords are valid UTF-8

### DIFF
--- a/account_manager/src/common.rs
+++ b/account_manager/src/common.rs
@@ -1,9 +1,8 @@
-use account_utils::PlainText;
-use account_utils::{read_input_from_user, strip_off_newlines};
+use account_utils::read_input_from_user;
+use account_utils::PlainTextString;
 use eth2_wallet::bip39::{Language, Mnemonic};
 use std::fs;
 use std::path::PathBuf;
-use std::str::from_utf8;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -15,16 +14,15 @@ pub fn read_mnemonic_from_cli(
     stdin_inputs: bool,
 ) -> Result<Mnemonic, String> {
     let mnemonic = match mnemonic_path {
-        Some(path) => fs::read(&path)
+        Some(path) => fs::read_to_string(&path)
             .map_err(|e| format!("Unable to read {:?}: {:?}", path, e))
-            .and_then(|bytes| {
-                let bytes_no_newlines: PlainText = strip_off_newlines(bytes).into();
-                let phrase = from_utf8(&bytes_no_newlines.as_ref())
-                    .map_err(|e| format!("Unable to derive mnemonic: {:?}", e))?;
-                Mnemonic::from_phrase(phrase, Language::English).map_err(|e| {
+            .and_then(|mnemonic| {
+                let phrase = PlainTextString::from(mnemonic).without_newlines();
+                Mnemonic::from_phrase(phrase.as_str(), Language::English).map_err(|e| {
                     format!(
                         "Unable to derive mnemonic from string {:?}: {:?}",
-                        phrase, e
+                        phrase.as_str(),
+                        e
                     )
                 })
             })?,

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -129,8 +129,8 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
 
         ValidatorDirBuilder::new(validator_dir.clone())
             .password_dir(secrets_dir.clone())
-            .voting_keystore(keystores.voting, voting_password.as_bytes())
-            .withdrawal_keystore(keystores.withdrawal, withdrawal_password.as_bytes())
+            .voting_keystore(keystores.voting, voting_password)
+            .withdrawal_keystore(keystores.withdrawal, withdrawal_password)
             .store_withdrawal_keystore(matches.is_present(STORE_WITHDRAW_FLAG))
             .build()
             .map_err(|e| format!("Unable to build validator directory: {:?}", e))?;

--- a/common/validator_dir/src/insecure_keys.rs
+++ b/common/validator_dir/src/insecure_keys.rs
@@ -7,7 +7,7 @@
 use crate::{Builder, BuilderError};
 use eth2_keystore::{
     json_keystore::{Kdf, Scrypt},
-    Keystore, KeystoreBuilder, PlainText, DKLEN,
+    Keystore, KeystoreBuilder, PlainTextString, DKLEN,
 };
 use std::path::PathBuf;
 use types::test_utils::generate_deterministic_keypair;
@@ -35,7 +35,7 @@ impl<'a> Builder<'a> {
 /// **unsafe** secret key.
 ///
 /// **NEVER** use these keys in production!
-pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainText), String> {
+pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainTextString), String> {
     let keypair = generate_deterministic_keypair(i);
 
     let keystore = KeystoreBuilder::new(&keypair, INSECURE_PASSWORD, "".into())
@@ -44,7 +44,10 @@ pub fn generate_deterministic_keystore(i: usize) -> Result<(Keystore, PlainText)
         .build()
         .map_err(|e| format!("Unable to build keystore: {:?}", e))?;
 
-    Ok((keystore, INSECURE_PASSWORD.to_vec().into()))
+    let password =
+        std::str::from_utf8(INSECURE_PASSWORD).expect("The static password is valid UTF-8");
+
+    Ok((keystore, password.into()))
 }
 
 /// Returns an INSECURE key derivation function.

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -4,9 +4,9 @@ use crate::builder::{
 };
 use deposit_contract::decode_eth1_tx_data;
 use derivative::Derivative;
-use eth2_keystore::{Error as KeystoreError, Keystore, PlainText};
+use eth2_keystore::{Error as KeystoreError, Keystore, PlainText, PlainTextString};
 use lockfile::{Lockfile, LockfileError};
-use std::fs::{read, write, OpenOptions};
+use std::fs::{read, read_to_string, write, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
 use tree_hash::TreeHash;
@@ -219,7 +219,7 @@ pub fn unlock_keypair<P: AsRef<Path>>(
     let password_path = password_dir
         .as_ref()
         .join(format!("0x{}", keystore.pubkey()));
-    let password: PlainText = read(&password_path)
+    let password: PlainTextString = read_to_string(&password_path)
         .map_err(|_| Error::UnableToReadPassword(password_path))?
         .into();
     keystore

--- a/crypto/eth2_key_derivation/src/lib.rs
+++ b/crypto/eth2_key_derivation/src/lib.rs
@@ -4,8 +4,10 @@
 mod derived_key;
 mod lamport_secret_key;
 mod plain_text;
+mod plain_text_string;
 mod secret_bytes;
 
 pub use bls::ZeroizeHash;
 pub use derived_key::DerivedKey;
 pub use plain_text::PlainText;
+pub use plain_text_string::PlainTextString;

--- a/crypto/eth2_key_derivation/src/plain_text_string.rs
+++ b/crypto/eth2_key_derivation/src/plain_text_string.rs
@@ -1,0 +1,96 @@
+use zeroize::Zeroize;
+
+/// Provides wrapper around `String` that implements `Zeroize` and guarantees the underlying bytes
+/// are UTF-8.
+#[derive(Zeroize, Clone, PartialEq)]
+#[zeroize(drop)]
+pub struct PlainTextString(String);
+
+impl PlainTextString {
+    /// Returns a reference to the underlying &str.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Returns a reference to the underlying bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    /// Returns a mutable reference to the underlying bytes.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        // This will panic if the resulting bytes are not UTF-8.
+        unsafe { self.0.as_bytes_mut() }
+    }
+
+    /// Remove any number of newline or carriage returns from the end of a vector of bytes.
+    pub fn without_newlines(&self) -> PlainTextString {
+        let stripped_string = self.0.trim_end_matches(|c| c == '\r' || c == '\n').into();
+        Self(stripped_string)
+    }
+}
+
+impl From<&str> for PlainTextString {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<String> for PlainTextString {
+    fn from(value: String) -> Self {
+        PlainTextString(value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PlainTextString;
+
+    #[test]
+    fn test_strip_off() {
+        let expected = "hello world";
+
+        assert_eq!(
+            PlainTextString::from("hello world\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world\n\n\n\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world\r")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world\r\r\r\r\r")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world\r\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world\r\n\r\n")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+        assert_eq!(
+            PlainTextString::from("hello world")
+                .without_newlines()
+                .as_str(),
+            expected
+        );
+    }
+}

--- a/crypto/eth2_keystore/src/lib.rs
+++ b/crypto/eth2_keystore/src/lib.rs
@@ -8,6 +8,7 @@ pub mod json_keystore;
 
 pub use bls::ZeroizeHash;
 pub use eth2_key_derivation::PlainText;
+pub use eth2_key_derivation::PlainTextString;
 pub use keystore::{
     decrypt, default_kdf, encrypt, keypair_from_secret, Error, Keystore, KeystoreBuilder, DKLEN,
     HASH_SIZE, IV_SIZE, SALT_SIZE,

--- a/crypto/eth2_wallet/src/lib.rs
+++ b/crypto/eth2_wallet/src/lib.rs
@@ -7,5 +7,5 @@ pub use bip39;
 pub use validator_path::{KeyType, ValidatorPath, COIN_TYPE, PURPOSE};
 pub use wallet::{
     recover_validator_secret, recover_validator_secret_from_mnemonic, DerivedKey, Error,
-    KeystoreError, PlainText, Uuid, ValidatorKeystores, Wallet, WalletBuilder,
+    KeystoreError, PlainText, PlainTextString, Uuid, ValidatorKeystores, Wallet, WalletBuilder,
 };

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -15,7 +15,7 @@ use std::io::{Read, Write};
 
 pub use bip39::{Mnemonic, Seed as Bip39Seed};
 pub use eth2_key_derivation::DerivedKey;
-pub use eth2_keystore::{Error as KeystoreError, PlainText};
+pub use eth2_keystore::{Error as KeystoreError, PlainText, PlainTextString};
 pub use uuid::Uuid;
 
 #[derive(Debug, PartialEq)]

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -92,8 +92,8 @@ pub async fn create_validators<P: AsRef<Path>, T: 'static + SlotClock, E: EthSpe
             })?;
 
         let validator_dir = ValidatorDirBuilder::new(validator_dir.as_ref().into())
-            .voting_keystore(keystores.voting, voting_password.as_bytes())
-            .withdrawal_keystore(keystores.withdrawal, withdrawal_password.as_bytes())
+            .voting_keystore(keystores.voting, voting_password)
+            .withdrawal_keystore(keystores.withdrawal, withdrawal_password)
             .create_eth1_tx_data(request.deposit_gwei, &spec)
             .store_withdrawal_keystore(false)
             .build()

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -369,7 +369,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         })?;
 
                     let validator_dir = ValidatorDirBuilder::new(validator_dir.clone())
-                        .voting_keystore(body.keystore.clone(), body.password.as_ref())
+                        .voting_keystore(body.keystore.clone(), body.password.as_str().into())
                         .store_withdrawal_keystore(false)
                         .build()
                         .map_err(|e| {

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -334,9 +334,7 @@ impl ApiTester {
         if !s.correct_password {
             let request = KeystoreValidatorsPostRequest {
                 enable: s.enabled,
-                password: String::from_utf8(random_password().as_ref().to_vec())
-                    .unwrap()
-                    .into(),
+                password: random_password().as_str().to_string().into(),
                 keystore,
             };
 
@@ -350,9 +348,7 @@ impl ApiTester {
 
         let request = KeystoreValidatorsPostRequest {
             enable: s.enabled,
-            password: String::from_utf8(password.as_ref().to_vec())
-                .unwrap()
-                .into(),
+            password: password.as_str().to_string().into(),
             keystore,
         };
 

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -162,7 +162,7 @@ impl InitializedValidator {
                                 // If the password is supplied, use it and ignore the path
                                 // (if supplied).
                                 (_, Some(password)) => (
-                                    password.as_ref().to_vec().into(),
+                                    password.as_str().into(),
                                     keystore
                                         .decrypt_keypair(password.as_ref())
                                         .map_err(Error::UnableToDecryptKeystore)?,
@@ -182,7 +182,7 @@ impl InitializedValidator {
                                         &keystore,
                                         &keystore_path,
                                     )?;
-                                    (password.as_ref().to_vec().into(), keypair)
+                                    (password.as_str().into(), keypair)
                                 }
                             },
                         )
@@ -447,15 +447,14 @@ impl InitializedValidators {
                     voting_keystore_path,
                 } => {
                     if let Some(p) = voting_keystore_password {
-                        p.as_ref().to_vec().into()
+                        p.as_str().into()
                     } else if let Some(path) = voting_keystore_password_path {
                         read_password(path).map_err(Error::UnableToReadVotingKeystorePassword)?
                     } else {
                         let keystore = open_keystore(voting_keystore_path)?;
                         unlock_keystore_via_stdin_password(&keystore, &voting_keystore_path)?
                             .0
-                            .as_ref()
-                            .to_vec()
+                            .as_str()
                             .into()
                     }
                 }


### PR DESCRIPTION
## Issue Addressed

Issue #1205
Feedback from PR #1217
This supersedes my previous PR https://github.com/sigp/lighthouse/pull/1770 .

## Proposed Changes

1. This uses `fs::read_to_string` to enforce utf8 when dealing with reading passwords from files.
2. In my previous PR I tried to change the inner value of `PlainText(Vec<u8>)` to become `PlainText(String)`. This was not possible because I found existing (and valid) instances where `PlainText` contained invalid utf8. I do like the idea of a `PlainTextString` though, so this PR introduces a new and more specific type, `PlainTextString(String)`. It might be a little clumsy to have two different `PlainText` types, but I think it makes sense.
3. There are a few methods that take a password as a `&[u8]`, and I switched _some_ (but not all) to use the new `PlainTextString`. Happy to remove what I added if you would like these changed in a followup PR.
4. The `PlainTextString` type uses an `unsafe` block to make `as_mut_bytes` work. This will panic if the caller of this method changes the internal bytes to become invalid utf8. Any ideas around making this more sound?

## Additional Info

I mentioned this in the other PR but I'm relatively new to rust, so don't hesitate to add lots of feedback!