### PR TITLE
[Merged by Bors] - Softer penalties for missing blocks

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -682,6 +682,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 // https://github.com/sigp/lighthouse/issues/1039
 
                 // TODO: Maintain this attestation and re-process once sync completes
+                // TODO: We then score based on whether we can download the block and re-process.
                 debug!(
                     self.log,
                     "Attestation for unknown block";
@@ -701,10 +702,6 @@ impl<T: BeaconChainTypes> Worker<T> {
                             "msg" => "UnknownBlockHash"
                         )
                     });
-                // We still penalize the peer slightly. We don't want this to be a recurring
-                // behaviour.
-                self.gossip_penalize_peer(peer_id.clone(), PeerAction::HighToleranceError);
-
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return;
             }


### PR DESCRIPTION
## Issue Addressed

Users are reporting errors for sending attestations to peers. If the clock sync is a little out or we receive attestations before blocks, peers are being too harshly penalized. They can get scored many times per missing block and we typically need these peers on subnets. 


## Proposed Changes

This removes the penalization for missing blocks with attestations. The penalty should be handled when #635 gets built as it will allow us to group attestations per missing block and penalize once. 

