### PR TITLE
[Merged by Bors] - Add cargo vendor test

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -235,7 +235,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
-      run:  make vendor
+      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
   cargo-udeps:
     name: cargo-udeps
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -228,6 +228,14 @@ jobs:
       run: rustup update stable
     - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
       run:  make audit
+  cargo-vendor:
+    name: cargo-vendor
+    runs-on: ubuntu-latest
+    needs: cargo-fmt
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
+      run:  make vendor
   cargo-udeps:
     name: cargo-udeps
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,10 @@ audit:
 	cargo install --force cargo-audit
 	cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
 
+# Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
+vendor:
+	cargo vendor
+
 # Runs `cargo udeps` to check for unused dependencies
 udeps:
 	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release


### PR DESCRIPTION
## Issue Addressed

This is related to #1926 and #1712.

## Proposed Changes

This PR adds a test that make sure that the used dependencies can be vendored.

Being able to vendor the dependencies is important for archival and repdroducibility purpose.
It's also required to package lighthouse for some Linux distributions. Specifically [NixOS](https://nixos.org/) and [Yocto](https://www.yoctoproject.org/).

## Additional Info

This PR only adds the test, it doesn't clean up the dependencies yet. That's why it is in draft.

