### PR TITLE
[Merged by Bors] - Improve docker auto builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,20 +44,20 @@ jobs:
               run: |
                   mkdir ./bin;
                   mv ./target/aarch64-unknown-linux-gnu/release/lighthouse ./bin;
-            - name: Install emulation dependencies
-              run: |
-                  docker run --privileged --rm tonistiigi/binfmt --install arm64
             - name: Set Env
               if: needs.extract-branch-name.outputs.BRANCH_NAME == 'unstable'
               run: |
                   echo "TAG_SUFFIX=-unstable" >> $GITHUB_ENV;
+            # Install dependencies for emulation. Have to create a new builder to pick up emulation support.
             - name: Build ARM64 dockerfile (with push)
               run: |
+                  docker run --privileged --rm tonistiigi/binfmt --install arm64
+                  docker buildx create --use --name cross-builder
                   docker buildx build \
                       --platform=linux/arm64 \
                       --file ./Dockerfile.cross . \
-                      --tag ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX}
-                  docker push {IMAGE_NAME}:latest-arm64${TAG_SUFFIX}
+                      --tag ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX} \
+                      --push
     build-docker-amd64:
         runs-on: ubuntu-18.04
         needs: [extract-branch-name]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
     extract-branch-name:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         steps:
             - name: Extract branch name
               run: echo "::set-output name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
@@ -21,8 +21,11 @@ jobs:
         outputs:
             BRANCH_NAME: ${{ steps.extract_branch.outputs.BRANCH_NAME }}
     build-docker-arm64:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         needs: [extract-branch-name]
+        # We need to enable experimental docker features in order to use `docker buildx`
+        env:
+            DOCKER_CLI_EXPERIMENTAL: enabled
         steps:
             - uses: actions/checkout@v2
             - name: Dockerhub login
@@ -41,17 +44,9 @@ jobs:
               run: |
                   mkdir ./bin;
                   mv ./target/aarch64-unknown-linux-gnu/release/lighthouse ./bin;
-            - name: Build Docker Buildx
+            - name: Install emulation dependencies
               run: |
-                  export DOCKER_BUILDKIT=1;
-                  docker build --platform=local -o . git://github.com/docker/buildx;
-                  mkdir -p ~/.docker/cli-plugins;
-                  mv buildx ~/.docker/cli-plugins/docker-buildx;
-            - name: Create Docker Builder
-              run: |
-                  docker run --rm --privileged multiarch/qemu-user-static --reset -p yes;
-                  docker context create builder;
-                  docker buildx create --use --name lighthouse builder;
+                  docker run --privileged --rm tonistiigi/binfmt --install arm64
             - name: Set Env
               if: needs.extract-branch-name.outputs.BRANCH_NAME == 'unstable'
               run: |
@@ -64,7 +59,7 @@ jobs:
                       --file ./Dockerfile.cross . \
                       --tag ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX}
     build-docker-amd64:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         needs: [extract-branch-name]
         steps:
             - uses: actions/checkout@v2
@@ -83,8 +78,11 @@ jobs:
                       --file ./Dockerfile .
                   docker push ${IMAGE_NAME}:latest-amd64${TAG_SUFFIX}
     build-docker-multiarch:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         needs: [build-docker-arm64, build-docker-amd64, extract-branch-name]
+        # We need to enable experimental docker features in order to use `docker manifest`
+        env:
+            DOCKER_CLI_EXPERIMENTAL: enabled
         steps:
             - name: Dockerhub login
               run: |
@@ -94,9 +92,7 @@ jobs:
               run: |
                   echo "TAG_SUFFIX=-unstable" >> $GITHUB_ENV;
             - name: Create and push multiarch manifest
-                # We need to enable experimental docker features in order to use `docker manifest`
               run: |
-                  export DOCKER_CLI_EXPERIMENTAL=enabled;
                   docker manifest create ${IMAGE_NAME}:latest${TAG_SUFFIX} \
                       --amend ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX} \
                       --amend ${IMAGE_NAME}:latest-amd64${TAG_SUFFIX};

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,9 +55,9 @@ jobs:
               run: |
                   docker buildx build \
                       --platform=linux/arm64 \
-                      --output "type=image,push=true" \
                       --file ./Dockerfile.cross . \
                       --tag ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX}
+                  docker push {IMAGE_NAME}:latest-arm64${TAG_SUFFIX}
     build-docker-amd64:
         runs-on: ubuntu-18.04
         needs: [extract-branch-name]


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

- hardcode `ubuntu-18.04` -- I don't think this was causing us issues, but github actions is in the process of migrating `ubuntu-latest` from Ubuntu 18 -> 20.. so just in case
- different source of emulation dependencies -> https://github.com/tonistiigi/binfmt 
  - this one is explicitly referenced in the `buildx` github docs
- install emulation dependencies and run `docker buildx` in the same `run` command
- enable `buildx` with  `DOCKER_CLI_EXPERIMENTAL: enabled` rather than re-building it

## Additional Info

N/A
