### PR TITLE
[Merged by Bors] - add caching to test suite

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: target/aarch64-unknown-linux-gnu/release
-                  key: ${{ runner.os }}-target-aarch64-release-${{ hashFiles('**/Cargo.lock') }}
+                  key: ${{ runner.os }}-target-aarch64-release-portable-${{ hashFiles('**/Cargo.lock') }}
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,19 @@ jobs:
             DOCKER_CLI_EXPERIMENTAL: enabled
         steps:
             - uses: actions/checkout@v2
+            - name: Cache cargo directory
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.cargo/registry/index/
+                      ~/.cargo/registry/cache/
+                      ~/.cargo/git/db/
+                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            - name: Cache target aarch64 release directory
+              uses: actions/cache@v2
+              with:
+                  path: target/aarch64-unknown-linux-gnu/release
+                  key: ${{ runner.os }}-target-aarch64-release-${{ hashFiles('**/Cargo.lock') }}
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -3,7 +3,7 @@ name: test-suite
 on:
   push:
     branches:
-      - master
+      - unstable
       - staging
       - trying
       - 'pr/*'
@@ -27,6 +27,19 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
+    - name: Cache cargo directory
+      uses: actions/cache@v2
+      with:
+          path: |
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache target release directory
+      uses: actions/cache@v2
+      with:
+          path: target/release
+          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -39,6 +52,19 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
+    - name: Cache cargo directory
+      uses: actions/cache@v2
+      with:
+          path: |
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache target debug directory
+      uses: actions/cache@v2
+      with:
+          path: target/debug
+          key: ${{ runner.os }}-target-debug-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -79,6 +105,19 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
+    - name: Cache cargo directory
+      uses: actions/cache@v2
+      with:
+          path: |
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache target release directory
+      uses: actions/cache@v2
+      with:
+          path: target/release
+          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim that starts from an eth1 contract
@@ -89,6 +128,19 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
+    - name: Cache cargo directory
+      uses: actions/cache@v2
+      with:
+          path: |
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Cache target release directory
+      uses: actions/cache@v2
+      with:
+          path: target/release
+          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim without an eth1 connection

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -11,6 +11,7 @@ on:
 env:
   # Deny warnings in CI
   RUSTFLAGS: "-D warnings"
+  PORTABLE: true
 jobs:
   cargo-fmt:
     name: cargo-fmt
@@ -39,7 +40,7 @@ jobs:
       uses: actions/cache@v2
       with:
           path: target/release
-          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -64,7 +65,7 @@ jobs:
       uses: actions/cache@v2
       with:
           path: target/debug
-          key: ${{ runner.os }}-target-debug-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-debug-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -117,7 +118,7 @@ jobs:
       uses: actions/cache@v2
       with:
           path: target/release
-          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim that starts from an eth1 contract
@@ -140,7 +141,7 @@ jobs:
       uses: actions/cache@v2
       with:
           path: target/release
-          key: ${{ runner.os }}-target-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim without an eth1 connection

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -61,7 +61,7 @@ jobs:
               ~/.cargo/registry/cache/
               ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target debug dir
+    - name: Cache target debug directory
       uses: actions/cache@v2
       with:
           path: target/debug

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -61,7 +61,7 @@ jobs:
               ~/.cargo/registry/cache/
               ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target debug directory
+    - name: Cache target debug dir
       uses: actions/cache@v2
       with:
           path: target/debug


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add some caching to the test suite and to the aarch64 cross-compile in the docker build. 

## Additional Info

Cache hits only occur if the Cargo.lock file is unchanged, Github Actions runner OS matches, and the cache is "in scope". Some documentation on github actions cache scoping is here:

https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key

I'm not sure how frequently we'll get cache hits, I imagine only on smaller PR's or updates to the same PR.  And there is a cache size limit that we may end up reaching quickly.  But Github actions handles evictions if we go over that limit. 

Not sure how much of an impact this will end up having but I don't really see a downside to trying it out.