### PR TITLE
[Merged by Bors] - Improve eth1 fallback logging

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -219,8 +219,8 @@ async fn get_remote_head_and_new_block_ranges(
             service.log,
             "Eth1 endpoint is not synced";
             "endpoint" => endpoint,
-            "action" => "trying fallback";
-            "last_seen_block_unix_timestamp" => remote_head_block.timestamp
+            "last_seen_block_unix_timestamp" => remote_head_block.timestamp,
+            "action" => "trying fallback"
         );
         return Err(SingleEndpointError::EndpointError(EndpointError::FarBehind));
     }
@@ -230,7 +230,7 @@ async fn get_remote_head_and_new_block_ranges(
             warn!(
                 service.log,
                 "Eth1 endpoint is not synced";
-                "endpoint" => endpoint
+                "endpoint" => endpoint,
                 "action" => "trying fallbacks"
             );
         }

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -139,8 +139,9 @@ async fn endpoint_state(
     let error_connecting = |_| {
         warn!(
             log,
-            "Error connecting to eth1 node. Trying fallback ...";
+            "Error connecting to eth1 node endpoint";
             "endpoint" => endpoint,
+            "action" => "trying fallbacks"
         );
         EndpointError::NotReachable
     };
@@ -150,9 +151,9 @@ async fn endpoint_state(
     if &network_id != config_network_id {
         warn!(
             log,
-            "Invalid eth1 network id. Please switch to correct network id. Trying \
-             fallback ...";
+            "Invalid eth1 network id on endpoint. Please switch to correct network id";
             "endpoint" => endpoint,
+            "action" => "trying fallbacks",
             "expected" => format!("{:?}",config_network_id),
             "received" => format!("{:?}",network_id),
         );
@@ -168,15 +169,16 @@ async fn endpoint_state(
             log,
             "Remote eth1 node is not synced";
             "endpoint" => endpoint,
+            "action" => "trying fallbacks"
         );
         return Err(EndpointError::FarBehind);
     }
     if &chain_id != config_chain_id {
         warn!(
             log,
-            "Invalid eth1 chain id. Please switch to correct chain id. Trying \
-             fallback ...";
+            "Invalid eth1 chain id. Please switch to correct chain id on endpoint";
             "endpoint" => endpoint,
+            "action" => "trying fallbacks",
             "expected" => format!("{:?}",config_chain_id),
             "received" => format!("{:?}", chain_id),
         );
@@ -215,8 +217,9 @@ async fn get_remote_head_and_new_block_ranges(
     if remote_head_block.timestamp + node_far_behind_seconds < now {
         warn!(
             service.log,
-            "Eth1 endpoint is far behind. Trying fallback ...";
+            "Eth1 endpoint is not synced";
             "endpoint" => endpoint,
+            "action" => "trying fallback";
             "last_seen_block_unix_timestamp" => remote_head_block.timestamp
         );
         return Err(SingleEndpointError::EndpointError(EndpointError::FarBehind));
@@ -224,7 +227,12 @@ async fn get_remote_head_and_new_block_ranges(
 
     let handle_remote_not_synced = |e| {
         if let SingleEndpointError::RemoteNotSynced { .. } = e {
-            warn!(service.log, "Eth1 node not synced. Trying fallback..."; "endpoint" => endpoint);
+            warn!(
+                service.log,
+                "Eth1 endpoint is not synced";
+                "endpoint" => endpoint
+                "action" => "trying fallbacks"
+            );
         }
         e
     };


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

There seemed to be confusion among discord users on the eth1 fallback logging
```
WARN Error connecting to eth1 node. Trying fallback ..., endpoint: http://127.0.0.1:8545/, service: eth1_rpc
```
The assumption users seem to be making here is that it is trying the fallback and fallback=endpoint in the log.

This PR improves the logging to be like
```
WARN Error connecting to eth1 node endpoint, endpoint: http://127.0.0.1:8545/, action: trying fallbacks, service: eth1_rpc
```

I think this is a bit more clear that the endpoint that failed is the one in the log. 
