### PR TITLE
[Merged by Bors] - Revert "add caching to test suite (#2089)"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,19 +28,6 @@ jobs:
             DOCKER_CLI_EXPERIMENTAL: enabled
         steps:
             - uses: actions/checkout@v2
-            - name: Cache cargo directory
-              uses: actions/cache@v2
-              with:
-                  path: |
-                      ~/.cargo/registry/index/
-                      ~/.cargo/registry/cache/
-                      ~/.cargo/git/db/
-                  key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-            - name: Cache target aarch64 release directory
-              uses: actions/cache@v2
-              with:
-                  path: target/aarch64-unknown-linux-gnu/release
-                  key: ${{ runner.os }}-target-aarch64-release-portable-${{ hashFiles('**/Cargo.lock') }}
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -3,7 +3,7 @@ name: test-suite
 on:
   push:
     branches:
-      - unstable
+      - master
       - staging
       - trying
       - 'pr/*'
@@ -11,7 +11,6 @@ on:
 env:
   # Deny warnings in CI
   RUSTFLAGS: "-D warnings"
-  PORTABLE: true
 jobs:
   cargo-fmt:
     name: cargo-fmt
@@ -28,19 +27,6 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
-    - name: Cache cargo directory
-      uses: actions/cache@v2
-      with:
-          path: |
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target release directory
-      uses: actions/cache@v2
-      with:
-          path: target/release
-          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -53,19 +39,6 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
-    - name: Cache cargo directory
-      uses: actions/cache@v2
-      with:
-          path: |
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target debug directory
-      uses: actions/cache@v2
-      with:
-          path: target/debug
-          key: ${{ runner.os }}-target-debug-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install ganache-cli
@@ -106,19 +79,6 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
-    - name: Cache cargo directory
-      uses: actions/cache@v2
-      with:
-          path: |
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target release directory
-      uses: actions/cache@v2
-      with:
-          path: target/release
-          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim that starts from an eth1 contract
@@ -129,19 +89,6 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v1
-    - name: Cache cargo directory
-      uses: actions/cache@v2
-      with:
-          path: |
-              ~/.cargo/registry/index/
-              ~/.cargo/registry/cache/
-              ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Cache target release directory
-      uses: actions/cache@v2
-      with:
-          path: target/release
-          key: ${{ runner.os }}-target-release-portable-${{ hashFiles('**/Cargo.lock') }}
     - name: Install ganache-cli
       run: sudo npm install -g ganache-cli
     - name: Run the beacon chain sim without an eth1 connection


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

I didn't realize the `PORTABLE` env variable is only picked up by `install` in the `Makefile` so we are still getting `SIGILL`s:

https://github.com/sigp/lighthouse/runs/1565004525?check_suite_focus=true

## Additional Info

