### PR TITLE
[Merged by Bors] - Fix typo in `ssz_snappy.rs` comment

### DIFF
--- a/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/eth2_libp2p/src/rpc/codec/ssz_snappy.rs
@@ -343,7 +343,7 @@ impl<TSpec: EthSpec> OutboundCodec<RPCRequest<TSpec>> for SSZSnappyOutboundCodec
 
         // Calculate worst case compression length for given uncompressed length
         let max_compressed_len = snap::raw::max_compress_len(length) as u64;
-        // // Create a limit reader as a wrapper that reads only upto `max_compressed_len` from `src`.
+        // Create a limit reader as a wrapper that reads only upto `max_compressed_len` from `src`.
         let limit_reader = Cursor::new(src.as_ref()).take(max_compressed_len);
         let mut reader = FrameDecoder::new(limit_reader);
         let mut decoded_buffer = vec![0; length];


### PR DESCRIPTION
## Issue Addressed

None

## Proposed Changes

Correct a typo in `ssz_snappy.rs`.

## Additional Info

Pedantry at it finest.