### PR TITLE
[Merged by Bors] - Tidy slasher logs for known slashings

### DIFF
--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -223,8 +223,6 @@ pub enum AttesterSlashingInvalid {
     IndexedAttestation2Invalid(BlockOperationError<IndexedAttestationInvalid>),
     /// The validator index is unknown. One cannot slash one who does not exist.
     UnknownValidator(u64),
-    /// The specified validator has already been withdrawn.
-    ValidatorAlreadyWithdrawn(u64),
     /// There were no indices able to be slashed.
     NoSlashableIndices,
 }


### PR DESCRIPTION
## Proposed Changes

This quiets the slasher logs when ingesting slashings that are already known. Previously we would log an `ERRO` when a slashing was rediscovered locally but had already been submitted on-chain. This is to be expected from time to time, as different users' slashers will run at different times, and it's likely that slashings will make it on-chain before all users have detected them locally. 
