### PR TITLE
[Merged by Bors] - Remove duplicate log in BN fallback

### DIFF
--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -256,17 +256,7 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
         log: &Logger,
     ) -> Result<(), CandidateError> {
         if let Some(slot_clock) = slot_clock {
-            match check_synced(&self.beacon_node, slot_clock, Some(log)).await {
-                r @ Err(CandidateError::NotSynced) => {
-                    warn!(
-                        log,
-                        "Beacon node is not synced";
-                        "endpoint" => %self.beacon_node,
-                    );
-                    r
-                }
-                result => result,
-            }
+            check_synced(&self.beacon_node, slot_clock, Some(log)).await
         } else {
             // Skip this check if we don't supply a slot clock.
             Ok(())

--- a/validator_client/src/check_synced.rs
+++ b/validator_client/src/check_synced.rs
@@ -48,7 +48,7 @@ pub async fn check_synced<T: SlotClock>(
 
             warn!(
                 log,
-                "Beacon node is syncing";
+                "Beacon node is not synced";
                 "sync_distance" => resp.data.sync_distance.as_u64(),
                 "head_slot" => resp.data.head_slot.as_u64(),
                 "endpoint" => %beacon_node,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Removes a duplicated log in the fallback code for the VC.
- Updates the text in the remaining de-duped log.

## Additional Info

Example

```
Dec 23 05:19:54.003 WARN Beacon node is syncing                  endpoint: http://xxxx:5052/, head_slot: 88224, sync_distance: 161774
Dec 23 05:19:54.003 WARN Beacon node is not synced               endpoint: http://xxxxx:5052/
```
