### PR TITLE
[Merged by Bors] - Remove default beacon node value from clap

### DIFF
--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -1,4 +1,3 @@
-use crate::config::DEFAULT_BEACON_NODE;
 use clap::{App, Arg};
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
@@ -23,7 +22,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("beacon-nodes")
                 .value_name("NETWORK_ADDRESSES")
                 .help("Comma-separated addresses to one or more beacon node HTTP APIs")
-                .default_value(&DEFAULT_BEACON_NODE)
                 .takes_value(true),
         )
         // This argument is deprecated, use `--beacon-nodes` instead.

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -21,7 +21,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("beacon-nodes")
                 .long("beacon-nodes")
                 .value_name("NETWORK_ADDRESSES")
-                .help("Comma-separated addresses to one or more beacon node HTTP APIs")
+                .help("Comma-separated addresses to one or more beacon node HTTP APIs. \
+                       Default is http://localhost:5052."
+                )
                 .takes_value(true),
         )
         // This argument is deprecated, use `--beacon-nodes` instead.


### PR DESCRIPTION
## Issue Addressed

Fixes #2118 

## Proposed Changes

Removes the default value in clap for `--beacon-nodes`. 
This was causing issues with cli picking `--beacon-nodes` default even when not specified and overriding `--beacon-node`.
Seems like it was more evident with docker setups because it doesn't use the default `http://localhost:5052` option.

Edit: we already set the default to `http://localhost:5052` here so this shouldn't break any existing setups.
https://github.com/sigp/lighthouse/blob/9ed65a64f8fc518c98b381e628556df9bf906acb/validator_client/src/config.rs#L58 

## Additional info
Tested this with docker-compose and binaries. Works as expected in both cases.