### PR TITLE
[Merged by Bors] - Use cross in linux x86 64 release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,28 +59,40 @@ jobs:
             #       Builds
             # ==============================
 
-            - name: Build Lighthouse for ${{matrix.arch}}
-              if:   startsWith(matrix.arch, 'aarch64') && endsWith(matrix.arch, 'portable')
+            - name: Build Lighthouse for aarch64-unknown-linux-gnu-portable
+              if:   matrix.arch == 'aarch64-unknown-linux-gnu-portable'
               run:  |
                 cargo install cross
                 make build-aarch64-portable
 
-            - name: Build Lighthouse for ${{matrix.arch}}
-              if:   startsWith(matrix.arch, 'aarch64') && !endsWith(matrix.arch, 'portable')
+            - name: Build Lighthouse for aarch64-unknown-linux-gnu
+              if:   matrix.arch == 'aarch64-unknown-linux-gnu'
               run:  |
                 cargo install cross
                 make build-aarch64
+
+            - name: Build Lighthouse for x86_64-unknown-linux-gnu-portable
+              if:   matrix.arch == 'x86_64-unknown-linux-gnu-portable'
+              run:  make make build-x86_64-portable
+
+            - name: Build Lighthouse for x86_64-unknown-linux-gnu
+              if:   matrix.arch == 'x86_64-unknown-linux-gnu'
+              run:  make build-x86_64
 
             - name: Move cross-compiled binary
               if:  startsWith(matrix.arch, 'aarch64')
               run: mv target/aarch64-unknown-linux-gnu/release/lighthouse ~/.cargo/bin/lighthouse
 
-            - name: Build Lighthouse for ${{matrix.arch}} portable
-              if:   startsWith(matrix.arch, 'x86_64') && endsWith(matrix.arch, 'portable')
+            - name: Move cross-compiled binary
+              if:  startsWith(matrix.arch, 'x86_64-unknown-linux-gnu')
+              run: mv target/x86_64-unknown-linux-gnu/release/lighthouse ~/.cargo/bin/lighthouse
+
+            - name: Build Lighthouse for x86_64-apple-darwin portable
+              if:   matrix.arch == 'x86_64-apple-darwin-portable'
               run:  cargo install --path lighthouse --force --locked --features portable
 
-            - name: Build Lighthouse for ${{matrix.arch}} modern
-              if:   startsWith(matrix.arch, 'x86_64') && !endsWith(matrix.arch, 'portable')
+            - name: Build Lighthouse for x86_64-apple-darwin modern
+              if:   matrix.arch == 'x86_64-apple-darwin'
               run:  cargo install --path lighthouse --force --locked --features modern
 
             - name: Configure GPG and create artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,15 @@ jobs:
 
             - name: Build Lighthouse for x86_64-unknown-linux-gnu-portable
               if:   matrix.arch == 'x86_64-unknown-linux-gnu-portable'
-              run:  make make build-x86_64-portable
+              run:  |
+                cargo install cross
+                make build-x86_64-portable
 
             - name: Build Lighthouse for x86_64-unknown-linux-gnu
               if:   matrix.arch == 'x86_64-unknown-linux-gnu'
-              run:  make build-x86_64
+              run:  |
+                cargo install cross
+                make build-x86_64
 
             - name: Move cross-compiled binary
               if:  startsWith(matrix.arch, 'aarch64')


### PR DESCRIPTION
## Issue Addressed

Resolves  #2120

## Proposed Changes

This updates github actions to use `cross` when compiling linux x86_64 binaries.

## Additional Info

I think we could alternatively be explicit with the version of macOS or ubuntu we are running actions on and that could solve #2120. I'm not sure which method is preferred here though. Github actions supports Ubuntu 16.04