### PR TITLE
[Merged by Bors] - [simulator] Fix race condition when creating LocalBeaconNode

### DIFF
--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -101,14 +101,15 @@ impl<E: EthSpec> LocalNetwork<E> {
             beacon_config.network.enr_tcp_port = Some(BOOTNODE_PORT + count);
         }
 
-        let index = self.beacon_nodes.read().len();
+        let mut write_lock = self_1.beacon_nodes.write();
+        let index = write_lock.len();
 
         let beacon_node = LocalBeaconNode::production(
             self.context.service_context(format!("node_{}", index)),
             beacon_config,
         )
         .await?;
-        self_1.beacon_nodes.write().push(beacon_node);
+        write_lock.push(beacon_node);
         Ok(())
     }
 


### PR DESCRIPTION
## Issue Addressed

We have a race condition when counting the number of beacon nodes. The user could end up seeing a duplicated service name (node_N).

## Proposed Changes

I have updated to acquire write lock before counting the number of beacon nodes.


