### PR TITLE
[Merged by Bors] -  Fix: `end_slot` returns incorrect value

### DIFF
--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -71,9 +71,8 @@ impl Epoch {
     pub fn end_slot(self, slots_per_epoch: u64) -> Slot {
         Slot::from(
             self.0
-                .saturating_add(1)
                 .saturating_mul(slots_per_epoch)
-                .saturating_sub(1),
+                .saturating_add(slots_per_epoch - 1)
         )
     }
 

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -145,6 +145,17 @@ mod epoch_tests {
     }
 
     #[test]
+    fn end_slot_boundary_test() {
+        let slots_per_epoch = 32;
+
+        // The last epoch which can be represented by u64.
+        let epoch = Epoch::new(u64::max_value() / slots_per_epoch);
+
+        // A slot number on the epoch should be equal to u64::max_value.
+        assert_eq!(epoch.end_slot(slots_per_epoch), Slot::new(u64::max_value()));
+    }
+
+    #[test]
     fn position() {
         let slots_per_epoch = 8;
 

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -72,7 +72,7 @@ impl Epoch {
         Slot::from(
             self.0
                 .saturating_mul(slots_per_epoch)
-                .saturating_add(slots_per_epoch - 1)
+                .saturating_add(slots_per_epoch - 1),
         )
     }
 

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -72,7 +72,7 @@ impl Epoch {
         Slot::from(
             self.0
                 .saturating_mul(slots_per_epoch)
-                .saturating_add(slots_per_epoch - 1),
+                .saturating_add(slots_per_epoch.saturating_sub(1)),
         )
     }
 


### PR DESCRIPTION
## Issue Addressed

`Epoch::end_slot()` returns incorrect value when the epoch is the last epoch which can be represented by u64.

```rust
        let slots_per_epoch = 32;

        // The last epoch which can be represented by u64.
        let epoch = Epoch::new(u64::max_value() / slots_per_epoch);

        println!("{}", epoch.end_slot(slots_per_epoch));
       // Slot(18446744073709551614)
       // -> correctly, the result should be `Slot(18446744073709551615)`.
```