### PR TITLE
[Merged by Bors] - replace tempdir by tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,7 +2011,7 @@ dependencies = [
  "smallvec",
  "snap",
  "task_executor",
- "tempdir",
+ "tempfile",
  "tiny-keccak 2.0.2",
  "tokio 0.3.6",
  "tokio-io-timeout",
@@ -2030,7 +2030,7 @@ dependencies = [
  "eth2_ssz",
  "serde",
  "serde_yaml",
- "tempdir",
+ "tempfile",
  "types",
  "zip",
 ]
@@ -3800,7 +3800,7 @@ name = "lockfile"
 version = "0.1.0"
 dependencies = [
  "fs2",
- "tempdir",
+ "tempfile",
 ]
 
 [[package]]
@@ -4261,7 +4261,7 @@ dependencies = [
  "genesis",
  "reqwest",
  "serde",
- "tempdir",
+ "tempfile",
  "types",
  "url",
  "validator_client",
@@ -4996,19 +4996,6 @@ checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -5269,7 +5256,7 @@ dependencies = [
  "remote_signer_test",
  "slog",
  "sloggers",
- "tempdir",
+ "tempfile",
  "types",
  "zeroize",
 ]
@@ -5317,7 +5304,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "tempdir",
+ "tempfile",
  "tokio 0.3.6",
  "tokio-compat-02",
  "types",
@@ -5897,7 +5884,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "sloggers",
- "tempdir",
+ "tempfile",
  "tree_hash",
  "tree_hash_derive",
  "types",
@@ -6352,16 +6339,6 @@ dependencies = [
  "slog",
  "tokio 0.3.6",
  "tokio-compat-02",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -7155,7 +7132,6 @@ dependencies = [
  "slog-async",
  "slog-term",
  "slot_clock",
- "tempdir",
  "tempfile",
  "tokio 0.3.6",
  "tokio-compat-02",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -24,7 +24,7 @@ fnv = "1.0.7"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 smallvec = "1.4.2"
-tokio-io-timeout = "0.5.0" 
+tokio-io-timeout = "0.5.0"
 lru = "0.6.0"
 parking_lot = "0.11.0"
 sha2 = "0.9.1"
@@ -50,7 +50,7 @@ features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dn
 tokio = { version = "0.3.2", features = ["full"] }
 slog-term = "2.6.0"
 slog-async = "2.5.0"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 exit-future = "0.2.0"
 
 [features]

--- a/beacon_node/eth2_libp2p/tests/common/mod.rs
+++ b/beacon_node/eth2_libp2p/tests/common/mod.rs
@@ -13,7 +13,7 @@ use tokio::runtime::Runtime;
 use types::{ChainSpec, EnrForkId, MinimalEthSpec};
 
 type E = MinimalEthSpec;
-use tempdir::TempDir;
+use tempfile::Builder as TempBuilder;
 
 pub struct Libp2pInstance(LibP2PService<E>, exit_future::Signal);
 
@@ -76,7 +76,10 @@ pub fn unused_port(transport: &str) -> Result<u16, String> {
 
 pub fn build_config(port: u16, mut boot_nodes: Vec<Enr>) -> NetworkConfig {
     let mut config = NetworkConfig::default();
-    let path = TempDir::new(&format!("libp2p_test{}", port)).unwrap();
+    let path = TempBuilder::new()
+        .prefix(&format!("libp2p_test{}", port))
+        .tempdir()
+        .unwrap();
 
     config.libp2p_port = port; // tcp port
     config.discovery_port = port; // udp port

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -11,7 +11,7 @@ zip = "0.5.8"
 eth2_config = { path = "../eth2_config"}
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 
 [dependencies]
 serde = "1.0.116"

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -239,7 +239,7 @@ impl Eth2NetworkConfig {
 mod tests {
     use super::*;
     use ssz::Encode;
-    use tempdir::TempDir;
+    use tempfile::Builder as TempBuilder;
     use types::{Eth1Data, Hash256, MainnetEthSpec, V012LegacyEthSpec, YamlConfig};
 
     type E = V012LegacyEthSpec;
@@ -301,7 +301,10 @@ mod tests {
         genesis_state: Option<BeaconState<E>>,
         yaml_config: Option<YamlConfig>,
     ) {
-        let temp_dir = TempDir::new("eth2_testnet_test").expect("should create temp dir");
+        let temp_dir = TempBuilder::new()
+            .prefix("eth2_testnet_test")
+            .tempdir()
+            .expect("should create temp dir");
         let base_dir = temp_dir.path().join("my_testnet");
         let deposit_contract_deploy_block = 42;
 

--- a/common/lockfile/Cargo.toml
+++ b/common/lockfile/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2018"
 fs2 = "0.4.3"
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempfile = "3.1.0"

--- a/common/lockfile/src/lib.rs
+++ b/common/lockfile/src/lib.rs
@@ -72,14 +72,14 @@ impl Drop for Lockfile {
 #[cfg(test)]
 mod test {
     use super::*;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[cfg(unix)]
     use std::{fs::Permissions, os::unix::fs::PermissionsExt};
 
     #[test]
     fn new_lock() {
-        let temp = TempDir::new("lock_test").unwrap();
+        let temp = tempdir().unwrap();
         let path = temp.path().join("lockfile");
 
         let _lock = Lockfile::new(path.clone()).unwrap();
@@ -91,7 +91,7 @@ mod test {
 
     #[test]
     fn relock_after_drop() {
-        let temp = TempDir::new("lock_test").unwrap();
+        let temp = tempdir().unwrap();
         let path = temp.path().join("lockfile");
 
         let lock1 = Lockfile::new(path.clone()).unwrap();
@@ -105,7 +105,7 @@ mod test {
 
     #[test]
     fn lockfile_exists() {
-        let temp = TempDir::new("lock_test").unwrap();
+        let temp = tempdir().unwrap();
         let path = temp.path().join("lockfile");
 
         let _lockfile = File::create(&path).unwrap();
@@ -117,7 +117,7 @@ mod test {
     #[test]
     #[cfg(unix)]
     fn permission_denied_create() {
-        let temp = TempDir::new("lock_test").unwrap();
+        let temp = tempdir().unwrap();
         let path = temp.path().join("lockfile");
 
         let lockfile = File::create(&path).unwrap();

--- a/remote_signer/backend/Cargo.toml
+++ b/remote_signer/backend/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 helpers = { path = "../../testing/remote_signer_test", package = "remote_signer_test"  }
 sloggers = "1.0.1"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 
 [dependencies]
 bls = { path = "../../crypto/bls" }

--- a/remote_signer/backend/src/lib.rs
+++ b/remote_signer/backend/src/lib.rs
@@ -88,12 +88,12 @@ pub mod tests_commons {
     pub use crate::Storage;
     use helpers::*;
     use sloggers::{null::NullLoggerBuilder, Build};
-    use tempdir::TempDir;
+    use tempfile::{tempdir, TempDir};
 
     type T = StorageRawDir;
 
     pub fn new_storage_with_tmp_dir() -> (T, TempDir) {
-        let tmp_dir = TempDir::new("bls-remote-signer-test").unwrap();
+        let tmp_dir = tempdir().unwrap();
         let storage = StorageRawDir::new(tmp_dir.path().to_str().unwrap()).unwrap();
         (storage, tmp_dir)
     }
@@ -104,7 +104,7 @@ pub mod tests_commons {
     }
 
     pub fn new_backend_for_get_keys() -> (Backend<T>, TempDir) {
-        let tmp_dir = TempDir::new("bls-remote-signer-test").unwrap();
+        let tmp_dir = tempdir().unwrap();
 
         let matches = set_matches(vec![
             "this_test",
@@ -145,7 +145,7 @@ pub mod backend_new {
     use super::*;
     use crate::tests_commons::*;
     use helpers::*;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
 
     #[test]
     fn no_storage_type_supplied() {
@@ -170,7 +170,7 @@ pub mod backend_new {
 
     #[test]
     fn given_inaccessible() {
-        let tmp_dir = TempDir::new("bls-remote-signer-test").unwrap();
+        let tmp_dir = tempdir().unwrap();
         set_permissions(tmp_dir.path(), 0o40311);
 
         let matches = set_matches(vec![

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -28,7 +28,7 @@ types = { path = "../consensus/types" }
 [dev-dependencies]
 maplit = "1.0.2"
 rayon = "1.3.0"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 
 [features]
 test_logger = []

--- a/slasher/tests/attester_slashings.rs
+++ b/slasher/tests/attester_slashings.rs
@@ -6,7 +6,7 @@ use slasher::{
     Config, Slasher,
 };
 use std::collections::HashSet;
-use tempdir::TempDir;
+use tempfile::tempdir;
 use types::{AttesterSlashing, Epoch, IndexedAttestation};
 
 #[test]
@@ -169,7 +169,7 @@ fn slasher_test(
     current_epoch: u64,
     should_process_after: impl Fn(usize) -> bool,
 ) {
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let config = Config::new(tempdir.path().into());
     let slasher = Slasher::open(config, logger()).unwrap();
     let current_epoch = Epoch::new(current_epoch);
@@ -196,7 +196,7 @@ fn parallel_slasher_test(
     expected_slashed_validators: HashSet<u64>,
     current_epoch: u64,
 ) {
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let config = Config::new(tempdir.path().into());
     let slasher = Slasher::open(config, logger()).unwrap();
     let current_epoch = Epoch::new(current_epoch);

--- a/slasher/tests/proposer_slashings.rs
+++ b/slasher/tests/proposer_slashings.rs
@@ -2,12 +2,12 @@ use slasher::{
     test_utils::{block as test_block, logger, E},
     Config, Slasher,
 };
-use tempdir::TempDir;
+use tempfile::tempdir;
 use types::{Epoch, EthSpec};
 
 #[test]
 fn empty_pruning() {
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let config = Config::new(tempdir.path().into());
     let slasher = Slasher::<E>::open(config.clone(), logger()).unwrap();
     slasher.prune_database(Epoch::new(0)).unwrap();
@@ -17,7 +17,7 @@ fn empty_pruning() {
 fn block_pruning() {
     let slots_per_epoch = E::slots_per_epoch();
 
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let mut config = Config::new(tempdir.path().into());
     config.chunk_size = 2;
     config.history_length = 2;

--- a/slasher/tests/random.rs
+++ b/slasher/tests/random.rs
@@ -8,7 +8,7 @@ use slasher::{
     Config, Slasher,
 };
 use std::cmp::max;
-use tempdir::TempDir;
+use tempfile::tempdir;
 use types::{Epoch, EthSpec};
 
 #[derive(Debug)]
@@ -38,7 +38,7 @@ fn random_test(seed: u64, test_config: TestConfig) {
     println!("Running with seed {}", seed);
     let mut rng = StdRng::seed_from_u64(seed);
 
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
 
     let mut config = Config::new(tempdir.path().into());
     config.validator_chunk_size = 1 << rng.gen_range(1, 4);

--- a/slasher/tests/wrap_around.rs
+++ b/slasher/tests/wrap_around.rs
@@ -2,12 +2,12 @@ use slasher::{
     test_utils::{indexed_att, logger},
     Config, Error, Slasher,
 };
-use tempdir::TempDir;
+use tempfile::tempdir;
 use types::Epoch;
 
 #[test]
 fn attestation_pruning_empty_wrap_around() {
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let mut config = Config::new(tempdir.path().into());
     config.validator_chunk_size = 1;
     config.chunk_size = 16;
@@ -41,7 +41,7 @@ fn attestation_pruning_empty_wrap_around() {
 // Test that pruning can recover from a `MapFull` error
 #[test]
 fn pruning_with_map_full() {
-    let tempdir = TempDir::new("slasher").unwrap();
+    let tempdir = tempdir().unwrap();
     let mut config = Config::new(tempdir.path().into());
     config.validator_chunk_size = 1;
     config.chunk_size = 16;

--- a/testing/node_test_rig/Cargo.toml
+++ b/testing/node_test_rig/Cargo.toml
@@ -9,7 +9,7 @@ environment = { path = "../../lighthouse/environment" }
 beacon_node = { path = "../../beacon_node" }
 types = { path = "../../consensus/types" }
 eth2_config = { path = "../../common/eth2_config" }
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 reqwest = { version = "0.10.8", features = ["native-tls-vendored"] }
 url = "2.1.1"
 serde = "1.0.116"

--- a/testing/node_test_rig/src/lib.rs
+++ b/testing/node_test_rig/src/lib.rs
@@ -11,7 +11,7 @@ use eth2::{
 use std::path::PathBuf;
 use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tempdir::TempDir;
+use tempfile::{Builder as TempBuilder, TempDir};
 use types::EthSpec;
 use validator_client::ProductionValidatorClient;
 use validator_dir::insecure_keys::build_deterministic_validator_dirs;
@@ -42,7 +42,9 @@ impl<E: EthSpec> LocalBeaconNode<E> {
         mut client_config: ClientConfig,
     ) -> Result<Self, String> {
         // Creates a temporary directory that will be deleted once this `TempDir` is dropped.
-        let datadir = TempDir::new("lighthouse_node_test_rig")
+        let datadir = TempBuilder::new()
+            .prefix("lighthouse_node_test_rig")
+            .tempdir()
             .expect("should create temp directory for client datadir");
 
         client_config.data_dir = datadir.path().into();
@@ -125,10 +127,14 @@ pub struct ValidatorFiles {
 impl ValidatorFiles {
     /// Creates temporary data and secrets dirs.
     pub fn new() -> Result<Self, String> {
-        let datadir = TempDir::new("lighthouse-validator-client")
+        let datadir = TempBuilder::new()
+            .prefix("lighthouse-validator-client")
+            .tempdir()
             .map_err(|e| format!("Unable to create VC data dir: {:?}", e))?;
 
-        let secrets_dir = TempDir::new("lighthouse-validator-client-secrets")
+        let secrets_dir = TempBuilder::new()
+            .prefix("lighthouse-validator-client-secrets")
+            .tempdir()
             .map_err(|e| format!("Unable to create VC secrets dir: {:?}", e))?;
 
         Ok(Self {

--- a/testing/remote_signer_test/Cargo.toml
+++ b/testing/remote_signer_test/Cargo.toml
@@ -14,7 +14,7 @@ remote_signer_consumer = { path = "../../common/remote_signer_consumer" }
 reqwest = { version = "0.10.8", features = ["blocking", "json"] }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 tokio = { version = "0.3.5", features = ["time"] }
 types = { path = "../../consensus/types" }
 tokio-compat-02 = "0.1"

--- a/testing/remote_signer_test/src/api_test_signer.rs
+++ b/testing/remote_signer_test/src/api_test_signer.rs
@@ -5,7 +5,7 @@ pub use local_signer_test_data::*;
 use remote_signer_client::Client;
 use serde_json::Value;
 use std::collections::HashMap;
-use tempdir::TempDir;
+use tempfile::{Builder as TempBuilder, TempDir};
 use types::EthSpec;
 
 pub struct ApiTestSigner<E: EthSpec> {
@@ -81,7 +81,10 @@ pub fn get_environment(is_log_active: bool) -> Environment<E> {
 }
 
 pub fn set_up_api_test_signer_raw_dir() -> (ApiTestSigner<E>, TempDir) {
-    let tmp_dir = TempDir::new("bls-remote-signer-test").unwrap();
+    let tmp_dir = TempBuilder::new()
+        .prefix("bls-remote-signer-test")
+        .tempdir()
+        .unwrap();
     let arg_vec = vec![
         "this_test",
         "--port",

--- a/testing/remote_signer_test/src/utils.rs
+++ b/testing/remote_signer_test/src/utils.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 use std::net::IpAddr::{V4, V6};
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use types::{
     AggregateSignature, Attestation, AttestationData, AttesterSlashing, BeaconBlock,
     BeaconBlockHeader, BitList, Checkpoint, Deposit, DepositData, Epoch, EthSpec, FixedVector,

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/lib.rs"
 
 [dev-dependencies]
 tokio = { version = "0.3.2", features = ["time", "rt-multi-thread", "macros"] }
-tempfile = "3.1.0"
 deposit_contract = { path = "../common/deposit_contract" }
 tokio-compat-02 = "0.1"
 
@@ -46,7 +45,7 @@ hex = "0.4.2"
 deposit_contract = { path = "../common/deposit_contract" }
 bls = { path = "../crypto/bls" }
 eth2 = { path = "../common/eth2" }
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 rayon = "1.4.1"
 validator_dir = { path = "../common/validator_dir" }
 clap_utils = { path = "../common/clap_utils" }

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -8,7 +8,7 @@ use slog::{crit, error, warn, Logger};
 use slot_clock::SlotClock;
 use std::path::Path;
 use std::sync::Arc;
-use tempdir::TempDir;
+use tempfile::TempDir;
 use types::{
     Attestation, BeaconBlock, ChainSpec, Domain, Epoch, EthSpec, Fork, Hash256, Keypair, PublicKey,
     SelectionProof, Signature, SignedAggregateAndProof, SignedBeaconBlock, SignedRoot, Slot,


### PR DESCRIPTION
## Issue Addressed

Fixes #2141 
Remove [tempdir](https://docs.rs/tempdir/0.3.7/tempdir/) in favor of [tempfile](https://docs.rs/tempfile/3.1.0/tempfile/).

## Proposed Changes

`tempfile` has a slightly different api that makes creating temp folders with a name prefix a chore (`tempdir::TempDir::new("toto")` => `tempfile::Builder::new().prefix("toto").tempdir()`).

So I removed temp folder name prefix where I deemed it not useful.

Otherwise, the functionality is the same.