### PR TITLE
Allow restore points to be omitted

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -302,7 +302,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("slots-per-restore-point")
                 .value_name("SLOT_COUNT")
                 .help("Specifies how often a freezer DB restore point should be stored. \
-                       Cannot be changed after initialization. \
+                       Cannot be changed after initialization. Set to 'none' to disable restore
+                       points entirely \
                        [default: 2048 (mainnet) or 64 (minimal)]")
                 .takes_value(true)
         )

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -197,14 +197,17 @@ pub fn get_config<E: EthSpec>(
     }
 
     if let Some(slots_per_restore_point) = cli_args.value_of("slots-per-restore-point") {
-        client_config.store.slots_per_restore_point = slots_per_restore_point
-            .parse()
-            .map_err(|_| "slots-per-restore-point is not a valid integer".to_string())?;
+        client_config.store.slots_per_restore_point = match slots_per_restore_point {
+            "none" => None,
+            x => Some(x.parse().map_err(|_| {
+                "slots-per-restore-point is not valid (integer or none)".to_string()
+            })?),
+        }
     } else {
-        client_config.store.slots_per_restore_point = std::cmp::min(
+        client_config.store.slots_per_restore_point = Some(std::cmp::min(
             E::slots_per_historical_root() as u64,
             store::config::DEFAULT_SLOTS_PER_RESTORE_POINT,
-        );
+        ));
     }
 
     if let Some(block_cache_size) = cli_args.value_of("block-cache-size") {

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::{DBColumn, Error, StoreItem};
 use ssz::{Decode, Encode};
 use types::{Checkpoint, Hash256};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(2);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(3);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -675,25 +675,6 @@ impl<T: EthSpec> BeaconState<T> {
         Ok(&self.state_roots[i])
     }
 
-    /// Gets the oldest (earliest slot) state root.
-    ///
-    /// Spec v0.12.1
-    pub fn get_oldest_state_root(&self) -> Result<&Hash256, Error> {
-        let i =
-            self.get_latest_state_roots_index(self.slot.saturating_sub(self.state_roots.len()))?;
-        Ok(&self.state_roots[i])
-    }
-
-    /// Gets the oldest (earliest slot) block root.
-    ///
-    /// Spec v0.12.1
-    pub fn get_oldest_block_root(&self) -> Result<&Hash256, Error> {
-        let i = self.get_latest_block_roots_index(
-            self.slot.saturating_sub(self.block_roots.len() as u64),
-        )?;
-        Ok(&self.block_roots[i])
-    }
-
     pub fn get_block_state_roots(
         &self,
         slot: Slot,


### PR DESCRIPTION
## Issue Addressed

Closes #2113

## Proposed Changes

Change `slots_per_restore_point` to an `Option<u64>`, using `None` to represent the case where no restore points are stored in the database. See #2113 for more info.

## Additional Info

Code quality is currently a bit rough.

This is a breaking schema change with no migration implemented (yet).
