### PR TITLE
[Merged by Bors] - Disconnect from peers quicker on internet issues

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -480,10 +480,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     Protocol::Status => return,
                 },
             },
-            RPCError::NegotiationTimeout => match protocol {
-                Protocol::Ping => PeerAction::LowToleranceError,
-                _ => PeerAction::HighToleranceError,
-            },
+            RPCError::NegotiationTimeout => PeerAction::LowToleranceError,
         };
 
         self.report_peer(peer_id, peer_action, ReportSource::RPC);

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -480,7 +480,10 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     Protocol::Status => return,
                 },
             },
-            RPCError::NegotiationTimeout => PeerAction::HighToleranceError,
+            RPCError::NegotiationTimeout => match protocol {
+                Protocol::Ping => PeerAction::LowToleranceError,
+                _ => PeerAction::HighToleranceError,
+            },
         };
 
         self.report_peer(peer_id, peer_action, ReportSource::RPC);


### PR DESCRIPTION
## Issue Addressed

Fixes #2146 

## Proposed Changes

Change ping timeout errors to return `LowToleranceErrors` so that we disconnect faster on internet failures/changes.