### PR TITLE
Remove the `is_syncing` flag from `node/syncing` endpoint.

### DIFF
--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -238,7 +238,7 @@ async fn is_syncing(client: &BeaconNodeHttpClient) -> Result<bool, String> {
         .get_node_health()
         .await
         .map_err(|e| format!("Failed to get node health: {:?}", e))?
-         == StatusCode::OK)
+        == StatusCode::OK)
 }
 
 /// Get fork object for the current state by querying the beacon node client.

--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -4,7 +4,7 @@ use clap::{App, Arg, ArgMatches};
 use environment::Environment;
 use eth2::{
     types::{GenesisData, StateId, ValidatorId, ValidatorStatus},
-    BeaconNodeHttpClient, Url,
+    BeaconNodeHttpClient, StatusCode, Url,
 };
 use eth2_keystore::Keystore;
 use eth2_network_config::Eth2NetworkConfig;
@@ -235,11 +235,10 @@ async fn get_geneisis_data(client: &BeaconNodeHttpClient) -> Result<GenesisData,
 /// Gets syncing status from beacon node client and returns true if syncing and false otherwise.
 async fn is_syncing(client: &BeaconNodeHttpClient) -> Result<bool, String> {
     Ok(client
-        .get_node_syncing()
+        .get_node_health()
         .await
-        .map_err(|e| format!("Failed to get sync status: {:?}", e))?
-        .data
-        .is_syncing)
+        .map_err(|e| format!("Failed to get node health: {:?}", e))?
+         == StatusCode::OK)
 }
 
 /// Get fork object for the current state by querying the beacon node client.

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1327,10 +1327,9 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("node"))
         .and(warp::path("syncing"))
         .and(warp::path::end())
-        .and(network_globals.clone())
         .and(chain_filter.clone())
         .and_then(
-            |network_globals: Arc<NetworkGlobals<T::EthSpec>>, chain: Arc<BeaconChain<T>>| {
+            |chain: Arc<BeaconChain<T>>| {
                 blocking_json_task(move || {
                     let head_slot = chain
                         .head_info()
@@ -1344,7 +1343,6 @@ pub fn serve<T: BeaconChainTypes>(
                     let sync_distance = current_slot - head_slot;
 
                     let syncing_data = api_types::SyncingData {
-                        is_syncing: network_globals.sync_state.read().is_syncing(),
                         head_slot,
                         sync_distance,
                     };

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1328,29 +1328,27 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("syncing"))
         .and(warp::path::end())
         .and(chain_filter.clone())
-        .and_then(
-            |chain: Arc<BeaconChain<T>>| {
-                blocking_json_task(move || {
-                    let head_slot = chain
-                        .head_info()
-                        .map(|info| info.slot)
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
-                    let current_slot = chain
-                        .slot()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+        .and_then(|chain: Arc<BeaconChain<T>>| {
+            blocking_json_task(move || {
+                let head_slot = chain
+                    .head_info()
+                    .map(|info| info.slot)
+                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                let current_slot = chain
+                    .slot()
+                    .map_err(warp_utils::reject::beacon_chain_error)?;
 
-                    // Taking advantage of saturating subtraction on slot.
-                    let sync_distance = current_slot - head_slot;
+                // Taking advantage of saturating subtraction on slot.
+                let sync_distance = current_slot - head_slot;
 
-                    let syncing_data = api_types::SyncingData {
-                        head_slot,
-                        sync_distance,
-                    };
+                let syncing_data = api_types::SyncingData {
+                    head_slot,
+                    sync_distance,
+                };
 
-                    Ok(api_types::GenericResponse::from(syncing_data))
-                })
-            },
-        );
+                Ok(api_types::GenericResponse::from(syncing_data))
+            })
+        });
 
     // GET node/health
     let get_node_health = eth1_v1

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1251,7 +1251,6 @@ impl ApiTester {
         let sync_distance = self.chain.slot().unwrap() - head_slot;
 
         let expected = SyncingData {
-            is_syncing: false,
             head_slot,
             sync_distance,
         };

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -435,7 +435,6 @@ pub struct VersionData {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncingData {
-    pub is_syncing: bool,
     pub head_slot: Slot,
     pub sync_distance: Slot,
 }

--- a/testing/simulator/src/sync_sim.rs
+++ b/testing/simulator/src/sync_sim.rs
@@ -3,6 +3,7 @@ use crate::local_network::LocalNetwork;
 use clap::ArgMatches;
 use futures::prelude::*;
 use node_test_rig::{
+    eth2::StatusCode,
     environment::EnvironmentBuilder, testing_client_config, ClientGenesis, ValidatorFiles,
 };
 use node_test_rig::{testing_validator_config, ClientConfig};
@@ -359,9 +360,9 @@ pub async fn check_still_syncing<E: EthSpec>(network: &LocalNetwork<E>) -> Resul
     for remote_node in network.remote_nodes()? {
         status.push(
             remote_node
-                .get_node_syncing()
+                .get_node_health()
                 .await
-                .map(|body| body.data.is_syncing)
+                .map(|status| status == StatusCode::OK)
                 .map_err(|e| format!("Get syncing status via http failed: {:?}", e))?,
         )
     }

--- a/testing/simulator/src/sync_sim.rs
+++ b/testing/simulator/src/sync_sim.rs
@@ -3,8 +3,8 @@ use crate::local_network::LocalNetwork;
 use clap::ArgMatches;
 use futures::prelude::*;
 use node_test_rig::{
-    eth2::StatusCode,
-    environment::EnvironmentBuilder, testing_client_config, ClientGenesis, ValidatorFiles,
+    environment::EnvironmentBuilder, eth2::StatusCode, testing_client_config, ClientGenesis,
+    ValidatorFiles,
 };
 use node_test_rig::{testing_validator_config, ClientConfig};
 use std::cmp::max;

--- a/validator_client/src/check_synced.rs
+++ b/validator_client/src/check_synced.rs
@@ -36,7 +36,7 @@ pub async fn check_synced<T: SlotClock>(
         }
     };
 
-    let is_synced = !resp.data.is_syncing || (resp.data.sync_distance.as_u64() < SYNC_TOLERANCE);
+    let is_synced = resp.data.sync_distance.as_u64() < SYNC_TOLERANCE;
 
     if let Some(log) = log_opt {
         if !is_synced {


### PR DESCRIPTION
## Issue Addressed

Resolves  #2133 

## Proposed Changes

- Remove the `is_syncing` field
- The sync simulator and voluntary exit mechanimsm now both use a 200 status code from the `node/health` endpoint
- The VC still uses the `node/syncing` endpoint

## Additional Info

Open question: The VC uses a margin of 4 slots to determine whether a BN is synced, but the BN API server uses a margin of 8 epochs to determine if it'll serve validator endpoints. Which one should we use?