### PR TITLE
[Merged by Bors] - update smallvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6042,9 +6042,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snap"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -21,7 +21,7 @@ merkle_proof = { path = "../../consensus/merkle_proof" }
 store = { path = "../store" }
 parking_lot = "0.11.0"
 lazy_static = "1.4.0"
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 log = "0.4.11"
 operation_pool = { path = "../operation_pool" }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -23,7 +23,7 @@ dirs = "3.0.1"
 fnv = "1.0.7"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 tokio-io-timeout = "0.5.0"
 lru = "0.6.0"
 parking_lot = "0.11.0"

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -32,7 +32,7 @@ futures = "0.3.7"
 error-chain = "0.12.4"
 tokio = { version = "0.3.2", features = ["full"] }
 parking_lot = "0.11.0"
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 rand = "0.7.3"
 fnv = "1.0.7"
 rlp = "0.4.6"

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -11,7 +11,7 @@ eth2_hashing = "0.1.0"
 eth2_ssz_derive = "0.1.0"
 eth2_ssz = "0.1.2"
 tree_hash = "0.1.1"
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 
 [dev-dependencies]
 quickcheck = "0.9.2"

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -14,7 +14,7 @@ eth2_ssz_derive = "0.1.0"
 
 [dependencies]
 ethereum-types = "0.9.2"
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 [dependencies]
 ethereum-types = "0.9.2"
 eth2_hashing = "0.1.0"
-smallvec = "1.4.2"
+smallvec = "1.6.1"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]


### PR DESCRIPTION
## Issue Addressed

`cargo audit` is failing because of a potential for an overflow in the version of `smallvec` we're using

## Proposed Changes

Update to the latest version of `smallvec`, which has the fix
