### PR TITLE
[Merged by Bors] - Fix timing issue in obtaining the Fork

### DIFF
--- a/validator_client/src/fork_service.rs
+++ b/validator_client/src/fork_service.rs
@@ -57,7 +57,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ForkServiceBuilder<T, E> {
     pub fn build(self) -> Result<ForkService<T, E>, String> {
         Ok(ForkService {
             inner: Arc::new(Inner {
-                fork: RwLock::new(self.fork),
+                fork: RwLock::new(self.fork.ok_or("Cannot build ForkService without fork")?),
                 slot_clock: self
                     .slot_clock
                     .ok_or("Cannot build ForkService without slot_clock")?,
@@ -105,7 +105,7 @@ impl<E: EthSpec> ForkServiceBuilder<slot_clock::TestingSlotClock, E> {
 
 /// Helper to minimise `Arc` usage.
 pub struct Inner<T, E: EthSpec> {
-    fork: RwLock<Option<Fork>>,
+    fork: RwLock<Fork>,
     beacon_nodes: Arc<BeaconNodeFallback<T, E>>,
     log: Logger,
     slot_clock: T,
@@ -134,7 +134,7 @@ impl<T, E: EthSpec> Deref for ForkService<T, E> {
 
 impl<T: SlotClock + 'static, E: EthSpec> ForkService<T, E> {
     /// Returns the last fork downloaded from the beacon node, if any.
-    pub fn fork(&self) -> Option<Fork> {
+    pub fn fork(&self) -> Fork {
         *self.fork.read()
     }
 
@@ -206,8 +206,8 @@ impl<T: SlotClock + 'static, E: EthSpec> ForkService<T, E> {
             .await
             .map_err(|_| ())?;
 
-        if self.fork.read().as_ref() != Some(&fork) {
-            *(self.fork.write()) = Some(fork);
+        if *(self.fork.read()) != fork {
+            *(self.fork.write()) = fork;
         }
 
         debug!(self.log, "Fork update success");

--- a/validator_client/src/fork_service.rs
+++ b/validator_client/src/fork_service.rs
@@ -34,6 +34,11 @@ impl<T: SlotClock + 'static, E: EthSpec> ForkServiceBuilder<T, E> {
         }
     }
 
+    pub fn fork(mut self, fork: Fork) -> Self {
+        self.fork = Some(fork);
+        self
+    }
+
     pub fn slot_clock(mut self, slot_clock: T) -> Self {
         self.slot_clock = Some(slot_clock);
         self

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -128,7 +128,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
         self.validators
             .read()
             .voting_keypair(validator_pubkey)
-            .and_then(|voting_keypair| {
+            .map(|voting_keypair| {
                 let domain = self.spec.get_domain(
                     epoch,
                     Domain::Randao,
@@ -137,7 +137,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
                 );
                 let message = epoch.signing_root(domain);
 
-                Some(voting_keypair.sk.sign(message))
+                voting_keypair.sk.sign(message)
             })
     }
 

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -120,13 +120,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
         self.validators.read().num_enabled()
     }
 
-    fn fork(&self) -> Option<Fork> {
-        if self.fork_service.fork().is_none() {
-            error!(
-                self.log,
-                "Unable to get Fork for signing";
-            );
-        }
+    fn fork(&self) -> Fork {
         self.fork_service.fork()
     }
 
@@ -138,7 +132,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
                 let domain = self.spec.get_domain(
                     epoch,
                     Domain::Randao,
-                    &self.fork()?,
+                    &self.fork(),
                     self.genesis_validators_root,
                 );
                 let message = epoch.signing_root(domain);
@@ -165,7 +159,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
         }
 
         // Check for slashing conditions.
-        let fork = self.fork()?;
+        let fork = self.fork();
         let domain = self.spec.get_domain(
             block.epoch(),
             Domain::BeaconProposer,
@@ -237,7 +231,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
         }
 
         // Checking for slashing conditions.
-        let fork = self.fork()?;
+        let fork = self.fork();
 
         let domain = self.spec.get_domain(
             attestation.data.target.epoch,
@@ -339,7 +333,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
             aggregate,
             Some(selection_proof),
             &voting_keypair.sk,
-            &self.fork()?,
+            &self.fork(),
             self.genesis_validators_root,
             &self.spec,
         ))
@@ -360,7 +354,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
         Some(SelectionProof::new::<E>(
             slot,
             &voting_keypair.sk,
-            &self.fork()?,
+            &self.fork(),
             self.genesis_validators_root,
             &self.spec,
         ))


### PR DESCRIPTION
## Issue Addressed

Related PR: https://github.com/sigp/lighthouse/pull/2137#issuecomment-754712492

The Fork is required for VC to perform signing. Currently, it is not guaranteed that the Fork has been obtained at the point of the signing as the Fork is obtained at after ForkService starts. We will see the [error](https://github.com/sigp/lighthouse/blob/851a4dca3c5a514455006589b1a756a8a994258a/validator_client/src/validator_store.rs#L127) if VC could not perform the signing due to the timing issue.

> Unable to get Fork for signing

## Proposed Changes

Obtain the Fork on `init_from_beacon_node` to fix the timing issue.

