### PR TITLE
Increase discv5 query timeout

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -157,7 +157,7 @@ impl Default for Config {
             .session_cache_capacity(1000)
             .request_timeout(Duration::from_secs(1))
             .query_peer_timeout(Duration::from_secs(2))
-            .query_timeout(Duration::from_secs(30))
+            .query_timeout(Duration::from_secs(60))
             .request_retries(1)
             .enr_peer_update_min(10)
             .query_parallelism(5)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Recently noticed a few missed attestations on mainnet due to `InsufficientPeers` on subnet. This happened with a healthy peer count of ~50. The problem was that the bn had very few peers on the required subnet (<=1) and was required to make a subnet discovery query which didn't return any peers. 
However, from just grokking at the logs, it looks like more often than not, the subnet discovery doesn't end up finding more than 1 peer on the subnet. Very rarely does the query end up finding more than 1 peer on the subnet.

I think the issue here is the timeout of 30 secs is too small for finding peers in a particular subnet. Here I'm proposing to increase the timeout to 60 secs to give enough time to find more subnet peers. Should be enough time even with the 1 epoch lookahead. From some experiments locally, looks like a 1 minute timeout finds atleast 2 peers on average. 

## Additional Info

Running this on pyrmont with 20 target peers to trigger more subnet discovery requests. Will report results here.

Edit: needs more testing