### PR TITLE
[Merged by Bors] - Add a GitHub Action to cancel previous runs

### DIFF
--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -6,7 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: styfle/cancel-workflow-action@0.7.0
+      # https://github.com/styfle/cancel-workflow-action/releases
+      - uses: styfle/cancel-workflow-action@514c783 # 0.7.0
         with:
           # https://api.github.com/repos/sigp/lighthouse/actions/workflows
           workflow_id: 697364,2434944,4462424,308241,2883401,316

--- a/.github/workflows/cancel-previous-runs.yml
+++ b/.github/workflows/cancel-previous-runs.yml
@@ -1,0 +1,13 @@
+name: cancel previous runs
+on: [push]
+jobs:
+  cancel:
+    name: 'Cancel Previous Runs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: styfle/cancel-workflow-action@0.7.0
+        with:
+          # https://api.github.com/repos/sigp/lighthouse/actions/workflows
+          workflow_id: 697364,2434944,4462424,308241,2883401,316
+          access_token: ${{ github.token }}


### PR DESCRIPTION
## Issue Addressed

It takes over 20 minutes to run the GitHub Workflow for lighthouse. It would be time-saving to cancel previous runs. 

## Proposed Changes

Added [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action) to our workflow. I've configured the action according to [Advanced settings](https://github.com/styfle/cancel-workflow-action#advanced).
