### PR TITLE
[Merged by Bors] - Avoid resizing attn signature sets vec

### DIFF
--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -202,13 +202,12 @@ where
     T: EthSpec,
     F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
 {
-    let pubkeys = indexed_attestation
-        .attesting_indices
-        .into_iter()
-        .map(|&validator_idx| {
-            Ok(get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?)
-        })
-        .collect::<Result<_>>()?;
+    let mut pubkeys = Vec::with_capacity(indexed_attestation.attesting_indices.len());
+    for &validator_idx in &indexed_attestation.attesting_indices {
+        pubkeys.push(
+            get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?,
+        );
+    }
 
     let domain = spec.get_domain(
         indexed_attestation.data.target.epoch,
@@ -236,13 +235,12 @@ where
     T: EthSpec,
     F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
 {
-    let pubkeys = indexed_attestation
-        .attesting_indices
-        .into_iter()
-        .map(|&validator_idx| {
-            Ok(get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?)
-        })
-        .collect::<Result<_>>()?;
+    let mut pubkeys = Vec::with_capacity(indexed_attestation.attesting_indices.len());
+    for &validator_idx in &indexed_attestation.attesting_indices {
+        pubkeys.push(
+            get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?,
+        );
+    }
 
     let domain = spec.get_domain(
         indexed_attestation.data.target.epoch,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Reduces allocations by initializing the `pubkeys` vec to its final size. I doubt this will make a substantial difference, but it's nice to do it this way.

Seeing as `indexed_attestation.attesting_indices` has a [fixed length](https://github.com/sigp/lighthouse/blob/e4b62139d7e2d5b0499648663af8de25b368f0bd/consensus/types/src/indexed_attestation.rs#L22), there's no real risk of a memory blow-up by pre-allocating the size of the `Vec`.

## Additional Info

NA