### PR TITLE
[Merged by Bors] - Check that pull requests target unstable

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,13 @@ env:
   # Deny warnings in CI
   RUSTFLAGS: "-D warnings"
 jobs:
+  target-branch-check:
+    name: target-branch-check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+        - name: Check that pull request is targeting unstable branch
+          run: test ${{ github.base_ref }} = "unstable"
   cargo-fmt:
     name: cargo-fmt
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -16,4 +16,4 @@ status = [
 ]
 use_squash_merge = true
 timeout_sec = 7200
-pr_status = ["license/cla"]
+pr_status = ["license/cla", "target-branch-check"]


### PR DESCRIPTION
Attempt to prevent accidental merges to `stable` due to GitHub's default behaviour of opening PRs against it.

I've intentionally opened this PR against `stable` to test the functionality ;)