### PR TITLE
[Merged by Bors] - Add slot offset computing to be downloaded slot

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -963,6 +963,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         if self
             .to_be_downloaded
             .start_slot(T::EthSpec::slots_per_epoch())
+            + 1
             > self.target_head_slot
         {
             return None;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -963,8 +963,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         if self
             .to_be_downloaded
             .start_slot(T::EthSpec::slots_per_epoch())
-            + 1
-            > self.target_head_slot
+            >= self.target_head_slot
         {
             return None;
         }


### PR DESCRIPTION
The current implementation assumes the range offset of slots downloaded on a batch to equal zero. This conflicts with the condition to consider this chain as sync. For finalized sync, it results in one extra batch being downloaded which can't be processed.

CC @wemeetagain

