### PR TITLE
[Merged by Bors] - Switch back to warp with cors wildcard support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7080,8 +7080,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
+source = "git+https://github.com/paulhauner/warp?branch=cors-wildcard#d3fac087253287eb0f716e5d9e49d46b33a02a7d"
 dependencies = [
  "bytes 1.0.1",
  "futures 0.3.12",

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-warp = "0.3.0"
+warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 serde = { version = "1.0.116", features = ["derive"] }
 tokio = { version = "1.1.0", features = ["macros","sync"] }
 tokio-stream = "0.1.2"

--- a/beacon_node/http_metrics/Cargo.toml
+++ b/beacon_node/http_metrics/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 prometheus = "0.11.0"
-warp = "0.3.0"
+warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 serde = { version = "1.0.116", features = ["derive"] }
 slog = "2.5.2"
 beacon_chain = { path = "../beacon_chain" }

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-warp = "0.3.0"
+warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 eth2 = { path = "../eth2" }
 types = { path = "../../consensus/types" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -52,7 +52,7 @@ eth2_keystore = { path = "../crypto/eth2_keystore" }
 account_utils = { path = "../common/account_utils" }
 lighthouse_version = { path = "../common/lighthouse_version" }
 warp_utils = { path = "../common/warp_utils" }
-warp = "0.3.0"
+warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 hyper = "0.14.4"
 serde_utils = { path = "../consensus/serde_utils" }
 libsecp256k1 = "0.3.5"


### PR DESCRIPTION
## Issue Addressed

- Resolves #2204
- Resolves #2205

## Proposed Changes

Switches to my fork of `warp` which contains support for cors wildcards: https://github.com/paulhauner/warp/tree/cors-wildcard

I have a PR open on the `warp` repo but it hasn't had any interest from the maintainers as of yet: https://github.com/seanmonstar/warp/pull/726. I think running from a fork is the best we can do for now.

## Additional Info

NA
