### PR TITLE
[Merged by Bors] - Address ENR update loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.3"
-source = "git+https://github.com/sigp/discv5?rev=a3de10f82426942ce9fb97e3d0987f8371638d8f#a3de10f82426942ce9fb97e3d0987f8371638d8f"
+source = "git+https://github.com/sigp/discv5?rev=02d2c896c66f8dc2b848c3996fedcd98e1dfec69#02d2c896c66f8dc2b848c3996fedcd98e1dfec69"
 dependencies = [
  "aes-ctr",
  "aes-gcm 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,8 +1610,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f52d2228d51e8f868a37d5b5b25b82c13552b635d5b47c3a5d53855a6fc4f0"
+source = "git+https://github.com/sigp/discv5?branch=enr-loop#ead92be331a1862ca4d163978f0f3842fc0340d3"
 dependencies = [
  "aes-ctr",
  "aes-gcm 0.8.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,7 +1610,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.3"
-source = "git+https://github.com/sigp/discv5?branch=enr-loop#ead92be331a1862ca4d163978f0f3842fc0340d3"
+source = "git+https://github.com/sigp/discv5?rev=a3de10f82426942ce9fb97e3d0987f8371638d8f#a3de10f82426942ce9fb97e3d0987f8371638d8f"
 dependencies = [
  "aes-ctr",
  "aes-gcm 0.8.0",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-discv5 = { version = "0.1.0-beta.3", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5 ", branch = "enr-loop", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-discv5 = { git = "https://github.com/sigp/discv5 ", branch = "enr-loop", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5 ", rev = "a3de10f82426942ce9fb97e3d0987f8371638d8f", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-discv5 = { git = "https://github.com/sigp/discv5 ", rev = "a3de10f82426942ce9fb97e3d0987f8371638d8f", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5 ", rev = "02d2c896c66f8dc2b848c3996fedcd98e1dfec69", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -34,4 +34,4 @@ futures = "0.3.8"
 store = { path = "../store" }
 environment = { path = "../../lighthouse/environment" }
 tree_hash = "0.1.1"
-discv5 = { git = "https://github.com/sigp/discv5 ", branch = "enr-loop", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5 ", rev = "a3de10f82426942ce9fb97e3d0987f8371638d8f", features = ["libp2p"] }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -34,4 +34,4 @@ futures = "0.3.8"
 store = { path = "../store" }
 environment = { path = "../../lighthouse/environment" }
 tree_hash = "0.1.1"
-discv5 = { version = "0.1.0-beta.3" }
+discv5 = { git = "https://github.com/sigp/discv5 ", branch = "enr-loop", features = ["libp2p"] }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -34,4 +34,4 @@ futures = "0.3.8"
 store = { path = "../store" }
 environment = { path = "../../lighthouse/environment" }
 tree_hash = "0.1.1"
-discv5 = { git = "https://github.com/sigp/discv5 ", rev = "a3de10f82426942ce9fb97e3d0987f8371638d8f", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5 ", rev = "02d2c896c66f8dc2b848c3996fedcd98e1dfec69", features = ["libp2p"] }


### PR DESCRIPTION
## Issue Addressed

- Resolves #2215

## Proposed Changes

Addresses a potential loop when the majority of peers indicate that we are contactable via an IPv6 address.

See https://github.com/sigp/discv5/pull/62 for further rationale.

## Additional Info

The alternative to this PR is to use `--disable-enr-auto-update` and then manually supply an `--enr-address` and `--enr-upd-port`. However, that requires the user to know their IP addresses in order for discovery to work properly. This might not be practical/achievable for some users, hence this hotfix. 
