### PR TITLE
[Merged by Bors] - Filter Disconnected Peers from Discv5 DHT

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -60,8 +60,6 @@ pub enum DiscoveryEvent {
     QueryResult(HashMap<PeerId, Option<Instant>>),
     /// This indicates that our local UDP socketaddr has been updated and we should inform libp2p.
     SocketUpdated(SocketAddr),
-    /// A new node has been inserted into the discovery DHT
-    PeerInserted(PeerId),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -932,14 +930,6 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                             // update  network globals
                             *self.network_globals.local_enr.write() = enr;
                             return Poll::Ready(DiscoveryEvent::SocketUpdated(socket));
-                        }
-                        Discv5Event::NodeInserted {
-                            node_id,
-                            replaced: _,
-                        } => {
-                            if let Some(enr) = self.discv5.find_enr(&node_id) {
-                                return Poll::Ready(DiscoveryEvent::PeerInserted(enr.peer_id()));
-                            }
                         }
                         _ => {} // Ignore all other discv5 server events
                     }

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -511,6 +511,13 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
         }
     }
 
+    // mark node as disconnected in DHT, freeing up space for other nodes
+    pub fn disconnect_peer(&mut self, peer_id: &PeerId) {
+        if let Ok(node_id) = peer_id_to_node_id(peer_id) {
+            self.discv5.disconnect_node(&node_id);
+        }
+    }
+
     /* Internal Functions */
 
     /// Adds a subnet query if one doesn't exist. If a subnet query already exists, this

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -60,6 +60,8 @@ pub enum DiscoveryEvent {
     QueryResult(HashMap<PeerId, Option<Instant>>),
     /// This indicates that our local UDP socketaddr has been updated and we should inform libp2p.
     SocketUpdated(SocketAddr),
+    /// A new node has been inserted into the discovery DHT
+    PeerInserted(PeerId),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -930,6 +932,14 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                             // update  network globals
                             *self.network_globals.local_enr.write() = enr;
                             return Poll::Ready(DiscoveryEvent::SocketUpdated(socket));
+                        }
+                        Discv5Event::NodeInserted {
+                            node_id,
+                            replaced: _,
+                        } => {
+                            if let Some(enr) = self.discv5.find_enr(&node_id) {
+                                return Poll::Ready(DiscoveryEvent::PeerInserted(enr.peer_id()));
+                            }
                         }
                         _ => {} // Ignore all other discv5 server events
                     }

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -317,6 +317,9 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         self.inbound_ping_peers.remove(peer_id);
         self.outbound_ping_peers.remove(peer_id);
         self.status_peers.remove(peer_id);
+
+        // set peer as disconnected in discovery DHT
+        self.discovery.disconnect_peer(peer_id);
     }
 
     /// A dial attempt has failed.

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -726,25 +726,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         }
     }
 
-    /// Immediately dial peers that have been newly inserted into the discovery DHT so that they
-    /// can be filtered on dial failure
-    fn peer_inserted_dht(&mut self, peer_id: PeerId) {
-        if !self
-            .network_globals
-            .peers
-            .read()
-            .is_connected_or_dialing(&peer_id)
-            && !self
-                .network_globals
-                .peers
-                .read()
-                .is_banned_or_disconnected(&peer_id)
-        {
-            debug!(self.log, "Dialing inserted peer"; "peer_id" => %peer_id);
-            self.dial_peer(&peer_id);
-        }
-    }
-
     /// Registers a peer as connected. The `ingoing` parameter determines if the peer is being
     /// dialed or connecting to us.
     ///
@@ -1003,7 +984,6 @@ impl<TSpec: EthSpec> Stream for PeerManager<TSpec> {
             match event {
                 DiscoveryEvent::SocketUpdated(socket_addr) => self.socket_updated(socket_addr),
                 DiscoveryEvent::QueryResult(results) => self.peers_discovered(results),
-                DiscoveryEvent::PeerInserted(peer_id) => self.peer_inserted_dht(peer_id),
             }
         }
 


### PR DESCRIPTION
## Issue Addressed
#2107

## Proposed Change
The peer manager will mark peers as disconnected in the discv5 DHT when they disconnect or dial fails

## Additional Info
Rationale for this particular change is explained in my comment on #2107 





