### PR TITLE
[Merged by Bors] - Fix lighthouse_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,6 +3689,7 @@ name = "lighthouse_version"
 version = "0.1.0"
 dependencies = [
  "git-version",
+ "regex",
  "target_info",
 ]
 

--- a/common/lighthouse_version/Cargo.toml
+++ b/common/lighthouse_version/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2018"
 [dependencies]
 git-version = "0.3.4"
 target_info = "0.1.0"
+
+[dev-dependencies]
+regex = "1"

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -9,7 +9,7 @@ use target_info::Target;
 ///
 /// `Lighthouse/v0.2.0-1419501f2+`
 pub const VERSION: &str = git_version!(
-    args = ["--always", "--dirty=+", "--abbrev=7"],
+    args = ["--always", "--dirty=+", "--abbrev=7", "--exclude='*'"],
     prefix = "Lighthouse/v1.1.3-",
     fallback = "unknown"
 );

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -30,9 +30,8 @@ mod test {
 
     #[test]
     fn version_formatting() {
-        let re =
-            Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.$[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$")
-                .unwrap();
+        let re = Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$")
+            .unwrap();
         assert!(re.is_match(VERSION), VERSION);
     }
 }

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -9,7 +9,7 @@ use target_info::Target;
 ///
 /// `Lighthouse/v0.2.0-1419501f2+`
 pub const VERSION: &str = git_version!(
-    args = ["--always", "--dirty=+", "--abbrev=7", "--exclude='*'"],
+    args = ["--always", "--dirty=+", "--abbrev=7", "--exclude=*"],
     prefix = "Lighthouse/v1.1.3-",
     fallback = "unknown"
 );
@@ -21,4 +21,18 @@ pub const VERSION: &str = git_version!(
 /// `Lighthouse/v0.2.0-1419501f2+/x86_64-linux`
 pub fn version_with_platform() -> String {
     format!("{}/{}-{}", VERSION, Target::arch(), Target::os())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use regex::Regex;
+
+    #[test]
+    fn version_formatting() {
+        let re =
+            Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.$[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$")
+                .unwrap();
+        assert!(re.is_match(VERSION), VERSION);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Somehow since Lighthouse v1.1.3 the behaviour of `git-describe` has changed so that it includes the version tag, the number of commits since that tag, _and_ the commit. According to the docs this is how it should always have behaved?? Weird!

https://git-scm.com/docs/git-describe/2.30.1

Anyway, this lead to `lighthouse_version` producing this monstrosity of a version string when building #2194:

```
Lighthouse/v1.1.3-v1.1.3-5-gac07
```

Observe it in the wild here: https://pyrmont.beaconcha.in/block/694880

Adding `--exclude="*"` prevents `git-describe` from trying to include the tag, and on that troublesome commit from #2194 it now produces the correct version string.
