### PR TITLE
[Merged by Bors] - Make lighthouse_version compatible with old Git

### DIFF
--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -9,7 +9,13 @@ use target_info::Target;
 ///
 /// `Lighthouse/v0.2.0-1419501f2+`
 pub const VERSION: &str = git_version!(
-    args = ["--always", "--dirty=+", "--abbrev=7", "--exclude=*"],
+    args = [
+        "--always",
+        "--dirty=+",
+        "--abbrev=7",
+        // NOTE: using --match instead of --exclude for compatibility with old Git
+        "--match=thiswillnevermatchlol"
+    ],
     prefix = "Lighthouse/v1.1.3-",
     fallback = "unknown"
 );


### PR DESCRIPTION
## Proposed Changes

When building the release binaries with Cross, Ubuntu 16.04 is used, which uses an old verison of Git lacking support for `--exclude`. This PR changes `lighthouse_version` to use `--match` instead.
