### PR TITLE
[Merged by Bors] - Lint for sum and product in consensus code

### DIFF
--- a/consensus/state_processing/clippy.toml
+++ b/consensus/state_processing/clippy.toml
@@ -1,0 +1,5 @@
+# Disallow sum and product methods which are prone to overflow.
+disallowed-methods = [
+    "core::iter::traits::iterator::Iterator::sum",
+    "core::iter::traits::iterator::Iterator::product",
+]

--- a/consensus/state_processing/src/lib.rs
+++ b/consensus/state_processing/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::integer_arithmetic)]
+#![deny(clippy::disallowed_method)]
 
 #[macro_use]
 mod macros;

--- a/consensus/types/clippy.toml
+++ b/consensus/types/clippy.toml
@@ -1,0 +1,5 @@
+# Disallow sum and product methods which are prone to overflow.
+disallowed-methods = [
+    "core::iter::traits::iterator::Iterator::sum",
+    "core::iter::traits::iterator::Iterator::product",
+]

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::integer_arithmetic)]
+#![allow(clippy::disallowed_method)]
 
 use super::Error;
 use crate::{BeaconState, EthSpec, Hash256, Slot, Unsigned, Validator};

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -4,6 +4,7 @@
 #![recursion_limit = "128"]
 // Clippy lint set up
 #![deny(clippy::integer_arithmetic)]
+#![deny(clippy::disallowed_method)]
 
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
## Issue Addressed

Closes #1621

## Proposed Changes

Use the `disallowed_method` lint to ban uses of `Iterator::{sum,product}` from `types` and `state_processing`.

## Additional Info

The lint is turned off in the tree hash caching code, as it is performance sensitive and overflowy arithmetic is already allowed there.
