### PR TITLE
[Merged by Bors] - Improve error when user doesn't have a wallet

### DIFF
--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -137,6 +137,18 @@ pub fn cli_run<T: EthSpec>(
     let count: Option<usize> = clap_utils::parse_optional(matches, COUNT_FLAG)?;
     let at_most: Option<usize> = clap_utils::parse_optional(matches, AT_MOST_FLAG)?;
 
+    // The command will always fail if the wallet dir does not exist.
+    if !wallet_base_dir.exists() {
+        return Err(format!(
+            "No wallet directory at {:?}. Use the `lighthouse --network {} {} {} {}` command to create a wallet",
+            wallet_base_dir,
+            matches.value_of("network").unwrap_or("<NETWORK>"),
+            crate::CMD,
+            crate::wallet::CMD,
+            crate::wallet::create::CMD
+        ));
+    }
+
     ensure_dir_exists(&validator_dir)?;
     ensure_dir_exists(&secrets_dir)?;
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

I was doing some testing and noticed that this error could be a bit nicer. It helps users understand that they need to create a wallet before a validator.

## Additional Info

NA
