### PR TITLE
[Merged by Bors] - Use advanced state for block production

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1242,8 +1242,9 @@ fn load_parent<T: BeaconChainTypes>(
     let result = if let Some(snapshot) = chain
         .snapshot_cache
         .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-        .and_then(|mut snapshot_cache| snapshot_cache.try_remove(block.parent_root()))
-    {
+        .and_then(|mut snapshot_cache| {
+            snapshot_cache.get_state_for_block_processing(block.parent_root())
+        }) {
         Ok((snapshot.into_pre_state(), block))
     } else {
         // Load the blocks parent block from the database, returning invalid if that block is not

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -137,6 +137,10 @@ pub enum BlockProductionError {
     /// The `BeaconChain` was explicitly configured _without_ a connection to eth1, therefore it
     /// cannot produce blocks.
     NoEth1ChainConnection,
+    StateSlotTooHigh {
+        produce_at_slot: Slot,
+        state_slot: Slot,
+    },
 }
 
 easy_from_to!(BlockProcessingError, BlockProductionError);

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -55,8 +55,17 @@ impl<T: EthSpec> CacheItem<T> {
     }
 }
 
+/// The information required for block production.
 pub struct BlockProductionPreState<T: EthSpec> {
+    /// This state may or may not have been advanced forward a single slot.
+    ///
+    /// See the documentation in the `crate::state_advance_timer` module for more information.
     pub pre_state: BeaconState<T>,
+    /// This value will only be `Some` if `self.pre_state` was **not** advanced forward a single
+    /// slot.
+    ///
+    /// This value can be used to avoid tree-hashing the state during the first call to
+    /// `per_slot_processing`.
     pub state_root: Option<Hash256>,
 }
 
@@ -157,14 +166,24 @@ impl<T: EthSpec> SnapshotCache<T> {
         }
     }
 
-    /// If there is a snapshot with `block_root`, remove and return it.
-    pub fn try_remove(&mut self, block_root: Hash256) -> Option<CacheItem<T>> {
+    /// If available, returns a `CacheItem` that should be used for importing/processing a block.
+    /// The method will remove the block from `self`, carrying across any caches that may or may not
+    /// be built.
+    pub fn get_state_for_block_processing(&mut self, block_root: Hash256) -> Option<CacheItem<T>> {
         self.snapshots
             .iter()
             .position(|snapshot| snapshot.beacon_block_root == block_root)
             .map(|i| self.snapshots.remove(i))
     }
 
+    /// If available, obtains a clone of a `BeaconState` that should be used for block production.
+    /// The clone will use `CloneConfig:all()`, ensuring any tree-hash cache is cloned too.
+    ///
+    /// ## Note
+    ///
+    /// This method clones the `BeaconState` (instead of removing it) since we assume that any block
+    /// we produce will soon be pushed to the `BeaconChain` for importing/processing. Keeping a copy
+    /// of that `BeaconState` in `self` will greatly help with import times.
     pub fn get_state_for_block_production(
         &self,
         block_root: Hash256,
@@ -315,7 +334,9 @@ mod test {
         assert_eq!(cache.snapshots.len(), CACHE_SIZE);
 
         assert!(
-            cache.try_remove(Hash256::from_low_u64_be(1)).is_none(),
+            cache
+                .get_state_for_block_processing(Hash256::from_low_u64_be(1))
+                .is_none(),
             "the snapshot with the lowest slot should have been removed during the insert function"
         );
         assert!(cache
@@ -332,17 +353,17 @@ mod test {
         );
         assert!(
             cache
-                .try_remove(Hash256::from_low_u64_be(0))
+                .get_state_for_block_processing(Hash256::from_low_u64_be(0))
                 .expect("the head should still be in the cache")
                 .beacon_block_root
                 == Hash256::from_low_u64_be(0),
-            "try_remove should get the correct snapshot"
+            "get_state_for_block_processing should get the correct snapshot"
         );
 
         assert_eq!(
             cache.snapshots.len(),
             CACHE_SIZE - 1,
-            "try_remove should shorten the cache"
+            "get_state_for_block_processing should shorten the cache"
         );
 
         // Prune the cache. Afterwards it should look like:
@@ -364,11 +385,11 @@ mod test {
         // Ensure that the new head value was not removed from the cache.
         assert!(
             cache
-                .try_remove(Hash256::from_low_u64_be(2))
+                .get_state_for_block_processing(Hash256::from_low_u64_be(2))
                 .expect("the new head should still be in the cache")
                 .beacon_block_root
                 == Hash256::from_low_u64_be(2),
-            "try_remove should get the correct snapshot"
+            "get_state_for_block_processing should get the correct snapshot"
         );
     }
 }

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -408,7 +408,7 @@ where
 
         let (block, state) = self
             .chain
-            .produce_block_on_state(state, slot, randao_reveal, Some(graffiti))
+            .produce_block_on_state(state, None, slot, randao_reveal, Some(graffiti))
             .unwrap();
 
         let signed_block = block.sign(

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -859,12 +859,12 @@ pub fn serve<T: BeaconChainTypes>(
                             //
                             // Check to see the thresholds are non-zero to avoid logging errors with small
                             // slot times (e.g., during testing)
-                            let error_threshold = chain.spec.seconds_per_slot / 3;
+                            let crit_threshold = chain.spec.seconds_per_slot / 3;
                             let warn_threshold = chain.spec.seconds_per_slot / 6;
-                            if error_threshold > 0 && delay.as_secs() > error_threshold {
-                                error!(
+                            if crit_threshold > 0 && delay.as_secs() > crit_threshold {
+                                crit!(
                                     log,
-                                    "Block is broadcast too late";
+                                    "Block was broadcast too late";
                                     "root" => ?root,
                                     "slot" => block.slot(),
                                     "delay_ms" => delay.as_millis(),

--- a/beacon_node/http_api/src/metrics.rs
+++ b/beacon_node/http_api/src/metrics.rs
@@ -29,4 +29,8 @@ lazy_static::lazy_static! {
         "http_api_beacon_proposer_cache_misses_total",
         "Count of times the proposer cache has been missed",
     );
+    pub static ref HTTP_API_BLOCK_BROADCAST_DELAY_TIMES: Result<Histogram> = try_create_histogram(
+        "http_api_block_broadcast_delay_times",
+        "Time between start of the slot and when the block was broadcast"
+    );
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Use the pre-states from #2174 during block production.
    - Running this on Pyrmont shows block production times dropping from ~550ms to ~150ms.
- Create `crit` and `warn` logs when a block is published to the API later than we expect.
    - On mainnet we are issuing a warn if the block is published more than 1s later than the slot start and a crit for more than 3s.
- Rename some methods on the `SnapshotCache` for clarity.
- Add the ability to pass the state root to `BeaconChain::produce_block_on_state` to avoid computing a state root. This is a very common LH optimization.
- Add a metric that tracks how late we broadcast blocks received from the HTTP API. This is *technically* a duplicate of a `ValidatorMonitor` log, but I wanted to have it for the case where we aren't monitoring validators too.
