### PR TITLE
[Merged by Bors] - Fix default implementation on FixedVector

### DIFF
--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -114,10 +114,10 @@ impl<T, N: Unsigned> Into<Vec<T>> for FixedVector<T, N> {
     }
 }
 
-impl<T, N: Unsigned> Default for FixedVector<T, N> {
+impl<T: Default, N: Unsigned> Default for FixedVector<T, N> {
     fn default() -> Self {
         Self {
-            vec: Vec::default(),
+            vec: (0..N::to_usize()).map(|_| T::default()).collect(),
             _phantom: PhantomData,
         }
     }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Whilst hacking on something I noticed that the default implementation of `FixedVector` can violate the length constraint!

E.g., `let v: FixedVector<u8; U4> = <_>::default()` would create a fixed vector with length 0, even though it promises to *always* have length 4! This causes SSZ deserialization to fail and probably other things too.

This isn't a security risk as it can't be triggered externally, however it's a foot gun for LH devs.

## Additional Info

NA
