### PR TITLE
[Merged by Bors] - Allow for a clock disparity on the duties endpoints

### DIFF
--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -26,6 +26,10 @@ pub fn attester_duties<T: BeaconChainTypes>(
 
     // Determine what the current epoch would be if we fast-forward our system clock by
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+    //
+    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`, however during
+    // the first `MAXIMUM_GOSSIP_CLOCK_DISPARITY` duration of the epoch `tolerant_current_epoch`
+    // will equal `current_epoch + 1`
     let tolerant_current_epoch = chain
         .slot_clock
         .now_with_future_tolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY)

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -27,7 +27,7 @@ pub fn attester_duties<T: BeaconChainTypes>(
     // Determine what the current epoch would be if we fast-forward our system clock by
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
     //
-    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`, however during
+    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`. However, during
     // the first `MAXIMUM_GOSSIP_CLOCK_DISPARITY` duration of the epoch `tolerant_current_epoch`
     // will equal `current_epoch + 1`
     let tolerant_current_epoch = chain

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -24,7 +24,7 @@ pub fn attester_duties<T: BeaconChainTypes>(
         .epoch()
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    // Determine what the current epoch would be if we rewound our system clock by
+    // Determine what the current epoch would be if we fast-forward our system clock by
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
     let tolerant_current_epoch = chain
         .slot_clock
@@ -35,6 +35,7 @@ pub fn attester_duties<T: BeaconChainTypes>(
     if request_epoch == current_epoch
         || request_epoch == tolerant_current_epoch
         || request_epoch == current_epoch + 1
+        || request_epoch == tolerant_current_epoch + 1
     {
         cached_attestation_duties(request_epoch, request_indices, chain)
     } else if request_epoch > current_epoch + 1 {

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -1,8 +1,11 @@
 //! Contains the handler for the `GET validator/duties/attester/{epoch}` endpoint.
 
 use crate::state_id::StateId;
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{
+    BeaconChain, BeaconChainError, BeaconChainTypes, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+};
 use eth2::types::{self as api_types};
+use slot_clock::SlotClock;
 use state_processing::state_advance::partial_state_advance;
 use types::{
     AttestationDuty, BeaconState, ChainSpec, CloneConfig, Epoch, EthSpec, Hash256, RelativeEpoch,
@@ -20,16 +23,27 @@ pub fn attester_duties<T: BeaconChainTypes>(
     let current_epoch = chain
         .epoch()
         .map_err(warp_utils::reject::beacon_chain_error)?;
-    let next_epoch = current_epoch + 1;
 
-    if request_epoch > next_epoch {
+    // Determine what the current epoch would be if we rewound our system clock by
+    // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+    let tolerant_current_epoch = chain
+        .slot_clock
+        .now_with_future_tolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY)
+        .ok_or_else(|| warp_utils::reject::custom_server_error("unable to read slot clock".into()))?
+        .epoch(T::EthSpec::slots_per_epoch());
+
+    if request_epoch == current_epoch
+        || request_epoch == tolerant_current_epoch
+        || request_epoch == current_epoch + 1
+    {
+        cached_attestation_duties(request_epoch, request_indices, chain)
+    } else if request_epoch > current_epoch + 1 {
         Err(warp_utils::reject::custom_bad_request(format!(
             "request epoch {} is more than one epoch past the current epoch {}",
             request_epoch, current_epoch
         )))
-    } else if request_epoch == current_epoch || request_epoch == next_epoch {
-        cached_attestation_duties(request_epoch, request_indices, chain)
     } else {
+        // request_epoch < current_epoch
         compute_historic_attester_duties(request_epoch, request_indices, chain)
     }
 }

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -1,9 +1,12 @@
 //! Contains the handler for the `GET validator/duties/proposer/{epoch}` endpoint.
 
 use crate::state_id::StateId;
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{
+    BeaconChain, BeaconChainError, BeaconChainTypes, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+};
 use eth2::types::{self as api_types};
 use slog::{debug, Logger};
+use slot_clock::SlotClock;
 use state_processing::state_advance::partial_state_advance;
 use std::cmp::Ordering;
 use types::{BeaconState, ChainSpec, CloneConfig, Epoch, EthSpec, Hash256, Slot};
@@ -21,35 +24,43 @@ pub fn proposer_duties<T: BeaconChainTypes>(
         .epoch()
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    match request_epoch.cmp(&current_epoch) {
-        // request_epoch > current_epoch
-        //
+    // Determine what the current epoch would be if we rewound our system clock by
+    // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+    let tolerant_current_epoch = chain
+        .slot_clock
+        .now_with_future_tolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY)
+        .ok_or_else(|| warp_utils::reject::custom_server_error("unable to read slot clock".into()))?
+        .epoch(T::EthSpec::slots_per_epoch());
+
+    if request_epoch > current_epoch {
         // Reject queries about the future as they're very expensive there's no look-ahead for
         // proposer duties.
-        Ordering::Greater => Err(warp_utils::reject::custom_bad_request(format!(
+        //
+        // Don't even allow requests with the clock disparity tolerance since it's rare we'll get
+        // late requests and it's difficult to determine the proposer shuffling cache key for such
+        // requests.
+        Err(warp_utils::reject::custom_bad_request(format!(
             "request epoch {} is ahead of the current epoch {}",
             request_epoch, current_epoch
-        ))),
-        // request_epoch == current_epoch
-        //
-        // Queries about the current epoch should attempt to find the value in the cache. If it
-        // can't be found, it should be computed and then stored in the cache for future gains.
-        Ordering::Equal => {
-            if let Some(duties) = try_proposer_duties_from_cache(request_epoch, chain)? {
-                Ok(duties)
-            } else {
-                debug!(
-                    log,
-                    "Proposer cache miss";
-                    "request_epoch" =>  request_epoch,
-                );
-                compute_and_cache_proposer_duties(request_epoch, chain)
-            }
+        )))
+    } else if request_epoch == current_epoch || request_epoch == tolerant_current_epoch {
+        // If we could consider ourselves in the `request_epoch` when allowing for clock disparity
+        // tolerance then serve this request from the cache.
+        if let Some(duties) = try_proposer_duties_from_cache(request_epoch, chain)? {
+            Ok(duties)
+        } else {
+            debug!(
+                log,
+                "Proposer cache miss";
+                "request_epoch" =>  request_epoch,
+            );
+            compute_and_cache_proposer_duties(request_epoch, chain)
         }
+    } else {
         // request_epoch < current_epoch
         //
         // Queries about the past are handled with a slow path.
-        Ordering::Less => compute_historic_proposer_duties(request_epoch, chain),
+        compute_historic_proposer_duties(request_epoch, chain)
     }
 }
 
@@ -58,10 +69,10 @@ pub fn proposer_duties<T: BeaconChainTypes>(
 ///
 /// ## Notes
 ///
-/// The `current_epoch` value should equal the current epoch on the slot clock, otherwise we risk
-/// washing out the proposer cache at the expense of block processing.
+/// The `current_epoch` value should equal the current epoch on the slot clock (with some
+/// tolerance), otherwise we risk washing out the proposer cache at the expense of block processing.
 fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
-    current_epoch: Epoch,
+    request_epoch: Epoch,
     chain: &BeaconChain<T>,
 ) -> Result<Option<ApiDuties>, warp::reject::Rejection> {
     let head = chain
@@ -69,16 +80,19 @@ fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
         .map_err(warp_utils::reject::beacon_chain_error)?;
     let head_epoch = head.slot.epoch(T::EthSpec::slots_per_epoch());
 
-    let dependent_root = match head_epoch.cmp(&current_epoch) {
-        // head_epoch == current_epoch
+    let dependent_root = match head_epoch.cmp(&request_epoch) {
+        // head_epoch == request_epoch
         Ordering::Equal => head.proposer_shuffling_decision_root,
-        // head_epoch < current_epoch
+        // head_epoch < request_epoch
+        //
+        // This path is only sensible whilst we restrict calls to this function to be within a small
+        // tolerance (i.e., less than a slot) from the current epoch.
         Ordering::Less => head.block_root,
-        // head_epoch > current_epoch
+        // head_epoch > request_epoch
         Ordering::Greater => {
             return Err(warp_utils::reject::custom_server_error(format!(
-                "head epoch {} is later than current epoch {}",
-                head_epoch, current_epoch
+                "head epoch {} is later than request epoch {}",
+                head_epoch, request_epoch
             )))
         }
     };
@@ -86,10 +100,10 @@ fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
     chain
         .beacon_proposer_cache
         .lock()
-        .get_epoch::<T::EthSpec>(dependent_root, current_epoch)
+        .get_epoch::<T::EthSpec>(dependent_root, request_epoch)
         .cloned()
         .map(|indices| {
-            convert_to_api_response(chain, current_epoch, dependent_root, indices.to_vec())
+            convert_to_api_response(chain, request_epoch, dependent_root, indices.to_vec())
         })
         .transpose()
 }

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -26,6 +26,10 @@ pub fn proposer_duties<T: BeaconChainTypes>(
 
     // Determine what the current epoch would be if we fast-forward our system clock by
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
+    //
+    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`, however during
+    // the first `MAXIMUM_GOSSIP_CLOCK_DISPARITY` duration of the epoch `tolerant_current_epoch`
+    // will equal `current_epoch + 1`
     let tolerant_current_epoch = chain
         .slot_clock
         .now_with_future_tolerance(MAXIMUM_GOSSIP_CLOCK_DISPARITY)

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -27,7 +27,7 @@ pub fn proposer_duties<T: BeaconChainTypes>(
     // Determine what the current epoch would be if we fast-forward our system clock by
     // `MAXIMUM_GOSSIP_CLOCK_DISPARITY`.
     //
-    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`, however during
+    // Most of the time, `tolerant_current_epoch` will be equal to `current_epoch`. However, during
     // the first `MAXIMUM_GOSSIP_CLOCK_DISPARITY` duration of the epoch `tolerant_current_epoch`
     // will equal `current_epoch + 1`
     let tolerant_current_epoch = chain
@@ -84,9 +84,6 @@ fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
         // head_epoch == request_epoch
         Ordering::Equal => head.proposer_shuffling_decision_root,
         // head_epoch < request_epoch
-        //
-        // This path is only sensible whilst we restrict calls to this function to be within a small
-        // tolerance (i.e., less than a slot) from the current epoch.
         Ordering::Less => head.block_root,
         // head_epoch > request_epoch
         Ordering::Greater => {

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1715,7 +1715,7 @@ impl ApiTester {
                 .status()
                 .map(Into::into),
             Some(400),
-            "should not get proposer duties outside of tolerance"
+            "should not get attester duties outside of tolerance"
         );
 
         self.chain


### PR DESCRIPTION
## Issue Addressed

Resolves #2280

## Proposed Changes

Allows for API consumers to call the proposer/attester duties endpoints [`MAXIMUM_GOSSIP_CLOCK_DISPARITY`](https://github.com/sigp/lighthouse/blob/b34a79dc0b02e04441ba01fd0f304d1e203d877d/beacon_node/beacon_chain/src/beacon_chain.rs#L99-L102) earlier than the current epoch. For additional reasoning, see https://github.com/sigp/lighthouse/issues/2280#issuecomment-805358897.

## Additional Info

NA
