### PR TITLE
[Merged by Bors] - Use generic BLS object instead of BLST

### DIFF
--- a/validator_client/src/graffiti_file.rs
+++ b/validator_client/src/graffiti_file.rs
@@ -5,7 +5,7 @@ use std::io::{prelude::*, BufReader};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use bls::blst_implementations::PublicKeyBytes;
+use bls::PublicKeyBytes;
 use types::{graffiti::GraffitiString, Graffiti};
 
 #[derive(Debug)]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Fixes a compile error when using the `milagro` feature. I can't see any need to use the specific BLST object here. @pawanjay176 can you please confirm?

## Additional Info

NA
