### PR TITLE
Tune GNU malloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,8 +1632,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f52d2228d51e8f868a37d5b5b25b82c13552b635d5b47c3a5d53855a6fc4f0"
+source = "git+https://github.com/sigp/discv5?rev=02d2c896c66f8dc2b848c3996fedcd98e1dfec69#02d2c896c66f8dc2b848c3996fedcd98e1dfec69"
 dependencies = [
  "aes-ctr",
  "aes-gcm 0.8.0",
@@ -1646,6 +1645,7 @@ dependencies = [
  "hkdf",
  "k256",
  "lazy_static",
+ "libp2p-core",
  "lru_time_cache",
  "parking_lot",
  "rand 0.7.3",
@@ -1664,7 +1664,8 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.3"
-source = "git+https://github.com/sigp/discv5?rev=02d2c896c66f8dc2b848c3996fedcd98e1dfec69#02d2c896c66f8dc2b848c3996fedcd98e1dfec69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f52d2228d51e8f868a37d5b5b25b82c13552b635d5b47c3a5d53855a6fc4f0"
 dependencies = [
  "aes-ctr",
  "aes-gcm 0.8.0",
@@ -1677,7 +1678,6 @@ dependencies = [
  "hkdf",
  "k256",
  "lazy_static",
- "libp2p-core",
  "lru_time_cache",
  "parking_lot",
  "rand 0.7.3",
@@ -3858,6 +3858,10 @@ dependencies = [
 [[package]]
 name = "malloc_ctl"
 version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+]
 
 [[package]]
 name = "maplit"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,6 +2860,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "lighthouse_version",
+ "malloc_ctl",
  "network",
  "parking_lot",
  "serde",
@@ -3727,6 +3728,7 @@ dependencies = [
  "lighthouse_metrics",
  "lighthouse_version",
  "logging",
+ "malloc_ctl",
  "remote_signer",
  "slashing_protection",
  "slog",
@@ -3852,6 +3854,10 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "malloc_ctl"
+version = "0.1.0"
 
 [[package]]
 name = "maplit"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "common/lockfile",
     "common/logging",
     "common/lru_cache",
+    "common/malloc_ctl",
     "common/remote_signer_consumer",
     "common/slot_clock",
     "common/task_executor",

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -26,6 +26,7 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
 warp_utils = { path = "../../common/warp_utils" }
 slot_clock = { path = "../../common/slot_clock" }
+malloc_ctl = { path = "../../common/malloc_ctl" }
 eth2_ssz = { path = "../../consensus/ssz" }
 bs58 = "0.4.0"
 futures = "0.3.8"

--- a/common/malloc_ctl/Cargo.toml
+++ b/common/malloc_ctl/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+parking_lot = "0.11.0"
+lazy_static = "1.4.0"

--- a/common/malloc_ctl/Cargo.toml
+++ b/common/malloc_ctl/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "malloc_ctl"
+version = "0.1.0"
+authors = ["Paul Hauner <paul@paulhauner.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/common/malloc_ctl/build.rs
+++ b/common/malloc_ctl/build.rs
@@ -1,3 +1,0 @@
-fn main() {
-    // println!("cargo:rustc-link-lib=libc");
-}

--- a/common/malloc_ctl/build.rs
+++ b/common/malloc_ctl/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    // println!("cargo:rustc-link-lib=libc");
+}

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -17,14 +17,17 @@ pub const DEFAULT_TRIM: c_ulong = 1_024 * 128;
 const M_ARENA_MAX: c_int = -8;
 
 mod ffi {
+    /// See: https://man7.org/linux/man-pages/man3/malloc_trim.3.html
     extern "C" {
         pub fn malloc_trim(__pad: std::os::raw::c_ulong) -> ::std::os::raw::c_int;
     }
 
+    /// See: https://man7.org/linux/man-pages/man3/malloc_stats.3.html
     extern "C" {
         pub fn malloc_stats();
     }
 
+    /// See: https://man7.org/linux/man-pages/man3/mallopt.3.html
     extern "C" {
         pub fn mallopt(
             __param: ::std::os::raw::c_int,
@@ -41,6 +44,15 @@ fn into_result(result: c_int) -> Result<(), c_int> {
     }
 }
 
+/// Uses `mallopt` to set the `M_ARENA_MAX` value, specifying the number of memory arenas to be
+/// created by malloc.
+///
+/// Generally speaking, a smaller arena count reduces memory fragmentation at the cost of memory contention
+/// between threads.
+///
+/// ## Resources
+///
+/// - https://man7.org/linux/man-pages/man3/mallopt.3.html
 pub fn malloc_arena_max(num_arenas: c_int) -> Result<(), c_int> {
     unsafe { into_result(ffi::mallopt(M_ARENA_MAX, num_arenas)) }
 }

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -1,0 +1,87 @@
+pub mod trimmer_thread;
+
+pub use std::os::raw::{c_int, c_ulong};
+
+/// A default value to be provided to `malloc_trim`.
+///
+/// Value sourced from:
+///
+/// - https://man7.org/linux/man-pages/man3/mallopt.3.html
+pub const DEFAULT_TRIM: c_ulong = 1_024 * 128;
+
+/// Used to configure malloc internals.
+///
+/// Source:
+///
+/// https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/malloc/malloc.h#L123
+const M_ARENA_MAX: c_int = -8;
+
+mod ffi {
+    extern "C" {
+        pub fn malloc_trim(__pad: std::os::raw::c_ulong) -> ::std::os::raw::c_int;
+    }
+
+    extern "C" {
+        pub fn malloc_stats();
+    }
+
+    extern "C" {
+        pub fn mallopt(
+            __param: ::std::os::raw::c_int,
+            __val: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int;
+    }
+}
+
+fn into_result(result: c_int) -> Result<(), c_int> {
+    if result == 1 {
+        Ok(())
+    } else {
+        Err(result)
+    }
+}
+
+pub fn malloc_arena_max(num_arenas: c_int) -> Result<(), c_int> {
+    unsafe { into_result(ffi::mallopt(M_ARENA_MAX, num_arenas)) }
+}
+
+/// Calls `malloc_trim(0)`, freeing up available memory at the expense of CPU time and arena
+/// locking.
+///
+/// ## Resources
+///
+/// - https://man7.org/linux/man-pages/man3/malloc_trim.3.html
+pub fn malloc_trim(pad: c_ulong) -> Result<(), c_int> {
+    unsafe { into_result(ffi::malloc_trim(pad)) }
+}
+
+/// Calls `malloc_stats`, printing the output to stderr.
+///
+/// ## Resources
+///
+/// - https://man7.org/linux/man-pages/man3/malloc_stats.3.html
+pub fn eprintln_malloc_stats() {
+    unsafe { ffi::malloc_stats() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malloc_arena_max_does_not_panic() {
+        malloc_arena_max(1).unwrap()
+    }
+
+    #[test]
+    fn malloc_default_trim_does_not_panic() {
+        malloc_trim(DEFAULT_TRIM).unwrap()
+    }
+
+    /// Unfortunately this test will print into the test results, even on success. I don't know any
+    /// way to avoid this.
+    #[test]
+    fn eprintln_malloc_stats_does_not_panic() {
+        eprintln_malloc_stats()
+    }
+}

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -9,11 +9,19 @@ pub use std::os::raw::{c_int, c_ulong};
 /// - https://man7.org/linux/man-pages/man3/mallopt.3.html
 pub const DEFAULT_TRIM: c_ulong = 1_024 * 128;
 
-/// Used to configure malloc internals.
+/// A default value to be provided to `malloc_mmap_threshold`.
+///
+/// One megabyte.
+///
+/// Value chosen so that it will store the values of the validators tree hash cache.
+pub const DEFAULT_MMAP_THRESHOLD: c_int = 1_024 * 1_024;
+
+/// Constants used to configure malloc internals.
 ///
 /// Source:
 ///
-/// https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/malloc/malloc.h#L123
+/// https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/malloc/malloc.h#L115-L123
+const M_MMAP_THRESHOLD: c_int = -4;
 const M_ARENA_MAX: c_int = -8;
 
 mod ffi {
@@ -55,6 +63,16 @@ fn into_result(result: c_int) -> Result<(), c_int> {
 /// - https://man7.org/linux/man-pages/man3/mallopt.3.html
 pub fn malloc_arena_max(num_arenas: c_int) -> Result<(), c_int> {
     unsafe { into_result(ffi::mallopt(M_ARENA_MAX, num_arenas)) }
+}
+
+/// Uses `mallopt` to set the `M_MMAP_THRESHOLD` value, specifying the threshold where objects of this
+/// size or larger are allocated via an `mmap`.
+///
+/// ## Resources
+///
+/// - https://man7.org/linux/man-pages/man3/mallopt.3.html
+pub fn malloc_mmap_threshold(num_arenas: c_int) -> Result<(), c_int> {
+    unsafe { into_result(ffi::mallopt(M_MMAP_THRESHOLD, num_arenas)) }
 }
 
 /// Calls `malloc_trim(0)`, freeing up available memory at the expense of CPU time and arena

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(backtrace)]
+
+pub mod profiling_allocator;
 pub mod trimmer_thread;
 
 pub use std::os::raw::{c_int, c_ulong};

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(backtrace)]
+#![feature(backtrace_frames)]
 
 pub mod profiling_allocator;
 pub mod trimmer_thread;

--- a/common/malloc_ctl/src/lib.rs
+++ b/common/malloc_ctl/src/lib.rs
@@ -11,10 +11,8 @@ pub const DEFAULT_TRIM: c_ulong = 1_024 * 128;
 
 /// A default value to be provided to `malloc_mmap_threshold`.
 ///
-/// One megabyte.
-///
 /// Value chosen so that it will store the values of the validators tree hash cache.
-pub const DEFAULT_MMAP_THRESHOLD: c_int = 1_024 * 1_024;
+pub const DEFAULT_MMAP_THRESHOLD: c_int = 2 * 1_024 * 1_024;
 
 /// Constants used to configure malloc internals.
 ///

--- a/common/malloc_ctl/src/profiling_allocator.rs
+++ b/common/malloc_ctl/src/profiling_allocator.rs
@@ -1,0 +1,87 @@
+use crate::DEFAULT_MMAP_THRESHOLD;
+use parking_lot::RwLock;
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::backtrace::Backtrace;
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::process;
+use std::path::PathBuf;
+use std::fs;
+use lazy_static::lazy_static;
+
+lazy_static! {
+    pub static ref STATS: RwLock<HashMap<String, Stat>> = <_>::default();
+}
+
+#[derive(Default, Clone)]
+pub struct Stat {
+    sum: usize,
+    count: usize,
+}
+
+pub struct ProfilingAllocator;
+
+unsafe impl GlobalAlloc for ProfilingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ret = System.alloc(layout);
+
+        if layout.size() >= DEFAULT_MMAP_THRESHOLD as usize {
+            let backtrace = Backtrace::capture().to_string();
+
+            let mut stat = STATS
+                .read()
+                .get(&backtrace)
+                .cloned()
+                .unwrap_or_default();
+
+            stat.count = stat.count.saturating_add(1);
+            stat.sum = stat.sum.saturating_add(layout.size());
+
+            STATS.write().insert(backtrace.clone(), stat.clone());
+
+            eprintln!("{} {} {}", stat.count, stat.sum, backtrace);
+        }
+
+        return ret;
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+    }
+}
+
+impl ProfilingAllocator {
+    fn dump(&self) -> Result<(), io::Error> {
+        let mut path = PathBuf::new();
+        path.push("tmp");
+        path.push(format!("profiling_allocator_{}.csv", process::id()));
+
+        let mut file = fs::File::create(&path)?;
+
+        std::write!(file, "count,sum,backtrace\n")?;
+
+        let stats = STATS.read();
+
+        for (backtrace, stat) in stats.iter() {
+            std::write!(
+                file,
+                "{},{},{}\n",
+                stat.count, stat.sum, backtrace
+            )?;
+        }
+
+        drop(stats);
+
+        eprintln!("successfully dumped profile to {:?}", path);
+
+        Ok(())
+    }
+}
+
+impl Drop for ProfilingAllocator {
+    fn drop(&mut self) {
+        if let Err(e) = self.dump() {
+            eprintln!("failed to dump profile: {}", e);
+        }
+    }
+}

--- a/common/malloc_ctl/src/trimmer_thread.rs
+++ b/common/malloc_ctl/src/trimmer_thread.rs
@@ -1,0 +1,20 @@
+use crate::{c_ulong, malloc_trim};
+use std::thread;
+use std::time::Duration;
+
+pub const DEFAULT_TRIM_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Spawns a thread which will call `crate::malloc_trim(trim)`, sleeping `interval` between each
+/// call.
+///
+/// The function will not call `malloc_trim` on start, the first call will happen after `interval`
+/// has elapsed.
+pub fn spawn_trimmer_thread(interval: Duration, trim: c_ulong) -> thread::JoinHandle<()> {
+    thread::spawn(move || loop {
+        thread::sleep(interval);
+
+        if let Err(e) = malloc_trim(trim) {
+            eprintln!("malloc_trim failed with {}", e);
+        }
+    })
+}

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -43,6 +43,7 @@ account_utils = { path = "../common/account_utils" }
 remote_signer = { "path" = "../remote_signer" }
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
+malloc_ctl = { path = "../common/malloc_ctl" }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit="256"]
+
 mod metrics;
 
 use beacon_node::{get_eth2_network_config, ProductionBeaconNode};
@@ -10,12 +12,16 @@ use malloc_ctl::{
     malloc_arena_max, malloc_mmap_threshold,
     trimmer_thread::{spawn_trimmer_thread, DEFAULT_TRIM_INTERVAL},
     DEFAULT_MMAP_THRESHOLD, DEFAULT_TRIM,
+    profiling_allocator::ProfilingAllocator
 };
 use slog::{crit, info, warn};
 use std::path::PathBuf;
 use std::process::exit;
 use types::{EthSpec, EthSpecId};
 use validator_client::ProductionValidatorClient;
+
+#[global_allocator]
+static A: ProfilingAllocator = ProfilingAllocator;
 
 pub const ETH2_CONFIG_FILENAME: &str = "eth2-spec.toml";
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -7,9 +7,9 @@ use environment::EnvironmentBuilder;
 use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK};
 use lighthouse_version::VERSION;
 use malloc_ctl::{
-    malloc_arena_max,
+    malloc_arena_max, malloc_mmap_threshold,
     trimmer_thread::{spawn_trimmer_thread, DEFAULT_TRIM_INTERVAL},
-    DEFAULT_TRIM,
+    DEFAULT_MMAP_THRESHOLD, DEFAULT_TRIM,
 };
 use slog::{crit, info, warn};
 use std::path::PathBuf;
@@ -38,6 +38,11 @@ fn main() {
     // TODO: check for env variable so we don't overwrite it.
     if let Err(e) = malloc_arena_max(1) {
         eprintln!("Failed (code {}) to set malloc max arena count", e);
+        exit(1)
+    }
+
+    if let Err(e) = malloc_mmap_threshold(DEFAULT_MMAP_THRESHOLD) {
+        eprintln!("Failed (code {}) to set malloc mmap threshold", e);
         exit(1)
     }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Modify the configuration of [GNU malloc](https://www.gnu.org/software/libc/manual/html_node/The-GNU-Allocator.html) to reduce memory footprint.

- Set `M_ARENA_MAX` to `1`.
    - This reduces memory fragmentation at the cost of contention between threads.
- Set `M_MMAP_THRESHOLD` to 2mb
    - This means that any allocation >= 2mb is allocated via an anonymous mmap, instead of on the heap/arena. This reduces memory fragmentation since we don't need to keep growing the heap to find big contiguous slabs of free memory.
- Run `malloc_trim` every 60 seconds.
    - This shaves unused memory from the top of the heap, preventing the heap from constantly growing.
    
## Additional Info

I'm going to close #2288 in favor of this for the following reasons:

- I've managed to get the memory footprint *smaller* here than with jemalloc.
- This PR seems to be less of a dramatic change than bringing in the jemalloc dep.
- The changes in this PR are strictly runtime changes, so we can create CLI flags which disable them completely. Since this change is wide-reaching and complex, it's nice to have an easy "escape hatch" if there are undesired consequences.

## TODO

- [ ] Allow configuration via CLI flags
- [ ] Test on Mac and some other Linux variants.
- [ ] Determine if GNU malloc is present?
- [ ] Make a clear argument regarding the affect of this on CPU utilization.
- [ ] Test with higher `M_ARENA_MAX` values.
- [ ] Test with longer trim intervals
- [ ] Add some stats about memory savings
