### PR TITLE
[Merged by Bors] - Correcting `disable-enr-auto-update` flag definition

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -143,7 +143,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("disable-enr-auto-update")
                 .help("Discovery automatically updates the nodes local ENR with an external IP address and port as seen by other peers on the network. \
                 This disables this feature, fixing the ENR's IP/PORT to those specified on boot.")
-                .takes_value(true),
+                .takes_value(false),
         )
         .arg(
             Arg::with_name("libp2p-addresses")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -142,8 +142,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .short("x")
                 .long("disable-enr-auto-update")
                 .help("Discovery automatically updates the nodes local ENR with an external IP address and port as seen by other peers on the network. \
-                This disables this feature, fixing the ENR's IP/PORT to those specified on boot.")
-                .takes_value(false),
+                This disables this feature, fixing the ENR's IP/PORT to those specified on boot."),
         )
         .arg(
             Arg::with_name("libp2p-addresses")


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Correct the `disable-enr-auto-update` boolean flag so that it no longer requires a value.
Previously it would require a value which was never used.

## Additional Info

Flag is read here: https://github.com/sigp/lighthouse/blob/unstable/beacon_node/src/config.rs#L585-L587
