### PR TITLE
Allow non-string extra_fields to YamlConfig

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -578,7 +578,7 @@ pub struct YamlConfig {
 
     // Extra fields (could be from a future hard-fork that we don't yet know).
     #[serde(flatten)]
-    pub extra_fields: HashMap<String, String>,
+    pub extra_fields: HashMap<String, serde_yaml::Value>,
 }
 
 impl Default for YamlConfig {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Presently, if we add something like  `MY_NEW_PARAM: 12` to a `config.yaml` (`YamlConfig`) then we'll get the following error:

```
Unable to load testnet parameters: Unable to parse "./mynetwork/public/config.yaml": Message("invalid type: integer `12`, expected a string", Some(Pos { marker: Marker { index: 135, line: 4, col: 11 }, path: "." }))
```

This PR allows for *any* type of serde value to be present as an extra field.

## Additional Info

NA
