### PR TITLE
[Merged by Bors] - Add NETWORK_ID variable

### DIFF
--- a/scripts/local_testnet/ganache_test_node.sh
+++ b/scripts/local_testnet/ganache_test_node.sh
@@ -9,5 +9,5 @@ ganache-cli \
 	--mnemonic "$ETH1_NETWORK_MNEMONIC" \
 	--port 8545 \
 	--blockTime 3 \
-	--networkId 4242 \
-	--chainId 4242
+	--networkId "$NETWORK_ID" \
+	--chainId "$NETWORK_ID"

--- a/scripts/local_testnet/setup.sh
+++ b/scripts/local_testnet/setup.sh
@@ -30,7 +30,7 @@ lcli \
 	--min-genesis-time $GENESIS_TIME \
 	--genesis-delay $GENESIS_DELAY \
 	--genesis-fork-version $GENESIS_FORK_VERSION \
-	--eth1-id $BOOTNODE_PORT \
+	--eth1-id $NETWORK_ID \
 	--eth1-follow-distance 1 \
 	--seconds-per-eth1-block 1 \
 	--force

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -23,5 +23,5 @@ GENESIS_DELAY=180
 # Port for p2p communication with bootnode
 BOOTNODE_PORT=4242
 
-# Network ID and Chain ID of local testnet network
+# Network ID and Chain ID of local eth1 test network
 NETWORK_ID=4242 

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -20,7 +20,7 @@ NODE_COUNT=4
 
 GENESIS_DELAY=180
 
-# Port for p2p communication with bootnode
+# Port for P2P communication with bootnode
 BOOTNODE_PORT=4242
 
 # Network ID and Chain ID of local eth1 test network

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -19,4 +19,9 @@ GENESIS_VALIDATOR_COUNT=80
 NODE_COUNT=4
 
 GENESIS_DELAY=180
+
+# Port for p2p communication with bootnode
 BOOTNODE_PORT=4242
+
+# Network ID and Chain ID of local testnet network
+NETWORK_ID=4242 


### PR DESCRIPTION
Same variable BOOTNODE_PORT was used for p2p port of bootnode and testnet Chain and Network ID. Adding variable NETWORK_ID to make scripts less confusing and create option to choose arbitrary ID. 