### PR TITLE
[Merged by Bors] - Reduce outbound requests to eth1 endpoints

### DIFF
--- a/beacon_node/eth1/src/inner.rs
+++ b/beacon_node/eth1/src/inner.rs
@@ -2,6 +2,7 @@ use crate::Config;
 use crate::{
     block_cache::{BlockCache, Eth1Block},
     deposit_cache::{DepositCache, SszDepositCache},
+    service::EndpointsCache,
 };
 use parking_lot::RwLock;
 use ssz::{Decode, Encode};
@@ -28,6 +29,7 @@ impl DepositUpdater {
 pub struct Inner {
     pub block_cache: RwLock<BlockCache>,
     pub deposit_cache: RwLock<DepositUpdater>,
+    pub endpoints_cache: RwLock<Option<EndpointsCache>>,
     pub config: RwLock<Config>,
     pub remote_head_block: RwLock<Option<Eth1Block>>,
     pub spec: ChainSpec,
@@ -87,6 +89,7 @@ impl SszEth1Cache {
                 cache: self.deposit_cache.to_deposit_cache()?,
                 last_processed_block: self.last_processed_block,
             }),
+            endpoints_cache: RwLock::new(None),
             // Set the remote head_block zero when creating a new instance. We only care about
             // present and future eth1 nodes.
             remote_head_block: RwLock::new(None),

--- a/beacon_node/eth1/src/inner.rs
+++ b/beacon_node/eth1/src/inner.rs
@@ -7,6 +7,7 @@ use crate::{
 use parking_lot::RwLock;
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
+use std::sync::Arc;
 use types::ChainSpec;
 
 #[derive(Default)]
@@ -29,7 +30,7 @@ impl DepositUpdater {
 pub struct Inner {
     pub block_cache: RwLock<BlockCache>,
     pub deposit_cache: RwLock<DepositUpdater>,
-    pub endpoints_cache: RwLock<Option<EndpointsCache>>,
+    pub endpoints_cache: RwLock<Option<Arc<EndpointsCache>>>,
     pub config: RwLock<Config>,
     pub remote_head_block: RwLock<Option<Eth1Block>>,
     pub spec: ChainSpec,

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -439,7 +439,7 @@ impl Default for Config {
             block_cache_truncation: Some(4_096),
             auto_update_interval_millis: 60_000,
             blocks_per_log_query: 1_000,
-            max_log_requests_per_update: Some(100),
+            max_log_requests_per_update: Some(5_000),
             max_blocks_per_update: Some(8_192),
             purge_cache: false,
         }

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -678,8 +678,7 @@ impl Service {
     ) -> Result<(DepositCacheUpdateOutcome, BlockCacheUpdateOutcome), String> {
         let endpoints = self.get_endpoints();
 
-        // Reset the state of any endpoints which have errored.
-        // This will ensure the endpoint state will be updated
+        // Reset the state of any endpoints which have errored so their state can be redetermined.
         endpoints.reset_errorred_endpoints().await;
 
         let node_far_behind_seconds = self.inner.config.read().node_far_behind_seconds;

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -139,9 +139,10 @@ impl EndpointsCache {
                                 );
                                 if let SingleEndpointError::EndpointError(e) = &t {
                                     *endpoint.state.write().await = Some(Err(*e));
+                                } else {
+                                    // A non-`EndpointError` error occurred, so reset the state.
+                                    self.reset_endpoint_state(endpoint).await;
                                 }
-                                // Endpoint had a non-`EndpointError` error so reset the state.
-                                self.reset_endpoint_state(endpoint).await;
                                 Err(t)
                             }
                         }

--- a/common/fallback/src/lib.rs
+++ b/common/fallback/src/lib.rs
@@ -2,8 +2,9 @@ use itertools::{join, zip};
 use std::fmt::{Debug, Display};
 use std::future::Future;
 
+#[derive(Clone)]
 pub struct Fallback<T> {
-    servers: Vec<T>,
+    pub servers: Vec<T>,
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
## Issue Addressed

#2282 

## Proposed Changes

Reduce the outbound requests made to eth1 endpoints by caching the results from `eth_chainId` and `net_version`.
Further reduce the overall request count by increasing `auto_update_interval_millis` from `7_000` (7 seconds) to `60_000` (1 minute). 
This will result in a reduction from ~2000 requests per hour to 360 requests per hour (during normal operation). A reduction of 82%.

## Additional Info

If an endpoint fails, its state is dropped from the cache and the `eth_chainId` and `net_version` calls will be made for that endpoint again during the regular update cycle (once per minute) until it is back online.
