### PR TITLE
[Altair] Add regression test for parsing non-Altair StandardConfig

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -148,10 +148,11 @@ impl ChainSpec {
     /// Construct a `ChainSpec` from a standard config.
     pub fn from_standard_config<T: EthSpec>(standard_config: &StandardConfig) -> Option<Self> {
         let mut spec = T::default_spec();
+        spec = standard_config.base().apply_to_chain_spec::<T>(&spec)?;
 
-        spec = standard_config.base.apply_to_chain_spec::<T>(&spec)?;
-        spec = standard_config.altair.apply_to_chain_spec::<T>(&spec)?;
-
+        if let Ok(altair) = standard_config.altair() {
+            spec = altair.apply_to_chain_spec::<T>(&spec)?;
+        }
         Some(spec)
     }
 
@@ -439,11 +440,17 @@ impl Default for ChainSpec {
 /// Ordering of these enum variants is significant because it determines serde's deserialisation
 /// priority. I.e. Altair before Base.
 ///
+#[superstruct(
+    variants(Altair, Base),
+    variant_attributes(derive(Serialize, Deserialize, Debug, PartialEq, Clone))
+)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(untagged)]
 pub struct StandardConfig {
     #[serde(flatten)]
     pub base: BaseConfig,
     /// Configuration related to the Altair hard fork.
+    #[superstruct(only(Altair))]
     #[serde(flatten)]
     pub altair: AltairConfig,
 
@@ -461,11 +468,11 @@ impl StandardConfig {
 
     pub fn from_parts(base: BaseConfig, altair: AltairConfig) -> Self {
         let extra_fields = HashMap::new();
-        StandardConfig {
+        StandardConfig::Altair(StandardConfigAltair {
             base,
             altair,
             extra_fields,
-        }
+        })
     }
 }
 
@@ -988,8 +995,9 @@ mod tests {
         let f = File::open(tmp_file.as_ref()).unwrap();
         let standard_config: StandardConfig = serde_yaml::from_reader(f).unwrap();
 
-        assert_eq!(standard_config.base, base_config);
-        assert!(standard_config.extra_fields.is_empty());
+        let standard_base = standard_config.as_base().unwrap();
+        assert_eq!(standard_base.base, base_config);
+        assert!(standard_base.extra_fields.is_empty());
     }
 }
 
@@ -1057,8 +1065,8 @@ mod yaml_tests {
         let mut yamlconfig = StandardConfig::from_chain_spec::<MainnetEthSpec>(&mainnet_spec);
         let (k1, v1) = ("SAMPLE_HARDFORK_KEY1", "123456789");
         let (k2, v2) = ("SAMPLE_HARDFORK_KEY2", "987654321");
-        yamlconfig.extra_fields.insert(k1.into(), v1.into());
-        yamlconfig.extra_fields.insert(k2.into(), v2.into());
+        yamlconfig.extra_fields_mut().insert(k1.into(), v1.into());
+        yamlconfig.extra_fields_mut().insert(k2.into(), v2.into());
         serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
         let reader = OpenOptions::new()

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1098,4 +1098,16 @@ mod yaml_tests {
             .expect("should have applied spec");
         assert_eq!(new_spec, ChainSpec::minimal());
     }
+
+    #[test]
+    fn parses_base_spec() {
+        let spec = ChainSpec::minimal();
+        let base_config = BaseConfig::from_chain_spec::<MinimalEthSpec>(&spec);
+        let std_conf =
+            serde_json::from_str::<StandardConfig>(&serde_json::to_string(&base_config).unwrap())
+                .expect("should parse base spec");
+        std_conf
+            .as_altair()
+            .expect_err("should not have altair params");
+    }
 }

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{sync::RwLock, time::sleep};
-use types::{ChainSpec, EthSpec, StandardConfig};
+use types::{ChainSpec, EthSpec};
 
 /// The number of seconds *prior* to slot start that we will try and update the state of fallback
 /// nodes.
@@ -235,20 +235,12 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
                 CandidateError::Incompatible
             })?;
 
-        if !std_config.extra_fields().is_empty() {
+        if !std_config.extra_fields.is_empty() {
             debug!(
                 log,
                 "Beacon spec includes unknown fields";
                 "endpoint" => %self.beacon_node,
-                "fields" => ?std_config.extra_fields(),
-            );
-        }
-
-        if let StandardConfig::Base { .. } = std_config {
-            warn!(
-                log,
-                "Beacon spec lacks Altair config";
-                "endpoint" => %self.beacon_node,
+                "fields" => ?std_config.extra_fields,
             );
         }
 

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{sync::RwLock, time::sleep};
-use types::{ChainSpec, EthSpec};
+use types::{ChainSpec, EthSpec, StandardConfig};
 
 /// The number of seconds *prior* to slot start that we will try and update the state of fallback
 /// nodes.
@@ -235,12 +235,20 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
                 CandidateError::Incompatible
             })?;
 
-        if !std_config.extra_fields.is_empty() {
+        if !std_config.extra_fields().is_empty() {
             debug!(
                 log,
                 "Beacon spec includes unknown fields";
                 "endpoint" => %self.beacon_node,
-                "fields" => ?std_config.extra_fields,
+                "fields" => ?std_config.extra_fields(),
+            );
+        }
+
+        if let StandardConfig::Base { .. } = std_config {
+            warn!(
+                log,
+                "Beacon spec lacks Altair config";
+                "endpoint" => %self.beacon_node,
             );
         }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

~~I was wondering why `StandardConfig` was wrapped in a `SuperStruct`, so I figured I'd let the compiler tell me. I'll let this run against CI to see if there's anything I've missed.~~

Adds a regression test to ensure we can parse a `StandardConfig` without Altair params.

## Additional Info

NA
