### PR TITLE
Speed up JSON load in slashing protection import

### DIFF
--- a/account_manager/src/validator/slashing_protection.rs
+++ b/account_manager/src/validator/slashing_protection.rs
@@ -72,8 +72,10 @@ pub fn cli_run<T: EthSpec>(
                 )
             })?;
 
+            eprintln!("Loading JSON file into memory & deserializing");
             let interchange = Interchange::from_json_reader(&import_file)
                 .map_err(|e| format!("Error parsing file for import: {:?}", e))?;
+            eprintln!("JSON load complete - performing import");
 
             let slashing_protection_database =
                 SlashingDatabase::open_or_create(&slashing_protection_db_path).map_err(|e| {


### PR DESCRIPTION
## Issue Addressed

One of our users had trouble exporting slashing protection data from Prysm to Lighthouse, and it turns out that Lighthouse was very slow at loading the JSON (for the related Prysm issue see https://github.com/prysmaticlabs/prysm/issues/8893).

## Proposed Changes

The reason for the slowness is that `serde_json::from_reader` isn't as heavily optimised as other deserialisation methods, as described here: https://github.com/serde-rs/json/issues/160. Instead of `from_reader`, the import function now reads the entire JSON object into memory and deserialises that. I think this is a reasonable tradeoff, as import JSON files should be reasonably sized (less than system memory :crossed_fingers:) due to pruning.

Marking this as WIP while I run the import on a modified version of the failing 1.2GB file (it's still taking a long time...).


