### PR TITLE
[Altair] Applying Base block to Altair chain

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1358,6 +1358,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .collect::<Vec<_>>();
 
         for (i, block) in chain_segment.into_iter().enumerate() {
+            // Ensure the block is the correct structure for the fork at `block.slot()`.
+            if let Err(e) = block.fork_name(&self.spec) {
+                return ChainSegmentResult::Failed {
+                    imported_blocks,
+                    error: BlockError::InconsistentFork(e),
+                };
+            }
+
             let block_root = get_block_root(&block);
 
             if let Some((child_parent_root, child_slot)) = children.get(i) {

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -289,6 +289,7 @@ mod test {
     fn get_harness() -> BeaconChainHarness<EphemeralHarnessType<MainnetEthSpec>> {
         let harness = BeaconChainHarness::new_with_store_config(
             MainnetEthSpec,
+            None,
             types::test_utils::generate_deterministic_keypairs(1),
             StoreConfig::default(),
         );

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -217,7 +217,7 @@ impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
         chain_config: ChainConfig,
     ) -> Self {
         let data_dir = tempdir().expect("should create temporary data_dir");
-        let mut spec = spec.unwrap_or_else(|| test_spec::<E>());
+        let mut spec = spec.unwrap_or_else(test_spec::<E>);
 
         spec.target_aggregators_per_committee = target_aggregators_per_committee;
 
@@ -270,7 +270,7 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
         validator_keypairs: Vec<Keypair>,
     ) -> Self {
         let data_dir = tempdir().expect("should create temporary data_dir");
-        let spec = spec.unwrap_or_else(|| test_spec::<E>());
+        let spec = spec.unwrap_or_else(test_spec::<E>);
 
         let log = test_logger();
         let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);
@@ -315,7 +315,7 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
         validator_keypairs: Vec<Keypair>,
         data_dir: TempDir,
     ) -> Self {
-        let spec = spec.unwrap_or_else(|| test_spec::<E>());
+        let spec = spec.unwrap_or_else(test_spec::<E>);
 
         let log = test_logger();
         let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -156,9 +156,14 @@ pub type HarnessAttestations<E> = Vec<(
 )>;
 
 impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
-    pub fn new(eth_spec_instance: E, validator_keypairs: Vec<Keypair>) -> Self {
+    pub fn new(
+        eth_spec_instance: E,
+        spec: Option<ChainSpec>,
+        validator_keypairs: Vec<Keypair>,
+    ) -> Self {
         Self::new_with_store_config(
             eth_spec_instance,
+            spec,
             validator_keypairs,
             StoreConfig::default(),
         )
@@ -166,6 +171,7 @@ impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
 
     pub fn new_with_store_config(
         eth_spec_instance: E,
+        spec: Option<ChainSpec>,
         validator_keypairs: Vec<Keypair>,
         config: StoreConfig,
     ) -> Self {
@@ -173,18 +179,26 @@ impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
         // committee are required to produce an aggregate. This is overkill, however with small
         // validator counts it's the only way to be certain there is _at least one_ aggregator per
         // committee.
-        Self::new_with_target_aggregators(eth_spec_instance, validator_keypairs, 1 << 32, config)
+        Self::new_with_target_aggregators(
+            eth_spec_instance,
+            spec,
+            validator_keypairs,
+            1 << 32,
+            config,
+        )
     }
 
     /// Instantiate a new harness with  a custom `target_aggregators_per_committee` spec value
     pub fn new_with_target_aggregators(
         eth_spec_instance: E,
+        spec: Option<ChainSpec>,
         validator_keypairs: Vec<Keypair>,
         target_aggregators_per_committee: u64,
         store_config: StoreConfig,
     ) -> Self {
         Self::new_with_chain_config(
             eth_spec_instance,
+            spec,
             validator_keypairs,
             target_aggregators_per_committee,
             store_config,
@@ -196,66 +210,14 @@ impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
     /// `target_aggregators_per_committee` spec value, and a `ChainConfig`
     pub fn new_with_chain_config(
         eth_spec_instance: E,
+        spec: Option<ChainSpec>,
         validator_keypairs: Vec<Keypair>,
         target_aggregators_per_committee: u64,
         store_config: StoreConfig,
         chain_config: ChainConfig,
     ) -> Self {
         let data_dir = tempdir().expect("should create temporary data_dir");
-        let mut spec = test_spec::<E>();
-
-        spec.target_aggregators_per_committee = target_aggregators_per_committee;
-
-        let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);
-
-        let log = test_logger();
-
-        let store = HotColdDB::open_ephemeral(store_config, spec.clone(), log.clone()).unwrap();
-        let chain = BeaconChainBuilder::new(eth_spec_instance)
-            .logger(log.clone())
-            .custom_spec(spec.clone())
-            .store(Arc::new(store))
-            .store_migrator_config(MigratorConfig::default().blocking())
-            .genesis_state(
-                interop_genesis_state::<E>(&validator_keypairs, HARNESS_GENESIS_TIME, &spec)
-                    .expect("should generate interop state"),
-            )
-            .expect("should build state using recent genesis")
-            .dummy_eth1_backend()
-            .expect("should build dummy backend")
-            .testing_slot_clock(HARNESS_SLOT_TIME)
-            .expect("should configure testing slot clock")
-            .shutdown_sender(shutdown_tx)
-            .chain_config(chain_config)
-            .event_handler(Some(ServerSentEventHandler::new_with_capacity(
-                log.clone(),
-                1,
-            )))
-            .monitor_validators(true, vec![], log)
-            .build()
-            .expect("should build");
-
-        Self {
-            spec: chain.spec.clone(),
-            chain,
-            validator_keypairs,
-            data_dir,
-            shutdown_receiver,
-            rng: make_rng(),
-        }
-    }
-
-    /// Instantiate a new harness with `validator_count` initial validators, a custom
-    /// `target_aggregators_per_committee` spec value, and a `ChainConfig`
-    pub fn new_with_chain_config_and_spec(
-        eth_spec_instance: E,
-        mut spec: ChainSpec,
-        validator_keypairs: Vec<Keypair>,
-        target_aggregators_per_committee: u64,
-        store_config: StoreConfig,
-        chain_config: ChainConfig,
-    ) -> Self {
-        let data_dir = tempdir().expect("should create temporary data_dir");
+        let mut spec = spec.unwrap_or_else(|| test_spec::<E>());
 
         spec.target_aggregators_per_committee = target_aggregators_per_committee;
 
@@ -303,11 +265,12 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
     /// Instantiate a new harness with `validator_count` initial validators.
     pub fn new_with_disk_store(
         eth_spec_instance: E,
+        spec: Option<ChainSpec>,
         store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
         validator_keypairs: Vec<Keypair>,
     ) -> Self {
         let data_dir = tempdir().expect("should create temporary data_dir");
-        let spec = test_spec::<E>();
+        let spec = spec.unwrap_or_else(|| test_spec::<E>());
 
         let log = test_logger();
         let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);
@@ -347,11 +310,12 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
     /// Instantiate a new harness with `validator_count` initial validators.
     pub fn resume_from_disk_store(
         eth_spec_instance: E,
+        spec: Option<ChainSpec>,
         store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
         validator_keypairs: Vec<Keypair>,
         data_dir: TempDir,
     ) -> Self {
-        let spec = test_spec::<E>();
+        let spec = spec.unwrap_or_else(|| test_spec::<E>());
 
         let log = test_logger();
         let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -330,6 +330,7 @@ mod test {
     fn get_state(validator_count: usize) -> (BeaconState<E>, Vec<Keypair>) {
         let harness = BeaconChainHarness::new_with_store_config(
             MainnetEthSpec,
+            None,
             types::test_utils::generate_deterministic_keypairs(validator_count),
             StoreConfig::default(),
         );

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -27,6 +27,7 @@ fn produces_attestations() {
 
     let harness = BeaconChainHarness::new_with_store_config(
         MainnetEthSpec,
+        None,
         KEYPAIRS[..].to_vec(),
         StoreConfig::default(),
     );

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -34,6 +34,7 @@ lazy_static! {
 fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::new_with_target_aggregators(
         MainnetEthSpec,
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         // A kind-of arbitrary number that ensures that _some_ validators are aggregators, but
         // not all.

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1,4 +1,4 @@
-// #![cfg(not(debug_assertions))]
+#![cfg(not(debug_assertions))]
 
 #[macro_use]
 extern crate lazy_static;

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -171,10 +171,7 @@ fn chain_segment_varying_chunk_size() {
                 .chain
                 .process_chain_segment(chunk.to_vec())
                 .into_block_error()
-                .expect(&format!(
-                    "should import chain segment of len {}",
-                    chunk_size
-                ));
+                .unwrap_or_else(|_| panic!("should import chain segment of len {}", chunk_size));
         }
 
         harness.chain.fork_choice().expect("should run fork choice");
@@ -209,7 +206,7 @@ fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks.clone())
+                .process_chain_segment(blocks)
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
         ),
@@ -228,7 +225,7 @@ fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks.clone())
+                .process_chain_segment(blocks)
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
         ),
@@ -257,7 +254,7 @@ fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks.clone())
+                .process_chain_segment(blocks)
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
         ),
@@ -277,7 +274,7 @@ fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks.clone())
+                .process_chain_segment(blocks)
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
         ),
@@ -922,7 +919,7 @@ fn add_base_block_to_altair_chain() {
 
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
-        let mut state = state.clone();
+        let mut state = state;
         per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(
@@ -1043,7 +1040,7 @@ fn add_altair_block_to_base_chain() {
 
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
-        let mut state = state.clone();
+        let mut state = state;
         per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -53,6 +53,7 @@ fn get_chain_segment() -> Vec<BeaconSnapshot<E>> {
 fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::new_with_store_config(
         MainnetEthSpec,
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         StoreConfig::default(),
     );
@@ -866,9 +867,9 @@ fn add_base_block_to_altair_chain() {
     // The Altair fork happens at epoch 1.
     spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
 
-    let harness = BeaconChainHarness::new_with_chain_config_and_spec(
+    let harness = BeaconChainHarness::new_with_chain_config(
         MainnetEthSpec,
-        spec,
+        Some(spec),
         KEYPAIRS[..].to_vec(),
         1 << 32,
         StoreConfig::default(),
@@ -986,9 +987,9 @@ fn add_altair_block_to_base_chain() {
     // Altair never happens.
     spec.altair_fork_slot = None;
 
-    let harness = BeaconChainHarness::new_with_chain_config_and_spec(
+    let harness = BeaconChainHarness::new_with_chain_config(
         MainnetEthSpec,
-        spec,
+        Some(spec),
         KEYPAIRS[..].to_vec(),
         1 << 32,
         StoreConfig::default(),

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -40,6 +40,7 @@ fn get_store(db_path: &TempDir) -> Arc<HotColdDB> {
 fn get_harness(store: Arc<HotColdDB>, validator_count: usize) -> TestHarness {
     let harness = BeaconChainHarness::new_with_disk_store(
         MinimalEthSpec,
+        None,
         store,
         KEYPAIRS[0..validator_count].to_vec(),
     );

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -50,6 +50,7 @@ fn get_harness(
 ) -> TestHarness {
     let harness = BeaconChainHarness::new_with_disk_store(
         MinimalEthSpec,
+        None,
         store,
         KEYPAIRS[0..validator_count].to_vec(),
     );
@@ -351,8 +352,12 @@ fn delete_blocks_and_states() {
     let store = get_store(&db_path);
     let validators_keypairs =
         types::test_utils::generate_deterministic_keypairs(LOW_VALIDATOR_COUNT);
-    let harness =
-        BeaconChainHarness::new_with_disk_store(MinimalEthSpec, store.clone(), validators_keypairs);
+    let harness = BeaconChainHarness::new_with_disk_store(
+        MinimalEthSpec,
+        None,
+        store.clone(),
+        validators_keypairs,
+    );
 
     let unforked_blocks: u64 = 4 * E::slots_per_epoch();
 
@@ -475,7 +480,7 @@ fn multi_epoch_fork_valid_blocks_test(
     let validators_keypairs =
         types::test_utils::generate_deterministic_keypairs(LOW_VALIDATOR_COUNT);
     let harness =
-        BeaconChainHarness::new_with_disk_store(MinimalEthSpec, store, validators_keypairs);
+        BeaconChainHarness::new_with_disk_store(MinimalEthSpec, None, store, validators_keypairs);
 
     let num_fork1_blocks: u64 = num_fork1_blocks_.try_into().unwrap();
     let num_fork2_blocks: u64 = num_fork2_blocks_.try_into().unwrap();
@@ -765,7 +770,7 @@ fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let slots_per_epoch = rig.slots_per_epoch();
     let (mut state, state_root) = rig.get_current_state_and_root();
 
@@ -870,7 +875,7 @@ fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let slots_per_epoch = rig.slots_per_epoch();
     let (state, state_root) = rig.get_current_state_and_root();
 
@@ -995,7 +1000,7 @@ fn pruning_does_not_touch_blocks_prior_to_finalization() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let slots_per_epoch = rig.slots_per_epoch();
     let (mut state, state_root) = rig.get_current_state_and_root();
 
@@ -1085,7 +1090,7 @@ fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let (state, state_root) = rig.get_current_state_and_root();
 
     // Fill up 0th epoch with canonical chain blocks
@@ -1223,7 +1228,7 @@ fn prunes_skipped_slots_states() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let (state, state_root) = rig.get_current_state_and_root();
 
     let canonical_slots_zeroth_epoch: Vec<Slot> =
@@ -1342,7 +1347,7 @@ fn finalizes_non_epoch_start_slot() {
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
     let adversarial_validators: Vec<usize> = (HONEST_VALIDATOR_COUNT..VALIDATOR_COUNT).collect();
-    let rig = BeaconChainHarness::new(MinimalEthSpec, validators_keypairs);
+    let rig = BeaconChainHarness::new(MinimalEthSpec, None, validators_keypairs);
     let (state, state_root) = rig.get_current_state_and_root();
 
     let canonical_slots_zeroth_epoch: Vec<Slot> =
@@ -1740,6 +1745,7 @@ fn finalizes_after_resuming_from_db() {
 
     let harness = BeaconChainHarness::new_with_disk_store(
         MinimalEthSpec,
+        None,
         store.clone(),
         KEYPAIRS[0..validator_count].to_vec(),
     );
@@ -1784,6 +1790,7 @@ fn finalizes_after_resuming_from_db() {
 
     let resumed_harness = BeaconChainHarness::resume_from_disk_store(
         MinimalEthSpec,
+        None,
         store,
         KEYPAIRS[0..validator_count].to_vec(),
         data_dir,

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -25,6 +25,7 @@ lazy_static! {
 fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessType<MinimalEthSpec>> {
     let harness = BeaconChainHarness::new_with_store_config(
         MinimalEthSpec,
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         StoreConfig::default(),
     );

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -38,7 +38,7 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessTyp
 #[test]
 fn massive_skips() {
     let harness = get_harness(8);
-    let spec = &MinimalEthSpec::default_spec();
+    let spec = &harness.chain.spec;
     let mut state = harness.chain.head().expect("should get head").beacon_state;
 
     // Run per_slot_processing until it returns an error.

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -77,6 +77,7 @@ impl ApiTester {
     pub fn new() -> Self {
         let mut harness = BeaconChainHarness::new(
             MainnetEthSpec,
+            None,
             generate_deterministic_keypairs(VALIDATOR_COUNT),
         );
 
@@ -230,6 +231,7 @@ impl ApiTester {
     pub fn new_from_genesis() -> Self {
         let harness = BeaconChainHarness::new(
             MainnetEthSpec,
+            None,
             generate_deterministic_keypairs(VALIDATOR_COUNT),
         );
 

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -66,6 +66,7 @@ impl TestRig {
     pub fn new(chain_length: u64) -> Self {
         let mut harness = BeaconChainHarness::new(
             MainnetEthSpec,
+            None,
             generate_deterministic_keypairs(VALIDATOR_COUNT),
         );
 

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -305,6 +305,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             | Err(e @ BlockError::InvalidSignature)
             | Err(e @ BlockError::TooManySkippedSlots { .. })
             | Err(e @ BlockError::WeakSubjectivityConflict)
+            | Err(e @ BlockError::InconsistentFork(_))
             | Err(e @ BlockError::GenesisBlock) => {
                 warn!(self.log, "Could not verify block for gossip, rejecting the block";
                             "error" => %e);

--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -38,6 +38,7 @@ mod tests {
         let beacon_chain = Arc::new(
             BeaconChainHarness::new_with_store_config(
                 MinimalEthSpec,
+                None,
                 generate_deterministic_keypairs(8),
                 StoreConfig::default(),
             )

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -525,6 +525,7 @@ mod release_tests {
     ) -> BeaconChainHarness<EphemeralHarnessType<E>> {
         let harness = BeaconChainHarness::new_with_store_config(
             E::default(),
+            None,
             KEYPAIRS[0..validator_count].to_vec(),
             StoreConfig::default(),
         );

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -349,6 +349,7 @@ mod test {
     fn get_state<T: EthSpec>() -> BeaconState<T> {
         let harness = BeaconChainHarness::new_with_store_config(
             T::default(),
+            None,
             vec![Keypair::random()],
             StoreConfig::default(),
         );

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -50,6 +50,7 @@ impl ForkChoiceTest {
     pub fn new() -> Self {
         let harness = BeaconChainHarness::new_with_target_aggregators(
             MainnetEthSpec,
+            None,
             generate_deterministic_keypairs(VALIDATOR_COUNT),
             // Ensure we always have an aggregator for each slot.
             u64::max_value(),
@@ -63,6 +64,7 @@ impl ForkChoiceTest {
     pub fn new_with_chain_config(chain_config: ChainConfig) -> Self {
         let harness = BeaconChainHarness::new_with_chain_config(
             MainnetEthSpec,
+            None,
             generate_deterministic_keypairs(VALIDATOR_COUNT),
             // Ensure we always have an aggregator for each slot.
             u64::max_value(),

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -41,7 +41,7 @@ pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
     // To support testnets with Altair enabled from genesis, perform a possible state upgrade here.
     // This must happen *after* deposits and activations are processed or the calculation of sync
     // committees during the upgrade will fail.
-    if spec.altair_fork_slot == Some(spec.genesis_slot) {
+    if spec.fork_name_at_slot(state.slot()) == ForkName::Altair {
         state.upgrade_to_altair(spec)?;
 
         // Reset the sync committees (this seems to be what the tests want)

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -84,6 +84,17 @@ pub fn per_block_processing<T: EthSpec>(
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     let block = signed_block.message();
+
+    // Verify that the `SignedBeaconBlock` instantiation matches the fork at `signed_block.slot()`.
+    signed_block
+        .fork_name(spec)
+        .map_err(BlockProcessingError::InconsistentBlockFork)?;
+
+    // Verify that the `BeaconState` instantiation matches the fork at `state.slot()`.
+    state
+        .fork_name(spec)
+        .map_err(BlockProcessingError::InconsistentStateFork)?;
+
     let verify_signatures = match block_signature_strategy {
         BlockSignatureStrategy::VerifyBulk => {
             // Verify all signatures in the block at once.

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -55,6 +55,8 @@ pub enum BlockProcessingError {
     SszTypesError(ssz_types::Error),
     MerkleTreeError(MerkleTreeError),
     ArithError(ArithError),
+    InconsistentBlockFork(InconsistentFork),
+    InconsistentStateFork(InconsistentFork),
 }
 
 impl From<BeaconStateError> for BlockProcessingError {

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -34,6 +34,7 @@ fn get_harness<E: EthSpec>(
         (MainnetEthSpec::genesis_epoch() + epoch_offset).end_slot(E::slots_per_epoch());
     let harness = BeaconChainHarness::new_with_store_config(
         E::default(),
+        None,
         KEYPAIRS[0..num_validators].to_vec(),
         StoreConfig::default(),
     );

--- a/consensus/state_processing/src/per_epoch_processing.rs
+++ b/consensus/state_processing/src/per_epoch_processing.rs
@@ -34,6 +34,11 @@ pub fn process_epoch<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,
 ) -> Result<EpochProcessingSummary, Error> {
+    // Verify that the `BeaconState` instantiation matches the fork at `state.slot()`.
+    state
+        .fork_name(spec)
+        .map_err(Error::InconsistentStateFork)?;
+
     match state {
         BeaconState::Base(_) => base::process_epoch(state, spec),
         BeaconState::Altair(_) => altair::process_epoch(state, spec),

--- a/consensus/state_processing/src/per_epoch_processing.rs
+++ b/consensus/state_processing/src/per_epoch_processing.rs
@@ -21,6 +21,7 @@ pub mod validator_statuses;
 pub mod weigh_justification_and_finalization;
 
 /// Provides a summary of validator participation during the epoch.
+#[derive(PartialEq, Debug)]
 pub struct EpochProcessingSummary {
     pub total_balances: TotalBalances,
     pub statuses: Vec<ValidatorStatus>,

--- a/consensus/state_processing/src/per_epoch_processing/errors.rs
+++ b/consensus/state_processing/src/per_epoch_processing/errors.rs
@@ -1,4 +1,4 @@
-use types::BeaconStateError;
+use types::{BeaconStateError, InconsistentFork};
 
 #[derive(Debug, PartialEq)]
 pub enum EpochProcessingError {
@@ -20,6 +20,7 @@ pub enum EpochProcessingError {
     InclusionError(InclusionError),
     SszTypesError(ssz_types::Error),
     ArithError(safe_arith::ArithError),
+    InconsistentStateFork(InconsistentFork),
 }
 
 impl From<InclusionError> for EpochProcessingError {

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -1,11 +1,14 @@
 #![cfg(test)]
-use crate::per_epoch_processing::process_epoch;
+use crate::{
+    per_epoch_processing::process_epoch, per_slot_processing::per_slot_processing,
+    EpochProcessingError, SlotProcessingError,
+};
 use beacon_chain::store::StoreConfig;
-use beacon_chain::test_utils::BeaconChainHarness;
+use beacon_chain::test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy};
 use beacon_chain::types::{EthSpec, MinimalEthSpec};
 use bls::Hash256;
 use env_logger::{Builder, Env};
-use types::Slot;
+use types::*;
 
 #[test]
 fn runs_without_error() {
@@ -36,4 +39,120 @@ fn runs_without_error() {
     let mut new_head_state = harness.get_current_state();
 
     process_epoch(&mut new_head_state, &spec).unwrap();
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn altair_state_on_base_fork() {
+    let mut spec = MainnetEthSpec::default_spec();
+    let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
+    // The Altair fork happens at epoch 1.
+    spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
+
+    let altair_state = {
+        let harness = BeaconChainHarness::new(
+            MainnetEthSpec,
+            Some(spec.clone()),
+            types::test_utils::generate_deterministic_keypairs(8),
+        );
+
+        harness.advance_slot();
+
+        harness.extend_chain(
+            // Build out enough blocks so we get an Altair block at the very end of an epoch.
+            (slots_per_epoch * 2 - 1) as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        );
+
+        harness.get_current_state()
+    };
+
+    // Pre-conditions for a valid test.
+    assert_eq!(altair_state.fork_name(&spec).unwrap(), ForkName::Altair);
+    assert_eq!(
+        altair_state.slot(),
+        altair_state.current_epoch().end_slot(slots_per_epoch)
+    );
+
+    // Check the state is valid before starting this test.
+    process_epoch(&mut altair_state.clone(), &spec).expect("state passes intial epoch processing");
+    per_slot_processing(&mut altair_state.clone(), None, &spec)
+        .expect("state passes intial slot processing");
+
+    // Modify the spec so altair never happens.
+    spec.altair_fork_slot = None;
+
+    let expected_err = InconsistentFork {
+        fork_at_slot: ForkName::Base,
+        object_fork: ForkName::Altair,
+    };
+
+    assert_eq!(altair_state.fork_name(&spec), Err(expected_err));
+    assert_eq!(
+        process_epoch(&mut altair_state.clone(), &spec),
+        Err(EpochProcessingError::InconsistentStateFork(expected_err))
+    );
+    assert_eq!(
+        per_slot_processing(&mut altair_state.clone(), None, &spec),
+        Err(SlotProcessingError::InconsistentStateFork(expected_err))
+    );
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn base_state_on_altair_fork() {
+    let mut spec = MainnetEthSpec::default_spec();
+    let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
+    // The Altair fork never happens.
+    spec.altair_fork_slot = None;
+
+    let base_state = {
+        let harness = BeaconChainHarness::new(
+            MainnetEthSpec,
+            Some(spec.clone()),
+            types::test_utils::generate_deterministic_keypairs(8),
+        );
+
+        harness.advance_slot();
+
+        harness.extend_chain(
+            // Build out enough blocks so we get a block at the very end of an epoch.
+            (slots_per_epoch * 2 - 1) as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        );
+
+        harness.get_current_state()
+    };
+
+    // Pre-conditions for a valid test.
+    assert_eq!(base_state.fork_name(&spec).unwrap(), ForkName::Base);
+    assert_eq!(
+        base_state.slot(),
+        base_state.current_epoch().end_slot(slots_per_epoch)
+    );
+
+    // Check the state is valid before starting this test.
+    process_epoch(&mut base_state.clone(), &spec).expect("state passes intial epoch processing");
+    per_slot_processing(&mut base_state.clone(), None, &spec)
+        .expect("state passes intial slot processing");
+
+    // Modify the spec so Altair happens at the first epoch.
+    spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
+
+    let expected_err = InconsistentFork {
+        fork_at_slot: ForkName::Altair,
+        object_fork: ForkName::Base,
+    };
+
+    assert_eq!(base_state.fork_name(&spec), Err(expected_err));
+    assert_eq!(
+        process_epoch(&mut base_state.clone(), &spec),
+        Err(EpochProcessingError::InconsistentStateFork(expected_err))
+    );
+    assert_eq!(
+        per_slot_processing(&mut base_state.clone(), None, &spec),
+        Err(SlotProcessingError::InconsistentStateFork(expected_err))
+    );
 }

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -13,6 +13,7 @@ fn runs_without_error() {
 
     let harness = BeaconChainHarness::new_with_store_config(
         MinimalEthSpec,
+        None,
         types::test_utils::generate_deterministic_keypairs(8),
         StoreConfig::default(),
     );

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -45,7 +45,7 @@ mod release_tests {
         per_slot_processing::per_slot_processing, EpochProcessingError, SlotProcessingError,
     };
     use beacon_chain::test_utils::{AttestationStrategy, BlockStrategy};
-    use types::{Epoch, ForkName, MainnetEthSpec};
+    use types::{Epoch, ForkName, InconsistentFork, MainnetEthSpec};
 
     #[test]
     fn altair_state_on_base_fork() {

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -1,14 +1,11 @@
 #![cfg(test)]
-use crate::{
-    per_epoch_processing::process_epoch, per_slot_processing::per_slot_processing,
-    EpochProcessingError, SlotProcessingError,
-};
+use crate::per_epoch_processing::process_epoch;
 use beacon_chain::store::StoreConfig;
-use beacon_chain::test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy};
+use beacon_chain::test_utils::BeaconChainHarness;
 use beacon_chain::types::{EthSpec, MinimalEthSpec};
 use bls::Hash256;
 use env_logger::{Builder, Env};
-use types::*;
+use types::Slot;
 
 #[test]
 fn runs_without_error() {
@@ -41,118 +38,128 @@ fn runs_without_error() {
     process_epoch(&mut new_head_state, &spec).unwrap();
 }
 
-#[test]
 #[cfg(not(debug_assertions))]
-fn altair_state_on_base_fork() {
-    let mut spec = MainnetEthSpec::default_spec();
-    let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
-    // The Altair fork happens at epoch 1.
-    spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
+mod release_tests {
+    use super::*;
+    use crate::{
+        per_slot_processing::per_slot_processing, EpochProcessingError, SlotProcessingError,
+    };
+    use beacon_chain::test_utils::{AttestationStrategy, BlockStrategy};
+    use types::{Epoch, ForkName, MainnetEthSpec};
 
-    let altair_state = {
-        let harness = BeaconChainHarness::new(
-            MainnetEthSpec,
-            Some(spec.clone()),
-            types::test_utils::generate_deterministic_keypairs(8),
+    #[test]
+    fn altair_state_on_base_fork() {
+        let mut spec = MainnetEthSpec::default_spec();
+        let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
+        // The Altair fork happens at epoch 1.
+        spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
+
+        let altair_state = {
+            let harness = BeaconChainHarness::new(
+                MainnetEthSpec,
+                Some(spec.clone()),
+                types::test_utils::generate_deterministic_keypairs(8),
+            );
+
+            harness.advance_slot();
+
+            harness.extend_chain(
+                // Build out enough blocks so we get an Altair block at the very end of an epoch.
+                (slots_per_epoch * 2 - 1) as usize,
+                BlockStrategy::OnCanonicalHead,
+                AttestationStrategy::AllValidators,
+            );
+
+            harness.get_current_state()
+        };
+
+        // Pre-conditions for a valid test.
+        assert_eq!(altair_state.fork_name(&spec).unwrap(), ForkName::Altair);
+        assert_eq!(
+            altair_state.slot(),
+            altair_state.current_epoch().end_slot(slots_per_epoch)
         );
 
-        harness.advance_slot();
+        // Check the state is valid before starting this test.
+        process_epoch(&mut altair_state.clone(), &spec)
+            .expect("state passes intial epoch processing");
+        per_slot_processing(&mut altair_state.clone(), None, &spec)
+            .expect("state passes intial slot processing");
 
-        harness.extend_chain(
-            // Build out enough blocks so we get an Altair block at the very end of an epoch.
-            (slots_per_epoch * 2 - 1) as usize,
-            BlockStrategy::OnCanonicalHead,
-            AttestationStrategy::AllValidators,
+        // Modify the spec so altair never happens.
+        spec.altair_fork_slot = None;
+
+        let expected_err = InconsistentFork {
+            fork_at_slot: ForkName::Base,
+            object_fork: ForkName::Altair,
+        };
+
+        assert_eq!(altair_state.fork_name(&spec), Err(expected_err));
+        assert_eq!(
+            process_epoch(&mut altair_state.clone(), &spec),
+            Err(EpochProcessingError::InconsistentStateFork(expected_err))
+        );
+        assert_eq!(
+            per_slot_processing(&mut altair_state.clone(), None, &spec),
+            Err(SlotProcessingError::InconsistentStateFork(expected_err))
+        );
+    }
+
+    #[test]
+    fn base_state_on_altair_fork() {
+        let mut spec = MainnetEthSpec::default_spec();
+        let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
+        // The Altair fork never happens.
+        spec.altair_fork_slot = None;
+
+        let base_state = {
+            let harness = BeaconChainHarness::new(
+                MainnetEthSpec,
+                Some(spec.clone()),
+                types::test_utils::generate_deterministic_keypairs(8),
+            );
+
+            harness.advance_slot();
+
+            harness.extend_chain(
+                // Build out enough blocks so we get a block at the very end of an epoch.
+                (slots_per_epoch * 2 - 1) as usize,
+                BlockStrategy::OnCanonicalHead,
+                AttestationStrategy::AllValidators,
+            );
+
+            harness.get_current_state()
+        };
+
+        // Pre-conditions for a valid test.
+        assert_eq!(base_state.fork_name(&spec).unwrap(), ForkName::Base);
+        assert_eq!(
+            base_state.slot(),
+            base_state.current_epoch().end_slot(slots_per_epoch)
         );
 
-        harness.get_current_state()
-    };
+        // Check the state is valid before starting this test.
+        process_epoch(&mut base_state.clone(), &spec)
+            .expect("state passes intial epoch processing");
+        per_slot_processing(&mut base_state.clone(), None, &spec)
+            .expect("state passes intial slot processing");
 
-    // Pre-conditions for a valid test.
-    assert_eq!(altair_state.fork_name(&spec).unwrap(), ForkName::Altair);
-    assert_eq!(
-        altair_state.slot(),
-        altair_state.current_epoch().end_slot(slots_per_epoch)
-    );
+        // Modify the spec so Altair happens at the first epoch.
+        spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
 
-    // Check the state is valid before starting this test.
-    process_epoch(&mut altair_state.clone(), &spec).expect("state passes intial epoch processing");
-    per_slot_processing(&mut altair_state.clone(), None, &spec)
-        .expect("state passes intial slot processing");
+        let expected_err = InconsistentFork {
+            fork_at_slot: ForkName::Altair,
+            object_fork: ForkName::Base,
+        };
 
-    // Modify the spec so altair never happens.
-    spec.altair_fork_slot = None;
-
-    let expected_err = InconsistentFork {
-        fork_at_slot: ForkName::Base,
-        object_fork: ForkName::Altair,
-    };
-
-    assert_eq!(altair_state.fork_name(&spec), Err(expected_err));
-    assert_eq!(
-        process_epoch(&mut altair_state.clone(), &spec),
-        Err(EpochProcessingError::InconsistentStateFork(expected_err))
-    );
-    assert_eq!(
-        per_slot_processing(&mut altair_state.clone(), None, &spec),
-        Err(SlotProcessingError::InconsistentStateFork(expected_err))
-    );
-}
-
-#[test]
-#[cfg(not(debug_assertions))]
-fn base_state_on_altair_fork() {
-    let mut spec = MainnetEthSpec::default_spec();
-    let slots_per_epoch = MainnetEthSpec::slots_per_epoch();
-    // The Altair fork never happens.
-    spec.altair_fork_slot = None;
-
-    let base_state = {
-        let harness = BeaconChainHarness::new(
-            MainnetEthSpec,
-            Some(spec.clone()),
-            types::test_utils::generate_deterministic_keypairs(8),
+        assert_eq!(base_state.fork_name(&spec), Err(expected_err));
+        assert_eq!(
+            process_epoch(&mut base_state.clone(), &spec),
+            Err(EpochProcessingError::InconsistentStateFork(expected_err))
         );
-
-        harness.advance_slot();
-
-        harness.extend_chain(
-            // Build out enough blocks so we get a block at the very end of an epoch.
-            (slots_per_epoch * 2 - 1) as usize,
-            BlockStrategy::OnCanonicalHead,
-            AttestationStrategy::AllValidators,
+        assert_eq!(
+            per_slot_processing(&mut base_state.clone(), None, &spec),
+            Err(SlotProcessingError::InconsistentStateFork(expected_err))
         );
-
-        harness.get_current_state()
-    };
-
-    // Pre-conditions for a valid test.
-    assert_eq!(base_state.fork_name(&spec).unwrap(), ForkName::Base);
-    assert_eq!(
-        base_state.slot(),
-        base_state.current_epoch().end_slot(slots_per_epoch)
-    );
-
-    // Check the state is valid before starting this test.
-    process_epoch(&mut base_state.clone(), &spec).expect("state passes intial epoch processing");
-    per_slot_processing(&mut base_state.clone(), None, &spec)
-        .expect("state passes intial slot processing");
-
-    // Modify the spec so Altair happens at the first epoch.
-    spec.altair_fork_slot = Some(Epoch::new(1).start_slot(slots_per_epoch));
-
-    let expected_err = InconsistentFork {
-        fork_at_slot: ForkName::Altair,
-        object_fork: ForkName::Base,
-    };
-
-    assert_eq!(base_state.fork_name(&spec), Err(expected_err));
-    assert_eq!(
-        process_epoch(&mut base_state.clone(), &spec),
-        Err(EpochProcessingError::InconsistentStateFork(expected_err))
-    );
-    assert_eq!(
-        per_slot_processing(&mut base_state.clone(), None, &spec),
-        Err(SlotProcessingError::InconsistentStateFork(expected_err))
-    );
+    }
 }

--- a/consensus/state_processing/src/per_epoch_processing/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/validator_statuses.rs
@@ -17,7 +17,7 @@ macro_rules! set_self_if_other_is_true {
 
 /// The information required to reward a block producer for including an attestation in a block.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct InclusionInfo {
     /// The distance between the attestation slot and the slot that attestation was included in a
     /// block.
@@ -49,7 +49,7 @@ impl InclusionInfo {
 
 /// Information required to reward some validator during the current and previous epoch.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct ValidatorStatus {
     /// True if the validator has been slashed, ever.
     pub is_slashed: bool,
@@ -114,7 +114,7 @@ impl ValidatorStatus {
 /// The total effective balances for different sets of validators during the previous and current
 /// epochs.
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
 pub struct TotalBalances {
     /// The effective balance increment from the spec.

--- a/consensus/tree_hash/examples/flamegraph_beacon_state.rs
+++ b/consensus/tree_hash/examples/flamegraph_beacon_state.rs
@@ -8,6 +8,7 @@ const VALIDATOR_COUNT: usize = 1_000;
 fn get_harness<T: EthSpec>() -> BeaconChainHarness<EphemeralHarnessType<T>> {
     let harness = BeaconChainHarness::new_with_store_config(
         T::default(),
+        None,
         types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT),
         StoreConfig::default(),
     );

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -364,10 +364,10 @@ impl<T: EthSpec> BeaconState<T> {
         if fork_at_slot == object_fork {
             Ok(object_fork)
         } else {
-            return Err(InconsistentFork {
+            Err(InconsistentFork {
                 fork_at_slot,
                 object_fork,
-            });
+            })
         }
     }
 

--- a/consensus/types/src/beacon_state/committee_cache/tests.rs
+++ b/consensus/types/src/beacon_state/committee_cache/tests.rs
@@ -15,6 +15,7 @@ lazy_static! {
 fn get_harness<E: EthSpec>(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::new_with_store_config(
         E::default(),
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         StoreConfig::default(),
     );

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -25,6 +25,7 @@ fn get_harness<E: EthSpec>(
 ) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::new_with_store_config(
         E::default(),
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         StoreConfig::default(),
     );

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -179,6 +179,14 @@ impl ChainSpec {
         None
     }
 
+    /// Returns the name of the fork which is active at `slot`.
+    pub fn fork_name_at_slot(&self, slot: Slot) -> ForkName {
+        match self.altair_fork_slot {
+            Some(fork_slot) if slot >= fork_slot => ForkName::Altair,
+            _ => ForkName::Base,
+        }
+    }
+
     /// Get the domain number, unmodified by the fork.
     ///
     /// Spec v0.12.1

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -26,3 +26,9 @@ impl ForkName {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InconsistentFork {
+    pub fork_at_slot: ForkName,
+    pub object_fork: ForkName,
+}

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -95,7 +95,7 @@ pub use crate::eth1_data::Eth1Data;
 pub use crate::eth_spec::EthSpecId;
 pub use crate::fork::Fork;
 pub use crate::fork_data::ForkData;
-pub use crate::fork_name::ForkName;
+pub use crate::fork_name::{ForkName, InconsistentFork};
 pub use crate::free_attestation::FreeAttestation;
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};
 pub use crate::historical_batch::HistoricalBatch;

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -1,8 +1,4 @@
-use crate::{
-    BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockRef, BeaconBlockRefMut, ChainSpec,
-    Domain, EthSpec, Fork, Hash256, PublicKey, SignedBeaconBlockHeader, SignedRoot, SigningData,
-    Slot,
-};
+use crate::*;
 use bls::Signature;
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -70,6 +66,27 @@ pub struct SignedBeaconBlock<E: EthSpec> {
 }
 
 impl<E: EthSpec> SignedBeaconBlock<E> {
+    /// Returns the name of the fork pertaining to `self`.
+    ///
+    /// Will return an `Err` if `self` has been instantiated to a variant conflicting with the fork
+    /// dictated by `self.slot()`.
+    pub fn fork_name(&self, spec: &ChainSpec) -> Result<ForkName, InconsistentFork> {
+        let fork_at_slot = spec.fork_name_at_slot(self.slot());
+        let object_fork = match self {
+            SignedBeaconBlock::Base { .. } => ForkName::Base,
+            SignedBeaconBlock::Altair { .. } => ForkName::Altair,
+        };
+
+        if fork_at_slot == object_fork {
+            Ok(object_fork)
+        } else {
+            return Err(InconsistentFork {
+                fork_at_slot,
+                object_fork,
+            });
+        }
+    }
+
     /// SSZ decode.
     pub fn from_ssz_bytes(bytes: &[u8], spec: &ChainSpec) -> Result<Self, ssz::DecodeError> {
         // We need to use the slot-switching `from_ssz_bytes` of `BeaconBlock`, which doesn't

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -160,6 +160,12 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
         genesis_validators_root: Hash256,
         spec: &ChainSpec,
     ) -> bool {
+        // Refuse to verify the signature of a block if its structure does not match the fork at
+        // `self.slot()`.
+        if self.fork_name(spec).is_err() {
+            return false;
+        }
+
         let domain = spec.get_domain(
             self.slot().epoch(E::slots_per_epoch()),
             Domain::BeaconProposer,

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -80,10 +80,10 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
         if fork_at_slot == object_fork {
             Ok(object_fork)
         } else {
-            return Err(InconsistentFork {
+            Err(InconsistentFork {
                 fork_at_slot,
                 object_fork,
-            });
+            })
         }
     }
 

--- a/testing/state_transition_vectors/src/main.rs
+++ b/testing/state_transition_vectors/src/main.rs
@@ -58,6 +58,7 @@ fn get_harness<E: EthSpec>(
 ) -> BeaconChainHarness<EphemeralHarnessType<E>> {
     let harness = BeaconChainHarness::new_with_store_config(
         E::default(),
+        None,
         KEYPAIRS[0..validator_count].to_vec(),
         StoreConfig::default(),
     );


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR addresses an issue where it's possible to apply a base block to an Altair chain.

To resolve this, I've added a `fork_name(&ChainSpec)` function to `BeaconState` and `SignedBeaconBlock` which will return an error if the object is instantiated to a different fork to that dictated by its slot.

Since the `fork_name` check is cheap, it is called in several places:

- `per_block_processing` (block and state)
- `per_slot_processing` (state only)
- `per_epoch_processing` (state only)
- Several other places inside the `BeaconChain` during block processing.

I've added tests to cover all the block import possibilities:

- Import via gossip
- Import via chain segment import
- `BeaconChain::process_block`

## Additional Info

I had to go on a bit of a journey when I wanted to start a `BecaonChainHarness` with a custom `ChainSpec`, hence the big diff.

## TODO

- [x] Add test for per-slot and per-epoch processing.