### PR TITLE
Minimum Outbound-Only Peers Requirement

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -182,6 +182,11 @@ impl<T: EthSpec> PeerInfo<T> {
         matches!(self.connection_status, Disconnected { .. })
     }
 
+    /// Checks if the peer is outbound-only
+    pub fn is_outbound_only(&self) -> bool {
+        matches!(self.connection_status, Connected {n_in, n_out} if n_in == 0 && n_out > 0)
+    }
+
     /// Returns the number of connections with this peer.
     pub fn connections(&self) -> (u8, u8) {
         match self.connection_status {

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -221,6 +221,14 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             .map(|(peer_id, _)| peer_id)
     }
 
+    ///Connected outbound-only peers
+    pub fn connected_outbound_only_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_outbound_only())
+            .map(|(peer_id, _)| peer_id)
+    }
+
     /// Gives the `peer_id` of all known connected and synced peers.
     pub fn synced_peers(&self) -> impl Iterator<Item = &PeerId> {
         self.peers
@@ -675,6 +683,25 @@ mod tests {
         assert_eq!(pdb.disconnected_peers, 0);
         assert!(peer_info.unwrap().is_connected());
         assert_eq!(peer_info.unwrap().connections(), (n_in, n_out));
+    }
+
+    #[test]
+    fn test_outbound_only_peers_counted_correctly() {
+        let mut pdb = get_db();
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        //create peer with no connections
+        let _p3 = PeerId::random();
+
+        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+
+        // we should only have one outbound-only peer (p2).
+        // peers that are inbound-only, have both types of connections, or no connections should not be counted
+        assert_eq!(pdb.connected_outbound_only_peers().count(), 1);
     }
 
     #[test]

--- a/beacon_node/eth2_libp2p/src/types/globals.rs
+++ b/beacon_node/eth2_libp2p/src/types/globals.rs
@@ -84,6 +84,11 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         self.peers.read().connected_peer_ids().count()
     }
 
+    /// Returns the number of libp2p connected peers with outbound-only connections
+    pub fn connected_outbound_only_peers(&self) -> usize {
+        self.peers.read().connected_outbound_only_peers().count()
+    }
+
     /// Returns the number of libp2p peers that are either connected or being dialed.
     pub fn connected_or_dialing_peers(&self) -> usize {
         self.peers.read().connected_or_dialing_peers().count()


### PR DESCRIPTION
## Issue Addressed

#2325 

## Proposed Changes

This pull request changes the behavior of the Peer Manager by including a minimum outbound-only peers requirement. The peer manager will continue querying for peers if this outbound-only target number hasn't been met. Additionally, when peers are being removed, an outbound-only peer will not be disconnected if doing so brings us below the minimum. 

## Additional Info

Unit test for heartbeat function tests that disconnection behavior is correct. Continual querying for peers if outbound-only hasn't been met is not directly tested, but indirectly through unit testing of the helper function that counts the number of outbound-only peers.
