### PR TITLE
[Merged by Bors] - Minimum Outbound-Only Peers Requirement

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -311,6 +311,11 @@ impl<T: EthSpec> PeerInfo<T> {
             self.score.test_add(score)
         }
     }
+
+    #[cfg(test)]
+    pub fn set_gossipsub_score(&mut self, score: f64) {
+        self.score.set_gossipsub_score(score);
+    }
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peer_info.rs
@@ -182,6 +182,11 @@ impl<T: EthSpec> PeerInfo<T> {
         matches!(self.connection_status, Disconnected { .. })
     }
 
+    /// Checks if the peer is outbound-only
+    pub fn is_outbound_only(&self) -> bool {
+        matches!(self.connection_status, Connected {n_in, n_out} if n_in == 0 && n_out > 0)
+    }
+
     /// Returns the number of connections with this peer.
     pub fn connections(&self) -> (u8, u8) {
         match self.connection_status {

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -221,6 +221,14 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             .map(|(peer_id, _)| peer_id)
     }
 
+    ///Connected outbound-only peers
+    pub fn connected_outbound_only_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(|(_, info)| info.is_outbound_only())
+            .map(|(peer_id, _)| peer_id)
+    }
+
     /// Gives the `peer_id` of all known connected and synced peers.
     pub fn synced_peers(&self) -> impl Iterator<Item = &PeerId> {
         self.peers
@@ -675,6 +683,25 @@ mod tests {
         assert_eq!(pdb.disconnected_peers, 0);
         assert!(peer_info.unwrap().is_connected());
         assert_eq!(peer_info.unwrap().connections(), (n_in, n_out));
+    }
+
+    #[test]
+    fn test_outbound_only_peers_counted_correctly() {
+        let mut pdb = get_db();
+        let p0 = PeerId::random();
+        let p1 = PeerId::random();
+        let p2 = PeerId::random();
+        //create peer with no connections
+        let _p3 = PeerId::random();
+
+        pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_ingoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
+        pdb.connect_outgoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
+
+        // we should only have one outbound-only peer (p2).
+        // peers that are inbound-only, have both types of connections, or no connections should not be counted
+        assert_eq!(pdb.connected_outbound_only_peers().count(), 1);
     }
 
     #[test]

--- a/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/peerdb.rs
@@ -221,7 +221,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             .map(|(peer_id, _)| peer_id)
     }
 
-    ///Connected outbound-only peers
+    /// Connected outbound-only peers
     pub fn connected_outbound_only_peers(&self) -> impl Iterator<Item = &PeerId> {
         self.peers
             .iter()
@@ -691,7 +691,7 @@ mod tests {
         let p0 = PeerId::random();
         let p1 = PeerId::random();
         let p2 = PeerId::random();
-        //create peer with no connections
+        // Create peer with no connections.
         let _p3 = PeerId::random();
 
         pdb.connect_ingoing(&p0, "/ip4/0.0.0.0".parse().unwrap(), None);
@@ -699,8 +699,8 @@ mod tests {
         pdb.connect_outgoing(&p1, "/ip4/0.0.0.0".parse().unwrap(), None);
         pdb.connect_outgoing(&p2, "/ip4/0.0.0.0".parse().unwrap(), None);
 
-        // we should only have one outbound-only peer (p2).
-        // peers that are inbound-only, have both types of connections, or no connections should not be counted
+        // We should only have one outbound-only peer (p2).
+        // Peers that are inbound-only, have both types of connections, or no connections should not be counted.
         assert_eq!(pdb.connected_outbound_only_peers().count(), 1);
     }
 

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -216,9 +216,9 @@ impl RealScore {
         self.set_lighthouse_score(0f64);
     }
 
-    #[cfg(test)]
     // Set the gossipsub_score to a specific f64.
     // Used in testing to induce score status changes during a heartbeat.
+    #[cfg(test)]
     pub fn set_gossipsub_score(&mut self, score: f64) {
         self.gossipsub_score = score;
     }

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -217,8 +217,8 @@ impl RealScore {
     }
 
     #[cfg(test)]
-    //set the gossipsub_score to a specific f64
-    //used in testing to induce score status changes during a heartbeat
+    // Set the gossipsub_score to a specific f64.
+    // Used in testing to induce score status changes during a heartbeat.
     pub fn set_gossipsub_score(&mut self, score: f64) {
         self.gossipsub_score = score;
     }

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -216,6 +216,13 @@ impl RealScore {
         self.set_lighthouse_score(0f64);
     }
 
+    #[cfg(test)]
+    //set the gossipsub_score to a specific f64
+    //used in testing to induce score status changes during a heartbeat
+    pub fn set_gossipsub_score(&mut self, score: f64) {
+        self.gossipsub_score = score;
+    }
+
     /// Applies time-based logic such as decay rates to the score.
     /// This function should be called periodically.
     pub fn update(&mut self) {
@@ -291,6 +298,8 @@ apply!(update_gossipsub_score, new_score: f64, ignore: bool);
 apply!(test_add, score: f64);
 #[cfg(test)]
 apply!(test_reset);
+#[cfg(test)]
+apply!(set_gossipsub_score, score: f64);
 
 impl Score {
     pub fn score(&self) -> f64 {

--- a/beacon_node/eth2_libp2p/src/types/globals.rs
+++ b/beacon_node/eth2_libp2p/src/types/globals.rs
@@ -84,6 +84,11 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         self.peers.read().connected_peer_ids().count()
     }
 
+    /// Returns the number of libp2p connected peers with outbound-only connections
+    pub fn connected_outbound_only_peers(&self) -> usize {
+        self.peers.read().connected_outbound_only_peers().count()
+    }
+
     /// Returns the number of libp2p peers that are either connected or being dialed.
     pub fn connected_or_dialing_peers(&self) -> usize {
         self.peers.read().connected_or_dialing_peers().count()

--- a/beacon_node/eth2_libp2p/src/types/globals.rs
+++ b/beacon_node/eth2_libp2p/src/types/globals.rs
@@ -84,7 +84,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         self.peers.read().connected_peer_ids().count()
     }
 
-    /// Returns the number of libp2p connected peers with outbound-only connections
+    /// Returns the number of libp2p connected peers with outbound-only connections.
     pub fn connected_outbound_only_peers(&self) -> usize {
         self.peers.read().connected_outbound_only_peers().count()
     }


### PR DESCRIPTION
## Issue Addressed

#2325 

## Proposed Changes

This pull request changes the behavior of the Peer Manager by including a minimum outbound-only peers requirement. The peer manager will continue querying for peers if this outbound-only target number hasn't been met. Additionally, when peers are being removed, an outbound-only peer will not be disconnected if doing so brings us below the minimum. 

## Additional Info

Unit test for heartbeat function tests that disconnection behavior is correct. Continual querying for peers if outbound-only hasn't been met is not directly tested, but indirectly through unit testing of the helper function that counts the number of outbound-only peers.

EDIT: Am concerned about the behavior of ```update_peer_scores```. If we have connected to a peer with a score below the disconnection threshold (-20), then its connection status will remain connected, while its score state will change to disconnected. 

```rust
let previous_state = info.score_state();            
// Update scores            
info.score_update();
Self::handle_score_transitions(                
               previous_state,
                peer_id,
                info, 
               &mut to_ban_peers,
               &mut to_unban_peers,
               &mut self.events,
               &self.log,
);
```

```previous_state``` will be set to Disconnected, and then because ```handle_score_transitions``` only changes connection status for a peer if the state changed, the peer remains connected. Then in the heartbeat code, because we only disconnect healthy peers if we have too many peers, these peers don't get disconnected. I'm not sure realistically how often this scenario would occur, but it might be better to adjust the logic to account for scenarios where the score state implies a connection status different from the current connection status. 