### PR TITLE
[Merged by Bors] - Add Windows to Bors config

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 status = [
     "cargo-fmt",
     "release-tests-ubuntu",
+    "release-tests-windows",
     "debug-tests-ubuntu",
     "state-transition-vectors-ubuntu",
     "ef-tests-ubuntu",


### PR DESCRIPTION
We accidentally omitted the new Windows tests (#2333) from the Bors config, meaning that PRs will merge before the tests pass. This PR corrects that.
