### PR TITLE
[Altair] Make anonymous var-length SSZ decoding explicit

### DIFF
--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -65,9 +65,7 @@ impl<T: EthSpec> StorageContainer<T> {
         // compose with the other SSZ utils, so we duplicate some parts of `ssz_derive` here.
         let mut builder = ssz::SszDecoderBuilder::new(bytes);
 
-        // Register the message type as `BeaconStateBase`, even though that isn't accurate.
-        // Really we just need some variable-length type to provide here.
-        builder.register_type::<BeaconStateBase<T>>()?;
+        builder.register_anonymous_variable_length_item()?;
         builder.register_type::<Vec<CommitteeCache>>()?;
 
         let mut decoder = builder.build()?;

--- a/beacon_node/store/src/impls/beacon_state.rs
+++ b/beacon_node/store/src/impls/beacon_state.rs
@@ -2,7 +2,7 @@ use crate::*;
 use ssz::{DecodeError, Encode};
 use ssz_derive::Encode;
 use std::convert::TryInto;
-use types::beacon_state::{BeaconStateBase, CloneConfig, CommitteeCache, CACHED_EPOCHS};
+use types::beacon_state::{CloneConfig, CommitteeCache, CACHED_EPOCHS};
 
 pub fn store_full_state<E: EthSpec>(
     state_root: &Hash256,

--- a/consensus/ssz/src/decode.rs
+++ b/consensus/ssz/src/decode.rs
@@ -150,7 +150,10 @@ impl<'a> SszDecoderBuilder<'a> {
     ///
     /// ## Notes
     ///
-    /// Use of this function is generally discouraged, use `Self::register_type` wherever possible.
+    /// Use of this function is generally discouraged since it cannot detect if some type changes
+    /// from variable to fixed length.
+    ///
+    /// Use `Self::register_type` wherever possible.
     pub fn register_anonymous_variable_length_item(&mut self) -> Result<(), DecodeError> {
         struct Anonymous;
 

--- a/consensus/ssz/src/decode.rs
+++ b/consensus/ssz/src/decode.rs
@@ -145,6 +145,28 @@ impl<'a> SszDecoderBuilder<'a> {
         }
     }
 
+    /// Registers a variable-length object as the next item in `bytes`, without specifying the
+    /// actual type.
+    ///
+    /// ## Notes
+    ///
+    /// Use of this function is generally discouraged, use `Self::register_type` wherever possible.
+    pub fn register_anonymous_variable_length_item(&mut self) -> Result<(), DecodeError> {
+        struct Anonymous;
+
+        impl Decode for Anonymous {
+            fn is_ssz_fixed_len() -> bool {
+                false
+            }
+
+            fn from_ssz_bytes(_bytes: &[u8]) -> Result<Self, DecodeError> {
+                unreachable!("Anonymous should never be decoded")
+            }
+        }
+
+        self.register_type::<Anonymous>()
+    }
+
     /// Declares that some type `T` is the next item in `bytes`.
     pub fn register_type<T: Decode>(&mut self) -> Result<(), DecodeError> {
         if T::is_ssz_fixed_len() {

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -76,9 +76,7 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
         // compose with the other SSZ utils, so we duplicate some parts of `ssz_derive` here.
         let mut builder = ssz::SszDecoderBuilder::new(bytes);
 
-        // Register the message type as `BeaconBlockBase`, even though that isn't accurate.
-        // Really we just need some variable-length type to provide here.
-        builder.register_type::<BeaconBlockBase<E>>()?;
+        builder.register_anonymous_variable_length_item()?;
         builder.register_type::<Signature>()?;
 
         let mut decoder = builder.build()?;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a function to the `SszDecoderBuilder` to allow decoding an anonymous variable length item. We started using this (completely valid) functionality in Altair and I thought it would be nice to add an explicit method to:

- Help prevent future changes from breaking this functionality (now it's part of the API rather than a trick).
- Make the code look a little cleaner when do this (no need to explain why we're doing tricky-looking things).

This should be a non-substantive change.

## Additional Info

NA
