### PR TITLE
[Altair] Return error when total balance is zero

### DIFF
--- a/consensus/state_processing/src/common/altair.rs
+++ b/consensus/state_processing/src/common/altair.rs
@@ -12,14 +12,11 @@ pub fn get_base_reward<T: EthSpec>(
     total_active_balance: u64,
     spec: &ChainSpec,
 ) -> Result<u64, Error> {
-    if total_active_balance == 0 {
-        Ok(0)
-    } else {
-        Ok(state
-            .get_effective_balance(index)?
-            .safe_div(spec.effective_balance_increment)?
-            .safe_mul(get_base_reward_per_increment(total_active_balance, spec)?)?)
-    }
+    state
+        .get_effective_balance(index)?
+        .safe_div(spec.effective_balance_increment)?
+        .safe_mul(get_base_reward_per_increment(total_active_balance, spec)?)
+        .map_err(Into::into)
 }
 
 /// Returns the base reward for some validator.

--- a/consensus/state_processing/src/common/base.rs
+++ b/consensus/state_processing/src/common/base.rs
@@ -10,13 +10,10 @@ pub fn get_base_reward<T: EthSpec>(
     total_active_balance: u64,
     spec: &ChainSpec,
 ) -> Result<u64, BeaconStateError> {
-    if total_active_balance == 0 {
-        Ok(0)
-    } else {
-        Ok(state
-            .get_effective_balance(index)?
-            .safe_mul(spec.base_reward_factor)?
-            .safe_div(total_active_balance.integer_sqrt())?
-            .safe_div(spec.base_rewards_per_epoch)?)
-    }
+    state
+        .get_effective_balance(index)?
+        .safe_mul(spec.base_reward_factor)?
+        .safe_div(total_active_balance.integer_sqrt())?
+        .safe_div(spec.base_rewards_per_epoch)
+        .map_err(Into::into)
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Returns an (implicit) divide-by-zero error whenever total balances are zero. This is a non-substantive change since this code is unreachable due to `total_active_balance` always being involved in a `std::cmp::max` with `spec.effective_balance_increment`:

https://github.com/sigp/lighthouse/blob/443793bcada3b90d48b3171e0cf028f79f9294ce/consensus/state_processing/src/per_epoch_processing/validator_statuses.rs#L141-L148

https://github.com/sigp/lighthouse/blob/443793bcada3b90d48b3171e0cf028f79f9294ce/consensus/types/src/beacon_state.rs#L1194-L1210

I can't see any actual issue with the current implementation, however it just *seems* safer to follow the spec in this scenario. Interested in thoughts.


## Additional Info

References:

- Base: [`get_base_reward`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/phase0/beacon-chain.md#helpers)
- Altair: [`get_base_reward`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.3/specs/altair/beacon-chain.md#get_base_reward)
