### PR TITLE
[Altair] Optimization for `get_unslashed_participating_indices`

### DIFF
--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -153,7 +153,7 @@ impl<T: EthSpec> OperationPool<T> {
             .get_cached_active_validator_indices(RelativeEpoch::Current)
             .map_err(OpPoolError::GetAttestationsTotalBalanceError)?;
         let total_active_balance = state
-            .get_total_balance(&active_indices, spec)
+            .get_total_balance(active_indices, spec)
             .map_err(OpPoolError::GetAttestationsTotalBalanceError)?;
 
         // Split attestations for the previous & current epochs, so that we

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -1022,7 +1022,7 @@ mod release_tests {
         let active_indices = state
             .get_cached_active_validator_indices(RelativeEpoch::Current)
             .unwrap();
-        let total_active_balance = state.get_total_balance(&active_indices, spec).unwrap();
+        let total_active_balance = state.get_total_balance(active_indices, spec).unwrap();
 
         // Set of indices covered by previous attestations in `best_attestations`.
         let mut seen_indices = BTreeSet::new();

--- a/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
@@ -2,7 +2,6 @@ use crate::EpochProcessingError;
 use core::result::Result;
 use core::result::Result::Ok;
 use safe_arith::SafeArith;
-use std::collections::HashSet;
 use types::beacon_state::BeaconState;
 use types::chain_spec::ChainSpec;
 use types::consts::altair::TIMELY_TARGET_FLAG_INDEX;
@@ -13,14 +12,11 @@ pub fn process_inactivity_updates<T: EthSpec>(
     state: &mut BeaconState<T>,
     spec: &ChainSpec,
 ) -> Result<(), EpochProcessingError> {
-    let unslashed_indices: HashSet<usize> = state
-        .get_unslashed_participating_indices(
-            TIMELY_TARGET_FLAG_INDEX,
-            state.previous_epoch(),
-            spec,
-        )?
-        .into_iter()
-        .collect();
+    let unslashed_indices = state.get_unslashed_participating_indices(
+        TIMELY_TARGET_FLAG_INDEX,
+        state.previous_epoch(),
+        spec,
+    )?;
 
     for index in state.get_eligible_validator_indices()? {
         if unslashed_indices.contains(&index) {

--- a/consensus/state_processing/src/per_epoch_processing/altair/justification_and_finalization.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/justification_and_finalization.rs
@@ -28,8 +28,8 @@ pub fn process_justification_and_finalization<T: EthSpec>(
             .as_slice(),
         spec,
     )?;
-    let previous_target_balance = state.get_total_balance(previous_indices.as_slice(), spec)?;
-    let current_target_balance = state.get_total_balance(current_indices.as_slice(), spec)?;
+    let previous_target_balance = state.get_total_balance(&previous_indices, spec)?;
+    let current_target_balance = state.get_total_balance(&current_indices, spec)?;
     weigh_justification_and_finalization(
         state,
         total_active_balance,

--- a/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
@@ -60,7 +60,7 @@ pub fn get_flag_index_deltas<T: EthSpec>(
         state.get_unslashed_participating_indices(flag_index, state.previous_epoch(), spec)?;
     let increment = spec.effective_balance_increment; //Factored out from balances to avoid uint64 overflow
     let unslashed_participating_increments = state
-        .get_total_balance(unslashed_participating_indices.as_slice(), spec)?
+        .get_total_balance(&unslashed_participating_indices, spec)?
         .safe_div(increment)?;
     let active_increments = total_active_balance.safe_div(increment)?;
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This started as simply lifting `state.get_unslashed_participating_indices` in `.../altair/inactivity_updates.rs` to avoid computing it for each validator, but I noticed a chance to reduce the big-O complexity of `process_inactivity_updates`, `get_flag_index_deltas` and `get_inactivity_deltas` whilst making `BeaconState::get_total_balances` more generic.

I assume this has *some* additional cost when computing `get_total_balances` based on the unslashed participating indices (i.e., it's slower to iterate a `HashSet` than a slice) but I think *overall* this is an optimization worth its salt.

I appreciate that our current version of Altair is not yet written with optimization in mind, so hopefully this isn't jumping the gun. It just seemed like low-hanging fruit I couldn't resist :peach: :drooling_face: 

## Additional Info

NA
