### PR TITLE
[Merged by Bors] - Use the forwards iterator more often

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -447,18 +447,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map(|result| result.map_err(|e| e.into())))
     }
 
-    /// Traverse backwards from `block_root` to find the root of the ancestor block at `slot`.
-    pub fn get_ancestor_block_root(
-        &self,
-        block_root: Hash256,
-        slot: Slot,
-    ) -> Result<Option<Hash256>, Error> {
-        process_results(self.rev_iter_block_roots_from(block_root)?, |mut iter| {
-            iter.find(|(_, ancestor_slot)| *ancestor_slot == slot)
-                .map(|(ancestor_block_root, _)| ancestor_block_root)
-        })
-    }
-
     /// Iterates across all `(state_root, slot)` pairs from the head of the chain (inclusive) to
     /// the earliest reachable ancestor (may or may not be genesis).
     ///

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -86,7 +86,7 @@ pub const ETH1_CACHE_DB_KEY: Hash256 = Hash256::zero();
 pub const FORK_CHOICE_DB_KEY: Hash256 = Hash256::zero();
 
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.
-pub enum Skips {
+pub enum WhenSlotSkipped {
     /// If the slot is a skip slot, return `None`.
     ///
     /// This is how the HTTP API behaves.
@@ -497,7 +497,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn block_at_slot(
         &self,
         target_slot: Slot,
-        skips: Skips,
+        skips: WhenSlotSkipped,
     ) -> Result<Option<SignedBeaconBlock<T::EthSpec>>, Error> {
         let root = self.block_root_at_slot(target_slot, skips)?;
 
@@ -526,11 +526,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn block_root_at_slot(
         &self,
         target_slot: Slot,
-        skips: Skips,
+        skips: WhenSlotSkipped,
     ) -> Result<Option<Hash256>, Error> {
         match skips {
-            Skips::None => self.block_root_at_slot_skips_none(target_slot),
-            Skips::Prev => self.block_root_at_slot_skips_prev(target_slot),
+            WhenSlotSkipped::None => self.block_root_at_slot_skips_none(target_slot),
+            WhenSlotSkipped::Prev => self.block_root_at_slot_skips_prev(target_slot),
         }
     }
 
@@ -2354,10 +2354,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         if let Some(event_handler) = self.event_handler.as_ref() {
             if event_handler.has_head_subscribers() {
                 if let Ok(Some(current_duty_dependent_root)) =
-                    self.block_root_at_slot(target_epoch_start_slot - 1, Skips::Prev)
+                    self.block_root_at_slot(target_epoch_start_slot - 1, WhenSlotSkipped::Prev)
                 {
-                    if let Ok(Some(previous_duty_dependent_root)) =
-                        self.block_root_at_slot(prev_target_epoch_start_slot - 1, Skips::Prev)
+                    if let Ok(Some(previous_duty_dependent_root)) = self
+                        .block_root_at_slot(prev_target_epoch_start_slot - 1, WhenSlotSkipped::Prev)
                     {
                         event_handler.register(EventKind::Head(SseHead {
                             slot: head_slot,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -596,9 +596,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     slot: curr_slot,
                 });
             }
-            return Ok((curr_root != prev_root).then(|| curr_root));
+            Ok((curr_root != prev_root).then(|| curr_root))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -555,22 +555,24 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         let prev_slot = target_slot.saturating_sub(1_u64);
-        let mut prev_root_opt = None;
 
         // Try an optimized path of reading the root directly from the head state.
         let fast_lookup: Option<Option<Hash256>> = self.with_head(|head| {
             let state = &head.beacon_state;
 
-            // It's always a skip slot if the target slot is higher than the head.
-            if target_slot > state.slot {
+            if state.slot == target_slot {
+                // The target slot is the head slot.
+                return Ok(Some(Some(head.beacon_block_root)));
+            } else if target_slot > state.slot {
+                // It's always a skip slot if the target slot is higher than the head.
                 return Ok(Some(None));
             }
 
             // If the previous and target roots are available in the state, read them and return
             // Some/None depending on if there is a skip slot.
             if let Ok(prev_root) = state.get_block_root(prev_slot) {
-                if let Ok(curr_root) = state.get_block_root(target_slot) {
-                    return Ok(Some((prev_root != curr_root).then(|| *curr_root)));
+                if let Ok(target_root) = state.get_block_root(target_slot) {
+                    return Ok(Some((prev_root != target_root).then(|| *target_root)));
                 }
             }
 
@@ -581,6 +583,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(root_opt);
         }
 
+        let mut prev_root_opt = None;
         process_results(self.forwards_iter_block_roots(prev_slot)?, |iter| {
             for (curr_root, curr_slot) in iter {
                 if let Some(prev_root) = prev_root_opt {
@@ -613,7 +616,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // Try an optimized path of reading the root directly from the head state.
-        let fast_lookup = self.with_head(|head| {
+        let fast_lookup: Option<Hash256> = self.with_head(|head| {
             if head.beacon_block.slot() <= target_slot {
                 // Return the head root if all slots between the target and the head are skipped.
                 Ok(Some(head.beacon_block_root))

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -113,6 +113,10 @@ pub enum BeaconChainError {
         state_epoch: Epoch,
         shuffling_epoch: Epoch,
     },
+    InconsistentForwardsIter {
+        request_slot: Slot,
+        slot: Slot,
+    },
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -31,7 +31,7 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, StateSkipConfig, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    ForkChoiceError, Skips, StateSkipConfig, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::chain_config::ChainConfig;

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -31,7 +31,7 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, Skips, StateSkipConfig, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    ForkChoiceError, StateSkipConfig, WhenSlotSkipped, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::chain_config::ChainConfig;

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy},
-    Skips, StateSkipConfig,
+    StateSkipConfig, WhenSlotSkipped,
 };
 use store::config::StoreConfig;
 use tree_hash::TreeHash;
@@ -60,7 +60,7 @@ fn produces_attestations() {
         };
 
         let block = chain
-            .block_at_slot(block_slot, Skips::Prev)
+            .block_at_slot(block_slot, WhenSlotSkipped::Prev)
             .expect("should get block")
             .expect("block should not be skipped");
         let block_root = block.message.tree_hash_root();

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy},
-    StateSkipConfig,
+    Skips, StateSkipConfig,
 };
 use store::config::StoreConfig;
 use tree_hash::TreeHash;
@@ -60,7 +60,7 @@ fn produces_attestations() {
         };
 
         let block = chain
-            .block_at_slot(block_slot)
+            .block_at_slot(block_slot, Skips::Prev)
             .expect("should get block")
             .expect("block should not be skipped");
         let block_root = block.message.tree_hash_root();

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 use beacon_chain::{
     attestation_verification::Error as AttnError,
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
-    BeaconChain, BeaconChainTypes, Skips,
+    BeaconChain, BeaconChainTypes, WhenSlotSkipped,
 };
 use int_to_bytes::int_to_bytes32;
 use state_processing::{
@@ -912,7 +912,7 @@ fn attestation_that_skips_epochs() {
     let earlier_slot = (current_epoch - 2).start_slot(MainnetEthSpec::slots_per_epoch());
     let earlier_block = harness
         .chain
-        .block_at_slot(earlier_slot, Skips::Prev)
+        .block_at_slot(earlier_slot, WhenSlotSkipped::Prev)
         .expect("should not error getting block at slot")
         .expect("should find block at slot");
 

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -6,7 +6,7 @@ extern crate lazy_static;
 use beacon_chain::{
     attestation_verification::Error as AttnError,
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
-    BeaconChain, BeaconChainTypes,
+    BeaconChain, BeaconChainTypes, Skips,
 };
 use int_to_bytes::int_to_bytes32;
 use state_processing::{
@@ -912,7 +912,7 @@ fn attestation_that_skips_epochs() {
     let earlier_slot = (current_epoch - 2).start_slot(MainnetEthSpec::slots_per_epoch());
     let earlier_block = harness
         .chain
-        .block_at_slot(earlier_slot)
+        .block_at_slot(earlier_slot, Skips::Prev)
         .expect("should not error getting block at slot")
         .expect("should find block at slot");
 

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -615,8 +615,10 @@ fn produces_and_processes_with_genesis_skip_slots() {
 fn block_roots_skip_slot_behaviour() {
     let harness = get_harness(VALIDATOR_COUNT);
 
-    let chain_length = 16;
-    let skipped_slots = [1, 6, 7, 10, 16];
+    // Test should be longer than the block roots to ensure a DB lookup is triggered.
+    let chain_length = harness.chain.head().unwrap().beacon_state.block_roots.len() as u64 * 3;
+
+    let skipped_slots = [1, 6, 7, 10, chain_length];
 
     // Build a chain with some skip slots.
     for i in 1..=chain_length {

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -9,7 +9,7 @@ use beacon_chain::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
         OP_POOL_DB_KEY,
     },
-    Skips,
+    WhenSlotSkipped,
 };
 use operation_pool::PersistedOperationPool;
 use state_processing::{
@@ -643,22 +643,22 @@ fn block_roots_skip_slot_behaviour() {
             assert!(
                 harness
                     .chain
-                    .block_root_at_slot(target_slot.into(), Skips::None)
+                    .block_root_at_slot(target_slot.into(), WhenSlotSkipped::None)
                     .unwrap()
                     .is_none(),
-                "Skips::None should return None on a skip slot"
+                "WhenSlotSkipped::None should return None on a skip slot"
             );
 
             let skipped_root = harness
                 .chain
-                .block_root_at_slot(target_slot.into(), Skips::Prev)
+                .block_root_at_slot(target_slot.into(), WhenSlotSkipped::Prev)
                 .unwrap()
-                .expect("Skips::Prev should always return Some");
+                .expect("WhenSlotSkipped::Prev should always return Some");
 
             assert_eq!(
                 skipped_root,
                 prev_unskipped_root.expect("test is badly formed"),
-                "Skips::Prev should accurately return the prior skipped block"
+                "WhenSlotSkipped::Prev should accurately return the prior skipped block"
             );
 
             let expected_block = harness.chain.get_block(&skipped_root).unwrap().unwrap();
@@ -666,7 +666,7 @@ fn block_roots_skip_slot_behaviour() {
             assert_eq!(
                 harness
                     .chain
-                    .block_at_slot(target_slot.into(), Skips::Prev)
+                    .block_at_slot(target_slot.into(), WhenSlotSkipped::Prev)
                     .unwrap()
                     .unwrap(),
                 expected_block,
@@ -675,10 +675,10 @@ fn block_roots_skip_slot_behaviour() {
             assert!(
                 harness
                     .chain
-                    .block_at_slot(target_slot.into(), Skips::None)
+                    .block_at_slot(target_slot.into(), WhenSlotSkipped::None)
                     .unwrap()
                     .is_none(),
-                "Skips::None should return None on a skip slot"
+                "WhenSlotSkipped::None should return None on a skip slot"
             );
         } else {
             /*
@@ -686,17 +686,17 @@ fn block_roots_skip_slot_behaviour() {
              */
             let skips_none = harness
                 .chain
-                .block_root_at_slot(target_slot.into(), Skips::None)
+                .block_root_at_slot(target_slot.into(), WhenSlotSkipped::None)
                 .unwrap()
-                .expect("Skips::None should return Some for non-skipped block");
+                .expect("WhenSlotSkipped::None should return Some for non-skipped block");
             let skips_prev = harness
                 .chain
-                .block_root_at_slot(target_slot.into(), Skips::Prev)
+                .block_root_at_slot(target_slot.into(), WhenSlotSkipped::Prev)
                 .unwrap()
-                .expect("Skips::Prev should always return Some");
+                .expect("WhenSlotSkipped::Prev should always return Some");
             assert_eq!(
                 skips_none, skips_prev,
-                "Skips::None and Skips::Prev should be equal on non-skipped slot"
+                "WhenSlotSkipped::None and WhenSlotSkipped::Prev should be equal on non-skipped slot"
             );
 
             let expected_block = harness.chain.get_block(&skips_prev).unwrap().unwrap();
@@ -704,7 +704,7 @@ fn block_roots_skip_slot_behaviour() {
             assert_eq!(
                 harness
                     .chain
-                    .block_at_slot(target_slot.into(), Skips::Prev)
+                    .block_at_slot(target_slot.into(), WhenSlotSkipped::Prev)
                     .unwrap()
                     .unwrap(),
                 expected_block
@@ -713,7 +713,7 @@ fn block_roots_skip_slot_behaviour() {
             assert_eq!(
                 harness
                     .chain
-                    .block_at_slot(target_slot.into(), Skips::None)
+                    .block_at_slot(target_slot.into(), WhenSlotSkipped::None)
                     .unwrap()
                     .unwrap(),
                 expected_block

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,4 +1,4 @@
-use beacon_chain::{BeaconChain, BeaconChainTypes, Skips};
+use beacon_chain::{BeaconChain, BeaconChainTypes, WhenSlotSkipped};
 use eth2::types::BlockId as CoreBlockId;
 use std::str::FromStr;
 use types::{Hash256, SignedBeaconBlock, Slot};
@@ -37,7 +37,7 @@ impl BlockId {
                 .map(|head| head.current_justified_checkpoint.root)
                 .map_err(warp_utils::reject::beacon_chain_error),
             CoreBlockId::Slot(slot) => chain
-                .block_root_at_slot(*slot, Skips::None)
+                .block_root_at_slot(*slot, WhenSlotSkipped::None)
                 .map_err(warp_utils::reject::beacon_chain_error)
                 .and_then(|root_opt| {
                     root_opt.ok_or_else(|| {

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,4 +1,4 @@
-use beacon_chain::{BeaconChain, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainTypes, Skips};
 use eth2::types::BlockId as CoreBlockId;
 use std::str::FromStr;
 use types::{Hash256, SignedBeaconBlock, Slot};
@@ -37,7 +37,7 @@ impl BlockId {
                 .map(|head| head.current_justified_checkpoint.root)
                 .map_err(warp_utils::reject::beacon_chain_error),
             CoreBlockId::Slot(slot) => chain
-                .block_root_at_slot(*slot)
+                .block_root_at_slot(*slot, Skips::None)
                 .map_err(warp_utils::reject::beacon_chain_error)
                 .and_then(|root_opt| {
                     root_opt.ok_or_else(|| {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -16,7 +16,8 @@ use beacon_chain::{
     attestation_verification::SignatureVerifiedAttestation,
     observed_operations::ObservationOutcome,
     validator_monitor::{get_block_delay_ms, timestamp_now},
-    AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes, Skips,
+    AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
+    WhenSlotSkipped,
 };
 use block_id::BlockId;
 use eth2::types::{self as api_types, ValidatorId};
@@ -751,7 +752,7 @@ pub fn serve<T: BeaconChainTypes>(
                 let block = BlockId::from_root(root).block(&chain)?;
 
                 let canonical = chain
-                    .block_root_at_slot(block.slot(), Skips::None)
+                    .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
                     .map_err(warp_utils::reject::beacon_chain_error)?
                     .map_or(false, |canonical| root == canonical);
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -16,7 +16,7 @@ use beacon_chain::{
     attestation_verification::SignatureVerifiedAttestation,
     observed_operations::ObservationOutcome,
     validator_monitor::{get_block_delay_ms, timestamp_now},
-    AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
+    AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes, Skips,
 };
 use block_id::BlockId;
 use eth2::types::{self as api_types, ValidatorId};
@@ -751,7 +751,7 @@ pub fn serve<T: BeaconChainTypes>(
                 let block = BlockId::from_root(root).block(&chain)?;
 
                 let canonical = chain
-                    .block_root_at_slot(block.slot())
+                    .block_root_at_slot(block.slot(), Skips::None)
                     .map_err(warp_utils::reject::beacon_chain_error)?
                     .map_or(false, |canonical| root == canonical);
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2,7 +2,7 @@
 
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
-    BeaconChain, Skips, StateSkipConfig, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    BeaconChain, StateSkipConfig, WhenSlotSkipped, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 use environment::null_logger;
 use eth2::Error;
@@ -791,7 +791,10 @@ impl ApiTester {
                     .current_justified_checkpoint
                     .root,
             ),
-            BlockId::Slot(slot) => self.chain.block_root_at_slot(slot, Skips::None).unwrap(),
+            BlockId::Slot(slot) => self
+                .chain
+                .block_root_at_slot(slot, WhenSlotSkipped::None)
+                .unwrap(),
             BlockId::Root(root) => Some(root),
         }
     }
@@ -812,7 +815,10 @@ impl ApiTester {
                 .unwrap()
                 .map(|res| res.data);
 
-            let root = self.chain.block_root_at_slot(slot, Skips::None).unwrap();
+            let root = self
+                .chain
+                .block_root_at_slot(slot, WhenSlotSkipped::None)
+                .unwrap();
 
             if root.is_none() && result.is_none() {
                 continue;
@@ -821,7 +827,7 @@ impl ApiTester {
             let root = root.unwrap();
             let block = self
                 .chain
-                .block_at_slot(slot, Skips::Prev)
+                .block_at_slot(slot, WhenSlotSkipped::Prev)
                 .unwrap()
                 .unwrap();
             let header = BlockHeaderData {
@@ -904,7 +910,7 @@ impl ApiTester {
             let block_root = block_root_opt.unwrap();
             let canonical = self
                 .chain
-                .block_root_at_slot(block.slot(), Skips::None)
+                .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
                 .unwrap()
                 .map_or(false, |canonical| block_root == canonical);
 
@@ -1538,7 +1544,7 @@ impl ApiTester {
                     .chain
                     .block_root_at_slot(
                         (epoch - 1).start_slot(E::slots_per_epoch()) - 1,
-                        Skips::Prev,
+                        WhenSlotSkipped::Prev,
                     )
                     .unwrap()
                     .unwrap_or(self.chain.head_beacon_block_root().unwrap());
@@ -1611,7 +1617,10 @@ impl ApiTester {
 
             let dependent_root = self
                 .chain
-                .block_root_at_slot(epoch.start_slot(E::slots_per_epoch()) - 1, Skips::Prev)
+                .block_root_at_slot(
+                    epoch.start_slot(E::slots_per_epoch()) - 1,
+                    WhenSlotSkipped::Prev,
+                )
                 .unwrap()
                 .unwrap_or(self.chain.head_beacon_block_root().unwrap());
 
@@ -2193,7 +2202,7 @@ impl ApiTester {
             current_duty_dependent_root,
             previous_duty_dependent_root: self
                 .chain
-                .block_root_at_slot(current_slot - E::slots_per_epoch(), Skips::Prev)
+                .block_root_at_slot(current_slot - E::slots_per_epoch(), WhenSlotSkipped::Prev)
                 .unwrap()
                 .unwrap(),
             epoch_transition: true,
@@ -2202,7 +2211,7 @@ impl ApiTester {
         let expected_finalized = EventKind::FinalizedCheckpoint(SseFinalizedCheckpoint {
             block: self
                 .chain
-                .block_root_at_slot(next_slot - finalization_distance, Skips::Prev)
+                .block_root_at_slot(next_slot - finalization_distance, WhenSlotSkipped::Prev)
                 .unwrap()
                 .unwrap(),
             state: self

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -819,7 +819,11 @@ impl ApiTester {
             }
 
             let root = root.unwrap();
-            let block = self.chain.block_at_slot(slot).unwrap().unwrap();
+            let block = self
+                .chain
+                .block_at_slot(slot, Skips::Prev)
+                .unwrap()
+                .unwrap();
             let header = BlockHeaderData {
                 root,
                 canonical: true,

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -2,7 +2,7 @@ use crate::beacon_processor::worker::FUTURE_SLOT_TOLERANCE;
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::SyncMessage;
-use beacon_chain::{BeaconChainError, BeaconChainTypes, Skips};
+use beacon_chain::{BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use eth2_libp2p::rpc::StatusMessage;
 use eth2_libp2p::rpc::*;
 use eth2_libp2p::{PeerId, PeerRequestId, ReportSource, Response, SyncInfo};
@@ -72,7 +72,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             && local.finalized_root != Hash256::zero()
             && self
                 .chain
-                .block_root_at_slot(start_slot(remote.finalized_epoch), Skips::Prev)
+                .block_root_at_slot(start_slot(remote.finalized_epoch), WhenSlotSkipped::Prev)
                 .map(|root_opt| root_opt != Some(remote.finalized_root))?
         {
             // The remote's finalized epoch is less than or equal to ours, but the block root is

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -2,7 +2,7 @@ use crate::beacon_processor::worker::FUTURE_SLOT_TOLERANCE;
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::SyncMessage;
-use beacon_chain::{BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChainError, BeaconChainTypes, Skips};
 use eth2_libp2p::rpc::StatusMessage;
 use eth2_libp2p::rpc::*;
 use eth2_libp2p::{PeerId, PeerRequestId, ReportSource, Response, SyncInfo};
@@ -72,7 +72,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             && local.finalized_root != Hash256::zero()
             && self
                 .chain
-                .root_at_slot(start_slot(remote.finalized_epoch))
+                .block_root_at_slot(start_slot(remote.finalized_epoch), Skips::Prev)
                 .map(|root_opt| root_opt != Some(remote.finalized_root))?
         {
             // The remote's finalized epoch is less than or equal to ours, but the block root is

--- a/beacon_node/store/src/chunked_vector.rs
+++ b/beacon_node/store/src/chunked_vector.rs
@@ -431,9 +431,15 @@ fn range_query<S: KeyValueStore<E>, E: EthSpec, T: Decode + Encode>(
     start_index: usize,
     end_index: usize,
 ) -> Result<Vec<Chunk<T>>, Error> {
-    let mut result = vec![];
+    let range = start_index..=end_index;
+    let len = range
+        .end()
+        // Add one to account for inclusive range.
+        .saturating_add(1)
+        .saturating_sub(*range.start());
+    let mut result = Vec::with_capacity(len);
 
-    for chunk_index in start_index..=end_index {
+    for chunk_index in range {
         let key = &chunk_key(chunk_index as u64)[..];
         let chunk = Chunk::load(store, column, key)?.ok_or(ChunkError::Missing { chunk_index })?;
         result.push(chunk);

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -2,7 +2,7 @@
 
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
-    BeaconChain, BeaconChainError, BeaconForkChoiceStore, ChainConfig, ForkChoiceError,
+    BeaconChain, BeaconChainError, BeaconForkChoiceStore, ChainConfig, ForkChoiceError, Skips,
     StateSkipConfig,
 };
 use fork_choice::{
@@ -872,7 +872,7 @@ fn invalid_attestation_future_block() {
             MutationDelay::Blocks(1),
             |attestation, chain| {
                 attestation.data.beacon_block_root = chain
-                    .block_at_slot(chain.slot().unwrap())
+                    .block_at_slot(chain.slot().unwrap(), Skips::Prev)
                     .unwrap()
                     .unwrap()
                     .canonical_root();
@@ -901,7 +901,7 @@ fn invalid_attestation_inconsistent_ffg_vote() {
             MutationDelay::NoDelay,
             |attestation, chain| {
                 attestation.data.target.root = chain
-                    .block_at_slot(Slot::new(1))
+                    .block_at_slot(Slot::new(1), Skips::Prev)
                     .unwrap()
                     .unwrap()
                     .canonical_root();
@@ -909,7 +909,7 @@ fn invalid_attestation_inconsistent_ffg_vote() {
                 *attestation_opt.lock().unwrap() = Some(attestation.data.target.root);
                 *local_opt.lock().unwrap() = Some(
                     chain
-                        .block_at_slot(Slot::new(0))
+                        .block_at_slot(Slot::new(0), Skips::Prev)
                         .unwrap()
                         .unwrap()
                         .canonical_root(),

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -159,7 +159,7 @@ impl ForkChoiceTest {
         self
     }
 
-    /// WhenSlotSkipped `count` slots, without producing a block.
+    /// Skips `count` slots, without producing a block.
     pub fn skip_slots(self, count: usize) -> Self {
         for _ in 0..count {
             self.harness.advance_slot();

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -2,8 +2,8 @@
 
 use beacon_chain::{
     test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType},
-    BeaconChain, BeaconChainError, BeaconForkChoiceStore, ChainConfig, ForkChoiceError, Skips,
-    StateSkipConfig,
+    BeaconChain, BeaconChainError, BeaconForkChoiceStore, ChainConfig, ForkChoiceError,
+    StateSkipConfig, WhenSlotSkipped,
 };
 use fork_choice::{
     ForkChoiceStore, InvalidAttestation, InvalidBlock, QueuedAttestation,
@@ -159,7 +159,7 @@ impl ForkChoiceTest {
         self
     }
 
-    /// Skips `count` slots, without producing a block.
+    /// WhenSlotSkipped `count` slots, without producing a block.
     pub fn skip_slots(self, count: usize) -> Self {
         for _ in 0..count {
             self.harness.advance_slot();
@@ -872,7 +872,7 @@ fn invalid_attestation_future_block() {
             MutationDelay::Blocks(1),
             |attestation, chain| {
                 attestation.data.beacon_block_root = chain
-                    .block_at_slot(chain.slot().unwrap(), Skips::Prev)
+                    .block_at_slot(chain.slot().unwrap(), WhenSlotSkipped::Prev)
                     .unwrap()
                     .unwrap()
                     .canonical_root();
@@ -901,7 +901,7 @@ fn invalid_attestation_inconsistent_ffg_vote() {
             MutationDelay::NoDelay,
             |attestation, chain| {
                 attestation.data.target.root = chain
-                    .block_at_slot(Slot::new(1), Skips::Prev)
+                    .block_at_slot(Slot::new(1), WhenSlotSkipped::Prev)
                     .unwrap()
                     .unwrap()
                     .canonical_root();
@@ -909,7 +909,7 @@ fn invalid_attestation_inconsistent_ffg_vote() {
                 *attestation_opt.lock().unwrap() = Some(attestation.data.target.root);
                 *local_opt.lock().unwrap() = Some(
                     chain
-                        .block_at_slot(Slot::new(0), Skips::Prev)
+                        .block_at_slot(Slot::new(0), WhenSlotSkipped::Prev)
                         .unwrap()
                         .unwrap()
                         .canonical_root(),


### PR DESCRIPTION
## Issue Addressed

NA

## Primary Change

When investigating memory usage, I noticed that retrieving a block from an early slot (e.g., slot 900) would cause a sharp increase in the memory footprint (from 400mb to 800mb+) which seemed to be ever-lasting.

After some investigation, I found that the reverse iteration from the head back to that slot was the likely culprit. To counter this, I've switched the `BeaconChain::block_root_at_slot` to use the forwards iterator, instead of the reverse one.

I also noticed that the networking stack is using `BeaconChain::root_at_slot` to check if a peer is relevant (`check_peer_relevance`). Perhaps the steep, seemingly-random-but-consistent increases in memory usage are caused by the use of this function.

Using the forwards iterator with the HTTP API alleviated the sharp increases in memory usage. It also made the response much faster (before it felt like to took 1-2s, now it feels instant).

## Additional Changes

In the process I also noticed that we have two functions for getting block roots:

- `BeaconChain::block_root_at_slot`: returns `None` for a skip slot.
- `BeaconChain::root_at_slot`: returns the previous root for a skip slot.

I unified these two functions into `block_root_at_slot` and added the `WhenSlotSkipped` enum. Now, the caller must be explicit about the skip-slot behaviour when requesting a root. 

Additionally, I replaced `vec![]` with `Vec::with_capacity` in `store::chunked_vector::range_query`. I stumbled across this whilst debugging and made this modification to see what effect it would have (not much). It seems like a decent change to keep around, but I'm not concerned either way.

Also, `BeaconChain::get_ancestor_block_root` is unused, so I got rid of it :wastebasket:.

## Additional Info

I haven't also done the same for state roots here. Whilst it's possible and a good idea, it's more work since the fwds iterators are presently block-roots-specific.

Whilst there's a few places a reverse iteration of state roots could be triggered (e.g., attestation production, HTTP API), they're no where near as common as the `check_peer_relevance` call. As such, I think we should get this PR merged first, then come back for the state root iters. I made an issue here https://github.com/sigp/lighthouse/issues/2377.
