### PR TITLE
[Merged by Bors] - v1.4.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "lcli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "account_utils",
  "bls",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -844,7 +844,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "lcli"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 dependencies = [
  "account_utils",
  "bls",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fb27eab85b17fbb9f6fd667089e07d6a2eb8743d02639ee7f6a7a7729c9c94"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -1313,11 +1313,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg 1.0.1",
  "cfg-if 1.0.0",
  "lazy_static",
 ]

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2018"
 

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2018"
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -16,7 +16,7 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v1.3.0-",
+    prefix = "Lighthouse/v1.4.0-",
     fallback = "unknown"
 );
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -16,7 +16,7 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v1.4.0-",
+    prefix = "Lighthouse/v1.4.0-rc.0-",
     fallback = "unknown"
 );
 

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "1.3.0"
+version = "1.4.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 autotests = false

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "1.4.0"
+version = "1.4.0-rc.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 autotests = false


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Bump versions.

## Additional Info

This is not exactly the v1.4.0 release described in [Lighthouse Update #36](https://lighthouse.sigmaprime.io/update-36.html).

Whilst it contains:

- Beta Windows support
- A reduction in Eth1 queries
- A reduction in memory footprint

It does not contain:

- Altair
- Doppelganger Protection
- The remote signer

We have decided to release some features early. This is primarily due to the desire to allow users to benefit from the memory saving improvements as soon as possible.

## TODO

- [x] Wait for #2340, #2356 and #2376 to merge and then rebase on `unstable`. 
- [x] Ensure discovery issues are fixed (see #2388)
- [x] Ensure https://github.com/sigp/lighthouse/pull/2382 is merged/removed.
- [x] Ensure https://github.com/sigp/lighthouse/pull/2383 is merged/removed.
- [x] Ensure https://github.com/sigp/lighthouse/pull/2384 is merged/removed.
- [x] Double-check eth1 cache is carried between boots
