### PR TITLE
Avoid pubkey cache timeouts

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -30,7 +30,7 @@
 mod batch;
 
 use crate::{
-    beacon_chain::{MAXIMUM_GOSSIP_CLOCK_DISPARITY, VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT},
+    beacon_chain::{HEAD_LOCK_TIMEOUT, MAXIMUM_GOSSIP_CLOCK_DISPARITY},
     metrics,
     observed_aggregates::ObserveOutcome,
     observed_attesters::Error as ObservedAttestersError,
@@ -1054,10 +1054,7 @@ pub fn verify_attestation_signature<T: BeaconChainTypes>(
     let signature_setup_timer =
         metrics::start_timer(&metrics::ATTESTATION_PROCESSING_SIGNATURE_SETUP_TIMES);
 
-    let pubkey_cache = chain
-        .validator_pubkey_cache
-        .try_read_for(VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT)
-        .ok_or(BeaconChainError::ValidatorPubkeyCacheLockTimeout)?;
+    let pubkey_cache = chain.validator_pubkey_cache.volatile_cache();
 
     let fork = chain
         .spec
@@ -1153,10 +1150,7 @@ pub fn verify_signed_aggregate_signatures<T: BeaconChainTypes>(
     signed_aggregate: &SignedAggregateAndProof<T::EthSpec>,
     indexed_attestation: &IndexedAttestation<T::EthSpec>,
 ) -> Result<bool, Error> {
-    let pubkey_cache = chain
-        .validator_pubkey_cache
-        .try_read_for(VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT)
-        .ok_or(BeaconChainError::ValidatorPubkeyCacheLockTimeout)?;
+    let pubkey_cache = chain.validator_pubkey_cache.volatile_cache();
 
     let aggregator_index = signed_aggregate.message.aggregator_index;
     if aggregator_index >= pubkey_cache.len() as u64 {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -761,7 +761,7 @@ where
             shuffling_cache: TimeoutRwLock::new(ShufflingCache::new()),
             beacon_proposer_cache: <_>::default(),
             block_times_cache: <_>::default(),
-            validator_pubkey_cache: TimeoutRwLock::new(validator_pubkey_cache),
+            validator_pubkey_cache,
             attester_cache: <_>::default(),
             disabled_forks: self.disabled_forks,
             shutdown_sender: self

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -146,7 +146,7 @@ impl<T: BeaconChainTypes> ValidatorPubkeyCache<T> {
         &self,
         state: &BeaconState<T::EthSpec>,
     ) -> Result<(), BeaconChainError> {
-        self.import(state.validators.iter().map(|v| v.pubkey))
+        self.import(state.validators().iter().map(|v| v.pubkey))
     }
 
     /// Adds zero or more validators to `self`.


### PR DESCRIPTION
## Issue Addressed

- Resolves #2327

## Proposed Changes

Move to a two-lock system for the `ValidatorPubkeyCache` which will not block read-access to the cache whilst writing to the DB or decompressing validator pubkeys.

## Additional Info

NA
