### PR TITLE
[Merged by Bors] - Return a specific error for frozen attn states

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -109,6 +109,7 @@ pub enum HotColdDBError {
     AttestationStateIsFinalized {
         split_slot: Slot,
         request_slot: Option<Slot>,
+        state_root: Hash256,
     },
 }
 
@@ -355,6 +356,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             Err(HotColdDBError::AttestationStateIsFinalized {
                 split_slot,
                 request_slot: slot,
+                state_root: *state_root,
             }
             .into())
         } else {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Return a very specific error when at attestation reads shuffling from a frozen `BeaconState`. Previously, this was returning `MissingBeaconState` which indicates a much more serious issue.

## Additional Info

Since `get_inconsistent_state_for_attestation_verification_only` is only called once in `BeaconChain::with_committee_cache`, it is quite easy to reason about the impact of this change.
