### PR TITLE
Gossipsub scoring improvements

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
@@ -17,6 +17,17 @@ const VOLUNTARY_EXIT_WEIGHT: f64 = 0.05;
 const PROPOSER_SLASHING_WEIGHT: f64 = 0.05;
 const ATTESTER_SLASHING_WEIGHT: f64 = 0.05;
 
+/// Builds the peer score thresholds.
+pub fn lighthouse_gossip_thresholds() -> PeerScoreThresholds {
+    PeerScoreThresholds {
+        gossip_threshold: -4000.0,
+        publish_threshold: -8000.0,
+        graylist_threshold: -16000.0,
+        accept_px_threshold: 100.0,
+        opportunistic_graft_threshold: 5.0,
+    }
+}
+
 pub struct PeerScoreSettings<TSpec: EthSpec> {
     slot: Duration,
     epoch: Duration,
@@ -75,7 +86,7 @@ impl<TSpec: EthSpec> PeerScoreSettings<TSpec> {
             decay_to_zero: self.decay_to_zero,
             retain_score: self.epoch * 100,
             app_specific_weight: 1.0,
-            ip_colocation_factor_threshold: 3.0,
+            ip_colocation_factor_threshold: 8.0, // Allow up to 8 nodes per IP
             behaviour_penalty_threshold: 6.0,
             behaviour_penalty_decay: self.score_parameter_decay(self.epoch * 10),
             ..Default::default()

--- a/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
@@ -17,6 +17,9 @@ const VOLUNTARY_EXIT_WEIGHT: f64 = 0.05;
 const PROPOSER_SLASHING_WEIGHT: f64 = 0.05;
 const ATTESTER_SLASHING_WEIGHT: f64 = 0.05;
 
+/// The time window (seconds) that we expect messages to be forwarded to us in the mesh.
+const MESH_MESSAGE_DELIVERIES_WINDOW: u64 = 2;
+
 // Const as this is used in the peer manager to prevent gossip from disconnecting peers.
 pub const GREYLIST_THRESHOLD: f64 = -16000.0;
 
@@ -327,7 +330,8 @@ impl<TSpec: EthSpec> PeerScoreSettings<TSpec> {
                     cap_factor * t_params.mesh_message_deliveries_threshold
                 };
             t_params.mesh_message_deliveries_activation = activation_window;
-            t_params.mesh_message_deliveries_window = Duration::from_secs(2);
+            t_params.mesh_message_deliveries_window =
+                Duration::from_secs(MESH_MESSAGE_DELIVERIES_WINDOW);
             t_params.mesh_failure_penalty_decay = t_params.mesh_message_deliveries_decay;
             t_params.mesh_message_deliveries_weight = -self.max_positive_score
                 / (t_params.topic_weight * t_params.mesh_message_deliveries_threshold.powi(2));

--- a/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
@@ -17,12 +17,15 @@ const VOLUNTARY_EXIT_WEIGHT: f64 = 0.05;
 const PROPOSER_SLASHING_WEIGHT: f64 = 0.05;
 const ATTESTER_SLASHING_WEIGHT: f64 = 0.05;
 
+// Const as this is used in the peer manager to prevent gossip from disconnecting peers.
+pub const GREYLIST_THRESHOLD: f64 = -16000.0;
+
 /// Builds the peer score thresholds.
 pub fn lighthouse_gossip_thresholds() -> PeerScoreThresholds {
     PeerScoreThresholds {
         gossip_threshold: -4000.0,
         publish_threshold: -8000.0,
-        graylist_threshold: -16000.0,
+        graylist_threshold: GREYLIST_THRESHOLD,
         accept_px_threshold: 100.0,
         opportunistic_graft_threshold: 5.0,
     }

--- a/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/gossipsub_scoring_parameters.rs
@@ -333,8 +333,7 @@ impl<TSpec: EthSpec> PeerScoreSettings<TSpec> {
             t_params.mesh_message_deliveries_window =
                 Duration::from_secs(MESH_MESSAGE_DELIVERIES_WINDOW);
             t_params.mesh_failure_penalty_decay = t_params.mesh_message_deliveries_decay;
-            t_params.mesh_message_deliveries_weight = -self.max_positive_score
-                / (t_params.topic_weight * t_params.mesh_message_deliveries_threshold.powi(2));
+            t_params.mesh_message_deliveries_weight = -t_params.topic_weight;
             t_params.mesh_failure_penalty_weight = t_params.mesh_message_deliveries_weight;
             if decay_slots >= current_slot.as_u64() {
                 t_params.mesh_message_deliveries_threshold = 0.0;

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1,7 +1,7 @@
-use crate::discovery::{subnet_predicate, Discovery, DiscoveryEvent, TARGET_SUBNET_PEERS};
 use crate::behaviour::gossipsub_scoring_parameters::{
     lighthouse_gossip_thresholds, PeerScoreSettings,
 };
+use crate::discovery::{subnet_predicate, Discovery, DiscoveryEvent, TARGET_SUBNET_PEERS};
 use crate::peer_manager::{
     score::ReportSource, ConnectionDirection, PeerManager, PeerManagerEvent,
 };

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1,5 +1,7 @@
-use crate::behaviour::gossipsub_scoring_parameters::PeerScoreSettings;
 use crate::discovery::{subnet_predicate, Discovery, DiscoveryEvent, TARGET_SUBNET_PEERS};
+use crate::behaviour::gossipsub_scoring_parameters::{
+    lighthouse_gossip_thresholds, PeerScoreSettings,
+};
 use crate::peer_manager::{
     score::ReportSource, ConnectionDirection, PeerManager, PeerManagerEvent,
 };
@@ -19,7 +21,7 @@ use libp2p::{
     gossipsub::{
         subscription_filter::{MaxCountSubscriptionFilter, WhitelistSubscriptionFilter},
         Gossipsub as BaseGossipsub, GossipsubEvent, IdentTopic as Topic, MessageAcceptance,
-        MessageAuthenticity, MessageId, PeerScoreThresholds,
+        MessageAuthenticity, MessageId,
     },
     identify::{Identify, IdentifyConfig, IdentifyEvent},
     swarm::{
@@ -45,7 +47,6 @@ use types::{ChainSpec, EnrForkId, EthSpec, SignedBeaconBlock, Slot, SubnetId};
 mod gossipsub_scoring_parameters;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
-pub const GOSSIPSUB_GREYLIST_THRESHOLD: f64 = -16000.0;
 
 /// Identifier of requests sent by a peer.
 pub type PeerRequestId = (ConnectionId, SubstreamId);
@@ -222,13 +223,7 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         let active_validators = TSpec::minimum_validator_count();
         let current_slot = Slot::new(0);
 
-        let thresholds = PeerScoreThresholds {
-            gossip_threshold: -4000.0,
-            publish_threshold: -8000.0,
-            graylist_threshold: GOSSIPSUB_GREYLIST_THRESHOLD,
-            accept_px_threshold: 100.0,
-            opportunistic_graft_threshold: 5.0,
-        };
+        let thresholds = lighthouse_gossip_thresholds();
 
         let score_settings = PeerScoreSettings::new(chain_spec, &config.gs_config);
 

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -44,7 +44,7 @@ use std::{
 };
 use types::{ChainSpec, EnrForkId, EthSpec, SignedBeaconBlock, Slot, SubnetId};
 
-mod gossipsub_scoring_parameters;
+pub mod gossipsub_scoring_parameters;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
 

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -20,7 +20,6 @@ pub const GOSSIP_MAX_SIZE: usize = 1_048_576;
 // specification. We leave it here for posterity.
 // const MESSAGE_DOMAIN_INVALID_SNAPPY: [u8; 4] = [0, 0, 0, 0];
 const MESSAGE_DOMAIN_VALID_SNAPPY: [u8; 4] = [1, 0, 0, 0];
-pub const MESH_N_LOW: usize = 6;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -134,13 +133,13 @@ impl Default for Config {
             .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_millis(700))
             .mesh_n(8)
-            .mesh_n_low(MESH_N_LOW)
+            .mesh_n_low(6)
             .mesh_n_high(12)
             .gossip_lazy(6)
             .fanout_ttl(Duration::from_secs(60))
             .history_length(6)
-            .max_messages_per_rpc(Some(10))
-            .history_gossip(3)
+            .max_messages_per_rpc(Some(500)) // Responses to IWANT can be quite large
+            .history_gossip(12)
             .validate_messages() // require validation before propagation
             .validation_mode(ValidationMode::Anonymous)
             // prevent duplicates for 550 heartbeats(700millis * 550) = 385 secs

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -14,7 +14,10 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// The maximum transmit size of gossip messages in bytes.
 pub const GOSSIP_MAX_SIZE: usize = 1_048_576;
+/// This is a constant to be used in discovery. The lower bound of the gossipsub mesh.
+pub const MESH_N_LOW: usize = 6;
 
 // We treat uncompressed messages as invalid and never use the INVALID_SNAPPY_DOMAIN as in the
 // specification. We leave it here for posterity.
@@ -133,7 +136,7 @@ impl Default for Config {
             .max_transmit_size(GOSSIP_MAX_SIZE)
             .heartbeat_interval(Duration::from_millis(700))
             .mesh_n(8)
-            .mesh_n_low(6)
+            .mesh_n_low(MESH_N_LOW)
             .mesh_n_high(12)
             .gossip_lazy(6)
             .fanout_ttl(Duration::from_secs(60))

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -137,9 +137,9 @@ impl Default for Config {
             .mesh_n_high(12)
             .gossip_lazy(6)
             .fanout_ttl(Duration::from_secs(60))
-            .history_length(6)
+            .history_length(12)
             .max_messages_per_rpc(Some(500)) // Responses to IWANT can be quite large
-            .history_gossip(12)
+            .history_gossip(3)
             .validate_messages() // require validation before propagation
             .validation_mode(ValidationMode::Anonymous)
             // prevent duplicates for 550 heartbeats(700millis * 550) = 385 secs

--- a/beacon_node/eth2_libp2p/src/peer_manager/score.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/score.rs
@@ -5,7 +5,7 @@
 //! As the logic develops this documentation will advance.
 //!
 //! The scoring algorithms are currently experimental.
-use crate::behaviour::GOSSIPSUB_GREYLIST_THRESHOLD;
+use crate::behaviour::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
 use serde::Serialize;
 use std::time::Instant;
 use strum::AsRefStr;


### PR DESCRIPTION
Gossipsub scoring is currently having issues on mainnet and the testnets. 

From some inspection the causes seem to be:
- Go gossipsub are packing more messages into RPC responses and for security limits we are limiting responses to 10 (some can gave > 200). I've changed this setting to allow up to 500 messages per RPC. 
- There are a number of nodes under the same IP. We currently only permit 3 nodes per IP before that start being scored down. The network is showing 5 or 6 peers on the same IP. I've increased this to 8. 
- On prater with lots of validators, messages are not being forward because we can't validate them in the time that we keep them around in the cache. The cache currently exists for 2.1 seconds, I've increased this to 8.4 seconds (will use more RAM however). 