### PR TITLE
[Merged by Bors] - Fix options for `--eth1-endpoints` flag

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -190,6 +190,7 @@ pub fn get_config<E: EthSpec>(
         client_config.eth1.endpoints = vec![SensitiveUrl::parse(endpoint)
             .map_err(|e| format!("eth1-endpoint was an invalid URL: {:?}", e))?];
     } else if let Some(endpoints) = cli_args.value_of("eth1-endpoints") {
+        client_config.sync_eth1_chain = true;
         client_config.eth1.endpoints = endpoints
             .split(',')
             .map(|s| SensitiveUrl::parse(s))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -257,6 +257,7 @@ fn eth1_endpoints_flag() {
                 "https://infura.io/secret"
             );
             assert_eq!(config.eth1.endpoints[1].to_string(), "https://infura.io/");
+            assert!(config.sync_eth1_chain);
         });
 }
 #[test]


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Set `config.sync_eth1_chain` to true when using just the  `--eth1-endpoints` flag (without `--eth1`).
