### PR TITLE
[Merged by Bors] - Make less logs for attn with unknown head

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -797,7 +797,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                 // TODO: Maintain this attestation and re-process once sync completes
                 // TODO: We then score based on whether we can download the block and re-process.
-                debug!(
+                trace!(
                     self.log,
                     "Attestation for unknown block";
                     "peer_id" => %peer_id,

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -554,6 +554,13 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             return;
         }
 
+        debug!(
+            self.log,
+            "Searching for block";
+            "peer_id" => %peer_id,
+            "block" => %block_hash
+        );
+
         let request = BlocksByRootRequest {
             block_roots: VariableList::from(vec![block_hash]),
         };


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

I am starting to see a lot of slog-async overflows (i.e., too many logs) on Prater whenever we see attestations for an unknown block. Since these logs are identical (except for peer id) and we expose volume/count of these errors via `metrics::GOSSIP_ATTESTATION_ERRORS_PER_TYPE`, I took the following actions to remove them from `DEBUG` logs:

- Push the "Attestation for unknown block" log to trace.
- Add a debug log in `search_for_block`. In effect, this should serve as a de-duped version of the previous, downgraded log.

## Additional Info

TBC
