### PR TITLE
[Merged by Bors] - Ignore inactive validators in validator monitor

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -353,8 +353,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                             "matched_head" => summary.is_previous_epoch_head_attester,
                             "epoch" => prev_epoch,
                             "validator" => id,
-
-                        )
+                        );
                     } else if summary.is_active_in_previous_epoch
                         && !summary.is_previous_epoch_attester
                     {
@@ -364,6 +363,11 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                             "epoch" => prev_epoch,
                             "validator" => id,
                         )
+                    } else if !summary.is_active_in_previous_epoch {
+                        // Monitored validator is not active, due to awaiting activation
+                        // or being exited/withdrawn. Do not attempt to report on its
+                        // attestations.
+                        continue;
                     }
 
                     if summary.is_previous_epoch_attester {


### PR DESCRIPTION
## Proposed Changes

A user on Discord (`@ChewsMacRibs`) reported that the validator monitor was logging `WARN Attested to an incorrect head` for their validator while it was awaiting activation.

This PR modifies the monitor so that it ignores inactive validators, by the logic that they are either awaiting activation, or have already exited. Either way, there's no way for an inactive validator to have their attestations included on chain, so no need for the monitor to report on them.

## Additional Info

To reproduce the bug requires registering validator keys manually with `--validator-monitor-pubkeys`. I don't think the bug will present itself with `--validator-monitor-auto`.
