### PR TITLE
[Merged by Bors] - Only perform malloc tuning for beacon node

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -165,7 +165,11 @@ fn main() {
 
     // Configure the allocator early in the process, before it has the chance to use the default values for
     // anything important.
-    if !matches.is_present(DISABLE_MALLOC_TUNING_FLAG) {
+    //
+    // Only apply this optimization for the beacon node. It's the only process with a substantial
+    // memory footprint.
+    let is_beacon_node = matches.subcommand_name() == Some("beacon_node");
+    if is_beacon_node && !matches.is_present(DISABLE_MALLOC_TUNING_FLAG) {
         if let Err(e) = configure_memory_allocator() {
             eprintln!(
                 "Unable to configure the memory allocator: {} \n\


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Only run `configure_memory_alllocator` for the BN process.

I noticed that VC memory usage increases significantly with the new malloc tuning parameters. This was also raised by a user on [r/ethstaker](https://www.reddit.com/r/ethstaker/comments/nr8998/lighthouse_prerelease_v140rc0/h0fnt9l?utm_source=share&utm_medium=web2x&context=3).

There wasn't any issue with memory usage by the VC before we implemented #2296, so I think we were a bit overzealous when we allowed these changes to affect it. This PR allows things that weren't broken to remain unfixed.

## Additional Info

NA
