### PR TITLE
[Merged by Bors] - Fix remote signer test

### DIFF
--- a/remote_signer/tests/sign.rs
+++ b/remote_signer/tests/sign.rs
@@ -281,7 +281,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0xINVALID_VALUE_\",\"current_version\":\"0x02020202\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \\\'I\\\', index: 0 })\", line: 1, column: 237097)",
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237097)",
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"INVALID_VALUE\",\"epoch\":\"1545\"},",
@@ -293,7 +293,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0xINVALID_VALUE_\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \\\'I\\\', index: 0 })\", line: 1, column: 237128)"
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237128)"
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0x02020202\",\"epoch\":},",

--- a/remote_signer/tests/sign.rs
+++ b/remote_signer/tests/sign.rs
@@ -281,7 +281,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0xINVALID_VALUE_\",\"current_version\":\"0x02020202\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237097)",
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \"I\", index: 0 })\", line: 1, column: 237097)",
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"INVALID_VALUE\",\"epoch\":\"1545\"},",
@@ -293,7 +293,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0xINVALID_VALUE_\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237128)"
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \"I\", index: 0 })\", line: 1, column: 237128)"
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0x02020202\",\"epoch\":},",

--- a/remote_signer/tests/sign.rs
+++ b/remote_signer/tests/sign.rs
@@ -281,7 +281,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0xINVALID_VALUE_\",\"current_version\":\"0x02020202\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \"I\", index: 0 })\", line: 1, column: 237097)",
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237097)",
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"INVALID_VALUE\",\"epoch\":\"1545\"},",
@@ -293,7 +293,7 @@ mod sign {
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0xINVALID_VALUE_\",\"epoch\":\"1545\"},",
-            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \"I\", index: 0 })\", line: 1, column: 237128)"
+            "Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237128)"
         );
         testcase(
             "\"fork\":{\"previous_version\":\"0x01010101\",\"current_version\":\"0x02020202\",\"epoch\":},",

--- a/remote_signer/tests/sign_randao.rs
+++ b/remote_signer/tests/sign_randao.rs
@@ -30,11 +30,11 @@ mod sign_randao {
 
         testcase(
             "\"beacon_proposer\"",
-            "Unable to parse block from JSON: Error(\"invalid type: string \\\"49463\\\", expected struct BeaconBlock\", line: 0, column: 0)"
+            "Unable to parse block from JSON: Error(\"invalid type: string \"49463\", expected struct BeaconBlock\", line: 0, column: 0)"
         );
         testcase(
             "\"beacon_attester\"",
-            "Unable to parse attestation from JSON: Error(\"invalid type: string \\\"49463\\\", expected struct AttestationData\", line: 0, column: 0)"
+            "Unable to parse attestation from JSON: Error(\"invalid type: string \"49463\", expected struct AttestationData\", line: 0, column: 0)"
         );
         testcase("\"blah\"", "Unsupported bls_domain parameter: blah");
 

--- a/testing/remote_signer_test/src/consumer.rs
+++ b/testing/remote_signer_test/src/consumer.rs
@@ -146,8 +146,7 @@ pub fn assert_sign_error(resp: ApiTestResponse, http_status: u16, error_msg: &st
             .as_str()
             .unwrap()
             // cross-platform compatiblity
-            .replace("\\", "")
-            .replace("'", "\""),
+            .replace("\\", ""),
         error_msg
     );
 }

--- a/testing/remote_signer_test/src/consumer.rs
+++ b/testing/remote_signer_test/src/consumer.rs
@@ -141,5 +141,13 @@ pub fn assert_sign_ok(resp: ApiTestResponse, expected_signature: &str) {
 
 pub fn assert_sign_error(resp: ApiTestResponse, http_status: u16, error_msg: &str) {
     assert_eq!(resp.status, http_status);
-    assert_eq!(resp.json["error"].as_str().unwrap(), error_msg);
+    assert_eq!(
+        resp.json["error"]
+            .as_str()
+            .unwrap()
+            // cross-platform compatiblity
+            .replace("\\", "")
+            .replace("'", "\""),
+        error_msg
+    );
 }


### PR DESCRIPTION
## Proposed Changes

Unescape text for json comparison in:

https://github.com/sigp/lighthouse/blob/3a24ca5f14c6e6d6612fd43eca82aa0c1e6aba16/remote_signer/tests/sign.rs#L282-L285

Which causes this error:

```
---- sign::invalid_field_fork stdout ----
thread 'sign::invalid_field_fork' panicked at 'assertion failed: `(left == right)`
  left: `"Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: 'I', index: 0 })\", line: 1, column: 237097)"`,
 right: `"Unable to parse body message from JSON: Error(\"invalid hex (InvalidHexCharacter { c: \\'I\\', index: 0 })\", line: 1, column: 237097)"`', testing/remote_signer_test/src/consumer.rs:144:5
```

This is my first contribution and happy to receive feedback if you have any. Thanks