### PR TITLE
Update to spec v1.1.0-alpha.7

### DIFF
--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -242,6 +242,13 @@ mod tests {
     type E = MainnetEthSpec;
 
     #[test]
+    fn mainnet_config_eq_chain_spec() {
+        let config = Eth2NetworkConfig::from_hardcoded_net(&MAINNET).unwrap();
+        let spec = ChainSpec::mainnet();
+        assert_eq!(spec, config.chain_spec::<E>().unwrap());
+    }
+
+    #[test]
     fn hard_coded_nets_work() {
         for net in HARDCODED_NETS {
             let config = Eth2NetworkConfig::from_hardcoded_net(net)

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -9,7 +9,7 @@ pub use self::verify_attester_slashing::{
     get_slashable_indices, get_slashable_indices_modular, verify_attester_slashing,
 };
 pub use self::verify_proposer_slashing::verify_proposer_slashing;
-pub use altair::sync_committee::process_sync_committee;
+pub use altair::sync_committee::process_sync_aggregate;
 pub use block_signature_verifier::BlockSignatureVerifier;
 pub use is_valid_indexed_attestation::is_valid_indexed_attestation;
 pub use process_operations::process_operations;
@@ -130,7 +130,7 @@ pub fn per_block_processing<T: EthSpec>(
     process_operations(state, block.body(), verify_signatures, spec)?;
 
     if let BeaconBlockRef::Altair(inner) = block {
-        process_sync_committee(state, &inner.body.sync_aggregate, proposer_index, spec)?;
+        process_sync_aggregate(state, &inner.body.sync_aggregate, proposer_index, spec)?;
     }
 
     Ok(())

--- a/consensus/types/presets/mainnet/altair.yaml
+++ b/consensus/types/presets/mainnet/altair.yaml
@@ -14,8 +14,8 @@ PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR: 2
 # ---------------------------------------------------------------
 # 2**9 (= 512)
 SYNC_COMMITTEE_SIZE: 512
-# 2**9 (= 512)
-EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 512
+# 2**8 (= 256)
+EPOCHS_PER_SYNC_COMMITTEE_PERIOD: 256
 
 
 # Sync protocol

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -728,26 +728,17 @@ impl<T: EthSpec> BeaconState<T> {
         Ok(hash(&preimage))
     }
 
-    /// Get the validator indices of all validators from `sync_committee` identified by
-    /// `sync_committee_bits`.
-    pub fn get_sync_committee_participant_indices(
+    /// Get the validator indices of all validators from `sync_committee`.
+    pub fn get_sync_committee_indices(
         &mut self,
         sync_committee: &SyncCommittee<T>,
-        sync_committee_bits: &BitVector<T::SyncCommitteeSize>,
     ) -> Result<Vec<usize>, Error> {
         sync_committee
             .pubkeys
             .iter()
-            .zip(sync_committee_bits.iter())
-            .flat_map(|(pubkey, bit)| {
-                if bit {
-                    let validator_index_res = self
-                        .get_validator_index(&pubkey)
-                        .and_then(|opt| opt.ok_or(Error::PubkeyCacheInconsistent));
-                    Some(validator_index_res)
-                } else {
-                    None
-                }
+            .map(|pubkey| {
+                self.get_validator_index(&pubkey)?
+                    .ok_or(Error::PubkeyCacheInconsistent)
             })
             .collect()
     }

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -391,7 +391,7 @@ impl ChainSpec {
             inactivity_score_bias: 4,
             inactivity_score_recovery_rate: 16,
             min_sync_committee_participants: 1,
-            epochs_per_sync_committee_period: Epoch::new(512),
+            epochs_per_sync_committee_period: Epoch::new(256),
             domain_sync_committee: 7,
             domain_sync_committee_selection_proof: 8,
             domain_contribution_and_proof: 9,

--- a/consensus/types/src/consts.rs
+++ b/consensus/types/src/consts.rs
@@ -2,10 +2,10 @@ pub mod altair {
     pub const TIMELY_SOURCE_FLAG_INDEX: usize = 0;
     pub const TIMELY_TARGET_FLAG_INDEX: usize = 1;
     pub const TIMELY_HEAD_FLAG_INDEX: usize = 2;
-    pub const TIMELY_SOURCE_WEIGHT: u64 = 12;
-    pub const TIMELY_TARGET_WEIGHT: u64 = 24;
-    pub const TIMELY_HEAD_WEIGHT: u64 = 12;
-    pub const SYNC_REWARD_WEIGHT: u64 = 8;
+    pub const TIMELY_SOURCE_WEIGHT: u64 = 14;
+    pub const TIMELY_TARGET_WEIGHT: u64 = 26;
+    pub const TIMELY_HEAD_WEIGHT: u64 = 14;
+    pub const SYNC_REWARD_WEIGHT: u64 = 2;
     pub const PROPOSER_WEIGHT: u64 = 8;
     pub const WEIGHT_DENOMINATOR: u64 = 64;
 

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-alpha.6
+TESTS_TAG := v1.1.0-alpha.7
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -1,4 +1,4 @@
-#! /bin/python
+#!/usr/bin/env python3
 
 # The purpose of this script is to compare a list of file names that were accessed during testing
 # against all the file names in the eth2.0-spec-tests repository. It then checks to see which files
@@ -54,9 +54,9 @@ excluded_paths = [
     # SyncCommitteeContribution
     "tests/minimal/altair/ssz_static/SyncCommitteeContribution",
     "tests/mainnet/altair/ssz_static/SyncCommitteeContribution",
-    # SyncCommitteeSignature
-    "tests/minimal/altair/ssz_static/SyncCommitteeSignature",
-    "tests/mainnet/altair/ssz_static/SyncCommitteeSignature",
+    # SyncCommitteeMessage
+    "tests/minimal/altair/ssz_static/SyncCommitteeMessage",
+    "tests/mainnet/altair/ssz_static/SyncCommitteeMessage",
     # SyncCommitteeSigningData
     "tests/minimal/altair/ssz_static/SyncCommitteeSigningData",
     "tests/mainnet/altair/ssz_static/SyncCommitteeSigningData",

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -3,47 +3,6 @@
 use ef_tests::*;
 use types::*;
 
-// FIXME(altair): fix these once alpha.7 is released and includes config files
-// Check that the config from the Eth2.0 spec tests matches our minimal/mainnet config.
-/*
-fn config_test<E: EthSpec + TypeName>() {
-    let config_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("eth2.0-spec-tests")
-        .join("tests")
-        .join(E::name())
-        .join("config");
-    let phase0_config_path = config_dir.join("phase0.yaml");
-    let altair_config_path = config_dir.join("altair.yaml");
-    let phase0_config = BaseConfig::from_file(&phase0_config_path).expect("config file loads OK");
-    let altair_config = AltairConfig::from_file(&altair_config_path).expect("altair config loads");
-    let std_config = StandardConfig::from_parts(phase0_config.clone(), altair_config.clone());
-    let spec = E::default_spec();
-
-    log_file_access(&phase0_config_path);
-    log_file_access(&altair_config_path);
-
-    let unified_spec =
-        ChainSpec::from_standard_config::<E>(&std_config).expect("config unification");
-    assert_eq!(unified_spec, spec);
-
-    let phase0_from_spec = BaseConfig::from_chain_spec::<E>(&spec);
-    assert_eq!(phase0_from_spec, phase0_config);
-
-    let altair_from_spec = AltairConfig::from_chain_spec::<E>(&spec);
-    assert_eq!(altair_from_spec, altair_config);
-}
-
-#[test]
-fn mainnet_config_ok() {
-    config_test::<MainnetEthSpec>();
-}
-
-#[test]
-fn minimal_config_ok() {
-    config_test::<MinimalEthSpec>();
-}
-*/
-
 // Check that the hand-computed multiplications on EthSpec are correctly computed.
 // This test lives here because one is most likely to muck these up during a spec update.
 fn check_typenum_values<E: EthSpec>() {


### PR DESCRIPTION
## Proposed Changes

Implement consensus changes from [alpha.7](https://github.com/ethereum/eth2.0-specs/releases/tag/v1.1.0-alpha.7), namely:

* Rename `process_sync_committee` -> `process_sync_aggregate`
* Tweak weights for sync aggregates, and add penalties (https://github.com/ethereum/eth2.0-specs/pull/2453)
* Delete config tests from `ef_tests`. It seems those configs won't be bundled in tests anymore, and in the meantime we have the presets bundled and tested in `consensus/types/presets`, and the built-in network configs tested. I added a new test to ensure that `ChainSpec::mainnet` matches the `mainnet` builtin.
* Made the Python script a tad more portable by using `env`

## Additional Info

This PR doesn't include the rename of `SyncCommitteeSignature` to `SyncCommitteeMessage`, because that type only exists in the higher layers. We'll coordinate the rename in #2321, and ripple it upwards.