### PR TITLE
Avoid write-lock on validator monitor in subscriptions API

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -440,6 +440,16 @@ impl<T: EthSpec> ValidatorMonitor<T> {
             .and_then(|pubkey| self.validators.get(pubkey))
     }
 
+    /// Return `true` if the `validator_index` has been registered with `self`.
+    pub fn contains_validator(&self, validator_index: u64) -> bool {
+        self.indices.contains_key(&validator_index)
+    }
+
+    /// Return `true` if the automatic validator registration is enabled.
+    pub fn auto_register_enabled(&self) -> bool {
+        self.auto_register
+    }
+
     /// Returns the number of validators monitored by `self`.
     pub fn num_validators(&self) -> usize {
         self.validators.len()

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1888,7 +1888,7 @@ pub fn serve<T: BeaconChainTypes>(
                         let should_register = {
                             let validator_monitor = chain.validator_monitor.read();
                             validator_monitor.auto_register_enabled()
-                                && validator_monitor
+                                && !validator_monitor
                                     .contains_validator(subscription.validator_index)
                         };
                         if should_register {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Whilst working on #2352, I noticed that the `beacon_committee_subscriptions` API endpoint was taking over 1s on our Prater nodes. Given the triviality of this endpoint, I suspect it's because we're taking a write-lock on the validator monitor for each subscription.

This PR first checks with a read-lock if a validator needs to be added, before taking the write-lock to add the validator.

## Additional Info

- [ ] Prove that this reduces the runtime on Prater.
