### PR TITLE
[Merged by Bors] - Use bulk verification for sync_aggregate signature

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -72,7 +72,8 @@ use store::{Error as DBError, HotColdDB, HotStateSummary, KeyValueStore, StoreOp
 use tree_hash::TreeHash;
 use types::{
     BeaconBlockRef, BeaconState, BeaconStateError, ChainSpec, CloneConfig, Epoch, EthSpec, Hash256,
-    InconsistentFork, PublicKey, RelativeEpoch, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    InconsistentFork, PublicKey, PublicKeyBytes, RelativeEpoch, SignedBeaconBlock,
+    SignedBeaconBlockHeader, Slot,
 };
 
 /// Maximum block slot number. Block with slots bigger than this constant will NOT be processed.
@@ -1382,22 +1383,31 @@ fn get_signature_verifier<'a, T: BeaconChainTypes>(
     state: &'a BeaconState<T::EthSpec>,
     validator_pubkey_cache: &'a ValidatorPubkeyCache<T>,
     spec: &'a ChainSpec,
-) -> BlockSignatureVerifier<'a, T::EthSpec, impl Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone> {
-    BlockSignatureVerifier::new(
-        state,
-        move |validator_index| {
-            // Disallow access to any validator pubkeys that are not in the current beacon
-            // state.
-            if validator_index < state.validators().len() {
-                validator_pubkey_cache
-                    .get(validator_index)
-                    .map(|pk| Cow::Borrowed(pk))
-            } else {
-                None
-            }
-        },
-        spec,
-    )
+) -> BlockSignatureVerifier<
+    'a,
+    T::EthSpec,
+    impl Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone,
+    impl Fn(&'a PublicKeyBytes) -> Option<Cow<'a, PublicKey>>,
+> {
+    let get_pubkey = move |validator_index| {
+        // Disallow access to any validator pubkeys that are not in the current beacon state.
+        if validator_index < state.validators().len() {
+            validator_pubkey_cache
+                .get(validator_index)
+                .map(Cow::Borrowed)
+        } else {
+            None
+        }
+    };
+
+    let decompressor = move |pk_bytes| {
+        // Map compressed pubkey to validator index.
+        let validator_index = validator_pubkey_cache.get_index(pk_bytes)?;
+        // Map validator index to pubkey (respecting guard on unknown validators).
+        get_pubkey(validator_index)
+    };
+
+    BlockSignatureVerifier::new(state, get_pubkey, decompressor, spec)
 }
 
 /// Verify that `header` was signed with a valid signature from its proposer.

--- a/crypto/bls/src/generic_aggregate_signature.rs
+++ b/crypto/bls/src/generic_aggregate_signature.rs
@@ -110,6 +110,11 @@ where
         self.point.is_none()
     }
 
+    /// Returns `true` if `self` is equal to the point at infinity.
+    pub fn is_infinity(&self) -> bool {
+        self.is_infinity
+    }
+
     /// Returns a reference to the underlying BLS point.
     pub(crate) fn point(&self) -> Option<&AggSig> {
         self.point.as_ref()
@@ -187,18 +192,6 @@ where
             Some(point) => point.fast_aggregate_verify(msg, pubkeys),
             None => false,
         }
-    }
-
-    /// Wrapper to `fast_aggregate_verify` accepting the infinity signature when `pubkeys` is empty.
-    pub fn eth2_fast_aggregate_verify(
-        &self,
-        msg: Hash256,
-        pubkeys: &[&GenericPublicKey<Pub>],
-    ) -> bool {
-        if pubkeys.is_empty() && self.is_infinity {
-            return true;
-        }
-        self.fast_aggregate_verify(msg, pubkeys)
     }
 
     /// Verify that `self` represents an aggregate signature where all `pubkeys` have signed their

--- a/crypto/bls/tests/tests.rs
+++ b/crypto/bls/tests/tests.rs
@@ -34,6 +34,7 @@ macro_rules! test_suite {
                 AggregateSignature::deserialize(&INFINITY_SIGNATURE).unwrap(),
                 AggregateSignature::infinity(),
             );
+            assert!(AggregateSignature::infinity().is_infinity());
         }
 
         #[test]
@@ -295,6 +296,17 @@ macro_rules! test_suite {
                 .aggregate_infinity_sig()
                 .aggregate_infinity_sig()
                 .assert_single_message_verify(true)
+        }
+
+        /// Adding two infinity signatures should yield the infinity signature.
+        #[test]
+        fn add_two_infinity_signatures() {
+            let tester = AggregateSignatureTester::new_with_single_msg(1)
+                .infinity_sig()
+                .aggregate_infinity_sig();
+            assert!(tester.sig.is_infinity());
+            assert_eq!(tester.sig, AggregateSignature::infinity());
+            tester.assert_single_message_verify(false)
         }
 
         /// The wrong signature should not verify.

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -192,7 +192,7 @@ impl<E: EthSpec> Operation<E> for SyncAggregate<E> {
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
         let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
-        process_sync_aggregate(state, self, proposer_index, spec)
+        process_sync_aggregate(state, self, proposer_index, VerifySignatures::True, spec)
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

Add the `sync_aggregate` from `BeaconBlock` to the bulk signature verifier for blocks. This necessitates a new signature set constructor for the sync aggregate, which is different from the others due to the use of [`eth2_fast_aggregate_verify`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.7/specs/altair/bls.md#eth2_fast_aggregate_verify) for sync aggregates, per [`process_sync_aggregate`](https://github.com/ethereum/eth2.0-specs/blob/v1.1.0-alpha.7/specs/altair/beacon-chain.md#sync-aggregate-processing). I made the choice to return an optional signature set, with `None` representing the case where the signature is valid on account of being the point at infinity (requires no further checking).

To "dogfood" the changes and prevent duplication, the consensus logic now uses the signature set approach as well whenever it is required to verify signatures (which should only be in testing AFAIK). The EF tests pass with the code as it exists currently, but failed before I adapted the `eth2_fast_aggregate_verify` changes (which is good).

As a result of this change Altair block processing should be a little faster, and importantly, we will no longer accidentally verify signatures when replaying blocks, e.g. when replaying blocks from the database.
