### PR TITLE
[Merged by Bors] - Run apt-get upgrade to get latest security updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM rust:1.50.0 AS builder
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake
 COPY . lighthouse
 ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make
 
 FROM debian:buster-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get -y upgrade
+  && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   && apt-get clean \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make
 
 FROM debian:buster-slim
-RUN apt-get update && apt-get -y upgrade
-  && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
   && apt-get clean \


### PR DESCRIPTION
## Issue Addressed

None.

## Proposed Changes

Run apt-get upgrade to install latest security updates.

## Additional Info

Images often take a long time to get the latest security updates, while running apt-get upgrade will pull the latest updates.
