### PR TITLE
[Merged by Bors] - Add Lighthouse version and commit hash to Prometheus metrics

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -274,6 +274,9 @@ fn run<E: EthSpec>(
     // Allow Prometheus to export the time at which the process was started.
     metrics::expose_process_start_time(&log);
 
+    // Allow Prometheus access to the version and commit of the Lighthouse build.
+    metrics::expose_lighthouse_version();
+
     if matches.is_present("spec") {
         warn!(
             log,

--- a/lighthouse/src/metrics.rs
+++ b/lighthouse/src/metrics.rs
@@ -14,7 +14,7 @@ lazy_static! {
 lazy_static! {
     pub static ref LIGHTHOUSE_VERSION: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "lighthouse_info",
-        "The build of Lighthouse running on the server.",
+        "The build of Lighthouse running on the server",
         &["version"],
     );
 }

--- a/lighthouse/src/metrics.rs
+++ b/lighthouse/src/metrics.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 pub use lighthouse_metrics::*;
+use lighthouse_version::VERSION;
 use slog::{error, Logger};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -7,6 +8,14 @@ lazy_static! {
     pub static ref PROCESS_START_TIME_SECONDS: Result<IntGauge> = try_create_int_gauge(
         "process_start_time_seconds",
         "The unix timestamp at which the process was started"
+    );
+}
+
+lazy_static! {
+    pub static ref LIGHTHOUSE_VERSION: Result<IntGaugeVec> = try_create_int_gauge_vec(
+        "lighthouse_info",
+        "The build of Lighthouse running on the server.",
+        &["version"],
     );
 }
 
@@ -19,4 +28,8 @@ pub fn expose_process_start_time(log: &Logger) {
             "error" => %e
         ),
     }
+}
+
+pub fn expose_lighthouse_version() {
+    set_gauge_vec(&LIGHTHOUSE_VERSION, &[VERSION], 1);
 }


### PR DESCRIPTION
## Issue Addressed

#2225 

## Proposed Changes

Exposes the version given from the `lighthouse_version` crate to the Prometheus metrics server.

## Additional Info

- This metric appears in both the Beacon Node and Validator Client metrics servers.
- This is the simplest solution. It might be better to include the version and commit hash as separate labels rather than combined, however this would be more involved. Happy to do it that way if this is too cumbersome to use.
- The metric appears as:
```
# HELP lighthouse_info The build of Lighthouse running on the server
# TYPE lighthouse_info gauge
lighthouse_info{version="Lighthouse/v1.4.0-379664a+"} 1
```
