### PR TITLE
[WIP] Accelerate loading of frozen states

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -8,7 +8,6 @@ use crate::{metrics, BeaconSnapshot};
 use fork_choice::ForkChoiceStore;
 use ssz_derive::{Decode, Encode};
 use std::marker::PhantomData;
-use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
 use types::{BeaconBlock, BeaconState, BeaconStateError, Checkpoint, EthSpec, Hash256, Slot};
 
@@ -156,7 +155,7 @@ impl BalancesCache {
 /// `fork_choice::ForkChoice` struct.
 #[derive(Debug)]
 pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
-    store: Arc<HotColdDB<E, Hot, Cold>>,
+    store: HotColdDB<E, Hot, Cold>,
     balances_cache: BalancesCache,
     time: Slot,
     finalized_checkpoint: Checkpoint,
@@ -201,7 +200,7 @@ where
     ///
     /// It is assumed that `anchor` is already persisted in `store`.
     pub fn get_forkchoice_store(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         anchor: &BeaconSnapshot<E>,
     ) -> Self {
         let anchor_state = &anchor.beacon_state;
@@ -245,7 +244,7 @@ where
     /// Restore `Self` from a previously-generated `PersistedForkChoiceStore`.
     pub fn from_persisted(
         persisted: PersistedForkChoiceStore,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
     ) -> Result<Self, Error> {
         Ok(Self {
             store,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -60,7 +60,7 @@ use state_processing::{
     block_signature_verifier::{BlockSignatureVerifier, Error as BlockSignatureVerifierError},
     per_block_processing, per_slot_processing,
     state_advance::partial_state_advance,
-    BlockProcessingError, BlockSignatureStrategy, SlotProcessingError,
+    BlockProcessingError, SlotProcessingError, VerificationStrategy,
 };
 use std::borrow::Cow;
 use std::fs;
@@ -969,7 +969,9 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                 state_root
             };
 
-            if let Some(summary) = per_slot_processing(&mut state, Some(state_root), &chain.spec)? {
+            if let Some(summary) =
+                per_slot_processing(&mut state, Some(state_root), None, &chain.spec)?
+            {
                 // Expose Prometheus metrics.
                 if let Err(e) = summary.observe_metrics() {
                     error!(
@@ -979,7 +981,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                         "error" => ?e
                     );
                 }
-                summaries.push(summary);
+                summaries.push(summary)
             }
         }
 
@@ -1041,7 +1043,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
             &block,
             Some(block_root),
             // Signatures were verified earlier in this function.
-            BlockSignatureStrategy::NoVerification,
+            VerificationStrategy::no_signatures(),
             &chain.spec,
         ) {
             match err {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::beacon_chain::{BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY};
+use crate::beacon_chain::{BeaconStore, BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, OP_POOL_DB_KEY};
 use crate::eth1_chain::{CachingEth1Backend, SszEth1};
 use crate::fork_revert::{reset_fork_choice_to_finalization, revert_to_fork_boundary};
 use crate::head_tracker::HeadTracker;
@@ -63,8 +63,7 @@ where
 ///
 /// See the tests for an example of a complete working example.
 pub struct BeaconChainBuilder<T: BeaconChainTypes> {
-    #[allow(clippy::type_complexity)]
-    store: Option<Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>>,
+    store: Option<BeaconStore<T>>,
     store_migrator_config: Option<MigratorConfig>,
     pub genesis_time: Option<u64>,
     genesis_block_root: Option<Hash256>,
@@ -153,7 +152,7 @@ where
     /// Sets the store (database).
     ///
     /// Should generally be called early in the build chain.
-    pub fn store(mut self, store: Arc<HotColdDB<TEthSpec, THotStore, TColdStore>>) -> Self {
+    pub fn store(mut self, store: HotColdDB<TEthSpec, THotStore, TColdStore>) -> Self {
         self.store = Some(store);
         self
     }
@@ -792,7 +791,7 @@ mod test {
 
         let chain = BeaconChainBuilder::new(MinimalEthSpec)
             .logger(log.clone())
-            .store(Arc::new(store))
+            .store(store)
             .genesis_state(genesis_state)
             .expect("should build state using recent genesis")
             .dummy_eth1_backend()

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -28,7 +28,7 @@ const COMPACTION_FINALITY_DISTANCE: u64 = 1024;
 /// The background migrator runs a thread to perform pruning and migrate state from the hot
 /// to the cold database.
 pub struct BackgroundMigrator<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
-    db: Arc<HotColdDB<E, Hot, Cold>>,
+    db: HotColdDB<E, Hot, Cold>,
     #[allow(clippy::type_complexity)]
     tx_thread: Option<Mutex<(mpsc::Sender<MigrationNotification>, thread::JoinHandle<()>)>>,
     /// Genesis block root, for persisting the `PersistedBeaconChain`.
@@ -83,7 +83,7 @@ pub struct MigrationNotification {
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Hot, Cold> {
     /// Create a new `BackgroundMigrator` and spawn its thread if necessary.
     pub fn new(
-        db: Arc<HotColdDB<E, Hot, Cold>>,
+        db: HotColdDB<E, Hot, Cold>,
         config: MigratorConfig,
         genesis_block_root: Hash256,
         log: Logger,
@@ -153,7 +153,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
     }
 
     /// Perform the actual work of `process_finalization`.
-    fn run_migration(db: Arc<HotColdDB<E, Hot, Cold>>, notif: MigrationNotification, log: &Logger) {
+    fn run_migration(db: HotColdDB<E, Hot, Cold>, notif: MigrationNotification, log: &Logger) {
         let finalized_state_root = notif.finalized_state_root;
 
         let finalized_state = match db.get_state(&finalized_state_root.into(), None) {
@@ -229,7 +229,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
     ///
     /// Return a channel handle for sending new finalized states to the thread.
     fn spawn_thread(
-        db: Arc<HotColdDB<E, Hot, Cold>>,
+        db: HotColdDB<E, Hot, Cold>,
         log: Logger,
     ) -> (mpsc::Sender<MigrationNotification>, thread::JoinHandle<()>) {
         let (tx, rx) = mpsc::channel();
@@ -258,7 +258,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
     /// space.
     #[allow(clippy::too_many_arguments)]
     fn prune_abandoned_forks(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         head_tracker: Arc<HeadTracker>,
         new_finalized_state_hash: BeaconStateHash,
         new_finalized_state: &BeaconState<E>,
@@ -516,7 +516,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
     /// Compact the database if it has been more than `COMPACTION_PERIOD_SECONDS` since it
     /// was last compacted.
     pub fn run_compaction(
-        db: Arc<HotColdDB<E, Hot, Cold>>,
+        db: HotColdDB<E, Hot, Cold>,
         old_finalized_epoch: Epoch,
         new_finalized_epoch: Epoch,
         log: &Logger,

--- a/beacon_node/beacon_chain/src/schema_change.rs
+++ b/beacon_node/beacon_chain/src/schema_change.rs
@@ -4,7 +4,6 @@ use crate::validator_pubkey_cache::ValidatorPubkeyCache;
 use operation_pool::{PersistedOperationPool, PersistedOperationPoolBase};
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
 use store::hot_cold_store::{HotColdDB, HotColdDBError};
 use store::metadata::{SchemaVersion, CURRENT_SCHEMA_VERSION};
 use store::Error as StoreError;
@@ -13,7 +12,7 @@ const PUBKEY_CACHE_FILENAME: &str = "pubkey_cache.ssz";
 
 /// Migrate the database from one schema version to another, applying all requisite mutations.
 pub fn migrate_schema<T: BeaconChainTypes>(
-    db: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
+    db: HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>,
     datadir: &Path,
     from: SchemaVersion,
     to: SchemaVersion,

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -230,7 +230,7 @@ fn advance_head<T: BeaconChainTypes>(
     };
 
     // Advance the state a single slot.
-    if let Some(summary) = per_slot_processing(&mut state, state_root, &beacon_chain.spec)
+    if let Some(summary) = per_slot_processing(&mut state, state_root, None, &beacon_chain.spec)
         .map_err(BeaconChainError::from)?
     {
         // Expose Prometheus metrics.

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -235,7 +235,7 @@ impl<E: EthSpec> BeaconChainHarness<EphemeralHarnessType<E>> {
     ) -> Self {
         let spec = spec.unwrap_or_else(test_spec::<E>);
         let log = test_logger();
-        let store = Arc::new(HotColdDB::open_ephemeral(store_config, spec.clone(), log).unwrap());
+        let store = HotColdDB::open_ephemeral(store_config, spec.clone(), log).unwrap();
         Self::new_with_mutator(
             eth_spec_instance,
             spec,
@@ -263,7 +263,7 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
     pub fn new_with_disk_store(
         eth_spec_instance: E,
         spec: Option<ChainSpec>,
-        store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
+        store: HotColdDB<E, LevelDB<E>, LevelDB<E>>,
         validator_keypairs: Vec<Keypair>,
     ) -> Self {
         let spec = spec.unwrap_or_else(test_spec::<E>);
@@ -294,7 +294,7 @@ impl<E: EthSpec> BeaconChainHarness<DiskHarnessType<E>> {
     pub fn resume_from_disk_store(
         eth_spec_instance: E,
         spec: Option<ChainSpec>,
-        store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
+        store: HotColdDB<E, LevelDB<E>, LevelDB<E>>,
         validator_keypairs: Vec<Keypair>,
     ) -> Self {
         let spec = spec.unwrap_or_else(test_spec::<E>);
@@ -329,7 +329,7 @@ where
     pub fn new_with_mutator(
         eth_spec_instance: E,
         spec: ChainSpec,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         validator_keypairs: Vec<Keypair>,
         chain_config: ChainConfig,
         mutator: impl FnOnce(

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -324,7 +324,6 @@ fn append_to_file(file: &mut File, index: usize, pubkey: &PublicKeyBytes) -> Res
 mod test {
     use super::*;
     use crate::test_utils::{test_logger, BeaconChainHarness, EphemeralHarnessType};
-    use std::sync::Arc;
     use store::{HotColdDB, StoreConfig};
     use tempfile::tempdir;
     use types::{
@@ -348,9 +347,7 @@ mod test {
     }
 
     fn get_store() -> BeaconStore<T> {
-        Arc::new(
-            HotColdDB::open_ephemeral(<_>::default(), E::default_spec(), test_logger()).unwrap(),
-        )
+        HotColdDB::open_ephemeral(<_>::default(), E::default_spec(), test_logger()).unwrap()
     }
 
     #[allow(clippy::needless_range_loop)]

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -929,7 +929,7 @@ fn attestation_that_skips_epochs() {
         .expect("should find state");
 
     while state.slot() < current_slot {
-        per_slot_processing(&mut state, None, &harness.spec).expect("should process slot");
+        per_slot_processing(&mut state, None, None, &harness.spec).expect("should process slot");
     }
 
     let state_root = state.update_tree_hash_cache().unwrap();

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -11,7 +11,7 @@ use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
     common::get_indexed_attestation,
     per_block_processing::{per_block_processing, BlockSignatureStrategy},
-    per_slot_processing, BlockProcessingError,
+    per_slot_processing, BlockProcessingError, VerificationStrategy,
 };
 use std::sync::Arc;
 use store::config::StoreConfig;
@@ -977,13 +977,13 @@ fn add_base_block_to_altair_chain() {
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
         let mut state = state;
-        per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
+        per_slot_processing(&mut state, None, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(
                 &mut state,
                 &base_block,
                 None,
-                BlockSignatureStrategy::NoVerification,
+                VerificationStrategy::no_signatures(),
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(
@@ -1097,13 +1097,13 @@ fn add_altair_block_to_base_chain() {
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
         let mut state = state;
-        per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
+        per_slot_processing(&mut state, None, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(
                 &mut state,
                 &altair_block,
                 None,
-                BlockSignatureStrategy::NoVerification,
+                VerificationStrategy::no_signatures(),
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -10,7 +10,6 @@ use beacon_chain::test_utils::{
     test_spec, AttestationStrategy, BeaconChainHarness, BlockStrategy, DiskHarnessType,
 };
 use sloggers::{null::NullLoggerBuilder, Build};
-use std::sync::Arc;
 use store::{LevelDB, StoreConfig};
 use tempfile::{tempdir, TempDir};
 use types::*;
@@ -27,7 +26,7 @@ type E = MinimalEthSpec;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 type HotColdDB = store::HotColdDB<E, LevelDB<E>, LevelDB<E>>;
 
-fn get_store(db_path: &TempDir) -> Arc<HotColdDB> {
+fn get_store(db_path: &TempDir) -> HotColdDB {
     let spec = test_spec::<E>();
     let hot_path = db_path.path().join("hot_db");
     let cold_path = db_path.path().join("cold_db");
@@ -37,7 +36,7 @@ fn get_store(db_path: &TempDir) -> Arc<HotColdDB> {
         .expect("disk store should initialize")
 }
 
-fn get_harness(store: Arc<HotColdDB>, validator_count: usize) -> TestHarness {
+fn get_harness(store: HotColdDB, validator_count: usize) -> TestHarness {
     let harness = BeaconChainHarness::new_with_disk_store(
         MinimalEthSpec,
         None,

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -12,7 +12,6 @@ use rand::Rng;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::convert::TryInto;
-use std::sync::Arc;
 use store::{
     iter::{BlockRootsIterator, StateRootsIterator},
     HotColdDB, LevelDB, StoreConfig,
@@ -34,7 +33,7 @@ lazy_static! {
 type E = MinimalEthSpec;
 type TestHarness = BeaconChainHarness<DiskHarnessType<E>>;
 
-fn get_store(db_path: &TempDir) -> Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>> {
+fn get_store(db_path: &TempDir) -> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
     get_store_with_spec(db_path, test_spec::<E>())
 }
 
@@ -51,10 +50,7 @@ fn get_store_with_spec(
         .expect("disk store should initialize")
 }
 
-fn get_harness(
-    store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
-    validator_count: usize,
-) -> TestHarness {
+fn get_harness(store: HotColdDB<E, LevelDB<E>, LevelDB<E>>, validator_count: usize) -> TestHarness {
     let harness = BeaconChainHarness::new_with_disk_store(
         MinimalEthSpec,
         None,
@@ -2063,7 +2059,7 @@ fn check_finalization(harness: &TestHarness, expected_slot: u64) {
 }
 
 /// Check that the HotColdDB's split_slot is equal to the start slot of the last finalized epoch.
-fn check_split_slot(harness: &TestHarness, store: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>) {
+fn check_split_slot(harness: &TestHarness, store: HotColdDB<E, LevelDB<E>, LevelDB<E>>) {
     let split_slot = store.get_split_slot();
     assert_eq!(
         harness

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -47,7 +47,7 @@ fn massive_skips() {
 
     // Run per_slot_processing until it returns an error.
     let error = loop {
-        match per_slot_processing(&mut state, None, spec) {
+        match per_slot_processing(&mut state, None, None, spec) {
             Ok(_) => continue,
             Err(e) => break e,
         }

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -8,7 +8,7 @@ use beacon_chain::{
     slot_clock::{SlotClock, SystemTimeSlotClock},
     state_advance_timer::spawn_state_advance_timer,
     store::{HotColdDB, ItemStore, LevelDB, StoreConfig},
-    BeaconChain, BeaconChainTypes, Eth1ChainBackend, ServerSentEventHandler,
+    BeaconChain, BeaconChainTypes, BeaconStore, Eth1ChainBackend, ServerSentEventHandler,
 };
 use environment::RuntimeContext;
 use eth1::{Config as Eth1Config, Service as Eth1Service};
@@ -45,8 +45,7 @@ pub const ETH1_GENESIS_UPDATE_INTERVAL_MILLIS: u64 = 7_000;
 /// `self.memory_store(..)` has been called.
 pub struct ClientBuilder<T: BeaconChainTypes> {
     slot_clock: Option<T::SlotClock>,
-    #[allow(clippy::type_complexity)]
-    store: Option<Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>>,
+    store: Option<BeaconStore<T>>,
     runtime_context: Option<RuntimeContext<T::EthSpec>>,
     chain_spec: Option<ChainSpec>,
     beacon_chain_builder: Option<BeaconChainBuilder<T>>,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1870,7 +1870,7 @@ impl ApiTester {
 
         let mut head = self.chain.head().unwrap();
         while head.beacon_state.current_epoch() < epoch {
-            per_slot_processing(&mut head.beacon_state, None, &self.chain.spec).unwrap();
+            per_slot_processing(&mut head.beacon_state, None, None, &self.chain.spec).unwrap();
         }
         head.beacon_state
             .build_committee_cache(RelativeEpoch::Current, &self.chain.spec)

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -1,5 +1,4 @@
 use eth2_libp2p::Enr;
-use std::sync::Arc;
 use store::{DBColumn, Error as StoreError, HotColdDB, ItemStore, StoreItem};
 use types::{EthSpec, Hash256};
 
@@ -7,7 +6,7 @@ use types::{EthSpec, Hash256};
 pub const DHT_DB_KEY: Hash256 = Hash256::zero();
 
 pub fn load_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-    store: Arc<HotColdDB<E, Hot, Cold>>,
+    store: HotColdDB<E, Hot, Cold>,
 ) -> Vec<Enr> {
     // Load DHT from store
     match store.get_item(&DHT_DB_KEY) {
@@ -21,7 +20,7 @@ pub fn load_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 
 /// Attempt to persist the ENR's in the DHT to `self.store`.
 pub fn persist_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-    store: Arc<HotColdDB<E, Hot, Cold>>,
+    store: HotColdDB<E, Hot, Cold>,
     enrs: Vec<Enr>,
 ) -> Result<(), store::Error> {
     store.put_item(&DHT_DB_KEY, &PersistedDht { enrs })
@@ -29,7 +28,7 @@ pub fn persist_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 
 /// Attempts to clear any DHT entries.
 pub fn clear_dht<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-    store: Arc<HotColdDB<E, Hot, Cold>>,
+    store: HotColdDB<E, Hot, Cold>,
 ) -> Result<(), store::Error> {
     store.hot_db.delete::<PersistedDht>(&DHT_DB_KEY)
 }

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -6,7 +6,7 @@ use crate::{
     subnet_service::{AttestationService, SubnetServiceMessage},
     NetworkConfig,
 };
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, BeaconStore};
 use eth2_libp2p::{
     rpc::{GoodbyeReason, RPCResponseErrorCode, RequestId},
     Libp2pEvent, PeerAction, PeerRequestId, PubsubMessage, ReportSource, Request, Response, Subnet,
@@ -20,7 +20,6 @@ use futures::future::OptionFuture;
 use futures::prelude::*;
 use slog::{crit, debug, error, info, o, trace, warn};
 use std::{net::SocketAddr, pin::Pin, sync::Arc, time::Duration};
-use store::HotColdDB;
 use task_executor::ShutdownReason;
 use tokio::sync::mpsc;
 use tokio::time::Sleep;
@@ -118,7 +117,7 @@ pub struct NetworkService<T: BeaconChainTypes> {
     /// lighthouse.
     router_send: mpsc::UnboundedSender<RouterMessage<T::EthSpec>>,
     /// A reference to lighthouse's database to persist the DHT.
-    store: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
+    store: BeaconStore<T>,
     /// A collection of global variables, accessible outside of the network service.
     network_globals: Arc<NetworkGlobals<T::EthSpec>>,
     /// Stores potentially created UPnP mappings to be removed on shutdown. (TCP port and UDP

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -50,7 +50,7 @@ impl TestBeaconChain {
             BeaconChainBuilder::new(MainnetEthSpec)
                 .logger(log.clone())
                 .custom_spec(spec.clone())
-                .store(Arc::new(store))
+                .store(store)
                 .genesis_state(
                     interop_genesis_state::<MainnetEthSpec>(&keypairs, 0, &spec)
                         .expect("should generate interop state"),

--- a/beacon_node/store/src/chunked_iter.rs
+++ b/beacon_node/store/src/chunked_iter.rs
@@ -1,7 +1,6 @@
 use crate::chunked_vector::{chunk_key, Chunk, Field};
 use crate::{HotColdDB, ItemStore};
 use slog::error;
-use std::sync::Arc;
 use types::{ChainSpec, EthSpec, Slot};
 
 /// Iterator over the values of a `BeaconState` vector field (like `block_roots`).
@@ -14,7 +13,7 @@ where
     Hot: ItemStore<E>,
     Cold: ItemStore<E>,
 {
-    pub(crate) store: Arc<HotColdDB<E, Hot, Cold>>,
+    pub(crate) store: HotColdDB<E, Hot, Cold>,
     current_vindex: usize,
     pub(crate) end_vindex: usize,
     next_cindex: usize,
@@ -35,7 +34,7 @@ where
     /// `HotColdDB::get_latest_restore_point_slot`. We pass it as a parameter so that the caller can
     /// maintain a stable view of the database (see `HybridForwardsBlockRootsIterator`).
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_vindex: usize,
         last_restore_point_slot: Slot,
         spec: &ChainSpec,

--- a/beacon_node/store/src/forwards_iter.rs
+++ b/beacon_node/store/src/forwards_iter.rs
@@ -4,7 +4,6 @@ use crate::errors::{Error, Result};
 use crate::iter::{BlockRootsIterator, StateRootsIterator};
 use crate::{HotColdDB, ItemStore};
 use itertools::process_results;
-use std::sync::Arc;
 use types::{BeaconState, ChainSpec, EthSpec, Hash256, Slot};
 
 /// Forwards block roots iterator that makes use of the `block_roots` table in the freezer DB.
@@ -34,7 +33,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     FrozenForwardsBlockRootsIterator<E, Hot, Cold>
 {
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         last_restore_point_slot: Slot,
         spec: &ChainSpec,
@@ -64,7 +63,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 
 impl SimpleForwardsBlockRootsIterator {
     pub fn new<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_block_root: Hash256,
@@ -95,7 +94,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     HybridForwardsBlockRootsIterator<E, Hot, Cold>
 {
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_block_root: Hash256,
@@ -200,7 +199,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     FrozenForwardsStateRootsIterator<E, Hot, Cold>
 {
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         last_restore_point_slot: Slot,
         spec: &ChainSpec,
@@ -230,7 +229,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> Iterator
 
 impl SimpleForwardsStateRootsIterator {
     pub fn new<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_state_root: Hash256,
@@ -261,7 +260,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     HybridForwardsStateRootsIterator<E, Hot, Cold>
 {
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_state_root: Hash256,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -27,8 +27,8 @@ use slog::{debug, error, info, trace, warn, Logger};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use state_processing::{
-    per_block_processing, per_slot_processing, BlockProcessingError, BlockSignatureStrategy,
-    SlotProcessingError,
+    per_block_processing, per_slot_processing, BlockProcessingError, SlotProcessingError,
+    VerificationStrategy,
 };
 use std::convert::TryInto;
 use std::marker::PhantomData;
@@ -52,7 +52,7 @@ pub enum BlockReplay {
 /// Stores vector fields like the `block_roots` and `state_roots` separately, and only stores
 /// intermittent "restore point" states pre-finalization.
 #[derive(Debug)]
-pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+pub struct HotColdDBInner<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
     /// The slot and state root at the point where the database is split between hot and cold.
     ///
     /// States with slots less than `split.slot` are in the cold DB, while states with slots
@@ -73,6 +73,38 @@ pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
     pub(crate) log: Logger,
     /// Mere vessel for E.
     _phantom: PhantomData<E>,
+}
+
+#[derive(Debug)]
+pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
+    inner: Arc<HotColdDBInner<E, Hot, Cold>>,
+}
+
+impl<E, Hot, Cold> std::ops::Deref for HotColdDB<E, Hot, Cold>
+where
+    E: EthSpec,
+    Hot: ItemStore<E>,
+    Cold: ItemStore<E>,
+{
+    type Target = HotColdDBInner<E, Hot, Cold>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+// FIXME(sproul): use derivative
+impl<E, Hot, Cold> Clone for HotColdDB<E, Hot, Cold>
+where
+    E: EthSpec,
+    Hot: ItemStore<E>,
+    Cold: ItemStore<E>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -124,15 +156,17 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
     ) -> Result<HotColdDB<E, MemoryStore<E>, MemoryStore<E>>, Error> {
         Self::verify_slots_per_restore_point(config.slots_per_restore_point)?;
 
-        let db = HotColdDB {
-            split: RwLock::new(Split::default()),
-            cold_db: MemoryStore::open(),
-            hot_db: MemoryStore::open(),
-            block_cache: Mutex::new(LruCache::new(config.block_cache_size)),
-            config,
-            spec,
-            log,
-            _phantom: PhantomData,
+        let db = Self {
+            inner: Arc::new(HotColdDBInner {
+                split: RwLock::new(Split::default()),
+                cold_db: MemoryStore::open(),
+                hot_db: MemoryStore::open(),
+                block_cache: Mutex::new(LruCache::new(config.block_cache_size)),
+                config,
+                spec,
+                log,
+                _phantom: PhantomData,
+            }),
         };
 
         Ok(db)
@@ -149,23 +183,25 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
     pub fn open(
         hot_path: &Path,
         cold_path: &Path,
-        migrate_schema: impl FnOnce(Arc<Self>, SchemaVersion, SchemaVersion) -> Result<(), Error>,
+        migrate_schema: impl FnOnce(Self, SchemaVersion, SchemaVersion) -> Result<(), Error>,
         config: StoreConfig,
         spec: ChainSpec,
         log: Logger,
-    ) -> Result<Arc<Self>, Error> {
+    ) -> Result<Self, Error> {
         Self::verify_slots_per_restore_point(config.slots_per_restore_point)?;
 
-        let db = Arc::new(HotColdDB {
-            split: RwLock::new(Split::default()),
-            cold_db: LevelDB::open(cold_path)?,
-            hot_db: LevelDB::open(hot_path)?,
-            block_cache: Mutex::new(LruCache::new(config.block_cache_size)),
-            config,
-            spec,
-            log,
-            _phantom: PhantomData,
-        });
+        let db = HotColdDB {
+            inner: Arc::new(HotColdDBInner {
+                split: RwLock::new(Split::default()),
+                cold_db: LevelDB::open(cold_path)?,
+                hot_db: LevelDB::open(hot_path)?,
+                block_cache: Mutex::new(LruCache::new(config.block_cache_size)),
+                config,
+                spec,
+                log,
+                _phantom: PhantomData,
+            }),
+        };
 
         // Ensure that the schema version of the on-disk database matches the software.
         // If the version is mismatched, an automatic migration will be attempted.
@@ -420,23 +456,23 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     pub fn forwards_block_roots_iterator(
-        store: Arc<Self>,
+        self,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_block_root: Hash256,
         spec: &ChainSpec,
     ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>>, Error> {
-        HybridForwardsBlockRootsIterator::new(store, start_slot, end_state, end_block_root, spec)
+        HybridForwardsBlockRootsIterator::new(self, start_slot, end_state, end_block_root, spec)
     }
 
     pub fn forwards_state_roots_iterator(
-        store: Arc<Self>,
+        self,
         start_slot: Slot,
         end_state_root: Hash256,
         end_state: BeaconState<E>,
         spec: &ChainSpec,
     ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>>, Error> {
-        HybridForwardsStateRootsIterator::new(store, start_slot, end_state, end_state_root, spec)
+        HybridForwardsStateRootsIterator::new(self, start_slot, end_state, end_state_root, spec)
     }
 
     /// Load an epoch boundary state by using the hot state summary look-up.
@@ -628,7 +664,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             } else {
                 let blocks =
                     self.load_blocks_to_replay(boundary_state.slot(), slot, latest_block_root)?;
-                self.replay_blocks(boundary_state, blocks, slot, block_replay)?
+                let _replay_blocks_timer = metrics::start_timer(&metrics::REPLAY_BLOCKS_TIME_HOT);
+                self.replay_blocks(boundary_state, blocks, slot, None, block_replay)?
             };
 
             Ok(Some(state))
@@ -734,6 +771,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
     /// Load a frozen state that lies between restore points.
     fn load_cold_intermediate_state(&self, slot: Slot) -> Result<BeaconState<E>, Error> {
+        let _t = metrics::start_timer(&metrics::LOAD_COLD_INTERMEDIATE_STATE_TIME);
         // 1. Load the restore points either side of the intermediate state.
         let low_restore_point_idx = slot.as_u64() / self.config.slots_per_restore_point;
         let high_restore_point_idx = low_restore_point_idx + 1;
@@ -741,9 +779,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         // Acquire the read lock, so that the split can't change while this is happening.
         let split = self.split.read_recursive();
 
+        let low_restore_timer = metrics::start_timer(&metrics::LOAD_LOW_RESTORE_POINT_TIME);
         let low_restore_point = self.load_restore_point_by_index(low_restore_point_idx)?;
+        drop(low_restore_timer);
+
         // If the slot of the high point lies outside the freezer, use the split state
         // as the upper restore point.
+        let high_restore_timer = metrics::start_timer(&metrics::LOAD_HIGH_RESTORE_POINT_TIME);
         let high_restore_point = if high_restore_point_idx * self.config.slots_per_restore_point
             >= split.slot.as_u64()
         {
@@ -753,16 +795,36 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         } else {
             self.load_restore_point_by_index(high_restore_point_idx)?
         };
+        drop(high_restore_timer);
 
         // 2. Load the blocks from the high restore point back to the low restore point.
+        let load_blocks_timer = metrics::start_timer(&metrics::LOAD_REPLAY_BLOCKS_TIME);
         let blocks = self.load_blocks_to_replay(
             low_restore_point.slot(),
             slot,
             self.get_high_restore_point_block_root(&high_restore_point, slot)?,
         )?;
+        drop(load_blocks_timer);
+
+        let state_root_iter = HybridForwardsStateRootsIterator::new(
+            self.clone(),
+            low_restore_point.slot(),
+            high_restore_point,
+            // Lie about the state root of the end state. We should never need to
+            // use the state root at the high restore point itself.
+            Hash256::zero(),
+            &self.spec,
+        )?;
 
         // 3. Replay the blocks on top of the low restore point.
-        self.replay_blocks(low_restore_point, blocks, slot, BlockReplay::Accurate)
+        let _replay_blocks_timer = metrics::start_timer(&metrics::REPLAY_BLOCKS_TIME_COLD);
+        self.replay_blocks(
+            low_restore_point,
+            blocks,
+            slot,
+            Some(state_root_iter),
+            BlockReplay::Accurate,
+        )
     }
 
     /// Get a suitable block root for backtracking from `high_restore_point` to the state at `slot`.
@@ -819,37 +881,24 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     fn replay_blocks(
         &self,
         mut state: BeaconState<E>,
-        mut blocks: Vec<SignedBeaconBlock<E>>,
+        blocks: Vec<SignedBeaconBlock<E>>,
         target_slot: Slot,
+        mut state_root_iter: Option<HybridForwardsStateRootsIterator<E, Hot, Cold>>,
         block_replay: BlockReplay,
     ) -> Result<BeaconState<E>, Error> {
-        if block_replay == BlockReplay::InconsistentStateRoots {
-            for i in 0..blocks.len() {
-                let prev_block_root = if i > 0 {
-                    blocks[i - 1].canonical_root()
-                } else {
-                    // Not read.
-                    Hash256::zero()
-                };
+        // If a state root iterator is provided, use it to fill in the state root when
+        // processing the block.
+        let mut state_root_from_iter = |slot| -> Option<Hash256> {
+            state_root_iter
+                .as_mut()?
+                // FIXME(frozen): better error handling
+                .filter_map(|res| res.ok())
+                .find(|(_, s)| *s == slot)
+                .map(|(state_root, _)| state_root)
+        };
 
-                let (state_root, parent_root) = match &mut blocks[i] {
-                    SignedBeaconBlock::Base(block) => (
-                        &mut block.message.state_root,
-                        &mut block.message.parent_root,
-                    ),
-                    SignedBeaconBlock::Altair(block) => (
-                        &mut block.message.state_root,
-                        &mut block.message.parent_root,
-                    ),
-                };
-
-                *state_root = Hash256::zero();
-                if i > 0 {
-                    *parent_root = prev_block_root;
-                }
-            }
-        }
-
+        // Otherwise, read the state root from the previous block. This only works for states at
+        // non-skipped slots.
         let state_root_from_prev_block = |i: usize, state: &BeaconState<E>| {
             if i > 0 {
                 let prev_block = blocks[i - 1].message();
@@ -868,20 +917,37 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 continue;
             }
 
+            let _total_timer = metrics::start_timer(&metrics::REPLAY_BLOCK_TIME);
+            let slot_timer = metrics::start_timer(&metrics::REPLAY_BLOCK_TIME_SLOT);
             while state.slot() < block.slot() {
                 let state_root = match block_replay {
-                    BlockReplay::Accurate => state_root_from_prev_block(i, &state),
+                    BlockReplay::Accurate => state_root_from_iter(state.slot())
+                        .or_else(|| state_root_from_prev_block(i, &state)),
                     BlockReplay::InconsistentStateRoots => Some(Hash256::zero()),
                 };
-                per_slot_processing(&mut state, state_root, &self.spec)
+                if state_root.is_none() {
+                    // FIXME(frozen): This shouldn't be an actual warning but it's interesting while
+                    // debugging. I think the case where we can't avoid recalculating the state root
+                    // is at skip slots, when loading a hot state with `BlockReplay::Accurate`.
+                    warn!(
+                        self.log,
+                        "Missing state root during block replay";
+                        "slot" => state.slot(),
+                    );
+                }
+                // Latest block root is the root of the parent block.
+                let latest_block_root = Some(block.parent_root());
+                per_slot_processing(&mut state, state_root, latest_block_root, &self.spec)
                     .map_err(HotColdDBError::BlockReplaySlotError)?;
             }
+            drop(slot_timer);
 
+            let _block_timer = metrics::start_timer(&metrics::REPLAY_BLOCK_TIME_BLOCK);
             per_block_processing(
                 &mut state,
                 block,
                 None,
-                BlockSignatureStrategy::NoVerification,
+                VerificationStrategy::no_verification(),
                 &self.spec,
             )
             .map_err(HotColdDBError::BlockReplayBlockError)?;
@@ -889,10 +955,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         while state.slot() < target_slot {
             let state_root = match block_replay {
-                BlockReplay::Accurate => state_root_from_prev_block(blocks.len(), &state),
+                BlockReplay::Accurate => state_root_from_iter(state.slot()),
                 BlockReplay::InconsistentStateRoots => Some(Hash256::zero()),
             };
-            per_slot_processing(&mut state, state_root, &self.spec)
+            // FIXME(frozen): could pass the latest block root here
+            per_slot_processing(&mut state, state_root, None, &self.spec)
                 .map_err(HotColdDBError::BlockReplaySlotError)?;
         }
 
@@ -1061,7 +1128,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
 /// Advance the split point of the store, moving new finalized states to the freezer.
 pub fn migrate_database<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
-    store: Arc<HotColdDB<E, Hot, Cold>>,
+    store: HotColdDB<E, Hot, Cold>,
     frozen_head_root: Hash256,
     frozen_head: &BeaconState<E>,
 ) -> Result<(), Error> {

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -1,7 +1,6 @@
 use crate::{Error, HotColdDB, ItemStore};
 use std::borrow::Cow;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use types::{
     typenum::Unsigned, BeaconState, BeaconStateError, EthSpec, Hash256, SignedBeaconBlock, Slot,
 };
@@ -14,7 +13,7 @@ use types::{
 /// case, the iterator will start returning `None` prior to genesis.
 pub trait AncestorIter<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>, I: Iterator> {
     /// Returns an iterator over the roots of the ancestors of `self`.
-    fn try_iter_ancestor_roots(&self, store: Arc<HotColdDB<E, Hot, Cold>>) -> Option<I>;
+    fn try_iter_ancestor_roots(&self, store: HotColdDB<E, Hot, Cold>) -> Option<I>;
 }
 
 impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
@@ -24,7 +23,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     /// at genesis.
     fn try_iter_ancestor_roots(
         &self,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
     ) -> Option<BlockRootsIterator<'a, E, Hot, Cold>> {
         let state = store
             .get_state(&self.message().state_root(), Some(self.slot()))
@@ -41,7 +40,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
     /// at genesis.
     fn try_iter_ancestor_roots(
         &self,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: HotColdDB<E, Hot, Cold>,
     ) -> Option<StateRootsIterator<'a, E, Hot, Cold>> {
         // The `self.clone()` here is wasteful.
         Some(StateRootsIterator::owned(store, self.clone()))
@@ -63,13 +62,13 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 }
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> StateRootsIterator<'a, T, Hot, Cold> {
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::new(store, beacon_state),
         }
     }
 
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::owned(store, beacon_state),
         }
@@ -112,14 +111,14 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> BlockRootsIterator<'a, T, Hot, Cold> {
     /// Create a new iterator over all block roots in the given `beacon_state` and prior states.
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::new(store, beacon_state),
         }
     }
 
     /// Create a new iterator over all block roots in the given `beacon_state` and prior states.
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::owned(store, beacon_state),
         }
@@ -140,7 +139,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Iterator
 
 /// Iterator over state and block roots that backtracks using the vectors from a `BeaconState`.
 pub struct RootsIterator<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> {
-    store: Arc<HotColdDB<T, Hot, Cold>>,
+    store: HotColdDB<T, Hot, Cold>,
     beacon_state: Cow<'a, BeaconState<T>>,
     slot: Slot,
 }
@@ -158,7 +157,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 }
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T, Hot, Cold> {
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             store,
             slot: beacon_state.slot(),
@@ -166,7 +165,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
         }
     }
 
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             store,
             slot: beacon_state.slot(),
@@ -174,10 +173,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
         }
     }
 
-    pub fn from_block(
-        store: Arc<HotColdDB<T, Hot, Cold>>,
-        block_hash: Hash256,
-    ) -> Result<Self, Error> {
+    pub fn from_block(store: HotColdDB<T, Hot, Cold>, block_hash: Hash256) -> Result<Self, Error> {
         let block = store
             .get_block(&block_hash)?
             .ok_or_else(|| BeaconStateError::MissingBeaconBlock(block_hash.into()))?;
@@ -202,7 +198,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
             (Err(BeaconStateError::SlotOutOfBounds), Err(BeaconStateError::SlotOutOfBounds)) => {
                 // Read a `BeaconState` from the store that has access to prior historical roots.
                 let beacon_state =
-                    next_historical_root_backtrack_state(&*self.store, &self.beacon_state)?;
+                    next_historical_root_backtrack_state(&self.store, &self.beacon_state)?;
 
                 self.beacon_state = Cow::Owned(beacon_state);
 
@@ -295,14 +291,14 @@ pub struct BlockIterator<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> 
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> BlockIterator<'a, T, Hot, Cold> {
     /// Create a new iterator over all blocks in the given `beacon_state` and prior states.
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             roots: BlockRootsIterator::new(store, beacon_state),
         }
     }
 
     /// Create a new iterator over all blocks in the given `beacon_state` and prior states.
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             roots: BlockRootsIterator::owned(store, beacon_state),
         }
@@ -374,9 +370,8 @@ mod test {
     #[test]
     fn block_root_iter() {
         let log = NullLoggerBuilder.build().unwrap();
-        let store = Arc::new(
-            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap(),
-        );
+        let store =
+            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap();
         let slots_per_historical_root = MainnetEthSpec::slots_per_historical_root();
 
         let mut state_a: BeaconState<MainnetEthSpec> = get_state();
@@ -422,9 +417,8 @@ mod test {
     #[test]
     fn state_root_iter() {
         let log = NullLoggerBuilder.build().unwrap();
-        let store = Arc::new(
-            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap(),
-        );
+        let store =
+            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap();
         let slots_per_historical_root = MainnetEthSpec::slots_per_historical_root();
 
         let mut state_a: BeaconState<MainnetEthSpec> = get_state();

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -90,6 +90,42 @@ lazy_static! {
         "store_beacon_state_write_bytes_total",
         "Total number of beacon state bytes written to the DB"
     );
+    pub static ref REPLAY_BLOCKS_TIME_HOT: Result<Histogram> = try_create_histogram(
+        "store_replay_blocks_total_time_hot",
+        "Total time to complete a replay_blocks call",
+    );
+    pub static ref REPLAY_BLOCKS_TIME_COLD: Result<Histogram> = try_create_histogram(
+        "store_replay_blocks_total_time_cold",
+        "Total time to complete a replay_blocks call",
+    );
+    pub static ref REPLAY_BLOCK_TIME: Result<Histogram> = try_create_histogram(
+        "store_replay_blocks_single",
+        "Time spent replaying a single block",
+    );
+    pub static ref REPLAY_BLOCK_TIME_SLOT: Result<Histogram> = try_create_histogram(
+        "store_replay_blocks_single_slot",
+        "Time spent replaying a single block",
+    );
+    pub static ref REPLAY_BLOCK_TIME_BLOCK: Result<Histogram> = try_create_histogram(
+        "store_replay_blocks_single_block",
+        "Time spent replaying a single block",
+    );
+    pub static ref LOAD_COLD_INTERMEDIATE_STATE_TIME: Result<Histogram> = try_create_histogram(
+        "store_load_cold_intermediate_state_time",
+        "Time spent loading a cold intermediate state",
+    );
+    pub static ref LOAD_LOW_RESTORE_POINT_TIME: Result<Histogram> = try_create_histogram(
+        "store_load_low_restore_point_time",
+        "Time required to load the low restore point for a frozen state",
+    );
+    pub static ref LOAD_HIGH_RESTORE_POINT_TIME: Result<Histogram> = try_create_histogram(
+        "store_load_high_restore_point_time",
+        "Time required to load the high restore point for a frozen state",
+    );
+    pub static ref LOAD_REPLAY_BLOCKS_TIME: Result<Histogram> = try_create_histogram(
+        "store_load_replay_blocks_time",
+        "Time spent loading blocks to replay for a frozen state",
+    );
     /*
      * Beacon Block
      */

--- a/consensus/state_processing/src/lib.rs
+++ b/consensus/state_processing/src/lib.rs
@@ -31,7 +31,7 @@ pub use genesis::{
 };
 pub use per_block_processing::{
     block_signature_verifier, errors::BlockProcessingError, per_block_processing, signature_sets,
-    BlockSignatureStrategy, BlockSignatureVerifier, VerifySignatures,
+    BlockSignatureVerifier, VerificationStrategy, VerifySignatures,
 };
 pub use per_epoch_processing::{
     errors::EpochProcessingError, process_epoch as per_epoch_processing,

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -6,7 +6,7 @@ use crate::per_block_processing::errors::{
     DepositInvalid, HeaderInvalid, IndexedAttestationInvalid, IntoWithIndex,
     ProposerSlashingInvalid,
 };
-use crate::{per_block_processing::process_operations, BlockSignatureStrategy, VerifySignatures};
+use crate::{per_block_processing::process_operations, VerificationStrategy, VerifySignatures};
 use beacon_chain::store::StoreConfig;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use lazy_static::lazy_static;
@@ -66,7 +66,7 @@ fn valid_block_ok() {
         &mut state,
         &block,
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         &spec,
     );
 
@@ -89,7 +89,7 @@ fn invalid_block_header_state_slot() {
         &mut state,
         &SignedBeaconBlock::from_block(block, signature),
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         &spec,
     );
 
@@ -117,7 +117,7 @@ fn invalid_parent_block_root() {
         &mut state,
         &SignedBeaconBlock::from_block(block, signature),
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         &spec,
     );
 
@@ -146,7 +146,7 @@ fn invalid_block_signature() {
         &mut state,
         &SignedBeaconBlock::from_block(block, Signature::empty()),
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         &spec,
     );
 
@@ -175,7 +175,7 @@ fn invalid_randao_reveal_signature() {
         &mut state,
         &signed_block,
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         &spec,
     );
 
@@ -195,8 +195,12 @@ fn valid_4_deposits() {
     let mut head_block = harness.chain.head_beacon_block().unwrap().deconstruct().0;
     *head_block.to_mut().body_mut().deposits_mut() = deposits;
 
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
 
     // Expecting Ok because these are valid deposits.
     assert_eq!(result, Ok(()));
@@ -216,8 +220,12 @@ fn invalid_deposit_deposit_count_too_big() {
 
     let big_deposit_count = NUM_DEPOSITS + 1;
     state.eth1_data_mut().deposit_count = big_deposit_count;
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
 
     // Expecting DepositCountInvalid because we incremented the deposit_count
     assert_eq!(
@@ -243,8 +251,12 @@ fn invalid_deposit_count_too_small() {
 
     let small_deposit_count = NUM_DEPOSITS - 1;
     state.eth1_data_mut().deposit_count = small_deposit_count;
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
 
     // Expecting DepositCountInvalid because we decremented the deposit_count
     assert_eq!(
@@ -272,8 +284,12 @@ fn invalid_deposit_bad_merkle_proof() {
     // Manually offsetting deposit count and index to trigger bad merkle proof
     state.eth1_data_mut().deposit_count += 1;
     *state.eth1_deposit_index_mut() += 1;
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
 
     // Expecting BadMerkleProof because the proofs were created with different indices
     assert_eq!(
@@ -298,8 +314,12 @@ fn invalid_deposit_wrong_sig() {
     let mut head_block = harness.chain.head_beacon_block().unwrap().deconstruct().0;
     *head_block.to_mut().body_mut().deposits_mut() = deposits;
 
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
     // Expecting Ok(()) even though the block signature does not correspond to the correct public key
     assert_eq!(result, Ok(()));
 }
@@ -317,8 +337,12 @@ fn invalid_deposit_invalid_pub_key() {
     let mut head_block = harness.chain.head_beacon_block().unwrap().deconstruct().0;
     *head_block.to_mut().body_mut().deposits_mut() = deposits;
 
-    let result =
-        process_operations::process_deposits(&mut state, head_block.body().deposits(), &spec);
+    let result = process_operations::process_deposits(
+        &mut state,
+        head_block.body().deposits(),
+        &VerificationStrategy::default(),
+        &spec,
+    );
 
     // Expecting Ok(()) even though we passed in invalid publickeybytes in the public key field of the deposit data.
     assert_eq!(result, Ok(()));

--- a/consensus/state_processing/src/per_epoch_processing/tests.rs
+++ b/consensus/state_processing/src/per_epoch_processing/tests.rs
@@ -83,7 +83,7 @@ mod release_tests {
         // Check the state is valid before starting this test.
         process_epoch(&mut altair_state.clone(), &spec)
             .expect("state passes intial epoch processing");
-        per_slot_processing(&mut altair_state.clone(), None, &spec)
+        per_slot_processing(&mut altair_state.clone(), None, None, &spec)
             .expect("state passes intial slot processing");
 
         // Modify the spec so altair never happens.
@@ -100,7 +100,7 @@ mod release_tests {
             Err(EpochProcessingError::InconsistentStateFork(expected_err))
         );
         assert_eq!(
-            per_slot_processing(&mut altair_state.clone(), None, &spec),
+            per_slot_processing(&mut altair_state.clone(), None, None, &spec),
             Err(SlotProcessingError::InconsistentStateFork(expected_err))
         );
     }
@@ -141,7 +141,7 @@ mod release_tests {
         // Check the state is valid before starting this test.
         process_epoch(&mut base_state.clone(), &spec)
             .expect("state passes intial epoch processing");
-        per_slot_processing(&mut base_state.clone(), None, &spec)
+        per_slot_processing(&mut base_state.clone(), None, None, &spec)
             .expect("state passes intial slot processing");
 
         // Modify the spec so Altair happens at the first epoch.
@@ -158,7 +158,7 @@ mod release_tests {
             Err(EpochProcessingError::InconsistentStateFork(expected_err))
         );
         assert_eq!(
-            per_slot_processing(&mut base_state.clone(), None, &spec),
+            per_slot_processing(&mut base_state.clone(), None, None, &spec),
             Err(SlotProcessingError::InconsistentStateFork(expected_err))
         );
     }

--- a/consensus/state_processing/src/per_slot_processing.rs
+++ b/consensus/state_processing/src/per_slot_processing.rs
@@ -25,6 +25,7 @@ impl From<ArithError> for Error {
 pub fn per_slot_processing<T: EthSpec>(
     state: &mut BeaconState<T>,
     state_root: Option<Hash256>,
+    latest_block_root: Option<Hash256>,
     spec: &ChainSpec,
 ) -> Result<Option<EpochProcessingSummary<T>>, Error> {
     // Verify that the `BeaconState` instantiation matches the fork at `state.slot()`.
@@ -32,7 +33,7 @@ pub fn per_slot_processing<T: EthSpec>(
         .fork_name(spec)
         .map_err(Error::InconsistentStateFork)?;
 
-    cache_state(state, state_root)?;
+    cache_state(state, state_root, latest_block_root)?;
 
     let summary = if state.slot() > spec.genesis_slot
         && state.slot().safe_add(1)?.safe_rem(T::slots_per_epoch())? == 0
@@ -57,6 +58,7 @@ pub fn per_slot_processing<T: EthSpec>(
 fn cache_state<T: EthSpec>(
     state: &mut BeaconState<T>,
     state_root: Option<Hash256>,
+    latest_block_root: Option<Hash256>,
 ) -> Result<(), Error> {
     let previous_state_root = if let Some(root) = state_root {
         root
@@ -80,7 +82,8 @@ fn cache_state<T: EthSpec>(
     }
 
     // Cache block root
-    let latest_block_root = state.latest_block_header().canonical_root();
+    let latest_block_root =
+        latest_block_root.unwrap_or_else(|| state.latest_block_header().canonical_root());
     state.set_block_root(previous_slot, latest_block_root)?;
 
     // Set the state slot back to what it should be.

--- a/consensus/state_processing/src/state_advance.rs
+++ b/consensus/state_processing/src/state_advance.rs
@@ -38,7 +38,7 @@ pub fn complete_state_advance<T: EthSpec>(
         // future iterations.
         let state_root_opt = state_root_opt.take();
 
-        per_slot_processing(state, state_root_opt, spec).map_err(Error::PerSlotProcessing)?;
+        per_slot_processing(state, state_root_opt, None, spec).map_err(Error::PerSlotProcessing)?;
     }
 
     Ok(())
@@ -87,7 +87,8 @@ pub fn partial_state_advance<T: EthSpec>(
         // with the correct state root.
         let state_root = initial_state_root.take().unwrap_or_else(Hash256::zero);
 
-        per_slot_processing(state, Some(state_root), spec).map_err(Error::PerSlotProcessing)?;
+        per_slot_processing(state, Some(state_root), None, spec)
+            .map_err(Error::PerSlotProcessing)?;
     }
 
     Ok(())

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -43,7 +43,7 @@ pub fn run<T: EthSpec>(testnet_dir: PathBuf, matches: &ArgMatches) -> Result<(),
 
     // Transition the parent state to the block slot.
     for i in 0..slots {
-        per_slot_processing(&mut state, None, spec)
+        per_slot_processing(&mut state, None, None, spec)
             .map_err(|e| format!("Failed to advance slot on iteration {}: {:?}", i, e))?;
     }
 

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -1,7 +1,7 @@
 use clap::ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
-use state_processing::{per_block_processing, per_slot_processing, BlockSignatureStrategy};
+use state_processing::{per_block_processing, per_slot_processing, VerificationStrategy};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -64,7 +64,7 @@ fn do_transition<T: EthSpec>(
 
     // Transition the parent state to the block slot.
     for i in pre_state.slot().as_u64()..block.slot().as_u64() {
-        per_slot_processing(&mut pre_state, None, spec)
+        per_slot_processing(&mut pre_state, None, None, spec)
             .map_err(|e| format!("Failed to advance slot on iteration {}: {:?}", i, e))?;
     }
 
@@ -76,7 +76,7 @@ fn do_transition<T: EthSpec>(
         &mut pre_state,
         &block,
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        VerificationStrategy::individual_signatures(),
         spec,
     )
     .map_err(|e| format!("State transition failed: {:?}", e))?;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -12,7 +12,7 @@ use state_processing::per_block_processing::{
         altair, base, process_attester_slashings, process_deposits, process_exits,
         process_proposer_slashings,
     },
-    process_sync_aggregate, VerifySignatures,
+    process_sync_aggregate, VerificationStrategy, VerifySignatures,
 };
 use std::fmt::Debug;
 use std::path::Path;
@@ -69,9 +69,13 @@ impl<E: EthSpec> Operation<E> for Attestation<E> {
     ) -> Result<(), BlockProcessingError> {
         let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
         match state {
-            BeaconState::Base(_) => {
-                base::process_attestations(state, &[self.clone()], VerifySignatures::True, spec)
-            }
+            BeaconState::Base(_) => base::process_attestations(
+                state,
+                &[self.clone()],
+                proposer_index,
+                VerifySignatures::True,
+                spec,
+            ),
             BeaconState::Altair(_) => altair::process_attestation(
                 state,
                 self,
@@ -112,7 +116,12 @@ impl<E: EthSpec> Operation<E> for Deposit {
         state: &mut BeaconState<E>,
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
-        process_deposits(state, &[self.clone()], spec)
+        process_deposits(
+            state,
+            &[self.clone()],
+            &VerificationStrategy::default(),
+            spec,
+        )
     }
 }
 
@@ -170,7 +179,7 @@ impl<E: EthSpec> Operation<E> for BeaconBlock<E> {
         state: &mut BeaconState<E>,
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
-        process_block_header(state, self.to_ref(), spec)?;
+        process_block_header(state, self.to_ref(), &VerificationStrategy::default(), spec)?;
         Ok(())
     }
 }

--- a/testing/ef_tests/src/cases/sanity_blocks.rs
+++ b/testing/ef_tests/src/cases/sanity_blocks.rs
@@ -4,7 +4,7 @@ use crate::case_result::compare_beacon_state_results_without_caches;
 use crate::decode::{ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use serde_derive::Deserialize;
 use state_processing::{
-    per_block_processing, per_slot_processing, BlockProcessingError, BlockSignatureStrategy,
+    per_block_processing, per_slot_processing, BlockProcessingError, VerificationStrategy,
 };
 use types::{BeaconState, EthSpec, ForkName, RelativeEpoch, SignedBeaconBlock};
 
@@ -81,8 +81,8 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
             .try_for_each(|signed_block| {
                 let block = signed_block.message();
                 while bulk_state.slot() < block.slot() {
-                    per_slot_processing(&mut bulk_state, None, spec).unwrap();
-                    per_slot_processing(&mut indiv_state, None, spec).unwrap();
+                    per_slot_processing(&mut bulk_state, None, None, spec).unwrap();
+                    per_slot_processing(&mut indiv_state, None, None, spec).unwrap();
                 }
 
                 bulk_state
@@ -97,7 +97,7 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
                     &mut indiv_state,
                     signed_block,
                     None,
-                    BlockSignatureStrategy::VerifyIndividual,
+                    VerificationStrategy::individual_signatures(),
                     spec,
                 )?;
 
@@ -105,7 +105,7 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
                     &mut bulk_state,
                     signed_block,
                     None,
-                    BlockSignatureStrategy::VerifyBulk,
+                    VerificationStrategy::bulk_signatures(),
                     spec,
                 )?;
 

--- a/testing/ef_tests/src/cases/sanity_slots.rs
+++ b/testing/ef_tests/src/cases/sanity_slots.rs
@@ -67,7 +67,7 @@ impl<E: EthSpec> Case for SanitySlots<E> {
         state.build_all_caches(spec).unwrap();
 
         let mut result = (0..self.slots)
-            .try_for_each(|_| per_slot_processing(&mut state, None, spec).map(|_| ()))
+            .try_for_each(|_| per_slot_processing(&mut state, None, None, spec).map(|_| ()))
             .map(|_| state);
 
         compare_beacon_state_results_without_caches(&mut result, &mut expected)

--- a/testing/ef_tests/src/cases/transition.rs
+++ b/testing/ef_tests/src/cases/transition.rs
@@ -3,7 +3,7 @@ use crate::case_result::compare_beacon_state_results_without_caches;
 use crate::decode::{ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use serde_derive::Deserialize;
 use state_processing::{
-    per_block_processing, state_advance::complete_state_advance, BlockSignatureStrategy,
+    per_block_processing, state_advance::complete_state_advance, VerificationStrategy,
 };
 use std::str::FromStr;
 use types::{BeaconState, Epoch, ForkName, SignedBeaconBlock};
@@ -90,7 +90,7 @@ impl<E: EthSpec> Case for TransitionTest<E> {
                     &mut state,
                     block,
                     None,
-                    BlockSignatureStrategy::VerifyBulk,
+                    VerificationStrategy::bulk_signatures(),
                     spec,
                 )
                 .map_err(|e| format!("Block processing failed: {:?}", e))?;

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -2,7 +2,7 @@ use super::*;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use state_processing::{
     per_block_processing, per_block_processing::errors::ExitInvalid, BlockProcessingError,
-    BlockSignatureStrategy,
+    VerificationStrategy,
 };
 use types::{BeaconBlock, BeaconState, Epoch, EthSpec, SignedBeaconBlock};
 
@@ -65,7 +65,7 @@ impl ExitTest {
             state,
             block,
             None,
-            BlockSignatureStrategy::VerifyIndividual,
+            VerificationStrategy::individual_signatures(),
             &E::default_spec(),
         )
     }


### PR DESCRIPTION
## Proposed Changes

This is an experimental branch attempting to speed up loading of states from the freezer DB.

* Use the state root iterator to avoid re-calculating state hashes during block replay.
* Push the `Arc` down into the `HotColdDB`. We should do this anyway even if this branch doesn't end up getting merged.
* Some consensus optimisations: proposer index is threaded through rather than re-calculated. Related:
    * #598
    * #2371