### PR TITLE
Relax enr predicate

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -737,7 +737,11 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
         };
         // predicate for finding nodes with a matching fork and valid tcp port
         let eth2_fork_predicate = move |enr: &Enr| {
-            enr.eth2() == Ok(enr_fork_id.clone()) && (enr.tcp().is_some() || enr.tcp6().is_some())
+            // `next_fork_epoch` and `next_fork_version` can be different so that
+            // we can connect to peers who aren't compatible with an upcoming fork.
+            // `fork_digest` **must** be same.
+            enr.eth2().map(|e| e.fork_digest) == Ok(enr_fork_id.fork_digest)
+                && (enr.tcp().is_some() || enr.tcp6().is_some())
         };
 
         // General predicate


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

This PR is in preparation for altair. 
Currently, we return a peer on a discovery search only if our entire `EnrForkId` matches with the discovered peer. This would be an issue once there are altair enabled nodes in the network with different values for `next_fork_digest` and `next_fork_epoch`. In this case, non-altair enabled nodes would reject altair enabled nodes in the discovery search. 

This PR relaxes the predicate to match only the `current_fork_digest`.

