### PR TITLE
Bleeding edge discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,7 +1538,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.5"
-source = "git+https://github.com/sigp/discv5?rev=4558ff41f38ca935067726b67a97e31317115c78#4558ff41f38ca935067726b67a97e31317115c78"
+source = "git+https://github.com/sigp/discv5?rev=f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d#f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1537,8 +1537,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.1.0-beta.5"
-source = "git+https://github.com/sigp/discv5?rev=f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d#f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d"
+version = "0.1.0-beta.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e28f2a50af946c29ce33d0c5ad9c33d2df172176d57c4b4b40295a9cfcf07ae"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,8 +1538,7 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 [[package]]
 name = "discv5"
 version = "0.1.0-beta.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5a5132ff1173d356fd78d09cd33d82fe8f7e6b4016d8c891edf2680a8cebe6"
+source = "git+https://github.com/sigp/discv5?rev=4558ff41f38ca935067726b67a97e31317115c78#4558ff41f38ca935067726b67a97e31317115c78"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -27,7 +27,7 @@ eth2_wallet = { path = "../crypto/eth2_wallet" }
 eth2_wallet_manager = { path = "../common/eth2_wallet_manager" }
 rand = "0.7.3"
 validator_dir = { path = "../common/validator_dir" }
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 eth2_keystore = { path = "../crypto/eth2_keystore" }
 account_utils = { path = "../common/account_utils" }
 slashing_protection = { path = "../validator_client/slashing_protection" }

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -26,7 +26,7 @@ slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_tr
 slog-term = "2.6.0"
 slog-async = "2.5.0"
 ctrlc = { version = "3.1.6", features = ["termination"] }
-tokio = { version = "1.1.0", features = ["time"] }
+tokio = { version = "1.7.1", features = ["time"] }
 exit-future = "0.2.0"
 dirs = "3.0.1"
 logging = { path = "../common/logging" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -40,7 +40,7 @@ eth2_ssz_derive = "0.1.0"
 state_processing = { path = "../../consensus/state_processing" }
 tree_hash = "0.1.1"
 types = { path = "../../consensus/types" }
-tokio = "1.1.0"
+tokio = "1.7.1"
 eth1 = { path = "../eth1" }
 futures = "0.3.7"
 genesis = { path = "../genesis" }

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -26,7 +26,7 @@ error-chain = "0.12.4"
 serde_yaml = "0.8.13"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 slog-async = "2.5.0"
-tokio = "1.1.0"
+tokio = "1.7.1"
 dirs = "3.0.1"
 futures = "0.3.7"
 reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -26,7 +26,7 @@ tree_hash = "0.1.1"
 eth2_hashing = "0.1.0"
 parking_lot = "0.11.0"
 slog = "2.5.2"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 state_processing = { path = "../../consensus/state_processing" }
 libflate = "1.0.2"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics"}

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-discv5 = { version = "0.1.0-beta.5", features = ["libp2p"] }
+#discv5 = { version = "0.1.0-beta.5", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5", rev = "4558ff41f38ca935067726b67a97e31317115c78", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }
@@ -16,7 +17,7 @@ eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 lighthouse_version = { path = "../../common/lighthouse_version" }
-tokio = { version = "1.1.0", features = ["time", "macros"] }
+tokio = { version = "1.7.1", features = ["time", "macros"] }
 futures = "0.3.7"
 futures-io = "0.3.7"
 error-chain = "0.12.4"
@@ -47,7 +48,7 @@ default-features = false
 features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns-tokio", "tcp-tokio"]
 
 [dev-dependencies]
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 slog-term = "2.6.0"
 slog-async = "2.5.0"
 tempfile = "3.1.0"

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 #discv5 = { version = "0.1.0-beta.5", features = ["libp2p"] }
-discv5 = { git = "https://github.com/sigp/discv5", rev = "4558ff41f38ca935067726b67a97e31317115c78", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5", rev = "f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-#discv5 = { version = "0.1.0-beta.5", features = ["libp2p"] }
-discv5 = { git = "https://github.com/sigp/discv5", rev = "f180c5bcb7a1ddeff0754cf0b6b7ce2e2a7d402d", features = ["libp2p"] }
+discv5 = { version = "0.1.0-beta.6", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }

--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -151,6 +151,16 @@ impl Default for Config {
             .build()
             .expect("valid gossipsub configuration");
 
+        // Discv5 Unsolicited Packet Rate Limiter
+        let filter_rate_limiter = Some(
+            discv5::RateLimiterBuilder::new()
+                .total_n_every(10, Duration::from_secs(1)) // Allow bursts, average 10 per second
+                .ip_n_every(9, Duration::from_secs(1)) // Allow bursts, average 9 per second
+                .node_n_every(8, Duration::from_secs(1)) // Allow bursts, average 8 per second
+                .build()
+                .expect("The total rate limit has been specified"),
+        );
+
         // discv5 configuration
         let discv5_config = Discv5ConfigBuilder::new()
             .enable_packet_filter()
@@ -164,6 +174,10 @@ impl Default for Config {
             .disable_report_discovered_peers()
             .ip_limit() // limits /24 IP's in buckets.
             .incoming_bucket_limit(8) // half the bucket size
+            .filter_rate_limiter(filter_rate_limiter)
+            .filter_max_bans_per_ip(Some(5))
+            .filter_max_nodes_per_ip(Some(10))
+            .ban_duration(Some(Duration::from_secs(3600)))
             .ping_interval(Duration::from_secs(300))
             .build();
 

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -497,13 +497,13 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
         // first try and convert the peer_id to a node_id.
         if let Ok(node_id) = peer_id_to_node_id(peer_id) {
             // If we could convert this peer id, remove it from the DHT and ban it from discovery.
-            self.discv5.ban_node(&node_id);
+            self.discv5.ban_node(&node_id, None);
             // Remove the node from the routing table.
             self.discv5.remove_node(&node_id);
         }
 
         for ip_address in ip_addresses {
-            self.discv5.ban_ip(ip_address);
+            self.discv5.ban_ip(ip_address, None);
         }
     }
 
@@ -512,11 +512,11 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
         // first try and convert the peer_id to a node_id.
         if let Ok(node_id) = peer_id_to_node_id(peer_id) {
             // If we could convert this peer id, remove it from the DHT and ban it from discovery.
-            self.discv5.permit_node(&node_id);
+            self.discv5.ban_node_remove(&node_id);
         }
 
         for ip_address in ip_addresses {
-            self.discv5.permit_ip(ip_address);
+            self.discv5.ban_ip_remove(&ip_address);
         }
     }
 

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -944,7 +944,9 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                             *self.network_globals.local_enr.write() = enr;
                             return Poll::Ready(DiscoveryEvent::SocketUpdated(socket));
                         }
-                        Discv5Event::EnrAdded { .. } | Discv5Event::TalkRequest(_) | Discv5Event::NodeInserted { .. } => {} // Ignore all other discv5 server events
+                        Discv5Event::EnrAdded { .. }
+                        | Discv5Event::TalkRequest(_)
+                        | Discv5Event::NodeInserted { .. } => {} // Ignore all other discv5 server events
                     }
                 }
             }

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -944,7 +944,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                             *self.network_globals.local_enr.write() = enr;
                             return Poll::Ready(DiscoveryEvent::SocketUpdated(socket));
                         }
-                        _ => {} // Ignore all other discv5 server events
+                        Discv5Event::EnrAdded { .. } | Discv5Event::TalkRequest(_) | Discv5Event::NodeInserted { .. } => {} // Ignore all other discv5 server events
                     }
                 }
             }

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -20,7 +20,7 @@ merkle_proof = { path = "../../consensus/merkle_proof" }
 eth2_ssz = "0.1.2"
 eth2_hashing = "0.1.0"
 tree_hash = "0.1.1"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 parking_lot = "0.11.0"
 slog = "2.5.2"
 exit-future = "0.2.0"

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.1.0", features = ["macros","sync"] }
+tokio = { version = "1.7.1", features = ["macros","sync"] }
 tokio-stream = { version = "0.1.3", features = ["sync"] }
 tokio-util = "0.6.3"
 parking_lot = "0.11.0"

--- a/beacon_node/http_metrics/Cargo.toml
+++ b/beacon_node/http_metrics/Cargo.toml
@@ -23,7 +23,7 @@ warp_utils = { path = "../../common/warp_utils" }
 malloc_utils = { path = "../../common/malloc_utils" }
 
 [dev-dependencies]
-tokio = { version = "1.1.0", features = ["sync"] }
+tokio = { version = "1.7.1", features = ["sync"] }
 reqwest = { version = "0.11.0", features = ["json"] }
 environment = { path = "../../lighthouse/environment" }
 types = { path = "../../consensus/types" }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -31,7 +31,7 @@ eth2_ssz_types = { path =  "../../consensus/ssz_types" }
 tree_hash = "0.1.1"
 futures = "0.3.7"
 error-chain = "0.12.4"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 tokio-stream = "0.1.3"
 parking_lot = "0.11.0"
 smallvec = "1.6.1"

--- a/beacon_node/timer/Cargo.toml
+++ b/beacon_node/timer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 beacon_chain =  { path = "../beacon_chain" }
 types = { path = "../../consensus/types" }
 slot_clock = { path = "../../common/slot_clock" }
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 slog = "2.5.2"
 parking_lot = "0.11.0"
 futures = "0.3.7"

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -13,7 +13,7 @@ eth2_network_config = { path = "../common/eth2_network_config" }
 eth2_ssz = "0.1.2"
 slog = "2.5.2"
 sloggers = "1.0.1"
-tokio = "1.1.0"
+tokio = "1.7.1"
 log = "0.4.11"
 slog-term = "2.6.0"
 logging = { path = "../common/logging" }

--- a/boot_node/src/server.rs
+++ b/boot_node/src/server.rs
@@ -89,6 +89,7 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
                         // Ignore these events here
                     }
                     Discv5Event::EnrAdded { .. } => {}     // Ignore
+                    Discv5Event::TalkRequest(_)  => {}     // Ignore
                     Discv5Event::NodeInserted { .. } => {} // Ignore
                     Discv5Event::SocketUpdated(socket_addr) => {
                         info!(log, "External socket address updated"; "socket_addr" => format!("{:?}", socket_addr));

--- a/common/hashset_delay/Cargo.toml
+++ b/common/hashset_delay/Cargo.toml
@@ -9,4 +9,4 @@ futures = "0.3.7"
 tokio-util = { version = "0.6.2", features = ["time"] }
 
 [dev-dependencies]
-tokio = { version = "1.1.0", features = ["time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.7.1", features = ["time", "rt-multi-thread", "macros"] }

--- a/common/monitoring_api/Cargo.toml
+++ b/common/monitoring_api/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 reqwest = { version = "0.11.0", features = ["json","stream"] }
 futures = "0.3.7"
 task_executor = { path = "../task_executor" }
-tokio = "1.1.0"
+tokio = "1.7.1"
 eth2 = {path = "../eth2"}
 serde_json = "1.0.58"
 serde = "1.0.116"

--- a/common/remote_signer_consumer/Cargo.toml
+++ b/common/remote_signer_consumer/Cargo.toml
@@ -11,6 +11,6 @@ remote_signer_test = { path = "../../testing/remote_signer_test" }
 [dependencies]
 reqwest = { version = "0.11.0", features = ["json"] }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.1.0", features = ["time"] }
+tokio = { version = "1.7.1", features = ["time"] }
 types = { path = "../../consensus/types" }
 sensitive_url = { path = "../sensitive_url" }

--- a/common/task_executor/Cargo.toml
+++ b/common/task_executor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.1.0", features = ["rt"] }
+tokio = { version = "1.7.1", features = ["rt"] }
 slog = "2.5.2"
 futures = "0.3.7"
 exit-future = "0.2.0"

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -14,7 +14,7 @@ beacon_chain = { path = "../../beacon_node/beacon_chain" }
 state_processing = { path = "../../consensus/state_processing" }
 safe_arith = { path = "../../consensus/safe_arith" }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.1.0", features = ["sync"] }
+tokio = { version = "1.7.1", features = ["sync"] }
 headers = "0.3.2"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -27,7 +27,7 @@ dirs = "3.0.1"
 genesis = { path = "../beacon_node/genesis" }
 deposit_contract = { path = "../common/deposit_contract" }
 tree_hash = "0.1.1"
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 clap_utils = { path = "../common/clap_utils" }
 eth2_libp2p = { path = "../beacon_node/eth2_libp2p" }
 validator_dir = { path = "../common/validator_dir", features = ["insecure_keys"] }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -21,7 +21,7 @@ spec-v12 = []
 
 [dependencies]
 beacon_node = { "path" = "../beacon_node" }
-tokio = "1.1.0"
+tokio = "1.7.1"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.1"
 types = { "path" = "../consensus/types" }

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.1.0", features = ["macros", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.7.1", features = ["macros", "rt", "rt-multi-thread" ] }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.1"
 types = { "path" = "../../consensus/types" }

--- a/slasher/service/Cargo.toml
+++ b/slasher/service/Cargo.toml
@@ -14,6 +14,6 @@ slog = "2.5.2"
 slot_clock = { path = "../../common/slot_clock" }
 state_processing = { path = "../../consensus/state_processing" }
 task_executor = { path = "../../common/task_executor" }
-tokio = { version = "1.1.0", features = ["full"] }
+tokio = { version = "1.7.1", features = ["full"] }
 tokio-stream = "0.1.3"
 types = { path = "../../consensus/types" }

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.1.0", features = ["time"] }
+tokio = { version = "1.7.1", features = ["time"] }
 tokio-compat-02 = "0.1"
 web3 = "0.14.0"
 futures = "0.3.7"

--- a/testing/remote_signer_test/Cargo.toml
+++ b/testing/remote_signer_test/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
 tempfile = "3.1.0"
-tokio = { version = "1.1.0", features = ["time"] }
+tokio = { version = "1.7.1", features = ["time"] }
 types = { path = "../../consensus/types" }
 sensitive_url = { path = "../../common/sensitive_url" }
 

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -13,7 +13,7 @@ types = { path = "../../consensus/types" }
 validator_client = { path = "../../validator_client" }
 parking_lot = "0.11.0"
 futures = "0.3.7"
-tokio = "1.1.0"
+tokio = "1.7.1"
 eth1_test_rig = { path = "../eth1_test_rig" }
 env_logger = "0.8.2"
 clap = "2.33.3"

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -9,7 +9,7 @@ name = "validator_client"
 path = "src/lib.rs"
 
 [dev-dependencies]
-tokio = { version = "1.1.0", features = ["time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.7.1", features = ["time", "rt-multi-thread", "macros"] }
 deposit_contract = { path = "../common/deposit_contract" }
 
 [dependencies]
@@ -30,7 +30,7 @@ serde_yaml = "0.8.13"
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "2.5.0"
 slog-term = "2.6.0"
-tokio = { version = "1.1.0", features = ["time"] }
+tokio = { version = "1.7.1", features = ["time"] }
 futures = "0.3.7"
 dirs = "3.0.1"
 directory = { path = "../common/directory" }


### PR DESCRIPTION
This updates discovery to the latest version. 

The changes include a more sophisticated rate-limiter, which can lead to more prevalent bans at the discovery level. Discovery now ban's nodes at the UDP level for a finite amount of time. Additionally bans that occur in lighthouse are propagated down to discovery also. 

A number of smaller improvements have also been made relating to timeouts of WHOAREYOU messages and logging.

The tokio version inside lighthouse has also been updated to the latest version.
