### PR TITLE
[Merged by Bors] - Capture a missed VC error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "slog-term",
  "slot_clock",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "validator_dir",
 ]
@@ -597,7 +597,7 @@ dependencies = [
  "strum",
  "task_executor",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tree_hash",
  "types",
 ]
@@ -636,7 +636,7 @@ dependencies = [
  "slog-term",
  "store",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
 ]
 
@@ -825,7 +825,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "sloggers 1.0.1",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
 ]
 
@@ -1086,7 +1086,7 @@ dependencies = [
  "task_executor",
  "time 0.2.27",
  "timer",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "toml",
  "tree_hash",
  "types",
@@ -1627,7 +1627,7 @@ dependencies = [
  "rlp 0.5.0",
  "sha2 0.9.5",
  "smallvec",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -1800,7 +1800,7 @@ dependencies = [
  "slog-term",
  "sloggers 1.0.1",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
 ]
 
@@ -1840,7 +1840,7 @@ dependencies = [
  "sloggers 1.0.1",
  "state_processing",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-compat-02",
  "toml",
  "tree_hash",
@@ -1855,7 +1855,7 @@ dependencies = [
  "deposit_contract",
  "futures",
  "serde_json",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-compat-02",
  "types",
  "web3",
@@ -1996,7 +1996,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "tiny-keccak 2.0.2",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-io-timeout",
  "tokio-util",
  "types",
@@ -2511,7 +2511,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "state_processing",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-compat-02",
  "tree_hash",
  "types",
@@ -2631,7 +2631,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-util",
  "tracing",
 ]
@@ -2671,7 +2671,7 @@ name = "hashset_delay"
 version = "0.2.0"
 dependencies = [
  "futures",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-util",
 ]
 
@@ -2839,7 +2839,7 @@ dependencies = [
  "slot_clock",
  "state_processing",
  "store",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "tokio-util",
  "tree_hash",
@@ -2866,7 +2866,7 @@ dependencies = [
  "slog",
  "slot_clock",
  "store",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "warp",
  "warp_utils",
@@ -2908,7 +2908,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -2935,7 +2935,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.0",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tower-service",
  "tracing",
  "want",
@@ -2950,7 +2950,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-native-tls",
 ]
 
@@ -3295,7 +3295,7 @@ dependencies = [
  "serde_yaml",
  "simple_logger",
  "state_processing",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tree_hash",
  "types",
  "validator_dir",
@@ -3603,7 +3603,7 @@ dependencies = [
  "libp2p-core 0.27.1",
  "log",
  "socket2 0.3.19",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -3708,7 +3708,7 @@ dependencies = [
  "target_check",
  "task_executor",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "validator_client",
  "validator_dir",
@@ -3963,7 +3963,7 @@ dependencies = [
  "slog",
  "store",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -4089,7 +4089,7 @@ dependencies = [
  "strum",
  "task_executor",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "tokio-util",
  "tree_hash",
@@ -5160,7 +5160,7 @@ dependencies = [
  "reqwest",
  "sensitive_url",
  "serde",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
 ]
 
@@ -5179,7 +5179,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "winapi",
  "windows-acl",
@@ -5220,7 +5220,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -5745,7 +5745,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "sensitive_url",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "validator_client",
 ]
@@ -5804,7 +5804,7 @@ dependencies = [
  "slot_clock",
  "state_processing",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "types",
 ]
@@ -6300,7 +6300,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "slog",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -6450,7 +6450,7 @@ dependencies = [
  "slog",
  "slot_clock",
  "task_executor",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
 ]
 
@@ -6529,9 +6529,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.7.1"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb2ed024293bb19f7a5dc54fe83bf86532a44c12a2bb8ba40d64a4509395ca2"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -6557,7 +6557,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite 0.2.7",
  "tokio 0.2.25",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
 ]
 
@@ -6568,7 +6568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -6589,7 +6589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -6600,7 +6600,7 @@ checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-util",
 ]
 
@@ -6613,7 +6613,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 1.0.7",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tungstenite",
 ]
 
@@ -6630,7 +6630,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.7",
  "slab",
- "tokio 1.7.1",
+ "tokio 1.8.1",
 ]
 
 [[package]]
@@ -7059,7 +7059,7 @@ dependencies = [
  "slog-term",
  "slot_clock",
  "tempfile",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tree_hash",
  "types",
  "validator_dir",
@@ -7167,7 +7167,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -7188,7 +7188,7 @@ dependencies = [
  "safe_arith",
  "serde",
  "state_processing",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "types",
  "warp",
 ]
@@ -7349,7 +7349,7 @@ dependencies = [
  "serde_json",
  "soketto",
  "tiny-keccak 2.0.2",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "tokio-stream",
  "tokio-util",
  "url",
@@ -7364,7 +7364,7 @@ checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
 dependencies = [
  "native-tls",
  "thiserror",
- "tokio 1.7.1",
+ "tokio 1.8.1",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "eth2_wallet",
  "eth2_wallet_manager",
  "filesystem",
- "futures 0.3.15",
+ "futures",
  "hex",
  "libc",
  "rand 0.7.3",
@@ -197,7 +197,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ dependencies = [
  "slab",
  "socket2 0.4.0",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -368,18 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e9e7a929bd34c68a82d58a4de7f86fffdaf97fb2af850162a7bb19dd7269b33"
-dependencies = [
- "native-tls",
- "thiserror",
- "tokio 0.2.25",
- "url",
 ]
 
 [[package]]
@@ -405,7 +393,7 @@ dependencies = [
  "libc",
  "once_cell",
  "signal-hook",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -500,7 +488,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -535,12 +523,6 @@ name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
-name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -582,7 +564,7 @@ dependencies = [
  "eth2_ssz_types",
  "exit-future",
  "fork_choice",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "int_to_bytes",
  "integer-sqrt",
@@ -637,10 +619,10 @@ dependencies = [
  "eth2_network_config",
  "eth2_ssz",
  "exit-future",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "hex",
- "hyper 0.14.9",
+ "hyper",
  "lighthouse_version",
  "logging",
  "monitoring_api",
@@ -801,7 +783,7 @@ dependencies = [
  "blst",
  "eth2_hashing",
  "eth2_ssz",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "hex",
  "milagro_bls",
  "rand 0.7.3",
@@ -833,7 +815,7 @@ dependencies = [
  "eth2_libp2p",
  "eth2_network_config",
  "eth2_ssz",
- "futures 0.3.15",
+ "futures",
  "hex",
  "log",
  "logging",
@@ -888,6 +870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,12 +892,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
 name = "bytes"
@@ -952,7 +934,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "quickcheck",
  "quickcheck_macros",
  "smallvec",
@@ -1019,7 +1001,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time 0.1.43",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1080,7 +1062,7 @@ dependencies = [
  "eth2_config",
  "eth2_libp2p",
  "eth2_ssz",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "http_api",
  "http_metrics",
@@ -1128,7 +1110,7 @@ checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
 dependencies = [
  "atty",
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1397,7 +1379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
 dependencies = [
  "nix 0.20.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1412,7 +1394,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2 0.4.0",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1428,7 +1410,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1481,7 +1463,7 @@ name = "deposit_contract"
 version = "0.2.0"
 dependencies = [
  "eth2_ssz",
- "ethabi",
+ "ethabi 12.0.0",
  "hex",
  "reqwest",
  "serde_json",
@@ -1601,7 +1583,7 @@ checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1612,7 +1594,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1633,7 +1615,7 @@ dependencies = [
  "digest 0.9.0",
  "enr",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "hex",
  "hkdf",
  "lazy_static",
@@ -1647,7 +1629,7 @@ dependencies = [
  "smallvec",
  "tokio 1.7.1",
  "tokio-stream",
- "tokio-util 0.6.7",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uint 0.9.1",
@@ -1704,7 +1686,7 @@ dependencies = [
  "compare_fields",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "hex",
  "rayon",
  "serde",
@@ -1809,7 +1791,7 @@ dependencies = [
  "eth2_config",
  "eth2_network_config",
  "exit-future",
- "futures 0.3.15",
+ "futures",
  "logging",
  "parking_lot",
  "slog",
@@ -1843,7 +1825,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "fallback",
- "futures 0.3.15",
+ "futures",
  "hex",
  "lazy_static",
  "libflate",
@@ -1871,7 +1853,7 @@ name = "eth1_test_rig"
 version = "0.2.0"
 dependencies = [
  "deposit_contract",
- "futures 0.3.15",
+ "futures",
  "serde_json",
  "tokio 1.7.1",
  "tokio-compat-02",
@@ -1889,7 +1871,7 @@ dependencies = [
  "eth2_libp2p",
  "eth2_ssz",
  "eth2_ssz_derive",
- "futures 0.3.15",
+ "futures",
  "futures-util",
  "hex",
  "libsecp256k1",
@@ -1990,7 +1972,7 @@ dependencies = [
  "eth2_ssz_types",
  "exit-future",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "futures-io",
  "hashset_delay",
  "hex",
@@ -2016,7 +1998,7 @@ dependencies = [
  "tiny-keccak 2.0.2",
  "tokio 1.7.1",
  "tokio-io-timeout",
- "tokio-util 0.6.7",
+ "tokio-util",
  "types",
  "unsigned-varint 0.6.0",
  "void",
@@ -2041,7 +2023,7 @@ name = "eth2_ssz"
 version = "0.1.2"
 dependencies = [
  "eth2_ssz_derive",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "smallvec",
 ]
 
@@ -2100,12 +2082,28 @@ version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "rustc-hex",
  "serde",
  "serde_json",
  "tiny-keccak 1.5.0",
  "uint 0.8.5",
+]
+
+[[package]]
+name = "ethabi"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c52991643379afc90bfe2df3c64d53983e59c35a82ba6e75c997cfc2880d8524"
+dependencies = [
+ "anyhow",
+ "ethereum-types 0.11.0",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -2115,8 +2113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
 dependencies = [
  "crunchy",
- "fixed-hash",
- "impl-rlp",
+ "fixed-hash 0.6.1",
+ "impl-rlp 0.2.1",
+ "impl-serde",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
  "impl-serde",
  "tiny-keccak 2.0.2",
 ]
@@ -2127,12 +2138,26 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
 dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
+ "ethbloom 0.9.2",
+ "fixed-hash 0.6.1",
+ "impl-rlp 0.2.1",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.7.3",
  "uint 0.8.5",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+dependencies = [
+ "ethbloom 0.11.0",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "primitive-types 0.9.1",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -2147,7 +2172,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e43f2f1833d64e33f15592464d6fdd70f349dda7b1a53088eb83cd94014008c5"
 dependencies = [
- "futures 0.3.15",
+ "futures",
 ]
 
 [[package]]
@@ -2209,7 +2234,7 @@ dependencies = [
 name = "filesystem"
 version = "0.1.0"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
  "windows-acl",
 ]
 
@@ -2222,6 +2247,18 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "rand 0.7.3",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2299,36 +2336,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
-
-[[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -2486,7 +2501,7 @@ dependencies = [
  "eth2_hashing",
  "eth2_ssz",
  "exit-future",
- "futures 0.3.15",
+ "futures",
  "int_to_bytes",
  "merkle_proof",
  "parking_lot",
@@ -2604,26 +2619,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
-dependencies = [
- "bytes 0.5.6",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio 0.2.25",
- "tokio-util 0.3.1",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
@@ -2637,7 +2632,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 1.7.1",
- "tokio-util 0.6.7",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2675,9 +2670,9 @@ dependencies = [
 name = "hashset_delay"
 version = "0.2.0"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "tokio 1.7.1",
- "tokio-util 0.6.7",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2809,16 +2804,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
-dependencies = [
- "bytes 0.5.6",
- "http",
-]
-
-[[package]]
-name = "http-body"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
@@ -2841,7 +2826,7 @@ dependencies = [
  "eth2_libp2p",
  "eth2_ssz",
  "fork_choice",
- "futures 0.3.15",
+ "futures",
  "hex",
  "lazy_static",
  "lighthouse_metrics",
@@ -2856,7 +2841,7 @@ dependencies = [
  "store",
  "tokio 1.7.1",
  "tokio-stream",
- "tokio-util 0.6.7",
+ "tokio-util",
  "tree_hash",
  "types",
  "warp",
@@ -2895,12 +2880,6 @@ checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
@@ -2919,7 +2898,7 @@ dependencies = [
  "crossbeam-utils",
  "difference",
  "futures-util",
- "hyper 0.14.9",
+ "hyper",
  "isahc",
  "lazy_static",
  "levenshtein",
@@ -2940,30 +2919,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
-dependencies = [
- "bytes 0.5.6",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.2.7",
- "http",
- "http-body 0.3.1",
- "httparse",
- "httpdate 0.3.2",
- "itoa",
- "pin-project 1.0.7",
- "socket2 0.3.19",
- "tokio 0.2.25",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
@@ -2972,11 +2927,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.3",
+ "h2",
  "http",
- "http-body 0.4.2",
+ "http-body",
  "httparse",
- "httpdate 1.0.1",
+ "httpdate",
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.0",
@@ -2987,44 +2942,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-proxy"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ec5be69758dfc06b9b29efa9d6e9306e387c85eb362c603912eead2ad98c7"
-dependencies = [
- "bytes 0.5.6",
- "futures 0.3.15",
- "http",
- "hyper 0.13.10",
- "hyper-tls 0.4.3",
- "native-tls",
- "tokio 0.2.25",
- "tokio-tls",
- "tower-service",
- "typed-headers",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
-dependencies = [
- "bytes 0.5.6",
- "hyper 0.13.10",
- "native-tls",
- "tokio 0.2.25",
- "tokio-tls",
-]
-
-[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes 1.0.1",
- "hyper 0.14.9",
+ "hyper",
  "native-tls",
  "tokio 1.7.1",
  "tokio-native-tls",
@@ -3049,7 +2973,7 @@ checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
 dependencies = [
  "if-addrs-sys",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3069,13 +2993,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b8538953a3f0d0d3868f0a706eb4273535e10d72acb5c82c1c23ae48835c85"
 dependencies = [
  "async-io",
- "futures 0.3.15",
+ "futures",
  "futures-lite",
  "if-addrs",
  "ipnet",
  "libc",
  "log",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3097,7 +3021,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 1.3.7",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec 2.2.0",
 ]
 
 [[package]]
@@ -3110,12 +3043,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp 0.5.0",
+]
+
+[[package]]
 name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3162,15 +3115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "276ec31bcb4a9ee45f58bec6f9ec700ae4cf4f4f8f2fa7e06cb406bd5ffdd770"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3240,11 +3184,13 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "15.1.0"
+version = "17.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0745a6379e3edc893c84ec203589790774e4247420033e71a76d3ab4687991fa"
+checksum = "d4467ab6dfa369b69e52bd0692e480c4d117410538526a57a304a0f2250fd95e"
 dependencies = [
- "futures 0.1.31",
+ "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "serde",
  "serde_derive",
@@ -3268,16 +3214,6 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
-
-[[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
 
 [[package]]
 name = "kv-log-macro"
@@ -3347,7 +3283,7 @@ dependencies = [
  "eth2_network_config",
  "eth2_ssz",
  "eth2_wallet",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "hex",
  "lighthouse_version",
@@ -3444,7 +3380,7 @@ checksum = "adc225a49973cf9ab10d0cdd6a4b8f0cda299df9b760824bbb623f15f8f0c95a"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
- "futures 0.3.15",
+ "futures",
  "lazy_static",
  "libp2p-core 0.27.1",
  "libp2p-dns",
@@ -3475,7 +3411,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
@@ -3509,7 +3445,7 @@ dependencies = [
  "ed25519-dalek",
  "either",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "futures-timer",
  "lazy_static",
  "libsecp256k1",
@@ -3538,7 +3474,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "libp2p-core 0.27.1",
  "log",
 ]
@@ -3554,7 +3490,7 @@ dependencies = [
  "byteorder",
  "bytes 1.0.1",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "hex_fmt",
  "libp2p-core 0.27.1",
  "libp2p-swarm",
@@ -3575,7 +3511,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "libp2p-core 0.27.1",
  "libp2p-swarm",
  "log",
@@ -3593,7 +3529,7 @@ checksum = "350ce8b3923594aedabd5d6e3f875d058435052a29c3f32df378bc70d10be464"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
- "futures 0.3.15",
+ "futures",
  "libp2p-core 0.27.1",
  "log",
  "nohash-hasher",
@@ -3611,7 +3547,7 @@ checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
  "bytes 1.0.1",
  "curve25519-dalek",
- "futures 0.3.15",
+ "futures",
  "lazy_static",
  "libp2p-core 0.27.1",
  "log",
@@ -3632,7 +3568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7955b973e1fd2bd61ffd43ce261c1223f61f4aacd5bae362a924993f9a25fd98"
 dependencies = [
  "either",
- "futures 0.3.15",
+ "futures",
  "libp2p-core 0.27.1",
  "log",
  "rand 0.7.3",
@@ -3658,7 +3594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a5aef80e519a6cb8e2663605142f97baaaea1a252eecbf8756184765f7471b"
 dependencies = [
  "async-io",
- "futures 0.3.15",
+ "futures",
  "futures-timer",
  "if-addrs",
  "if-watch",
@@ -3677,7 +3613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3b1c6a3431045da8b925ed83384e4c5163e14b990572307fca9c507435d4d22"
 dependencies = [
  "either",
- "futures 0.3.15",
+ "futures",
  "futures-rustls",
  "libp2p-core 0.27.1",
  "log",
@@ -3694,7 +3630,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4819358c542a86ff95f6ae691efb4b94ddaf477079b01a686f5705b79bfc232a"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "libp2p-core 0.27.1",
  "parking_lot",
  "thiserror",
@@ -3756,7 +3692,7 @@ dependencies = [
  "environment",
  "eth2_libp2p",
  "eth2_network_config",
- "futures 0.3.15",
+ "futures",
  "lazy_static",
  "lighthouse_metrics",
  "lighthouse_version",
@@ -3942,7 +3878,7 @@ name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
  "eth2_hashing",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
@@ -3989,69 +3925,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.7",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio 0.6.23",
- "miow 0.3.7",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio 0.6.23",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4060,7 +3942,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4068,7 +3950,7 @@ name = "monitoring_api"
 version = "0.1.0"
 dependencies = [
  "eth2",
- "futures 0.3.15",
+ "futures",
  "lazy_static",
  "lighthouse_metrics",
  "lighthouse_version",
@@ -4142,7 +4024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d91ec0a2440aaff5f78ec35631a7027d50386c6163aa975f7caa0d5da4b6ff8"
 dependencies = [
  "bytes 1.0.1",
- "futures 0.3.15",
+ "futures",
  "log",
  "pin-project 1.0.7",
  "smallvec",
@@ -4168,17 +4050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "network"
 version = "0.2.0"
 dependencies = [
@@ -4191,7 +4062,7 @@ dependencies = [
  "eth2_ssz_types",
  "exit-future",
  "fnv",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "hashset_delay",
  "hex",
@@ -4220,7 +4091,7 @@ dependencies = [
  "tempfile",
  "tokio 1.7.1",
  "tokio-stream",
- "tokio-util 0.6.7",
+ "tokio-util",
  "tree_hash",
  "types",
 ]
@@ -4264,7 +4135,7 @@ dependencies = [
  "environment",
  "eth2",
  "eth2_config",
- "futures 0.3.15",
+ "futures",
  "genesis",
  "reqwest",
  "sensitive_url",
@@ -4294,7 +4165,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4492,8 +4363,34 @@ checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
 dependencies = [
  "arrayvec 0.5.2",
  "bitvec 0.17.4",
- "byte-slice-cast",
+ "byte-slice-cast 0.3.5",
  "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
+dependencies = [
+ "arrayvec 0.7.1",
+ "bitvec 0.20.4",
+ "byte-slice-cast 1.0.0",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4524,7 +4421,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4703,7 +4600,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4757,11 +4654,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
- "fixed-hash",
- "impl-codec",
- "impl-rlp",
+ "fixed-hash 0.6.1",
+ "impl-codec 0.4.2",
+ "impl-rlp 0.2.1",
  "impl-serde",
  "uint 0.8.5",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
+dependencies = [
+ "fixed-hash 0.7.0",
+ "impl-codec 0.5.1",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -5229,8 +5139,8 @@ version = "0.2.0"
 dependencies = [
  "clap",
  "environment",
- "futures 0.3.15",
- "hyper 0.14.9",
+ "futures",
+ "hyper",
  "lazy_static",
  "regex",
  "remote_signer_backend",
@@ -5271,7 +5181,7 @@ dependencies = [
  "tempfile",
  "tokio 1.7.1",
  "types",
- "winapi 0.3.9",
+ "winapi",
  "windows-acl",
 ]
 
@@ -5281,7 +5191,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5296,9 +5206,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http",
- "http-body 0.4.2",
- "hyper 0.14.9",
- "hyper-tls 0.5.0",
+ "http-body",
+ "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
@@ -5331,7 +5241,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5366,7 +5276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5445,7 +5355,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "pin-project 0.4.28",
  "static_assertions",
 ]
@@ -5491,7 +5401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5539,18 +5449,18 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.19.0"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
 dependencies = [
  "secp256k1-sys",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+checksum = "827cb7cce42533829c792fc51b82fbf18b125b45a702ef2c8be77fce65463a7b"
 dependencies = [
  "cc",
 ]
@@ -5819,7 +5729,7 @@ dependencies = [
  "chrono",
  "colored",
  "log",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -5830,7 +5740,7 @@ dependencies = [
  "env_logger 0.8.4",
  "eth1",
  "eth1_test_rig",
- "futures 0.3.15",
+ "futures",
  "node_test_rig",
  "parking_lot",
  "rayon",
@@ -6093,7 +6003,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6103,7 +6013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6115,7 +6025,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes 0.5.6",
  "flate2",
- "futures 0.3.15",
+ "futures",
  "httparse",
  "log",
  "rand 0.7.3",
@@ -6330,7 +6240,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "eth2_hashing",
- "ethereum-types",
+ "ethereum-types 0.9.2",
 ]
 
 [[package]]
@@ -6386,7 +6296,7 @@ name = "task_executor"
 version = "0.1.0"
 dependencies = [
  "exit-future",
- "futures 0.3.15",
+ "futures",
  "lazy_static",
  "lighthouse_metrics",
  "slog",
@@ -6404,7 +6314,7 @@ dependencies = [
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6415,7 +6325,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6489,7 +6399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6504,7 +6414,7 @@ dependencies = [
  "stdweb",
  "time-macros",
  "version_check",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -6535,7 +6445,7 @@ name = "timer"
 version = "0.2.0"
 dependencies = [
  "beacon_chain",
- "futures 0.3.15",
+ "futures",
  "parking_lot",
  "slog",
  "slot_clock",
@@ -6612,32 +6522,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
- "libc",
- "memchr",
- "mio 0.6.23",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
  "pin-project-lite 0.1.12",
- "signal-hook-registry",
  "slab",
- "tokio-macros 0.2.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "tokio"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46409491c9375a693ce7032101970a54f8a2010efb77e13f70788f0d84489e39"
-dependencies = [
- "autocfg 1.0.1",
- "futures-core",
- "pin-project-lite 0.2.7",
 ]
 
 [[package]]
@@ -6650,27 +6537,28 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.13",
+ "mio",
  "num_cpus",
  "once_cell",
  "parking_lot",
  "pin-project-lite 0.2.7",
  "signal-hook-registry",
- "tokio-macros 1.2.0",
- "winapi 0.3.9",
+ "tokio-macros",
+ "winapi",
 ]
 
 [[package]]
 name = "tokio-compat-02"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4cec419b8b6f06c32e74aae6d8c5e79646d038a38e5ea2b36045f2c3296e22"
+checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
 dependencies = [
  "bytes 0.5.6",
  "once_cell",
- "pin-project-lite 0.1.12",
+ "pin-project-lite 0.2.7",
  "tokio 0.2.25",
- "tokio 0.3.7",
+ "tokio 1.7.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -6681,17 +6569,6 @@ checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
  "tokio 1.7.1",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -6724,17 +6601,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
  "tokio 1.7.1",
- "tokio-util 0.6.7",
-]
-
-[[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio 0.2.25",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6748,35 +6615,6 @@ dependencies = [
  "pin-project 1.0.7",
  "tokio 1.7.1",
  "tungstenite",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
-dependencies = [
- "bytes 0.5.6",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.12",
- "tokio 0.2.25",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3137de2b078e95274b696cc522e87f22c9a753fe3ef3344116ffb94f104f10a3"
-dependencies = [
- "bytes 0.6.0",
- "futures-core",
- "futures-io",
- "futures-sink",
- "log",
- "pin-project-lite 0.2.7",
- "tokio 0.3.7",
 ]
 
 [[package]]
@@ -6921,7 +6759,7 @@ version = "0.1.1"
 dependencies = [
  "criterion",
  "eth2_hashing",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "lazy_static",
  "rand 0.7.3",
  "smallvec",
@@ -6972,19 +6810,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typed-headers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3179a61e9eccceead5f1574fd173cf2e162ac42638b9bf214c6ad0baf7efa24a"
-dependencies = [
- "base64 0.11.0",
- "bytes 0.5.6",
- "chrono",
- "http",
- "mime",
-]
-
-[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7006,7 +6831,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types",
+ "ethereum-types 0.9.2",
  "hex",
  "int_to_bytes",
  "lazy_static",
@@ -7136,7 +6961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "bytes 1.0.1",
- "tokio-util 0.6.7",
+ "tokio-util",
 ]
 
 [[package]]
@@ -7205,9 +7030,9 @@ dependencies = [
  "exit-future",
  "fallback",
  "filesystem",
- "futures 0.3.15",
+ "futures",
  "hex",
- "hyper 0.14.9",
+ "hyper",
  "lazy_static",
  "libc",
  "libsecp256k1",
@@ -7308,7 +7133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -7328,10 +7153,10 @@ version = "0.3.0"
 source = "git+https://github.com/paulhauner/warp?branch=cors-wildcard#1f7daf462e6286fe5fd1743f7b788227efd3fa5c"
 dependencies = [
  "bytes 1.0.1",
- "futures 0.3.15",
+ "futures",
  "headers",
  "http",
- "hyper 0.14.9",
+ "hyper",
  "log",
  "mime",
  "mime_guess",
@@ -7345,7 +7170,7 @@ dependencies = [
  "tokio 1.7.1",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.6.7",
+ "tokio-util",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -7478,7 +7303,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "js-sys",
  "parking_lot",
  "pin-utils",
@@ -7499,36 +7324,47 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c736dcabf7a4d4b9e724ff6696914e205cb37f111a54903b17f76c20d59f7e6"
+checksum = "bc4c18ae15621f764fab919f7e4a83d87163494cbc3460884debef7c6bc1bc6b"
 dependencies = [
  "arrayvec 0.5.2",
- "async-native-tls",
  "base64 0.13.0",
+ "bytes 1.0.1",
  "derive_more",
- "ethabi",
- "ethereum-types",
- "futures 0.3.15",
+ "ethabi 14.0.0",
+ "ethereum-types 0.11.0",
+ "futures",
  "futures-timer",
+ "headers",
  "hex",
- "hyper 0.13.10",
- "hyper-proxy",
- "hyper-tls 0.4.3",
  "jsonrpc-core",
  "log",
- "native-tls",
  "parking_lot",
  "pin-project 1.0.7",
- "rlp 0.4.6",
+ "reqwest",
+ "rlp 0.5.0",
  "secp256k1",
  "serde",
  "serde_json",
  "soketto",
  "tiny-keccak 2.0.2",
- "tokio 0.2.25",
- "tokio-util 0.5.1",
- "typed-headers",
+ "tokio 1.7.1",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "web3-async-native-tls",
+]
+
+[[package]]
+name = "web3-async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
+dependencies = [
+ "native-tls",
+ "thiserror",
+ "tokio 1.7.1",
  "url",
 ]
 
@@ -7578,12 +7414,6 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -7591,12 +7421,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -7610,7 +7434,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -7628,7 +7452,7 @@ dependencies = [
  "field-offset",
  "libc",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -7637,17 +7461,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]
@@ -7697,7 +7511,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cc7bd8c983209ed5d527f44b01c41b7dc146fd960c61cf9e1d25399841dc271"
 dependencies = [
- "futures 0.3.15",
+ "futures",
  "log",
  "nohash-hasher",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7350,7 +7350,6 @@ dependencies = [
  "soketto",
  "tiny-keccak 2.0.2",
  "tokio 1.8.1",
- "tokio-stream",
  "tokio-util",
  "url",
  "web3-async-native-tls",

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit
+	cargo audit --ignore RUSTSEC-2021-0073
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit --ignore RUSTSEC-2021-0072
+	cargo audit
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit
+	cargo audit --ignore RUSTSEC-2021-0072
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -10,7 +10,7 @@ toml = "0.5.6"
 web3 = "0.14.0"
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
-tokio-compat-02 = "0.1"
+tokio-compat-02 = "0.2.0"
 
 [dependencies]
 reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
 toml = "0.5.6"
-web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
 tokio-compat-02 = "0.2.0"

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
 toml = "0.5.6"
-web3 = "0.14.0"
+web3 = "0.16.0"
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
 tokio-compat-02 = "0.2.0"

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
 toml = "0.5.6"
-web3 = "0.16.0"
+web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
 tokio-compat-02 = "0.2.0"

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
-tokio-compat-02 = "0.1"
+tokio-compat-02 = "0.2.0"
 sensitive_url = { path = "../../common/sensitive_url" }
 
 [dependencies]

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -69,6 +69,20 @@ impl TaskExecutor {
         }
     }
 
+    /// A convenience wrapper for `Self::spawn` which ignores a `Result` as long as both `Ok`/`Err`
+    /// are of type `()`.
+    ///
+    /// The purpose of this function is to create a compile error if some function which previously
+    /// returned `()` starts returning something else. Such a case may otherwise result in
+    /// accidental error suppression.
+    pub fn spawn_ignoring_error(
+        &self,
+        task: impl Future<Output = Result<(), ()>> + Send + 'static,
+        name: &'static str,
+    ) {
+        self.spawn(task.map(|_| ()), name)
+    }
+
     /// Spawn a future on the tokio runtime wrapped in an `exit_future::Exit`. The task is canceled
     /// when the corresponding exit_future `Signal` is fired/dropped.
     ///

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -37,6 +37,6 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 directory = { path = "../common/directory" }
 account_utils = { path = "../common/account_utils" }
 eth2_wallet = { path = "../crypto/eth2_wallet" }
-web3 = "0.14.0"
+web3 = "0.16.0"
 eth1_test_rig = { path = "../testing/eth1_test_rig" }
 sensitive_url = { path = "../common/sensitive_url" }

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -37,6 +37,6 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 directory = { path = "../common/directory" }
 account_utils = { path = "../common/account_utils" }
 eth2_wallet = { path = "../crypto/eth2_wallet" }
-web3 = "0.16.0"
+web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
 eth1_test_rig = { path = "../testing/eth1_test_rig" }
 sensitive_url = { path = "../common/sensitive_url" }

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -37,6 +37,6 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 directory = { path = "../common/directory" }
 account_utils = { path = "../common/account_utils" }
 eth2_wallet = { path = "../crypto/eth2_wallet" }
-web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 eth1_test_rig = { path = "../testing/eth1_test_rig" }
 sensitive_url = { path = "../common/sensitive_url" }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -379,8 +379,8 @@ fn run<E: EthSpec>(
             if !shutdown_flag {
                 environment.runtime().spawn(async move {
                     if let Err(e) = ProductionValidatorClient::new(context, config)
-                        .await?
-                        .start_service()
+                        .await
+                        .and_then(|mut vc| vc.start_service())
                     {
                         crit!(log, "Failed to start validator client"; "reason" => e);
                         // Ignore the error since it always occurs during normal operation when

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -389,7 +389,6 @@ fn run<E: EthSpec>(
                             .shutdown_sender()
                             .try_send(ShutdownReason::Failure("Failed to start validator client"));
                     }
-                    Ok::<(), String>(())
                 });
             } else {
                 let _ = executor.shutdown_sender().try_send(ShutdownReason::Success(

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.1.0", features = ["time"] }
-tokio-compat-02 = "0.1"
+tokio-compat-02 = "0.2.0"
 web3 = "0.14.0"
 futures = "0.3.7"
 types = { path = "../../consensus/types"}

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.1.0", features = ["time"] }
 tokio-compat-02 = "0.2.0"
-web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 futures = "0.3.7"
 types = { path = "../../consensus/types"}
 serde_json = "1.0.58"

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.1.0", features = ["time"] }
 tokio-compat-02 = "0.2.0"
-web3 = "0.16.0"
+web3 = { version = "0.16.0", features = ["http-tls", "signing", "ws-tls-tokio"] }
 futures = "0.3.7"
 types = { path = "../../consensus/types"}
 serde_json = "1.0.58"

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.1.0", features = ["time"] }
 tokio-compat-02 = "0.2.0"
-web3 = "0.14.0"
+web3 = "0.16.0"
 futures = "0.3.7"
 types = { path = "../../consensus/types"}
 serde_json = "1.0.58"

--- a/testing/eth1_test_rig/src/lib.rs
+++ b/testing/eth1_test_rig/src/lib.rs
@@ -206,6 +206,8 @@ impl DepositContract {
             data: encode_eth1_tx_data(&deposit_data).map(Into::into).ok(),
             nonce: None,
             condition: None,
+            transaction_type: None,
+            access_list: None,
         };
 
         self.web3

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -5,7 +5,6 @@ use crate::{
     validator_store::ValidatorStore,
 };
 use environment::RuntimeContext;
-use futures::future::FutureExt;
 use slog::{crit, error, info, trace};
 use slot_clock::SlotClock;
 use std::collections::HashMap;
@@ -205,15 +204,13 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .into_iter()
             .for_each(|(committee_index, validator_duties)| {
                 // Spawn a separate task for each attestation.
-                self.inner.context.executor.spawn(
-                    self.clone()
-                        .publish_attestations_and_aggregates(
-                            slot,
-                            committee_index,
-                            validator_duties,
-                            aggregate_production_instant,
-                        )
-                        .map(|_| ()),
+                self.inner.context.executor.spawn_ignoring_error(
+                    self.clone().publish_attestations_and_aggregates(
+                        slot,
+                        committee_index,
+                        validator_duties,
+                        aggregate_production_instant,
+                    ),
                     "attestation publish",
                 );
             });

--- a/validator_client/src/fork_service.rs
+++ b/validator_client/src/fork_service.rs
@@ -2,7 +2,6 @@ use crate::beacon_node_fallback::{BeaconNodeFallback, RequireSynced};
 use crate::http_metrics::metrics;
 use environment::RuntimeContext;
 use eth2::types::StateId;
-use futures::future::FutureExt;
 use parking_lot::RwLock;
 use slog::{debug, trace};
 use slog::{error, Logger};
@@ -142,7 +141,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ForkService<T, E> {
         // Run an immediate update before starting the updater service.
         context
             .executor
-            .spawn(self.clone().do_update().map(|_| ()), "fork service update");
+            .spawn_ignoring_error(self.clone().do_update(), "fork service update");
 
         let executor = context.executor.clone();
         let log = context.log().clone();


### PR DESCRIPTION
## Issue Addressed

Related to #2430, #2394

## Proposed Changes

As per https://github.com/sigp/lighthouse/issues/2430#issuecomment-875323615, ensure that the `ProductionValidatorClient::new` error raises a log and shuts down the VC. Also, I implemened `spawn_ignoring_error`, as per @michaelsproul's suggestion in https://github.com/sigp/lighthouse/pull/2436#issuecomment-876084419.

I got unlucky and CI picked up a [new rustsec vuln](https://rustsec.org/advisories/RUSTSEC-2021-0072). To fix this, I had to update the following crates:

- `tokio`
- `web3`
- `tokio-compat-02`

## Additional Info

NA
