### PR TITLE
[Merged by Bors] - Metrics for sync aggregate fullness

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1985,10 +1985,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 block.body().attestations().len() as f64,
             );
 
-            if let Ok(block) = block.as_altair() {
+            if let Some(sync_aggregate) = block.body().sync_aggregate() {
                 metrics::set_gauge(
                     &metrics::BLOCK_SYNC_AGGREGATE_SET_BITS,
-                    block.body.sync_aggregate.num_set_bits() as i64,
+                    sync_aggregate.num_set_bits() as i64,
                 );
             }
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1981,6 +1981,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             block.body().attestations().len() as f64,
         );
 
+        if let Ok(block) = block.as_altair() {
+            metrics::set_gauge(
+                &metrics::BLOCK_SYNC_AGGREGATE_SET_BITS,
+                block.body.sync_aggregate.num_set_bits() as i64,
+            );
+        }
+
         let db_write_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_DB_WRITE);
 
         // Store the block and its state, and execute the confirmation batch for the intermediate

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1976,16 +1976,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         drop(validator_monitor);
 
-        metrics::observe(
-            &metrics::OPERATIONS_PER_BLOCK_ATTESTATION,
-            block.body().attestations().len() as f64,
-        );
-
-        if let Ok(block) = block.as_altair() {
-            metrics::set_gauge(
-                &metrics::BLOCK_SYNC_AGGREGATE_SET_BITS,
-                block.body.sync_aggregate.num_set_bits() as i64,
+        // Only present some metrics for blocks from the previous epoch or later.
+        //
+        // This helps avoid noise in the metrics during sync.
+        if block.slot().epoch(T::EthSpec::slots_per_epoch()) + 1 >= self.epoch()? {
+            metrics::observe(
+                &metrics::OPERATIONS_PER_BLOCK_ATTESTATION,
+                block.body().attestations().len() as f64,
             );
+
+            if let Ok(block) = block.as_altair() {
+                metrics::set_gauge(
+                    &metrics::BLOCK_SYNC_AGGREGATE_SET_BITS,
+                    block.body.sync_aggregate.num_set_bits() as i64,
+                );
+            }
         }
 
         let db_write_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_DB_WRITE);

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -54,6 +54,10 @@ lazy_static! {
         "beacon_block_processing_attestation_observation_seconds",
         "Time spent hashing and remembering all the attestations in the block"
     );
+    pub static ref BLOCK_SYNC_AGGREGATE_SET_BITS: Result<IntGauge> = try_create_int_gauge(
+        "block_sync_aggregate_set_bits",
+        "The number of true bits in the last sync aggregate in a block"
+    );
 
     /*
      * Block Production

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -45,6 +45,16 @@ pub struct BeaconBlockBody<T: EthSpec> {
     pub sync_aggregate: SyncAggregate<T>,
 }
 
+impl<'a, T: EthSpec> BeaconBlockBodyRef<'a, T> {
+    /// Access the sync aggregate from the block's body, if one exists.
+    pub fn sync_aggregate(self) -> Option<&'a SyncAggregate<T>> {
+        match self {
+            BeaconBlockBodyRef::Base(_) => None,
+            BeaconBlockBodyRef::Altair(inner) => Some(&inner.sync_aggregate),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     mod base {

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -33,4 +33,9 @@ impl<T: EthSpec> SyncAggregate<T> {
             sync_committee_signature: AggregateSignature::empty(),
         }
     }
+
+    /// Returns how many bits are `true` in `self.sync_committee_bits`.
+    pub fn num_set_bits(&self) -> usize {
+        self.sync_committee_bits.num_set_bits()
+    }
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a metric to see how many set bits are in the sync aggregate for each beacon block being imported.

## Additional Info

NA