### PR TITLE
[Merged by Bors] - Update direct libsecp256k1 dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1914,7 +1914,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "procinfo",
  "proto_array",
  "psutil",
@@ -2833,6 +2833,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac-drbg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "hmac 0.8.1",
+]
+
+[[package]]
 name = "http"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,7 +3472,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "log",
  "multihash",
  "multistream-select",
@@ -3495,7 +3506,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "lazy_static",
- "libsecp256k1",
+ "libsecp256k1 0.3.5",
  "log",
  "multihash",
  "multistream-select",
@@ -3693,11 +3704,59 @@ dependencies = [
  "arrayref",
  "crunchy",
  "digest 0.8.1",
- "hmac-drbg",
+ "hmac-drbg 0.2.0",
  "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.4.0",
  "typenum",
+]
+
+[[package]]
+name = "libsecp256k1"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd1137239ab33b41aa9637a88a28249e5e70c40a42ccc92db7f12cc356c1fcd7"
+dependencies = [
+ "arrayref",
+ "base64 0.12.3",
+ "digest 0.9.0",
+ "hmac-drbg 0.3.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
+ "rand 0.7.3",
+ "serde",
+ "sha2 0.9.5",
+ "typenum",
+]
+
+[[package]]
+name = "libsecp256k1-core"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee11012b293ea30093c129173cac4335513064094619f4639a25b310fd33c11"
+dependencies = [
+ "crunchy",
+ "digest 0.9.0",
+ "subtle 2.4.0",
+]
+
+[[package]]
+name = "libsecp256k1-gen-ecmult"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32239626ffbb6a095b83b37a02ceb3672b2443a87a000a884fc3c4d16925c9c0"
+dependencies = [
+ "libsecp256k1-core",
+]
+
+[[package]]
+name = "libsecp256k1-gen-genmult"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76acb433e21d10f5f9892b1962c2856c58c7f39a9e4bd68ac82b9436a0ffd5b9"
+dependencies = [
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -7109,7 +7168,7 @@ dependencies = [
  "hyper",
  "lazy_static",
  "libc",
- "libsecp256k1",
+ "libsecp256k1 0.5.0",
  "lighthouse_metrics",
  "lighthouse_version",
  "lockfile",

--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit --ignore RUSTSEC-2021-0073
+	cargo audit --ignore RUSTSEC-2021-0073 --ignore RUSTSEC-2021-0076
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -17,7 +17,7 @@ proto_array = { path = "../../consensus/proto_array", optional = true }
 serde_utils = { path = "../../consensus/serde_utils" }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
-libsecp256k1 = "0.3.5"
+libsecp256k1 = "0.5.0"
 ring = "0.16.19"
 bytes = "1.0.1"
 account_utils = { path = "../../common/account_utils" }

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -2,12 +2,12 @@ use super::{types::*, PK_LEN, SECRET_PREFIX};
 use crate::Error;
 use account_utils::ZeroizeString;
 use bytes::Bytes;
+use libsecp256k1::{Message, PublicKey, Signature};
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     IntoUrl,
 };
 use ring::digest::{digest, SHA256};
-use secp256k1::{Message, PublicKey, Signature};
 use sensitive_url::SensitiveUrl;
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -94,7 +94,7 @@ impl ValidatorClientHttpClient {
             .ok()
             .and_then(|bytes| {
                 let sig = Signature::parse_der(&bytes).ok()?;
-                Some(secp256k1::verify(&message, &sig, &self.server_pubkey))
+                Some(libsecp256k1::verify(&message, &sig, &self.server_pubkey))
             })
             .filter(|is_valid| *is_valid)
             .ok_or(Error::InvalidSignatureHeader)?;

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -57,7 +57,7 @@ warp_utils = { path = "../common/warp_utils" }
 warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 hyper = "0.14.4"
 serde_utils = { path = "../consensus/serde_utils" }
-libsecp256k1 = "0.3.5"
+libsecp256k1 = "0.5.0"
 ring = "0.16.19"
 rand = "0.7.3"
 scrypt = { version = "0.5.0", default-features = false }

--- a/validator_client/src/http_api/api_secret.rs
+++ b/validator_client/src/http_api/api_secret.rs
@@ -1,7 +1,7 @@
 use eth2::lighthouse_vc::{PK_LEN, SECRET_PREFIX as PK_PREFIX};
+use libsecp256k1::{Message, PublicKey, SecretKey};
 use rand::thread_rng;
 use ring::digest::{digest, SHA256};
-use secp256k1::{Message, PublicKey, SecretKey};
 use std::fs;
 use std::path::Path;
 use warp::Filter;
@@ -177,7 +177,7 @@ impl ApiSecret {
         move |input: &[u8]| -> String {
             let message =
                 Message::parse_slice(digest(&SHA256, input).as_ref()).expect("sha256 is 32 bytes");
-            let (signature, _) = secp256k1::sign(&message, &sk);
+            let (signature, _) = libsecp256k1::sign(&message, &sk);
             serde_utils::hex::encode(signature.serialize_der().as_ref())
         }
     }

--- a/validator_client/src/http_api/api_secret.rs
+++ b/validator_client/src/http_api/api_secret.rs
@@ -173,7 +173,7 @@ impl ApiSecret {
     /// Returns a closure which produces a signature over some bytes using the secret key in
     /// `self`. The signature is a 32-byte hash formatted as a 0x-prefixed string.
     pub fn signer(&self) -> impl Fn(&[u8]) -> String + Clone {
-        let sk = self.sk.clone();
+        let sk = self.sk;
         move |input: &[u8]| -> String {
             let message =
                 Message::parse_slice(digest(&SHA256, input).as_ref()).expect("sha256 is 32 bytes");


### PR DESCRIPTION
## Proposed Changes

* Remove direct dependencies on vulnerable `libsecp256k1 0.3.5`
* Ignore the RUSTSEC issue until it is resolved in #2389
