### PR TITLE
adds docker-compose of the simple local testnet

### DIFF
--- a/scripts/local_testnet/Dockerfile
+++ b/scripts/local_testnet/Dockerfile
@@ -24,7 +24,9 @@ COPY --from=builder /lighthouse /lighthouse
 
 RUN npm -g install ganache-cli
 
-ADD ganache_test_node.sh /ganache_test_node.sh
-ADD vars.env /lighthouse/scripts/local_testnet/vars.env
-
 WORKDIR /lighthouse/scripts/local_testnet/
+
+ADD ganache_test_node.sh ./ganache_test_node.sh
+ADD vars.env ./vars.env
+ADD setup.sh ./setup.sh
+

--- a/scripts/local_testnet/Dockerfile
+++ b/scripts/local_testnet/Dockerfile
@@ -1,32 +1,17 @@
-FROM rust:1.50.0 AS builder
-RUN apt-get update && apt-get install -y cmake
+FROM sigp/lcli:latest-unstable
 
-RUN git clone https://github.com/sigp/lighthouse
-ARG PORTABLE
-ENV PORTABLE $PORTABLE
-RUN cd lighthouse && make
-RUN env
-RUN cd lighthouse && make install-lcli
-
-##################################################
-FROM debian:buster-slim
+COPY --from=sigp/lighthouse /usr/local/bin/lighthouse /usr/local/bin/lighthouse
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  libssl-dev \
-  ca-certificates \
   nodejs npm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse
-COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli
-COPY --from=builder /lighthouse /lighthouse
-
 RUN npm -g install ganache-cli
 
-WORKDIR /lighthouse/scripts/local_testnet/
+RUN mkdir /app
 
-ADD ganache_test_node.sh ./ganache_test_node.sh
-ADD vars.env ./vars.env
-ADD setup.sh ./setup.sh
+WORKDIR /app
+
+ADD ./* /app/
 

--- a/scripts/local_testnet/Dockerfile
+++ b/scripts/local_testnet/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.50.0 AS builder
+RUN apt-get update && apt-get install -y cmake
+# COPY lighthouse lighthouse
+RUN git clone https://github.com/sigp/lighthouse
+ARG PORTABLE
+ENV PORTABLE $PORTABLE
+RUN cd lighthouse && make
+RUN env
+RUN cd lighthouse && make install-lcli
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libssl-dev \
+  ca-certificates \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse
+COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli
+COPY --from=builder /lighthouse /lighthouse
+
+ADD vars.env /lighthouse/scripts/local_testnet/vars.env
+WORKDIR /lighthouse/scripts/local_testnet/

--- a/scripts/local_testnet/Dockerfile
+++ b/scripts/local_testnet/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.50.0 AS builder
 RUN apt-get update && apt-get install -y cmake
-# COPY lighthouse lighthouse
+
 RUN git clone https://github.com/sigp/lighthouse
 ARG PORTABLE
 ENV PORTABLE $PORTABLE
@@ -8,15 +8,23 @@ RUN cd lighthouse && make
 RUN env
 RUN cd lighthouse && make install-lcli
 
+##################################################
 FROM debian:buster-slim
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \
+  nodejs npm \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /usr/local/cargo/bin/lighthouse /usr/local/bin/lighthouse
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli
 COPY --from=builder /lighthouse /lighthouse
 
+RUN npm -g install ganache-cli
+
+ADD ganache_test_node.sh /ganache_test_node.sh
 ADD vars.env /lighthouse/scripts/local_testnet/vars.env
+
 WORKDIR /lighthouse/scripts/local_testnet/

--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -3,6 +3,8 @@
 These scripts allow for running a small local testnet with multiple beacon nodes and validator clients.
 This setup can be useful for testing and development.
 
+The implementation using `docker` and `docker-compose` is present. This downloads the repository and builds the docker image. The whole setup can be run by launching `docker-compose up` in this directory. For manual setup follow the description below.
+
 ## Requirements
 
 The scripts require `lcli` and `lighthouse` to be installed on `PATH`. From the

--- a/scripts/local_testnet/docker-compose.yml
+++ b/scripts/local_testnet/docker-compose.yml
@@ -1,0 +1,94 @@
+version: '3'
+services:
+  ganache:
+    image: hive/clients/ganache
+    network_mode: "host"
+  
+  boot:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - ganache
+    entrypoint: bash -c "sleep 5 && ./setup.sh && ./bootnode.sh"
+
+  ##################################################
+  beacon1:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - boot
+    entrypoint: bash -c "sleep 25 && ./beacon_node.sh $HOME/.lighthouse/local-testnet/node_1 9000 8000"
+
+  validator1:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - beacon1
+    entrypoint: bash -c "sleep 35 && ./validator_client.sh $HOME/.lighthouse/local-testnet/node_1 http://localhost:8000"
+
+  ##################################################
+  beacon2:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - boot
+    entrypoint: bash -c "sleep 25 && ./beacon_node.sh $HOME/.lighthouse/local-testnet/node_2 9002 8002"
+
+  validator2:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - beacon2
+    entrypoint: bash -c "sleep 35 && ./validator_client.sh $HOME/.lighthouse/local-testnet/node_2 http://localhost:8002"
+
+  ##################################################
+  beacon3:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - boot
+    entrypoint: bash -c "sleep 25 && ./beacon_node.sh $HOME/.lighthouse/local-testnet/node_3 9003 8003"
+
+  validator3:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - beacon3
+    entrypoint: bash -c "sleep 35 && ./validator_client.sh $HOME/.lighthouse/local-testnet/node_3 http://localhost:8003"
+
+  ##################################################
+  beacon4:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - boot
+    entrypoint: bash -c "sleep 25 && ./beacon_node.sh $HOME/.lighthouse/local-testnet/node_4 9004 8004"
+
+  validator4:
+    build: .
+    network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
+    depends_on: 
+      - beacon4
+    entrypoint: bash -c "sleep 35 && ./validator_client.sh $HOME/.lighthouse/local-testnet/node_4 http://localhost:8004"
+
+volumes:
+  data:
+    

--- a/scripts/local_testnet/docker-compose.yml
+++ b/scripts/local_testnet/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   ganache:
     build: .
     # network_mode: "host"
+    volumes:
+      - data:/root/.lighthouse
     networks:
       - testnet
     entrypoint: "./ganache_test_node.sh"

--- a/scripts/local_testnet/docker-compose.yml
+++ b/scripts/local_testnet/docker-compose.yml
@@ -2,12 +2,15 @@ version: '3'
 services:
   ganache:
     build: .
-    network_mode: "host"
+    # network_mode: "host"
+    networks:
+      - testnet
     entrypoint: "./ganache_test_node.sh"
   
   boot:
     build: .
-    network_mode: "host"
+    networks:
+      - testnet
     volumes:
       - data:/root/.lighthouse
     depends_on: 
@@ -93,3 +96,5 @@ services:
 volumes:
   data:
     
+networks:
+  testnet:

--- a/scripts/local_testnet/docker-compose.yml
+++ b/scripts/local_testnet/docker-compose.yml
@@ -1,8 +1,9 @@
 version: '3'
 services:
   ganache:
-    image: hive/clients/ganache
+    build: .
     network_mode: "host"
+    entrypoint: "./ganache_test_node.sh"
   
   boot:
     build: .

--- a/scripts/local_testnet/ganache_test_node.sh
+++ b/scripts/local_testnet/ganache_test_node.sh
@@ -3,6 +3,7 @@
 source ./vars.env
 
 ganache-cli \
+	--host "0.0.0.0" \
 	--defaultBalanceEther 1000000000 \
 	--gasLimit 1000000000 \
 	--accounts 10 \

--- a/scripts/local_testnet/setup.sh
+++ b/scripts/local_testnet/setup.sh
@@ -13,7 +13,7 @@ source ./vars.env
 
 lcli \
 	deploy-deposit-contract \
-	--eth1-http http://localhost:8545 \
+	--eth1-http http://ganache:8545 \
 	--confirmations 1 \
 	--validator-count $VALIDATOR_COUNT
 


### PR DESCRIPTION
## Issue Addressed

This is a spontaneous PR not addressing any official issue, but made in a belief that automation of the creation of local testnet might be useful for some users.

## Proposed Changes

This PR automates the creation of the simple local testnet by using a docker containers and docker-compose.

## Additional Info

By this setup the user can launch the testnet within seconds and observe the communication of the nodes.