### PR TITLE
Auto publish crates

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,66 @@
+name:   Publish Crate
+
+on:
+    push:
+        tags:
+            - *
+env:
+    CARGO_API_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
+
+jobs:
+    extract-tag:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Extract tag
+              run: echo "::set-output name=TAG::$(echo ${GITHUB_REF#refs/tags/})"
+              id: extract_tag
+        outputs:
+            TAG: ${{ steps.extract_tag.outputs.TAG }}
+
+    publish-crate:
+        runs-on: ubuntu-latest
+        needs: [extract-tag]
+        env:
+            TAG: ${{ needs.extract-tag.outputs.TAG }}
+        steps:
+            - uses: actions/checkout@v2
+            - name: Update Rust
+              run: rustup update stable
+            - name: Cargo login
+              run: |
+                  echo "${CARGO_API_TOKEN}" | cargo login
+            - name: publish tree hash
+              if: startsWith($TAG, 'tree-hash-v')
+              run: |
+                VERSION=$(sed -e 's#.*tree-hash-v\(\)#\1#' <<< "$TAG")
+                ./scripts/ci/publish.sh consensus/tree_hash tree_hash "$VERSION"
+            - name: publish tree hash derive
+              if: startsWith($TAG, 'tree-hash-derive-v')
+              run: |
+                  VERSION=$(sed -e 's#.*tree-hash-derive-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/tree_hash_derive tree_hash_derive "$VERSION"
+            - name: publish eth2 ssz
+              if: startsWith($TAG, 'eth2-ssz-v')
+              run: |
+                  VERSION=$(sed -e 's#.*eth2-ssz-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/ssz eth2_ssz "$VERSION"
+            - name: publish eth2 ssz derive
+              if: startsWith($TAG, 'eth2-ssz-derive-v')
+              run: |
+                  VERSION=$(sed -e 's#.*eth2-ssz-derive-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/ssz_derive eth2_ssz_derive "$VERSION"
+            - name: publish ssz types
+              if: startsWith($TAG, 'eth2-ssz-types-v')
+              run: |
+                  VERSION=$(sed -e 's#.*eth2-ssz-types-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/ssz_types eth2_ssz_types "$VERSION"
+            - name: publish serde util
+              if: startsWith($TAG, 'eth2-serde-util-v')
+              run: |
+                  VERSION=$(sed -e 's#.*eth2-serde-util-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/serde_utils eth2_serde_utils "$VERSION"
+            - name: publish eth2 hashing
+              if: startsWith($TAG, 'eth2-hashing-v')
+              run: |
+                  VERSION=$(sed -e 's#.*eth2-hashing-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh crypto/eth2_hashing eth2_hashing "$VERSION"

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -3,7 +3,14 @@ name:   Publish Crate
 on:
     push:
         tags:
-            - *
+            - tree-hash-v*
+            - tree-hash-derive-v*
+            - eth2-ssz-v*
+            - eth2-ssz-derive-v*
+            - eth2-ssz-types-v*
+            - eth2-serde-util-v*
+            - eth2-hashing-v*
+
 env:
     CARGO_API_TOKEN: ${{ secrets.CARGO_API_TOKEN }}
 
@@ -30,37 +37,37 @@ jobs:
               run: |
                   echo "${CARGO_API_TOKEN}" | cargo login
             - name: publish tree hash
-              if: startsWith($TAG, 'tree-hash-v')
+              if: startsWith(env.TAG, 'tree-hash-v')
               run: |
-                VERSION=$(sed -e 's#.*tree-hash-v\(\)#\1#' <<< "$TAG")
-                ./scripts/ci/publish.sh consensus/tree_hash tree_hash "$VERSION"
+                  VERSION=$(sed -e 's#.*tree-hash-v\(\)#\1#' <<< "$TAG")
+                  ./scripts/ci/publish.sh consensus/tree_hash tree_hash "$VERSION"
             - name: publish tree hash derive
-              if: startsWith($TAG, 'tree-hash-derive-v')
+              if: startsWith(env.TAG, 'tree-hash-derive-v')
               run: |
                   VERSION=$(sed -e 's#.*tree-hash-derive-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh consensus/tree_hash_derive tree_hash_derive "$VERSION"
             - name: publish eth2 ssz
-              if: startsWith($TAG, 'eth2-ssz-v')
+              if: startsWith(env.TAG, 'eth2-ssz-v')
               run: |
                   VERSION=$(sed -e 's#.*eth2-ssz-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh consensus/ssz eth2_ssz "$VERSION"
             - name: publish eth2 ssz derive
-              if: startsWith($TAG, 'eth2-ssz-derive-v')
+              if: startsWith(env.TAG, 'eth2-ssz-derive-v')
               run: |
                   VERSION=$(sed -e 's#.*eth2-ssz-derive-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh consensus/ssz_derive eth2_ssz_derive "$VERSION"
             - name: publish ssz types
-              if: startsWith($TAG, 'eth2-ssz-types-v')
+              if: startsWith(env.TAG, 'eth2-ssz-types-v')
               run: |
                   VERSION=$(sed -e 's#.*eth2-ssz-types-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh consensus/ssz_types eth2_ssz_types "$VERSION"
             - name: publish serde util
-              if: startsWith($TAG, 'eth2-serde-util-v')
+              if: startsWith(env.TAG, 'eth2-serde-util-v')
               run: |
                   VERSION=$(sed -e 's#.*eth2-serde-util-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh consensus/serde_utils eth2_serde_utils "$VERSION"
             - name: publish eth2 hashing
-              if: startsWith($TAG, 'eth2-hashing-v')
+              if: startsWith(env.TAG, 'eth2-hashing-v')
               run: |
                   VERSION=$(sed -e 's#.*eth2-hashing-v\(\)#\1#' <<< "$TAG")
                   ./scripts/ci/publish.sh crypto/eth2_hashing eth2_hashing "$VERSION"

--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Based on: https://github.com/tokio-rs/tokio/blob/master/bin/publish
+
+set -e
+USAGE="Publish a new release of a lighthouse crate
+USAGE:
+    $(basename "$0") [OPTIONS] [CRATE_PATH] [CRATE] [VERSION]
+OPTIONS:
+    -v, --verbose       Use verbose Cargo output
+    -d, --dry-run       Perform a dry run (do not publish the release)
+    -h, --help          Show this help text and exit
+        --allow-dirty   Allow dirty working directories to be packaged"
+
+DRY_RUN=""
+DIRTY=""
+VERBOSE=""
+
+verify() {
+    echo "Verifying if $CRATE v$VERSION can be released"
+    ACTUAL=$(cargo pkgid | sed -n 's/.*:\(.*\)/\1/p')
+
+    if [ "$ACTUAL" != "$VERSION" ]; then
+        echo "expected to release version $VERSION, but Cargo.toml contained $ACTUAL"
+        exit 1
+    fi
+}
+
+release() {
+    echo  "Releasing $CRATE v$VERSION"
+    cargo package $VERBOSE $DIRTY
+    cargo publish $VERBOSE $DRY_RUN $DIRTY
+}
+
+while [[ $# -gt 0 ]]
+do
+
+case "$1" in
+    -h|--help)
+    echo "$USAGE"
+    exit 0
+    ;;
+    -v|--verbose)
+    VERBOSE="--verbose"
+    set +x
+    shift
+    ;;
+    --allow-dirty)
+    DIRTY="--allow-dirty"
+    shift
+    ;;
+    -d|--dry-run)
+    DRY_RUN="--dry-run"
+    shift
+    ;;
+    -*)
+    err "unknown flag \"$1\""
+    echo "$USAGE"
+    exit 1
+    ;;
+    *) # crate, crate path, or version
+    if [ -z "$CRATE_PATH" ]; then
+        CRATE_PATH="$1"
+    elif [ -z "$CRATE" ]; then
+        CRATE="$1"
+    elif [ -z "$VERSION" ]; then
+        VERSION="$1"
+    else
+        err "unknown positional argument \"$1\""
+        echo "$USAGE"
+        exit 1
+    fi
+    shift
+    ;;
+esac
+done
+# set -- "${POSITIONAL[@]}"
+
+if [ -z "$VERSION" ]; then
+    err "no version specified!"
+    HELP=1
+fi
+
+if [ -z "$CRATE" ]; then
+    err "no crate specified!"
+    HELP=1
+fi
+
+if [ -n "$HELP" ]; then
+    echo "$USAGE"
+    exit 1
+fi
+
+if [ -d "$CRATE_PATH" ]; then
+    (cd "$CRATE_PATH" && verify && release )
+else
+    err "no such dir \"$CRATE_PATH\""
+    exit 1
+fi


### PR DESCRIPTION
## Issue Addressed

Resolves: #2259

## Proposed Changes

- Add a script that verifies versions/names and publishes crates. (Based largely on what I found in the tokio repo)
- Add a github actions workflow that is triggered on tags formatted: `crate-name-v0.0.0`

## Additional Info
Have done some manual testing and there's a few things we'll need to clean up in the various crates to make them publish-able:

 - `tree_hash` -- need to publish `tree_hash_derive` and `eth2_hashing` first
 - `tree_hash_derive`
 - `eth2_ssz`
 - `eth2_ssz_derive`
 - `eth2_ssz_types` -- need to add license, description. Need to publish `serde_util` first
 - `serde_util` -- need to add license, description and likely rename it 
 - `eth2_hashing`