### PR TITLE
[Merged by Bors] - Add lcli Dockerfile and auto-build to CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,8 +9,8 @@ on:
 env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    IMAGE_NAME: sigp/lighthouse
-    LCLI_IMAGE_NAME: sigp/lcli
+    IMAGE_NAME: ${{ github.repository_owner}}/lighthouse
+    LCLI_IMAGE_NAME: ${{ github.repository_owner }}/lcli
 
 jobs:
     extract-branch-name:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,6 +112,6 @@ jobs:
               run: |
                   docker build \
                       --build-arg PORTABLE=true \
-                      --tag ${LCLI_IMAGE_NAME}:latest-{TAG_SUFFIX} \
+                      --tag ${LCLI_IMAGE_NAME}:latest{TAG_SUFFIX} \
                       --file ./lcli/Dockerfile .
-                  docker push ${LCLI_IMAGE_NAME}:latest-{TAG_SUFFIX}
+                  docker push ${LCLI_IMAGE_NAME}:latest{TAG_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -112,6 +112,6 @@ jobs:
               run: |
                   docker build \
                       --build-arg PORTABLE=true \
-                      --tag ${LCLI_IMAGE_NAME}:latest{TAG_SUFFIX} \
+                      --tag ${LCLI_IMAGE_NAME}:latest${TAG_SUFFIX} \
                       --file ./lcli/Dockerfile .
-                  docker push ${LCLI_IMAGE_NAME}:latest{TAG_SUFFIX}
+                  docker push ${LCLI_IMAGE_NAME}:latest${TAG_SUFFIX}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,6 +101,7 @@ jobs:
         runs-on: ubuntu-18.04
         needs: [extract-branch-name]
         steps:
+            - uses: actions/checkout@v2
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     IMAGE_NAME: sigp/lighthouse
+    LCLI_IMAGE_NAME: sigp/lcli
 
 jobs:
     extract-branch-name:
@@ -96,3 +97,21 @@ jobs:
                       --amend ${IMAGE_NAME}:latest-arm64${TAG_SUFFIX} \
                       --amend ${IMAGE_NAME}:latest-amd64${TAG_SUFFIX};
                   docker manifest push ${IMAGE_NAME}:latest${TAG_SUFFIX}
+    build-docker-lcli:
+        runs-on: ubuntu-18.04
+        needs: [extract-branch-name]
+        steps:
+            - name: Dockerhub login
+              run: |
+                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+            - name: Set Env
+              if: needs.extract-branch-name.outputs.BRANCH_NAME == 'unstable'
+              run: |
+                  echo "TAG_SUFFIX=-unstable" >> $GITHUB_ENV;
+            - name: Build lcli dockerfile (with push)
+              run: |
+                  docker build \
+                      --build-arg PORTABLE=true \
+                      --tag ${LCLI_IMAGE_NAME}:latest-{TAG_SUFFIX} \
+                      --file ./lcli/Dockerfile .
+                  docker push ${LCLI_IMAGE_NAME}:latest-{TAG_SUFFIX}

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,0 +1,13 @@
+# `lcli` requires the full project to be in scope, so this should be built either:
+#  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
+#  - from the current directory with the command: `docker build -f ./Dockerfile ../`
+FROM rust:1.53.0 AS builder
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake
+COPY . lighthouse
+ARG PORTABLE
+ENV PORTABLE $PORTABLE
+RUN cd lighthouse && make install-lcli
+
+FROM debian:buster-slim
+RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
## Issue Addressed

Resolves: #2087

## Proposed Changes

- Add a `Dockerfile` to the `lcli` directory
- Add a github actions job to build and push and `lcli` docker image on pushes to `unstable` and `stable`

## Additional Info

It's a little awkward but `lcli` requires the full project scope so must be built: 
- from the `lighthouse` dir with: `docker build -f ./lcli/Dockerflie .`
- from the `lcli` dir with: `docker build -f ./Dockerfile ../`

Didn't include `libssl-dev` or `ca-certificates`, `lcli` doesn't need these right?