### PR TITLE
[Merged by Bors] - Add `AttesterCache` for attestation production

### DIFF
--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -3,7 +3,7 @@
 //!
 //! This cache is required *as well as* the `ShufflingCache` since the `ShufflingCache` does not
 //! provide any information about the `state.current_justified_checkpoint`. It is not trivial to add
-//! the justified checkpoint to the `ShufflingCache` since that cache keyed by shuffling decision
+//! the justified checkpoint to the `ShufflingCache` since that cache is keyed by shuffling decision
 //! root, which is not suitable for the justified checkpoint. Whilst we can know the shuffling for
 //! epoch `n` during `n - 1`, we *cannot* know the justified checkpoint. Instead, we *must* perform
 //! `per_epoch_processing` to transform the state from epoch `n - 1` to epoch `n` so that rewards
@@ -73,7 +73,7 @@ impl From<BeaconChainError> for Error {
     }
 }
 
-/// Stores the minimal amount of data required compute the committee length for any committee at any
+/// Stores the minimal amount of data required to compute the committee length for any committee at any
 /// slot in a given `epoch`.
 struct CommitteeLengths {
     /// The `epoch` to which the lengths pertain.
@@ -204,7 +204,7 @@ impl AttesterCacheKey {
     ///
     /// The `latest_block_root` should be the latest block that has been applied to `state`. This
     /// parameter is required since the state does not store the block root for any block with the
-    /// same slot as `slot.slot()`.
+    /// same slot as `state.slot()`.
     ///
     /// ## Errors
     ///
@@ -288,7 +288,7 @@ impl AttesterCache {
     ///
     /// This function takes a write-lock on the internal cache. Prefer attempting a `Self::get` call
     /// before running this function as `Self::get` only takes a read-lock and is therefore less
-    /// likely to create head contention.
+    /// likely to create contention.
     pub fn load_and_cache_state<T: BeaconChainTypes>(
         &self,
         state_root: Hash256,

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -125,9 +125,23 @@ impl AttesterCacheValue {
     }
 }
 
+/// The `AttesterCacheKey` is fundamentally the same thing as the shuffling decision roots, however
+/// it provides a unique key for both of the following values:
+///
+/// 1. The `state.current_justified_checkpoint`.
+/// 2. The attester shuffling.
+///
+/// This struct relies upon the premise that the `state.current_justified_checkpoint` in epoch `n`
+/// is determined by the root of the latest block in epoch `n - 1`. Notably, this is identical to
+/// how the proposer shuffling is keyed in `BeaconProposerCache`.
+///
+/// It is also safe, but not maximally efficient, to key the attester shuffling by the same block
+/// root. For better shuffling keying strategies, see the `ShufflingCache`.
 #[derive(PartialEq, Hash, Clone, Copy)]
 pub struct AttesterCacheKey {
+    /// The epoch from which the justified checkpoint should be observed.
     epoch: Epoch,
+    /// The root of the block at the last slot of `self.epoch - 1`.
     decision_root: Hash256,
 }
 

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -1,0 +1,181 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use types::{
+    BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, Hash256, RelativeEpoch, Slot,
+};
+
+type TargetRoot = Hash256;
+type TargetCheckpoint = Checkpoint;
+type JustifiedCheckpoint = Checkpoint;
+type CommitteeLength = usize;
+type CommitteeIndex = u64;
+
+#[derive(Debug)]
+pub enum Error {
+    BeaconState(BeaconStateError),
+    SlotTooLow {
+        slot: Slot,
+        first_slot: Slot,
+    },
+    SlotTooHigh {
+        slot: Slot,
+        first_slot: Slot,
+    },
+    InvalidCommitteeIndex {
+        slot_offset: usize,
+        committee_index: u64,
+    },
+}
+
+impl From<BeaconStateError> for Error {
+    fn from(e: BeaconStateError) -> Self {
+        Error::BeaconState(e)
+    }
+}
+
+struct CommitteeLengths {
+    first_slot: Slot,
+    lengths: Vec<CommitteeLength>,
+    slot_offsets: Vec<usize>,
+}
+
+impl CommitteeLengths {
+    fn new<T: EthSpec>(state: &BeaconState<T>) -> Result<Self, Error> {
+        let slots_per_epoch = T::slots_per_epoch();
+        let current_epoch = state.current_epoch();
+        let committee_cache = state.committee_cache(RelativeEpoch::Current)?;
+        let committees_per_slot = committee_cache.committees_per_slot();
+
+        let mut lengths = Vec::with_capacity((committees_per_slot * slots_per_epoch) as usize);
+        let mut slot_offsets = Vec::with_capacity(slots_per_epoch as usize);
+
+        for slot in current_epoch.slot_iter(slots_per_epoch) {
+            slot_offsets.push(lengths.len());
+            for index in 0..committees_per_slot {
+                let length = state
+                    .get_beacon_committee(slot, index as u64)?
+                    .committee
+                    .len();
+                lengths.push(length);
+            }
+        }
+
+        Ok(Self {
+            first_slot: current_epoch.start_slot(slots_per_epoch),
+            lengths,
+            slot_offsets,
+        })
+    }
+
+    fn get(&self, slot: Slot, committee_index: CommitteeIndex) -> Result<CommitteeLength, Error> {
+        let first_slot = self.first_slot;
+        let relative_slot = slot
+            .as_usize()
+            .checked_sub(first_slot.as_usize())
+            .ok_or(Error::SlotTooLow { slot, first_slot })?;
+        let slot_offset = *self
+            .slot_offsets
+            .get(relative_slot)
+            .ok_or(Error::SlotTooHigh { slot, first_slot })?;
+        slot_offset
+            .checked_add(committee_index as usize)
+            .and_then(|lengths_index| self.lengths.get(lengths_index).copied())
+            .ok_or(Error::InvalidCommitteeIndex {
+                slot_offset,
+                committee_index,
+            })
+    }
+}
+
+pub struct CacheItem {
+    current_justified_checkpoint: Checkpoint,
+    committee_lengths: CommitteeLengths,
+}
+
+impl CacheItem {
+    pub fn new<T: EthSpec>(state: &BeaconState<T>) -> Result<Self, Error> {
+        let current_justified_checkpoint = state.current_justified_checkpoint();
+        let committee_lengths = CommitteeLengths::new(state)?;
+        Ok(Self {
+            current_justified_checkpoint,
+            committee_lengths,
+        })
+    }
+
+    fn get(
+        &self,
+        slot: Slot,
+        committee_index: CommitteeIndex,
+    ) -> Result<(JustifiedCheckpoint, CommitteeLength), Error> {
+        self.committee_lengths
+            .get(slot, committee_index)
+            .map(|committee_length| (self.current_justified_checkpoint, committee_length))
+    }
+}
+
+#[derive(Default)]
+pub struct AttesterCache {
+    cache: RwLock<HashMap<TargetCheckpoint, CacheItem>>,
+}
+
+impl AttesterCache {
+    pub fn get(
+        &self,
+        target: &TargetCheckpoint,
+        slot: Slot,
+        committee_index: CommitteeIndex,
+    ) -> Result<Option<(JustifiedCheckpoint, CommitteeLength)>, Error> {
+        self.cache
+            .read()
+            .get(target)
+            .map(|cache_item| cache_item.get(slot, committee_index))
+            .transpose()
+    }
+
+    pub fn cache_state<T: EthSpec>(
+        &self,
+        state: &BeaconState<T>,
+        latest_beacon_block_root: Hash256,
+    ) -> Result<(), Error> {
+        let target = get_state_target(state, latest_beacon_block_root)?;
+        let cache_item = CacheItem::new(state)?;
+        self.cache.write().insert(target, cache_item);
+        Ok(())
+    }
+
+    pub fn cache_state_and_return_value<T: EthSpec>(
+        &self,
+        state: &BeaconState<T>,
+        latest_beacon_block_root: Hash256,
+        slot: Slot,
+        index: CommitteeIndex,
+    ) -> Result<(JustifiedCheckpoint, CommitteeLength), Error> {
+        let target = get_state_target(state, latest_beacon_block_root)?;
+        let cache_item = CacheItem::new(state)?;
+        let value = cache_item.get(slot, index)?;
+        self.cache.write().insert(target, cache_item);
+        Ok(value)
+    }
+
+    pub fn prune_below(&self, epoch: Epoch) {
+        self.cache.write().retain(|target, _| target.epoch >= epoch);
+    }
+}
+
+fn get_state_target<T: EthSpec>(
+    state: &BeaconState<T>,
+    latest_beacon_block_root: Hash256,
+) -> Result<Checkpoint, BeaconStateError> {
+    let target_epoch = state.current_epoch();
+    let target_slot = target_epoch.start_slot(T::slots_per_epoch());
+    let target_root = if state.slot() <= target_slot {
+        latest_beacon_block_root
+    } else {
+        *state.get_block_root(target_slot)?
+    };
+
+    Ok(Checkpoint {
+        epoch: target_epoch,
+        root: target_root,
+    })
+}

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -278,13 +278,9 @@ impl AttesterCache {
         Ok(())
     }
 
-    /// Read the state identified by `state_root` from the database*, advance it to the required
+    /// Read the state identified by `state_root` from the database, advance it to the required
     /// slot, use it to prime the cache and return the values for the provided `slot` and
     /// `committee_index`.
-    ///
-    /// *: The database read is avoided if `state_opt.is_some()`.
-    ///
-    /// If `state_opt.is_some()`, the `state_root` *must* match that state.
     ///
     /// ## Notes
     ///
@@ -294,7 +290,6 @@ impl AttesterCache {
     pub fn load_and_cache_state<T: BeaconChainTypes>(
         &self,
         state_root: Hash256,
-        state_opt: Option<BeaconState<T::EthSpec>>,
         key: AttesterCacheKey,
         slot: Slot,
         committee_index: CommitteeIndex,
@@ -321,13 +316,9 @@ impl AttesterCache {
             return Ok(value);
         }
 
-        let mut state = if let Some(state) = state_opt {
-            state
-        } else {
-            chain
-                .get_state(&state_root, None)?
-                .ok_or(Error::MissingBeaconState(state_root))?
-        };
+        let mut state: BeaconState<T::EthSpec> = chain
+            .get_state(&state_root, None)?
+            .ok_or(Error::MissingBeaconState(state_root))?;
 
         if state.slot() > slot {
             // This indicates an internal inconsistency.

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -189,7 +189,7 @@ impl AttesterCacheValue {
 ///
 /// It is also safe, but not maximally efficient, to key the attester shuffling with the same
 /// strategy. For better shuffling keying strategies, see the `ShufflingCache`.
-#[derive(PartialEq, Hash, Clone, Copy)]
+#[derive(Eq, PartialEq, Hash, Clone, Copy)]
 pub struct AttesterCacheKey {
     /// The epoch from which the justified checkpoint should be observed.
     ///
@@ -235,8 +235,6 @@ impl AttesterCacheKey {
         })
     }
 }
-
-impl Eq for AttesterCacheKey {}
 
 /// Provides a cache for the justified checkpoint and committee length when producing an
 /// attestation.
@@ -355,16 +353,15 @@ impl AttesterCache {
         key: AttesterCacheKey,
         value: AttesterCacheValue,
     ) {
-        if cache.len() >= MAX_CACHE_LEN {
-            while let Some(oldest) = cache
+        while cache.len() >= MAX_CACHE_LEN {
+            if let Some(oldest) = cache
                 .iter()
-                .map(|(key, _)| key)
+                .map(|(key, _)| *key)
                 .min_by_key(|key| key.epoch)
-                // Only return values whilst the cache is full.
-                .filter(|_| cache.len() >= MAX_CACHE_LEN)
-                .copied()
             {
                 cache.remove(&oldest);
+            } else {
+                break;
             }
         }
 

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -28,7 +28,13 @@ type CommitteeIndex = u64;
 type CacheHashMap = HashMap<AttesterCacheKey, AttesterCacheValue>;
 
 /// The maximum number of `AttesterCacheValues` to be kept in memory.
-const MAX_CACHE_LEN: usize = 64;
+///
+/// Each `AttesterCacheValues` is very small (~16 bytes) and the cache will generally be kept small
+/// by pruning on finality.
+///
+/// The value provided here is much larger than will be used during ideal network conditions,
+/// however we make it large since the values are so small.
+const MAX_CACHE_LEN: usize = 1_024;
 
 #[derive(Debug)]
 pub enum Error {

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -1,3 +1,14 @@
+//! This module provides the `AttesterCache`, a cache designed for reducing state-reads when
+//! validators produce `AttestationData`.
+//!
+//! This cache is required *as well as* the `ShufflingCache` since the `ShufflingCache` does not
+//! provide any information about the `state.current_justified_checkpoint`. It is not trivial to add
+//! the justified checkpoint to the `ShufflingCache` since that cache keyed by shuffling decision
+//! root, which is not suitable for the justified checkpoint. Whilst we can know the shuffling for
+//! epoch `n` during `n - 1`, we *cannot* know the justified checkpoint. Instead, we *must* perform
+//! `per_epoch_processing` to transform the state from epoch `n - 1` to epoch `n` so that rewards
+//! and penalties can be computed and the `state.current_justified_checkpoint` can be updated.
+
 use parking_lot::RwLock;
 use std::collections::HashMap;
 use types::{
@@ -9,6 +20,7 @@ type JustifiedCheckpoint = Checkpoint;
 type CommitteeLength = usize;
 type CommitteeIndex = u64;
 
+/// The maximum number of `CacheItems` to be kept in memory.
 const MAX_CACHE_LEN: usize = 64;
 
 #[derive(Debug)]

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -4,7 +4,6 @@ use types::{
     BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, Hash256, RelativeEpoch, Slot,
 };
 
-type TargetRoot = Hash256;
 type TargetCheckpoint = Checkpoint;
 type JustifiedCheckpoint = Checkpoint;
 type CommitteeLength = usize;
@@ -132,14 +131,17 @@ impl AttesterCache {
             .transpose()
     }
 
-    pub fn cache_state<T: EthSpec>(
+    pub fn maybe_cache_state<T: EthSpec>(
         &self,
         state: &BeaconState<T>,
         latest_beacon_block_root: Hash256,
     ) -> Result<(), Error> {
         let target = get_state_target(state, latest_beacon_block_root)?;
-        let cache_item = CacheItem::new(state)?;
-        self.cache.write().insert(target, cache_item);
+        let key_exists = self.cache.read().contains_key(&target);
+        if !key_exists {
+            let cache_item = CacheItem::new(state)?;
+            self.cache.write().insert(target, cache_item);
+        }
         Ok(())
     }
 

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -278,9 +278,13 @@ impl AttesterCache {
         Ok(())
     }
 
-    /// Read the state identified by `state_root` from the database, advance it to the required
+    /// Read the state identified by `state_root` from the database*, advance it to the required
     /// slot, use it to prime the cache and return the values for the provided `slot` and
     /// `committee_index`.
+    ///
+    /// *: The database read is avoided if `state_opt.is_some()`.
+    ///
+    /// If `state_opt.is_some()`, the `state_root` *must* match that state.
     ///
     /// ## Notes
     ///
@@ -290,6 +294,7 @@ impl AttesterCache {
     pub fn load_and_cache_state<T: BeaconChainTypes>(
         &self,
         state_root: Hash256,
+        state_opt: Option<BeaconState<T::EthSpec>>,
         key: AttesterCacheKey,
         slot: Slot,
         committee_index: CommitteeIndex,
@@ -316,9 +321,13 @@ impl AttesterCache {
             return Ok(value);
         }
 
-        let mut state: BeaconState<T::EthSpec> = chain
-            .get_state(&state_root, None)?
-            .ok_or(Error::MissingBeaconState(state_root))?;
+        let mut state = if let Some(state) = state_opt {
+            state
+        } else {
+            chain
+                .get_state(&state_root, None)?
+                .ok_or(Error::MissingBeaconState(state_root))?
+        };
 
         if state.slot() > slot {
             // This indicates an internal inconsistency.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1354,10 +1354,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // The suitable values were already cached. Return them.
                 cached_values
             } else {
-                // This scenario is likely to happen occasionally. It is reasonable to drop this to
-                // a `debug!` if it turns out to be frequent and unavoidable. At least whilst the
-                // feature is new it is nice to see if the cache is getting a lot of misses.
-                warn!(
+                debug!(
                     self.log,
                     "Attester cache miss";
                     "beacon_block_root" => ?beacon_block_root,
@@ -2223,12 +2220,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         }
 
-        // Apply the state to the attester cache, only if it is from the previous epoch or earlier.
+        // Apply the state to the attester cache, only if it is from the previous epoch or later.
         //
         // In a perfect scenario there should be no need to add previous-epoch states to the cache.
         // However, latency between the VC and the BN might cause the VC to produce attestations at
         // a previous slot.
-        if state.current_epoch().saturating_add(2_u64) >= current_epoch {
+        if state.current_epoch().saturating_add(1_u64) >= current_epoch {
             self.attester_cache
                 .maybe_cache_state(&state, block_root, &self.spec)
                 .map_err(BeaconChainError::from)?;

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1382,10 +1382,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let (justified_checkpoint, committee_len) = if head_state_epoch == request_epoch {
             (head_state_justified_checkpoint, head_state_committee_len)
-        } else if let Some(tuple) =
-            self.attester_cache
-                .get(&attester_cache_key, request_slot, request_index)?
-        {
+        } else if let Some(tuple) = self.attester_cache.get::<T::EthSpec>(
+            &attester_cache_key,
+            request_slot,
+            request_index,
+            &self.spec,
+        )? {
             tuple
         } else {
             let mut state: BeaconState<T::EthSpec> = self
@@ -1406,8 +1408,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 state.build_committee_cache(RelativeEpoch::Current, &self.spec)?;
             }
 
-            self.attester_cache
-                .cache_state_and_return_value(&state, request_slot, request_index)?
+            self.attester_cache.cache_state_and_return_value(
+                &state,
+                request_slot,
+                request_index,
+                &self.spec,
+            )?
         };
 
         self.produce_unaggregated_attestation_parameterized(

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1360,7 +1360,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 warn!(
                     self.log,
                     "Attester cache miss";
-                    "beacon_block_root" => %beacon_block_root,
+                    "beacon_block_root" => ?beacon_block_root,
                     "head_state_slot" => %head_state_slot,
                     "request_slot" => %request_slot,
                 );

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1248,6 +1248,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let beacon_state_root;
         let target;
         let current_epoch_attesting_info: Option<(Checkpoint, usize)>;
+        let head_state_clone: Option<Box<BeaconState<T::EthSpec>>>;
         let attester_cache_key;
         let head_timer = metrics::start_timer(&metrics::ATTESTATION_PRODUCTION_HEAD_SCRAPE_SECONDS);
         if let Some(head) = self.canonical_head.try_read_for(HEAD_LOCK_TIMEOUT) {
@@ -1305,21 +1306,41 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 root: target_root,
             };
 
-            current_epoch_attesting_info = if head_state.current_epoch() == request_epoch {
-                // When the head state is in the same epoch as the request, all the information
-                // required to attest is available on the head state.
-                Some((
-                    head_state.current_justified_checkpoint(),
-                    head_state
-                        .get_beacon_committee(request_slot, request_index)?
-                        .committee
-                        .len(),
-                ))
-            } else {
-                // If the head state is in a *different* epoch to the request, more work is required
-                // to determine the justified checkpoint and committee length.
-                None
-            };
+            match request_epoch.cmp(&head_state.current_epoch()) {
+                // The request is in the same epoch as the head state.
+                Ordering::Equal => {
+                    // When the head state is in the same epoch as the request, all the information
+                    // required to attest is available on the head state.
+                    current_epoch_attesting_info = Some((
+                        head_state.current_justified_checkpoint(),
+                        head_state
+                            .get_beacon_committee(request_slot, request_index)?
+                            .committee
+                            .len(),
+                    ));
+                    // There is no need to clone the head state, all required information has
+                    // already been obtained.
+                    head_state_clone = None;
+                }
+                // The request is in a *later* epoch than the head state.
+                Ordering::Greater => {
+                    // The justified checkpoint in the head state is not useful in this scenario.
+                    current_epoch_attesting_info = None;
+                    // The head state *is* useful in this this scenario because we can advance it
+                    // into the required epoch.
+                    head_state_clone = Some(Box::new(
+                        head_state.clone_with(CloneConfig::committee_caches_only()),
+                    ));
+                }
+                // The request is in a *earlier* epoch than the head state.
+                Ordering::Less => {
+                    // The justified checkpoint in the head state is not useful in this scenario.
+                    current_epoch_attesting_info = None;
+                    // The head state is not useful in this scenario, we must load an older one from
+                    // disk.
+                    head_state_clone = None;
+                }
+            }
 
             // Determine the key for `self.attester_cache`, in case it is required later in this
             // routine.
@@ -1369,6 +1390,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     metrics::start_timer(&metrics::ATTESTATION_PRODUCTION_CACHE_PRIME_SECONDS);
                 self.attester_cache.load_and_cache_state(
                     beacon_state_root,
+                    head_state_clone.map(|boxed| *boxed),
                     attester_cache_key,
                     request_slot,
                     request_index,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2241,7 +2241,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // a previous slot.
         if state.current_epoch().saturating_add(2_u64) >= current_epoch {
             self.attester_cache
-                .maybe_cache_state(&state, block_root)
+                .maybe_cache_state(&state, block_root, &self.spec)
                 .map_err(BeaconChainError::from)?;
         }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1285,10 +1285,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             if request_slot >= head_state.slot() {
                 // When attesting to the head slot or later, always use the head of the chain.
                 beacon_block_root = head.beacon_block_root;
+                beacon_state_root = head.beacon_state_root();
             } else {
                 // Permit attesting to slots *prior* to the current head. This is desirable when
                 // the VC and BN are out-of-sync due to time issues or overloading.
                 beacon_block_root = *head_state.get_block_root(request_slot)?;
+                beacon_state_root = *head_state.get_state_root(request_slot)?;
             };
 
             let target_slot = request_epoch.start_slot(T::EthSpec::slots_per_epoch());
@@ -1319,8 +1321,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     // There is no need to clone the head state, all required information has
                     // already been obtained.
                     head_state_clone = None;
-                    // This value is not required, yet we set it to something sensible nonetheless.
-                    beacon_state_root = *head_state.get_state_root(request_slot)?;
                 }
                 // The request is in a *later* epoch than the head state.
                 Ordering::Greater => {
@@ -1331,8 +1331,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     head_state_clone = Some(Box::new(
                         head_state.clone_with(CloneConfig::committee_caches_only()),
                     ));
-                    // The beacon state being used is that of the head state.
-                    beacon_state_root = head.beacon_state_root();
                 }
                 // The request is in a *earlier* epoch than the head state.
                 Ordering::Less => {
@@ -1341,11 +1339,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     // The head state is not useful in this scenario, we must load an older one from
                     // disk.
                     head_state_clone = None;
-                    // This state root will be loaded from the database.
-                    //
-                    // Use the `target_slot` here instead of the `slot` to avoid replaying blocks
-                    // during the database read.
-                    beacon_state_root = *head_state.get_state_root(target_slot)?;
                 }
             }
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -562,6 +562,16 @@ where
             .head()
             .map_err(|e| format!("Failed to get head: {:?}", e))?;
 
+        // Prime the attester cache with the head state.
+        beacon_chain
+            .attester_cache
+            .maybe_cache_state(
+                &head.beacon_state,
+                head.beacon_block_root,
+                &beacon_chain.spec,
+            )
+            .map_err(|e| format!("Failed to prime attester cache: {:?}", e))?;
+
         // Only perform the check if it was configured.
         if let Some(wss_checkpoint) = beacon_chain.config.weak_subjectivity_checkpoint {
             if let Err(e) = beacon_chain.verify_weak_subjectivity_checkpoint(

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -547,6 +547,7 @@ where
             shuffling_cache: TimeoutRwLock::new(ShufflingCache::new()),
             beacon_proposer_cache: <_>::default(),
             validator_pubkey_cache: TimeoutRwLock::new(validator_pubkey_cache),
+            attester_cache: <_>::default(),
             disabled_forks: self.disabled_forks,
             shutdown_sender: self
                 .shutdown_sender

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -109,6 +109,10 @@ pub enum BeaconChainError {
         finalized_slot: Slot,
         request_slot: Slot,
     },
+    AttestingToAncientSlot {
+        head_state_slot: Slot,
+        lowest_permissible_slot: Slot,
+    },
     BadPreState {
         parent_root: Hash256,
         parent_slot: Slot,

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -101,17 +101,13 @@ pub enum BeaconChainError {
     },
     WeakSubjectivtyVerificationFailure,
     WeakSubjectivtyShutdownError(TrySendError<ShutdownReason>),
-    AttestingPriorToHead {
-        head_slot: Slot,
-        request_slot: Slot,
-    },
     AttestingToFinalizedSlot {
         finalized_slot: Slot,
         request_slot: Slot,
     },
     AttestingToAncientSlot {
-        head_state_slot: Slot,
         lowest_permissible_slot: Slot,
+        request_slot: Slot,
     },
     BadPreState {
         parent_root: Hash256,

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -1,3 +1,4 @@
+use crate::attester_cache::Error as AttesterCacheError;
 use crate::beacon_chain::ForkChoiceError;
 use crate::beacon_fork_choice_store::Error as ForkChoiceStoreError;
 use crate::eth1_chain::Error as Eth1ChainError;
@@ -91,6 +92,7 @@ pub enum BeaconChainError {
     ObservedAttestationsError(ObservedAttestationsError),
     ObservedAttestersError(ObservedAttestersError),
     ObservedBlockProducersError(ObservedBlockProducersError),
+    AttesterCacheError(AttesterCacheError),
     PruningError(PruningError),
     ArithError(ArithError),
     InvalidShufflingId {
@@ -137,6 +139,7 @@ easy_from_to!(NaiveAggregationError, BeaconChainError);
 easy_from_to!(ObservedAttestationsError, BeaconChainError);
 easy_from_to!(ObservedAttestersError, BeaconChainError);
 easy_from_to!(ObservedBlockProducersError, BeaconChainError);
+easy_from_to!(AttesterCacheError, BeaconChainError);
 easy_from_to!(BlockSignatureVerifierError, BeaconChainError);
 easy_from_to!(PruningError, BeaconChainError);
 easy_from_to!(ArithError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -105,6 +105,10 @@ pub enum BeaconChainError {
         head_slot: Slot,
         request_slot: Slot,
     },
+    AttestingToFinalizedSlot {
+        finalized_slot: Slot,
+        request_slot: Slot,
+    },
     BadPreState {
         parent_root: Hash256,
         parent_slot: Slot,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "128"] // For lazy-static
 pub mod attestation_verification;
+mod attester_cache;
 mod beacon_chain;
 mod beacon_fork_choice_store;
 mod beacon_proposer_cache;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -210,17 +210,21 @@ lazy_static! {
     /*
      * Attestation Production
      */
-    pub static ref ATTESTATION_PRODUCTION_REQUESTS: Result<IntCounter> = try_create_int_counter(
-        "beacon_attestation_production_requests_total",
-        "Count of all attestation production requests"
-    );
-    pub static ref ATTESTATION_PRODUCTION_SUCCESSES: Result<IntCounter> = try_create_int_counter(
-        "beacon_attestation_production_successes_total",
-        "Count of attestations processed without error"
-    );
-    pub static ref ATTESTATION_PRODUCTION_TIMES: Result<Histogram> = try_create_histogram(
+    pub static ref ATTESTATION_PRODUCTION_SECONDS: Result<Histogram> = try_create_histogram(
         "beacon_attestation_production_seconds",
         "Full runtime of attestation production"
+    );
+    pub static ref ATTESTATION_PRODUCTION_HEAD_SCRAPE_SECONDS: Result<Histogram> = try_create_histogram(
+        "attestation_production_head_scrape_seconds",
+        "Time taken to read the head state"
+    );
+    pub static ref ATTESTATION_PRODUCTION_CACHE_INTERACTION_SECONDS: Result<Histogram> = try_create_histogram(
+        "attestation_production_cache_interaction_seconds",
+        "Time spent interacting with the attester cache"
+    );
+    pub static ref ATTESTATION_PRODUCTION_CACHE_PRIME_SECONDS: Result<Histogram> = try_create_histogram(
+        "attestation_production_cache_prime_seconds",
+        "Time spent loading a new state from the disk due to a cache miss"
     );
 }
 

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -304,6 +304,12 @@ fn advance_head<T: BeaconChainTypes>(
         );
     }
 
+    // Apply the state to the attester cache, if the cache deems it interesting.
+    beacon_chain
+        .attester_cache
+        .maybe_cache_state(&state, head_root)
+        .map_err(BeaconChainError::from)?;
+
     let final_slot = state.slot();
 
     // Insert the advanced state back into the snapshot cache.

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -307,7 +307,7 @@ fn advance_head<T: BeaconChainTypes>(
     // Apply the state to the attester cache, if the cache deems it interesting.
     beacon_chain
         .attester_cache
-        .maybe_cache_state(&state, head_root)
+        .maybe_cache_state(&state)
         .map_err(BeaconChainError::from)?;
 
     let final_slot = state.slot();

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -307,7 +307,7 @@ fn advance_head<T: BeaconChainTypes>(
     // Apply the state to the attester cache, if the cache deems it interesting.
     beacon_chain
         .attester_cache
-        .maybe_cache_state(&state, head_root)
+        .maybe_cache_state(&state, head_root, &beacon_chain.spec)
         .map_err(BeaconChainError::from)?;
 
     let final_slot = state.slot();

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -307,7 +307,7 @@ fn advance_head<T: BeaconChainTypes>(
     // Apply the state to the attester cache, if the cache deems it interesting.
     beacon_chain
         .attester_cache
-        .maybe_cache_state(&state)
+        .maybe_cache_state(&state, head_root)
         .map_err(BeaconChainError::from)?;
 
     let final_slot = state.slot();

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1699,15 +1699,30 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
                 blocking_json_task(move || {
+                    let slots_per_epoch = T::EthSpec::slots_per_epoch();
                     let current_slot = chain
                         .slot()
                         .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_epoch = current_slot.epoch(slots_per_epoch);
+                    let query_epoch = query.slot.epoch(slots_per_epoch);
 
                     // allow a tolerance of one slot to account for clock skew
                     if query.slot > current_slot + 1 {
                         return Err(warp_utils::reject::custom_bad_request(format!(
                             "request slot {} is more than one slot past the current slot {}",
                             query.slot, current_slot
+                        )));
+                    } else if query_epoch + 1 < current_epoch {
+                        // Restrict attestations that are earlier than the previous epoch. This is
+                        // an artificial restriction employed for two purposes:
+                        //
+                        // 1. To avoid presenting 500 errors to the user by requesting an epoch too
+                        //    low for the beacon chain to handle.
+                        // 2. Because producing an attestation for a slot earlier than the previous
+                        //    epoch will not be helpful to the network.
+                        return Err(warp_utils::reject::custom_bad_request(format!(
+                            "request epoch {} is  prior to the current epoch",
+                            query_epoch
                         )));
                     }
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1721,7 +1721,7 @@ pub fn serve<T: BeaconChainTypes>(
                         // 2. Because producing an attestation for a slot earlier than the previous
                         //    epoch will not be helpful to the network.
                         return Err(warp_utils::reject::custom_bad_request(format!(
-                            "request epoch {} is  prior to the current epoch",
+                            "request epoch {} is prior to the previous epoch",
                             query_epoch
                         )));
                     }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1703,26 +1703,12 @@ pub fn serve<T: BeaconChainTypes>(
                     let current_slot = chain
                         .slot()
                         .map_err(warp_utils::reject::beacon_chain_error)?;
-                    let current_epoch = current_slot.epoch(slots_per_epoch);
-                    let query_epoch = query.slot.epoch(slots_per_epoch);
 
                     // allow a tolerance of one slot to account for clock skew
                     if query.slot > current_slot + 1 {
                         return Err(warp_utils::reject::custom_bad_request(format!(
                             "request slot {} is more than one slot past the current slot {}",
                             query.slot, current_slot
-                        )));
-                    } else if query_epoch + 1 < current_epoch {
-                        // Restrict attestations that are earlier than the previous epoch. This is
-                        // an artificial restriction employed for two purposes:
-                        //
-                        // 1. To avoid presenting 500 errors to the user by requesting an epoch too
-                        //    low for the beacon chain to handle.
-                        // 2. Because producing an attestation for a slot earlier than the previous
-                        //    epoch will not be helpful to the network.
-                        return Err(warp_utils::reject::custom_bad_request(format!(
-                            "request epoch {} is prior to the previous epoch",
-                            query_epoch
                         )));
                     }
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1699,7 +1699,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
                 blocking_json_task(move || {
-                    let slots_per_epoch = T::EthSpec::slots_per_epoch();
                     let current_slot = chain
                         .slot()
                         .map_err(warp_utils::reject::beacon_chain_error)?;

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1311,8 +1311,17 @@ impl<T: EthSpec> BeaconState<T> {
         let epoch = relative_epoch.into_epoch(self.current_epoch());
         let i = Self::committee_cache_index(relative_epoch);
 
-        *self.committee_cache_at_index_mut(i)? = CommitteeCache::initialized(&self, epoch, spec)?;
+        *self.committee_cache_at_index_mut(i)? = self.initialize_committee_cache(epoch, spec)?;
         Ok(())
+    }
+
+    /// Returns a committee cache initialized for the given `epoch`.
+    pub fn initialize_committee_cache(
+        &self,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> Result<CommitteeCache, Error> {
+        CommitteeCache::initialized(&self, epoch, spec)
     }
 
     /// Advances the cache for this state into the next epoch.

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1315,7 +1315,10 @@ impl<T: EthSpec> BeaconState<T> {
         Ok(())
     }
 
-    /// Returns a committee cache initialized for the given `epoch`.
+    /// Initializes a new committee cache for the given `epoch`, regardless of whether one already
+    /// exists. Returns the committee cache without attaching it to `self`.
+    ///
+    /// To build a cache and store it on `self`, use `Self::build_committee_cache`.
     pub fn initialize_committee_cache(
         &self,
         epoch: Epoch,

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -22,7 +22,10 @@ use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-pub use self::committee_cache::CommitteeCache;
+pub use self::committee_cache::{
+    compute_committee_index_in_epoch, compute_committee_range_in_epoch, epoch_committee_count,
+    CommitteeCache,
+};
 pub use clone_config::CloneConfig;
 pub use eth_spec::*;
 pub use iter::BlockRootsIter;

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -263,7 +263,10 @@ impl CommitteeCache {
 }
 
 /// Computes the position of the given `committee_index` with respect to all committees in the
-/// epoch. Generally used to provide input to the `compute_committee_range_in_epoch` function.
+/// epoch.
+///
+/// The return result may be used to provide input to the `compute_committee_range_in_epoch`
+/// function.
 pub fn compute_committee_index_in_epoch(
     slot: Slot,
     slots_per_epoch: usize,
@@ -275,19 +278,19 @@ pub fn compute_committee_index_in_epoch(
 
 /// Computes the range for slicing the shuffled indices to determine the members of a committee.
 ///
-/// The `index_in_epoch` is generally computed using `compute_committee_index_in_epoch`.
+/// The `index_in_epoch` parameter can be computed computed using
+/// `compute_committee_index_in_epoch`.
 pub fn compute_committee_range_in_epoch(
     epoch_committee_count: usize,
     index_in_epoch: usize,
     shuffling_len: usize,
 ) -> Option<Range<usize>> {
-    let count = epoch_committee_count;
-    if count == 0 || index_in_epoch >= count {
+    if epoch_committee_count == 0 || index_in_epoch >= epoch_committee_count {
         return None;
     }
 
-    let start = (shuffling_len * index_in_epoch) / count;
-    let end = (shuffling_len * (index_in_epoch + 1)) / count;
+    let start = (shuffling_len * index_in_epoch) / epoch_committee_count;
+    let end = (shuffling_len * (index_in_epoch + 1)) / epoch_committee_count;
 
     Some(start..end)
 }

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -121,8 +121,12 @@ impl CommitteeCache {
             return None;
         }
 
-        let committee_index =
-            (slot.as_u64() % self.slots_per_epoch) * self.committees_per_slot + index;
+        let committee_index = compute_committee_index_in_epoch(
+            slot,
+            self.slots_per_epoch as usize,
+            self.committees_per_slot as usize,
+            index as usize,
+        );
         let committee = self.compute_committee(committee_index as usize)?;
 
         Some(BeaconCommittee {
@@ -219,7 +223,10 @@ impl CommitteeCache {
     ///
     /// Spec v0.12.1
     pub fn epoch_committee_count(&self) -> usize {
-        self.committees_per_slot as usize * self.slots_per_epoch as usize
+        epoch_committee_count(
+            self.committees_per_slot as usize,
+            self.slots_per_epoch as usize,
+        )
     }
 
     /// Returns the number of committees per slot for this cache's epoch.
@@ -242,16 +249,7 @@ impl CommitteeCache {
     ///
     /// Spec v0.12.1
     fn compute_committee_range(&self, index: usize) -> Option<Range<usize>> {
-        let count = self.epoch_committee_count();
-        if count == 0 || index >= count {
-            return None;
-        }
-
-        let num_validators = self.shuffling.len();
-        let start = (num_validators * index) / count;
-        let end = (num_validators * (index + 1)) / count;
-
-        Some(start..end)
+        compute_committee_range_in_epoch(self.epoch_committee_count(), index, self.shuffling.len())
     }
 
     /// Returns the index of some validator in `self.shuffling`.
@@ -262,6 +260,35 @@ impl CommitteeCache {
             .get(validator_index)?
             .and_then(|p| Some(p.get() - 1))
     }
+}
+
+pub fn compute_committee_index_in_epoch(
+    slot: Slot,
+    slots_per_epoch: usize,
+    committees_per_slot: usize,
+    committee_index: usize,
+) -> usize {
+    (slot.as_usize() % slots_per_epoch) * committees_per_slot + committee_index
+}
+
+pub fn compute_committee_range_in_epoch(
+    epoch_committee_count: usize,
+    index_in_epoch: usize,
+    shuffling_len: usize,
+) -> Option<Range<usize>> {
+    let count = epoch_committee_count;
+    if count == 0 || index_in_epoch >= count {
+        return None;
+    }
+
+    let start = (shuffling_len * index_in_epoch) / count;
+    let end = (shuffling_len * (index_in_epoch + 1)) / count;
+
+    Some(start..end)
+}
+
+pub fn epoch_committee_count(committees_per_slot: usize, slots_per_epoch: usize) -> usize {
+    committees_per_slot * slots_per_epoch
 }
 
 /// Returns a list of all `validators` indices where the validator is active at the given

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -262,6 +262,8 @@ impl CommitteeCache {
     }
 }
 
+/// Computes the position of the given `committee_index` with respect to all committees in the
+/// epoch. Generally used to provide input to the `compute_committee_range_in_epoch` function.
 pub fn compute_committee_index_in_epoch(
     slot: Slot,
     slots_per_epoch: usize,
@@ -271,6 +273,9 @@ pub fn compute_committee_index_in_epoch(
     (slot.as_usize() % slots_per_epoch) * committees_per_slot + committee_index
 }
 
+/// Computes the range for slicing the shuffled indices to determine the members of a committee.
+///
+/// The `index_in_epoch` is generally computed using `compute_committee_index_in_epoch`.
 pub fn compute_committee_range_in_epoch(
     epoch_committee_count: usize,
     index_in_epoch: usize,
@@ -287,6 +292,7 @@ pub fn compute_committee_range_in_epoch(
     Some(start..end)
 }
 
+/// Returns the total number of committees in an epoch.
 pub fn epoch_committee_count(committees_per_slot: usize, slots_per_epoch: usize) -> usize {
     committees_per_slot * slots_per_epoch
 }


### PR DESCRIPTION
## Issue Addressed

- Resolves #2169

## Proposed Changes

Adds the `AttesterCache` to allow validators to produce attestations for older slots. Presently, some arbitrary restrictions can force validators to receive an error when attesting to a slot earlier than the present one. This can cause attestation misses when there is excessive load on the validator client or time sync issues between the VC and BN.

## Additional Info

NA
