### PR TITLE
[Merged by Bors] - Bump discv5 to v0.1.0-beta.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,9 +1534,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "discv5"
-version = "0.1.0-beta.8"
+version = "0.1.0-beta.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c594d301eb954fc101dec75f59a5291761e4ffe6169b249523b1086b9779b91f"
+checksum = "80d466b10228737f4a018909c97531c232ed215608473a4036e94e9191075dfc"
 dependencies = [
  "aes",
  "aes-gcm",

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-discv5 = { version = "0.1.0-beta.8", features = ["libp2p"] }
+discv5 = { version = "0.1.0-beta.9", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }


### PR DESCRIPTION
Bump discv5 to fix the issues with IP filters and removing nodes.

~~Blocked on an upstream release, and more testnet data.~~
