### PR TITLE
[Merged by Bors] - Bump tests to v1.1.0-beta.2

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-beta.1
+TESTS_TAG := v1.1.0-beta.2
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 


### PR DESCRIPTION
## Proposed Changes

Bump spec tests to v1.1.0-beta.2, for conformance with the latest spec release: https://github.com/ethereum/eth2.0-specs/releases/tag/v1.1.0-beta.2

## Additional Info

We already happen to be compatible with the latest spec change that requires sync contributions to have at least one bit set. I'm gonna call it foresight on @realbigsean's part :sunglasses:

https://github.com/sigp/lighthouse/blob/6e3ca48cb934a63cafdc940068825a48cba740d1/beacon_node/beacon_chain/src/sync_committee_verification.rs#L285-L288
