### PR TITLE
[Merged by Bors] - Add more unix signal handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,6 @@ dependencies = [
  "clap",
  "clap_utils",
  "client",
- "ctrlc",
  "directory",
  "dirs",
  "environment",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -25,7 +25,6 @@ rand = "0.7.3"
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_trace"] }
 slog-term = "2.6.0"
 slog-async = "2.5.0"
-ctrlc = { version = "3.1.6", features = ["termination"] }
 tokio = { version = "1.10.0", features = ["time"] }
 exit-future = "0.2.0"
 dirs = "3.0.1"

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -15,8 +15,10 @@ eth2_network_config = { path = "../../common/eth2_network_config" }
 logging = { path = "../../common/logging" }
 slog-term = "2.6.0"
 slog-async = "2.5.0"
-ctrlc = { version = "3.1.6", features = ["termination"] }
 futures = "0.3.7"
 parking_lot = "0.11.0"
 slog-json = "2.3.0"
 exit-future = "0.2.0"
+
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+ctrlc = { version = "3.1.6", features = ["termination"] }

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -20,5 +20,5 @@ parking_lot = "0.11.0"
 slog-json = "2.3.0"
 exit-future = "0.2.0"
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
+[target.'cfg(not(target_family = "unix"))'.dependencies]
 ctrlc = { version = "3.1.6", features = ["termination"] }

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread", "signal" ] }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.1"
-types = { "path" = "../../consensus/types" }
-eth2_config = { "path" = "../../common/eth2_config" }
-task_executor = { "path" = "../../common/task_executor" }
+types = { path = "../../consensus/types" }
+eth2_config = { path = "../../common/eth2_config" }
+task_executor = { path = "../../common/task_executor" }
 eth2_network_config = { path = "../../common/eth2_network_config" }
 logging = { path = "../../common/logging" }
 slog-term = "2.6.0"

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -493,17 +493,20 @@ pub fn null_logger() -> Result<Logger, String> {
         .map_err(|e| format!("Failed to start null logger: {:?}", e))
 }
 
+#[cfg(target_os = "linux")]
 struct SignalFuture {
     signal: Signal,
     message: &'static str,
 }
 
+#[cfg(target_os = "linux")]
 impl SignalFuture {
     pub fn new(signal: Signal, message: &'static str) -> SignalFuture {
         SignalFuture { signal, message }
     }
 }
 
+#[cfg(target_os = "linux")]
 impl Future for SignalFuture {
     type Output = Option<ShutdownReason>;
 

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -23,14 +23,14 @@ use task_executor::{ShutdownReason, TaskExecutor};
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use types::{EthSpec, MainnetEthSpec, MinimalEthSpec};
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 use {
     futures::Future,
     std::{pin::Pin, task::Context, task::Poll},
     tokio::signal::unix::{signal, Signal, SignalKind},
 };
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(target_family = "unix"))]
 use {futures::channel::oneshot, std::cell::RefCell};
 
 const LOG_CHANNEL_SIZE: usize = 2048;
@@ -346,7 +346,7 @@ impl<E: EthSpec> Environment<E> {
     /// Block the current thread until a shutdown signal is received.
     ///
     /// This can be either the user Ctrl-C'ing or a task requesting to shutdown.
-    #[cfg(target_os = "linux")]
+    #[cfg(target_family = "unix")]
     pub fn block_until_shutdown_requested(&mut self) -> Result<ShutdownReason, String> {
         // future of a task requesting to shutdown
         let mut rx = self
@@ -412,7 +412,7 @@ impl<E: EthSpec> Environment<E> {
     /// Block the current thread until a shutdown signal is received.
     ///
     /// This can be either the user Ctrl-C'ing or a task requesting to shutdown.
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(target_family = "unix"))]
     pub fn block_until_shutdown_requested(&mut self) -> Result<ShutdownReason, String> {
         // future of a task requesting to shutdown
         let mut rx = self
@@ -493,20 +493,20 @@ pub fn null_logger() -> Result<Logger, String> {
         .map_err(|e| format!("Failed to start null logger: {:?}", e))
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 struct SignalFuture {
     signal: Signal,
     message: &'static str,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 impl SignalFuture {
     pub fn new(signal: Signal, message: &'static str) -> SignalFuture {
         SignalFuture { signal, message }
     }
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(target_family = "unix")]
 impl Future for SignalFuture {
     type Output = Option<ShutdownReason>;
 

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -396,7 +396,7 @@ impl<E: EthSpec> Environment<E> {
             }
             future::Either::Left((Err(e), _)) => Err(e.into()),
             future::Either::Right(((res, _, _), _)) => {
-                res.ok_or("Handler channel closed".to_string())
+                res.ok_or_else(|| "Handler channel closed".to_string())
             }
         }
     }


### PR DESCRIPTION
## Issue Addressed

Resolves #2114 

Swapped out the ctrlc crate for tokio signals to hook register handlers for SIGPIPE and SIGHUP along with SIGTERM and SIGINT.

## Proposed Changes

- Swap out the ctrlc crate for tokio signals for unix signal handing
- Register signals for SIGPIPE and SHIGUP that trigger the same shutdown procedure as SIGTERM and SIGINT

## Additional Info

I tested these changes against the examples in the original issue and noticed some interesting behavior on my machine. When running `lighthouse bn --network pyrmont |& tee -a pyrmont_bn.log` or `lighthouse bn --network pyrmont 2>&1 | tee -a pyrmont_bn.log` none of the above signals are sent to the lighthouse program in a way I was able to observe. 

The only time it seems that the signal gets sent to the lighthouse program is if there is no redirection of stderr to stdout. I'm not as familiar with the details of how unix signals work in linux with a redirect like that so I'm not sure if this is a bug in the program or expected behavior.

Signals are correctly received without the redirection and if the above signals are sent directly to the program with something like `kill`.