### PR TITLE
[Merged by Bors] - Improve ergonomics of adding a new network config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,6 +1848,7 @@ dependencies = [
 name = "eth2_config"
 version = "0.2.0"
 dependencies = [
+ "paste",
  "serde",
  "serde_derive",
  "types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "enr",
  "eth2_config",
  "eth2_ssz",
+ "paste",
  "serde",
  "serde_yaml",
  "tempfile",
@@ -4638,6 +4639,12 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,6 @@ dependencies = [
  "enr",
  "eth2_config",
  "eth2_ssz",
- "paste",
  "serde",
  "serde_yaml",
  "tempfile",

--- a/common/eth2_config/Cargo.toml
+++ b/common/eth2_config/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 types = { path = "../../consensus/types" }
+paste = "1.0.5"

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -74,9 +74,11 @@ impl<'a> Eth2NetArchiveAndDirectory<'a> {
     }
 }
 
+/// Indicates that the `genesis.ssz.zip` file is present on the filesystem. This means that the
+/// deposit ceremony has concluded and the final genesis `BeaconState` is known.
 const GENESIS_STATE_IS_KNOWN: bool = true;
 
-macro_rules! define_net {
+macro_rules! define_archive {
     ($title: ident, $genesis_is_known: ident) => {
         paste! {
             #[macro_use]
@@ -110,24 +112,24 @@ macro_rules! define_net {
     };
 }
 
-macro_rules! define_nets {
+macro_rules! define_archives {
     ($(($name: ident, $genesis_is_known: ident)),+) => {
         paste! {
             $(
-            define_net!($name, $genesis_is_known);
+            define_archive!($name, $genesis_is_known);
             )+
             pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name::ETH2_NET_DIR,)+];
         }
     };
 }
 
-// Add a new "baked-in" network by adding it to the list below.
+// Add a new "built-in" network by adding it to the list below.
 //
 // ## Notes
 //
 // - The last entry must not end with a comma.
 // - The network must also be added in the `eth2_network_config` crate.
-define_nets!(
+define_archives!(
     (mainnet, GENESIS_STATE_IS_KNOWN),
     (pyrmont, GENESIS_STATE_IS_KNOWN),
     (prater, GENESIS_STATE_IS_KNOWN)

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -189,7 +189,7 @@ macro_rules! define_nets {
 /// their files in this crate. Then, we must use another crate (`eth2_network_configs`) to run a
 /// `build.rs` which will unzip the genesis states. Then, that `eth2_network_configs` crate can
 /// perform the final step of using `std::include_bytes` to bake the files (bytes) into the binary.
-macro_rules! define_archives {
+macro_rules! define_hardcoded_nets {
     ($(($name: ident, $genesis_is_known: ident)),+) => {
         paste! {
             $(
@@ -220,7 +220,7 @@ macro_rules! define_archives {
 //
 // This is the canonical place for defining the built-in network configurations that are present in
 // the `common/eth2_network_config/built_in_network_configs` directory.
-define_archives!(
+define_hardcoded_nets!(
     (mainnet, GENESIS_STATE_IS_KNOWN),
     (pyrmont, GENESIS_STATE_IS_KNOWN),
     (prater, GENESIS_STATE_IS_KNOWN)

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -98,7 +98,7 @@ pub struct HardcodedNet {
 
 /// Defines an `Eth2NetArchiveAndDirectory` for some network.
 ///
-/// It also defines a `include_<title>_bytes!` macro which provides a wrapper around
+/// It also defines a `include_<title>_file!` macro which provides a wrapper around
 /// `std::include_bytes`, allowing the inclusion of bytes from the specific testnet directory.
 macro_rules! define_archive {
     ($name_ident: ident, $name_str: tt, $genesis_is_known: ident) => {
@@ -137,7 +137,7 @@ macro_rules! define_archive {
 /// Creates a `HardcodedNet` definition for some network.
 #[macro_export]
 macro_rules! define_net {
-    ($this_crate: tt, $mod: ident, $include_file: tt) => {{
+    ($this_crate: ident, $mod: ident, $include_file: tt) => {{
         use $this_crate::$mod::ETH2_NET_DIR;
 
         $this_crate::HardcodedNet {
@@ -191,24 +191,22 @@ macro_rules! define_nets {
 /// perform the final step of using `std::include_bytes` to bake the files (bytes) into the binary.
 macro_rules! define_hardcoded_nets {
     ($(($name_ident: ident, $name_str: tt, $genesis_is_known: ident)),+) => {
-        paste! {
-            $(
-            define_archive!($name_ident, $name_str, $genesis_is_known);
-            )+
+        $(
+        define_archive!($name_ident, $name_str, $genesis_is_known);
+        )+
 
-            pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name_ident::ETH2_NET_DIR,)+];
+        pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name_ident::ETH2_NET_DIR,)+];
 
-            /// This macro is designed to be called by an external crate. When called, it will
-            /// define in that external crate:
-            ///
-            /// - A `HardcodedNet` for each network.
-            /// - `HARDCODED_NETS`: a list of all the above `HardcodedNet`.
-            /// - `HARDCODED_NET_NAMES`: a list of all the names of the above `HardcodedNet` (as `&str`).
-            #[macro_export]
-            macro_rules! instantiate_hardcoded_nets {
-                ($this_crate: ident) => {
-                    $this_crate::define_nets!($this_crate, $($name_ident, $name_str,)+);
-                }
+        /// This macro is designed to be called by an external crate. When called, it will
+        /// define in that external crate:
+        ///
+        /// - A `HardcodedNet` for each network.
+        /// - `HARDCODED_NETS`: a list of all the above `HardcodedNet`.
+        /// - `HARDCODED_NET_NAMES`: a list of all the names of the above `HardcodedNet` (as `&str`).
+        #[macro_export]
+        macro_rules! instantiate_hardcoded_nets {
+            ($this_crate: ident) => {
+                $this_crate::define_nets!($this_crate, $($name_ident, $name_str,)+);
             }
         }
     };

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -20,4 +20,3 @@ types = { path = "../../consensus/types"}
 eth2_ssz = "0.1.2"
 eth2_config = { path = "../eth2_config"}
 enr = { version = "0.5.1", features = ["ed25519", "k256"] }
-paste = "1.0.5"

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -20,3 +20,4 @@ types = { path = "../../consensus/types"}
 eth2_ssz = "0.1.2"
 eth2_config = { path = "../eth2_config"}
 enr = { version = "0.5.1", features = ["ed25519", "k256"] }
+paste = "1.0.5"

--- a/common/eth2_network_config/build.rs
+++ b/common/eth2_network_config/build.rs
@@ -1,14 +1,8 @@
 //! Extracts zipped genesis states on first run.
-use eth2_config::{mainnet, prater, pyrmont, Eth2NetArchiveAndDirectory, GENESIS_FILE_NAME};
+use eth2_config::{Eth2NetArchiveAndDirectory, ETH2_NET_DIRS, GENESIS_FILE_NAME};
 use std::fs::File;
 use std::io;
 use zip::ZipArchive;
-
-const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[
-    mainnet::ETH2_NET_DIR,
-    pyrmont::ETH2_NET_DIR,
-    prater::ETH2_NET_DIR,
-];
 
 fn main() {
     for network in ETH2_NET_DIRS {

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -1,6 +1,7 @@
 use eth2_config::{predefined_networks_dir, *};
 
 use enr::{CombinedKey, Enr};
+use paste::paste;
 use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -37,19 +38,17 @@ macro_rules! define_net {
 }
 
 macro_rules! define_nets {
-    ($(($name: ident, $mod: ident, $include_file: tt)),+) => {
-        $(
-        const $name: HardcodedNet = define_net!($mod, $include_file);
-        )+
+    ($($name: ident),+) => {
+        paste! {
+            $(
+            const $name: HardcodedNet = define_net!([<$name:lower>], [<include_ $name:lower _file>]);
+            )+
+        }
         const HARDCODED_NETS: &[HardcodedNet] = &[$($name,)+];
     };
 }
 
-define_nets!(
-    (MAINNET, mainnet, include_mainnet_file),
-    (PYRMONT, pyrmont, include_pyrmont_file),
-    (PRATER, prater, include_prater_file)
-);
+define_nets!(MAINNET, PYRMONT, PRATER);
 
 pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -36,11 +36,21 @@ macro_rules! define_net {
     }};
 }
 
-const PYRMONT: HardcodedNet = define_net!(pyrmont, include_pyrmont_file);
-const MAINNET: HardcodedNet = define_net!(mainnet, include_mainnet_file);
-const PRATER: HardcodedNet = define_net!(prater, include_prater_file);
+macro_rules! define_nets {
+    ($(($name: ident, $mod: ident, $include_file: tt)),+) => {
+        $(
+        const $name: HardcodedNet = define_net!($mod, $include_file);
+        )+
+        const HARDCODED_NETS: &[HardcodedNet] = &[$($name,)+];
+    };
+}
 
-const HARDCODED_NETS: &[HardcodedNet] = &[PYRMONT, MAINNET, PRATER];
+define_nets!(
+    (MAINNET, mainnet, include_mainnet_file),
+    (PYRMONT, pyrmont, include_pyrmont_file),
+    (PRATER, prater, include_prater_file)
+);
+
 pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 
 /// Specifies an Eth2 network.

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -1,3 +1,26 @@
+//! Provides the `Eth2NetworkConfig` struct which defines the configuration of an eth2 network or
+//! test-network (aka "testnet").
+//!
+//! Whilst the `Eth2NetworkConfig` struct can be used to read a specification from a directory at
+//! runtime, this crate also includes some pre-defined network configurations "built-in" to the
+//! binary itself (the most notable of these being the "mainnet" configuration). When a network is
+//! "built-in", the  genesis state and configuration files is included in the final binary via the
+//! `std::include_bytes` macro. This provides convenience to the user, the binary is self-sufficient
+//! and does not require the configuration to be read from the filesystem at runtime.
+//!
+//! ## How to "build-in" a network configuration.
+//!
+//! First, create a new directory in the `built_in_network_configs` in the root of the crate. This
+//! directory requires a specific structure, see the other baked-in networks for reference.
+//!
+//! Next, go to the `../eth2_config/src/lib.rs` file and add the testnet to the `define_archives`
+//! invocation.
+//!
+//! Finally, add the network to the `define_nets` invocation in this file.
+//!
+//! The `build.rs` script for this crate will magically include all the files in the binary and then
+//! this crate will export the network as a member of the `HARDCODED_NETS` slice.
+
 use eth2_config::{predefined_networks_dir, *};
 
 use enr::{CombinedKey, Enr};
@@ -49,7 +72,7 @@ macro_rules! define_nets {
     };
 }
 
-// Add a new "baked-in" network by adding it to the list below.
+// Add a new "built-in" network by adding it to the list below.
 //
 // ## Notes
 //

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -64,10 +64,10 @@ macro_rules! define_nets {
     ($($name: ident),+) => {
         paste! {
             $(
-            const $name: HardcodedNet = define_net!([<$name:lower>], [<include_ $name:lower _file>]);
+            const [<$name:upper>]: HardcodedNet = define_net!($name, [<include_ $name _file>]);
             )+
-            const HARDCODED_NETS: &[HardcodedNet] = &[$($name,)+];
-            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$(stringify!([<$name:lower>]),)+];
+            const HARDCODED_NETS: &[HardcodedNet] = &[$([<$name:upper>],)+];
+            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$(stringify!($name),)+];
         }
     };
 }
@@ -78,7 +78,7 @@ macro_rules! define_nets {
 //
 // - The last entry must not end with a comma.
 // - The network must also be added in the `eth2_config` crate.
-define_nets!(MAINNET, PYRMONT, PRATER);
+define_nets!(mainnet, pyrmont, prater);
 
 pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -286,6 +286,14 @@ mod tests {
     }
 
     #[test]
+    fn hardcoded_testnet_names() {
+        assert_eq!(HARDCODED_NET_NAMES.len(), HARDCODED_NETS.len());
+        for (name, net) in HARDCODED_NET_NAMES.iter().zip(HARDCODED_NETS.iter()) {
+            assert_eq!(name, &net.name);
+        }
+    }
+
+    #[test]
     fn mainnet_config_eq_chain_spec() {
         let config = Eth2NetworkConfig::from_hardcoded_net(&MAINNET).unwrap();
         let spec = ChainSpec::mainnet();

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -8,7 +8,7 @@
 //! `std::include_bytes` macro. This provides convenience to the user, the binary is self-sufficient
 //! and does not require the configuration to be read from the filesystem at runtime.
 //!
-//! To add a new built-in testnet, add it to the `define_archives` invocation in the `eth2_config`
+//! To add a new built-in testnet, add it to the `define_hardcoded_nets` invocation in the `eth2_config`
 //! crate.
 
 use enr::{CombinedKey, Enr};

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -43,8 +43,9 @@ macro_rules! define_nets {
             $(
             const $name: HardcodedNet = define_net!([<$name:lower>], [<include_ $name:lower _file>]);
             )+
+            const HARDCODED_NETS: &[HardcodedNet] = &[$($name,)+];
+            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$(stringify!([<$name:lower>]),)+];
         }
-        const HARDCODED_NETS: &[HardcodedNet] = &[$($name,)+];
     };
 }
 
@@ -249,6 +250,11 @@ mod tests {
     use types::{Config, Eth1Data, Hash256, MainnetEthSpec};
 
     type E = MainnetEthSpec;
+
+    #[test]
+    fn default_network_exists() {
+        assert!(HARDCODED_NET_NAMES.contains(&DEFAULT_HARDCODED_NETWORK));
+    }
 
     #[test]
     fn mainnet_config_eq_chain_spec() {

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -49,6 +49,12 @@ macro_rules! define_nets {
     };
 }
 
+// Add a new "baked-in" network by adding it to the list below.
+//
+// ## Notes
+//
+// - The last entry must not end with a comma.
+// - The network must also be added in the `eth2_config` crate.
 define_nets!(MAINNET, PYRMONT, PRATER);
 
 pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -8,7 +8,7 @@ use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
 use env_logger::{Builder, Env};
 use environment::EnvironmentBuilder;
 use eth2_hashing::have_sha_extensions;
-use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK};
+use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK, HARDCODED_NET_NAMES};
 use lighthouse_version::VERSION;
 use malloc_utils::configure_memory_allocator;
 use slog::{crit, info, warn};
@@ -127,7 +127,7 @@ fn main() {
                 .long("network")
                 .value_name("network")
                 .help("Name of the Eth2 chain Lighthouse will sync and follow.")
-                .possible_values(&["pyrmont", "mainnet", "prater"])
+                .possible_values(HARDCODED_NET_NAMES)
                 .conflicts_with("testnet-dir")
                 .takes_value(true)
                 .global(true)


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR adds some more fancy macro magic to make it easier to add a new built-in (aka "baked-in") testnet config to the `lighthouse` binary.

Previously, a user needed to modify several files and repeat themselves several times. Now, they only need to add a single definition in the `eth2_config` crate. No repetition :tada: 