### PR TITLE
[Merged by Bors] - Improve eth1 fallback logging

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -121,10 +121,12 @@ impl EndpointsCache {
         state
     }
 
+    /// Return the first successful result along with number of previous errors encountered
+    /// or all the errors encountered if every none of the fallback endpoints return required output.
     pub async fn first_success<'a, F, O, R>(
         &'a self,
         func: F,
-    ) -> Result<O, FallbackError<SingleEndpointError>>
+    ) -> Result<(O, usize), FallbackError<SingleEndpointError>>
     where
         F: Fn(&'a SensitiveUrl) -> R,
         R: Future<Output = Result<O, SingleEndpointError>>,
@@ -160,12 +162,6 @@ impl EndpointsCache {
                 }
             })
             .await
-            .map(|(res, num_errors)| {
-                if num_errors > 0 {
-                    info!(self.log, "Fetched data from fallback"; "fallback_number" => num_errors);
-                }
-                res
-            })
     }
 
     pub async fn reset_errorred_endpoints(&self) {
@@ -719,18 +715,24 @@ impl Service {
             e => format!("{:?}", e),
         };
 
-        let (remote_head_block, new_block_numbers_deposit, new_block_numbers_block_cache) =
-            endpoints
-                .first_success(|e| async move {
-                    get_remote_head_and_new_block_ranges(e, self, node_far_behind_seconds).await
-                })
-                .await
-                .map_err(|e| {
-                    format!(
-                        "Failed to update Eth1 service: {:?}",
-                        process_single_err(&e)
-                    )
-                })?;
+        let (
+            (remote_head_block, new_block_numbers_deposit, new_block_numbers_block_cache),
+            num_errors,
+        ) = endpoints
+            .first_success(|e| async move {
+                get_remote_head_and_new_block_ranges(e, self, node_far_behind_seconds).await
+            })
+            .await
+            .map_err(|e| {
+                format!(
+                    "Failed to update Eth1 service: {:?}",
+                    process_single_err(&e)
+                )
+            })?;
+
+        if num_errors > 0 {
+            info!(self.log, "Fetched data from fallback"; "fallback_number" => num_errors);
+        }
 
         *self.inner.remote_head_block.write() = Some(remote_head_block);
 
@@ -890,6 +892,7 @@ impl Service {
                         relevant_new_block_numbers_from_endpoint(e, self, HeadType::Deposit).await
                     })
                     .await
+                    .map(|(res, _)| res)
                     .map_err(Error::FallbackError)?,
             }
         };
@@ -936,6 +939,7 @@ impl Service {
                     .map_err(SingleEndpointError::GetDepositLogsFailed)
                 })
                 .await
+                .map(|(res, _)| res)
                 .map_err(Error::FallbackError)?;
 
             /*
@@ -1044,6 +1048,7 @@ impl Service {
                             .await
                     })
                     .await
+                    .map(|(res, _)| res)
                     .map_err(Error::FallbackError)?,
             }
         };
@@ -1109,6 +1114,7 @@ impl Service {
                     download_eth1_block(e, self.inner.clone(), Some(block_number)).await
                 })
                 .await
+                .map(|(res, _)| res)
                 .map_err(Error::FallbackError)?;
 
             self.inner

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -160,6 +160,12 @@ impl EndpointsCache {
                 }
             })
             .await
+            .map(|(res, num_errors)| {
+                if num_errors > 0 {
+                    info!(self.log, "Fetched data from fallback"; "fallback_number" => num_errors);
+                }
+                res
+            })
     }
 
     pub async fn reset_errorred_endpoints(&self) {


### PR DESCRIPTION
## Issue Addressed

Resolves #2487 

## Proposed Changes

Logs a message once in every invocation of `Eth1Service::update` method if the primary endpoint is unavailable for some reason. 

e.g.
```log
Aug 03 00:09:53.517 WARN Error connecting to eth1 node endpoint  action: trying fallbacks, endpoint: http://localhost:8545/, service: eth1_rpc
Aug 03 00:09:56.959 INFO Fetched data from fallback              fallback_number: 1, service: eth1_rpc
```

The main aim of this PR is to have an accompanying message to the "action: trying fallbacks" error message that is returned when checking the endpoint for liveness. This is mainly to indicate to the user that the fallback was live and reachable. 

## Additional info
This PR is not meant to be a catch all for all cases where the primary endpoint failed. For instance, this won't log anything if the primary node was working fine during endpoint liveness checking and failed during deposit/block fetching. This is done intentionally to reduce number of logs while initial deposit/block sync and to avoid more complicated logic.