### PR TITLE
[Merged by Bors] - Fix starting-epoch check in doppelganger

### DIFF
--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -540,7 +540,7 @@ impl DoppelgangerService {
                 continue;
             };
 
-            if response.is_live && next_check_epoch >= response.epoch {
+            if response.is_live && next_check_epoch <= response.epoch {
                 violators.push(response.index);
             }
         }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Fixes a bug in Doppelganger Protection which would cause false-positives when a VC is restarted in the same epoch where it has already produced a signed message.

It could also cause a false-negative in the scenario where time skips forward (perhaps due to host suspend/wake). The new `time_skips_forward_with_doppelgangers` test covers this case.

This was a simple (and embarrassing, on my behalf) `>=` instead of `<=` bug that was missed by my tests but detected during manual testing by @michaelsproul (:pray:). Regression tests have been added.

## Additional Info

NA

## TODO

- [x] Add test for doppelganger in epoch > next_check_epoch