### PR TITLE
[Merged by Bors] - Register vals with doppelganger earlier

### DIFF
--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -745,6 +745,11 @@ mod test {
             self
         }
 
+        pub fn assert_prior_to_genesis(self) -> Self {
+            assert!(self.slot_clock.is_prior_to_genesis().unwrap());
+            self
+        }
+
         pub fn register_all_in_doppelganger_protection_if_enabled(self) -> Self {
             let mut this = self;
             for i in 0..this.validators.len() {
@@ -1114,6 +1119,7 @@ mod test {
         TestBuilder::default()
             .build()
             .set_current_time(prior_to_genesis)
+            .assert_prior_to_genesis()
             .register_all_in_doppelganger_protection_if_enabled();
     }
 

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -371,7 +371,8 @@ impl DoppelgangerService {
         slot_clock: &T,
     ) -> Result<(), String> {
         let current_epoch = slot_clock
-            .now()
+            // If registering before genesis, use the genesis slot.
+            .now_or_genesis()
             .ok_or_else(|| "Unable to read slot clock when registering validator".to_string())?
             .epoch(E::slots_per_epoch());
         let genesis_epoch = slot_clock.genesis_slot().epoch(E::slots_per_epoch());
@@ -674,6 +675,9 @@ mod test {
 
     const DEFAULT_VALIDATORS: usize = 8;
 
+    const GENESIS_TIME: Duration = Duration::from_secs(42);
+    const SLOT_DURATION: Duration = Duration::from_secs(1);
+
     type E = MainnetEthSpec;
 
     fn genesis_epoch() -> Epoch {
@@ -703,8 +707,7 @@ mod test {
     impl TestBuilder {
         fn build(self) -> TestScenario {
             let mut rng = XorShiftRng::from_seed([42; 16]);
-            let slot_clock =
-                TestingSlotClock::new(Slot::new(0), Duration::from_secs(0), Duration::from_secs(1));
+            let slot_clock = TestingSlotClock::new(Slot::new(0), GENESIS_TIME, SLOT_DURATION);
             let log = null_logger().unwrap();
 
             TestScenario {
@@ -734,6 +737,11 @@ mod test {
 
         pub fn set_slot(self, slot: Slot) -> Self {
             self.slot_clock.set_slot(slot.into());
+            self
+        }
+
+        pub fn set_current_time(self, time: Duration) -> Self {
+            self.slot_clock.set_current_time(time);
             self
         }
 
@@ -1097,6 +1105,16 @@ mod test {
         detect_after_genesis_test(|liveness_responses| {
             liveness_responses.previous_epoch_responses[0].is_live = true
         })
+    }
+
+    #[test]
+    fn register_prior_to_genesis() {
+        let prior_to_genesis = GENESIS_TIME.checked_sub(SLOT_DURATION).unwrap();
+
+        TestBuilder::default()
+            .build()
+            .set_current_time(prior_to_genesis)
+            .register_all_in_doppelganger_protection_if_enabled();
     }
 
     #[test]

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -348,6 +348,9 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             "voting_validators" => validator_store.num_voting_validators()
         );
 
+        // Ensure all validators are registered in doppelganger protection.
+        validator_store.register_all_in_doppelganger_protection_if_enabled()?;
+
         // Perform pruning of the slashing protection database on start-up. In case the database is
         // oversized from having not been pruned (by a prior version) we don't want to prune
         // concurrently, as it will hog the lock and cause the attestation service to spew CRITs.
@@ -399,9 +402,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
         // It seems most sensible to move this into the `start_service` function, but I'm caution
         // of making too many changes this close to genesis (<1 week).
         wait_for_genesis(&beacon_nodes, genesis_time, &context).await?;
-
-        // Ensure all validators are registered in doppelganger protection.
-        validator_store.register_all_in_doppelganger_protection_if_enabled()?;
 
         Ok(Self {
             context,

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -342,14 +342,14 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                 log.clone(),
             ));
 
+        // Ensure all validators are registered in doppelganger protection.
+        validator_store.register_all_in_doppelganger_protection_if_enabled()?;
+
         info!(
             log,
             "Loaded validator keypair store";
             "voting_validators" => validator_store.num_voting_validators()
         );
-
-        // Ensure all validators are registered in doppelganger protection.
-        validator_store.register_all_in_doppelganger_protection_if_enabled()?;
 
         // Perform pruning of the slashing protection database on start-up. In case the database is
         // oversized from having not been pruned (by a prior version) we don't want to prune


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Registers validators with the doppelganger service at the earliest possible point.

This avoids the following (non-harmful, but scary) log when pruning the slashing DB on startup:

```
CRIT Validator unknown to doppelganger service, pubkey: 0xabc..., msg: preventing validator from performing duties, service: doppelganger
```

## Additional Info

NA
