### PR TITLE
[Merged by Bors] - Update mdbook version in github actions

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.3.5'
+          mdbook-version: 'latest'
 
       - run: mdbook build
         working-directory: book


### PR DESCRIPTION
## Issue Addressed

Resolves #2477 

## Proposed Changes

Always use the latest mdbook version in github actions. [Source](https://github.com/peaceiris/actions-mdbook#%EF%B8%8F-use-the-latest-version-of-mdbook)