### PR TITLE
[Merged by Bors] - Update file permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,6 +1747,7 @@ dependencies = [
  "eth2_config",
  "eth2_network_config",
  "exit-future",
+ "filesystem",
  "futures",
  "logging",
  "parking_lot",

--- a/book/src/api-vc-auth-header.md
+++ b/book/src/api-vc-auth-header.md
@@ -17,10 +17,6 @@ Authorization Basic api-token-0x03eace4c98e8f77477bb99efb74f9af10d800bd3318f92c3
 
 ## Obtaining the API token
 
-The API token can be obtained via two methods:
-
-### Method 1: Reading from a file
-
 The API token is stored as a file in the `validators` directory. For most users
 this is `~/.lighthouse/{network}/validators/api-token.txt`. Here's an
 example using the `cat` command to print the token to the terminal, but any
@@ -31,13 +27,12 @@ $ cat api-token.txt
 api-token-0x03eace4c98e8f77477bb99efb74f9af10d800bd3318f92c33b719a4644254d4123
 ```
 
-### Method 2: Reading from logs
 
-When starting the validator client it will output a log message containing an
-`api-token` field:
+When starting the validator client it will output a log message containing the path
+to the file containing the api token.
 
 ```
-Sep 28 19:17:52.615 INFO HTTP API started                        api_token: api-token-0x03eace4c98e8f77477bb99efb74f9af10d800bd3318f92c33b719a4644254d4123, listen_address: 127.0.0.1:5062
+Sep 28 19:17:52.615 INFO HTTP API started                        api_token_file: "$HOME/prater/validators/api-token.txt", listen_address: 127.0.0.1:5062
 ```
 
 ## Example

--- a/common/filesystem/src/lib.rs
+++ b/common/filesystem/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Error {
     UnableToRemoveACLEntry(String),
 }
 
-/// Creates a file with `600 (-rw-------)` permissions.
+/// Creates a file with `600 (-rw-------)` permissions and writes the specified bytes to file.
 pub fn create_with_600_perms<P: AsRef<Path>>(path: P, bytes: &[u8]) -> Result<(), Error> {
     let path = path.as_ref();
     let mut file = File::create(&path).map_err(Error::UnableToCreateFile)?;

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -19,6 +19,7 @@ futures = "0.3.7"
 parking_lot = "0.11.0"
 slog-json = "2.3.0"
 exit-future = "0.2.0"
+filesystem = {"path" = "../../common/filesystem"}
 
 [target.'cfg(not(target_family = "unix"))'.dependencies]
 ctrlc = { version = "3.1.6", features = ["termination"] }

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -161,12 +161,6 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
             let backup_name = format!("{}_backup_{}", file_stem, timestamp);
             let backup_path = path.with_file_name(backup_name).with_extension(file_ext);
             FsRename(&path, &backup_path).map_err(|e| e.to_string())?;
-            restrict_file_permissions(&backup_path).map_err(|e| {
-                format!(
-                    "Unable to set file permissions for {:?}: {:?}",
-                    backup_path, e
-                )
-            })?;
         }
 
         let file = OpenOptions::new()

--- a/validator_client/src/http_api/api_secret.rs
+++ b/validator_client/src/http_api/api_secret.rs
@@ -4,7 +4,7 @@ use libsecp256k1::{Message, PublicKey, SecretKey};
 use rand::thread_rng;
 use ring::digest::{digest, SHA256};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use warp::Filter;
 
 /// The name of the file which stores the secret key.
@@ -38,6 +38,7 @@ pub const PK_FILENAME: &str = "api-token.txt";
 pub struct ApiSecret {
     pk: PublicKey,
     sk: SecretKey,
+    pk_path: PathBuf,
 }
 
 impl ApiSecret {
@@ -140,7 +141,7 @@ impl ApiSecret {
             ));
         }
 
-        Ok(Self { pk, sk })
+        Ok(Self { pk, sk, pk_path })
     }
 
     /// Returns the public key of `self` as a 0x-prefixed hex string.
@@ -151,6 +152,11 @@ impl ApiSecret {
     /// Returns the API token.
     pub fn api_token(&self) -> String {
         format!("{}{}", PK_PREFIX, self.pubkey_string())
+    }
+
+    /// Returns the path for the API token file
+    pub fn api_token_path(&self) -> &PathBuf {
+        &self.pk_path
     }
 
     /// Returns the value of the `Authorization` header which is used for verifying incoming HTTP

--- a/validator_client/src/http_api/api_secret.rs
+++ b/validator_client/src/http_api/api_secret.rs
@@ -1,4 +1,5 @@
 use eth2::lighthouse_vc::{PK_LEN, SECRET_PREFIX as PK_PREFIX};
+use filesystem::restrict_file_permissions;
 use libsecp256k1::{Message, PublicKey, SecretKey};
 use rand::thread_rng;
 use ring::digest::{digest, SHA256};
@@ -71,6 +72,12 @@ impl ApiSecret {
             )
             .map_err(|e| e.to_string())?;
         }
+
+        // Restrict file permissions to allow only current user read-write permissions.
+        restrict_file_permissions(&sk_path)
+            .map_err(|e| format!("Unable to set file permissions for {:?}: {:?}", sk_path, e))?;
+        restrict_file_permissions(&pk_path)
+            .map_err(|e| format!("Unable to set file permissions for {:?}: {:?}", pk_path, e))?;
 
         let sk = fs::read(&sk_path)
             .map_err(|e| format!("cannot read {}: {}", SK_FILENAME, e))

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -125,7 +125,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     }
 
     let authorization_header_filter = ctx.api_secret.authorization_header_filter();
-    let api_token = ctx.api_secret.api_token();
+    let api_token_path = ctx.api_secret.api_token_path();
     let signer = ctx.api_secret.signer();
     let signer = warp::any().map(move || signer.clone());
 
@@ -505,7 +505,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         log,
         "HTTP API started";
         "listen_address" => listening_socket.to_string(),
-        "api_token" => api_token,
+        "api_token_file" => ?api_token_path,
     );
 
     Ok((listening_socket, server))


### PR DESCRIPTION
## Issue Addressed

Resolves #2438 
Resolves #2437 

## Proposed Changes

Changes the permissions for validator client http server api token file and secret key to 600 from 644. Also changes the permission for logfiles generated using the `--logfile` cli option to 600.

Logs the path to the api token instead of the actual api token. Updates docs to reflect the change.
