### PR TITLE
[Merged by Bors] - Add Altair fork schedule for Pyrmont

### DIFF
--- a/common/eth2_network_config/built_in_network_configs/pyrmont/config.yaml
+++ b/common/eth2_network_config/built_in_network_configs/pyrmont/config.yaml
@@ -14,6 +14,7 @@ GENESIS_FORK_VERSION: 0x00002009
 # Customized for Pyrmont: 432000 seconds (5 days)
 GENESIS_DELAY: 432000
 
+
 # Forking
 # ---------------------------------------------------------------
 # Some forks are disabled for now:
@@ -21,13 +22,13 @@ GENESIS_DELAY: 432000
 #  - Temporarily set to max uint64 value: 2**64 - 1
 
 # Altair
-ALTAIR_FORK_VERSION: 0x01000000
-ALTAIR_FORK_EPOCH: 18446744073709551615
+ALTAIR_FORK_VERSION: 0x01002009
+ALTAIR_FORK_EPOCH: 61650
 # Merge
-MERGE_FORK_VERSION: 0x02000000
+MERGE_FORK_VERSION: 0x02002009
 MERGE_FORK_EPOCH: 18446744073709551615
 # Sharding
-SHARDING_FORK_VERSION: 0x03000000
+SHARDING_FORK_VERSION: 0x03002009
 SHARDING_FORK_EPOCH: 18446744073709551615
 
 # TBD, 2**32 is a placeholder. Merge transition approach is in active R&D.
@@ -60,6 +61,7 @@ EJECTION_BALANCE: 16000000000
 MIN_PER_EPOCH_CHURN_LIMIT: 4
 # 2**16 (= 65,536)
 CHURN_LIMIT_QUOTIENT: 65536
+
 
 # Deposit contract
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds the Altair fork schedule for Pyrmont, as per https://github.com/eth2-clients/eth2-networks/pull/56 (credits to @ajsutton).

## Additional Info

- I've marked this as `do-not-merge` until the upstream PR is merged.
- I've tagged this for `v1.5.0` because I expect the upstream PR to be merged soon, and I think it would be great if v1.5.0 shipped fully ready for the Pyrmont fork.
