### PR TITLE
initial commit for reuse password option

### DIFF
--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -97,7 +97,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("reuse-password")
                 .long("reuse-password")
-                .help("If present, the same password will be used for all keystores without a password."),
+                .help("If present, the same password will be used to unlock all keystores without a password."),
         )
         .arg(
             Arg::with_name("use-long-timeouts")

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -95,6 +95,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 ),
         )
         .arg(
+            Arg::with_name("reuse-password")
+                .long("reuse-password")
+                .help("If present, the same password will be used for all keystores without a password."),
+        )
+        .arg(
             Arg::with_name("use-long-timeouts")
                 .long("use-long-timeouts")
                 .help("If present, the validator client will use longer timeouts for requests \

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -50,7 +50,7 @@ pub struct Config {
     /// If true, enable functionality that monitors the network for attestations or proposals from
     /// any of the validators managed by this client before starting up.
     pub enable_doppelganger_protection: bool,
-    /// If true, the password read from STDIN will be used multiple times for all keystores without password
+    /// If true, the password read from STDIN will be used multiple times for all keystores without password.
     pub reuse_password: bool,
 }
 

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -50,6 +50,8 @@ pub struct Config {
     /// If true, enable functionality that monitors the network for attestations or proposals from
     /// any of the validators managed by this client before starting up.
     pub enable_doppelganger_protection: bool,
+    /// If true, the password read from STDIN will be used multiple times for all keystores without password
+    pub reuse_password: bool,
 }
 
 impl Default for Config {
@@ -80,6 +82,7 @@ impl Default for Config {
             http_metrics: <_>::default(),
             monitoring_api: None,
             enable_doppelganger_protection: false,
+            reuse_password: false,
         }
     }
 }
@@ -164,6 +167,7 @@ impl Config {
         config.disable_auto_discover = cli_args.is_present("disable-auto-discover");
         config.init_slashing_protection = cli_args.is_present("init-slashing-protection");
         config.use_long_timeouts = cli_args.is_present("use-long-timeouts");
+        config.reuse_password = cli_args.is_present("reuse-password");
 
         if let Some(graffiti_file_path) = cli_args.value_of("graffiti-file") {
             let mut graffiti_file = GraffitiFile::new(graffiti_file_path.into());

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -61,6 +61,7 @@ impl ApiTester {
             validator_defs,
             validator_dir.path().into(),
             log.clone(),
+            false,
         )
         .await
         .unwrap();

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -321,7 +321,7 @@ pub struct InitializedValidators {
     log: Logger,
     /// If true, reuse the same password entered via STDIN for all keystores without password.
     reuse_password: bool,
-    /// Temporarily stores password that will be re-used
+    /// Temporarily stores password that will be re-used.
     reuse_password_text: Option<PlainText>,
 }
 

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -319,7 +319,7 @@ pub struct InitializedValidators {
     validators: HashMap<PublicKeyBytes, InitializedValidator>,
     /// For logging via `slog`.
     log: Logger,
-    /// If true, reuse the same password entered via STDIN for all keystores without password
+    /// If true, reuse the same password entered via STDIN for all keystores without password.
     reuse_password: bool,
     /// Temporarily stores password that will be re-used
     reuse_password_text: Option<PlainText>,

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -169,6 +169,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             validator_defs,
             config.validator_dir.clone(),
             log.clone(),
+            config.reuse_password,
         )
         .await
         .map_err(|e| format!("Unable to initialize validators: {:?}", e))?;


### PR DESCRIPTION
## Issue Addressed

#1881

## Proposed Changes

Adds a --reuse-password option to the vc so that a user who's created their keys from the launchpad that has all of them encrypted with the same password can just type their password once and it will decrypt all their validators. It's much faster than typing it multiple times if you have multiple validators so this should result in less downtime.

## Additional Info

This is a first attempt so feel free to give feedback.
