### PR TITLE
[Merged by Bors] - Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
  "slog-term",
  "slot_clock",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "validator_dir",
 ]
@@ -538,7 +538,7 @@ dependencies = [
  "strum",
  "task_executor",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "tree_hash",
  "types",
 ]
@@ -577,7 +577,7 @@ dependencies = [
  "slog-term",
  "store",
  "task_executor",
- "tokio 1.8.1",
+ "tokio",
  "types",
 ]
 
@@ -736,7 +736,7 @@ dependencies = [
  "slog-stdlog",
  "slog-term",
  "sloggers 1.0.1",
- "tokio 1.8.1",
+ "tokio",
  "types",
 ]
 
@@ -993,7 +993,7 @@ dependencies = [
  "task_executor",
  "time 0.2.27",
  "timer",
- "tokio 1.8.1",
+ "tokio",
  "toml",
  "tree_hash",
  "types",
@@ -1556,7 +1556,7 @@ dependencies = [
  "rlp 0.5.0",
  "sha2",
  "smallvec",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -1756,7 +1756,7 @@ dependencies = [
  "slog-term",
  "sloggers 1.0.1",
  "task_executor",
- "tokio 1.8.1",
+ "tokio",
  "types",
 ]
 
@@ -1796,8 +1796,7 @@ dependencies = [
  "sloggers 1.0.1",
  "state_processing",
  "task_executor",
- "tokio 1.8.1",
- "tokio-compat-02",
+ "tokio",
  "toml",
  "tree_hash",
  "types",
@@ -1811,8 +1810,7 @@ dependencies = [
  "deposit_contract",
  "futures",
  "serde_json",
- "tokio 1.8.1",
- "tokio-compat-02",
+ "tokio",
  "types",
  "web3",
 ]
@@ -1954,7 +1952,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "tiny-keccak 2.0.2",
- "tokio 1.8.1",
+ "tokio",
  "tokio-io-timeout",
  "tokio-util",
  "types",
@@ -2454,8 +2452,7 @@ dependencies = [
  "serde_derive",
  "slog",
  "state_processing",
- "tokio 1.8.1",
- "tokio-compat-02",
+ "tokio",
  "tree_hash",
  "types",
 ]
@@ -2564,7 +2561,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
  "tracing",
 ]
@@ -2604,7 +2601,7 @@ name = "hashset_delay"
 version = "0.2.0"
 dependencies = [
  "futures",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
 ]
 
@@ -2772,7 +2769,7 @@ dependencies = [
  "slot_clock",
  "state_processing",
  "store",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tree_hash",
@@ -2799,7 +2796,7 @@ dependencies = [
  "slog",
  "slot_clock",
  "store",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "warp",
  "warp_utils",
@@ -2841,7 +2838,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2868,7 +2865,7 @@ dependencies = [
  "itoa",
  "pin-project-lite 0.2.7",
  "socket2 0.4.0",
- "tokio 1.8.1",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -2883,7 +2880,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper",
  "native-tls",
- "tokio 1.8.1",
+ "tokio",
  "tokio-native-tls",
 ]
 
@@ -3246,7 +3243,7 @@ dependencies = [
  "serde_yaml",
  "simple_logger",
  "state_processing",
- "tokio 1.8.1",
+ "tokio",
  "tree_hash",
  "types",
  "validator_dir",
@@ -3714,7 +3711,7 @@ dependencies = [
  "libp2p-core 0.30.0",
  "log",
  "socket2 0.4.0",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -3893,7 +3890,7 @@ dependencies = [
  "target_check",
  "task_executor",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "validator_client",
  "validator_dir",
@@ -4183,7 +4180,7 @@ dependencies = [
  "slog",
  "store",
  "task_executor",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -4339,7 +4336,7 @@ dependencies = [
  "strum",
  "task_executor",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tree_hash",
@@ -5385,7 +5382,7 @@ dependencies = [
  "reqwest",
  "sensitive_url",
  "serde",
- "tokio 1.8.1",
+ "tokio",
  "types",
 ]
 
@@ -5404,7 +5401,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "winapi",
  "windows-acl",
@@ -5445,7 +5442,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.8.1",
+ "tokio",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -5992,7 +5989,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "sensitive_url",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "validator_client",
 ]
@@ -6051,7 +6048,7 @@ dependencies = [
  "slot_clock",
  "state_processing",
  "task_executor",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "types",
 ]
@@ -6553,7 +6550,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "slog",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -6703,7 +6700,7 @@ dependencies = [
  "slog",
  "slot_clock",
  "task_executor",
- "tokio 1.8.1",
+ "tokio",
  "types",
 ]
 
@@ -6770,21 +6767,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "num_cpus",
- "pin-project-lite 0.1.12",
- "slab",
-]
-
-[[package]]
-name = "tokio"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -6801,27 +6786,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-compat-02"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d4237822b7be8fff0a7a27927462fad435dcb6650f95cea9e946bf6bdc7e07"
-dependencies = [
- "bytes 0.5.6",
- "once_cell",
- "pin-project-lite 0.2.7",
- "tokio 0.2.25",
- "tokio 1.8.1",
- "tokio-stream",
-]
-
-[[package]]
 name = "tokio-io-timeout"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
 dependencies = [
  "pin-project-lite 0.2.7",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -6842,7 +6813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -6853,7 +6824,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
 ]
 
@@ -6866,7 +6837,7 @@ dependencies = [
  "futures-util",
  "log",
  "pin-project 1.0.7",
- "tokio 1.8.1",
+ "tokio",
  "tungstenite",
 ]
 
@@ -6883,7 +6854,7 @@ dependencies = [
  "log",
  "pin-project-lite 0.2.7",
  "slab",
- "tokio 1.8.1",
+ "tokio",
 ]
 
 [[package]]
@@ -7049,7 +7020,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "tinyvec",
- "tokio 1.8.1",
+ "tokio",
  "url",
 ]
 
@@ -7069,7 +7040,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 1.8.1",
+ "tokio",
  "trust-dns-proto",
 ]
 
@@ -7359,7 +7330,7 @@ dependencies = [
  "slot_clock",
  "task_executor",
  "tempfile",
- "tokio 1.8.1",
+ "tokio",
  "tree_hash",
  "types",
  "validator_dir",
@@ -7467,7 +7438,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.8.1",
+ "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
@@ -7488,7 +7459,7 @@ dependencies = [
  "safe_arith",
  "serde",
  "state_processing",
- "tokio 1.8.1",
+ "tokio",
  "types",
  "warp",
 ]
@@ -7649,7 +7620,7 @@ dependencies = [
  "serde_json",
  "soketto",
  "tiny-keccak 2.0.2",
- "tokio 1.8.1",
+ "tokio",
  "tokio-util",
  "url",
  "web3-async-native-tls",
@@ -7663,7 +7634,7 @@ checksum = "1f6d8d1636b2627fe63518d5a9b38a569405d9c9bc665c43c9c341de57227ebb"
 dependencies = [
  "native-tls",
  "thiserror",
- "tokio 1.8.1",
+ "tokio",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
+checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
 dependencies = [
  "gimli",
 ]
@@ -97,31 +97,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "495ee669413bfbe9e8cace80f4d3d78e6d8c8d99579f97fb93bde351b185f2d4"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
- "ctr",
+ "ctr 0.7.0",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc3be92e19a7ef47457b8e6f90707e12b6ac5d20c6f3866584fa3be0787d839f"
+checksum = "b2a930fd487faaa92a30afa92cc9dd1526a5cff67124abbbb1c617ce070f4dcf"
 dependencies = [
  "aead",
  "aes",
- "cipher 0.3.0",
- "ctr",
+ "cipher",
+ "ctr 0.8.0",
  "ghash",
  "subtle",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+dependencies = [
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -169,6 +174,12 @@ checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arbitrary"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237430fd6ed3740afe94eefcc278ae21e050285be882804e0d6e8695f0c94691"
 
 [[package]]
 name = "arc-swap"
@@ -274,7 +285,7 @@ dependencies = [
  "parking",
  "polling",
  "slab",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "waker-fn",
  "winapi",
 ]
@@ -308,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f38756dd9ac84671c428afbf7c9f7495feff9ec5b0710f17100098e5b354ac"
+checksum = "b21b63ab5a0db0369deb913540af2892750e42d949faacc7a61495ac418a1692"
 dependencies = [
  "async-io",
  "blocking",
@@ -373,9 +384,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -446,9 +457,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.60"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
+checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
@@ -509,7 +520,7 @@ dependencies = [
  "genesis",
  "int_to_bytes",
  "integer-sqrt",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "lighthouse_metrics",
  "log",
@@ -607,9 +618,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "bitvec"
@@ -690,11 +701,11 @@ dependencies = [
 name = "bls"
 version = "0.2.0"
 dependencies = [
- "arbitrary",
+ "arbitrary 0.4.7",
  "blst",
  "eth2_hashing",
  "eth2_ssz",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "hex",
  "milagro_bls",
  "rand 0.7.3",
@@ -839,7 +850,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "quickcheck",
  "quickcheck_macros",
  "smallvec",
@@ -875,25 +886,25 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee7ad89dc1128635074c268ee661f90c3f7e83d9fd12910608c36b47d6c3412"
+checksum = "ea8756167ea0aca10e066cdbe7813bd71d2f24e69b0bc7b50509590cef2ce0b9"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.3.0",
+ "cipher",
  "cpufeatures",
  "zeroize",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580317203210c517b6d44794abfbe600698276db18127e37ad3e69bf5e848e5"
+checksum = "175a11316f33592cf2b71416ee65283730b5b7849813c4891d02a12906ed9acc"
 dependencies = [
  "aead",
  "chacha20",
- "cipher 0.3.0",
+ "cipher",
  "poly1305",
  "zeroize",
 ]
@@ -909,15 +920,6 @@ dependencies = [
  "num-traits",
  "time 0.1.43",
  "winapi",
-]
-
-[[package]]
-name = "cipher"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1108,16 +1110,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -1134,12 +1136,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools",
 ]
 
 [[package]]
@@ -1154,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -1204,19 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1260,16 +1252,25 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a232f92a03f37dd7d7dd2adc67166c77e9cd88de5b019b9a9eecfaeaf7bfd481"
 dependencies = [
- "cipher 0.3.0",
+ "cipher",
+]
+
+[[package]]
+name = "ctr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
 name = "ctrlc"
-version = "3.1.9"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232295399409a8b7ae41276757b5a1cc21032848d42bff2352261f958b3ca29a"
+checksum = "377c9b002a72a0b2c1a18c62e2f3864bdfea4a015e3683a96e24aa45dd6c02d1"
 dependencies = [
- "nix 0.20.0",
+ "nix 0.22.0",
  "winapi",
 ]
 
@@ -1295,15 +1296,15 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "winapi",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.44+curl-7.77.0"
+version = "0.4.45+curl-7.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
+checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
 dependencies = [
  "cc",
  "libc",
@@ -1317,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639891fde0dbea823fc3d798a0fdf9d2f9440a42d64a78ab3488b0ca025117b3"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest",
@@ -1553,7 +1554,7 @@ dependencies = [
  "lru_time_cache",
  "parking_lot",
  "rand 0.8.4",
- "rlp 0.5.0",
+ "rlp 0.5.1",
  "sha2",
  "smallvec",
  "tokio",
@@ -1595,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d0860415b12243916284c67a9be413e044ee6668247b99ba26d94b2bc06c8f6"
+checksum = "4620d40f6d2601794401d6dd95a5cf69b6c157852539470eeda433a99b3c0efc"
 dependencies = [
  "signature",
 ]
@@ -1627,7 +1628,7 @@ dependencies = [
  "derivative",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "fs2",
  "hex",
  "parking_lot",
@@ -1698,7 +1699,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.4",
- "rlp 0.5.0",
+ "rlp 0.5.1",
  "serde",
  "sha3",
  "zeroize",
@@ -1728,9 +1729,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime",
@@ -1899,8 +1900,8 @@ dependencies = [
  "eth2_key_derivation",
  "eth2_ssz",
  "hex",
- "hmac 0.10.1",
- "pbkdf2 0.6.0",
+ "hmac 0.11.0",
+ "pbkdf2 0.8.0",
  "rand 0.7.3",
  "scrypt",
  "serde",
@@ -1979,7 +1980,7 @@ name = "eth2_ssz"
 version = "0.1.2"
 dependencies = [
  "eth2_ssz_derive",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "smallvec",
 ]
 
@@ -1995,7 +1996,7 @@ dependencies = [
 name = "eth2_ssz_types"
 version = "0.2.0"
 dependencies = [
- "arbitrary",
+ "arbitrary 0.4.7",
  "eth2_ssz",
  "serde",
  "serde_derive",
@@ -2135,7 +2136,7 @@ dependencies = [
 name = "fallback"
 version = "0.1.0"
 dependencies = [
- "itertools 0.10.1",
+ "itertools",
 ]
 
 [[package]]
@@ -2152,9 +2153,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
 ]
@@ -2169,6 +2170,12 @@ dependencies = [
  "rand_core 0.6.3",
  "subtle",
 ]
+
+[[package]]
+name = "ffi-opaque"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec54ac60a7f2ee9a97cad9946f9bf629a3bc6a7ae59e68983dc9318f5a54b81a"
 
 [[package]]
 name = "field-offset"
@@ -2194,7 +2201,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
- "arbitrary",
  "byteorder",
  "rand 0.7.3",
  "rustc-hex",
@@ -2207,6 +2213,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
+ "arbitrary 0.4.7",
  "byteorder",
  "rand 0.8.4",
  "rustc-hex",
@@ -2297,9 +2304,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2312,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2322,15 +2329,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2340,9 +2347,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-lite"
@@ -2361,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg 1.0.1",
  "proc-macro-hack",
@@ -2385,15 +2392,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-timer"
@@ -2403,9 +2410,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg 1.0.1",
  "futures-channel",
@@ -2481,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbd60caa311237d508927dbba7594b483db3ef05faa55172fcf89b1bcda7853"
+checksum = "b442c439366184de619215247d24e908912b175e824a530253845ac4c251a5c1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -2491,15 +2498,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
+checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "git-version"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94918e83f1e01dedc2e361d00ce9487b14c58c7f40bab148026fa39d42cb41e2"
+checksum = "f6b0decc02f4636b9ccad390dcbe77b722a77efedfa393caf8379a51d5c61899"
 dependencies = [
  "git-version-macro",
  "proc-macro-hack",
@@ -2507,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "git-version-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a97a52fdee1870a34fa6e4b77570cba531b27d1838874fef4429a791a3d657"
+checksum = "fe69f1cbdb6e28af2bac214e943b99ce8a0a06b447d15d3e61161b0423139f3f"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -2574,26 +2581,20 @@ checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "hashlink"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2682,21 +2683,11 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac 0.10.0",
- "digest",
-]
-
-[[package]]
-name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
- "crypto-mac 0.11.0",
+ "crypto-mac 0.11.1",
  "digest",
 ]
 
@@ -2735,9 +2726,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes 1.0.1",
  "http",
@@ -2849,9 +2840,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -2864,7 +2855,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite 0.2.7",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2984,7 +2975,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.5.0",
+ "rlp 0.5.1",
 ]
 
 [[package]]
@@ -3014,7 +3005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg 1.0.1",
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3099,15 +3090,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -3123,18 +3105,18 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonrpc-core"
-version = "17.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4467ab6dfa369b69e52bd0692e480c4d117410538526a57a304a0f2250fd95e"
+checksum = "14f7f76aef2d054868398427f6c54943cf3d1caa9a7ec7d0c38d69df97a965eb"
 dependencies = [
  "futures",
  "futures-executor",
@@ -3183,7 +3165,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.10.1",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -3263,11 +3245,12 @@ dependencies = [
 
 [[package]]
 name = "leveldb-sys"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618aee5ba3d32cb8456420a9a454aa71c1af5b3e9c7a2ec20a0f3cbbe47246cb"
+checksum = "9dd94a4d0242a437e5e41a27c782b69a624469ca1c4d1e5cb3c337f74a8031d4"
 dependencies = [
  "cmake",
+ "ffi-opaque",
  "libc",
  "num_cpus",
 ]
@@ -3280,9 +3263,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libflate"
@@ -3353,7 +3336,7 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr",
  "parking_lot",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "smallvec",
  "wasm-timer",
 ]
@@ -3378,7 +3361,7 @@ dependencies = [
  "multihash",
  "multistream-select 0.10.2",
  "parking_lot",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3411,7 +3394,7 @@ dependencies = [
  "multihash",
  "multistream-select 0.10.4",
  "parking_lot",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3546,7 +3529,7 @@ dependencies = [
  "log",
  "rand 0.8.4",
  "smallvec",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "void",
 ]
 
@@ -3625,9 +3608,9 @@ source = "git+https://github.com/libp2p/rust-libp2p?rev=ce23cbe76a0382b6fcb0e49f
 dependencies = [
  "futures",
  "log",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "rand 0.7.3",
- "salsa20 0.8.0",
+ "salsa20",
  "sha3",
 ]
 
@@ -3643,7 +3626,7 @@ dependencies = [
  "libp2p-core 0.30.0",
  "libp2p-swarm",
  "log",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "prost",
  "prost-build",
  "rand 0.7.3",
@@ -3710,7 +3693,7 @@ dependencies = [
  "libc",
  "libp2p-core 0.30.0",
  "log",
- "socket2 0.4.0",
+ "socket2 0.4.1",
  "tokio",
 ]
 
@@ -3750,7 +3733,7 @@ dependencies = [
  "log",
  "quicksink",
  "rw-stream-sink",
- "soketto",
+ "soketto 0.4.2",
  "url",
  "webpki-roots",
 ]
@@ -3836,9 +3819,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.20.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d31059f22935e6c31830db5249ba2b7ecd54fd73a9909286f0a67aa55c2fbd"
+checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3869,7 +3852,7 @@ dependencies = [
  "clap",
  "clap_utils",
  "directory",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "environment",
  "eth2_hashing",
  "eth2_libp2p",
@@ -3980,11 +3963,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f374d42cdfc1d7dbf3d3dec28afab2eb97ffbf43a3234d795b5986dbf4b90ba"
+checksum = "7ea2d928b485416e8908cff2d97d621db22b27f7b3b6729e438bcf42c671ba91"
 dependencies = [
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -4051,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
@@ -4075,7 +4058,7 @@ name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
  "eth2_hashing",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
@@ -4261,7 +4244,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "log",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "smallvec",
  "unsigned-varint 0.7.0",
 ]
@@ -4274,16 +4257,16 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "log",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "smallvec",
  "unsigned-varint 0.7.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -4315,7 +4298,7 @@ dependencies = [
  "hex",
  "if-addrs",
  "igd",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "lighthouse_metrics",
  "logging",
@@ -4324,7 +4307,7 @@ dependencies = [
  "num_cpus",
  "parking_lot",
  "rand 0.7.3",
- "rlp 0.5.0",
+ "rlp 0.5.1",
  "slog",
  "slog-async",
  "slog-term",
@@ -4364,14 +4347,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4487,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38f2be3697a57b4060074ff41b44c16870d916ad7877c17696e063257482bc7"
+checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
 dependencies = [
  "memchr",
 ]
@@ -4567,7 +4551,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "int_to_bytes",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "lighthouse_metrics",
  "parking_lot",
@@ -4667,11 +4651,11 @@ dependencies = [
 
 [[package]]
 name = "pbkdf2"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b8c0d71734018084da0c0354193a5edfb81b20d2d57a92c5b154aefc554a4a"
+checksum = "d95f5254224e617595d2cc3cc73ff0a5eaf2637519e25f03388154e9378b6ffa"
 dependencies = [
- "crypto-mac 0.10.0",
+ "crypto-mac 0.11.1",
 ]
 
 [[package]]
@@ -4725,11 +4709,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
- "pin-project-internal 1.0.7",
+ "pin-project-internal 1.0.8",
 ]
 
 [[package]]
@@ -4745,9 +4729,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4837,9 +4821,9 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe800695325da85083cd23b56826fccb2e2dc29b218e7811a6f33bc93f414be"
+checksum = "9fcffab1f78ebbdf4b93b68c1ffebc24037eedf271edaca795732b24e5e4e349"
 dependencies = [
  "cpufeatures",
  "opaque-debug",
@@ -4848,9 +4832,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e597450cbf209787f0e6de80bf3795c6b2356a380ee87837b545aded8dbc1823"
+checksum = "a6ba6a405ef63530d6cb12802014b22f9c5751bd17cdcddbe9e46d5c8ae83287"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4944,9 +4928,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -4996,7 +4980,7 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -5013,7 +4997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -5043,9 +5027,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.24.1"
+version = "2.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db50e77ae196458ccd3dc58a31ea1a90b0698ab1b7928d89f644c25d72070267"
+checksum = "020f86b07722c5c4291f7c723eac4676b3892d47d9a7708dc2779696407f039b"
 
 [[package]]
 name = "psutil"
@@ -5137,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "r2d2_sqlite"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227ab35ff4cbb01fa76da8f062590fe677b93c8d9e8415eb5fa981f2c1dba9d8"
+checksum = "9d24607049214c5e42d3df53ac1d8a23c34cc6a5eefe3122acb2c72174719959"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -5280,9 +5264,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -5493,9 +5477,9 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
 dependencies = [
  "bytes 1.0.1",
  "rustc-hex",
@@ -5513,9 +5497,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.24.2"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38ee71cbab2c827ec0ac24e76f82eca723cee92c509a65f67dee393c25112"
+checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -5568,7 +5552,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.3",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -5619,20 +5603,11 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "salsa20"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399f290ffc409596022fce5ea5d4138184be4784f2b28c62c59f0d8389059a15"
+checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
- "cipher 0.2.5",
-]
-
-[[package]]
-name = "salsa20"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7c5f10864beba947e1a1b43f3ef46c8cc58d1c2ae549fa471713e8ff60787a"
-dependencies = [
- "cipher 0.3.0",
+ "cipher",
 ]
 
 [[package]]
@@ -5677,13 +5652,13 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scrypt"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da492dab03f925d977776a0b7233d7b934d6dc2b94faead48928e2e9bacedb9"
+checksum = "879588d8f90906e73302547e20fffefdd240eb3e0e744e142321f5d49dea0518"
 dependencies = [
- "hmac 0.10.1",
- "pbkdf2 0.6.0",
- "salsa20 0.7.2",
+ "hmac 0.11.0",
+ "pbkdf2 0.8.0",
+ "salsa20",
  "sha2",
 ]
 
@@ -5758,9 +5733,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -5787,9 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -5806,9 +5781,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5817,9 +5792,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -5883,9 +5858,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
+checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -5927,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
 dependencies = [
  "lazy_static",
 ]
@@ -5965,9 +5940,9 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
+checksum = "b7de33c687404ec3045d4a0d437580455257c0436f858d702f244e7d652f9f07"
 dependencies = [
  "atty",
  "chrono",
@@ -5981,7 +5956,7 @@ name = "simulator"
 version = "0.2.0"
 dependencies = [
  "clap",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "eth1",
  "eth1_test_rig",
  "futures",
@@ -5996,15 +5971,15 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbce6d4507c7e4a3962091436e56e95290cb71fa302d0d270e32130b75fbff27"
+checksum = "729a25c17d72b06c68cb47955d44fda88ad2d3e7d77e025663fdd69b93dd71a1"
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "slasher"
@@ -6081,9 +6056,9 @@ checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
+checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
 dependencies = [
  "crossbeam-channel",
  "slog",
@@ -6093,9 +6068,9 @@ dependencies = [
 
 [[package]]
 name = "slog-json"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
+checksum = "52e9b96fb6b5e80e371423b4aca6656eb537661ce8f82c2697e619f8ca85d043"
 dependencies = [
  "chrono",
  "serde",
@@ -6252,9 +6227,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -6273,6 +6248,21 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.7.3",
+ "sha-1",
+]
+
+[[package]]
+name = "soketto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.4",
  "sha-1",
 ]
 
@@ -6304,16 +6294,16 @@ dependencies = [
 name = "state_processing"
 version = "0.2.0"
 dependencies = [
- "arbitrary",
+ "arbitrary 0.4.7",
  "beacon_chain",
  "bls",
- "env_logger 0.8.4",
+ "env_logger 0.9.0",
  "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_types",
  "int_to_bytes",
  "integer-sqrt",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "lighthouse_metrics",
  "log",
@@ -6404,7 +6394,7 @@ dependencies = [
  "directory",
  "eth2_ssz",
  "eth2_ssz_derive",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "leveldb",
  "lighthouse_metrics",
@@ -6446,18 +6436,18 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -6478,7 +6468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7f6700d7c135cf4e4900c2cfba9a12ecad1fdc45594aad48f6b344b2589a0"
 dependencies = [
  "darling",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -6490,14 +6480,14 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "eth2_hashing",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6752,9 +6742,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6836,7 +6826,7 @@ checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "tokio",
  "tungstenite",
 ]
@@ -6911,7 +6901,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "tracing",
 ]
 
@@ -6983,7 +6973,7 @@ version = "0.1.1"
 dependencies = [
  "beacon_chain",
  "eth2_hashing",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "lazy_static",
  "rand 0.7.3",
  "smallvec",
@@ -7088,7 +7078,7 @@ checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 name = "types"
 version = "0.2.0"
 dependencies = [
- "arbitrary",
+ "arbitrary 0.4.7",
  "beacon_chain",
  "bls",
  "cached_tree_hash",
@@ -7101,10 +7091,10 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.9.2",
+ "ethereum-types 0.11.0",
  "hex",
  "int_to_bytes",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "log",
  "merkle_proof",
@@ -7141,7 +7131,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
- "arbitrary",
  "byteorder",
  "crunchy",
  "rustc-hex",
@@ -7154,6 +7143,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
+ "arbitrary 1.0.1",
  "byteorder",
  "crunchy",
  "hex",
@@ -7177,12 +7167,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"
@@ -7213,9 +7200,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
@@ -7302,10 +7289,10 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "libc",
- "libsecp256k1 0.5.0",
+ "libsecp256k1 0.6.0",
  "lighthouse_metrics",
  "lighthouse_version",
  "lockfile",
@@ -7433,7 +7420,7 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "scoped-tls",
  "serde",
  "serde_json",
@@ -7478,9 +7465,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -7490,9 +7477,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -7505,9 +7492,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -7517,9 +7504,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7527,9 +7514,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7540,15 +7527,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cab416a9b970464c2882ed92d55b0c33046b08e0bdc9d59b3b718acd4e1bae8"
+checksum = "ce783b6c3854292723f498b7bfcf65a782a320b6f1cb3012d08dfbc603fa62f5"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -7560,9 +7547,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4543fc6cf3541ef0d98bf720104cc6bd856d7eba449fd2aa365ef4fed0e782"
+checksum = "3859815cf8435b92f3a34381bef950daffc1403bbb77ef99e35422a7b0abb194"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7585,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7595,9 +7582,9 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4c18ae15621f764fab919f7e4a83d87163494cbc3460884debef7c6bc1bc6b"
+checksum = "cd24abe6f2b68e0677f843059faea87bcbd4892e39f02886f366d8222c3c540d"
 dependencies = [
  "arrayvec 0.5.2",
  "base64 0.13.0",
@@ -7612,13 +7599,13 @@ dependencies = [
  "jsonrpc-core",
  "log",
  "parking_lot",
- "pin-project 1.0.7",
+ "pin-project 1.0.8",
  "reqwest",
- "rlp 0.5.0",
+ "rlp 0.5.1",
  "secp256k1",
  "serde",
  "serde_json",
- "soketto",
+ "soketto 0.5.0",
  "tiny-keccak 2.0.2",
  "tokio",
  "tokio-util",
@@ -7668,11 +7655,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
 ]
 
@@ -7762,9 +7750,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07db065a5cf61a7e4ba64f29e67db906fb1787316516c4e6e5ff0fea1efcd8a"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmltree"

--- a/account_manager/Cargo.toml
+++ b/account_manager/Cargo.toml
@@ -27,7 +27,7 @@ eth2_wallet = { path = "../crypto/eth2_wallet" }
 eth2_wallet_manager = { path = "../common/eth2_wallet_manager" }
 rand = "0.7.3"
 validator_dir = { path = "../common/validator_dir" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 eth2_keystore = { path = "../crypto/eth2_keystore" }
 account_utils = { path = "../common/account_utils" }
 slashing_protection = { path = "../validator_client/slashing_protection" }

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -26,7 +26,7 @@ slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_tr
 slog-term = "2.6.0"
 slog-async = "2.5.0"
 ctrlc = { version = "3.1.6", features = ["termination"] }
-tokio = { version = "1.7.1", features = ["time"] }
+tokio = { version = "1.10.0", features = ["time"] }
 exit-future = "0.2.0"
 dirs = "3.0.1"
 logging = { path = "../common/logging" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -62,4 +62,4 @@ regex = "1.3.9"
 exit-future = "0.2.0"
 slasher = { path = "../../slasher" }
 eth2 = { path = "../../common/eth2" }
-strum = { version = "0.20", features = ["derive"] }
+strum = { version = "0.21.0", features = ["derive"] }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -40,7 +40,7 @@ eth2_ssz_derive = "0.1.0"
 state_processing = { path = "../../consensus/state_processing" }
 tree_hash = "0.1.1"
 types = { path = "../../consensus/types" }
-tokio = "1.7.1"
+tokio = "1.10.0"
 eth1 = { path = "../eth1" }
 futures = "0.3.7"
 genesis = { path = "../genesis" }

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -26,7 +26,7 @@ error-chain = "0.12.4"
 serde_yaml = "0.8.13"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 slog-async = "2.5.0"
-tokio = "1.7.1"
+tokio = "1.10.0"
 dirs = "3.0.1"
 futures = "0.3.7"
 reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -10,7 +10,6 @@ toml = "0.5.6"
 web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
-tokio-compat-02 = "0.2.0"
 
 [dependencies]
 reqwest = { version = "0.11.0", features = ["native-tls-vendored"] }
@@ -26,7 +25,7 @@ tree_hash = "0.1.1"
 eth2_hashing = "0.1.0"
 parking_lot = "0.11.0"
 slog = "2.5.2"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 state_processing = { path = "../../consensus/state_processing" }
 libflate = "1.0.2"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics"}

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
 toml = "0.5.6"
-web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 sloggers = "1.0.1"
 environment = { path = "../../lighthouse/environment" }
 

--- a/beacon_node/eth1/tests/test.rs
+++ b/beacon_node/eth1/tests/test.rs
@@ -10,7 +10,6 @@ use slog::Logger;
 use sloggers::{null::NullLoggerBuilder, Build};
 use std::ops::Range;
 use std::time::Duration;
-use tokio_compat_02::FutureExt;
 use tree_hash::TreeHash;
 use types::{DepositData, EthSpec, Hash256, Keypair, MainnetEthSpec, MinimalEthSpec, Signature};
 use web3::{transports::Http, Web3};
@@ -90,7 +89,6 @@ async fn blocking_deposit_count(eth1: &GanacheEth1Instance, block_number: u64) -
 async fn get_block_number(web3: &Web3<Http>) -> u64 {
     web3.eth()
         .block_number()
-        .compat()
         .await
         .map(|v| v.as_u64())
         .expect("should get block number")
@@ -180,7 +178,6 @@ mod eth1_cache {
                 }
             }
         }
-        .compat()
         .await;
     }
 
@@ -235,7 +232,6 @@ mod eth1_cache {
                 "should not grow cache beyond target"
             );
         }
-        .compat()
         .await;
     }
 
@@ -288,7 +284,6 @@ mod eth1_cache {
                 "should not grow cache beyond target"
             );
         }
-        .compat()
         .await;
     }
 
@@ -335,7 +330,6 @@ mod eth1_cache {
 
             assert!(service.block_cache_len() >= n, "should grow the cache");
         }
-        .compat()
         .await;
     }
 }
@@ -420,7 +414,6 @@ mod deposit_tree {
                 );
             }
         }
-        .compat()
         .await;
     }
 
@@ -470,7 +463,6 @@ mod deposit_tree {
 
             assert_eq!(service.deposit_cache_len(), n);
         }
-        .compat()
         .await;
     }
 
@@ -571,7 +563,6 @@ mod deposit_tree {
                 }
             }
         }
-        .compat()
         .await;
     }
 }
@@ -675,7 +666,6 @@ mod http {
                 );
             }
         }
-        .compat()
         .await;
     }
 }
@@ -756,7 +746,6 @@ mod fast {
                 );
             }
         }
-        .compat()
         .await;
     }
 }
@@ -838,7 +827,6 @@ mod persist {
                 "Should have equal cached deposits as before recovery"
             );
         }
-        .compat()
         .await;
     }
 }
@@ -918,7 +906,6 @@ mod fallbacks {
                 endpoint2_block_number
             );
         }
-        .compat()
         .await;
     }
 
@@ -988,7 +975,6 @@ mod fallbacks {
                 endpoint2_block_number
             );
         }
-        .compat()
         .await;
     }
 
@@ -1058,7 +1044,6 @@ mod fallbacks {
                 endpoint2_block_number
             );
         }
-        .compat()
         .await;
     }
 
@@ -1136,7 +1121,6 @@ mod fallbacks {
                 endpoint2_block_number
             );
         }
-        .compat()
         .await;
     }
 }

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -16,7 +16,7 @@ eth2_ssz = "0.1.2"
 eth2_ssz_derive = "0.1.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 lighthouse_version = { path = "../../common/lighthouse_version" }
-tokio = { version = "1.7.1", features = ["time", "macros"] }
+tokio = { version = "1.10.0", features = ["time", "macros"] }
 futures = "0.3.7"
 futures-io = "0.3.7"
 error-chain = "0.12.4"
@@ -54,7 +54,7 @@ rev = "ce23cbe76a0382b6fcb0e49f1b2612df86f6465d"
 features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns-tokio", "tcp-tokio"]
 
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 slog-term = "2.6.0"
 slog-async = "2.5.0"
 tempfile = "3.1.0"

--- a/beacon_node/eth2_libp2p/Cargo.toml
+++ b/beacon_node/eth2_libp2p/Cargo.toml
@@ -39,7 +39,7 @@ task_executor = { path = "../../common/task_executor" }
 rand = "0.7.3"
 directory = { path = "../../common/directory" }
 regex = "1.3.9"
-strum = { version = "0.20", features = ["derive"] }
+strum = { version = "0.21.0", features = ["derive"] }
 superstruct = "0.2.0"
 
 # TODO: remove the rev-reference and go back to release versions once there is a release that

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
-tokio-compat-02 = "0.2.0"
 sensitive_url = { path = "../../common/sensitive_url" }
 
 [dependencies]
@@ -20,7 +19,7 @@ merkle_proof = { path = "../../consensus/merkle_proof" }
 eth2_ssz = "0.1.2"
 eth2_hashing = "0.1.0"
 tree_hash = "0.1.1"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 parking_lot = "0.11.0"
 slog = "2.5.2"
 exit-future = "0.2.0"

--- a/beacon_node/genesis/tests/tests.rs
+++ b/beacon_node/genesis/tests/tests.rs
@@ -10,7 +10,6 @@ use genesis::{Eth1Config, Eth1GenesisService};
 use sensitive_url::SensitiveUrl;
 use state_processing::is_valid_genesis_state;
 use std::time::Duration;
-use tokio_compat_02::FutureExt;
 use types::{test_utils::generate_deterministic_keypair, Hash256, MinimalEthSpec};
 
 pub fn new_env() -> Environment<MinimalEthSpec> {
@@ -29,86 +28,82 @@ fn basic() {
     let log = env.core_context().log().clone();
     let mut spec = env.eth2_config().spec.clone();
 
-    env.runtime().block_on(
-        async {
-            let eth1 = GanacheEth1Instance::new(DEFAULT_NETWORK_ID.into(), DEFAULT_CHAIN_ID.into())
-                .await
-                .expect("should start eth1 environment");
-            let deposit_contract = &eth1.deposit_contract;
-            let web3 = eth1.web3();
+    env.runtime().block_on(async {
+        let eth1 = GanacheEth1Instance::new(DEFAULT_NETWORK_ID.into(), DEFAULT_CHAIN_ID.into())
+            .await
+            .expect("should start eth1 environment");
+        let deposit_contract = &eth1.deposit_contract;
+        let web3 = eth1.web3();
 
-            let now = web3
-                .eth()
-                .block_number()
-                .compat()
-                .await
-                .map(|v| v.as_u64())
-                .expect("should get block number");
+        let now = web3
+            .eth()
+            .block_number()
+            .await
+            .map(|v| v.as_u64())
+            .expect("should get block number");
 
-            let service = Eth1GenesisService::new(
-                Eth1Config {
-                    endpoints: vec![SensitiveUrl::parse(eth1.endpoint().as_str()).unwrap()],
-                    deposit_contract_address: deposit_contract.address(),
-                    deposit_contract_deploy_block: now,
-                    lowest_cached_block_number: now,
-                    follow_distance: 0,
-                    block_cache_truncation: None,
-                    ..Eth1Config::default()
-                },
-                log,
-                spec.clone(),
-            );
+        let service = Eth1GenesisService::new(
+            Eth1Config {
+                endpoints: vec![SensitiveUrl::parse(eth1.endpoint().as_str()).unwrap()],
+                deposit_contract_address: deposit_contract.address(),
+                deposit_contract_deploy_block: now,
+                lowest_cached_block_number: now,
+                follow_distance: 0,
+                block_cache_truncation: None,
+                ..Eth1Config::default()
+            },
+            log,
+            spec.clone(),
+        );
 
-            // NOTE: this test is sensitive to the response speed of the external web3 server. If
-            // you're experiencing failures, try increasing the update_interval.
-            let update_interval = Duration::from_millis(500);
+        // NOTE: this test is sensitive to the response speed of the external web3 server. If
+        // you're experiencing failures, try increasing the update_interval.
+        let update_interval = Duration::from_millis(500);
 
-            spec.min_genesis_time = 0;
-            spec.min_genesis_active_validator_count = 8;
+        spec.min_genesis_time = 0;
+        spec.min_genesis_active_validator_count = 8;
 
-            let deposits = (0..spec.min_genesis_active_validator_count + 2)
-                .map(|i| {
-                    deposit_contract.deposit_helper::<MinimalEthSpec>(
-                        generate_deterministic_keypair(i as usize),
-                        Hash256::from_low_u64_le(i),
-                        32_000_000_000,
-                    )
-                })
-                .map(|deposit| DelayThenDeposit {
-                    delay: Duration::from_secs(0),
-                    deposit,
-                })
-                .collect::<Vec<_>>();
+        let deposits = (0..spec.min_genesis_active_validator_count + 2)
+            .map(|i| {
+                deposit_contract.deposit_helper::<MinimalEthSpec>(
+                    generate_deterministic_keypair(i as usize),
+                    Hash256::from_low_u64_le(i),
+                    32_000_000_000,
+                )
+            })
+            .map(|deposit| DelayThenDeposit {
+                delay: Duration::from_secs(0),
+                deposit,
+            })
+            .collect::<Vec<_>>();
 
-            let deposit_future = deposit_contract.deposit_multiple(deposits);
+        let deposit_future = deposit_contract.deposit_multiple(deposits);
 
-            let wait_future =
-                service.wait_for_genesis_state::<MinimalEthSpec>(update_interval, spec.clone());
+        let wait_future =
+            service.wait_for_genesis_state::<MinimalEthSpec>(update_interval, spec.clone());
 
-            let state = futures::try_join!(deposit_future, wait_future)
-                .map(|(_, state)| state)
-                .expect("should finish waiting for genesis");
+        let state = futures::try_join!(deposit_future, wait_future)
+            .map(|(_, state)| state)
+            .expect("should finish waiting for genesis");
 
-            // Note: using ganache these deposits are 1-per-block, therefore we know there should only be
-            // the minimum number of validators.
-            assert_eq!(
-                state.validators().len(),
-                spec.min_genesis_active_validator_count as usize,
-                "should have expected validator count"
-            );
+        // Note: using ganache these deposits are 1-per-block, therefore we know there should only be
+        // the minimum number of validators.
+        assert_eq!(
+            state.validators().len(),
+            spec.min_genesis_active_validator_count as usize,
+            "should have expected validator count"
+        );
 
-            assert!(state.genesis_time() > 0, "should have some genesis time");
+        assert!(state.genesis_time() > 0, "should have some genesis time");
 
-            assert!(
-                is_valid_genesis_state(&state, &spec),
-                "should be valid genesis state"
-            );
+        assert!(
+            is_valid_genesis_state(&state, &spec),
+            "should be valid genesis state"
+        );
 
-            assert!(
-                is_valid_genesis_state(&state, &spec),
-                "should be valid genesis state"
-            );
-        }
-        .compat(),
-    );
+        assert!(
+            is_valid_genesis_state(&state, &spec),
+            "should be valid genesis state"
+        );
+    });
 }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -8,7 +8,7 @@ autotests = false # using a single test binary compiles faster
 [dependencies]
 warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["macros","sync"] }
+tokio = { version = "1.10.0", features = ["macros","sync"] }
 tokio-stream = { version = "0.1.3", features = ["sync"] }
 tokio-util = "0.6.3"
 parking_lot = "0.11.0"

--- a/beacon_node/http_metrics/Cargo.toml
+++ b/beacon_node/http_metrics/Cargo.toml
@@ -23,7 +23,7 @@ warp_utils = { path = "../../common/warp_utils" }
 malloc_utils = { path = "../../common/malloc_utils" }
 
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["sync"] }
+tokio = { version = "1.10.0", features = ["sync"] }
 reqwest = { version = "0.11.0", features = ["json"] }
 environment = { path = "../../lighthouse/environment" }
 types = { path = "../../consensus/types" }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -31,7 +31,7 @@ eth2_ssz_types = { path =  "../../consensus/ssz_types" }
 tree_hash = "0.1.1"
 futures = "0.3.7"
 error-chain = "0.12.4"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 tokio-stream = "0.1.3"
 parking_lot = "0.11.0"
 smallvec = "1.6.1"

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -46,5 +46,5 @@ itertools = "0.10.0"
 num_cpus = "1.13.0"
 lru_cache = { path = "../../common/lru_cache" }
 if-addrs = "0.6.4"
-strum = { version = "0.20"}
+strum = "0.21.0"
 tokio-util = { version = "0.6.3", features = ["time"] }

--- a/beacon_node/timer/Cargo.toml
+++ b/beacon_node/timer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 beacon_chain =  { path = "../beacon_chain" }
 types = { path = "../../consensus/types" }
 slot_clock = { path = "../../common/slot_clock" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 slog = "2.5.2"
 parking_lot = "0.11.0"
 futures = "0.3.7"

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -13,7 +13,7 @@ eth2_network_config = { path = "../common/eth2_network_config" }
 eth2_ssz = "0.1.2"
 slog = "2.5.2"
 sloggers = "1.0.1"
-tokio = "1.7.1"
+tokio = "1.10.0"
 log = "0.4.11"
 slog-term = "2.6.0"
 logging = { path = "../common/logging" }

--- a/common/account_utils/src/lib.rs
+++ b/common/account_utils/src/lib.rs
@@ -90,6 +90,7 @@ pub fn random_password() -> PlainText {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(DEFAULT_PASSWORD_LEN)
+        .map(char::from)
         .collect::<String>()
         .into_bytes()
         .into()

--- a/common/hashset_delay/Cargo.toml
+++ b/common/hashset_delay/Cargo.toml
@@ -9,4 +9,4 @@ futures = "0.3.7"
 tokio-util = { version = "0.6.2", features = ["time"] }
 
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.10.0", features = ["time", "rt-multi-thread", "macros"] }

--- a/common/monitoring_api/Cargo.toml
+++ b/common/monitoring_api/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 reqwest = { version = "0.11.0", features = ["json","stream"] }
 futures = "0.3.7"
 task_executor = { path = "../task_executor" }
-tokio = "1.7.1"
+tokio = "1.10.0"
 eth2 = {path = "../eth2"}
 serde_json = "1.0.58"
 serde = "1.0.116"

--- a/common/remote_signer_consumer/Cargo.toml
+++ b/common/remote_signer_consumer/Cargo.toml
@@ -11,6 +11,6 @@ remote_signer_test = { path = "../../testing/remote_signer_test" }
 [dependencies]
 reqwest = { version = "0.11.0", features = ["json"] }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["time"] }
+tokio = { version = "1.10.0", features = ["time"] }
 types = { path = "../../consensus/types" }
 sensitive_url = { path = "../sensitive_url" }

--- a/common/task_executor/Cargo.toml
+++ b/common/task_executor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.7.1", features = ["rt"] }
+tokio = { version = "1.10.0", features = ["rt"] }
 slog = "2.5.2"
 futures = "0.3.7"
 exit-future = "0.2.0"

--- a/common/validator_dir/src/builder.rs
+++ b/common/validator_dir/src/builder.rs
@@ -294,6 +294,7 @@ fn random_keystore() -> Result<(Keystore, PlainText), Error> {
     let password: PlainText = rand::thread_rng()
         .sample_iter(&Alphanumeric)
         .take(DEFAULT_PASSWORD_LEN)
+        .map(char::from)
         .collect::<String>()
         .into_bytes()
         .into();

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -14,7 +14,7 @@ beacon_chain = { path = "../../beacon_node/beacon_chain" }
 state_processing = { path = "../../consensus/state_processing" }
 safe_arith = { path = "../../consensus/safe_arith" }
 serde = { version = "1.0.116", features = ["derive"] }
-tokio = { version = "1.7.1", features = ["sync"] }
+tokio = { version = "1.10.0", features = ["sync"] }
 headers = "0.3.2"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 eth2_ssz_types = { path = "../ssz_types" }
 eth2_hashing = "0.1.0"
 eth2_ssz_derive = "0.1.0"

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 eth2_hashing = "0.1.0"
 lazy_static = "1.4.0"
 safe_arith = { path = "../safe_arith" }

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -13,7 +13,7 @@ name = "ssz"
 eth2_ssz_derive = "0.1.0"
 
 [dependencies]
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 smallvec = "1.6.1"
 
 [features]

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>", "Michael Sproul <michael@sigmapr
 edition = "2018"
 
 [dev-dependencies]
-env_logger = "0.8.2"
+env_logger = "0.9.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 lazy_static = "1.4.0"

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -13,7 +13,7 @@ criterion = "0.3.3"
 
 [dependencies]
 eth2_hashing = "0.1.0"
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "1.4.0"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 
 [dependencies]
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 eth2_hashing = "0.1.0"
 smallvec = "1.6.1"
 

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -13,7 +13,7 @@ bls = { path = "../../crypto/bls" }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 eth2_hashing = "0.1.0"
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }
@@ -37,7 +37,7 @@ cached_tree_hash = { path = "../cached_tree_hash" }
 serde_yaml = "0.8.13"
 tempfile = "3.1.0"
 derivative = "2.1.1"
-rusqlite = { version = "0.24.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.25.3", features = ["bundled"], optional = true }
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 serde_utils = { path = "../serde_utils" }
 regex = "1.3.9"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -14,7 +14,7 @@ serde_derive = "1.0.116"
 serde_utils = { path = "../../consensus/serde_utils" }
 hex = "0.4.2"
 eth2_hashing = "0.1.0"
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
 blst = "0.3.3"

--- a/crypto/eth2_keystore/Cargo.toml
+++ b/crypto/eth2_keystore/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7.3"
-hmac = "0.10.1"
-pbkdf2 = { version = "0.6.0", default-features = false }
-scrypt = { version = "0.5.0", default-features = false }
+hmac = "0.11.0"
+pbkdf2 = { version = "0.8.0", default-features = false }
+scrypt = { version = "0.7.0", default-features = false }
 sha2 = "0.9.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 zeroize = { version = "1.1.1", features = ["zeroize_derive"] }

--- a/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
@@ -67,9 +67,8 @@ pub enum Prf {
 impl Prf {
     pub fn mac(&self, password: &[u8]) -> impl Mac {
         match &self {
-            Prf::HmacSha256 => {
-                Hmac::<Sha256>::new_varkey(password).expect("Could not derive HMAC using SHA256.")
-            }
+            Prf::HmacSha256 => Hmac::<Sha256>::new_from_slice(password)
+                .expect("Could not derive HMAC using SHA256."),
         }
     }
 }

--- a/crypto/eth2_keystore/src/keystore.rs
+++ b/crypto/eth2_keystore/src/keystore.rs
@@ -17,7 +17,7 @@ use pbkdf2::pbkdf2;
 use rand::prelude::*;
 use scrypt::{
     errors::{InvalidOutputLen, InvalidParams},
-    scrypt, ScryptParams,
+    scrypt, Params as ScryptParams,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -37,6 +37,6 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 directory = { path = "../common/directory" }
 account_utils = { path = "../common/account_utils" }
 eth2_wallet = { path = "../crypto/eth2_wallet" }
-web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 eth1_test_rig = { path = "../testing/eth1_test_rig" }
 sensitive_url = { path = "../common/sensitive_url" }

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -27,7 +27,7 @@ dirs = "3.0.1"
 genesis = { path = "../beacon_node/genesis" }
 deposit_contract = { path = "../common/deposit_contract" }
 tree_hash = "0.1.1"
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 clap_utils = { path = "../common/clap_utils" }
 eth2_libp2p = { path = "../beacon_node/eth2_libp2p" }
 validator_dir = { path = "../common/validator_dir", features = ["insecure_keys"] }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -19,7 +19,7 @@ spec-minimal = []
 
 [dependencies]
 beacon_node = { "path" = "../beacon_node" }
-tokio = "1.7.1"
+tokio = "1.10.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.1"
 types = { "path" = "../consensus/types" }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -26,7 +26,7 @@ types = { "path" = "../consensus/types" }
 bls = { path = "../crypto/bls" }
 eth2_hashing = "0.1.0"
 clap = "2.33.3"
-env_logger = "0.8.2"
+env_logger = "0.9.0"
 logging = { path = "../common/logging" }
 slog-term = "2.6.0"
 slog-async = "2.5.0"

--- a/lighthouse/environment/Cargo.toml
+++ b/lighthouse/environment/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.7.1", features = ["macros", "rt", "rt-multi-thread" ] }
+tokio = { version = "1.10.0", features = ["macros", "rt", "rt-multi-thread" ] }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "1.0.1"
 types = { "path" = "../../consensus/types" }

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -16,7 +16,7 @@ filesystem = { path = "../common/filesystem" }
 lmdb = "0.8"
 lmdb-sys = "0.8"
 parking_lot = "0.11.0"
-rand = "0.7"
+rand = "0.7.3"
 safe_arith = { path = "../consensus/safe_arith" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/slasher/service/Cargo.toml
+++ b/slasher/service/Cargo.toml
@@ -14,6 +14,6 @@ slog = "2.5.2"
 slot_clock = { path = "../../common/slot_clock" }
 state_processing = { path = "../../consensus/state_processing" }
 task_executor = { path = "../../common/task_executor" }
-tokio = { version = "1.7.1", features = ["full"] }
+tokio = { version = "1.10.0", features = ["full"] }
 tokio-stream = "0.1.3"
 types = { path = "../../consensus/types" }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -15,7 +15,7 @@ bls = { path = "../../crypto/bls", default-features = false }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 derivative = "2.1.1"
-ethereum-types = "0.9.2"
+ethereum-types = "0.11.0"
 hex = "0.4.2"
 rayon = "1.4.1"
 serde = "1.0.116"

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 tokio = { version = "1.10.0", features = ["time"] }
-web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 futures = "0.3.7"
 types = { path = "../../consensus/types"}
 serde_json = "1.0.58"

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-tokio = { version = "1.7.1", features = ["time"] }
-tokio-compat-02 = "0.2.0"
+tokio = { version = "1.10.0", features = ["time"] }
 web3 = { version = "0.16.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 futures = "0.3.7"
 types = { path = "../../consensus/types"}

--- a/testing/eth1_test_rig/src/ganache.rs
+++ b/testing/eth1_test_rig/src/ganache.rs
@@ -4,7 +4,6 @@ use std::io::BufReader;
 use std::net::TcpListener;
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
-use tokio_compat_02::FutureExt;
 use web3::{transports::Http, Transport, Web3};
 
 /// How long we will wait for ganache to indicate that it is ready.
@@ -156,7 +155,6 @@ impl GanacheInstance {
         self.web3
             .transport()
             .execute("evm_increaseTime", vec![json!(increase_by)])
-            .compat()
             .await
             .map(|_json_value| ())
             .map_err(|e| format!("Failed to increase time on EVM (is this ganache?): {:?}", e))
@@ -167,7 +165,6 @@ impl GanacheInstance {
         self.web3
             .eth()
             .block_number()
-            .compat()
             .await
             .map(|v| v.as_u64())
             .map_err(|e| format!("Failed to get block number: {:?}", e))
@@ -178,7 +175,6 @@ impl GanacheInstance {
         self.web3
             .transport()
             .execute("evm_mine", vec![])
-            .compat()
             .await
             .map(|_| ())
             .map_err(|_| {

--- a/testing/eth1_test_rig/src/lib.rs
+++ b/testing/eth1_test_rig/src/lib.rs
@@ -13,7 +13,6 @@ use deposit_contract::{
 use ganache::GanacheInstance;
 use std::time::Duration;
 use tokio::time::sleep;
-use tokio_compat_02::FutureExt;
 use types::DepositData;
 use types::{test_utils::generate_deterministic_keypair, EthSpec, Hash256, Keypair, Signature};
 use web3::contract::{Contract, Options};
@@ -182,7 +181,6 @@ impl DepositContract {
             .web3
             .eth()
             .accounts()
-            .compat()
             .await
             .map_err(|e| format!("Failed to get accounts: {:?}", e))
             .and_then(|accounts| {
@@ -213,7 +211,6 @@ impl DepositContract {
         self.web3
             .eth()
             .send_transaction(tx_request)
-            .compat()
             .await
             .map_err(|e| format!("Failed to call deposit fn: {:?}", e))?;
         Ok(())
@@ -257,7 +254,6 @@ async fn deploy_deposit_contract(
     let from_address = web3
         .eth()
         .accounts()
-        .compat()
         .await
         .map_err(|e| format!("Failed to get accounts: {:?}", e))
         .and_then(|accounts| {
@@ -271,7 +267,6 @@ async fn deploy_deposit_contract(
         let result = web3
             .personal()
             .unlock_account(from_address, &password, None)
-            .compat()
             .await;
         match result {
             Ok(true) => return Ok(from_address),
@@ -292,7 +287,6 @@ async fn deploy_deposit_contract(
         .execute(bytecode, (), deploy_address);
 
     pending_contract
-        .compat()
         .await
         .map(|contract| contract.address())
         .map_err(|e| format!("Unable to resolve pending contract: {:?}", e))

--- a/testing/remote_signer_test/Cargo.toml
+++ b/testing/remote_signer_test/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
 tempfile = "3.1.0"
-tokio = { version = "1.7.1", features = ["time"] }
+tokio = { version = "1.10.0", features = ["time"] }
 types = { path = "../../consensus/types" }
 sensitive_url = { path = "../../common/sensitive_url" }
 

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -15,7 +15,7 @@ parking_lot = "0.11.0"
 futures = "0.3.7"
 tokio = "1.10.0"
 eth1_test_rig = { path = "../eth1_test_rig" }
-env_logger = "0.8.2"
+env_logger = "0.9.0"
 clap = "2.33.3"
 rayon = "1.4.1"
 sensitive_url  = { path = "../../common/sensitive_url" }

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -13,7 +13,7 @@ types = { path = "../../consensus/types" }
 validator_client = { path = "../../validator_client" }
 parking_lot = "0.11.0"
 futures = "0.3.7"
-tokio = "1.7.1"
+tokio = "1.10.0"
 eth1_test_rig = { path = "../eth1_test_rig" }
 env_logger = "0.8.2"
 clap = "2.33.3"

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -57,10 +57,10 @@ warp_utils = { path = "../common/warp_utils" }
 warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
 hyper = "0.14.4"
 serde_utils = { path = "../consensus/serde_utils" }
-libsecp256k1 = "0.5.0"
+libsecp256k1 = "0.6.0"
 ring = "0.16.19"
 rand = "0.7.3"
-scrypt = { version = "0.5.0", default-features = false }
+scrypt = { version = "0.7.0", default-features = false }
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
 fallback = { path = "../common/fallback" }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -9,7 +9,7 @@ name = "validator_client"
 path = "src/lib.rs"
 
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["time", "rt-multi-thread", "macros"] }
+tokio = { version = "1.10.0", features = ["time", "rt-multi-thread", "macros"] }
 deposit_contract = { path = "../common/deposit_contract" }
 
 [dependencies]
@@ -30,7 +30,7 @@ serde_yaml = "0.8.13"
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "2.5.0"
 slog-term = "2.6.0"
-tokio = { version = "1.7.1", features = ["time"] }
+tokio = { version = "1.10.0", features = ["time"] }
 futures = "0.3.7"
 dirs = "3.0.1"
 directory = { path = "../common/directory" }

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 tempfile = "3.1.0"
 types = { path = "../../consensus/types" }
 tree_hash = "0.1.1"
-rusqlite = { version = "0.24.0", features = ["bundled"] }
+rusqlite = { version = "0.25.3", features = ["bundled"] }
 r2d2 = "0.8.9"
-r2d2_sqlite = "0.17.0"
+r2d2_sqlite = "0.18.0"
 parking_lot = "0.11.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -160,7 +160,7 @@ impl SlashingDatabase {
         let mut stmt = txn.prepare("INSERT INTO validators (public_key) VALUES (?1)")?;
         for pubkey in public_keys {
             if self.get_validator_id_opt(txn, pubkey)?.is_none() {
-                stmt.execute(&[pubkey.as_hex_string()])?;
+                stmt.execute([pubkey.as_hex_string()])?;
             }
         }
         Ok(())


### PR DESCRIPTION
## Proposed Changes

* Consolidate Tokio versions: everything now uses the latest v1.10.0, no more `tokio-compat`.
* Many semver-compatible changes via `cargo update`. Notably this upgrades from the yanked v0.8.0 version of crossbeam-deque which is present in v1.5.0-rc.0
* Many semver incompatible upgrades via `cargo upgrades` and `cargo upgrade --workspace pkg_name`. Notable ommissions:
    - Prometheus, to be handled separately: https://github.com/sigp/lighthouse/issues/2485
    - `rand`, `rand_xorshift`: the libsecp256k1 package requires 0.7.x, so we'll stick with that for now
    - `ethereum-types` is pinned at 0.11.0 because that's what `web3` is using and it seems nice to have just a single version
    
## Additional Info

We still have two versions of `libp2p-core` due to `discv5` depending on the v0.29.0 release rather than `master`. AFAIK it should be OK to release in this state (cc @AgeManning )