### PR TITLE
[Merged by Bors] - Refactor discovery queries

### DIFF
--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -641,7 +641,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
         let mut subnet_queries: Vec<SubnetQuery> = Vec::new();
         let mut processed = false;
         // Check that we are within our query concurrency limit
-        while !self.at_capacity() {
+        while !self.at_capacity() && !self.queued_queries.is_empty() {
             // consume and process the query queue
             if let Some(subnet_query) = self.queued_queries.pop_front() {
                 subnet_queries.push(subnet_query);


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Refactor discovery queries such that only `QueryType::Subnet` queries are queued for grouping. `QueryType::FindPeers` is always made regardless of the number of active `Subnet` queries (max = 2). This prevents `FindPeers` queries from getting starved if `Subnet` queries start queuing up. 

Also removes `GroupedQueryType` struct and use `QueryType` for all queuing and processing of discovery requests.

## Additional Info

Currently, no distinction is made between subnet discovery queries for attestation and sync committee subnets when grouping queries. Potentially we could prioritise attestation queries over sync committee queries in the future.