### PR TITLE
[Merged by Bors] - Shutdown after sync

### DIFF
--- a/beacon_node/eth2_libp2p/src/config.rs
+++ b/beacon_node/eth2_libp2p/src/config.rs
@@ -95,6 +95,9 @@ pub struct Config {
     /// prevents sending client identifying information over identify.
     pub private: bool,
 
+    /// Shutdown beacon node after sync is completed.
+    pub shutdown_after_sync: bool,
+
     /// List of extra topics to initially subscribe to as strings.
     pub topics: Vec<GossipKind>,
 }
@@ -169,6 +172,7 @@ impl Default for Config {
             private: false,
             subscribe_all_subnets: false,
             import_all_attestations: false,
+            shutdown_after_sync: false,
             topics: Vec::new(),
         }
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -46,6 +46,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("shutdown-after-sync")
+                .long("shutdown-after-sync")
+                .help("Shutdown beacon node as soon as sync is completed")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("zero-ports")
                 .long("zero-ports")
                 .short("z")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -467,6 +467,10 @@ pub fn set_network_config(
         config.import_all_attestations = true;
     }
 
+    if cli_args.is_present("shutdown-after-sync") {
+        config.shutdown_after_sync = true;
+    }
+
     if let Some(listen_address_str) = cli_args.value_of("listen-address") {
         let listen_address = listen_address_str
             .parse()

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -315,6 +315,12 @@ fn network_shutdown_after_sync_flag() {
         .with_config(|config| assert!(config.network.shutdown_after_sync));
 }
 #[test]
+fn network_shutdown_after_sync_disabled_flag() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert!(!config.network.shutdown_after_sync));
+}
+#[test]
 fn network_listen_address_flag() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
     CommandLineTest::new()

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -308,6 +308,13 @@ fn network_import_all_attestations_flag() {
         .with_config(|config| assert!(config.network.import_all_attestations));
 }
 #[test]
+fn network_shutdown_after_sync_flag() {
+    CommandLineTest::new()
+        .flag("shutdown-after-sync", None)
+        .run()
+        .with_config(|config| assert!(config.network.shutdown_after_sync));
+}
+#[test]
 fn network_listen_address_flag() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
     CommandLineTest::new()


### PR DESCRIPTION
## Issue Addressed

Resolves #2033 

## Proposed Changes

Adds a flag to enable shutting down beacon node right after sync is completed.

## Additional Info

Will need modification after weak subjectivity sync is enabled to change definition of a fully synced node.