### PR TITLE
[Merged by Bors] - Packet filter cli option

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -46,6 +46,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("disable-packet-filter")
+                .long("disable-packet-filter")
+                .help("Disables the discovery packet filter. Useful for testing in smaller networks")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("zero-ports")
                 .long("zero-ports")
                 .short("z")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -612,6 +612,11 @@ pub fn set_network_config(
         config.discv5_config.enr_update = false;
     }
 
+    if cli_args.is_present("disable-packet-filter") {
+        warn!(log, "Discv5 packet filter is disabled");
+        config.discv5_config.enable_packet_filter = false;
+    }
+
     if cli_args.is_present("disable-discovery") {
         config.disable_discovery = true;
         warn!(log, "Discovery is disabled. New peers will not be found");

--- a/boot_node/src/cli.rs
+++ b/boot_node/src/cli.rs
@@ -61,6 +61,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 This enables this feature.")
         )
         .arg(
+            Arg::with_name("disable-packet-filter")
+                .long("disable-packet-filter")
+                .help("Disables discv5 packet filter. Useful for testing in smaller networks")
+        )
+        .arg(
             Arg::with_name("network-dir")
             .value_name("NETWORK_DIR")
                 .long("network-dir")

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -19,6 +19,7 @@ pub struct BootNodeConfig<T: EthSpec> {
     pub local_enr: Enr,
     pub local_key: CombinedKey,
     pub auto_update: bool,
+    pub disable_packet_filter: bool,
     phantom: PhantomData<T>,
 }
 
@@ -69,6 +70,7 @@ impl<T: EthSpec> TryFrom<&ArgMatches<'_>> for BootNodeConfig<T> {
         }
 
         let auto_update = matches.is_present("enable-enr_auto_update");
+        let disable_packet_filter = matches.is_present("disable-packet-filter");
 
         // the address to listen on
         let listen_socket =
@@ -128,6 +130,7 @@ impl<T: EthSpec> TryFrom<&ArgMatches<'_>> for BootNodeConfig<T> {
             local_enr,
             local_key,
             auto_update,
+            disable_packet_filter,
             phantom: PhantomData,
         })
     }

--- a/boot_node/src/server.rs
+++ b/boot_node/src/server.rs
@@ -32,7 +32,9 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
 
     let discv5_config = {
         let mut builder = Discv5ConfigBuilder::new();
-        builder.enable_packet_filter();
+        if !config.disable_packet_filter {
+            builder.enable_packet_filter();
+        }
         if !config.auto_update {
             builder.disable_enr_update();
         }

--- a/scripts/local_testnet/beacon_node.sh
+++ b/scripts/local_testnet/beacon_node.sh
@@ -21,4 +21,5 @@ exec lighthouse \
 	--enr-tcp-port $2 \
 	--port $2 \
 	--http-port $3 \
+	--disable-packet-filter \
 	--target-peers $((NODE_COUNT - 1))

--- a/scripts/local_testnet/bootnode.sh
+++ b/scripts/local_testnet/bootnode.sh
@@ -30,4 +30,5 @@ exec lighthouse boot_node \
     --testnet-dir $TESTNET_DIR \
     --port $BOOTNODE_PORT \
     --listen-address 127.0.0.1 \
+	--disable-packet-filter \
     --network-dir $DATADIR/bootnode \


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Adds a cli option to disable packet filter in `lighthouse bootnode`. This is useful in running local testnets as the bootnode bans requests from the same ip(localhost) if the packet filter is enabled.
