### PR TITLE
[Merged by Bors] - Fork schedule api

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1377,7 +1377,7 @@ pub fn serve<T: BeaconChainTypes>(
             blocking_json_task(move || {
                 let forks = ForkName::list_all()
                     .into_iter()
-                    .map(|fork_name| chain.spec.fork_for_name(fork_name))
+                    .filter_map(|fork_name| chain.spec.fork_for_name(fork_name))
                     .collect::<Vec<_>>();
                 Ok(api_types::GenericResponse::from(forks))
             })

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -40,7 +40,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use types::{
     Attestation, AttesterSlashing, BeaconStateError, CommitteeCache, ConfigAndPreset, Epoch,
-    EthSpec, ProposerSlashing, RelativeEpoch, SignedAggregateAndProof, SignedBeaconBlock,
+    EthSpec, ForkName, ProposerSlashing, RelativeEpoch, SignedAggregateAndProof, SignedBeaconBlock,
     SignedContributionAndProof, SignedVoluntaryExit, Slot, SyncCommitteeMessage,
     SyncContributionData,
 };
@@ -1363,7 +1363,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     /*
-     * config/fork_schedule
+     * config
      */
 
     let config_path = eth1_v1.and(warp::path("config"));
@@ -1375,9 +1375,11 @@ pub fn serve<T: BeaconChainTypes>(
         .and(chain_filter.clone())
         .and_then(|chain: Arc<BeaconChain<T>>| {
             blocking_json_task(move || {
-                StateId::head()
-                    .fork(&chain)
-                    .map(|fork| api_types::GenericResponse::from(vec![fork]))
+                let forks = ForkName::list_all()
+                    .into_iter()
+                    .map(|fork_name| chain.spec.fork_for_name(fork_name))
+                    .collect::<Vec<_>>();
+                Ok(api_types::GenericResponse::from(forks))
             })
         });
 

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -8,10 +8,6 @@ use types::{BeaconState, EthSpec, Fork, Hash256, Slot};
 pub struct StateId(CoreStateId);
 
 impl StateId {
-    pub fn head() -> Self {
-        Self(CoreStateId::Head)
-    }
-
     pub fn slot(slot: Slot) -> Self {
         Self(CoreStateId::Slot(slot))
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1190,7 +1190,7 @@ impl ApiTester {
     pub async fn test_get_config_fork_schedule(self) -> Self {
         let result = self.client.get_config_fork_schedule().await.unwrap().data;
 
-        let expected = ForkName::list_all()
+        let expected: Vec<Fork> = ForkName::list_all()
             .into_iter()
             .map(|fork| self.chain.spec.fork_for_name(fork))
             .collect();

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1192,7 +1192,7 @@ impl ApiTester {
 
         let expected: Vec<Fork> = ForkName::list_all()
             .into_iter()
-            .map(|fork| self.chain.spec.fork_for_name(fork))
+            .filter_map(|fork| self.chain.spec.fork_for_name(fork))
             .collect();
 
         assert_eq!(result, expected);

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1190,7 +1190,10 @@ impl ApiTester {
     pub async fn test_get_config_fork_schedule(self) -> Self {
         let result = self.client.get_config_fork_schedule().await.unwrap().data;
 
-        let expected = vec![self.chain.head_info().unwrap().fork];
+        let expected = ForkName::list_all()
+            .into_iter()
+            .map(|fork| self.chain.spec.fork_for_name(fork))
+            .collect();
 
         assert_eq!(result, expected);
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -237,7 +237,8 @@ impl ChainSpec {
         }
     }
 
-    /// Returns a full `Fork` struct for a given `ForkName`.
+    /// Returns a full `Fork` struct for a given `ForkName` or `None` if the fork does not yet have
+    /// an activation epoch.
     pub fn fork_for_name(&self, fork_name: ForkName) -> Option<Fork> {
         let previous_fork_name = fork_name.previous_fork().unwrap_or(ForkName::Base);
         let epoch = self.fork_epoch(fork_name)?;

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -225,19 +225,28 @@ impl ChainSpec {
     /// Returns a full `Fork` struct for a given epoch.
     pub fn fork_at_epoch(&self, epoch: Epoch) -> Fork {
         let current_fork_name = self.fork_name_at_epoch(epoch);
-        self.fork_for_name(current_fork_name)
-    }
-
-    /// Returns a full `Fork` struct for a given `ForkName`.
-    pub fn fork_for_name(&self, fork_name: ForkName) -> Fork {
-        let previous_fork_name = fork_name.previous_fork().unwrap_or(ForkName::Base);
-        let epoch = self.fork_epoch(fork_name).unwrap_or_else(|| Epoch::new(0));
+        let previous_fork_name = current_fork_name.previous_fork().unwrap_or(ForkName::Base);
+        let epoch = self
+            .fork_epoch(current_fork_name)
+            .unwrap_or_else(|| Epoch::new(0));
 
         Fork {
             previous_version: self.fork_version_for_name(previous_fork_name),
-            current_version: self.fork_version_for_name(fork_name),
+            current_version: self.fork_version_for_name(current_fork_name),
             epoch,
         }
+    }
+
+    /// Returns a full `Fork` struct for a given `ForkName`.
+    pub fn fork_for_name(&self, fork_name: ForkName) -> Option<Fork> {
+        let previous_fork_name = fork_name.previous_fork().unwrap_or(ForkName::Base);
+        let epoch = self.fork_epoch(fork_name)?;
+
+        Some(Fork {
+            previous_version: self.fork_version_for_name(previous_fork_name),
+            current_version: self.fork_version_for_name(fork_name),
+            epoch,
+        })
     }
 
     /// Get the domain number, unmodified by the fork.

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -225,14 +225,17 @@ impl ChainSpec {
     /// Returns a full `Fork` struct for a given epoch.
     pub fn fork_at_epoch(&self, epoch: Epoch) -> Fork {
         let current_fork_name = self.fork_name_at_epoch(epoch);
-        let previous_fork_name = current_fork_name.previous_fork().unwrap_or(ForkName::Base);
-        let epoch = self
-            .fork_epoch(current_fork_name)
-            .unwrap_or_else(|| Epoch::new(0));
+        self.fork_for_name(current_fork_name)
+    }
+
+    /// Returns a full `Fork` struct for a given `ForkName`.
+    pub fn fork_for_name(&self, fork_name: ForkName) -> Fork {
+        let previous_fork_name = fork_name.previous_fork().unwrap_or(ForkName::Base);
+        let epoch = self.fork_epoch(fork_name).unwrap_or_else(|| Epoch::new(0));
 
         Fork {
             previous_version: self.fork_version_for_name(previous_fork_name),
-            current_version: self.fork_version_for_name(current_fork_name),
+            current_version: self.fork_version_for_name(fork_name),
             epoch,
         }
     }


### PR DESCRIPTION
## Issue Addressed

Resolves #2524

## Proposed Changes

- Return all known forks in the `/config/fork_schedule`, previously returned only the head of the chain's fork.
- Deleted the `StateId::head` method because it was only previously used in this endpoint.
