### PR TITLE
[Merged by Bors] - Remove penality for duplicate attestation from same validator

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -975,9 +975,6 @@ impl<T: BeaconChainTypes> Worker<T> {
                     "validator_index" => validator_index,
                     "type" => ?attestation_type,
                 );
-                // We still penalize the peer slightly. We don't want this to be a recurring
-                // behaviour.
-                self.gossip_penalize_peer(peer_id, PeerAction::HighToleranceError);
 
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
 

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -734,6 +734,18 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
         };
 
+        /*TODO:
+        // Register the sync signature with any monitored validators.
+        self.chain
+            .validator_monitor
+            .read()
+            .register_gossip_unaggregated_attestation(
+                seen_timestamp,
+                attestation.indexed_attestation(),
+                &self.chain.slot_clock,
+            );
+        */
+
         // Indicate to the `Network` service that this message is valid and can be
         // propagated on the gossip network.
         self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
@@ -788,6 +800,20 @@ impl<T: BeaconChainTypes> Worker<T> {
         // Indicate to the `Network` service that this message is valid and can be
         // propagated on the gossip network.
         self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
+
+        /* TODO
+        // Register the attestation with any monitored validators.
+        self.chain
+            .validator_monitor
+            .read()
+            .register_gossip_aggregated_attestation(
+                seen_timestamp,
+                aggregate.aggregate(),
+                aggregate.indexed_attestation(),
+                &self.chain.slot_clock,
+            );
+        metrics::inc_counter(&metrics::BEACON_PROCESSOR_AGGREGATED_ATTESTATION_VERIFIED_TOTAL);
+        */
 
         if let Err(e) = self
             .chain

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -734,18 +734,6 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
         };
 
-        /*TODO:
-        // Register the sync signature with any monitored validators.
-        self.chain
-            .validator_monitor
-            .read()
-            .register_gossip_unaggregated_attestation(
-                seen_timestamp,
-                attestation.indexed_attestation(),
-                &self.chain.slot_clock,
-            );
-        */
-
         // Indicate to the `Network` service that this message is valid and can be
         // propagated on the gossip network.
         self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
@@ -800,20 +788,6 @@ impl<T: BeaconChainTypes> Worker<T> {
         // Indicate to the `Network` service that this message is valid and can be
         // propagated on the gossip network.
         self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
-
-        /* TODO
-        // Register the attestation with any monitored validators.
-        self.chain
-            .validator_monitor
-            .read()
-            .register_gossip_aggregated_attestation(
-                seen_timestamp,
-                aggregate.aggregate(),
-                aggregate.indexed_attestation(),
-                &self.chain.slot_clock,
-            );
-        metrics::inc_counter(&metrics::BEACON_PROCESSOR_AGGREGATED_ATTESTATION_VERIFIED_TOTAL);
-        */
 
         if let Err(e) = self
             .chain


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

A Discord user presented logs which indicated a drop in their peer count caused by a variety of peers sending attestations where we'd already seen an attestation for that validator. It's presently unclear how this case came about, but during our investigation I noticed that we are down-voting peers for sending such attestations.

There are three scenarios where we may receive duplicate unagg. attestations from the same validator:

1. The validator is committing a slashable offense.
2. The gossipsub message-deduping functionality is not working as expected.
3. We received the message via the HTTP prior to seeing it via gossip.

Scenario (1) would be so costly for an attacker that I don't think we need to add DoS protection for it.

Scenario (2) seems feasible. Our "seen message" caches in gossipsub might fill up/expire and let through these duplicates. There are also cases involving message ID mismatches with the other peers. In both these cases, I don't think we should be doing 1 attestation == -1 point down-voting.

Scenario (3) is not necessarily a fault of the peer and we shouldn't down-score them for it.

## Additional Info

NA
