### PR TITLE
[Merged by Bors] - Add `BlockTimesCache` to allow additional block delay metrics

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3230,12 +3230,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
 
             if !block_from_sync && late_head && event_handler.has_late_head_subscribers() {
-                let peer_id = self
+                let peer_info = self
                     .block_times_cache
                     .read()
-                    .cache
-                    .get(&beacon_block_root)
-                    .and_then(|x| x.peer_id.clone());
+                    .get_peer_info(beacon_block_root);
                 let block_delays = self.block_times_cache.read().get_block_delays(
                     beacon_block_root,
                     self.slot_clock
@@ -3245,7 +3243,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 event_handler.register(EventKind::LateHead(SseLateHead {
                     slot: head_slot,
                     block: beacon_block_root,
-                    peer_id,
+                    peer_id: peer_info.id,
+                    peer_client: peer_info.client,
                     proposer_index: head_proposer_index,
                     proposer_graffiti,
                     block_delay: block_delay_total,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3026,7 +3026,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let update_head_timer = metrics::start_timer(&metrics::UPDATE_HEAD_TIMES);
 
-        // These fields are used for server-sent events
+        // These fields are used for server-sent events.
         let state_root = new_head.beacon_state_root();
         let head_slot = new_head.beacon_state.slot();
         let target_epoch_start_slot = new_head

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3230,6 +3230,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
 
             if !block_from_sync && late_head && event_handler.has_late_head_subscribers() {
+                let peer_id = self
+                    .block_times_cache
+                    .read()
+                    .cache
+                    .get(&beacon_block_root)
+                    .and_then(|x| x.peer_id.clone());
                 let block_delays = self.block_times_cache.read().get_block_delays(
                     beacon_block_root,
                     self.slot_clock
@@ -3239,6 +3245,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 event_handler.register(EventKind::LateHead(SseLateHead {
                     slot: head_slot,
                     block: beacon_block_root,
+                    peer_id,
                     proposer_index: head_proposer_index,
                     proposer_graffiti,
                     block_delay: block_delay_total,

--- a/beacon_node/beacon_chain/src/block_times_cache.rs
+++ b/beacon_node/beacon_chain/src/block_times_cache.rs
@@ -1,0 +1,138 @@
+//! This module provides the `BlockTimesCache' which contains information regarding block timings.
+//!
+//! This provides `BeaconChain` and associated functions with access to the timestamps of when a
+//! certain block was observed, imported and set as head.
+//! This allows for better traceability and allows us to determine the root cause for why a block
+//! was set as head late.
+//! This allows us to distingush between the following scenarios:
+//! - The block was observed late.
+//! - We were too slow to import it.
+//! - We were too slow to set it as head.
+
+use eth2::types::{Hash256, Slot};
+use std::collections::HashMap;
+use std::time::Duration;
+
+type BlockRoot = Hash256;
+
+#[derive(Clone)]
+pub struct Timestamps {
+    pub observed: Option<Duration>,
+    pub imported: Option<Duration>,
+    pub set_as_head: Option<Duration>,
+}
+
+impl Default for Timestamps {
+    fn default() -> Self {
+        Timestamps {
+            observed: None,
+            imported: None,
+            set_as_head: None,
+        }
+    }
+}
+
+// Helps arrange delay data so it is more relevant to metrics.
+pub struct BlockDelays {
+    pub observed: Option<Duration>,
+    pub imported: Option<Duration>,
+    pub set_as_head: Option<Duration>,
+}
+
+impl Default for BlockDelays {
+    fn default() -> Self {
+        BlockDelays {
+            observed: None,
+            imported: None,
+            set_as_head: None,
+        }
+    }
+}
+
+impl BlockDelays {
+    fn new(times: Timestamps, slot_start_time: Duration) -> BlockDelays {
+        let observed = times
+            .observed
+            .and_then(|observed_time| observed_time.checked_sub(slot_start_time));
+        let imported = times
+            .imported
+            .and_then(|imported_time| imported_time.checked_sub(times.observed?));
+        let set_as_head = times
+            .set_as_head
+            .and_then(|set_as_head_time| set_as_head_time.checked_sub(times.imported?));
+        BlockDelays {
+            observed,
+            imported,
+            set_as_head,
+        }
+    }
+}
+
+pub struct BlockTimesCacheValue {
+    pub timestamps: Timestamps,
+    pub slot: Slot,
+}
+
+#[derive(Default)]
+pub struct BlockTimesCache {
+    pub cache: HashMap<BlockRoot, BlockTimesCacheValue>,
+}
+
+/// Helper methods to read from and write to the cache.
+impl BlockTimesCache {
+    pub fn set_time_observed(&mut self, block_root: BlockRoot, slot: Slot, timestamp: Duration) {
+        if let Some(mut block_times) = self.cache.get_mut(&block_root) {
+            block_times.timestamps.observed = Some(timestamp);
+        } else {
+            let timestamps = Timestamps {
+                observed: Some(timestamp),
+                ..Default::default()
+            };
+            self.cache
+                .insert(block_root, BlockTimesCacheValue { timestamps, slot });
+        }
+    }
+
+    pub fn set_time_imported(&mut self, block_root: BlockRoot, slot: Slot, timestamp: Duration) {
+        if let Some(mut block_times) = self.cache.get_mut(&block_root) {
+            block_times.timestamps.imported = Some(timestamp);
+        } else {
+            let timestamps = Timestamps {
+                imported: Some(timestamp),
+                ..Default::default()
+            };
+            self.cache
+                .insert(block_root, BlockTimesCacheValue { timestamps, slot });
+        }
+    }
+
+    pub fn set_time_set_as_head(&mut self, block_root: BlockRoot, slot: Slot, timestamp: Duration) {
+        if let Some(mut block_times) = self.cache.get_mut(&block_root) {
+            block_times.timestamps.set_as_head = Some(timestamp);
+        } else {
+            let timestamps = Timestamps {
+                set_as_head: Some(timestamp),
+                ..Default::default()
+            };
+            self.cache
+                .insert(block_root, BlockTimesCacheValue { timestamps, slot });
+        }
+    }
+
+    pub fn get_block_delays(
+        &self,
+        block_root: BlockRoot,
+        slot_start_time: Duration,
+    ) -> BlockDelays {
+        if let Some(block_times) = self.cache.get(&block_root) {
+            BlockDelays::new(block_times.timestamps.clone(), slot_start_time)
+        } else {
+            BlockDelays::default()
+        }
+    }
+
+    // Prune the cache to only store the most recent 2 epochs.
+    pub fn prune(&mut self, current_slot: Slot) {
+        self.cache.retain(|_, cache| cache.slot < current_slot - 64)
+    }
+}

--- a/beacon_node/beacon_chain/src/block_times_cache.rs
+++ b/beacon_node/beacon_chain/src/block_times_cache.rs
@@ -105,7 +105,6 @@ impl BlockTimesCache {
             .entry(block_root)
             .or_insert_with(|| BlockTimesCacheValue::new(slot));
         block_times.timestamps.imported = Some(timestamp);
-        block_times.peer_info = BlockPeerInfo::default();
     }
 
     pub fn set_time_set_as_head(&mut self, block_root: BlockRoot, slot: Slot, timestamp: Duration) {
@@ -114,7 +113,6 @@ impl BlockTimesCache {
             .entry(block_root)
             .or_insert_with(|| BlockTimesCacheValue::new(slot));
         block_times.timestamps.set_as_head = Some(timestamp);
-        block_times.peer_info = BlockPeerInfo::default();
     }
 
     pub fn get_block_delays(

--- a/beacon_node/beacon_chain/src/block_times_cache.rs
+++ b/beacon_node/beacon_chain/src/block_times_cache.rs
@@ -138,6 +138,6 @@ impl BlockTimesCache {
     // Prune the cache to only store the most recent 2 epochs.
     pub fn prune(&mut self, current_slot: Slot) {
         self.cache
-            .retain(|_, cache| cache.slot < current_slot.saturating_sub(64_u64));
+            .retain(|_, cache| cache.slot > current_slot.saturating_sub(64_u64));
     }
 }

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -724,6 +724,7 @@ where
             )),
             shuffling_cache: TimeoutRwLock::new(ShufflingCache::new()),
             beacon_proposer_cache: <_>::default(),
+            block_times_cache: <_>::default(),
             validator_pubkey_cache: TimeoutRwLock::new(validator_pubkey_cache),
             attester_cache: <_>::default(),
             disabled_forks: self.disabled_forks,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -5,6 +5,7 @@ mod beacon_chain;
 mod beacon_fork_choice_store;
 mod beacon_proposer_cache;
 mod beacon_snapshot;
+mod block_times_cache;
 mod block_verification;
 pub mod builder;
 pub mod chain_config;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -736,11 +736,11 @@ lazy_static! {
     );
     pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_TIME: Result<Histogram> = try_create_histogram(
         "beacon_block_head_slot_start_delay_time",
-        "Duration between the start of the block's slot and the time when it was as head.",
+        "Duration between the start of the block's slot and the time when it was set as head.",
     );
     pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_EXCEEDED_TOTAL: Result<IntCounter> = try_create_int_counter(
         "beacon_block_head_slot_start_delay_exceeded_total",
-        "Triggered when the duration between the start of the blocks slot and the current time \
+        "Triggered when the duration between the start of the block's slot and the current time \
         will result in failed attestations.",
     );
 

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -722,13 +722,21 @@ lazy_static! {
     /*
      * Block Delay Metrics
      */
-    pub static ref BEACON_BLOCK_IMPORTED_SLOT_START_DELAY_TIME: Result<Histogram> = try_create_histogram(
-        "beacon_block_imported_slot_start_delay_time",
-        "Duration between the start of the blocks slot and the current time when it was imported.",
+    pub static ref BEACON_BLOCK_OBSERVED_SLOT_START_DELAY_TIME: Result<Histogram> = try_create_histogram(
+        "beacon_block_observed_slot_start_delay_time",
+        "Duration between the start of the block's slot and the time the block was observed.",
+    );
+    pub static ref BEACON_BLOCK_IMPORTED_OBSERVED_DELAY_TIME: Result<Histogram> = try_create_histogram(
+        "beacon_block_imported_observed_delay_time",
+        "Duration between the time the block was observed and the time when it was imported.",
+    );
+    pub static ref BEACON_BLOCK_HEAD_IMPORTED_DELAY_TIME: Result<Histogram> = try_create_histogram(
+        "beacon_block_head_imported_delay_time",
+        "Duration between the time the block was imported and the time when it was set as head.",
     );
     pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_TIME: Result<Histogram> = try_create_histogram(
         "beacon_block_head_slot_start_delay_time",
-        "Duration between the start of the blocks slot and the current time when it was as head.",
+        "Duration between the start of the block's slot and the time when it was as head.",
     );
     pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_EXCEEDED_TOTAL: Result<IntCounter> = try_create_int_counter(
         "beacon_block_head_slot_start_delay_exceeded_total",

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2475,6 +2475,9 @@ pub fn serve<T: BeaconChainTypes>(
                                 api_types::EventTopic::ContributionAndProof => {
                                     event_handler.subscribe_contributions()
                                 }
+                                api_types::EventTopic::LateHead => {
+                                    event_handler.subscribe_late_head()
+                                }
                             };
 
                             receivers.push(BroadcastStream::new(receiver).map(|msg| {

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -231,6 +231,7 @@ impl TestRig {
             .try_send(WorkEvent::gossip_beacon_block(
                 junk_message_id(),
                 junk_peer_id(),
+                Client::default(),
                 Box::new(self.next_block.clone()),
                 Duration::from_secs(0),
             ))

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -639,6 +639,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             block.canonical_root(),
             block.slot(),
             seen_duration,
+            Some(peer_id.to_string()),
         );
 
         let verified_block = match self.chain.verify_block_for_gossip(block) {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -634,6 +634,13 @@ impl<T: BeaconChainTypes> Worker<T> {
             block_delay,
         );
 
+        // Write the time the block was observed into delay cache.
+        self.chain.block_times_cache.write().set_time_observed(
+            block.canonical_root(),
+            block.slot(),
+            seen_duration,
+        );
+
         let verified_block = match self.chain.verify_block_for_gossip(block) {
             Ok(verified_block) => {
                 if block_delay >= self.chain.slot_clock.unagg_attestation_production_delay() {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -7,7 +7,7 @@ use beacon_chain::{
     validator_monitor::get_block_delay_ms,
     BeaconChainError, BeaconChainTypes, BlockError, ForkChoiceError, GossipVerifiedBlock,
 };
-use eth2_libp2p::{MessageAcceptance, MessageId, PeerAction, PeerId, ReportSource};
+use eth2_libp2p::{Client, MessageAcceptance, MessageId, PeerAction, PeerId, ReportSource};
 use slog::{crit, debug, error, info, trace, warn};
 use slot_clock::SlotClock;
 use ssz::Encode;
@@ -622,6 +622,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         self,
         message_id: MessageId,
         peer_id: PeerId,
+        peer_client: Client,
         block: SignedBeaconBlock<T::EthSpec>,
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         seen_duration: Duration,
@@ -640,6 +641,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             block.slot(),
             seen_duration,
             Some(peer_id.to_string()),
+            Some(peer_client.to_string()),
         );
 
         let verified_block = match self.chain.verify_block_for_gossip(block) {

--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -223,7 +223,12 @@ impl<T: BeaconChainTypes> Router<T> {
                 );
             }
             PubsubMessage::BeaconBlock(block) => {
-                self.processor.on_block_gossip(id, peer_id, block);
+                self.processor.on_block_gossip(
+                    id,
+                    peer_id,
+                    self.network_globals.client(&peer_id),
+                    block,
+                );
             }
             PubsubMessage::VoluntaryExit(exit) => {
                 debug!(self.log, "Received a voluntary exit"; "peer_id" => %peer_id);

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -5,7 +5,7 @@ use crate::service::NetworkMessage;
 use crate::sync::SyncMessage;
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 use eth2_libp2p::rpc::*;
-use eth2_libp2p::{MessageId, NetworkGlobals, PeerId, PeerRequestId, Request, Response};
+use eth2_libp2p::{Client, MessageId, NetworkGlobals, PeerId, PeerRequestId, Request, Response};
 use slog::{debug, error, o, trace, warn};
 use std::cmp;
 use std::sync::Arc;
@@ -230,11 +230,13 @@ impl<T: BeaconChainTypes> Processor<T> {
         &mut self,
         message_id: MessageId,
         peer_id: PeerId,
+        peer_client: Client,
         block: Box<SignedBeaconBlock<T::EthSpec>>,
     ) {
         self.send_beacon_processor_work(BeaconWorkEvent::gossip_beacon_block(
             message_id,
             peer_id,
+            peer_client,
             block,
             timestamp_now(),
         ))

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -211,6 +211,7 @@ impl<T: BeaconChainTypes> Processor<T> {
                 peer_id,
                 request_id: id,
                 beacon_block,
+                seen_timestamp: timestamp_now(),
             });
         } else {
             debug!(

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -477,6 +477,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     block.slot(),
                     seen_timestamp,
                     None,
+                    None,
                 );
                 info!(self.log, "Processed block"; "block" => %block_root);
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -476,6 +476,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     block_root,
                     block.slot(),
                     seen_timestamp,
+                    None,
                 );
                 info!(self.log, "Processed block"; "block" => %block_root);
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -54,6 +54,7 @@ use ssz_types::VariableList;
 use std::boxed::Box;
 use std::ops::Sub;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
 
@@ -90,6 +91,7 @@ pub enum SyncMessage<T: EthSpec> {
         peer_id: PeerId,
         request_id: RequestId,
         beacon_block: Option<Box<SignedBeaconBlock<T>>>,
+        seen_timestamp: Duration,
     },
 
     /// A block with an unknown parent has been received.
@@ -313,6 +315,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: PeerId,
         request_id: RequestId,
         block: Option<SignedBeaconBlock<T::EthSpec>>,
+        seen_timestamp: Duration,
     ) {
         match block {
             Some(block) => {
@@ -326,7 +329,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     single_block_hash = Some(block_request.hash);
                 }
                 if let Some(block_hash) = single_block_hash {
-                    self.single_block_lookup_response(peer_id, block, block_hash)
+                    self.single_block_lookup_response(peer_id, block, block_hash, seen_timestamp)
                         .await;
                     return;
                 }
@@ -449,6 +452,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: PeerId,
         block: SignedBeaconBlock<T::EthSpec>,
         expected_block_hash: Hash256,
+        seen_timestamp: Duration,
     ) {
         // verify the hash is correct and try and process the block
         if expected_block_hash != block.canonical_root() {
@@ -467,6 +471,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         // we have the correct block, try and process it
         match block_result {
             Ok(block_root) => {
+                // Block has been processed, so write the block time to the cache.
+                self.chain.block_times_cache.write().set_time_observed(
+                    block_root,
+                    block.slot(),
+                    seen_timestamp,
+                );
                 info!(self.log, "Processed block"; "block" => %block_root);
 
                 match self.chain.fork_choice() {
@@ -1007,9 +1017,15 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         peer_id,
                         request_id,
                         beacon_block,
+                        seen_timestamp,
                     } => {
-                        self.blocks_by_root_response(peer_id, request_id, beacon_block.map(|b| *b))
-                            .await;
+                        self.blocks_by_root_response(
+                            peer_id,
+                            request_id,
+                            beacon_block.map(|b| *b),
+                            seen_timestamp,
+                        )
+                        .await;
                     }
                     SyncMessage::UnknownBlock(peer_id, block) => {
                         self.add_unknown_block(peer_id, *block);

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -767,6 +767,7 @@ pub struct SseLateHead {
     pub slot: Slot,
     pub block: Hash256,
     pub proposer_index: u64,
+    pub peer_id: Option<String>,
     pub proposer_graffiti: String,
     pub block_delay: Duration,
     pub observed_delay: Option<Duration>,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -768,6 +768,7 @@ pub struct SseLateHead {
     pub block: Hash256,
     pub proposer_index: u64,
     pub peer_id: Option<String>,
+    pub peer_client: Option<String>,
     pub proposer_graffiti: String,
     pub block_delay: Duration,
     pub observed_delay: Option<Duration>,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::{from_utf8, FromStr};
+use std::time::Duration;
 pub use types::*;
 
 /// An API error serializable to JSON.
@@ -761,6 +762,17 @@ pub struct SseChainReorg {
     pub epoch: Epoch,
 }
 
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+pub struct SseLateHead {
+    pub slot: Slot,
+    pub block: Hash256,
+    pub proposer_index: u64,
+    pub block_delay: Duration,
+    pub observed_delay: Option<Duration>,
+    pub imported_delay: Option<Duration>,
+    pub set_as_head_delay: Option<Duration>,
+}
+
 #[derive(PartialEq, Debug, Serialize, Clone)]
 #[serde(bound = "T: EthSpec", untagged)]
 pub enum EventKind<T: EthSpec> {
@@ -771,6 +783,7 @@ pub enum EventKind<T: EthSpec> {
     VoluntaryExit(SignedVoluntaryExit),
     ChainReorg(SseChainReorg),
     ContributionAndProof(Box<SignedContributionAndProof<T>>),
+    LateHead(SseLateHead),
 }
 
 impl<T: EthSpec> EventKind<T> {
@@ -783,6 +796,7 @@ impl<T: EthSpec> EventKind<T> {
             EventKind::FinalizedCheckpoint(_) => "finalized_checkpoint",
             EventKind::ChainReorg(_) => "chain_reorg",
             EventKind::ContributionAndProof(_) => "contribution_and_proof",
+            EventKind::LateHead(_) => "late_head",
         }
     }
 
@@ -822,6 +836,9 @@ impl<T: EthSpec> EventKind<T> {
             "head" => Ok(EventKind::Head(serde_json::from_str(data).map_err(
                 |e| ServerError::InvalidServerSentEvent(format!("Head: {:?}", e)),
             )?)),
+            "late_head" => Ok(EventKind::LateHead(serde_json::from_str(data).map_err(
+                |e| ServerError::InvalidServerSentEvent(format!("Late Head: {:?}", e)),
+            )?)),
             "voluntary_exit" => Ok(EventKind::VoluntaryExit(
                 serde_json::from_str(data).map_err(|e| {
                     ServerError::InvalidServerSentEvent(format!("Voluntary Exit: {:?}", e))
@@ -854,6 +871,7 @@ pub enum EventTopic {
     FinalizedCheckpoint,
     ChainReorg,
     ContributionAndProof,
+    LateHead,
 }
 
 impl FromStr for EventTopic {
@@ -868,6 +886,7 @@ impl FromStr for EventTopic {
             "finalized_checkpoint" => Ok(EventTopic::FinalizedCheckpoint),
             "chain_reorg" => Ok(EventTopic::ChainReorg),
             "contribution_and_proof" => Ok(EventTopic::ContributionAndProof),
+            "late_head" => Ok(EventTopic::LateHead),
             _ => Err("event topic cannot be parsed.".to_string()),
         }
     }
@@ -883,6 +902,7 @@ impl fmt::Display for EventTopic {
             EventTopic::FinalizedCheckpoint => write!(f, "finalized_checkpoint"),
             EventTopic::ChainReorg => write!(f, "chain_reorg"),
             EventTopic::ContributionAndProof => write!(f, "contribution_and_proof"),
+            EventTopic::LateHead => write!(f, "late_head"),
         }
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -767,6 +767,7 @@ pub struct SseLateHead {
     pub slot: Slot,
     pub block: Hash256,
     pub proposer_index: u64,
+    pub proposer_graffiti: String,
     pub block_delay: Duration,
     pub observed_delay: Option<Duration>,
     pub imported_delay: Option<Duration>,


### PR DESCRIPTION
## Issue Addressed

Closes #2528

## Proposed Changes

- Add `BlockTimesCache` to provide block timing information to `BeaconChain`. This allows additional metrics to be calculated for blocks that are set as head too late.
- Thread the `seen_timestamp` of blocks received from RPC responses (except blocks from syncing) through to the sync manager, similar to what is done for blocks from gossip.

## Additional Info

This provides the following additional metrics:
- `BEACON_BLOCK_OBSERVED_SLOT_START_DELAY_TIME`
  - The delay between the start of the slot and when the block was first observed.
- `BEACON_BLOCK_IMPORTED_OBSERVED_DELAY_TIME`
   - The delay between when the block was first observed and when the block was imported.
- `BEACON_BLOCK_HEAD_IMPORTED_DELAY_TIME`
  - The delay between when the block was imported and when the block was set as head.

The metric `BEACON_BLOCK_IMPORTED_SLOT_START_DELAY_TIME` was removed.

A log is produced when a block is set as head too late, e.g.:
```
Aug 27 03:46:39.006 DEBG Delayed head block                      set_as_head_delay: Some(21.731066ms), imported_delay: Some(119.929934ms), observed_delay: Some(3.864596988s), block_delay: 4.006257988s, slot: 1931331, proposer_index: 24294, block_root: 0x937602c89d3143afa89088a44bdf4b4d0d760dad082abacb229495c048648a9e, service: beacon
```
