### PR TITLE
[Merged by Bors] - Fix log output for INFO Found no doppelganger

### DIFF
--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -635,7 +635,7 @@ impl DoppelgangerService {
                     self.log,
                     "Found no doppelganger";
                     "further_checks_remaining" => doppelganger_state.remaining_epochs,
-                    "epoch" => response.index,
+                    "epoch" => response.epoch,
                     "validator_index" => response.index
                 );
 


### PR DESCRIPTION
## Issue Addressed

log output "INFO Found no doppelganger validator_index: 11111, epoch: 11111, further_checks_remaining: 0, service: doppelganger"
whereby validator_index = epoch

## Proposed Changes

epoch = current epoch