### PR TITLE
[Merged by Bors] - Make local-testnet setup more discoverable

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -33,7 +33,6 @@
     * [Custom Data Directories](./advanced-datadir.md)
     * [Validator Graffiti](./graffiti.md)
     * [Database Configuration](./advanced_database.md)
-	* [Local Testnets](./local-testnets.md)
     * [Advanced Networking](./advanced_networking.md)
     * [Running a Slasher](./slasher.md)
     * [Redundancy](./redundancy.md)

--- a/book/src/local-testnets.md
+++ b/book/src/local-testnets.md
@@ -1,8 +1,0 @@
-# Local Testnets
-
-During development and testing it can be useful to start a small, local
-testnet.
-
-The
-[scripts/local_testnet/](https://github.com/sigp/lighthouse/tree/unstable/scripts)
-directory contains several scripts and a README that should make this process easy.

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -47,3 +47,12 @@ These tests are quite large (100's of MB) so they're only downloaded if you run
 `$ make test-ef` (or anything that run it). You may want to avoid
 downloading these tests if you're on a slow or metered Internet connection. CI
 will require them to pass, though.
+
+## Local Testnets
+
+During development and testing it can be useful to start a small, local
+testnet.
+
+The
+[scripts/local_testnet/](https://github.com/sigp/lighthouse/tree/unstable/scripts/local_testnet)
+directory contains several scripts and a README that should make this process easy.


### PR DESCRIPTION
Move the contents of book/src/local-testnets.md into book/src/setup.md
to make it more discoverable.

Also, the link to scripts/local_testnet was missing `/local_testnet`.
