### PR TITLE
Additional logging when endpoint changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "lighthouse_metrics",
+ "logging",
  "merkle_proof",
  "parking_lot",
  "reqwest",

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -32,3 +32,4 @@ task_executor = { path = "../../common/task_executor" }
 eth2 = { path = "../../common/eth2" }
 fallback = { path = "../../common/fallback" }
 sensitive_url = { path = "../../common/sensitive_url" }
+logging = { path = "../../common/logging" }

--- a/beacon_node/eth1/src/inner.rs
+++ b/beacon_node/eth1/src/inner.rs
@@ -36,6 +36,7 @@ pub struct Inner {
     pub block_cache: RwLock<BlockCache>,
     pub deposit_cache: RwLock<DepositUpdater>,
     pub endpoints_cache: RwLock<Option<Arc<EndpointsCache>>>,
+    pub endpoint_index: RwLock<Option<usize>>,
     pub config: RwLock<Config>,
     pub remote_head_block: RwLock<Option<Eth1Block>>,
     pub spec: ChainSpec,
@@ -49,6 +50,15 @@ impl Inner {
         if let Some(block_cache_truncation) = self.config.read().block_cache_truncation {
             self.block_cache.write().truncate(block_cache_truncation);
         }
+    }
+
+    /// Update the endpoint_index to index
+    /// Returns previous value
+    pub fn update_endpoint_index(&self, index: usize) -> Option<usize> {
+        let mut rw_ref = self.endpoint_index.write();
+        let prev_index = *rw_ref;
+        *rw_ref = Some(index);
+        prev_index
     }
 
     /// Encode the eth1 block and deposit cache as bytes.
@@ -97,6 +107,7 @@ impl SszEth1Cache {
                 last_processed_block: self.last_processed_block,
             }),
             endpoints_cache: RwLock::new(None),
+            endpoint_index: RwLock::new(None),
             // Set the remote head_block zero when creating a new instance. We only care about
             // present and future eth1 nodes.
             remote_head_block: RwLock::new(None),

--- a/beacon_node/eth1/src/inner.rs
+++ b/beacon_node/eth1/src/inner.rs
@@ -36,7 +36,6 @@ pub struct Inner {
     pub block_cache: RwLock<BlockCache>,
     pub deposit_cache: RwLock<DepositUpdater>,
     pub endpoints_cache: RwLock<Option<Arc<EndpointsCache>>>,
-    pub endpoint_index: RwLock<Option<usize>>,
     pub config: RwLock<Config>,
     pub remote_head_block: RwLock<Option<Eth1Block>>,
     pub spec: ChainSpec,
@@ -50,15 +49,6 @@ impl Inner {
         if let Some(block_cache_truncation) = self.config.read().block_cache_truncation {
             self.block_cache.write().truncate(block_cache_truncation);
         }
-    }
-
-    /// Update the endpoint_index to index
-    /// Returns previous value
-    pub fn update_endpoint_index(&self, index: usize) -> Option<usize> {
-        let mut rw_ref = self.endpoint_index.write();
-        let prev_index = *rw_ref;
-        *rw_ref = Some(index);
-        prev_index
     }
 
     /// Encode the eth1 block and deposit cache as bytes.
@@ -107,7 +97,6 @@ impl SszEth1Cache {
                 last_processed_block: self.last_processed_block,
             }),
             endpoints_cache: RwLock::new(None),
-            endpoint_index: RwLock::new(None),
             // Set the remote head_block zero when creating a new instance. We only care about
             // present and future eth1 nodes.
             remote_head_block: RwLock::new(None),

--- a/beacon_node/eth1/tests/test.rs
+++ b/beacon_node/eth1/tests/test.rs
@@ -4,6 +4,7 @@ use eth1::http::{get_deposit_count, get_deposit_logs_in_range, get_deposit_root,
 use eth1::{Config, Service};
 use eth1::{DepositCache, DEFAULT_CHAIN_ID, DEFAULT_NETWORK_ID};
 use eth1_test_rig::GanacheEth1Instance;
+use logging::test_logger;
 use merkle_proof::verify_merkle_proof;
 use sensitive_url::SensitiveUrl;
 use slog::Logger;
@@ -839,7 +840,7 @@ mod fallbacks {
     #[tokio::test]
     async fn test_fallback_when_offline() {
         async {
-            let log = null_logger();
+            let log = test_logger();
             let endpoint2 = new_ganache_instance()
                 .await
                 .expect("should start eth1 environment");


### PR DESCRIPTION
This adds logging so the user is informed whenever the endpoint changes.

beacon_node/eth1/Cargo.toml:
 * Added test_logger features

beacon_node/eth1/src/inner.rs:
 * Added endpoint_index to Inner to track the current endpoint index
 * Added fn update_endpoint_index which updates endpoint_index and
   returns the old value.

beacon_node/eth1/src/service.rs:
 * Changed num_errors to cur_index
 * Changed to logging to output different messages based on when
   the endpoint changed.

beacon_node/eth1/tests/test.rs
 * Added fn test_logger extracted from
   beacon_node/beacon_chain/src/test_utils.rs
 * Use test_logger instead of null_logger in test_fallback_when_offline

Output of test_fallback_when_offline with test_logger feature enabled:

  wink@3900x:~/prgs/ethereum/myrepos/lighthouse/beacon_node/eth1 (Additional-logging-when-endpoint-changes-take2)
  $ cargo test test_fallback_when_offline --features test_logger -- --nocapture
      Finished test [unoptimized + debuginfo] target(s) in 0.19s
       Running unittests (/home/wink/prgs/ethereum/myrepos/lighthouse/target/debug/deps/eth1-209b6ecb1bd266e0)

  running 0 tests

  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s

       Running tests/test.rs (/home/wink/prgs/ethereum/myrepos/lighthouse/target/debug/deps/test-5ed8c8c2ba222544)

  running 1 test
  Sep 09 14:49:28.039 INFO First endpoint is preferred, url: http://localhost:45637/, index: 0, module: eth1::service:755
  Sep 09 14:49:28.046 DEBG Downloading eth1 blocks, last: None, first: None, module: eth1::service:1134
  Sep 09 14:49:28.046 DEBG No new eth1 blocks imported, cached_blocks: 0, latest_block: None, module: eth1::service:1206
  Sep 09 14:49:28.100 DEBG Imported deposit logs chunk, logs: 0, module: eth1::service:1016
  Sep 09 14:49:28.100 DEBG No new deposits found, total_deposits: 0, latest_block: None, module: eth1::service:1040
  Sep 09 14:49:28.139 INFO Endoint changed to fallback, url: http://localhost:46809/, index: 1, module: eth1::service:745
  Sep 09 14:49:28.145 DEBG Downloading eth1 blocks, last: Some(6), first: Some(1), module: eth1::service:1134
  Sep 09 14:49:28.146 WARN Error connecting to eth1 node endpoint, action: trying fallbacks, endpoint: http://localhost:45637/, module: eth1::service:187
  Sep 09 14:49:28.158 DEBG Imported deposit logs chunk, logs: 0, module: eth1::service:1016
  Sep 09 14:49:28.158 DEBG No new deposits found, total_deposits: 0, latest_block: None, module: eth1::service:1040
  Sep 09 14:49:28.197 DEBG Imported eth1 block(s), new: 6, total_cached_blocks: 6, latest_block: 6, latest_block_age: 0 mins, module: eth1::service:1197
  test fallbacks::test_fallback_when_offline ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 2.95s


Output when test_logger feature is NOT enabled:

  wink@3900x:~/prgs/ethereum/myrepos/lighthouse/beacon_node/eth1 (Additional-logging-when-endpoint-changes-take2)
  $ cargo test test_fallback_when_offline -- --nocapture
     Compiling eth1 v0.2.0 (/home/wink/prgs/ethereum/myrepos/lighthouse/beacon_node/eth1)
      Finished test [unoptimized + debuginfo] target(s) in 9.92s
       Running unittests (/home/wink/prgs/ethereum/myrepos/lighthouse/target/debug/deps/eth1-675a42b60865a619)

  running 0 tests

  test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 0.00s

       Running tests/test.rs (/home/wink/prgs/ethereum/myrepos/lighthouse/target/debug/deps/test-d4f896e20deed138)

  running 1 test
  test fallbacks::test_fallback_when_offline ... ok

  test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 3.06s
