### PR TITLE
[Merged by Bors] - Add quoted u64/u64_vec to SyncCommitteeSubscription

### DIFF
--- a/consensus/types/src/sync_committee_subscription.rs
+++ b/consensus/types/src/sync_committee_subscription.rs
@@ -7,8 +7,10 @@ use ssz_derive::{Decode, Encode};
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode)]
 pub struct SyncCommitteeSubscription {
     /// The validators index.
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub validator_index: u64,
     /// The sync committee indices.
+    #[serde(with = "eth2_serde_utils::quoted_u64_vec")]
     pub sync_committee_indices: Vec<u64>,
     /// Epoch until which this subscription is required.
     pub until_epoch: Epoch,


### PR DESCRIPTION
## Issue Addressed

Resolves #2582 

## Proposed Changes

Use `quoted_u64` and `quoted_u64_vec` custom serde deserializers from `eth2_serde_utils` to support the proper Eth2.0 API spec for `/eth/v1/validator/sync_committee_subscriptions`

## Additional Info

N/A