### PR TITLE
Update urls for interactive API spec

### DIFF
--- a/book/src/api-bn.md
+++ b/book/src/api-bn.md
@@ -153,5 +153,5 @@ lighthouse bn --http --http-allow-origin "*"
 > **Warning:** Adding the wild-card allow-origin flag can pose a security risk.
 > Only use it in production if you understand the risks of a loose CORS policy.
 
-[OpenAPI]: https://ethereum.github.io/eth2.0-APIs/#/
+[OpenAPI]: https://ethereum.github.io/beacon-APIs/
 [ssh_tunnel]: https://www.ssh.com/academy/ssh/tunneling/example

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -322,7 +322,7 @@ Obtains a `BeaconState` in SSZ bytes. Useful for obtaining a genesis state.
 
 The `state_id` parameter is identical to that used in the [Standard Eth2.0 API
 `beacon/state`
-routes](https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateRoot).
+routes](https://ethereum.github.io/beacon-APIs/#/Beacon/getStateRoot).
 
 ```bash
 curl -X GET "http://localhost:5052/lighthouse/beacon/states/0/ssz" | jq

--- a/book/src/http.md
+++ b/book/src/http.md
@@ -1,6 +1,6 @@
 # HTTP API
 
-[OpenAPI Specification](https://ethereum.github.io/eth2.0-APIs/#/)
+[OpenAPI Specification](https://ethereum.github.io/beacon-APIs/)
 
 ## Beacon Node
 
@@ -16,7 +16,7 @@ The following CLI flags control the HTTP server:
 The schema of the API aligns with the standard Eth2 Beacon Node API as defined
 at [github.com/ethereum/eth2.0-APIs](https://github.com/ethereum/eth2.0-APIs).
 It is an easy-to-use RESTful HTTP/JSON API.  An interactive specification is
-available [here](https://ethereum.github.io/eth2.0-APIs/#/).
+available [here](https://ethereum.github.io/beacon-APIs/).
 
 ## Troubleshooting
 

--- a/book/src/redundancy.md
+++ b/book/src/redundancy.md
@@ -1,6 +1,6 @@
 # Redundancy
 
-[subscribe-api]: https://ethereum.github.io/eth2.0-APIs/#/Validator/prepareBeaconCommitteeSubnet
+[subscribe-api]: https://ethereum.github.io/beacon-APIs/#/Validator/prepareBeaconCommitteeSubnet
 
 There are three places in Lighthouse where redundancy is notable:
 

--- a/book/src/validator-monitoring.md
+++ b/book/src/validator-monitoring.md
@@ -27,7 +27,7 @@ automatic and manual.
 ### Automatic
 
 When the `--validator-monitor-auto` flag is supplied, any validator which uses the
-[`beacon_committee_subscriptions`](https://ethereum.github.io/eth2.0-APIs/#/Validator/prepareBeaconCommitteeSubnet)
+[`beacon_committee_subscriptions`](https://ethereum.github.io/beacon-APIs/#/Validator/prepareBeaconCommitteeSubnet)
 API endpoint will be enrolled for additional monitoring. All active validators will use this
 endpoint each epoch, so you can expect it to detect all local and active validators within several
 minutes after start up.


### PR DESCRIPTION
## Issue Addressed

Closes #2563 

## Proposed Changes

Update links to the interactive API spec in the book from https://ethereum.github.io/eth2.0-APIs/ to https://ethereum.github.io/beacon-APIs/

## Additional Info

N/A
