### PR TITLE
[Merged by Bors] - Fix nightly bump num bigint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
+checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",

--- a/common/eth2_interop_keypairs/Cargo.toml
+++ b/common/eth2_interop_keypairs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.4.0"
-num-bigint = "0.3.0"
+num-bigint = "0.4.2"
 eth2_hashing = "0.2.0"
 hex = "0.4.2"
 serde_yaml = "0.8.13"


### PR DESCRIPTION
## Issue Addressed

Builds again on latest nightly

## Proposed Changes

Break was caused by: https://github.com/rust-lang/rust/issues/88581