### PR TITLE
[Merged by Bors] - Reduce network debug noise

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -1004,14 +1004,6 @@ impl<TSpec: EthSpec> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour<T
                 }
                 // send peer info to the peer manager.
                 self.peer_manager.identify(&peer_id, &info);
-
-                debug!(self.log, "Identified Peer"; "peer" => %peer_id,
-                    "protocol_version" => info.protocol_version,
-                    "agent_version" => info.agent_version,
-                    "listening_ addresses" => ?info.listen_addrs,
-                    "observed_address" => ?info.observed_addr,
-                    "protocols" => ?info.protocols
-                );
             }
             IdentifyEvent::Sent { .. } => {}
             IdentifyEvent::Error { .. } => {}

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -483,10 +483,15 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn identify(&mut self, peer_id: &PeerId, info: &IdentifyInfo) {
         if let Some(peer_info) = self.network_globals.peers.write().peer_info_mut(peer_id) {
             let previous_kind = peer_info.client.kind.clone();
-            let previous_listening_addresses = std::mem::replace(&mut peer_info.listening_addresses, info.listen_addrs.clone());
+            let previous_listening_addresses = std::mem::replace(
+                &mut peer_info.listening_addresses,
+                info.listen_addrs.clone(),
+            );
             peer_info.client = client::Client::from_identify_info(info);
 
-            if previous_kind != peer_info.client.kind || peer_info.listening_addresses != previous_listening_addresses {
+            if previous_kind != peer_info.client.kind
+                || peer_info.listening_addresses != previous_listening_addresses
+            {
                 debug!(self.log, "Identified Peer"; "peer" => %peer_id,
                     "protocol_version" => &info.protocol_version,
                     "agent_version" => &info.agent_version,

--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -483,10 +483,18 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     pub fn identify(&mut self, peer_id: &PeerId, info: &IdentifyInfo) {
         if let Some(peer_info) = self.network_globals.peers.write().peer_info_mut(peer_id) {
             let previous_kind = peer_info.client.kind.clone();
+            let previous_listening_addresses = std::mem::replace(&mut peer_info.listening_addresses, info.listen_addrs.clone());
             peer_info.client = client::Client::from_identify_info(info);
-            peer_info.listening_addresses = info.listen_addrs.clone();
 
-            if previous_kind != peer_info.client.kind {
+            if previous_kind != peer_info.client.kind || peer_info.listening_addresses != previous_listening_addresses {
+                debug!(self.log, "Identified Peer"; "peer" => %peer_id,
+                    "protocol_version" => &info.protocol_version,
+                    "agent_version" => &info.agent_version,
+                    "listening_ addresses" => ?info.listen_addrs,
+                    "observed_address" => ?info.observed_addr,
+                    "protocols" => ?info.protocols
+                );
+
                 // update the peer client kind metric
                 if let Some(v) = metrics::get_int_gauge(
                     &metrics::PEERS_PER_CLIENT,


### PR DESCRIPTION
The identify network debug logs can get quite noisy and are unnecessary to print on every request/response. 

This PR reduces debug noise by only printing messages for identify messages that offer some new information.