### PR TITLE
[Merged by Bors] - Make slashing protection import more resilient

### DIFF
--- a/account_manager/src/validator/slashing_protection.rs
+++ b/account_manager/src/validator/slashing_protection.rs
@@ -33,11 +33,10 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     Arg::with_name(MINIFY_FLAG)
                         .long(MINIFY_FLAG)
                         .takes_value(true)
-                        .default_value("true")
                         .possible_values(&["false", "true"])
                         .help(
-                            "Minify the input file before processing. This is *much* faster, \
-                             but will not detect slashable data in the input.",
+                            "Deprecated: Lighthouse no longer requires minification on import \
+                             because it always minifies",
                         ),
                 ),
         )
@@ -88,7 +87,7 @@ pub fn cli_run<T: EthSpec>(
     match matches.subcommand() {
         (IMPORT_CMD, Some(matches)) => {
             let import_filename: PathBuf = clap_utils::parse_required(matches, IMPORT_FILE_ARG)?;
-            let minify: bool = clap_utils::parse_required(matches, MINIFY_FLAG)?;
+            let minify: Option<bool> = clap_utils::parse_optional(matches, MINIFY_FLAG)?;
             let import_file = File::open(&import_filename).map_err(|e| {
                 format!(
                     "Unable to open import file at {}: {:?}",
@@ -102,12 +101,17 @@ pub fn cli_run<T: EthSpec>(
                 .map_err(|e| format!("Error parsing file for import: {:?}", e))?;
             eprintln!(" [done].");
 
-            if minify {
-                eprint!("Minifying input file for faster loading");
-                interchange = interchange
-                    .minify()
-                    .map_err(|e| format!("Minification failed: {:?}", e))?;
-                eprintln!(" [done].");
+            if let Some(minify) = minify {
+                eprintln!(
+                    "WARNING: --minify flag is deprecated and will be removed in a future release"
+                );
+                if minify {
+                    eprint!("Minifying input file for faster loading");
+                    interchange = interchange
+                        .minify()
+                        .map_err(|e| format!("Minification failed: {:?}", e))?;
+                    eprintln!(" [done].");
+                }
             }
 
             let slashing_protection_database =
@@ -120,14 +124,16 @@ pub fn cli_run<T: EthSpec>(
                 })?;
 
             let display_slot = |slot: Option<Slot>| {
-                slot.map_or("none".to_string(), |slot| format!("{}", slot.as_u64()))
+                slot.map_or("none".to_string(), |slot| format!("slot {}", slot.as_u64()))
             };
             let display_epoch = |epoch: Option<Epoch>| {
-                epoch.map_or("?".to_string(), |epoch| format!("{}", epoch.as_u64()))
+                epoch.map_or("?".to_string(), |epoch| format!("epoch {}", epoch.as_u64()))
             };
             let display_attestation = |source, target| match (source, target) {
                 (None, None) => "none".to_string(),
-                (source, target) => format!("{}=>{}", display_epoch(source), display_epoch(target)),
+                (source, target) => {
+                    format!("{} => {}", display_epoch(source), display_epoch(target))
+                }
             };
 
             match slashing_protection_database
@@ -140,18 +146,11 @@ pub fn cli_run<T: EthSpec>(
                             InterchangeImportOutcome::Success { pubkey, summary } => {
                                 eprintln!("- {:?}", pubkey);
                                 eprintln!(
-                                    "    - min block: {}",
-                                    display_slot(summary.min_block_slot)
+                                    "    - latest block: {}",
+                                    display_slot(summary.max_block_slot)
                                 );
                                 eprintln!(
-                                    "    - min attestation: {}",
-                                    display_attestation(
-                                        summary.min_attestation_source,
-                                        summary.min_attestation_target
-                                    )
-                                );
-                                eprintln!(
-                                    "    - max attestation: {}",
+                                    "    - latest attestation: {}",
                                     display_attestation(
                                         summary.max_attestation_source,
                                         summary.max_attestation_target
@@ -168,18 +167,17 @@ pub fn cli_run<T: EthSpec>(
                     }
                 }
                 Err(InterchangeError::AtomicBatchAborted(outcomes)) => {
-                    eprintln!("ERROR, slashable data in input:");
+                    eprintln!("ERROR: import aborted due to one or more errors");
                     for outcome in &outcomes {
                         if let InterchangeImportOutcome::Failure { pubkey, error } = outcome {
                             eprintln!("- {:?}", pubkey);
                             eprintln!("    - error: {:?}", error);
                         }
                     }
-                    return Err(
-                        "ERROR: import aborted due to slashable data, see above.\n\
-                         Please see https://lighthouse-book.sigmaprime.io/slashing-protection.html#slashable-data-in-import\n\
-                         IT IS NOT SAFE TO START VALIDATING".to_string()
-                    );
+                    return Err("ERROR: import aborted due to errors, see above.\n\
+                                No data has been imported and the slashing protection \
+                                database *should* be in the same state it was in before the import.\n\
+                                IT IS NOT SAFE TO START VALIDATING".to_string());
                 }
                 Err(e) => {
                     return Err(format!(
@@ -192,7 +190,7 @@ pub fn cli_run<T: EthSpec>(
 
             eprintln!("Import completed successfully.");
             eprintln!(
-                "Please double-check that the minimum and maximum blocks and attestations above \
+                "Please double-check that the latest blocks and attestations above \
                  match your expectations."
             );
 

--- a/account_manager/src/validator/slashing_protection.rs
+++ b/account_manager/src/validator/slashing_protection.rs
@@ -176,8 +176,11 @@ pub fn cli_run<T: EthSpec>(
                     }
                     return Err("ERROR: import aborted due to errors, see above.\n\
                                 No data has been imported and the slashing protection \
-                                database *should* be in the same state it was in before the import.\n\
-                                IT IS NOT SAFE TO START VALIDATING".to_string());
+                                database is in the same state it was in before the import.\n\
+                                Due to the failed import it is NOT SAFE to start validating\n\
+                                with any newly imported validator keys, as your database lacks\n\
+                                slashing protection data for them."
+                        .to_string());
                 }
                 Err(e) => {
                     return Err(format!(

--- a/validator_client/slashing_protection/Makefile
+++ b/validator_client/slashing_protection/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v5.1.0
+TESTS_TAG := v5.2.0
 GENERATE_DIR := generated-tests
 OUTPUT_DIR := interchange-tests
 TARBALL := $(OUTPUT_DIR)-$(TESTS_TAG).tar.gz

--- a/validator_client/slashing_protection/src/bin/test_generator.rs
+++ b/validator_client/slashing_protection/src/bin/test_generator.rs
@@ -216,7 +216,7 @@ fn main() {
             ],
         ),
         MultiTestCase::new(
-            "multiple_interchanges_single_validator_single_message_out_of_order",
+            "multiple_interchanges_single_validator_single_block_out_of_order",
             vec![
                 TestCase::new(interchange(vec![(0, vec![40], vec![])])),
                 TestCase::new(interchange(vec![(0, vec![20], vec![])]))
@@ -231,6 +231,131 @@ fn main() {
                 TestCase::new(interchange(vec![(0, vec![20, 50], vec![])]))
                     .contains_slashable_data()
                     .with_blocks(vec![(0, 20, false), (0, 50, false)]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_single_validator_single_att_out_of_order",
+            vec![
+                TestCase::new(interchange(vec![(0, vec![], vec![(12, 13)])])),
+                TestCase::new(interchange(vec![(0, vec![], vec![(10, 11)])]))
+                    .contains_slashable_data()
+                    .with_attestations(vec![
+                        (0, 10, 14, false),
+                        (0, 12, 13, false),
+                        (0, 12, 14, true),
+                        (0, 13, 15, true),
+                    ]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_single_validator_second_surrounds_first",
+            vec![
+                TestCase::new(interchange(vec![(0, vec![], vec![(10, 20)])])),
+                TestCase::new(interchange(vec![(0, vec![], vec![(9, 21)])]))
+                    .contains_slashable_data()
+                    .with_attestations(vec![
+                        (0, 10, 20, false),
+                        (0, 10, 21, false),
+                        (0, 9, 21, false),
+                        (0, 9, 22, false),
+                        (0, 10, 22, true),
+                    ]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_single_validator_first_surrounds_second",
+            vec![
+                TestCase::new(interchange(vec![(0, vec![], vec![(9, 21)])])),
+                TestCase::new(interchange(vec![(0, vec![], vec![(10, 20)])]))
+                    .contains_slashable_data()
+                    .with_attestations(vec![
+                        (0, 10, 20, false),
+                        (0, 10, 21, false),
+                        (0, 9, 21, false),
+                        (0, 9, 22, false),
+                        (0, 10, 22, true),
+                    ]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_multiple_validators_repeat_idem",
+            vec![
+                TestCase::new(interchange(vec![
+                    (0, vec![2, 4, 6], vec![(0, 1), (1, 2)]),
+                    (1, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                ])),
+                TestCase::new(interchange(vec![
+                    (0, vec![2, 4, 6], vec![(0, 1), (1, 2)]),
+                    (1, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                ]))
+                .contains_slashable_data()
+                .with_blocks(vec![
+                    (0, 0, false),
+                    (0, 3, true),
+                    (0, 7, true),
+                    (0, 3, true),
+                    (1, 0, false),
+                ])
+                .with_attestations(vec![(0, 0, 4, false), (1, 0, 4, true)]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_overlapping_validators_repeat_idem",
+            vec![
+                TestCase::new(interchange(vec![
+                    (0, vec![2, 4, 6], vec![(0, 1), (1, 2)]),
+                    (1, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                ])),
+                TestCase::new(interchange(vec![
+                    (0, vec![2, 4, 6], vec![(0, 1), (1, 2)]),
+                    (2, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                ]))
+                .contains_slashable_data(),
+                TestCase::new(interchange(vec![
+                    (1, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                    (2, vec![8, 10, 12], vec![(0, 1), (0, 3)]),
+                ]))
+                .contains_slashable_data()
+                .with_attestations(vec![
+                    (0, 0, 4, false),
+                    (1, 1, 2, false),
+                    (2, 1, 2, false),
+                ]),
+            ],
+        ),
+        MultiTestCase::new(
+            "multiple_interchanges_overlapping_validators_merge_stale",
+            vec![
+                TestCase::new(interchange(vec![
+                    (0, vec![100], vec![(12, 13)]),
+                    (1, vec![101], vec![(12, 13)]),
+                    (2, vec![4], vec![(4, 5)]),
+                ])),
+                TestCase::new(interchange(vec![
+                    (0, vec![2], vec![(4, 5)]),
+                    (1, vec![3], vec![(3, 4)]),
+                    (2, vec![102], vec![(12, 13)]),
+                ]))
+                .contains_slashable_data()
+                .with_blocks(vec![
+                    (0, 100, false),
+                    (1, 101, false),
+                    (2, 102, false),
+                    (0, 103, true),
+                    (1, 104, true),
+                    (2, 105, true),
+                ])
+                .with_attestations(vec![
+                    (0, 12, 13, false),
+                    (0, 11, 14, false),
+                    (1, 12, 13, false),
+                    (1, 11, 14, false),
+                    (2, 12, 13, false),
+                    (2, 11, 14, false),
+                    (0, 12, 14, true),
+                    (1, 13, 14, true),
+                    (2, 13, 14, true),
+                ]),
             ],
         ),
         MultiTestCase::single(

--- a/validator_client/slashing_protection/src/interchange.rs
+++ b/validator_client/slashing_protection/src/interchange.rs
@@ -119,7 +119,7 @@ impl Interchange {
                     }
                 }
                 (None, None) => {}
-                _ => return Err(InterchangeError::MinAndMaxInconsistent),
+                _ => return Err(InterchangeError::MaxInconsistent),
             };
 
             // Find maximum block slot.

--- a/validator_client/slashing_protection/src/interchange_test.rs
+++ b/validator_client/slashing_protection/src/interchange_test.rs
@@ -64,15 +64,15 @@ impl MultiTestCase {
         let slashing_db_file = dir.path().join("slashing_protection.sqlite");
         let slashing_db = SlashingDatabase::create(&slashing_db_file).unwrap();
 
-        // If minification is used, false positives are allowed, i.e. there may be some situations
-        // in which signing is safe but the minified file prevents it.
-        let allow_false_positives = minify;
+        // Now that we are using implicit minification on import, we must always allow
+        // false positives.
+        let allow_false_positives = true;
 
         for test_case in &self.steps {
-            // If the test case is marked as containing slashable data, then it is permissible
-            // that we fail to import the file, in which case execution of the whole test should
-            // be aborted.
-            let allow_import_failure = test_case.contains_slashable_data;
+            // If the test case is marked as containing slashable data, then the spec allows us to
+            // fail to import the file. However, we minify on import and ignore slashable data, so
+            // we should be capable of importing no matter what.
+            let allow_import_failure = false;
 
             let interchange = if minify {
                 let minified = test_case.interchange.minify().unwrap();

--- a/validator_client/slashing_protection/src/signed_attestation.rs
+++ b/validator_client/slashing_protection/src/signed_attestation.rs
@@ -1,4 +1,4 @@
-use crate::{hash256_from_row, SigningRoot};
+use crate::{signing_root_from_row, SigningRoot};
 use types::{AttestationData, Epoch, Hash256, SignedRoot};
 
 /// An attestation that has previously been signed.
@@ -56,7 +56,7 @@ impl SignedAttestation {
     pub fn from_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
         let source = row.get(0)?;
         let target = row.get(1)?;
-        let signing_root = hash256_from_row(2, row)?.into();
+        let signing_root = signing_root_from_row(2, row)?;
         Ok(SignedAttestation::new(source, target, signing_root))
     }
 }

--- a/validator_client/slashing_protection/src/signed_block.rs
+++ b/validator_client/slashing_protection/src/signed_block.rs
@@ -1,4 +1,4 @@
-use crate::{hash256_from_row, SigningRoot};
+use crate::{signing_root_from_row, SigningRoot};
 use types::{BeaconBlockHeader, Hash256, SignedRoot, Slot};
 
 /// A block that has previously been signed.
@@ -30,7 +30,7 @@ impl SignedBlock {
     /// Parse an SQLite row of `(slot, signing_root)`.
     pub fn from_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
         let slot = row.get(0)?;
-        let signing_root = hash256_from_row(1, row)?.into();
+        let signing_root = signing_root_from_row(1, row)?;
         Ok(SignedBlock { slot, signing_root })
     }
 }

--- a/validator_client/slashing_protection/src/test_utils.rs
+++ b/validator_client/slashing_protection/src/test_utils.rs
@@ -129,6 +129,8 @@ impl StreamTest<BeaconBlockHeader> {
     }
 }
 
+// This function roundtrips the database, but applies minification in order to be compatible with
+// the implicit minification done on import.
 fn roundtrip_database(dir: &TempDir, db: &SlashingDatabase, is_empty: bool) {
     let exported = db
         .export_interchange_info(DEFAULT_GENESIS_VALIDATORS_ROOT)
@@ -142,6 +144,9 @@ fn roundtrip_database(dir: &TempDir, db: &SlashingDatabase, is_empty: bool) {
         .export_interchange_info(DEFAULT_GENESIS_VALIDATORS_ROOT)
         .unwrap();
 
-    assert_eq!(exported, reexported);
+    assert!(exported
+        .minify()
+        .unwrap()
+        .equiv(&reexported.minify().unwrap()));
     assert_eq!(is_empty, exported.is_empty());
 }


### PR DESCRIPTION
## Issue Addressed

Closes #2419

## Proposed Changes

Address a long-standing issue with the import of slashing protection data where the import would fail due to the data appearing slashable w.r.t the existing database. Importing is now idempotent, and will have no issues importing data that has been handed back and forth between different validator clients, or different implementations.

The implementation works by updating the high and low watermarks if they need updating, and not attempting to check if the input is slashable w.r.t itself or the database. This is a strengthening of the minification that we started to do by default since #2380, and what Teku has been doing since the beginning.

## Additional Info

The only feature we lose by doing this is the ability to do non-minified imports of clock drifted messages (cf. Prysm on Medalla). In theory, with the previous implementation we could import all the messages in case of clock drift and be aware of the "gap" between the real present time and the messages signed in the far future. _However_ for attestations this is close to useless, as the source epoch will advance as soon as justification occurs, which will require us to make slashable attestations with respect to our bogus attestation(s). E.g. if I sign an attestation 100=>200 when the current epoch is 101, then I won't be able to vote in any epochs prior to 101 becoming justified because 101=>102, 101=>103, etc are all surrounded by 100=>200. Seeing as signing attestations gets blocked almost immediately in this case regardless of our import behaviour, there's no point trying to handle it. For blocks the situation is more hopeful due to the lack of surrounds, but losing block proposals from validators who by definition can't attest doesn't seem like an issue (the other block proposers can pick up the slack).