### PR TITLE
Enable --import-all-attestations by default

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2387,6 +2387,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     &self.spec,
                 );
             }
+
+            // Only add to the op pool if within 32 slots of the current slot. This usually doesn't
+            // gain us anything, but may net a few attestations in the case of a re-org.
+            if block.slot() + T::EthSpec::slots_per_epoch() >= current_slot {
+                self.op_pool
+                    .insert_attestation(
+                        attestation.clone(),
+                        &state.fork(),
+                        self.genesis_validators_root,
+                        &self.spec,
+                    )
+                    .map_err(Error::from)?;
+            }
         }
 
         // Register sync aggregate with validator monitor

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -43,7 +43,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Import and aggregate all attestations, regardless of validator subscriptions. \
                        This will only import attestations from already-subscribed subnets, use with \
                        --subscribe-all-subnets to ensure all attestations are received for import.")
-                .takes_value(false),
+                .takes_value(true)
+                .default_value("true")
+                .possible_values(&["true", "false"])
         )
         .arg(
             Arg::with_name("disable-packet-filter")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -463,8 +463,8 @@ pub fn set_network_config(
         config.subscribe_all_subnets = true;
     }
 
-    if cli_args.is_present("import-all-attestations") {
-        config.import_all_attestations = true;
+    if let Some(import_all) = clap_utils::parse_optional(cli_args, "import-all-attestations")? {
+        config.import_all_attestations = import_all;
     }
 
     if cli_args.is_present("shutdown-after-sync") {

--- a/book/src/redundancy.md
+++ b/book/src/redundancy.md
@@ -61,8 +61,6 @@ following flags:
 	`5052`). This is only required if your backup node is on a different host.
 - `--subscribe-all-subnets`: ensures that the beacon node subscribes to *all*
 	subnets, not just on-demand requests from validators.
-- `--import-all-attestations`: ensures that the beacon node performs
-	aggregation on all seen attestations.
 
 Subsequently, one could use the following command to provide a backup beacon
 node:
@@ -71,25 +69,23 @@ node:
 lighthouse bn \
   --staking \
   --http-address 0.0.0.0 \
-  --subscribe-all-subnets \
-  --import-all-attestations
+  --subscribe-all-subnets
 ```
 
 ### Resource usage of redundant Beacon Nodes
 
-The `--subscribe-all-subnets` and `--import-all-attestations` flags typically
-cause a significant increase in resource consumption. A doubling in CPU
-utilization and RAM consumption is expected.
+The `--subscribe-all-subnets` flag typically causes a significant increase in resource consumption.
+A doubling in CPU utilization and RAM consumption is expected.
 
 The increase in resource consumption is due to the fact that the beacon node is
 now processing, validating, aggregating and forwarding *all* attestations,
 whereas previously it was likely only doing a fraction of this work. Without
-these flags, subscription to attestation subnets and aggregation of
+this flag, subscription to attestation subnets and aggregation of
 attestations is only performed for validators which [explicitly request
 subscriptions](subscribe-api).
 
 There are 64 subnets and each validator will result in a subscription to *at
-least* one subnet. So, using the two aforementioned flags will result in
+least* one subnet. So, using the aforementioned flag will result in
 resource consumption akin to running 64+ validators.
 
 ## Redundant Eth1 nodes

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -308,6 +308,26 @@ fn network_import_all_attestations_flag() {
         .with_config(|config| assert!(config.network.import_all_attestations));
 }
 #[test]
+fn network_import_all_attestations_true_flag() {
+    CommandLineTest::new()
+        .flag("import-all-attestations", Some("true"))
+        .run()
+        .with_config(|config| assert!(config.network.import_all_attestations));
+}
+#[test]
+fn network_import_all_attestations_false_flag() {
+    CommandLineTest::new()
+        .flag("import-all-attestations", Some("false"))
+        .run()
+        .with_config(|config| assert!(!config.network.import_all_attestations));
+}
+#[test]
+fn network_import_all_attestations_on_by_default_flag() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert!(config.network.import_all_attestations));
+}
+#[test]
 fn network_shutdown_after_sync_flag() {
     CommandLineTest::new()
         .flag("shutdown-after-sync", None)


### PR DESCRIPTION
## Proposed Changes

* Change `--import-all-attestations` to a flag that takes a boolean, defaulting to `true` if no arg is provided (backwards compatible).
* Add attestations from blocks to the op pool. This may get us some extra attestations that we didn't see on gossip which we can include in case of re-orgs.
