### PR TITLE
[Merged by Bors] - Add a note about doppelganger protection interoperability to the docs

### DIFF
--- a/book/src/validator-doppelganger.md
+++ b/book/src/validator-doppelganger.md
@@ -15,6 +15,10 @@ instances of a validator operating on the network before any slashable offences 
 achieves this by staying silent for 2-3 epochs after a validator is started so it can listen for
 other instances of that validator before starting to sign potentially slashable messages.
 
+> Note: Doppelganger Protection is not yet interoperable, so if it is configured on a Lighthouse
+> validator client, the client must be connected to a Lighthouse beacon node. Because Infura
+> uses Teku, Lighthouse's Doppelganger Protection cannot yet be used with Infura's Eth2 service.
+
 ## Initial Considerations
 
 There are two important initial considerations when using DP:


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add a note to the Doppelganger Protection docs about how it is not interoperable until an endpoint facilitating it is standardized (https://github.com/ethereum/beacon-APIs/pull/131).

## Additional Info

N/A
