### PR TITLE
[Merged by Bors] - Don't log errors on resubscription of gossip topics

### DIFF
--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -358,13 +358,13 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         let topic: Topic = topic.into();
 
         match self.gossipsub.subscribe(&topic) {
-            Err(_) => {
-                warn!(self.log, "Failed to subscribe to topic"; "topic" => %topic);
+            Err(e) => {
+                warn!(self.log, "Failed to subscribe to topic"; "topic" => %topic, "error" => ?e);
                 false
             }
-            Ok(v) => {
+            Ok(_) => {
                 debug!(self.log, "Subscribed to topic"; "topic" => %topic);
-                v
+                true
             }
         }
     }

--- a/beacon_node/eth2_libp2p/src/behaviour/mod.rs
+++ b/beacon_node/eth2_libp2p/src/behaviour/mod.rs
@@ -348,6 +348,8 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
     }
 
     /// Subscribes to a gossipsub topic.
+    ///
+    /// Returns `true` if the subscription was successful and `false` otherwise.
     pub fn subscribe(&mut self, topic: GossipTopic) -> bool {
         // update the network globals
         self.network_globals

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -444,17 +444,6 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                     ));
                 }
 
-                if current_bitfield
-                    .get(id)
-                    .map_err(|_| String::from("Subnet ID out of bounds"))?
-                    == value
-                {
-                    return Err(format!(
-                        "Subnet id: {} already in the local ENR already has value: {}",
-                        id, value
-                    ));
-                }
-
                 // set the subnet bitfield in the ENR
                 current_bitfield.set(id, value).map_err(|_| {
                     String::from("Subnet ID out of bounds, could not set subnet ID")
@@ -477,17 +466,6 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                         "Subnet id: {} is outside the ENR bitfield length: {}",
                         id,
                         current_bitfield.len()
-                    ));
-                }
-
-                if current_bitfield
-                    .get(id)
-                    .map_err(|_| String::from("Subnet ID out of bounds"))?
-                    == value
-                {
-                    return Err(format!(
-                        "Subnet id: {} already in the local ENR already has value: {}",
-                        id, value
                     ));
                 }
 

--- a/beacon_node/eth2_libp2p/src/discovery/mod.rs
+++ b/beacon_node/eth2_libp2p/src/discovery/mod.rs
@@ -444,6 +444,15 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                     ));
                 }
 
+                // The bitfield is already set to required value
+                if current_bitfield
+                    .get(id)
+                    .map_err(|_| String::from("Subnet ID out of bounds"))?
+                    == value
+                {
+                    return Ok(());
+                }
+
                 // set the subnet bitfield in the ENR
                 current_bitfield.set(id, value).map_err(|_| {
                     String::from("Subnet ID out of bounds, could not set subnet ID")
@@ -467,6 +476,15 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                         id,
                         current_bitfield.len()
                     ));
+                }
+
+                // The bitfield is already set to required value
+                if current_bitfield
+                    .get(id)
+                    .map_err(|_| String::from("Subnet ID out of bounds"))?
+                    == value
+                {
+                    return Ok(());
                 }
 
                 // set the subnet bitfield in the ENR


### PR DESCRIPTION
## Issue Addressed

Resolves #2555

## Proposed Changes

Don't log errors on resubscribing to topics. Also don't log errors if we are setting already set attnet/syncnet bits.
