### PR TITLE
[Merged by Bors] - Improve valmon inclusion delay calculation

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2439,11 +2439,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 + block.slot().as_u64()
                 >= current_slot.as_u64()
             {
-                validator_monitor.register_attestation_in_block(
-                    &indexed_attestation,
-                    block.to_ref(),
-                    &self.spec,
-                );
+                match self.store.get_block(&block.parent_root()) {
+                    Ok(Some(parent_block)) => validator_monitor.register_attestation_in_block(
+                        &indexed_attestation,
+                        parent_block.slot(),
+                        &self.spec,
+                    ),
+                    _ => warn!(self.log, "Failed to get parent block"; "slot" => %block.slot()),
+                }
             }
         }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2439,13 +2439,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 + block.slot().as_u64()
                 >= current_slot.as_u64()
             {
-                match self.store.get_block(&block.parent_root()) {
-                    Ok(Some(parent_block)) => validator_monitor.register_attestation_in_block(
+                match fork_choice.get_block(&block.parent_root()) {
+                    Some(parent_block) => validator_monitor.register_attestation_in_block(
                         &indexed_attestation,
-                        parent_block.slot(),
+                        parent_block.slot,
                         &self.spec,
                     ),
-                    _ => warn!(self.log, "Failed to get parent block"; "slot" => %block.slot()),
+                    None => warn!(self.log, "Failed to get parent block"; "slot" => %block.slot()),
                 }
             }
         }

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -648,8 +648,8 @@ lazy_static! {
         "Number of sync contributions seen",
         &["src", "validator"]
     );
-    pub static ref VALIDATOR_MONITOR_SYNC_COONTRIBUTIONS_DELAY_SECONDS: Result<HistogramVec> = try_create_histogram_vec(
-        "validator_monitor_sync_contribtions_delay_seconds",
+    pub static ref VALIDATOR_MONITOR_SYNC_CONTRIBUTIONS_DELAY_SECONDS: Result<HistogramVec> = try_create_histogram_vec(
+        "validator_monitor_sync_contributions_delay_seconds",
         "The delay between when the aggregator should send the sync contribution and when it was received.",
         &["src", "validator"]
     );

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1042,7 +1042,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 &[src, id],
             );
             metrics::observe_timer_vec(
-                &metrics::VALIDATOR_MONITOR_SYNC_COONTRIBUTIONS_DELAY_SECONDS,
+                &metrics::VALIDATOR_MONITOR_SYNC_CONTRIBUTIONS_DELAY_SECONDS,
                 &[src, id],
                 delay,
             );

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -866,7 +866,9 @@ impl<T: EthSpec> ValidatorMonitor<T> {
         spec: &ChainSpec,
     ) {
         let data = &indexed_attestation.data;
-        // best effort inclusion distance which ignores skip slots
+        // Best effort inclusion distance which ignores skip slots between the parent
+        // and the current block. Skipped slots between the attestation slot and the parent
+        // slot are still counted for simplicity's sake.
         let inclusion_distance = parent_slot.saturating_sub(data.slot) + 1;
 
         let delay = inclusion_distance - spec.min_attestation_inclusion_delay;


### PR DESCRIPTION
## Issue Addressed

Resolves #2552 

## Proposed Changes

Offers some improvement in inclusion distance calculation in the validator monitor. 

When registering an attestation from a block, instead of doing `block.slot() - attesstation.data.slot()` to get the inclusion distance, we now pass the parent block slot from the beacon chain and do `parent_slot.saturating_sub(attestation.data.slot())`. This allows us to give best effort inclusion distance in scenarios where the attestation was included right after a skip slot. Note that this does not give accurate results in scenarios where the attestation was included few blocks after the skip slot.

In this case, if the attestation slot was `b1` and was included in block `b2` with a skip slot in between, we would get the inclusion delay as 0  (by ignoring the skip slot) which is the best effort inclusion delay.
```
b1 <- missed <- b2
``` 

Here, if the attestation slot was `b1` and was included in block `b3` with a skip slot and valid block `b2` in between, then we would get the inclusion delay as 2 instead of 1 (by ignoring the skip slot).
```
b1 <- missed <- b2 <- b3 
```
A solution for the scenario 2 would be to count number of slots between included slot and attestation slot ignoring the skip slots in the beacon chain and pass the value to the validator monitor. But I'm concerned that it could potentially lead to db accesses for older blocks in extreme cases.


This PR also uses the validator monitor data for logging per epoch inclusion distance. This is useful as we won't get inclusion data in post-altair summaries.
