### PR TITLE
[Merged by Bors] - Fixed Gossip Topics on Fork Boundary

### DIFF
--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -300,8 +300,8 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                 let next_fork_context_bytes =
                     fork_context.to_context_bytes(next_fork).unwrap_or_else(|| {
                         panic!(
-                            "{} fork bytes should exist as it's initialized in ForkContext",
-                            next_fork
+                            "context bytes should exist as spec.next_fork_epoch({}) returned Some({})",
+                            current_slot, next_fork
                         )
                     });
                 result.push(next_fork_context_bytes);


### PR DESCRIPTION
## Issue Addressed

The [p2p-interface section of the `altair` spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/p2p-interface.md#transitioning-the-gossip) says you should subscribe to the topics for a fork "In advance of the fork" and unsubscribe from old topics `2 Epochs` after the new fork is activated. We've chosen to subscribe to new fork topics `2 slots` before the fork is initiated.

This function is supposed to return the required fork digests at any given time but as it was currently written, it doesn't return the fork digest for a previous fork if you've switched to the current fork less than 2 epoch's ago. Also this function required modification for every new fork we add.

## Proposed Changes

Make this function fork-agnostic and correctly handle the previous fork topic digests when you've only just switched to the new fork.