### PR TITLE
[Merged by Bors] - Update zeroize_derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6318,13 +6321,14 @@ dependencies = [
 
 [[package]]
 name = "tiny-bip39"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e44c4759bae7f1032e286a7ef990bd9ed23fe831b7eeba0beb97484c2e59b8"
+checksum = "524daa5624d9d4ffb5a0625971d35205b882111daa6b6338a7a6c578a3c36928"
 dependencies = [
  "anyhow",
  "hmac 0.8.1",
  "once_cell",
+ "parking_lot",
  "pbkdf2 0.4.0",
  "rand 0.7.3",
  "rustc-hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7459,18 +7459,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/common/account_utils/Cargo.toml
+++ b/common/account_utils/Cargo.toml
@@ -11,7 +11,7 @@ rand = "0.7.3"
 eth2_wallet = { path = "../../crypto/eth2_wallet" }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 filesystem = { path = "../filesystem" }
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_yaml = "0.8.13"

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -15,7 +15,7 @@ reqwest = { version = "0.11.0", features = ["json","stream"] }
 eth2_libp2p = { path = "../../beacon_node/eth2_libp2p" }
 proto_array = { path = "../../consensus/proto_array", optional = true }
 eth2_serde_utils = "0.1.0"
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 libsecp256k1 = "0.6.0"
 ring = "0.16.19"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -16,7 +16,7 @@ hex = "0.4.2"
 eth2_hashing = "0.2.0"
 ethereum-types = "0.11.0"
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 blst = "0.3.3"
 
 [features]

--- a/crypto/eth2_key_derivation/Cargo.toml
+++ b/crypto/eth2_key_derivation/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 sha2 = "0.9.1"
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 num-bigint-dig = { version = "0.6.0", features = ["zeroize"] }
 ring = "0.16.19"
 bls = { path = "../bls" }

--- a/crypto/eth2_keystore/Cargo.toml
+++ b/crypto/eth2_keystore/Cargo.toml
@@ -13,7 +13,7 @@ pbkdf2 = { version = "0.8.0", default-features = false }
 scrypt = { version = "0.7.0", default-features = false }
 sha2 = "0.9.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-zeroize = { version = "1.1.1", features = ["zeroize_derive"] }
+zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 serde = "1.0.116"
 serde_repr = "0.1.6"
 hex = "0.4.2"

--- a/crypto/eth2_wallet/Cargo.toml
+++ b/crypto/eth2_wallet/Cargo.toml
@@ -14,7 +14,7 @@ uuid = { version = "0.8.1", features = ["serde", "v4"] }
 rand = "0.7.3"
 eth2_keystore = { path = "../eth2_keystore" }
 eth2_key_derivation = { path = "../eth2_key_derivation" }
-tiny-bip39 = "0.8.0"
+tiny-bip39 = "0.8.1"
 
 [dev-dependencies]
 hex = "0.4.2"


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

As `cargo audit` astutely pointed out, the version of `zeroize_derive` were were using had a vulnerability:

```
Crate:         zeroize_derive
Version:       1.1.0
Title:         `#[zeroize(drop)]` doesn't implement `Drop` for `enum`s
Date:          2021-09-24
ID:            RUSTSEC-2021-0115
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0115
Solution:      Upgrade to >=1.2.0
```

This PR updates `zeroize` and `zeroize_derive` to appease `cargo audit`.

`tiny-bip39` was also updated to allow compile.

## Additional Info

I don't believe this vulnerability actually affected the Lighthouse code-base directly. However, `tiny-bip39` may have been affected which may have resulted in some uncleaned memory in Lighthouse. Whilst this is not ideal, it's not a major issue. Zeroization is a nice-to-have since it only protects from sophisticated attacks or attackers that already have a high level of access already.
