### PR TITLE
Update merge consensus to v1.1.0-beta.5

### DIFF
--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -127,6 +127,17 @@ pub fn per_block_processing<T: EthSpec>(
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
 
+    // The call to the `process_execution_payload` must happen before the call to the
+    // `process_randao` as the former depends on the `randao_mix` computed with the reveal of the
+    // previous block.
+    if is_execution_enabled(state, block.body()) {
+        let payload = block
+            .body()
+            .execution_payload()
+            .ok_or(BlockProcessingError::IncorrectStateType)?;
+        process_execution_payload(state, payload, spec)?;
+    }
+
     process_randao(state, block, verify_signatures, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
     process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
@@ -139,14 +150,6 @@ pub fn per_block_processing<T: EthSpec>(
             verify_signatures,
             spec,
         )?;
-    }
-
-    if is_execution_enabled(state, block.body()) {
-        let payload = block
-            .body()
-            .execution_payload()
-            .ok_or(BlockProcessingError::IncorrectStateType)?;
-        process_execution_payload(state, payload, spec)?;
     }
 
     Ok(())
@@ -345,13 +348,6 @@ pub fn process_execution_payload<T: EthSpec>(
             }
         );
         block_verify!(
-            payload.random == *state.get_randao_mix(state.current_epoch())?,
-            BlockProcessingError::ExecutionRandaoMismatch {
-                expected: *state.get_randao_mix(state.current_epoch())?,
-                found: payload.random,
-            }
-        );
-        block_verify!(
             is_valid_gas_limit(payload, state.latest_execution_payload_header()?)?,
             BlockProcessingError::ExecutionInvalidGasLimit {
                 used: payload.gas_used,
@@ -359,6 +355,13 @@ pub fn process_execution_payload<T: EthSpec>(
             }
         );
     }
+    block_verify!(
+        payload.random == *state.get_randao_mix(state.current_epoch())?,
+        BlockProcessingError::ExecutionRandaoMismatch {
+            expected: *state.get_randao_mix(state.current_epoch())?,
+            found: payload.random,
+        }
+    );
 
     let timestamp = compute_timestamp_at_slot(state, spec)?;
     block_verify!(
@@ -380,6 +383,7 @@ pub fn process_execution_payload<T: EthSpec>(
         gas_limit: payload.gas_limit,
         gas_used: payload.gas_used,
         timestamp: payload.timestamp,
+        extra_data: payload.extra_data.clone(),
         base_fee_per_gas: payload.base_fee_per_gas,
         block_hash: payload.block_hash,
         transactions_root: payload.transactions.tree_hash_root(),

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -91,6 +91,7 @@ pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq +
     type BytesPerLogsBloom: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type GasLimitDenominator: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MinGasLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type MaxExtraDataBytes: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     /*
      * Derived values (set these CAREFULLY)
      */
@@ -262,6 +263,7 @@ impl EthSpec for MainnetEthSpec {
     type BytesPerLogsBloom = U256;
     type GasLimitDenominator = U1024;
     type MinGasLimit = U5000;
+    type MaxExtraDataBytes = U32;
     type SyncSubcommitteeSize = U128; // 512 committee size / 4 sync committee subnet count
     type MaxPendingAttestations = U4096; // 128 max attestations * 32 slots per epoch
     type SlotsPerEth1VotingPeriod = U2048; // 64 epochs * 32 slots per epoch
@@ -308,7 +310,8 @@ impl EthSpec for MinimalEthSpec {
         MaxTransactionsPerPayload,
         BytesPerLogsBloom,
         GasLimitDenominator,
-        MinGasLimit
+        MinGasLimit,
+        MaxExtraDataBytes
     });
 
     fn default_spec() -> ChainSpec {

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -57,6 +57,8 @@ pub struct ExecutionPayload<T: EthSpec> {
     pub gas_used: u64,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub timestamp: u64,
+    #[serde(with = "ssz_types::serde_utils::hex_var_list")]
+    pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
     pub base_fee_per_gas: Hash256,
     pub block_hash: Hash256,
     #[test_random(default)]
@@ -77,6 +79,7 @@ impl<T: EthSpec> ExecutionPayload<T> {
             gas_limit: 0,
             gas_used: 0,
             timestamp: 0,
+            extra_data: VariableList::empty(),
             base_fee_per_gas: Hash256::zero(),
             block_hash: Hash256::zero(),
             transactions: VariableList::empty(),

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -24,6 +24,8 @@ pub struct ExecutionPayloadHeader<T: EthSpec> {
     pub gas_used: u64,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub timestamp: u64,
+    #[serde(with = "ssz_types::serde_utils::hex_var_list")]
+    pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
     pub base_fee_per_gas: Hash256,
     pub block_hash: Hash256,
     pub transactions_root: Hash256,

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-beta.4
+TESTS_TAG := v1.1.0-beta.5
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 


### PR DESCRIPTION
## Proposed Changes

Update the merge consensus code to match spec v1.1.0-beta.5

Specifically, this PR incorporates the changes from these 3 spec PRs:

* https://github.com/ethereum/consensus-specs/pull/2595
* https://github.com/ethereum/consensus-specs/pull/2606
* https://github.com/ethereum/consensus-specs/pull/2609

We already matched the new spec on 2 other consensus PRs:

* https://github.com/ethereum/consensus-specs/pull/2581
* https://github.com/ethereum/consensus-specs/pull/2605

I haven't done anything to update execution engine stuff or gossip validation conditions, as I believe others are working on that (@paulhauner, @ethDreamer).

The tests are updated and passing :+1:
