### PR TITLE
Checkout Cargo.lock from unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7457,9 +7457,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Run `git checkout unstable Cargo.lock` to get the latest version of `zeroize_derive`. Related to #2625.

## Additional Info

NA
