### PR TITLE
Update test vectors to v1.1.0

### DIFF
--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -2,9 +2,10 @@ use super::per_block_processing::{
     errors::BlockProcessingError, process_operations::process_deposit,
 };
 use crate::common::DepositDataTree;
-use crate::upgrade::upgrade_to_altair;
+use crate::upgrade::{upgrade_to_altair, upgrade_to_merge};
 use safe_arith::{ArithError, SafeArith};
 use tree_hash::TreeHash;
+use types::consts::merge_testing::{GENESIS_BASE_FEE_PER_GAS, GENESIS_GAS_LIMIT};
 use types::DEPOSIT_TREE_DEPTH;
 use types::*;
 
@@ -46,11 +47,34 @@ pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
     // use of `BeaconBlock::empty` in `BeaconState::new` is sufficient to correctly initialise
     // the `latest_block_header` as per:
     // https://github.com/ethereum/eth2.0-specs/pull/2323
-    if spec.fork_name_at_epoch(state.current_epoch()) == ForkName::Altair {
+    if spec
+        .altair_fork_epoch
+        .map_or(false, |fork_epoch| fork_epoch == T::genesis_epoch())
+    {
         upgrade_to_altair(&mut state, spec)?;
     }
 
-    // TODO: handle upgrade_to_merge() here
+    // Similarly, perform an upgrade to the merge if configured from genesis.
+    if spec
+        .merge_fork_epoch
+        .map_or(false, |fork_epoch| fork_epoch == T::genesis_epoch())
+    {
+        upgrade_to_merge(&mut state, spec)?;
+
+        // Remove intermediate Altair fork from `state.fork`.
+        state.fork_mut().previous_version = spec.genesis_fork_version;
+
+        // Override latest execution payload header.
+        // See https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/merge/beacon-chain.md#testing
+        *state.latest_execution_payload_header_mut()? = ExecutionPayloadHeader {
+            block_hash: eth1_block_hash,
+            timestamp: eth1_timestamp,
+            random: eth1_block_hash,
+            gas_limit: GENESIS_GAS_LIMIT,
+            base_fee_per_gas: GENESIS_BASE_FEE_PER_GAS,
+            ..ExecutionPayloadHeader::default()
+        };
+    }
 
     // Now that we have our validators, initialize the caches (including the committees)
     state.build_all_caches(spec)?;

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -482,7 +482,9 @@ impl ChainSpec {
             altair_fork_epoch: None,
             merge_fork_version: [0x02, 0x00, 0x00, 0x00],
             merge_fork_epoch: None,
-            terminal_total_difficulty: Uint256::MAX,
+            terminal_total_difficulty: Uint256::MAX
+                .checked_sub(Uint256::from(2u64.pow(10)))
+                .expect("calculation does not overflow"),
 
             /*
              * Network specific
@@ -523,6 +525,9 @@ impl ChainSpec {
             epochs_per_sync_committee_period: Epoch::new(8),
             altair_fork_version: [0x01, 0x00, 0x00, 0x01],
             altair_fork_epoch: None,
+            // Merge
+            merge_fork_version: [0x02, 0x00, 0x00, 0x01],
+            merge_fork_epoch: None,
             // Other
             network_id: 2, // lighthouse testnet network id
             deposit_chain_id: 5,

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -34,7 +34,7 @@ impl ForkName {
                 spec
             }
             ForkName::Merge => {
-                spec.altair_fork_epoch = None;
+                spec.altair_fork_epoch = Some(Epoch::new(0));
                 spec.merge_fork_epoch = Some(Epoch::new(0));
                 spec
             }

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-beta.5
+TESTS_TAG := v1.1.0
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -20,16 +20,19 @@ tests_dir_filename = sys.argv[2]
 # following regular expressions, we will assume they are to be ignored (i.e., we are purposefully
 # *not* running the spec tests).
 excluded_paths = [
-    # Eth1Block
+    # Eth1Block and PowBlock
     #
     # Intentionally omitted, as per https://github.com/sigp/lighthouse/issues/1835
     "tests/.*/.*/ssz_static/Eth1Block/",
+    "tests/.*/.*/ssz_static/PowBlock/",
     # LightClientStore
     "tests/.*/.*/ssz_static/LightClientStore",
     # LightClientUpdate
     "tests/.*/.*/ssz_static/LightClientUpdate",
     # LightClientSnapshot
     "tests/.*/.*/ssz_static/LightClientSnapshot",
+    # Merkle proof tests, omitted for now
+    "tests/.*/.*/merkle/.*",
     # Fork choice
     "tests/.*/*/fork_choice",
 ]

--- a/testing/ef_tests/src/cases/genesis_initialization.rs
+++ b/testing/ef_tests/src/cases/genesis_initialization.rs
@@ -56,9 +56,7 @@ impl<E: EthSpec> LoadCase for GenesisInitialization<E> {
 impl<E: EthSpec> Case for GenesisInitialization<E> {
     fn is_enabled_for_fork(fork_name: ForkName) -> bool {
         // Altair genesis and later requires real crypto.
-        // FIXME(merge): enable merge tests once available
-        fork_name == ForkName::Base
-            || cfg!(not(feature = "fake_crypto")) && fork_name != ForkName::Merge
+        fork_name == ForkName::Base || cfg!(not(feature = "fake_crypto"))
     }
 
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -446,11 +446,6 @@ pub struct GenesisValidityHandler<E>(PhantomData<E>);
 impl<E: EthSpec + TypeName> Handler for GenesisValidityHandler<E> {
     type Case = cases::GenesisValidity<E>;
 
-    // FIXME(merge): enable merge test once available
-    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        fork_name != ForkName::Merge
-    }
-
     fn config_name() -> &'static str {
         E::name()
     }


### PR DESCRIPTION
Bump test vectors to v1.1.0. Main changes:

* Fix merge genesis initialization by calling `upgrade_to_merge` and overriding some parameters. This beats re-implementing `initialize_beacon_state_from_eth1` IMO.
* Adjust the palceholder `terminal_total_difficulty` value
