### PR TITLE
[Merged by Bors] - Consistent tracking of disconnected peers

### DIFF
--- a/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
+++ b/beacon_node/eth2_libp2p/src/peer_manager/mod.rs
@@ -13,7 +13,7 @@ use futures::Stream;
 use hashset_delay::HashSetDelay;
 use libp2p::core::ConnectedPoint;
 use libp2p::identify::IdentifyInfo;
-use slog::{crit, debug, error, warn};
+use slog::{debug, error, warn};
 use smallvec::SmallVec;
 use std::{
     pin::Pin,
@@ -529,7 +529,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 };
             }
         } else {
-            crit!(self.log, "Received an Identify response from an unknown peer"; "peer_id" => peer_id.to_string());
+            error!(self.log, "Received an Identify response from an unknown peer"; "peer_id" => peer_id.to_string());
         }
     }
 
@@ -672,7 +672,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 self.events.push(PeerManagerEvent::MetaData(*peer_id));
             }
         } else {
-            crit!(self.log, "Received a PING from an unknown peer";
+            error!(self.log, "Received a PING from an unknown peer";
                 "peer_id" => %peer_id);
         }
     }
@@ -696,7 +696,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 self.events.push(PeerManagerEvent::MetaData(*peer_id));
             }
         } else {
-            crit!(self.log, "Received a PONG from an unknown peer"; "peer_id" => %peer_id);
+            error!(self.log, "Received a PONG from an unknown peer"; "peer_id" => %peer_id);
         }
     }
 
@@ -720,7 +720,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             }
             peer_info.meta_data = Some(meta_data);
         } else {
-            crit!(self.log, "Received METADATA from an unknown peer";
+            error!(self.log, "Received METADATA from an unknown peer";
                 "peer_id" => %peer_id);
         }
     }
@@ -842,7 +842,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             let mut peerdb = self.network_globals.peers.write();
             if !matches!(peerdb.ban_status(peer_id), BanResult::NotBanned) {
                 // don't connect if the peer is banned
-                slog::crit!(self.log, "Connection has been allowed to a banned peer"; "peer_id" => %peer_id);
+                error!(self.log, "Connection has been allowed to a banned peer"; "peer_id" => %peer_id);
             }
 
             match connection {

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -137,15 +137,15 @@ impl<TSpec: EthSpec> Service<TSpec> {
                 .with_max_pending_outgoing(Some(16))
                 .with_max_established_incoming(Some(
                     (config.target_peers as f32
-                        * (1.0 + PEER_EXCESS_FACTOR - MIN_OUTBOUND_ONLY_FACTOR)).ceil()
-                        as u32,
+                        * (1.0 + PEER_EXCESS_FACTOR - MIN_OUTBOUND_ONLY_FACTOR))
+                        .ceil() as u32,
                 ))
                 .with_max_established_outgoing(Some(
                     (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR)).ceil() as u32,
                 ))
                 .with_max_established(Some(
-                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS)).ceil()
-                        as u32,
+                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS))
+                        .ceil() as u32,
                 ))
                 .with_max_established_per_peer(Some(MAX_CONNECTIONS_PER_PEER));
 

--- a/beacon_node/eth2_libp2p/src/service.rs
+++ b/beacon_node/eth2_libp2p/src/service.rs
@@ -137,14 +137,14 @@ impl<TSpec: EthSpec> Service<TSpec> {
                 .with_max_pending_outgoing(Some(16))
                 .with_max_established_incoming(Some(
                     (config.target_peers as f32
-                        * (1.0 + PEER_EXCESS_FACTOR - MIN_OUTBOUND_ONLY_FACTOR))
+                        * (1.0 + PEER_EXCESS_FACTOR - MIN_OUTBOUND_ONLY_FACTOR)).ceil()
                         as u32,
                 ))
                 .with_max_established_outgoing(Some(
-                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR)) as u32,
+                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR)).ceil() as u32,
                 ))
                 .with_max_established(Some(
-                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS))
+                    (config.target_peers as f32 * (1.0 + PEER_EXCESS_FACTOR + PRIORITY_PEER_EXCESS)).ceil()
                         as u32,
                 ))
                 .with_max_established_per_peer(Some(MAX_CONNECTIONS_PER_PEER));

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -660,7 +660,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             }
             peer_info.is_connected()
         } else {
-            crit!(self.log, "Status'd peer is unknown"; "peer_id" => %peer_id);
+            error!(self.log, "Status'd peer is unknown"; "peer_id" => %peer_id);
             false
         }
     }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

When peers switching to a disconnecting state, decrement the disconnected peers counter. This also downgrades some crit logs to errors. 

I've also added a re-sync point when peers get unbanned the disconnected peer count will match back to the number of disconnected peers if it has gone out of sync previously. 