### PR TITLE
Disable `autotests` for `beacon_chain` crate

### DIFF
--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -3,6 +3,7 @@ name = "beacon_chain"
 version = "0.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com>"]
 edition = "2018"
+autotests = false # using a single test binary compiles faster
 
 [features]
 default = ["participation_metrics"]
@@ -56,3 +57,7 @@ slasher = { path = "../../slasher" }
 eth2 = { path = "../../common/eth2" }
 strum = { version = "0.21.0", features = ["derive"] }
 execution_layer = { path = "../execution_layer" }
+
+[[test]]
+name = "beacon_chain_tests"
+path = "tests/main.rs"

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -1,10 +1,8 @@
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::test_utils::{AttestationStrategy, BeaconChainHarness, BlockStrategy};
 use beacon_chain::{StateSkipConfig, WhenSlotSkipped};
+use lazy_static::lazy_static;
 use tree_hash::TreeHash;
 use types::{AggregateSignature, EthSpec, Keypair, MainnetEthSpec, RelativeEpoch, Slot};
 

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -1,8 +1,5 @@
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::{
     attestation_verification::Error as AttnError,
     test_utils::{
@@ -11,6 +8,7 @@ use beacon_chain::{
     BeaconChain, BeaconChainTypes, WhenSlotSkipped,
 };
 use int_to_bytes::int_to_bytes32;
+use lazy_static::lazy_static;
 use state_processing::{
     per_block_processing::errors::AttestationValidationError, per_slot_processing,
 };

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1,12 +1,10 @@
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::test_utils::{
     test_logger, AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
 };
 use beacon_chain::{BeaconSnapshot, BlockError, ChainSegmentResult};
+use lazy_static::lazy_static;
 use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
     common::get_indexed_attestation,

--- a/beacon_node/beacon_chain/tests/main.rs
+++ b/beacon_node/beacon_chain/tests/main.rs
@@ -1,0 +1,7 @@
+mod attestation_production;
+mod attestation_verification;
+mod block_verification;
+mod op_verification;
+mod store_tests;
+mod sync_committee_verification;
+mod tests;

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -2,13 +2,11 @@
 
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::observed_operations::ObservationOutcome;
 use beacon_chain::test_utils::{
     test_spec, AttestationStrategy, BeaconChainHarness, BlockStrategy, DiskHarnessType,
 };
+use lazy_static::lazy_static;
 use sloggers::{null::NullLoggerBuilder, Build};
 use std::sync::Arc;
 use store::{LevelDB, StoreConfig};

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -1,11 +1,9 @@
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::sync_committee_verification::Error as SyncCommitteeError;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType, RelativeSyncCommittee};
 use int_to_bytes::int_to_bytes32;
+use lazy_static::lazy_static;
 use safe_arith::SafeArith;
 use store::{SignedContributionAndProof, SyncCommitteeMessage};
 use tree_hash::TreeHash;

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -1,8 +1,5 @@
 #![cfg(not(debug_assertions))]
 
-#[macro_use]
-extern crate lazy_static;
-
 use beacon_chain::{
     attestation_verification::Error as AttnError,
     test_utils::{
@@ -11,6 +8,7 @@ use beacon_chain::{
     },
     StateSkipConfig, WhenSlotSkipped,
 };
+use lazy_static::lazy_static;
 use operation_pool::PersistedOperationPool;
 use state_processing::{
     per_slot_processing, per_slot_processing::Error as SlotProcessingError, EpochProcessingError,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Following @michaelsproul's example in #2404, this disables `autotests` for the `beacon_chain` crate. This means the tests in the `tests` directory all compile as a single binary, rather than individual binaries. This reduces total compilation time.

### Benchmarks

With autotests (i.e., `unstable`):

```
   Compiling lighthouse_version v0.1.0 (/home/paul/development/lighthouse/common/lighthouse_version)
   Compiling eth2_libp2p v0.2.0 (/home/paul/development/lighthouse/beacon_node/eth2_libp2p)
   Compiling eth2 v0.1.0 (/home/paul/development/lighthouse/common/eth2)
   Compiling eth1 v0.2.0 (/home/paul/development/lighthouse/beacon_node/eth1)
   Compiling genesis v0.2.0 (/home/paul/development/lighthouse/beacon_node/genesis)
   Compiling beacon_chain v0.2.0 (/home/paul/development/lighthouse/beacon_node/beacon_chain)
    Finished release [optimized] target(s) in 1m 19s
```

Without autotests (this PR):

```
   Compiling lighthouse_version v0.1.0 (/home/paul/development/lighthouse/common/lighthouse_version)
   Compiling eth2_libp2p v0.2.0 (/home/paul/development/lighthouse/beacon_node/eth2_libp2p)
   Compiling eth2 v0.1.0 (/home/paul/development/lighthouse/common/eth2)
   Compiling eth1 v0.2.0 (/home/paul/development/lighthouse/beacon_node/eth1)
   Compiling genesis v0.2.0 (/home/paul/development/lighthouse/beacon_node/genesis)
   Compiling beacon_chain v0.2.0 (/home/paul/development/lighthouse/beacon_node/beacon_chain)
    Finished release [optimized] target(s) in 43.48s
```

This is running on my hex-core machine. I suspect the improvement will be much greater on lower-core-count hardware since they can't compile multiple crates in parallel.

## Additional Info

@michaelsproul I'm not very well informed on `autotests`, I could use your eyes to make sure I'm not missing anything :pray: 
