### PR TITLE
[Merged by Bors] - Fix chain_id value in config/deposit_contract RPC method

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1414,7 +1414,7 @@ pub fn serve<T: BeaconChainTypes>(
                 Ok(api_types::GenericResponse::from(
                     api_types::DepositContractData {
                         address: chain.spec.deposit_contract_address,
-                        chain_id: eth1::DEFAULT_NETWORK_ID.into(),
+                        chain_id: chain.spec.deposit_chain_id,
                     },
                 ))
             })

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -1,0 +1,32 @@
+//! Generic tests that make use of the (newer) `InteractiveApiTester`
+use crate::common::*;
+use eth2::types::DepositContractData;
+use types::{EthSpec, MainnetEthSpec};
+
+type E = MainnetEthSpec;
+
+// Test that the deposit_contract endpoint returns the correct chain_id and address.
+// Regression test for https://github.com/sigp/lighthouse/issues/2657
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deposit_contract_custom_network() {
+    let validator_count = 24;
+    let mut spec = E::default_spec();
+
+    // Rinkeby, which we don't use elsewhere.
+    spec.deposit_chain_id = 4;
+    spec.deposit_network_id = 4;
+    // Arbitrary contract address.
+    spec.deposit_contract_address = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".parse().unwrap();
+
+    let tester = InteractiveTester::<E>::new(Some(spec.clone()), validator_count);
+    let client = &tester.client;
+
+    let result = client.get_config_deposit_contract().await.unwrap().data;
+
+    let expected = DepositContractData {
+        address: spec.deposit_contract_address,
+        chain_id: spec.deposit_chain_id,
+    };
+
+    assert_eq!(result, expected);
+}

--- a/beacon_node/http_api/tests/main.rs
+++ b/beacon_node/http_api/tests/main.rs
@@ -3,4 +3,5 @@
 
 pub mod common;
 pub mod fork_tests;
+pub mod interactive_tests;
 pub mod tests;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1252,7 +1252,7 @@ impl ApiTester {
 
         let expected = DepositContractData {
             address: self.chain.spec.deposit_contract_address,
-            chain_id: eth1::DEFAULT_NETWORK_ID.into(),
+            chain_id: self.chain.spec.deposit_chain_id,
         };
 
         assert_eq!(result, expected);


### PR DESCRIPTION
## Issue Addressed

This PR addresses issue #2657

## Proposed Changes

Changes `/eth/v1/config/deposit_contract` endpoint to return the chain ID from the loaded chain spec instead of eth1::DEFAULT_NETWORK_ID which is the Goerli chain ID of 5.