### PR TITLE
Misc changes for merge testnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ PINNED_NIGHTLY ?= nightly
 # Binaries will most likely be found in `./target/release`
 install:
 ifeq ($(PORTABLE), true)
-	cargo install --path lighthouse --force --locked --features portable
+	cargo install --path lighthouse --force --locked --features portable,spec-minimal
 else
-	cargo install --path lighthouse --force --locked
+	cargo install --path lighthouse --force --locked --features spec-minimal
 endif
 
 # Builds the lcli binary in release (optimized).

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -893,7 +893,9 @@ fn descriptive_db_error(item: &str, error: &StoreError) -> String {
 mod test {
     use super::*;
     use eth2_hashing::hash;
-    use genesis::{generate_deterministic_keypairs, interop_genesis_state};
+    use genesis::{
+        generate_deterministic_keypairs, interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH,
+    };
     use sloggers::{null::NullLoggerBuilder, Build};
     use ssz::Encode;
     use std::time::Duration;
@@ -925,6 +927,7 @@ mod test {
         let genesis_state = interop_genesis_state(
             &generate_deterministic_keypairs(validator_count),
             genesis_time,
+            Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
             &spec,
         )
         .expect("should create interop genesis state");
@@ -990,8 +993,13 @@ mod test {
 
         let keypairs = generate_deterministic_keypairs(validator_count);
 
-        let state = interop_genesis_state::<TestEthSpec>(&keypairs, genesis_time, spec)
-            .expect("should build state");
+        let state = interop_genesis_state::<TestEthSpec>(
+            &keypairs,
+            genesis_time,
+            Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+            spec,
+        )
+        .expect("should build state");
 
         assert_eq!(
             state.eth1_data().block_hash,

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -18,7 +18,7 @@ use execution_layer::{
     ExecutionLayer,
 };
 use futures::channel::mpsc::Receiver;
-pub use genesis::interop_genesis_state;
+pub use genesis::{interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
 use int_to_bytes::int_to_bytes32;
 use merkle_proof::MerkleTree;
 use parking_lot::Mutex;
@@ -203,6 +203,7 @@ impl<E: EthSpec> Builder<EphemeralHarnessType<E>> {
             let genesis_state = interop_genesis_state::<E>(
                 &validator_keypairs,
                 HARNESS_GENESIS_TIME,
+                Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
                 builder.get_spec(),
             )
             .expect("should generate interop state");
@@ -227,6 +228,7 @@ impl<E: EthSpec> Builder<DiskHarnessType<E>> {
             let genesis_state = interop_genesis_state::<E>(
                 &validator_keypairs,
                 HARNESS_GENESIS_TIME,
+                Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
                 builder.get_spec(),
             )
             .expect("should generate interop state");

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -18,7 +18,7 @@ use eth2::{
 };
 use eth2_libp2p::NetworkGlobals;
 use execution_layer::ExecutionLayer;
-use genesis::{interop_genesis_state, Eth1GenesisService};
+use genesis::{interop_genesis_state, Eth1GenesisService, DEFAULT_ETH1_BLOCK_HASH};
 use monitoring_api::{MonitoringHttpClient, ProcessType};
 use network::{NetworkConfig, NetworkMessage, NetworkService};
 use slasher::Slasher;
@@ -31,7 +31,8 @@ use std::time::Duration;
 use timer::spawn_timer;
 use tokio::sync::{mpsc::UnboundedSender, oneshot};
 use types::{
-    test_utils::generate_deterministic_keypairs, BeaconState, ChainSpec, EthSpec, SignedBeaconBlock,
+    test_utils::generate_deterministic_keypairs, BeaconState, ChainSpec, EthSpec, Hash256,
+    SignedBeaconBlock,
 };
 
 /// Interval between polling the eth1 node for genesis information.
@@ -229,7 +230,12 @@ where
                 genesis_time,
             } => {
                 let keypairs = generate_deterministic_keypairs(validator_count);
-                let genesis_state = interop_genesis_state(&keypairs, genesis_time, &spec)?;
+                let genesis_state = interop_genesis_state(
+                    &keypairs,
+                    genesis_time,
+                    Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+                    &spec,
+                )?;
                 builder.genesis_state(genesis_state).map(|v| (v, None))?
             }
             ClientGenesis::SszBytes {

--- a/beacon_node/genesis/src/interop.rs
+++ b/beacon_node/genesis/src/interop.rs
@@ -5,6 +5,8 @@ use ssz::Encode;
 use state_processing::initialize_beacon_state_from_eth1;
 use types::{BeaconState, ChainSpec, DepositData, EthSpec, Hash256, Keypair, PublicKey, Signature};
 
+pub const DEFAULT_ETH1_BLOCK_HASH: &[u8] = &[0x42; 32];
+
 /// Builds a genesis state as defined by the Eth2 interop procedure (see below).
 ///
 /// Reference:
@@ -12,9 +14,10 @@ use types::{BeaconState, ChainSpec, DepositData, EthSpec, Hash256, Keypair, Publ
 pub fn interop_genesis_state<T: EthSpec>(
     keypairs: &[Keypair],
     genesis_time: u64,
+    eth1_block_hash: Hash256,
     spec: &ChainSpec,
 ) -> Result<BeaconState<T>, String> {
-    let eth1_block_hash = Hash256::from_slice(&[0x42; 32]);
+    let eth1_block_hash = eth1_block_hash;
     let eth1_timestamp = 2_u64.pow(40);
     let amount = spec.max_effective_balance;
 
@@ -73,8 +76,13 @@ mod test {
 
         let keypairs = generate_deterministic_keypairs(validator_count);
 
-        let state = interop_genesis_state::<TestEthSpec>(&keypairs, genesis_time, spec)
-            .expect("should build state");
+        let state = interop_genesis_state::<TestEthSpec>(
+            &keypairs,
+            genesis_time,
+            Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+            spec,
+        )
+        .expect("should build state");
 
         assert_eq!(
             state.eth1_data().block_hash,

--- a/beacon_node/genesis/src/lib.rs
+++ b/beacon_node/genesis/src/lib.rs
@@ -4,5 +4,5 @@ mod interop;
 
 pub use eth1::Config as Eth1Config;
 pub use eth1_genesis_service::{Eth1GenesisService, Statistics};
-pub use interop::interop_genesis_state;
+pub use interop::{interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
 pub use types::test_utils::generate_deterministic_keypairs;

--- a/beacon_node/http_api/tests/common.rs
+++ b/beacon_node/http_api/tests/common.rs
@@ -116,6 +116,7 @@ pub fn create_api_server<T: BeaconChainTypes>(
             listen_port: 0,
             allow_origin: None,
             serve_legacy_spec: true,
+            allow_sync_stalled: false,
         },
         chain: Some(chain.clone()),
         network_tx: Some(network_tx),

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
 };
 use eth2_libp2p::NetworkConfig;
 use futures::prelude::*;
-use genesis::{generate_deterministic_keypairs, interop_genesis_state};
+use genesis::{generate_deterministic_keypairs, interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
 use lazy_static::lazy_static;
 use slog::Logger;
 use sloggers::{null::NullLoggerBuilder, Build};
@@ -16,8 +16,8 @@ use std::time::{Duration, SystemTime};
 use store::config::StoreConfig;
 use store::{HotColdDB, MemoryStore};
 use types::{
-    CommitteeIndex, Epoch, EthSpec, MainnetEthSpec, Slot, SubnetId, SyncCommitteeSubscription,
-    SyncSubnetId, ValidatorSubscription,
+    CommitteeIndex, Epoch, EthSpec, Hash256, MainnetEthSpec, Slot, SubnetId,
+    SyncCommitteeSubscription, SyncSubnetId, ValidatorSubscription,
 };
 
 const SLOT_DURATION_MILLIS: u64 = 400;
@@ -52,8 +52,13 @@ impl TestBeaconChain {
                 .custom_spec(spec.clone())
                 .store(Arc::new(store))
                 .genesis_state(
-                    interop_genesis_state::<MainnetEthSpec>(&keypairs, 0, &spec)
-                        .expect("should generate interop state"),
+                    interop_genesis_state::<MainnetEthSpec>(
+                        &keypairs,
+                        0,
+                        Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+                        &spec,
+                    )
+                    .expect("should generate interop state"),
                 )
                 .expect("should build state using recent genesis")
                 .dummy_eth1_backend()

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -217,6 +217,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Disable serving of legacy data on the /config/spec endpoint. May be \
                        disabled by default in a future release.")
         )
+        .arg(
+            Arg::with_name("http-allow-sync-stalled")
+                .long("http-allow-sync-stalled")
+                .help("Forces the HTTP to indicate that the node is synced when sync is actually \
+                    stalled. This is useful for very small testnets. TESTING ONLY. DO NOT USE ON \
+                    MAINNET.")
+        )
         /* Prometheus metrics HTTP server related arguments */
         .arg(
             Arg::with_name("metrics")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -111,6 +111,10 @@ pub fn get_config<E: EthSpec>(
         client_config.http_api.serve_legacy_spec = false;
     }
 
+    if cli_args.is_present("http-allow-sync-stalled") {
+        client_config.http_api.allow_sync_stalled = true;
+    }
+
     /*
      * Prometheus metrics HTTP server
      */

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -3,6 +3,7 @@ use crate::test_utils::*;
 use crate::test_utils::{SeedableRng, XorShiftRng};
 use beacon_chain::test_utils::{
     interop_genesis_state, test_spec, BeaconChainHarness, EphemeralHarnessType,
+    DEFAULT_ETH1_BLOCK_HASH,
 };
 use beacon_chain::types::{
     test_utils::TestRandom, BeaconState, BeaconStateAltair, BeaconStateBase, BeaconStateError,
@@ -557,7 +558,13 @@ fn tree_hash_cache_linear_history_long_skip() {
     let spec = &test_spec::<MinimalEthSpec>();
 
     // This state has a cache that advances normally each slot.
-    let mut state: BeaconState<MinimalEthSpec> = interop_genesis_state(&keypairs, 0, spec).unwrap();
+    let mut state: BeaconState<MinimalEthSpec> = interop_genesis_state(
+        &keypairs,
+        0,
+        Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+        spec,
+    )
+    .unwrap();
 
     state.update_tree_hash_cache().unwrap();
 

--- a/lcli/src/interop_genesis.rs
+++ b/lcli/src/interop_genesis.rs
@@ -1,11 +1,11 @@
 use clap::ArgMatches;
 use clap_utils::parse_ssz_optional;
 use eth2_network_config::Eth2NetworkConfig;
-use genesis::interop_genesis_state;
+use genesis::{interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
 use ssz::Encode;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
-use types::{test_utils::generate_deterministic_keypairs, EthSpec};
+use types::{test_utils::generate_deterministic_keypairs, EthSpec, Hash256};
 
 pub fn run<T: EthSpec>(testnet_dir: PathBuf, matches: &ArgMatches) -> Result<(), String> {
     let validator_count = matches
@@ -34,7 +34,12 @@ pub fn run<T: EthSpec>(testnet_dir: PathBuf, matches: &ArgMatches) -> Result<(),
     }
 
     let keypairs = generate_deterministic_keypairs(validator_count);
-    let genesis_state = interop_genesis_state::<T>(&keypairs, genesis_time, &spec)?;
+    let genesis_state = interop_genesis_state::<T>(
+        &keypairs,
+        genesis_time,
+        Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+        &spec,
+    )?;
 
     eth2_network_config.genesis_state_bytes = Some(genesis_state.as_ssz_bytes());
     eth2_network_config.force_write_to_file(testnet_dir)?;

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -402,6 +402,15 @@ fn main() {
                             "The epoch at which to enable the Altair hard fork",
                         ),
                 )
+                .arg(
+                    Arg::with_name("merge-fork-epoch")
+                        .long("merge-fork-epoch")
+                        .value_name("EPOCH")
+                        .takes_value(true)
+                        .help(
+                            "The epoch at which to enable the Merge hard fork",
+                        ),
+                )
         )
         .subcommand(
             SubCommand::with_name("check-deposit-data")

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -285,6 +285,14 @@ fn main() {
                         .help("Overwrites any previous testnet configurations"),
                 )
                 .arg(
+                    Arg::with_name("interop-genesis-state")
+                        .long("interop-genesis-state")
+                        .takes_value(false)
+                        .help(
+                            "If present, a interop-style genesis.ssz file will be generated.",
+                        ),
+                )
+                .arg(
                     Arg::with_name("min-genesis-time")
                         .long("min-genesis-time")
                         .value_name("UNIX_SECONDS")
@@ -410,6 +418,27 @@ fn main() {
                         .help(
                             "The epoch at which to enable the Merge hard fork",
                         ),
+                )
+                .arg(
+                    Arg::with_name("eth1-block-hash")
+                        .long("eth1-block-hash")
+                        .value_name("BLOCK_HASH")
+                        .takes_value(true)
+                        .help("The eth1 block hash used when generating a genesis state."),
+                )
+                .arg(
+                    Arg::with_name("validator-count")
+                        .long("validator-count")
+                        .value_name("INTEGER")
+                        .takes_value(true)
+                        .help("The number of validators when generating a genesis state."),
+                )
+                .arg(
+                    Arg::with_name("genesis-time")
+                        .long("genesis-time")
+                        .value_name("INTEGER")
+                        .takes_value(true)
+                        .help("The genesis time when generating a genesis state."),
                 )
         )
         .subcommand(

--- a/lcli/src/new_testnet.rs
+++ b/lcli/src/new_testnet.rs
@@ -54,6 +54,10 @@ pub fn run<T: EthSpec>(testnet_dir_path: PathBuf, matches: &ArgMatches) -> Resul
         spec.altair_fork_epoch = Some(fork_epoch);
     }
 
+    if let Some(fork_epoch) = parse_optional(matches, "merge-fork-epoch")? {
+        spec.merge_fork_epoch = Some(fork_epoch);
+    }
+
     let testnet = Eth2NetworkConfig {
         deposit_contract_deploy_block,
         boot_enr: Some(vec![]),

--- a/lcli/src/new_testnet.rs
+++ b/lcli/src/new_testnet.rs
@@ -1,8 +1,11 @@
 use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required, parse_ssz_optional};
 use eth2_network_config::Eth2NetworkConfig;
+use genesis::interop_genesis_state;
+use ssz::Encode;
 use std::path::PathBuf;
-use types::{Address, Config, EthSpec};
+use std::time::{SystemTime, UNIX_EPOCH};
+use types::{test_utils::generate_deterministic_keypairs, Address, Config, EthSpec};
 
 pub fn run<T: EthSpec>(testnet_dir_path: PathBuf, matches: &ArgMatches) -> Result<(), String> {
     let deposit_contract_address: Address = parse_required(matches, "deposit-contract-address")?;
@@ -58,10 +61,31 @@ pub fn run<T: EthSpec>(testnet_dir_path: PathBuf, matches: &ArgMatches) -> Resul
         spec.merge_fork_epoch = Some(fork_epoch);
     }
 
+    let genesis_state_bytes = if matches.is_present("interop-genesis-state") {
+        let eth1_block_hash = parse_required(matches, "eth1-block-hash")?;
+        let validator_count = parse_required(matches, "validator-count")?;
+        let genesis_time = if let Some(time) = parse_optional(matches, "genesis-time")? {
+            time
+        } else {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| format!("Unable to get time: {:?}", e))?
+                .as_secs()
+        };
+
+        let keypairs = generate_deterministic_keypairs(validator_count);
+        let genesis_state =
+            interop_genesis_state::<T>(&keypairs, genesis_time, eth1_block_hash, &spec)?;
+
+        Some(genesis_state.as_ssz_bytes())
+    } else {
+        None
+    };
+
     let testnet = Eth2NetworkConfig {
         deposit_contract_deploy_block,
         boot_enr: Some(vec![]),
-        genesis_state_bytes: None,
+        genesis_state_bytes,
         config: Config::from_chain_spec::<T>(&spec),
     };
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Thread the `eth1_block_hash` into the `interop_genesis_state` so it doesn't always use `[42; 32]`. Merge testnets require this to be an actual block hash.
- Modify `lcli new-testnet` so it can optionally create a genesis `BeaconState` with some merge-specific params.
- Add verbose `info` logs to the `execution_layer`. I don't think we'll want these long-term, but I think they'll be really handy for testnet interop.
- Always build LH with the `spec-minimal` feature. We won't want this long-term, but it'll be used during merge testnets.
- Add a `--http-allow-sync-stalled` flag to the BN that means the BN HTTP API won't prevent API requests when sync is stalled. This allows us to run single-node testnets. This reduces the overhead of execution/consensus client interop tests.

## Additional Info

NA
