### PR TITLE
[Merge] Block validator duties when EL is not ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
+ "slot_clock",
  "task_executor",
  "tokio",
  "tree_hash",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3415,7 +3415,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         if let Some(execution_layer) = &self.execution_layer {
-            if execution_layer.is_online().await {
+            if execution_layer.is_synced().await {
                 Ok(ExecutionLayerStatus::Ready)
             } else {
                 Ok(ExecutionLayerStatus::NotReady)

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -194,6 +194,7 @@ pub struct HeadInfo {
     pub genesis_time: u64,
     pub genesis_validators_root: Hash256,
     pub proposer_shuffling_decision_root: Hash256,
+    pub is_merge_complete: bool,
 }
 
 pub trait BeaconChainTypes: Send + Sync + 'static {
@@ -997,6 +998,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 genesis_time: head.beacon_state.genesis_time(),
                 genesis_validators_root: head.beacon_state.genesis_validators_root(),
                 proposer_shuffling_decision_root,
+                is_merge_complete: is_merge_complete(&head.beacon_state),
             })
         })
     }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -36,7 +36,8 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, StateSkipConfig, WhenSlotSkipped, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    ExecutionLayerStatus, ForkChoiceError, StateSkipConfig, WhenSlotSkipped,
+    MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::chain_config::ChainConfig;

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -649,6 +649,10 @@ where
             let state_advance_context = runtime_context.service_context("state_advance".into());
             let log = state_advance_context.log().clone();
             spawn_state_advance_timer(state_advance_context.executor, beacon_chain.clone(), log);
+
+            if let Some(execution_layer) = beacon_chain.execution_layer.as_ref() {
+                execution_layer.spawn_watchdog_routine(beacon_chain.slot_clock.clone());
+            }
         }
 
         Ok(Client {

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -647,10 +647,53 @@ where
 
         if let Some(beacon_chain) = self.beacon_chain.as_ref() {
             let state_advance_context = runtime_context.service_context("state_advance".into());
-            let log = state_advance_context.log().clone();
-            spawn_state_advance_timer(state_advance_context.executor, beacon_chain.clone(), log);
+            let state_advance_log = state_advance_context.log().clone();
+            spawn_state_advance_timer(
+                state_advance_context.executor,
+                beacon_chain.clone(),
+                state_advance_log,
+            );
 
             if let Some(execution_layer) = beacon_chain.execution_layer.as_ref() {
+                let store = beacon_chain.store.clone();
+                let inner_execution_layer = execution_layer.clone();
+
+                let head = beacon_chain
+                    .head_info()
+                    .map_err(|e| format!("Unable to read beacon chain head: {:?}", e))?;
+
+                // Issue the head to the execution engine on startup. This ensures it can start
+                // syncing.
+                if head.is_merge_complete {
+                    let result = runtime_context
+                        .executor
+                        .runtime()
+                        .upgrade()
+                        .ok_or_else(|| "Cannot update engine head, shutting down".to_string())?
+                        .block_on(async move {
+                            BeaconChain::<
+                                Witness<TSlotClock, TEth1Backend, TEthSpec, THotStore, TColdStore>,
+                            >::update_execution_engine_forkchoice(
+                                inner_execution_layer,
+                                store,
+                                head.finalized_checkpoint.root,
+                                head.block_root,
+                            )
+                            .await
+                        });
+
+                    // No need to exit early if setting the head fails. It will be set again if/when the
+                    // node comes online.
+                    if let Err(e) = result {
+                        warn!(
+                            log,
+                            "Failed to update head on execution engines";
+                            "error" => ?e
+                        );
+                    }
+                }
+
+                // Spawn a routine that tracks the status of the execution engines.
                 execution_layer.spawn_watchdog_routine(beacon_chain.slot_clock.clone());
             }
         }

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -28,3 +28,4 @@ exit-future = "0.2.0"
 tree_hash = { path = "../../consensus/tree_hash"}
 tree_hash_derive = { path = "../../consensus/tree_hash_derive"}
 parking_lot = "0.11.0"
+slot_clock = { path = "../../common/slot_clock" }

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -76,7 +76,7 @@ impl<T: EngineApi> Engines<T> {
     /// Run the `EngineApi::upcheck` function on all nodes which are currently offline.
     ///
     /// This can be used to try and recover any offline nodes.
-    async fn upcheck_offline(&self) {
+    pub async fn upcheck_offline(&self) {
         let upcheck_futures = self.engines.iter().map(|engine| async move {
             let mut state = engine.state.write().await;
             if state.is_offline() {

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -63,6 +63,16 @@ pub enum EngineError {
 }
 
 impl<T: EngineApi> Engines<T> {
+    /// Returns `true` if there is at least one engine with an "online" status.
+    pub async fn any_online(&self) -> bool {
+        for engine in &self.engines {
+            if engine.state.read().await.is_online() {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Run the `EngineApi::upcheck` function on all nodes which are currently offline.
     ///
     /// This can be used to try and recover any offline nodes.

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -164,6 +164,16 @@ impl ExecutionLayer {
         self.executor().spawn(generate_future(self.clone()), name);
     }
 
+    /// Returns `true` if there is at least one "online" engine.
+    ///
+    /// For an engine to be online, it must be both:
+    ///
+    /// - Reachable
+    /// - Synced
+    pub async fn is_online(&self) -> bool {
+        self.engines().any_online().await
+    }
+
     /// Maps to the `engine_preparePayload` JSON-RPC function.
     ///
     /// ## Fallback Behavior

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -197,13 +197,13 @@ impl ExecutionLayer {
                     let third_execution = second_execution + interval;
 
                     sleep_until(now + first_execution).await;
-                    el.engines().upcheck_offline(Logging::Disabled).await;
+                    el.engines().upcheck_not_synced(Logging::Disabled).await;
 
                     sleep_until(now + second_execution).await;
-                    el.engines().upcheck_offline(Logging::Disabled).await;
+                    el.engines().upcheck_not_synced(Logging::Disabled).await;
 
                     sleep_until(now + third_execution).await;
-                    el.engines().upcheck_offline(Logging::Disabled).await;
+                    el.engines().upcheck_not_synced(Logging::Disabled).await;
                 };
 
             // Start the loop to periodically update.
@@ -227,17 +227,12 @@ impl ExecutionLayer {
     /// Performs a single execution of the watchdog routine.
     async fn watchdog_task(&self) {
         // Disable logging since this runs frequently and may get annoying.
-        self.engines().upcheck_offline(Logging::Disabled).await;
+        self.engines().upcheck_not_synced(Logging::Disabled).await;
     }
 
-    /// Returns `true` if there is at least one "online" engine.
-    ///
-    /// For an engine to be online, it must be both:
-    ///
-    /// - Reachable
-    /// - Synced
-    pub async fn is_online(&self) -> bool {
-        self.engines().any_online().await
+    /// Returns `true` if there is at least one synced and reachable engine.
+    pub async fn is_synced(&self) -> bool {
+        self.engines().any_synced().await
     }
 
     /// Maps to the `engine_preparePayload` JSON-RPC function.

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -20,7 +20,7 @@ use beacon_chain::{
     observed_operations::ObservationOutcome,
     validator_monitor::{get_block_delay_ms, timestamp_now},
     AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
-    WhenSlotSkipped,
+    ExecutionLayerStatus, WhenSlotSkipped,
 };
 use block_id::BlockId;
 use eth2::types::{self as api_types, EndpointVersion, ValidatorId};
@@ -323,7 +323,7 @@ pub fn serve<T: BeaconChainTypes>(
             }
         });
 
-    // Create a `warp` filter that rejects request whilst the node is syncing.
+    // Create a `warp` filter that rejects requests whilst the node is syncing.
     let not_while_syncing_filter =
         warp::any()
             .and(network_globals.clone())
@@ -367,6 +367,28 @@ pub fn serve<T: BeaconChainTypes>(
                 },
             )
             .untuple_one();
+
+    // Create a `warp` filter that rejects requests unless the execution layer (EL) is ready.
+    let only_while_el_is_ready = warp::any()
+        .and(chain_filter.clone())
+        .and_then(move |chain: Arc<BeaconChain<T>>| async move {
+            let status = chain.execution_layer_status().await.map_err(|e| {
+                warp_utils::reject::custom_server_error(format!(
+                    "failed to read execution engine status: {:?}",
+                    e
+                ))
+            })?;
+            match status {
+                ExecutionLayerStatus::Ready | ExecutionLayerStatus::NotRequired => Ok(()),
+                ExecutionLayerStatus::NotReady => Err(warp_utils::reject::custom_server_error(
+                    "execution engine(s) not ready".to_string(),
+                )),
+                ExecutionLayerStatus::Missing => Err(warp_utils::reject::custom_server_error(
+                    "no execution engines configured".to_string(),
+                )),
+            }
+        })
+        .untuple_one();
 
     // Create a `warp` filter that provides access to the logger.
     let inner_ctx = ctx.clone();
@@ -1779,6 +1801,7 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and(log_filter.clone())
         .and_then(|epoch: Epoch, chain: Arc<BeaconChain<T>>, log: Logger| {
@@ -1796,6 +1819,7 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(warp::query::<api_types::ValidatorBlocksQuery>())
         .and(chain_filter.clone())
         .and_then(
@@ -1827,6 +1851,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAttestationDataQuery>())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
@@ -1859,6 +1884,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAggregateAttestationQuery>())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAggregateAttestationQuery, chain: Arc<BeaconChain<T>>| {
@@ -1890,6 +1916,7 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(warp::body::json())
         .and(chain_filter.clone())
         .and_then(
@@ -1912,6 +1939,7 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(warp::body::json())
         .and(chain_filter.clone())
         .and_then(
@@ -1929,6 +1957,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<SyncContributionData>())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and_then(
             |sync_committee_data: SyncContributionData, chain: Arc<BeaconChain<T>>| {
@@ -1951,6 +1980,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("aggregate_and_proofs"))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and(warp::body::json())
         .and(network_tx_filter.clone())
@@ -2051,6 +2081,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("contribution_and_proofs"))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
+        .and(only_while_el_is_ready)
         .and(chain_filter.clone())
         .and(warp::body::json())
         .and(network_tx_filter.clone())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1085,6 +1085,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::body::json())
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and_then(
             |chain: Arc<BeaconChain<T>>,
              attestations: Vec<Attestation<T::EthSpec>>,
@@ -1382,6 +1383,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::body::json())
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
+        .and(only_while_el_is_ready.clone())
         .and_then(
             |chain: Arc<BeaconChain<T>>,
              signatures: Vec<SyncCommitteeMessage>,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Causes the BN HTTP API to return errors for various API endpoints when we don't have a synced and reachable execution engine.

We do for two reasons:

1. To help inform the user that their node is presently unable to follow head due to the lack of an available EE.
1. To help prevent network chaos.

An example of network chaos would be nodes who can't follow the head still producing attestations for old heads with lots of skip slots. As we saw in the Medalla chaos, this is very resource intensive for nodes and is the sort of thing that leads to *death spirals* :scream_cat:.

I've also added a "watchdog" task that will run on startup and every 2.5s. This task will attempt to contact all offline execution engines and see if they're now online again. This should help ensure that quickly discover when an offline node comes back online.

## Additional Info

NA
