### PR TITLE
[Merged by Bors] - Export slashing protection per validator 

### DIFF
--- a/validator_client/slashing_protection/src/extra_interchange_tests.rs
+++ b/validator_client/slashing_protection/src/extra_interchange_tests.rs
@@ -1,0 +1,75 @@
+#![cfg(test)]
+
+use crate::test_utils::pubkey;
+use crate::*;
+use tempfile::tempdir;
+
+#[test]
+fn export_non_existent_key() {
+    let dir = tempdir().unwrap();
+    let slashing_db_file = dir.path().join("slashing_protection.sqlite");
+    let slashing_db = SlashingDatabase::create(&slashing_db_file).unwrap();
+
+    let key1 = pubkey(1);
+    let key2 = pubkey(2);
+
+    // Exporting two non-existent keys should fail on the first one.
+    let err = slashing_db
+        .export_interchange_info(Hash256::zero(), Some(&[key1, key2]))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        InterchangeError::NotSafe(NotSafe::UnregisteredValidator(k)) if k == key1
+    ));
+
+    slashing_db.register_validator(key1).unwrap();
+
+    // Exporting one key that exists and one that doesn't should fail on the one that doesn't.
+    let err = slashing_db
+        .export_interchange_info(Hash256::zero(), Some(&[key1, key2]))
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        InterchangeError::NotSafe(NotSafe::UnregisteredValidator(k)) if k == key2
+    ));
+
+    // Exporting only keys that exist should work.
+    let interchange = slashing_db
+        .export_interchange_info(Hash256::zero(), Some(&[key1]))
+        .unwrap();
+    assert_eq!(interchange.data.len(), 1);
+    assert_eq!(interchange.data[0].pubkey, key1);
+}
+
+#[test]
+fn export_same_key_twice() {
+    let dir = tempdir().unwrap();
+    let slashing_db_file = dir.path().join("slashing_protection.sqlite");
+    let slashing_db = SlashingDatabase::create(&slashing_db_file).unwrap();
+
+    let key1 = pubkey(1);
+
+    slashing_db.register_validator(key1).unwrap();
+
+    let export_single = slashing_db
+        .export_interchange_info(Hash256::zero(), Some(&[key1]))
+        .unwrap();
+    let export_double = slashing_db
+        .export_interchange_info(Hash256::zero(), Some(&[key1, key1]))
+        .unwrap();
+
+    assert_eq!(export_single.data.len(), 1);
+
+    // Allow the same data to be exported twice, this is harmless, albeit slightly inefficient.
+    assert_eq!(export_double.data.len(), 2);
+    assert_eq!(export_double.data[0], export_double.data[1]);
+
+    // The data should be identical to the single export.
+    assert_eq!(export_double.data[0], export_single.data[0]);
+
+    // The minified versions should be equal too.
+    assert_eq!(
+        export_single.minify().unwrap(),
+        export_double.minify().unwrap()
+    );
+}

--- a/validator_client/slashing_protection/src/lib.rs
+++ b/validator_client/slashing_protection/src/lib.rs
@@ -1,5 +1,6 @@
 mod attestation_tests;
 mod block_tests;
+mod extra_interchange_tests;
 pub mod interchange;
 pub mod interchange_test;
 mod parallel_tests;


### PR DESCRIPTION
## Issue Addressed

Part of https://github.com/sigp/lighthouse/issues/2557

## Proposed Changes

Refactor the slashing protection export so that it can export data for a subset of validators.

This is the last remaining building block required for supporting the standard validator API (which I'll start to build atop this branch)

## Additional Info

Built on and requires #2598
