### PR TITLE
Accept `--terminal-total-difficuty-override` as decimal

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -379,7 +379,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("terminal-total-difficulty-override")
                 .long("terminal-total-difficulty-override")
-                .value_name("TERMINAL_TOTAL_DIFFICULTY")
+                .value_name("INTEGER")
                 .help("Used to coordinate manual overrides to the TERMINAL_TOTAL_DIFFICULTY parameter. \
                        This flag should only be used if the user has a clear understanding that \
                        the broad Ethereum community has elected to override the terminal difficulty. \
@@ -392,6 +392,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("terminal-block-hash-override")
                 .value_name("TERMINAL_BLOCK_HASH")
                 .help("Used to coordinate manual overrides to the TERMINAL_BLOCK_HASH parameter. \
+                       Accepts a 256-bit decimal integer (not a hex value). \
                        This flag should only be used if the user has a clear understanding that \
                        the broad Ethereum community has elected to override the terminal PoW block. \
                        Incorrect use of this flag will cause your node to experience a consensus

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -13,7 +13,9 @@ use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::net::{TcpListener, UdpSocket};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use types::{ChainSpec, Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
+use types::{
+    ChainSpec, Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, Uint256, GRAFFITI_BYTES_LEN,
+};
 
 /// Gets the fully-initialized global client.
 ///
@@ -228,9 +230,17 @@ pub fn get_config<E: EthSpec>(
         client_config.execution_endpoints = Some(client_config.eth1.endpoints.clone());
     }
 
-    if let Some(terminal_total_difficulty) =
-        clap_utils::parse_optional(cli_args, "terminal-total-difficulty-override")?
+    if let Some(string) =
+        clap_utils::parse_optional::<String>(cli_args, "terminal-total-difficulty-override")?
     {
+        let stripped = string.replace(",", "");
+        let terminal_total_difficulty = Uint256::from_dec_str(&stripped).map_err(|e| {
+            format!(
+                "Could not parse --terminal-total-difficulty-override as decimal value: {:?}",
+                e
+            )
+        })?;
+
         if client_config.execution_endpoints.is_none() {
             return Err(
                 "The --merge flag must be provided when using --terminal-total-difficulty-override"

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Output};
 use std::str::{from_utf8, FromStr};
 use std::string::ToString;
 use tempfile::TempDir;
-use types::{Checkpoint, Epoch, Hash256};
+use types::{Checkpoint, Epoch, Hash256, Uint256};
 
 const BEACON_CMD: &str = "beacon_node";
 const CONFIG_NAME: &str = "bn_dump.json";
@@ -834,6 +834,83 @@ pub fn malloc_tuning_flag() {
         .with_config(|config| {
             assert!(!config.http_metrics.allocator_metrics_enabled);
         });
+}
+#[test]
+pub fn ttd_override_decimal() {
+    CommandLineTest::new().run().with_config(|config| {
+        assert!(config.terminal_total_difficulty_override.is_none());
+    });
+
+    CommandLineTest::new()
+        .flag("merge", None)
+        .flag(
+            "terminal-total-difficulty-override",
+            Some("31,841,035,257,753,085,493,511"),
+        )
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.terminal_total_difficulty_override.unwrap(),
+                Uint256::from_dec_str(&"31841035257753085493511").unwrap()
+            );
+        });
+
+    CommandLineTest::new()
+        .flag("merge", None)
+        .flag(
+            "terminal-total-difficulty-override",
+            Some("31841035257753085493511"),
+        )
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.terminal_total_difficulty_override.unwrap(),
+                Uint256::from_dec_str(&"31841035257753085493511").unwrap()
+            );
+        });
+
+    CommandLineTest::new()
+        .flag("merge", None)
+        .flag("terminal-total-difficulty-override", Some("1234"))
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.terminal_total_difficulty_override.unwrap(),
+                Uint256::from(1234)
+            );
+        });
+
+    CommandLineTest::new()
+        .flag("merge", None)
+        .flag("terminal-total-difficulty-override", Some("1,234"))
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.terminal_total_difficulty_override.unwrap(),
+                Uint256::from(1234)
+            );
+        });
+}
+#[test]
+#[should_panic]
+pub fn ttd_override_without_merge() {
+    CommandLineTest::new()
+        .flag("terminal-total-difficulty-override", Some("1234"))
+        .run();
+}
+#[test]
+#[should_panic]
+pub fn ttd_override_hex() {
+    CommandLineTest::new()
+        .flag("terminal-total-difficulty-override", Some("0xabcd"))
+        .run();
+}
+#[test]
+#[should_panic]
+pub fn ttd_override_none() {
+    CommandLineTest::new()
+        .flag("terminal-total-difficulty-override", None)
+        .run();
 }
 #[test]
 #[should_panic]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

As per the presently un-approved https://github.com/ethereum/consensus-specs/pull/2645, parse `--terminal-total-difficuty-override` as a decimal integer instead of 0x-prefixed hex.

Although we don't have clear guidance on this from the spec, I understand that this is the most convenient format for the merge event.

## Additional Info

NA
