### PR TITLE
[Merged by Bors] - Fix name collision in script

### DIFF
--- a/scripts/ci/publish.sh
+++ b/scripts/ci/publish.sh
@@ -5,7 +5,7 @@
 set -e
 USAGE="Publish a new release of a lighthouse crate
 USAGE:
-    $(basename "$0") [OPTIONS] [CRATE_PATH] [CRATE] [TAG]
+    $(basename "$0") [OPTIONS] [CRATE_PATH] [CRATE] [TAG_NAME]
 OPTIONS:
     -v, --verbose       Use verbose Cargo output
     -d, --dry-run       Perform a dry run (do not publish the release)
@@ -72,9 +72,9 @@ case "$1" in
         CRATE_PATH="$1"
     elif [ -z "$CRATE" ]; then
         CRATE="$1"
-    elif [ -z "$TAG" ]; then
-        TAG="$1"
-        VERSION=$(sed -e 's#.*-v\([0-9]\)#\1#' <<< "$TAG")
+    elif [ -z "$TAG_NAME" ]; then
+        TAG_NAME="$1"
+        VERSION=$(sed -e 's#.*-v\([0-9]\)#\1#' <<< "$TAG_NAME")
     else
         echo "unknown positional argument \"$1\""
         echo "$USAGE"


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

We set a `$TAG` env variable in the github actions workflow, and then re-use this name in the `publish.sh` script. It makes this check `if [[ -z "$TAG" ]]` return true, when it should return false on the first time it's hit.

## Additional Info

N/A
