### PR TITLE
Disable eth1 sync warnings when using dummy backend

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -223,6 +223,11 @@ where
         }
     }
 
+    /// Returns `true` if the "dummy" backend is being used.
+    pub fn is_dummy_backend(&self) -> bool {
+        self.use_dummy_backend
+    }
+
     /// Returns the `Eth1Data` that should be included in a block being produced for the given
     /// `state`.
     pub fn eth1_data_for_block_production(

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -302,6 +302,11 @@ fn eth1_logging<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>, log: &Logger
     if let Ok(head_info) = beacon_chain.head_info() {
         // Perform some logging about the eth1 chain
         if let Some(eth1_chain) = beacon_chain.eth1_chain.as_ref() {
+            // No need to do logging if using the dummy backend.
+            if eth1_chain.is_dummy_backend() {
+                return;
+            }
+
             if let Some(status) =
                 eth1_chain.sync_status(head_info.genesis_time, current_slot_opt, &beacon_chain.spec)
             {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Disable the pointless and never-ending `WARN Syncing eth1 block cache` warnings when using `--dummy-eth1`.

## Additional Info

NA
