### PR TITLE
Fix db paths when datadir is relative to current path

### DIFF
--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -116,58 +116,47 @@ impl Default for Config {
 
 impl Config {
     /// Get the database path without initialising it.
-    pub fn get_db_path(&self) -> Option<PathBuf> {
-        self.get_data_dir()
-            .map(|data_dir| data_dir.join(&self.db_name))
+    pub fn get_db_path(&self) -> PathBuf {
+        self.get_data_dir().join(&self.db_name)
     }
 
     /// Get the database path, creating it if necessary.
     pub fn create_db_path(&self) -> Result<PathBuf, String> {
-        let db_path = self
-            .get_db_path()
-            .ok_or("Unable to locate user home directory")?;
-        ensure_dir_exists(db_path)
+        ensure_dir_exists(self.get_db_path())
     }
 
     /// Fetch default path to use for the freezer database.
-    fn default_freezer_db_path(&self) -> Option<PathBuf> {
-        self.get_data_dir()
-            .map(|data_dir| data_dir.join(DEFAULT_FREEZER_DB_DIR))
+    fn default_freezer_db_path(&self) -> PathBuf {
+        self.get_data_dir().join(DEFAULT_FREEZER_DB_DIR)
     }
 
     /// Returns the path to which the client may initialize the on-disk freezer database.
     ///
     /// Will attempt to use the user-supplied path from e.g. the CLI, or will default
     /// to a directory in the data_dir if no path is provided.
-    pub fn get_freezer_db_path(&self) -> Option<PathBuf> {
+    pub fn get_freezer_db_path(&self) -> PathBuf {
         self.freezer_db_path
             .clone()
-            .or_else(|| self.default_freezer_db_path())
+            .unwrap_or_else(|| self.default_freezer_db_path())
     }
 
     /// Get the freezer DB path, creating it if necessary.
     pub fn create_freezer_db_path(&self) -> Result<PathBuf, String> {
-        let freezer_db_path = self
-            .get_freezer_db_path()
-            .ok_or("Unable to locate user home directory")?;
-        ensure_dir_exists(freezer_db_path)
+        ensure_dir_exists(self.get_freezer_db_path())
     }
 
     /// Returns the core path for the client.
     ///
     /// Will not create any directories.
-    pub fn get_data_dir(&self) -> Option<PathBuf> {
-        dirs::home_dir().map(|home_dir| home_dir.join(&self.data_dir))
+    pub fn get_data_dir(&self) -> PathBuf {
+        self.data_dir.clone()
     }
 
     /// Returns the core path for the client.
     ///
     /// Creates the directory if it does not exist.
     pub fn create_data_dir(&self) -> Result<PathBuf, String> {
-        let path = self
-            .get_data_dir()
-            .ok_or("Unable to locate user home directory")?;
-        ensure_dir_exists(path)
+        ensure_dir_exists(self.get_data_dir())
     }
 }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -35,16 +35,12 @@ pub fn get_config<E: EthSpec>(
     // If necessary, remove any existing database and configuration
     if client_config.data_dir.exists() && cli_args.is_present("purge-db") {
         // Remove the chain_db.
-        fs::remove_dir_all(client_config.get_db_path().ok_or("Failed to get db_path")?)
+        fs::remove_dir_all(client_config.get_db_path())
             .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
 
         // Remove the freezer db.
-        fs::remove_dir_all(
-            client_config
-                .get_freezer_db_path()
-                .ok_or("Failed to get freezer db path")?,
-        )
-        .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
+        fs::remove_dir_all(client_config.get_freezer_db_path())
+            .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
     }
 
     // Create `datadir` and any non-existing parent directories.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

While running merge testnets, we noticed that passing relative paths for datadirs leads to the database directories being created relative to `$HOME`. This PR fixes the issue such that database directories are generated relative to the datadir passed through cli or the default.

