### PR TITLE
[Merge] Optimistic EL verification: Stage 0

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3367,7 +3367,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         )
                         .await
                         {
-                            error!(
+                            debug!(
                                 log,
                                 "Failed to update execution head";
                                 "error" => ?e

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1160,7 +1160,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
 
             match execute_payload_response {
                 Ok((status, handle)) => match status {
-                    ExecutePayloadResponse::Valid => Some(handle),
+                    ExecutePayloadResponse::Valid => handle,
                     ExecutePayloadResponse::Invalid => {
                         return Err(ExecutionPayloadError::RejectedByExecutionEngine.into());
                     }
@@ -1170,7 +1170,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                             "Optimistically accepting payload";
                             "msg" => "execution engine is syncing"
                         );
-                        Some(handle)
+                        handle
                     }
                 },
                 Err(e) => {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -55,7 +55,7 @@ use fork_choice::{ForkChoice, ForkChoiceStore};
 use parking_lot::RwLockReadGuard;
 use proto_array::Block as ProtoBlock;
 use safe_arith::ArithError;
-use slog::{debug, error, Logger};
+use slog::{debug, error, info, Logger};
 use slot_clock::SlotClock;
 use ssz::Encode;
 use state_processing::per_block_processing::{is_execution_enabled, is_merge_block};
@@ -1127,7 +1127,15 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
             match is_valid_terminal_pow_block {
                 Some(true) => Ok(()),
                 Some(false) => Err(ExecutionPayloadError::InvalidTerminalPoWBlock),
-                None => Err(ExecutionPayloadError::TerminalPoWBlockNotFound),
+                None => {
+                    info!(
+                        chain.log,
+                        "Optimistically accepting terminal block";
+                        "block_hash" => ?execution_payload.parent_hash,
+                        "msg" => "the terminal block/parent was unavailable"
+                    );
+                    Ok(())
+                }
             }?;
         }
 
@@ -1147,21 +1155,34 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
                         object_fork: block.message().body().fork_name(),
                     })?;
 
-            let (execute_payload_status, execute_payload_handle) = execution_layer
-                .block_on(|execution_layer| execution_layer.execute_payload(execution_payload))
-                .map_err(ExecutionPayloadError::from)?;
+            let execute_payload_response = execution_layer
+                .block_on(|execution_layer| execution_layer.execute_payload(execution_payload));
 
-            match execute_payload_status {
-                ExecutePayloadResponse::Valid => Ok(()),
-                ExecutePayloadResponse::Invalid => {
-                    Err(ExecutionPayloadError::RejectedByExecutionEngine)
+            match execute_payload_response {
+                Ok((status, handle)) => match status {
+                    ExecutePayloadResponse::Valid => Some(handle),
+                    ExecutePayloadResponse::Invalid => {
+                        return Err(ExecutionPayloadError::RejectedByExecutionEngine.into());
+                    }
+                    ExecutePayloadResponse::Syncing => {
+                        debug!(
+                            chain.log,
+                            "Optimistically accepting payload";
+                            "msg" => "execution engine is syncing"
+                        );
+                        Some(handle)
+                    }
+                },
+                Err(e) => {
+                    error!(
+                        chain.log,
+                        "Optimistically accepting payload";
+                        "error" => ?e,
+                        "msg" => "execution engine returned an error"
+                    );
+                    None
                 }
-                ExecutePayloadResponse::Syncing => {
-                    Err(ExecutionPayloadError::ExecutionEngineIsSyncing)
-                }
-            }?;
-
-            Some(execute_payload_handle)
+            }
         } else {
             None
         };

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -2,7 +2,7 @@
 
 use crate::engine_api::{EngineApi, Error as EngineApiError};
 use futures::future::join_all;
-use slog::{crit, debug, error, info, warn, Logger};
+use slog::{crit, debug, info, warn, Logger};
 use std::future::Future;
 use tokio::sync::RwLock;
 use types::Hash256;
@@ -89,7 +89,7 @@ impl<T: EngineApi> Engines<T> {
                 .forkchoice_updated(head.head_block_hash, head.finalized_block_hash)
                 .await
             {
-                error!(
+                debug!(
                     self.log,
                     "Failed to issue latest head to engine";
                     "error" => ?e,
@@ -291,7 +291,7 @@ impl<T: EngineApi> Engines<T> {
             let is_offline = *engine.state.read().await == EngineState::Offline;
             if !is_offline {
                 func(engine).await.map_err(|error| {
-                    error!(
+                    debug!(
                         self.log,
                         "Execution engine call failed";
                         "error" => ?error,

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -225,7 +225,7 @@ impl<T: EngineApi> Engines<T> {
                 match func(engine).await {
                     Ok(result) => return Ok(result),
                     Err(error) => {
-                        error!(
+                        debug!(
                             self.log,
                             "Execution engine call failed";
                             "error" => ?error,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -8,7 +8,7 @@ use engine_api::{Error as ApiError, *};
 use engines::{Engine, EngineError, Engines, ForkChoiceHead, Logging};
 use lru::LruCache;
 use sensitive_url::SensitiveUrl;
-use slog::{crit, error, info, Logger};
+use slog::{crit, debug, error, info, Logger};
 use slot_clock::SlotClock;
 use std::future::Future;
 use std::sync::Arc;
@@ -249,7 +249,7 @@ impl ExecutionLayer {
         random: Hash256,
     ) -> Result<PayloadId, Error> {
         let fee_recipient = self.fee_recipient()?;
-        info!(
+        debug!(
             self.log(),
             "Issuing engine_preparePayload";
             "fee_recipient" => ?fee_recipient,
@@ -285,7 +285,7 @@ impl ExecutionLayer {
         random: Hash256,
     ) -> Result<ExecutionPayload<T>, Error> {
         let fee_recipient = self.fee_recipient()?;
-        info!(
+        debug!(
             self.log(),
             "Issuing engine_getPayload";
             "fee_recipient" => ?fee_recipient,
@@ -324,7 +324,7 @@ impl ExecutionLayer {
         &self,
         execution_payload: &ExecutionPayload<T>,
     ) -> Result<(ExecutePayloadResponse, Option<ExecutePayloadHandle>), Error> {
-        info!(
+        debug!(
             self.log(),
             "Issuing engine_executePayload";
             "parent_hash" => ?execution_payload.parent_hash,
@@ -389,7 +389,7 @@ impl ExecutionLayer {
         block_hash: Hash256,
         status: ConsensusStatus,
     ) -> Result<(), Error> {
-        info!(
+        debug!(
             self.log(),
             "Issuing engine_consensusValidated";
             "status" => ?status,
@@ -427,7 +427,7 @@ impl ExecutionLayer {
         head_block_hash: Hash256,
         finalized_block_hash: Hash256,
     ) -> Result<(), Error> {
-        info!(
+        debug!(
             self.log(),
             "Issuing engine_forkchoiceUpdated";
             "finalized_block_hash" => ?finalized_block_hash,

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -123,11 +123,13 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         assert_eq!(payload.timestamp, timestamp);
         assert_eq!(payload.random, random);
 
-        let (payload_response, mut payload_handle) =
-            self.el.execute_payload(&payload).await.unwrap();
+        let (payload_response, payload_handle) = self.el.execute_payload(&payload).await.unwrap();
         assert_eq!(payload_response, ExecutePayloadResponse::Valid);
 
-        payload_handle.publish_async(ConsensusStatus::Valid).await;
+        payload_handle
+            .unwrap()
+            .publish_async(ConsensusStatus::Valid)
+            .await;
 
         self.el
             .forkchoice_updated(block_hash, Hash256::zero())


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Enables a rough and interop-ready "optimistic" style of `BeaconChain` sync where we still advance the chain if the execution engine is syncing.

This PR is very limited in its functionality, it just blindly imports blocks regardless of whether or not it's verified by the execution layer, assuming it will catch up at some point.


## Additional Info

A follow-up PR will need to add the logic to prevent building atop a non-execution-verified block. It will also need to communicate to the user whether or not their head is fully verified or optimistic.
