### PR TITLE
[Merge] Optimistic Sync: Stage 1

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -50,7 +50,7 @@ use eth2::types::{
     EventKind, SseBlock, SseChainReorg, SseFinalizedCheckpoint, SseHead, SseLateHead, SyncDuty,
 };
 use execution_layer::ExecutionLayer;
-use fork_choice::{ForkChoice, PayloadVerificationStatus};
+use fork_choice::ForkChoice;
 use futures::channel::mpsc::Sender;
 use itertools::process_results;
 use itertools::Itertools;
@@ -2291,6 +2291,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let current_slot = self.slot()?;
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
         let mut ops = fully_verified_block.confirmation_db_batch;
+        let payload_verification_status = fully_verified_block.payload_verification_status;
 
         let attestation_observation_timer =
             metrics::start_timer(&metrics::BLOCK_PROCESSING_ATTESTATION_OBSERVATION);
@@ -2415,8 +2416,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     &block,
                     block_root,
                     &state,
-                    //TODO(paul): set this correctly.
-                    PayloadVerificationStatus::Verified,
+                    payload_verification_status,
                 )
                 .map_err(|e| BlockError::BeaconChainError(e.into()))?;
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -50,7 +50,7 @@ use eth2::types::{
     EventKind, SseBlock, SseChainReorg, SseFinalizedCheckpoint, SseHead, SseLateHead, SyncDuty,
 };
 use execution_layer::ExecutionLayer;
-use fork_choice::ForkChoice;
+use fork_choice::{ForkChoice, PayloadVerificationStatus};
 use futures::channel::mpsc::Sender;
 use itertools::process_results;
 use itertools::Itertools;
@@ -2410,7 +2410,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let _fork_choice_block_timer =
                 metrics::start_timer(&metrics::FORK_CHOICE_PROCESS_BLOCK_TIMES);
             fork_choice
-                .on_block(current_slot, &block, block_root, &state)
+                .on_block(
+                    current_slot,
+                    &block,
+                    block_root,
+                    &state,
+                    //TODO(paul): set this correctly.
+                    PayloadVerificationStatus::Verified,
+                )
                 .map_err(|e| BlockError::BeaconChainError(e.into()))?;
         }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -196,6 +196,7 @@ pub struct HeadInfo {
     pub genesis_validators_root: Hash256,
     pub proposer_shuffling_decision_root: Hash256,
     pub is_merge_complete: bool,
+    pub execution_payload_block_hash: Option<Hash256>,
 }
 
 pub trait BeaconChainTypes: Send + Sync + 'static {
@@ -1006,6 +1007,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 genesis_validators_root: head.beacon_state.genesis_validators_root(),
                 proposer_shuffling_decision_root,
                 is_merge_complete: is_merge_complete(&head.beacon_state),
+                execution_payload_block_hash: head
+                    .beacon_block
+                    .message()
+                    .body()
+                    .execution_payload()
+                    .map(|ep| ep.block_hash),
             })
         })
     }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -208,19 +208,6 @@ pub trait BeaconChainTypes: Send + Sync + 'static {
 
 /// Indicates the status of the `ExecutionLayer`.
 #[derive(Debug, PartialEq)]
-pub enum ExecutionLayerStatus {
-    /// The execution layer is synced and reachable.
-    Ready,
-    /// The execution layer either syncing or unreachable.
-    NotReady,
-    /// The execution layer is required, but has not been enabled. This is a configuration error.
-    Missing,
-    /// The execution layer is not yet required, therefore the status is irrelevant.
-    NotRequired,
-}
-
-/// Indicates the status of the `ExecutionLayer`.
-#[derive(Debug, PartialEq)]
 pub enum HeadSafetyStatus {
     Safe,
     Unsafe,
@@ -3443,39 +3430,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         };
 
         Ok(status)
-    }
-
-    /// Indicates the status of the execution layer.
-    pub async fn execution_layer_status(&self) -> Result<ExecutionLayerStatus, BeaconChainError> {
-        let epoch = self.epoch()?;
-        if self.spec.merge_fork_epoch.map_or(true, |fork| epoch < fork) {
-            return Ok(ExecutionLayerStatus::NotRequired);
-        }
-
-        if let Some(execution_layer) = &self.execution_layer {
-            if execution_layer.is_synced().await {
-                Ok(ExecutionLayerStatus::Ready)
-            } else {
-                Ok(ExecutionLayerStatus::NotReady)
-            }
-        } else {
-            // This branch is slightly more restrictive than what is minimally required.
-            //
-            // It is possible for a node without an execution layer (EL) to follow the chain
-            // *after* the merge fork and *before* the terminal execution block, as long as
-            // that node is not required to produce blocks.
-            //
-            // However, here we say that all nodes *must* have an EL as soon as the merge fork
-            // happens. We do this because it's very difficult to determine that the terminal
-            // block has been met if we don't already have an EL. As far as we know, the
-            // terminal execution block might already exist and we've been rejecting it since
-            // we don't have an EL to verify it.
-            //
-            // I think it is very reasonable to say that the beacon chain expects all BNs to
-            // be paired with an EL node by the time the merge fork epoch is reached. So, we
-            // enforce that here.
-            Ok(ExecutionLayerStatus::Missing)
-        }
     }
 
     /// This function takes a configured weak subjectivity `Checkpoint` and the latest finalized `Checkpoint`.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -206,11 +206,22 @@ pub trait BeaconChainTypes: Send + Sync + 'static {
     type EthSpec: types::EthSpec;
 }
 
-/// Indicates the status of the `ExecutionLayer`.
+/// Indicates the EL payload verification status of the head beacon block.
 #[derive(Debug, PartialEq)]
 pub enum HeadSafetyStatus {
+    /// The head block has either been verified by an EL or is does not require EL verification
+    /// (e.g., it is pre-merge or pre-terminal-block).
+    ///
+    /// If the block is post-terminal-block, `Some(execution_payload.block_hash)` is included with
+    /// the variant.
     Safe(Option<Hash256>),
+    /// The head block execution payload has not yet been verified by an EL.
+    ///
+    /// The `execution_payload.block_hash` of the head block is returned.
     Unsafe(Hash256),
+    /// The head block execution payload was deemed to be invalid by an EL.
+    ///
+    /// The `execution_payload.block_hash` of the head block is returned.
     Invalid(Hash256),
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -209,9 +209,9 @@ pub trait BeaconChainTypes: Send + Sync + 'static {
 /// Indicates the status of the `ExecutionLayer`.
 #[derive(Debug, PartialEq)]
 pub enum HeadSafetyStatus {
-    Safe,
-    Unsafe,
-    Invalid,
+    Safe(Option<Hash256>),
+    Unsafe(Hash256),
+    Invalid(Hash256),
 }
 
 pub type BeaconForkChoice<T> = ForkChoice<
@@ -3423,10 +3423,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .ok_or(BeaconChainError::HeadMissingFromForkChoice(head.block_root))?;
 
         let status = match head_block.execution_status {
-            ExecutionStatus::Valid(_) => HeadSafetyStatus::Safe,
-            ExecutionStatus::Invalid(_) => HeadSafetyStatus::Invalid,
-            ExecutionStatus::Unknown(_) => HeadSafetyStatus::Unsafe,
-            ExecutionStatus::Irrelevant(_) => HeadSafetyStatus::Safe,
+            ExecutionStatus::Valid(block_hash) => HeadSafetyStatus::Safe(Some(block_hash)),
+            ExecutionStatus::Invalid(block_hash) => HeadSafetyStatus::Invalid(block_hash),
+            ExecutionStatus::Unknown(block_hash) => HeadSafetyStatus::Unsafe(block_hash),
+            ExecutionStatus::Irrelevant(_) => HeadSafetyStatus::Safe(None),
         };
 
         Ok(status)

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -136,6 +136,7 @@ pub enum BeaconChainError {
     AltairForkDisabled,
     ExecutionLayerMissing,
     ExecutionForkChoiceUpdateFailed(execution_layer::Error),
+    HeadMissingFromForkChoice(Hash256),
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -137,6 +137,8 @@ pub enum BeaconChainError {
     ExecutionLayerMissing,
     ExecutionForkChoiceUpdateFailed(execution_layer::Error),
     HeadMissingFromForkChoice(Hash256),
+    FinalizedBlockMissingFromForkChoice(Hash256),
+    InvalidFinalizedPayloadShutdownError(TrySendError<ShutdownReason>),
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -164,8 +164,10 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
         )
         .map_err(|e| format!("Error replaying block: {:?}", e))?;
 
-        // TODO(paul): figure out how to determine if this is verified or not. I'm returning
-        // `NotVerified` for now since it's safest.
+        // Setting this to unverified is the safest solution, since we don't have a way to
+        // retro-actively determine if they were valid or not.
+        //
+        // This scenario is so rare that it seems OK to double-verify some blocks.
         let payload_verification_status = PayloadVerificationStatus::NotVerified;
 
         let (block, _) = block.deconstruct();

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -36,7 +36,7 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ExecutionLayerStatus, ForkChoiceError, HeadSafetyStatus, StateSkipConfig, WhenSlotSkipped,
+    ForkChoiceError, HeadSafetyStatus, StateSkipConfig, WhenSlotSkipped,
     MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -36,7 +36,7 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ExecutionLayerStatus, ForkChoiceError, StateSkipConfig, WhenSlotSkipped,
+    ExecutionLayerStatus, ForkChoiceError, HeadSafetyStatus, StateSkipConfig, WhenSlotSkipped,
     MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -664,7 +664,7 @@ where
 
                 // Issue the head to the execution engine on startup. This ensures it can start
                 // syncing.
-                if head.is_merge_complete {
+                if let Some(block_hash) = head.execution_payload_block_hash {
                     runtime_context.executor.spawn(
                         async move {
                             let result = BeaconChain::<
@@ -673,7 +673,7 @@ where
                                 inner_execution_layer,
                                 store,
                                 head.finalized_checkpoint.root,
-                                head.block_root,
+                                block_hash,
                             )
                             .await;
 

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -1,8 +1,8 @@
 use crate::metrics;
-use beacon_chain::{BeaconChain, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainTypes, HeadSafetyStatus};
 use eth2_libp2p::{types::SyncState, NetworkGlobals};
 use parking_lot::Mutex;
-use slog::{debug, error, info, warn, Logger};
+use slog::{crit, debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -263,10 +263,44 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 } else {
                     head_root.to_string()
                 };
+
+                let block_hash = match beacon_chain.head_safety_status() {
+                    Ok(HeadSafetyStatus::Safe(hash_opt)) => hash_opt,
+                    Ok(HeadSafetyStatus::Unsafe(block_hash)) => {
+                        warn!(
+                            log,
+                            "Head execution payload is unverified";
+                            "execution_block_hash" => ?block_hash,
+                        );
+                        Some(block_hash)
+                    }
+                    Ok(HeadSafetyStatus::Invalid(block_hash)) => {
+                        crit!(
+                            log,
+                            "Head execution payload is invalid";
+                            "msg" => "this scenario may be unrecoverable",
+                            "execution_block_hash" => ?block_hash,
+                        );
+                        Some(block_hash)
+                    }
+                    Err(e) => {
+                        error!(
+                            log,
+                            "Failed to read head safety status";
+                            "error" => ?e
+                        );
+                        None
+                    }
+                };
+                let block_hash_string = block_hash
+                    .map(|hash| format!("{:?}", hash))
+                    .unwrap_or_else(|| "n/a".to_string());
+
                 info!(
                     log,
                     "Synced";
                     "peers" => peer_count_pretty(connected_peer_count),
+                    "execution_block_hash" => block_hash_string,
                     "finalized_root" => format!("{}", finalized_root),
                     "finalized_epoch" => finalized_epoch,
                     "epoch" => current_epoch,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -380,13 +380,19 @@ pub fn serve<T: BeaconChainTypes>(
                 ))
             })?;
             match status {
-                HeadSafetyStatus::Safe => Ok(()),
-                HeadSafetyStatus::Unsafe => Err(warp_utils::reject::custom_server_error(
-                    "optimistic head has not been verified by the execution layer".to_string(),
-                )),
-                HeadSafetyStatus::Invalid => Err(warp_utils::reject::custom_server_error(
-                    "the head block has an invalid payload, this may be unrecoverable".to_string(),
-                )),
+                HeadSafetyStatus::Safe(_) => Ok(()),
+                HeadSafetyStatus::Unsafe(hash) => {
+                    Err(warp_utils::reject::custom_server_error(format!(
+                        "optimistic head hash {:?} has not been verified by the execution layer",
+                        hash
+                    )))
+                }
+                HeadSafetyStatus::Invalid(hash) => {
+                    Err(warp_utils::reject::custom_server_error(format!(
+                        "the head block has an invalid payload {:?}, this may be unrecoverable",
+                        hash
+                    )))
+                }
             }
         })
         .untuple_one();

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1825,7 +1825,6 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_with_safe_head.clone())
         .and(warp::query::<api_types::ValidatorBlocksQuery>())
         .and(chain_filter.clone())
         .and_then(

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -20,7 +20,7 @@ use beacon_chain::{
     observed_operations::ObservationOutcome,
     validator_monitor::{get_block_delay_ms, timestamp_now},
     AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
-    ExecutionLayerStatus, WhenSlotSkipped,
+    HeadSafetyStatus, WhenSlotSkipped,
 };
 use block_id::BlockId;
 use eth2::types::{self as api_types, EndpointVersion, ValidatorId};
@@ -368,23 +368,24 @@ pub fn serve<T: BeaconChainTypes>(
             )
             .untuple_one();
 
-    // Create a `warp` filter that rejects requests unless the execution layer (EL) is ready.
-    let only_while_el_is_ready = warp::any()
+    // Create a `warp` filter that rejects requests unless the head has been verified by the
+    // execution layer.
+    let only_with_safe_head = warp::any()
         .and(chain_filter.clone())
         .and_then(move |chain: Arc<BeaconChain<T>>| async move {
-            let status = chain.execution_layer_status().await.map_err(|e| {
+            let status = chain.head_safety_status().map_err(|e| {
                 warp_utils::reject::custom_server_error(format!(
-                    "failed to read execution engine status: {:?}",
+                    "failed to read head safety status: {:?}",
                     e
                 ))
             })?;
             match status {
-                ExecutionLayerStatus::Ready | ExecutionLayerStatus::NotRequired => Ok(()),
-                ExecutionLayerStatus::NotReady => Err(warp_utils::reject::custom_server_error(
-                    "execution engine(s) not ready".to_string(),
+                HeadSafetyStatus::Safe => Ok(()),
+                HeadSafetyStatus::Unsafe => Err(warp_utils::reject::custom_server_error(
+                    "optimistic head has not been verified by the execution layer".to_string(),
                 )),
-                ExecutionLayerStatus::Missing => Err(warp_utils::reject::custom_server_error(
-                    "no execution engines configured".to_string(),
+                HeadSafetyStatus::Invalid => Err(warp_utils::reject::custom_server_error(
+                    "the head block has an invalid payload, this may be unrecoverable".to_string(),
                 )),
             }
         })
@@ -1085,7 +1086,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::body::json())
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and_then(
             |chain: Arc<BeaconChain<T>>,
              attestations: Vec<Attestation<T::EthSpec>>,
@@ -1383,7 +1383,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::body::json())
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and_then(
             |chain: Arc<BeaconChain<T>>,
              signatures: Vec<SyncCommitteeMessage>,
@@ -1803,7 +1802,6 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and(log_filter.clone())
         .and_then(|epoch: Epoch, chain: Arc<BeaconChain<T>>, log: Logger| {
@@ -1821,7 +1819,7 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
+        .and(only_with_safe_head.clone())
         .and(warp::query::<api_types::ValidatorBlocksQuery>())
         .and(chain_filter.clone())
         .and_then(
@@ -1853,7 +1851,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAttestationDataQuery>())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
+        .and(only_with_safe_head.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
@@ -1886,7 +1884,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAggregateAttestationQuery>())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
+        .and(only_with_safe_head.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAggregateAttestationQuery, chain: Arc<BeaconChain<T>>| {
@@ -1918,7 +1916,6 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and(warp::body::json())
         .and(chain_filter.clone())
         .and_then(
@@ -1941,7 +1938,6 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and(warp::body::json())
         .and(chain_filter.clone())
         .and_then(
@@ -1959,7 +1955,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<SyncContributionData>())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
+        .and(only_with_safe_head)
         .and(chain_filter.clone())
         .and_then(
             |sync_committee_data: SyncContributionData, chain: Arc<BeaconChain<T>>| {
@@ -1982,7 +1978,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("aggregate_and_proofs"))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready.clone())
         .and(chain_filter.clone())
         .and(warp::body::json())
         .and(network_tx_filter.clone())
@@ -2083,7 +2078,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("contribution_and_proofs"))
         .and(warp::path::end())
         .and(not_while_syncing_filter.clone())
-        .and(only_while_el_is_ready)
         .and(chain_filter.clone())
         .and(warp::body::json())
         .and(network_tx_filter.clone())

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -663,7 +663,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     self.log,
                     "New block received";
                     "slot" => verified_block.block.slot(),
-                    "hash" => ?verified_block.block_root
+                    "root" => ?verified_block.block_root
                 );
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
 

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -726,8 +726,10 @@ impl<T: BeaconChainTypes> Worker<T> {
             | Err(e @ BlockError::TooManySkippedSlots { .. })
             | Err(e @ BlockError::WeakSubjectivityConflict)
             | Err(e @ BlockError::InconsistentFork(_))
-            // TODO: is this what we should be doing when block verification fails?
-            | Err(e @BlockError::ExecutionPayloadError(_))
+            // TODO(merge): reconsider peer scoring for this event.
+            | Err(e @ BlockError::ExecutionPayloadError(_))
+            // TODO(merge): reconsider peer scoring for this event.
+            | Err(e @ BlockError::ParentExecutionPayloadInvalid { .. })
             | Err(e @ BlockError::GenesisBlock) => {
                 warn!(self.log, "Could not verify block for gossip, rejecting the block";
                             "error" => %e);

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -2,8 +2,8 @@ mod fork_choice;
 mod fork_choice_store;
 
 pub use crate::fork_choice::{
-    Error, ForkChoice, InvalidAttestation, InvalidBlock, PersistedForkChoice, QueuedAttestation,
-    SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
+    Error, ForkChoice, InvalidAttestation, InvalidBlock, PayloadVerificationStatus,
+    PersistedForkChoice, QueuedAttestation, SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
 };
 pub use fork_choice_store::ForkChoiceStore;
 pub use proto_array::Block as ProtoBlock;

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -11,8 +11,8 @@ use beacon_chain::{
     StateSkipConfig, WhenSlotSkipped,
 };
 use fork_choice::{
-    ForkChoiceStore, InvalidAttestation, InvalidBlock, QueuedAttestation,
-    SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
+    ForkChoiceStore, InvalidAttestation, InvalidBlock, PayloadVerificationStatus,
+    QueuedAttestation, SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
 };
 use store::MemoryStore;
 use types::{
@@ -270,7 +270,13 @@ impl ForkChoiceTest {
             .chain
             .fork_choice
             .write()
-            .on_block(current_slot, &block, block.canonical_root(), &state)
+            .on_block(
+                current_slot,
+                &block,
+                block.canonical_root(),
+                &state,
+                PayloadVerificationStatus::Verified,
+            )
             .unwrap();
         self
     }
@@ -305,7 +311,13 @@ impl ForkChoiceTest {
             .chain
             .fork_choice
             .write()
-            .on_block(current_slot, &block, block.canonical_root(), &state)
+            .on_block(
+                current_slot,
+                &block,
+                block.canonical_root(),
+                &state,
+                PayloadVerificationStatus::Verified,
+            )
             .err()
             .expect("on_block did not return an error");
         comparison_func(err);

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -30,4 +30,8 @@ pub enum Error {
         head_justified_epoch: Epoch,
         head_finalized_epoch: Epoch,
     },
+    InvalidAncestorOfValidPayload {
+        ancestor_block_root: Hash256,
+        ancestor_payload_block_hash: Hash256,
+    },
 }

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -2,7 +2,7 @@ mod ffg_updates;
 mod no_votes;
 mod votes;
 
-use crate::proto_array_fork_choice::{Block, ProtoArrayForkChoice};
+use crate::proto_array_fork_choice::{Block, ExecutionStatus, ProtoArrayForkChoice};
 use serde_derive::{Deserialize, Serialize};
 use types::{AttestationShufflingId, Epoch, Hash256, Slot};
 
@@ -57,7 +57,7 @@ impl ForkChoiceTestDefinition {
     pub fn run(self) {
         let junk_shuffling_id =
             AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
-        let execution_block_hash = Hash256::zero();
+        let execution_status = ExecutionStatus::irrelevant();
         let mut fork_choice = ProtoArrayForkChoice::new(
             self.finalized_block_slot,
             Hash256::zero(),
@@ -66,7 +66,7 @@ impl ForkChoiceTestDefinition {
             self.finalized_root,
             junk_shuffling_id.clone(),
             junk_shuffling_id,
-            execution_block_hash,
+            execution_status,
         )
         .expect("should create fork choice struct");
 
@@ -141,7 +141,7 @@ impl ForkChoiceTestDefinition {
                         ),
                         justified_epoch,
                         finalized_epoch,
-                        execution_block_hash,
+                        execution_status,
                     };
                     fork_choice.process_block(block).unwrap_or_else(|e| {
                         panic!(

--- a/consensus/proto_array/src/lib.rs
+++ b/consensus/proto_array/src/lib.rs
@@ -4,7 +4,7 @@ mod proto_array;
 mod proto_array_fork_choice;
 mod ssz_container;
 
-pub use crate::proto_array_fork_choice::{Block, ProtoArrayForkChoice};
+pub use crate::proto_array_fork_choice::{Block, ExecutionStatus, ProtoArrayForkChoice};
 pub use error::Error;
 
 pub mod core {

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -16,15 +16,24 @@ pub struct VoteTracker {
     next_epoch: Epoch,
 }
 
+/// Represents the verification status of an execution payload.
 #[derive(Clone, Copy, Debug, PartialEq, Encode, Decode, Serialize, Deserialize)]
 #[ssz(enum_behaviour = "union")]
 pub enum ExecutionStatus {
+    /// An EL has determined that the payload is valid.
     Valid(Hash256),
+    /// An EL has determined that the payload is invalid.
     Invalid(Hash256),
+    /// An EL has not yet verified the execution payload.
     Unknown(Hash256),
-    // Note: this `bool` only exists to satisfy our SSZ implementation which requires all variants
-    // to have a value. It can be set to anything.
-    Irrelevant(bool),
+    /// The block is either prior to the merge fork, or after the merge fork but before the terminal
+    /// PoW block has been found.
+    ///
+    /// # Note:
+    ///
+    /// This `bool` only exists to satisfy our SSZ implementation which requires all variants
+    /// to have a value. It can be set to anything.
+    Irrelevant(bool), // TODO(merge): fix bool.
 }
 
 impl ExecutionStatus {

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use crate::proto_array::ProtoArray;
 use crate::ssz_container::{LegacySszContainer, SszContainer};
+use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::collections::HashMap;
@@ -13,6 +14,23 @@ pub struct VoteTracker {
     current_root: Hash256,
     next_root: Hash256,
     next_epoch: Epoch,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[ssz(enum_behaviour = "union")]
+pub enum ExecutionStatus {
+    Valid(Hash256),
+    Invalid(Hash256),
+    Unknown(Hash256),
+    // Note: this `bool` only exists to satisfy our SSZ implementation which requires all variants
+    // to have a value. It can be set to anything.
+    Irrelevant(bool),
+}
+
+impl ExecutionStatus {
+    pub fn irrelevant() -> Self {
+        ExecutionStatus::Irrelevant(false)
+    }
 }
 
 /// A block that is to be applied to the fork choice.
@@ -29,7 +47,9 @@ pub struct Block {
     pub next_epoch_shuffling_id: AttestationShufflingId,
     pub justified_epoch: Epoch,
     pub finalized_epoch: Epoch,
-    pub execution_block_hash: Hash256,
+    /// Indicates if an execution node has marked this block as valid. Also contains the execution
+    /// block hash.
+    pub execution_status: ExecutionStatus,
 }
 
 /// A Vec-wrapper which will grow to match any request.
@@ -76,7 +96,7 @@ impl ProtoArrayForkChoice {
         finalized_root: Hash256,
         current_epoch_shuffling_id: AttestationShufflingId,
         next_epoch_shuffling_id: AttestationShufflingId,
-        execution_block_hash: Hash256,
+        execution_status: ExecutionStatus,
     ) -> Result<Self, String> {
         let mut proto_array = ProtoArray {
             prune_threshold: DEFAULT_PRUNE_THRESHOLD,
@@ -98,7 +118,7 @@ impl ProtoArrayForkChoice {
             next_epoch_shuffling_id,
             justified_epoch,
             finalized_epoch,
-            execution_block_hash,
+            execution_status,
         };
 
         proto_array
@@ -208,7 +228,7 @@ impl ProtoArrayForkChoice {
             next_epoch_shuffling_id: block.next_epoch_shuffling_id.clone(),
             justified_epoch: block.justified_epoch,
             finalized_epoch: block.finalized_epoch,
-            execution_block_hash: block.execution_block_hash,
+            execution_status: block.execution_status,
         })
     }
 
@@ -372,7 +392,7 @@ mod test_compute_deltas {
         let unknown = Hash256::from_low_u64_be(4);
         let junk_shuffling_id =
             AttestationShufflingId::from_components(Epoch::new(0), Hash256::zero());
-        let execution_block_hash = Hash256::zero();
+        let execution_status = ExecutionStatus::irrelevant();
 
         let mut fc = ProtoArrayForkChoice::new(
             genesis_slot,
@@ -382,7 +402,7 @@ mod test_compute_deltas {
             finalized_root,
             junk_shuffling_id.clone(),
             junk_shuffling_id.clone(),
-            execution_block_hash,
+            execution_status,
         )
         .unwrap();
 
@@ -398,7 +418,7 @@ mod test_compute_deltas {
                 next_epoch_shuffling_id: junk_shuffling_id.clone(),
                 justified_epoch: genesis_epoch,
                 finalized_epoch: genesis_epoch,
-                execution_block_hash,
+                execution_status,
             })
             .unwrap();
 
@@ -414,7 +434,7 @@ mod test_compute_deltas {
                 next_epoch_shuffling_id: junk_shuffling_id,
                 justified_epoch: genesis_epoch,
                 finalized_epoch: genesis_epoch,
-                execution_block_hash,
+                execution_status,
             })
             .unwrap();
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Introduces what I have called "stage 1" of optimistic, post-merge Beacon Chain sync. The sync is "optimistic", since it will still sync the Beacon Chain even if the EL is still SYNCING. For background, these are are the three stages in my mind:

- **Stage 0: naive optimistic sync:** simply ignores any SYNCING status from the EL and hopes it catches up one day. Still attests to blocks even if we don't know if they're valid.
    - Implemented in the `merge-f2f` branch already.
- **Stage 1: stalling optimistic sync:** ignores any SYNCING status from the EL, however prevents attestations/sync-committee messages if the head execution payload has not been verified yet. If an invalid payload becomes the head, it's possible that the beacon chain stalls indefinitely.
    - Implemented here.
- **Stage 2: safe optimistic sync:** Introduces the idea of an "optimistic" head and a "safe" head. The optimistic head is simply the head of the Beacon Chain, assuming all execution payloads are valid. It allows the EL to keep getting fresh payloads so it can sync. The safe head is the Beacon Chain block tree, filtered to only contain blocks that have a valid execution payload. Blocks/attestations can be created which fork-out/conflict-with the optimistic head, allowing recovery from the scenario when there is an invalid payload as head. 
    - Not implemented yet.
    
### Detail

We add a new `execution_status` field to each block in our fork choice tree, which can be either `Valid | Invalid | Unknown`. When importing the block we try to verify the payload with the EL. If it returns `INVALID`, we drop the block and do not apply it to the fork choice tree. If it returns `VALID`, we import the block as `Valid` and mark all ancestors as `Valid` too. If it returns `SYNCING`, we mark the status as `Unknown`.

When we receive an attestation/sync-committee message from the API, we will return an error unless the head block is marked as `Valid`.

We also log some info each slot (via the `client::notifier`) which informs the user if their head block is verified or not.

### What this PR *does not* do

It doesn't actively go and try to resolve any "Unknown" status blocks. It just relies on new blocks coming and and being EL-verified in order to verify ancestor blocks. Such a routine is fairly complicated and I can't pull it off during the merge F2F. This means that it will probably never actually discover if any blocks it has already imported are invalid. It'll just leave them as unknown.

It also won't go back and check the TTD block if it has to skip it due to a syncing/unavailable EL. 

## Additional Info

I've modified the fork choice struct in this PR, which means it will be incompatible with the `merge-f2f` branch. You'll see this error when starting if your DB is compatible.

```
CRIT Failed to start beacon node             reason: Unable to load fork choice from disk: ForkChoiceError(InvalidProtoArrayBytes("Failed to decode ProtoArrayForkChoice: OffsetOutOfBounds(8193149)"))
```

Whilst there is a migration from the current `stable` version of the DB, I haven't bothered to eternally burden the code-base with a migration from the version of fork choice that existed temporarily in the `merge-f2f` branch.