### PR TITLE
remove keep alive events from events endpoint

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2505,7 +2505,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let s = futures::stream::select_all(receivers);
 
-                    Ok::<_, warp::Rejection>(warp::sse::reply(warp::sse::keep_alive().stream(s)))
+                    Ok::<_, warp::Rejection>(warp::sse::reply(s))
                 })
             },
         );


### PR DESCRIPTION
## Issue Addressed

Closes #2681

## Proposed Changes
We currently use warp's `keep_alive` method which sends heartbeat events, but because this isn't specified behavior, this PR removes it.

