### PR TITLE
[Merged by Bors] - Get arbitrary check passing (2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb833f0bf979d8475d38fbf09ed3b8a55e1885fe93ad3f93239fc6a4f17b98"
+checksum = "991984e3fd003e7ba02eb724f87a0f997b78677c46c0e91f8424ad7394c9886a"
 dependencies = [
  "getrandom 0.2.3",
  "once_cell",
@@ -156,18 +156,12 @@ checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
 
 [[package]]
 name = "arbitrary"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db55d72333851e17d572bec876e390cd3b11eb1ef53ae821dd9f3b653d2b4569"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
-name = "arbitrary"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577b08a4acd7b99869f863c50011b01eb73424ccc798ecd996f2e24817adfca7"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -597,12 +591,12 @@ dependencies = [
 name = "bls"
 version = "0.2.0"
 dependencies = [
- "arbitrary 0.4.7",
+ "arbitrary",
  "blst",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "hex",
  "milagro_bls",
  "rand 0.7.3",
@@ -614,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccca1872d592bb8cdf9a48fe8f0ca1695d543511745e3790091b1816549dc93a"
+checksum = "1f073f59a150a1dca74aab43d794ae5a7578d52bb1e73121e559f3ee3e6a837e"
 dependencies = [
  "cc",
  "glob",
@@ -743,7 +737,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "quickcheck",
  "quickcheck_macros",
  "smallvec",
@@ -889,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+checksum = "b7b858541263efe664aead4a5209a4ae5c5d2811167d4ed4ee0944503f8d2089"
 dependencies = [
  "cc",
 ]
@@ -922,11 +916,11 @@ dependencies = [
 
 [[package]]
 name = "console_error_panic_hook"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen",
 ]
 
@@ -1305,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "0.4.7"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a012b5e473dc912f0db0546a1c9c6a194ce8494feb66fa0237160926f9e0e6"
+checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,7 +1400,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "rand 0.8.4",
- "rlp 0.5.1",
+ "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2",
  "smallvec",
  "tokio",
@@ -1414,7 +1408,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uint 0.9.1",
+ "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize",
 ]
 
@@ -1480,7 +1474,7 @@ dependencies = [
  "derivative",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "fs2",
  "hex",
  "rayon",
@@ -1541,7 +1535,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.4",
- "rlp 0.5.1",
+ "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "sha3",
  "zeroize",
@@ -1845,7 +1839,7 @@ name = "eth2_ssz"
 version = "0.4.0"
 dependencies = [
  "eth2_ssz_derive",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "smallvec",
 ]
 
@@ -1863,7 +1857,7 @@ dependencies = [
 name = "eth2_ssz_types"
 version = "0.2.1"
 dependencies = [
- "arbitrary 0.4.7",
+ "arbitrary",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz",
  "serde",
@@ -1926,7 +1920,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
- "uint 0.9.1",
+ "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1938,7 +1932,19 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.6.1",
  "impl-rlp 0.2.1",
- "impl-serde",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 2.0.2",
+]
+
+[[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "crunchy",
+ "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
  "tiny-keccak 2.0.2",
 ]
 
@@ -1949,9 +1955,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp 0.3.0",
- "impl-serde",
+ "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 2.0.2",
 ]
 
@@ -1964,7 +1970,7 @@ dependencies = [
  "ethbloom 0.9.2",
  "fixed-hash 0.6.1",
  "impl-rlp 0.2.1",
- "impl-serde",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.7.3",
  "uint 0.8.5",
 ]
@@ -1976,11 +1982,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
  "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp 0.3.0",
- "impl-serde",
+ "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitive-types 0.9.1",
- "uint 0.9.1",
+ "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.12.0"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "ethbloom 0.11.0",
+ "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "primitive-types 0.10.1",
+ "uint 0.9.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
 ]
 
 [[package]]
@@ -2079,7 +2098,18 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
- "arbitrary 0.4.7",
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "arbitrary",
  "byteorder",
  "rand 0.8.4",
  "rustc-hex",
@@ -2788,6 +2818,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "parity-scale-codec 2.3.1",
+]
+
+[[package]]
 name = "impl-rlp"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,7 +2840,15 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.5.1",
+ "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "rlp 0.5.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
 ]
 
 [[package]]
@@ -2810,6 +2856,14 @@ name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
 dependencies = [
  "serde",
 ]
@@ -3255,7 +3309,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2",
  "smallvec",
- "uint 0.9.1",
+ "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unsigned-varint 0.7.0",
  "void",
  "wasm-timer",
@@ -3793,7 +3847,7 @@ name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
@@ -4040,7 +4094,7 @@ dependencies = [
  "matches",
  "num_cpus",
  "rand 0.7.3",
- "rlp 0.5.1",
+ "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog",
  "slog-async",
  "slog-term",
@@ -4547,7 +4601,7 @@ dependencies = [
  "fixed-hash 0.6.1",
  "impl-codec 0.4.2",
  "impl-rlp 0.2.1",
- "impl-serde",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.8.5",
 ]
 
@@ -4557,11 +4611,23 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp 0.3.0",
- "impl-serde",
- "uint 0.9.1",
+ "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-codec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-codec 0.5.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "uint 0.9.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
 ]
 
 [[package]]
@@ -4612,9 +4678,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "edc3358ebc67bc8b7fa0c007f945b0b18226f78437d61bec735a9eb96b61ee70"
 dependencies = [
  "unicode-xid",
 ]
@@ -5076,6 +5142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.1"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "bytes 1.1.0",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rpassword"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5466,9 +5541,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
@@ -5787,7 +5862,7 @@ dependencies = [
 name = "state_processing"
 version = "0.2.0"
 dependencies = [
- "arbitrary 0.4.7",
+ "arbitrary",
  "beacon_chain",
  "bls",
  "env_logger 0.9.0",
@@ -5906,7 +5981,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
 ]
 
 [[package]]
@@ -6389,7 +6464,7 @@ dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "rand 0.7.3",
  "smallvec",
  "tree_hash_derive",
@@ -6494,7 +6569,7 @@ checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 name = "types"
 version = "0.2.0"
 dependencies = [
- "arbitrary 0.4.7",
+ "arbitrary",
  "beacon_chain",
  "bls",
  "cached_tree_hash",
@@ -6508,7 +6583,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.11.0",
+ "ethereum-types 0.12.0",
  "hex",
  "int_to_bytes",
  "itertools",
@@ -6558,7 +6633,18 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
 dependencies = [
- "arbitrary 1.0.2",
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
+name = "uint"
+version = "0.9.1"
+source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+dependencies = [
+ "arbitrary",
  "byteorder",
  "crunchy",
  "hex",
@@ -7003,7 +7089,7 @@ dependencies = [
  "parking_lot",
  "pin-project 1.0.8",
  "reqwest",
- "rlp 0.5.1",
+ "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,7 @@ dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "hex",
  "milagro_bls",
  "rand 0.7.3",
@@ -737,7 +737,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "quickcheck",
  "quickcheck_macros",
  "smallvec",
@@ -1400,7 +1400,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "rand 0.8.4",
- "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.5.1",
  "sha2",
  "smallvec",
  "tokio",
@@ -1408,7 +1408,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.9.1",
  "zeroize",
 ]
 
@@ -1474,7 +1474,7 @@ dependencies = [
  "derivative",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "fs2",
  "hex",
  "rayon",
@@ -1535,7 +1535,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.4",
- "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.5.1",
  "serde",
  "sha3",
  "zeroize",
@@ -1839,7 +1839,7 @@ name = "eth2_ssz"
 version = "0.4.0"
 dependencies = [
  "eth2_ssz_derive",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "smallvec",
 ]
 
@@ -1920,7 +1920,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
- "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -1932,19 +1932,7 @@ dependencies = [
  "crunchy",
  "fixed-hash 0.6.1",
  "impl-rlp 0.2.1",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.11.0"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
-dependencies = [
- "crunchy",
- "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "impl-serde",
  "tiny-keccak 2.0.2",
 ]
 
@@ -1955,9 +1943,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
- "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
  "tiny-keccak 2.0.2",
 ]
 
@@ -1970,7 +1958,7 @@ dependencies = [
  "ethbloom 0.9.2",
  "fixed-hash 0.6.1",
  "impl-rlp 0.2.1",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde",
  "primitive-types 0.7.3",
  "uint 0.8.5",
 ]
@@ -1982,24 +1970,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
  "ethbloom 0.11.1",
- "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
  "primitive-types 0.9.1",
- "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.9.1",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.12.0"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom 0.11.0",
- "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "ethbloom 0.11.1",
+ "fixed-hash 0.7.0",
+ "impl-rlp 0.3.0",
+ "impl-serde",
  "primitive-types 0.10.1",
- "uint 0.9.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -2088,18 +2077,6 @@ checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
 dependencies = [
  "byteorder",
  "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.4",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2818,14 +2795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.5.1"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
-dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
 name = "impl-rlp"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,15 +2809,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.3.0"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
-dependencies = [
- "rlp 0.5.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "rlp 0.5.1",
 ]
 
 [[package]]
@@ -2856,14 +2817,6 @@ name = "impl-serde"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.1"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
 dependencies = [
  "serde",
 ]
@@ -3309,7 +3262,7 @@ dependencies = [
  "rand 0.7.3",
  "sha2",
  "smallvec",
- "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.9.1",
  "unsigned-varint 0.7.0",
  "void",
  "wasm-timer",
@@ -3847,7 +3800,7 @@ name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "lazy_static",
  "quickcheck",
  "quickcheck_macros",
@@ -4094,7 +4047,7 @@ dependencies = [
  "matches",
  "num_cpus",
  "rand 0.7.3",
- "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.5.1",
  "slog",
  "slog-async",
  "slog-term",
@@ -4601,7 +4554,7 @@ dependencies = [
  "fixed-hash 0.6.1",
  "impl-codec 0.4.2",
  "impl-rlp 0.2.1",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "impl-serde",
  "uint 0.8.5",
 ]
 
@@ -4611,23 +4564,24 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
- "fixed-hash 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-codec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-rlp 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "impl-serde 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uint 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.7.0",
+ "impl-codec 0.5.1",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "uint 0.9.1",
 ]
 
 [[package]]
 name = "primitive-types"
 version = "0.10.1"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
- "fixed-hash 0.7.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-codec 0.5.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-rlp 0.3.0 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "impl-serde 0.3.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
- "uint 0.9.1 (git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d)",
+ "fixed-hash 0.7.0",
+ "impl-codec 0.5.1",
+ "impl-rlp 0.3.0",
+ "impl-serde",
+ "uint 0.9.1",
 ]
 
 [[package]]
@@ -5136,15 +5090,6 @@ name = "rlp"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
-dependencies = [
- "bytes 1.1.0",
- "rustc-hex",
-]
-
-[[package]]
-name = "rlp"
-version = "0.5.1"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
 dependencies = [
  "bytes 1.1.0",
  "rustc-hex",
@@ -5981,7 +5926,7 @@ version = "0.2.0"
 dependencies = [
  "criterion",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
 ]
 
 [[package]]
@@ -6464,7 +6409,7 @@ dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "rand 0.7.3",
  "smallvec",
  "tree_hash_derive",
@@ -6583,7 +6528,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.12.0",
+ "ethereum-types 0.12.1",
  "hex",
  "int_to_bytes",
  "itertools",
@@ -6632,17 +6577,6 @@ name = "uint"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
-
-[[package]]
-name = "uint"
-version = "0.9.1"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
 dependencies = [
  "arbitrary",
  "byteorder",
@@ -7089,7 +7023,7 @@ dependencies = [
  "parking_lot",
  "pin-project 1.0.8",
  "reqwest",
- "rlp 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.5.1",
  "secp256k1",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,7 +2084,7 @@ dependencies = [
 [[package]]
 name = "fixed-hash"
 version = "0.7.0"
-source = "git+https://github.com/realbigsean/parity-common?rev=5b19b17e2c9acf339e445978b1ad8f56a5c7942d#5b19b17e2c9acf339e445978b1ad8f56a5c7942d"
+source = "git+https://github.com/paritytech/parity-common?rev=df638ab0885293d21d656dc300d39236b69ce57d#df638ab0885293d21d656dc300d39236b69ce57d"
 dependencies = [
  "arbitrary",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,4 @@ eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
-ethereum-types = { git = "https://github.com/realbigsean/parity-common", rev="5b19b17e2c9acf339e445978b1ad8f56a5c7942d" }
+fixed-hash = { git = "https://github.com/realbigsean/parity-common", rev="5b19b17e2c9acf339e445978b1ad8f56a5c7942d", features = ["arbitrary"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,4 @@ eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
+ethereum-types = { git = "https://github.com/realbigsean/parity-common", rev="5b19b17e2c9acf339e445978b1ad8f56a5c7942d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,4 @@ eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
-fixed-hash = { git = "https://github.com/realbigsean/parity-common", rev="5b19b17e2c9acf339e445978b1ad8f56a5c7942d", features = ["arbitrary"]}
+fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d", features = ["arbitrary"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,4 +90,4 @@ eth2_ssz_types = { path = "consensus/ssz_types" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
-fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d", features = ["arbitrary"]}
+fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d" }

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 eth2_ssz_types = "0.2.1"
 eth2_hashing = "0.2.0"
 eth2_ssz_derive = "0.3.0"

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 eth2_ssz_types = "0.2.1"
 eth2_hashing = "0.2.0"
 eth2_ssz_derive = "0.3.0"

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 eth2_hashing = "0.2.0"
 lazy_static = "1.4.0"
 safe_arith = { path = "../safe_arith" }

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 eth2_hashing = "0.2.0"
 lazy_static = "1.4.0"
 safe_arith = { path = "../safe_arith" }

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -13,7 +13,7 @@ name = "ssz"
 eth2_ssz_derive = "0.3.0"
 
 [dependencies]
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 smallvec = "1.6.1"
 
 [features]

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -13,7 +13,7 @@ name = "ssz"
 eth2_ssz_derive = "0.3.0"
 
 [dependencies]
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 smallvec = "1.6.1"
 
 [features]

--- a/consensus/ssz_types/Cargo.toml
+++ b/consensus/ssz_types/Cargo.toml
@@ -16,7 +16,7 @@ serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.0"
 eth2_ssz = "0.4.0"
 typenum = "1.12.0"
-arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.58"

--- a/consensus/ssz_types/src/bitfield.rs
+++ b/consensus/ssz_types/src/bitfield.rs
@@ -644,7 +644,7 @@ impl<N: Unsigned + Clone> tree_hash::TreeHash for Bitfield<Fixed<N>> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<N: 'static + Unsigned> arbitrary::Arbitrary for Bitfield<Fixed<N>> {
+impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Fixed<N>> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let size = N::to_usize();
         let mut vec: Vec<u8> = vec![0u8; size];
@@ -654,7 +654,7 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary for Bitfield<Fixed<N>> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<N: 'static + Unsigned> arbitrary::Arbitrary for Bitfield<Variable<N>> {
+impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Variable<N>> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let max_size = N::to_usize();
         let rand = usize::arbitrary(u)?;

--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -280,8 +280,10 @@ where
 }
 
 #[cfg(feature = "arbitrary")]
-impl<T: arbitrary::Arbitrary, N: 'static + Unsigned> arbitrary::Arbitrary for FixedVector<T, N> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+impl<'a, T: arbitrary::Arbitrary<'a>, N: 'static + Unsigned> arbitrary::Arbitrary<'a>
+    for FixedVector<T, N>
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let size = N::to_usize();
         let mut vec: Vec<T> = Vec::with_capacity(size);
         for _ in 0..size {

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -259,8 +259,10 @@ where
 }
 
 #[cfg(feature = "arbitrary")]
-impl<T: arbitrary::Arbitrary, N: 'static + Unsigned> arbitrary::Arbitrary for VariableList<T, N> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+impl<'a, T: arbitrary::Arbitrary<'a>, N: 'static + Unsigned> arbitrary::Arbitrary<'a>
+    for VariableList<T, N>
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let max_size = N::to_usize();
         let rand = usize::arbitrary(u)?;
         let size = std::cmp::min(rand, max_size);

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.4.1"
 eth2_hashing = "0.2.0"
 int_to_bytes = { path = "../int_to_bytes" }
 smallvec = "1.6.1"
-arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 lighthouse_metrics = { path = "../../common/lighthouse_metrics", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -13,7 +13,7 @@ criterion = "0.3.3"
 
 [dependencies]
 eth2_hashing = "0.2.0"
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -13,7 +13,7 @@ criterion = "0.3.3"
 
 [dependencies]
 eth2_hashing = "0.2.0"
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -15,7 +15,7 @@ eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 
 [dependencies]
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 eth2_hashing = "0.2.0"
 smallvec = "1.6.1"
 

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -15,7 +15,7 @@ eth2_ssz = "0.4.0"
 eth2_ssz_derive = "0.3.0"
 
 [dependencies]
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 eth2_hashing = "0.2.0"
 smallvec = "1.6.1"
 

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -13,7 +13,7 @@ bls = { path = "../../crypto/bls" }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 eth2_hashing = "0.2.0"
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -13,7 +13,7 @@ bls = { path = "../../crypto/bls" }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 eth2_hashing = "0.2.0"
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }
@@ -37,7 +37,7 @@ serde_yaml = "0.8.13"
 tempfile = "3.1.0"
 derivative = "2.1.1"
 rusqlite = { version = "0.25.3", features = ["bundled"], optional = true }
-arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 eth2_serde_utils = "0.1.0"
 regex = "1.3.9"
 lazy_static = "1.4.0"

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -327,7 +327,7 @@ pub fn get_active_validator_indices(validators: &[Validator], epoch: Epoch) -> V
 }
 
 #[cfg(feature = "arbitrary-fuzz")]
-impl arbitrary::Arbitrary for CommitteeCache {
+impl arbitrary::Arbitrary<'_> for CommitteeCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())
     }

--- a/consensus/types/src/beacon_state/exit_cache.rs
+++ b/consensus/types/src/beacon_state/exit_cache.rs
@@ -62,7 +62,7 @@ impl ExitCache {
 }
 
 #[cfg(feature = "arbitrary-fuzz")]
-impl arbitrary::Arbitrary for ExitCache {
+impl arbitrary::Arbitrary<'_> for ExitCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())
     }

--- a/consensus/types/src/beacon_state/pubkey_cache.rs
+++ b/consensus/types/src/beacon_state/pubkey_cache.rs
@@ -43,7 +43,7 @@ impl PubkeyCache {
 }
 
 #[cfg(feature = "arbitrary-fuzz")]
-impl arbitrary::Arbitrary for PubkeyCache {
+impl arbitrary::Arbitrary<'_> for PubkeyCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())
     }

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -589,7 +589,7 @@ impl OptionalTreeHashCacheInner {
 }
 
 #[cfg(feature = "arbitrary-fuzz")]
-impl<T: EthSpec> arbitrary::Arbitrary for BeaconTreeHashCache<T> {
+impl<T: EthSpec> arbitrary::Arbitrary<'_> for BeaconTreeHashCache<T> {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())
     }

--- a/consensus/types/src/pending_attestation.rs
+++ b/consensus/types/src/pending_attestation.rs
@@ -20,7 +20,7 @@ pub struct PendingAttestation<T: EthSpec> {
 }
 
 #[cfg(feature = "arbitrary-fuzz")]
-impl<T: EthSpec> arbitrary::Arbitrary for PendingAttestation<T> {
+impl<T: EthSpec> arbitrary::Arbitrary<'_> for PendingAttestation<T> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self {
             aggregation_bits: <BitList<T::MaxValidatorsPerCommittee>>::arbitrary(u)?,

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -14,7 +14,7 @@ serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.0"
 hex = "0.4.2"
 eth2_hashing = "0.2.0"
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 blst = "0.3.3"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -14,8 +14,8 @@ serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.0"
 hex = "0.4.2"
 eth2_hashing = "0.2.0"
-ethereum-types = "0.11.0"
-arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
+ethereum-types = "0.12.0"
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 blst = "0.3.3"
 

--- a/crypto/bls/src/generic_aggregate_signature.rs
+++ b/crypto/bls/src/generic_aggregate_signature.rs
@@ -307,7 +307,7 @@ where
 }
 
 #[cfg(feature = "arbitrary")]
-impl<Pub, AggPub, Sig, AggSig> arbitrary::Arbitrary
+impl<Pub, AggPub, Sig, AggSig> arbitrary::Arbitrary<'_>
     for GenericAggregateSignature<Pub, AggPub, Sig, AggSig>
 where
     Pub: 'static,

--- a/crypto/bls/src/generic_public_key.rs
+++ b/crypto/bls/src/generic_public_key.rs
@@ -125,6 +125,6 @@ impl<Pub: TPublicKey> fmt::Debug for GenericPublicKey<Pub> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<Pub: TPublicKey + 'static> arbitrary::Arbitrary for GenericPublicKey<Pub> {
+impl<Pub: TPublicKey + 'static> arbitrary::Arbitrary<'_> for GenericPublicKey<Pub> {
     impl_arbitrary!(PUBLIC_KEY_BYTES_LEN);
 }

--- a/crypto/bls/src/generic_public_key_bytes.rs
+++ b/crypto/bls/src/generic_public_key_bytes.rs
@@ -177,6 +177,6 @@ impl<Pub> fmt::Debug for GenericPublicKeyBytes<Pub> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<Pub: 'static> arbitrary::Arbitrary for GenericPublicKeyBytes<Pub> {
+impl<Pub: 'static> arbitrary::Arbitrary<'_> for GenericPublicKeyBytes<Pub> {
     impl_arbitrary!(PUBLIC_KEY_BYTES_LEN);
 }

--- a/crypto/bls/src/generic_signature.rs
+++ b/crypto/bls/src/generic_signature.rs
@@ -166,7 +166,7 @@ impl<PublicKey, T: TSignature<PublicKey>> fmt::Debug for GenericSignature<Public
 }
 
 #[cfg(feature = "arbitrary")]
-impl<PublicKey: 'static, T: TSignature<PublicKey> + 'static> arbitrary::Arbitrary
+impl<PublicKey: 'static, T: TSignature<PublicKey> + 'static> arbitrary::Arbitrary<'_>
     for GenericSignature<PublicKey, T>
 {
     impl_arbitrary!(SIGNATURE_BYTES_LEN);

--- a/crypto/bls/src/generic_signature_bytes.rs
+++ b/crypto/bls/src/generic_signature_bytes.rs
@@ -145,6 +145,6 @@ impl<Pub, Sig> fmt::Debug for GenericSignatureBytes<Pub, Sig> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<Pub: 'static, Sig: 'static> arbitrary::Arbitrary for GenericSignatureBytes<Pub, Sig> {
+impl<Pub: 'static, Sig: 'static> arbitrary::Arbitrary<'_> for GenericSignatureBytes<Pub, Sig> {
     impl_arbitrary!(SIGNATURE_BYTES_LEN);
 }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -15,7 +15,7 @@ bls = { path = "../../crypto/bls", default-features = false }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 derivative = "2.1.1"
-ethereum-types = "0.11.0"
+ethereum-types = "0.12.0"
 hex = "0.4.2"
 rayon = "1.4.1"
 serde = "1.0.116"

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -15,7 +15,7 @@ bls = { path = "../../crypto/bls", default-features = false }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 derivative = "2.1.1"
-ethereum-types = "0.12.0"
+ethereum-types = "0.12.1"
 hex = "0.4.2"
 rayon = "1.4.1"
 serde = "1.0.116"


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This is a wholesale rip-off of #2708, see that PR for more of a description.

I've made this PR since @realbigsean is offline and I can't merge his PR due to Github's frustrating `target-branch-check` bug. I also changed the branch to `unstable`, since I'm trying to minimize the diff between `merge-f2f`/`unstable`. I'll just rebase `merge-f2f` onto `unstable` after this PR merges.

When running `make lint` I noticed the following warning:

```
warning: patch for `fixed-hash` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
```

So, I removed the `features` section from the patch.

## Additional Info

NA
