### PR TITLE
[Merged by Bors] - Update to consensus-spec-tests v1.1.3

### DIFF
--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -48,6 +48,8 @@ pub fn initialize_beacon_state_from_eth1<T: EthSpec>(
     // https://github.com/ethereum/eth2.0-specs/pull/2323
     if spec.fork_name_at_epoch(state.current_epoch()) == ForkName::Altair {
         upgrade_to_altair(&mut state, spec)?;
+
+        state.fork_mut().previous_version = spec.altair_fork_version;
     }
 
     // Now that we have our validators, initialize the caches (including the committees)

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.0-beta.4
+TESTS_TAG := v1.1.3
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -44,7 +44,8 @@ excluded_paths = [
     "tests/mainnet/altair/fork_choice",
     "tests/minimal/altair/fork_choice",
     # Merkle-proof tests for light clients
-    "tests/mainnet/altair/merkle/single_proof/pyspec_tests/"
+    "tests/mainnet/altair/merkle/single_proof/pyspec_tests/",
+    "tests/minimal/altair/merkle/single_proof/pyspec_tests/"
 ]
 
 def normalize_path(path):

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -43,6 +43,8 @@ excluded_paths = [
     "tests/minimal/phase0/fork_choice",
     "tests/mainnet/altair/fork_choice",
     "tests/minimal/altair/fork_choice",
+    # Merkle-proof tests for light clients
+    "tests/mainnet/altair/merkle/single_proof/pyspec_tests/"
 ]
 
 def normalize_path(path):


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Updates to `testing/ef_tests` to use https://github.com/ethereum/consensus-spec-tests/releases/tag/v1.1.3.

Also updates `initialize_beacon_state_from_eth1` to set the `state.fork.previous_version` to the Altair fork version when starting a new Altair chain from genesis. This will not have an effect on mainnet or any long-lived testnets. This was introduced in https://github.com/ethereum/consensus-specs/releases/tag/v1.1.1.

## Additional Info

NA
