### PR TITLE
[Merged by Bors] - Resolve Rust 1.56 lints and warnings

### DIFF
--- a/beacon_node/store/src/chunked_vector.rs
+++ b/beacon_node/store/src/chunked_vector.rs
@@ -150,11 +150,7 @@ pub trait Field<E: EthSpec>: Copy {
 
                 new_chunk.values[i] = vector_value;
             } else {
-                new_chunk.values[i] = existing_chunk
-                    .values
-                    .get(i)
-                    .cloned()
-                    .unwrap_or_else(Self::Value::default);
+                new_chunk.values[i] = existing_chunk.values.get(i).cloned().unwrap_or_default();
             }
         }
 
@@ -407,7 +403,7 @@ where
         let chunk_key = &chunk_key(chunk_index)[..];
 
         let existing_chunk =
-            Chunk::<F::Value>::load(store, F::column(), chunk_key)?.unwrap_or_else(Chunk::default);
+            Chunk::<F::Value>::load(store, F::column(), chunk_key)?.unwrap_or_default();
 
         let new_chunk = F::get_updated_chunk(
             &existing_chunk,

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -178,7 +178,7 @@ impl Eth2NetworkConfig {
                     .and_then(|file| {
                         serde_yaml::from_reader(file)
                             .map_err(|e| format!("Unable to parse {}: {:?}", $file, e))
-                    })?;
+                    })?
             };
         }
 

--- a/testing/simulator/src/cli.rs
+++ b/testing/simulator/src/cli.rs
@@ -13,7 +13,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     simulation using a local `ganache-cli` instance (you must have `ganache-cli` \
                     installed and avaliable on your path). All beacon nodes independently listen \
                     for genesis from the deposit contract, then start operating. \
-
+                    \
                     As the simulation runs, there are checks made to ensure that all components \
                     are running correctly. If any of these checks fail, the simulation will \
                     exit immediately.",


### PR DESCRIPTION
## Issue Addressed

When compiling with Rust 1.56.0 the compiler generates 3 instances of this warning:

```
warning: trailing semicolon in macro used in expression position
   --> common/eth2_network_config/src/lib.rs:181:24
    |
181 |                     })?;
    |                        ^
...
195 |         let deposit_contract_deploy_block = load_from_file!(DEPLOY_BLOCK_FILE);
    |                                             ---------------------------------- in this macro invocation
    |
    = note: `#[warn(semicolon_in_expressions_from_macros)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
    = note: this warning originates in the macro `load_from_file` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This warning is completely harmless, but will be visible to users compiling Lighthouse v2.0.1 (or earlier) with Rust 1.56.0 (to be released October 21st). It is **completely safe** to ignore this warning, it's just a superficial change to Rust's syntax.

## Proposed Changes

This PR removes the semi-colon as recommended, and fixes the new Clippy lints from 1.56.0
