### PR TITLE
Peer manager peer tracking experiment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2 0.4.2",
+ "waker-fn",
+ "winapi",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a8ea61bf9947a1007c5cada31e647dbc77b103c679858150003ba697ea798b"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8056f1455169ab86dd47b47391e4ab0cbd25410a70e9fe675544f49bafaf952"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite 0.2.7",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-std-resolver"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4e2c3da14d8ad45acb1e3191db7a918e9505b6f155b218e70a7c9a1a48c638"
+dependencies = [
+ "async-std",
+ "async-trait",
+ "futures-io",
+ "futures-util",
+ "pin-utils",
+ "trust-dns-resolver",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
 name = "async-trait"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +350,12 @@ checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
 dependencies = [
  "autocfg 1.0.1",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "attohttpc"
@@ -443,6 +574,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "bls"
 version = "0.2.0"
 dependencies = [
@@ -571,6 +716,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cached_tree_hash"
@@ -746,6 +897,15 @@ version = "0.2.0"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -939,6 +1099,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1752,6 +1922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
 name = "exit-future"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1954,15 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "ff"
@@ -1972,6 +2157,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.7",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2332,19 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "group"
@@ -2471,6 +2684,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-watch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8ab7f67bad3240049cb24fb9cb0b4c2c6af4c245840917fbbdededeee91179"
+dependencies = [
+ "async-io",
+ "futures",
+ "futures-lite",
+ "if-addrs",
+ "ipnet",
+ "libc",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "igd"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2659,6 +2888,15 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2859,6 +3097,7 @@ version = "0.30.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3756d04f91224c95ca24d2894e6b180f5465f1ed0f03d070f77bfd74c527b9"
 dependencies = [
+ "async-std-resolver",
  "futures",
  "libp2p-core 0.30.0-rc.2",
  "log",
@@ -2993,9 +3232,11 @@ version = "0.30.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0431b74198d05004a706b78fd5f7d217d15fbacd2b8e4d116ade24d5510992b3"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-addrs",
+ "if-watch",
  "ipnet",
  "libc",
  "libp2p-core 0.30.0-rc.2",
@@ -3317,6 +3558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+ "value-bag",
 ]
 
 [[package]]
@@ -3930,6 +4172,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4119,6 +4367,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521fa9638fa597e1dc53e9412a4f9cefb01187ee1f7413076f9e6749e2885ba9"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92341d779fa34ea8437ef4d82d440d5e1ce3f3ff7f824aa64424cd481f9a1f25"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi",
 ]
 
 [[package]]
@@ -6430,6 +6691,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79923f7731dc61ebfba3633098bf3ac533bbd35ccd8c57e7088d9a5eebe0263f"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6452,6 +6723,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -6735,6 +7012,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabe153544e473b775453675851ecc86863d2a81d786d741f6b76778f2a48940"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -49,6 +49,7 @@ slog-term = "2.6.0"
 slog-async = "2.5.0"
 tempfile = "3.1.0"
 exit-future = "0.2.0"
+libp2p = { version = "0.40.0-rc.3", default-features = false, features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "tcp-async-io", "dns-async-std"] }
 
 [features]
 libp2p-websocket = []

--- a/beacon_node/lighthouse_network/tests/common/behaviours.rs
+++ b/beacon_node/lighthouse_network/tests/common/behaviours.rs
@@ -1,7 +1,3 @@
-//! Test the PeerManager's NetworkBehaviour implementation. This attempts to isolate problems in
-//! the peer_manager's impl vs external calls done to the peer manager by other components.
-//! It also attempts to test the peer_manager's ability to maintain consistency with the swarm in the
-//! presence of another behaviour.
 use std::collections::{HashMap, VecDeque};
 
 use futures::task::{Context, Poll};
@@ -13,6 +9,7 @@ use libp2p::PeerId;
 use lighthouse_network::{ConnectedPoint, Multiaddr};
 
 pub use libp2p::swarm::NetworkBehaviourAction as NBAction;
+
 /// Calls the swarm makes to the Behaviour.
 #[derive(PartialEq, Eq, Hash, Debug)]
 pub enum MethodCall {
@@ -65,7 +62,9 @@ impl NetworkBehaviour for PuppetBehaviour {
     /* Required members */
 
     fn new_handler(&mut self) -> Self::ProtocolsHandler {
-        DummyProtocolsHandler::default()
+        DummyProtocolsHandler {
+            keep_alive: libp2p::swarm::KeepAlive::Yes,
+        }
     }
 
     fn inject_event(

--- a/beacon_node/lighthouse_network/tests/common/behaviours.rs
+++ b/beacon_node/lighthouse_network/tests/common/behaviours.rs
@@ -1,0 +1,191 @@
+//! Test the PeerManager's NetworkBehaviour implementation. This attempts to isolate problems in
+//! the peer_manager's impl vs external calls done to the peer manager by other components.
+//! It also attempts to test the peer_manager's ability to maintain consistency with the swarm in the
+//! presence of another behaviour.
+use std::collections::{HashMap, VecDeque};
+
+use futures::task::{Context, Poll};
+use futures::StreamExt;
+use libp2p::core::connection::{ConnectionId, ListenerId};
+use libp2p::swarm::protocols_handler::{DummyProtocolsHandler, ProtocolsHandler};
+use libp2p::swarm::{DialError, NetworkBehaviour, PollParameters, SwarmEvent};
+use libp2p::PeerId;
+use lighthouse_network::{ConnectedPoint, Multiaddr};
+
+pub use libp2p::swarm::NetworkBehaviourAction as NBAction;
+/// Calls the swarm makes to the Behaviour.
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub enum MethodCall {
+    AddressesOfPeer,
+    InjectConnected,
+    InjectDisconnected,
+    InjectConnectionEstablished,
+    InjectConnectionClosed,
+    InjectAddressChange,
+    InjectListenFailure,
+    InjectDialFailure,
+    InjectNewListener,
+    InjectNewListenAddr,
+    InjectExpiredListenAddr,
+    InjectListenerError,
+    InjectListenerClosed,
+    InjectNewExternalAddr,
+    InjectExpiredExternalAddr,
+}
+
+pub type PuppetEvent = NBAction<(), DummyProtocolsHandler>;
+
+/// Behaviour used to generate events for the swarm.
+#[derive(Default)]
+pub struct PuppetBehaviour {
+    events: VecDeque<PuppetEvent>,
+    // Number of times the swarm functions have been called. This is useful for debugging.
+    call_counts: HashMap<MethodCall, usize>,
+}
+
+impl PuppetBehaviour {
+    pub fn queue_event(&mut self, ev: PuppetEvent) {
+        self.events.push_back(ev)
+    }
+
+    pub fn calls(&self) -> &HashMap<MethodCall, usize> {
+        &self.call_counts
+    }
+
+    fn register_call(&mut self, call: MethodCall) {
+        *self.call_counts.entry(call).or_default() += 1;
+    }
+}
+
+impl NetworkBehaviour for PuppetBehaviour {
+    type ProtocolsHandler = DummyProtocolsHandler;
+
+    type OutEvent = ();
+
+    /* Required members */
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        DummyProtocolsHandler::default()
+    }
+
+    fn inject_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection: ConnectionId,
+        _event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
+    ) {
+        unreachable!("Dummy handler produces no events")
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _params: &mut impl PollParameters,
+    ) -> Poll<NBAction<Self::OutEvent, Self::ProtocolsHandler>> {
+        self.events.pop_front().map_or(Poll::Pending, Poll::Ready)
+    }
+
+    /* Overwritten default trait members */
+
+    fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+        self.register_call(MethodCall::AddressesOfPeer);
+        vec![]
+    }
+
+    fn inject_connected(&mut self, _: &PeerId) {
+        self.register_call(MethodCall::InjectConnected)
+    }
+
+    fn inject_disconnected(&mut self, _: &PeerId) {
+        self.register_call(MethodCall::InjectDisconnected)
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        _peer_id: &PeerId,
+        _connection_id: &ConnectionId,
+        _endpoint: &ConnectedPoint,
+        _failed_addresses: Option<&Vec<Multiaddr>>,
+    ) {
+        self.register_call(MethodCall::InjectConnectionEstablished)
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        _: &PeerId,
+        _: &ConnectionId,
+        _: &ConnectedPoint,
+        _: Self::ProtocolsHandler,
+    ) {
+        self.register_call(MethodCall::InjectConnectionClosed)
+    }
+
+    fn inject_address_change(
+        &mut self,
+        _: &PeerId,
+        _: &ConnectionId,
+        _old: &ConnectedPoint,
+        _new: &ConnectedPoint,
+    ) {
+        self.register_call(MethodCall::InjectAddressChange)
+    }
+
+    fn inject_dial_failure(
+        &mut self,
+        _peer_id: Option<PeerId>,
+        _handler: Self::ProtocolsHandler,
+        _error: &DialError,
+    ) {
+        self.register_call(MethodCall::InjectDialFailure)
+    }
+
+    fn inject_listen_failure(
+        &mut self,
+        _local_addr: &Multiaddr,
+        _send_back_addr: &Multiaddr,
+        _handler: Self::ProtocolsHandler,
+    ) {
+        self.register_call(MethodCall::InjectListenFailure)
+    }
+
+    fn inject_new_listener(&mut self, _id: ListenerId) {
+        self.register_call(MethodCall::InjectNewListener)
+    }
+
+    fn inject_new_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {
+        self.register_call(MethodCall::InjectNewListenAddr)
+    }
+
+    fn inject_expired_listen_addr(&mut self, _id: ListenerId, _addr: &Multiaddr) {
+        self.register_call(MethodCall::InjectExpiredListenAddr)
+    }
+
+    fn inject_listener_error(&mut self, _id: ListenerId, _err: &(dyn std::error::Error + 'static)) {
+        self.register_call(MethodCall::InjectListenerError)
+    }
+
+    fn inject_listener_closed(&mut self, _id: ListenerId, _reason: Result<(), &std::io::Error>) {
+        self.register_call(MethodCall::InjectListenerClosed)
+    }
+
+    fn inject_new_external_addr(&mut self, _addr: &Multiaddr) {
+        self.register_call(MethodCall::InjectNewExternalAddr)
+    }
+
+    fn inject_expired_external_addr(&mut self, _addr: &Multiaddr) {
+        self.register_call(MethodCall::InjectExpiredExternalAddr)
+    }
+}
+
+/// Bind this swarm to a random listener. This must be called before any other interaction with the
+/// swarm.
+pub async fn bind_listener<T: libp2p::swarm::NetworkBehaviour>(
+    swarm: &mut libp2p::Swarm<T>,
+) -> Multiaddr {
+    swarm.listen_on(crate::common::local_multiaddr()).unwrap();
+
+    match swarm.select_next_some().await {
+        SwarmEvent::NewListenAddr { address, .. } => address,
+        _ => unreachable!(),
+    }
+}

--- a/beacon_node/lighthouse_network/tests/common/mod.rs
+++ b/beacon_node/lighthouse_network/tests/common/mod.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 use tokio::runtime::Runtime;
 use types::{ChainSpec, EnrForkId, EthSpec, ForkContext, Hash256, MinimalEthSpec};
 
+pub mod behaviours;
+
 type E = MinimalEthSpec;
 use tempfile::Builder as TempBuilder;
 
@@ -237,4 +239,12 @@ pub async fn build_linear(rt: Weak<Runtime>, log: slog::Logger, n: usize) -> Vec
         };
     }
     nodes
+}
+
+pub fn local_multiaddr() -> Multiaddr {
+    let ip_addr: std::net::IpAddr = "127.0.0.1".parse().unwrap();
+    let port = unused_port("tcp").expect("gets a port");
+    let mut m = Multiaddr::from(ip_addr);
+    m.push(lighthouse_network::multiaddr::Protocol::Tcp(port));
+    m
 }

--- a/beacon_node/lighthouse_network/tests/connection_tracking.rs
+++ b/beacon_node/lighthouse_network/tests/connection_tracking.rs
@@ -1,16 +1,20 @@
 mod common;
 
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::task::Poll;
+use std::time::Instant;
 
 use common::behaviours::{MethodCall, PuppetBehaviour, PuppetEvent};
 use futures::StreamExt;
+use libp2p::core::connection::{ConnectedPoint, ConnectionId};
 use libp2p::swarm::protocols_handler::DummyProtocolsHandler;
-use libp2p::swarm::{DialPeerCondition, DummyBehaviour, SwarmEvent};
-use libp2p::swarm::{NetworkBehaviourAction as NBAction, Swarm};
-use libp2p::{development_transport, NetworkBehaviour, PeerId};
-use lighthouse_network::{Multiaddr, NetworkGlobals};
-use slog::{debug, info, o};
+use libp2p::swarm::{DialError, DummyBehaviour};
+use libp2p::swarm::{
+    NetworkBehaviour, NetworkBehaviourAction as NBAction, ProtocolsHandler, Swarm,
+};
+use libp2p::{development_transport, Multiaddr, NetworkBehaviour, PeerId};
+use slog::{debug, o};
 use tokio;
 
 #[derive(Debug)]
@@ -19,11 +23,230 @@ struct Event(());
 #[derive(NetworkBehaviour)]
 #[behaviour(event_process = false, out_event = "Event")]
 struct Behaviour {
-    /// Behaviour used to fake other sibling behaviour's "calls" to the swarm. It also registeres
+    /// Behaviour used to fake other sibling behaviour's "calls" to the swarm. It also registers
     /// calls from the swarm to the behaviour.
     pub puppet: PuppetBehaviour,
     // pub peer_manager: PeerManager<E>,
 }
+
+/* Connection tracker implementation */
+
+enum ConnectionStatus {
+    Connected {
+        connections: HashMap<ConnectionId, (ConnectedPoint, Instant)>,
+        disconnections: HashSet<ConnectionId>,
+    },
+    Disconnected {
+        since: Instant,
+    },
+}
+
+struct PeerInfo {
+    connection_status: ConnectionStatus,
+    dialing_attempts: u16,
+}
+
+struct ConnTracker {
+    peers: HashMap<PeerId, PeerInfo>,
+}
+
+impl NetworkBehaviour for ConnTracker {
+    type ProtocolsHandler = DummyProtocolsHandler;
+
+    type OutEvent = ();
+
+    fn addresses_of_peer(&mut self, _: &PeerId) -> Vec<Multiaddr> {
+        vec![]
+    }
+
+    fn inject_connected(&mut self, peer_id: &PeerId) {
+        // This is the first time the peer connects to us. Thus the peer must be either new or be
+        // disconnected. Check this. The connection will be registered in
+        // `inject_connection_established`.
+        if let Some(info) = self.peers.get(peer_id) {
+            assert!(matches!(
+                info.connection_status,
+                ConnectionStatus::Disconnected { .. }
+            ))
+        }
+    }
+
+    fn inject_disconnected(&mut self, peer_id: &PeerId) {
+        // This is the last connection to this peer. Check that the peer exists, is connected, and
+        // has only one active connection. The disconnection will be registered in
+        // `inject_connection_closed`.
+        let info = self.peers.get(peer_id).expect("Peer exists");
+        match &info.connection_status {
+            ConnectionStatus::Connected {
+                connections,
+                disconnections: _,
+            } => {
+                assert_eq!(
+                    connections.len(),
+                    1,
+                    "Disconnected notification must be for peer with only one connection"
+                )
+            }
+            ConnectionStatus::Disconnected { since } => {
+                panic!("Peer was already disconnected. Since: {:?}", since)
+            }
+        }
+    }
+
+    fn inject_connection_established(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+        _failed_addresses: Option<&Vec<Multiaddr>>,
+    ) {
+        match self.peers.entry(*peer_id) {
+            Entry::Occupied(mut entry) => {
+                let info = entry.get_mut();
+                if matches!(endpoint, ConnectedPoint::Dialer { .. }) {
+                    // Another behaviour could have dialed this peer via a multiaddr, and we
+                    // wouldn't be aware of the dialing attempt for this peer.
+                    info.dialing_attempts = info.dialing_attempts.saturating_sub(1);
+                    // About this subtraction. The successful dialing attempts must be always
+                    // more than the registered/known dialing attempts.
+                }
+                // now register the connection.
+                match &mut info.connection_status {
+                    ConnectionStatus::Connected {
+                        connections,
+                        disconnections: _,
+                    } => {
+                        assert!(
+                            connections
+                                .insert(connection_id.clone(), (endpoint.clone(), Instant::now()))
+                                .is_none(),
+                            "inject_connection_established is called only once per ConnectionId"
+                        );
+                    }
+                    ConnectionStatus::Disconnected { since: _ } => {
+                        // register the connection
+                        let mut connections = HashMap::with_capacity(1);
+                        connections
+                            .insert(connection_id.clone(), (endpoint.clone(), Instant::now()));
+                        let disconnections = HashSet::new();
+                        info.connection_status = ConnectionStatus::Connected {
+                            connections,
+                            disconnections,
+                        };
+                    }
+                }
+            }
+            Entry::Vacant(entry) => {
+                // Peer is new
+                let mut connections = HashMap::with_capacity(1);
+                connections.insert(connection_id.clone(), (endpoint.clone(), Instant::now()));
+                let disconnections = HashSet::new();
+                entry.insert(PeerInfo {
+                    connection_status: ConnectionStatus::Connected {
+                        connections,
+                        disconnections,
+                    },
+                    dialing_attempts: 0,
+                });
+            }
+        }
+    }
+
+    fn inject_connection_closed(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        endpoint: &ConnectedPoint,
+        _handler: Self::ProtocolsHandler,
+    ) {
+        let info = self.peers.get_mut(peer_id).expect("Peer exists.");
+        match &mut info.connection_status {
+            ConnectionStatus::Connected {
+                connections,
+                disconnections,
+            } => {
+                // If we disconnect because we asked it, remove this disconnection attempt.
+                disconnections.remove(connection_id);
+                let (old_endpoint, _connection_instant) = connections
+                    .remove(connection_id)
+                    .expect("Closed connection was registered.");
+                assert_eq!(endpoint, &old_endpoint);
+                if connections.is_empty() {
+                    info.connection_status = ConnectionStatus::Disconnected {
+                        since: Instant::now(),
+                    };
+                }
+            }
+            ConnectionStatus::Disconnected { since } => panic!(
+                "Connection closed for a peer disconnected since {:?}",
+                since
+            ),
+        }
+    }
+
+    fn inject_address_change(
+        &mut self,
+        peer_id: &PeerId,
+        connection_id: &ConnectionId,
+        old: &ConnectedPoint,
+        new: &ConnectedPoint,
+    ) {
+        let info = self.peers.get_mut(peer_id).expect("Peer exists.");
+        match &mut info.connection_status {
+            ConnectionStatus::Connected {
+                connections,
+                disconnections: _,
+            } => match connections.entry(*connection_id) {
+                Entry::Occupied(mut entry) => {
+                    let (old_registered, _) = entry.get_mut();
+                    assert_eq!(old_registered, old);
+                    *old_registered = new.clone();
+                }
+                Entry::Vacant(_) => panic!("Address change for connection not registered."),
+            },
+            ConnectionStatus::Disconnected { since } => {
+                panic!("Address change for a peer disconnected since {:?}", since)
+            }
+        }
+    }
+
+    fn inject_dial_failure(
+        &mut self,
+        peer_id: Option<PeerId>,
+        _handler: Self::ProtocolsHandler,
+        _error: &DialError,
+    ) {
+        if let Some(peer_id) = peer_id {
+            // This was an explicit dial to a peer. We should have it registered.
+            let info = self.peers.get_mut(&peer_id).expect("Peer exists.");
+            assert!(info.dialing_attempts > 0);
+            info.dialing_attempts -= 1;
+        }
+    }
+
+    fn new_handler(&mut self) -> Self::ProtocolsHandler {
+        DummyProtocolsHandler::default()
+    }
+
+    fn inject_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection: ConnectionId,
+        _event: <Self::ProtocolsHandler as ProtocolsHandler>::OutEvent,
+    ) {
+        unreachable!("No events from dummy handler.")
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+        _params: &mut impl lighthouse_network::discovery::PollParameters,
+    ) -> Poll<NBAction<Self::OutEvent, Self::ProtocolsHandler>> {
+        Poll::Pending
+    }
+}
+
+/* utilities */
 
 // Simply to make some code shorter
 struct Node {
@@ -62,7 +285,7 @@ impl From<()> for Event {
     }
 }
 
-async fn build_swarm(log: slog::Logger) -> Node {
+async fn build_swarm(_log: slog::Logger) -> Node {
     let local_key = libp2p::identity::Keypair::generate_secp256k1();
     let local_peer_id = PeerId::from(local_key.public());
 

--- a/beacon_node/lighthouse_network/tests/connection_tracking.rs
+++ b/beacon_node/lighthouse_network/tests/connection_tracking.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 
 use common::behaviours::{MethodCall, PuppetBehaviour, PuppetEvent};
 use futures::StreamExt;
+use libp2p::swarm::protocols_handler::DummyProtocolsHandler;
 use libp2p::swarm::{DialPeerCondition, DummyBehaviour, SwarmEvent};
 use libp2p::swarm::{NetworkBehaviourAction as NBAction, Swarm};
-use libp2p::{tokio_development_transport, NetworkBehaviour, PeerId};
+use libp2p::{development_transport, NetworkBehaviour, PeerId};
 use lighthouse_network::{Multiaddr, NetworkGlobals};
 use slog::{debug, info, o};
 use tokio;
-use types::MinimalEthSpec as E;
 
 #[derive(Debug)]
 struct Event(());
@@ -62,5 +62,71 @@ impl From<()> for Event {
     }
 }
 
+async fn build_swarm(log: slog::Logger) -> Node {
+    let local_key = libp2p::identity::Keypair::generate_secp256k1();
+    let local_peer_id = PeerId::from(local_key.public());
 
+    // Build the swarm
+    let swarm = {
+        let transport = development_transport(local_key)
+            .await
+            .expect("builds dev transport");
 
+        let behaviour = Behaviour {
+            puppet: Default::default(),
+            // peer_manager,
+        };
+        Swarm::new(transport, behaviour, local_peer_id)
+    };
+    Node { swarm }
+}
+
+async fn build_dummy_swarm() -> Swarm<DummyBehaviour> {
+    let local_key = libp2p::identity::Keypair::generate_secp256k1();
+    let local_peer_id = PeerId::from(local_key.public());
+    let transport = development_transport(local_key)
+        .await
+        .expect("builds dev transport");
+    let behaviour = DummyBehaviour::with_keep_alive(libp2p::swarm::KeepAlive::Yes);
+    Swarm::new(transport, behaviour, local_peer_id)
+}
+
+#[tokio::test]
+async fn peer_manager_dial() {
+    let log = common::build_log(slog::Level::Trace, true);
+
+    // Build the peer manager node and bind a listener
+    // let (mut node, globals) =
+    // build_swarm(log.new(o!("node" => "peer_manager")), Config::default()).await;
+    let mut node = build_swarm(log.new(o!("node" => "puppet"))).await;
+    let _our_addr = common::behaviours::bind_listener(&mut node).await;
+
+    // Build the dummy swarm and bind a listener
+    let mut dummy = build_dummy_swarm().await;
+    let dummy_addr = common::behaviours::bind_listener(&mut dummy).await;
+
+    // Dial dummy from a sibling behaviour
+    node.queue_event(NBAction::DialAddress {
+        address: dummy_addr,
+        handler: DummyProtocolsHandler {
+            keep_alive: libp2p::swarm::KeepAlive::Yes,
+        },
+    });
+    debug!(log, "running loop");
+    loop {
+        tokio::select! {
+            ev = node.select_next_some() => {
+                debug!(log, "Swarm event"; "ev" => ?ev);
+            }
+            ev = dummy.select_next_some() => {
+                debug!(log, "Dummy swarm event"; "ev" => ?ev);
+            }
+            _ = tokio::time::sleep(tokio::time::Duration::from_secs(20)) => {
+                // TODO: No way for the behaviour to know about this change.
+                debug!(log, "Method calls"; "calls" => ?node.calls());
+                return;
+            }
+
+        }
+    }
+}

--- a/beacon_node/lighthouse_network/tests/connection_tracking.rs
+++ b/beacon_node/lighthouse_network/tests/connection_tracking.rs
@@ -1,0 +1,66 @@
+mod common;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use common::behaviours::{MethodCall, PuppetBehaviour, PuppetEvent};
+use futures::StreamExt;
+use libp2p::swarm::{DialPeerCondition, DummyBehaviour, SwarmEvent};
+use libp2p::swarm::{NetworkBehaviourAction as NBAction, Swarm};
+use libp2p::{tokio_development_transport, NetworkBehaviour, PeerId};
+use lighthouse_network::{Multiaddr, NetworkGlobals};
+use slog::{debug, info, o};
+use tokio;
+use types::MinimalEthSpec as E;
+
+#[derive(Debug)]
+struct Event(());
+
+#[derive(NetworkBehaviour)]
+#[behaviour(event_process = false, out_event = "Event")]
+struct Behaviour {
+    /// Behaviour used to fake other sibling behaviour's "calls" to the swarm. It also registeres
+    /// calls from the swarm to the behaviour.
+    pub puppet: PuppetBehaviour,
+    // pub peer_manager: PeerManager<E>,
+}
+
+// Simply to make some code shorter
+struct Node {
+    swarm: Swarm<Behaviour>,
+}
+impl std::ops::Deref for Node {
+    type Target = Swarm<Behaviour>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.swarm
+    }
+}
+impl std::ops::DerefMut for Node {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.swarm
+    }
+}
+
+impl Node {
+    pub fn queue_event(&mut self, ev: PuppetEvent) {
+        self.swarm.behaviour_mut().puppet.queue_event(ev)
+    }
+
+    pub fn calls(&self) -> &HashMap<MethodCall, usize> {
+        self.swarm.behaviour().puppet.calls()
+    }
+
+    // pub fn peer_manager(&mut self) -> &mut PeerManager<E> {
+    // &mut self.swarm.behaviour_mut().peer_manager
+    // }
+}
+
+impl From<()> for Event {
+    fn from(_: ()) -> Self {
+        unreachable!("Puppet Behaviour does not emit events")
+    }
+}
+
+
+


### PR DESCRIPTION
## Issue Addressed

~Isolates the change of peer manager as behavior and adds tests for this.~
I've come to the conclusion that we shouldn't track the disconnecting and dialing states because:
1. they are not technically connection states. 
    - A peer can be connected with "active disconnections" and active dialing attempts at the same time.
    - A disconnected peer can have active dialing attempts too. 
    - A connected peer with disconnections can still be connected at the end of the disconnections. We allow only one connection per peer, but that's relying on an external configuration that could change.

2. There is no reliable way to track the disconnection and dial attempts since those could come from another behaviour. And due to the async nature of the swarm, even a wrapper structure that tracks the events that sibling behaviour emit to the swarm, there is no guarantee that the conditions those register are evaluated the same way when the swarm gets then to when we see them. Same with the swarm events: There it no way to ensure that once we receive a swarm emitted event a synchronous call to a inject_connection_closed /inject_connection_established has not already been made that makes the event invalid. Both cases are because we are essentially trying to track state across a mixed async and sync api. 

I've changed this PR as an experiment on what we would need to do to correctly track those states. Code is there and commented with thought on what we would need to do / why it would not be reliable. For this experiment I didn't use the peer manager, but a simile of it.

So now this is intended more as a discussion
