### PR TITLE
[Merged by Bors] - Ignore cargo audit advisory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit --ignore RUSTSEC-2020-0071
+	cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:


### PR DESCRIPTION
## Issue Addressed
Related to #2727 

Ignores the audit failure for the same reasons in #2727 
