### PR TITLE
[Merged by Bors] - Add metrics for individual async tasks

### DIFF
--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -96,6 +96,7 @@ impl TaskExecutor {
 
         if let Some(runtime) = self.runtime.upgrade() {
             runtime.spawn(async move {
+                let timer = metrics::start_timer_vec(&metrics::TASKS_HISTOGRAM, &[name]);
                 if let Err(join_error) = task_handle.await {
                     if let Ok(panic) = join_error.try_into_panic() {
                         let message = panic.downcast_ref::<&str>().unwrap_or(&"<none>");
@@ -112,6 +113,7 @@ impl TaskExecutor {
                             .try_send(ShutdownReason::Failure("Panic (fatal error)"));
                     }
                 }
+                drop(timer);
             });
         } else {
             debug!(

--- a/common/task_executor/src/metrics.rs
+++ b/common/task_executor/src/metrics.rs
@@ -18,4 +18,9 @@ lazy_static! {
         "Time taken by blocking tasks",
         &["blocking_task_hist"]
     );
+    pub static ref TASKS_HISTOGRAM: Result<HistogramVec> = try_create_histogram_vec(
+        "async_tasks_time_histogram",
+        "Time taken by async tasks",
+        &["async_task_hist"]
+    );
 }


### PR DESCRIPTION
I have been in the process of debugging libp2p tasks as there is something locking our executor. 

This addition adds a metric allowing us to track all tasks within lighthouse allowing us to identify various sections of Lighthouse code that may be taking longer than normal to process.