### PR TITLE
[Merged by Bors] - Update mainnet altair types test

### DIFF
--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -556,13 +556,7 @@ mod tests {
         test_base_types("mainnet", 4242).await
     }
 
-    /* The Altair fork for mainnet has not been announced, so this test will always fail.
-     *
-     * If this test starts failing, it's likely that the fork has been decided and we should remove
-     * the `#[should_panic]`
-     */
     #[tokio::test]
-    #[should_panic]
     async fn mainnet_altair_types() {
         test_altair_types("mainnet", 4243).await
     }


### PR DESCRIPTION
## Issue Addressed
e895074ba updated the altair fork and now that we are a week away this test no longer panics.

## Proposed Changes
Remove the expected panic and explanatory note.
