### PR TITLE
[Merged by Bors] - Check proposer index during block production

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2889,7 +2889,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut state,
             &block,
             None,
-            BlockSignatureStrategy::NoVerification,
+            BlockSignatureStrategy::VerifyRandao,
             &self.spec,
         )?;
         drop(process_timer);

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2889,7 +2889,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut state,
             &block,
             None,
-            BlockSignatureStrategy::VerifyIndividual,
+            BlockSignatureStrategy::NoVerification,
             &self.spec,
         )?;
         drop(process_timer);

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2889,7 +2889,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             &mut state,
             &block,
             None,
-            BlockSignatureStrategy::NoVerification,
+            BlockSignatureStrategy::VerifyIndividual,
             &self.spec,
         )?;
         drop(process_timer);

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -127,7 +127,7 @@ pub fn per_block_processing<T: EthSpec>(
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
 
-    process_randao(state, block, verify_signatures, spec)?;
+    process_randao(state, block, VerifySignatures::True, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
     process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
 

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -129,7 +129,7 @@ pub fn per_block_processing<T: EthSpec>(
     let verify_randao = if let BlockSignatureStrategy::VerifyRandao = block_signature_strategy {
         VerifySignatures::True
     } else {
-        VerifySignatures::False
+        verify_signatures
     };
     // Ensure the current and previous epoch caches are built.
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -46,6 +46,8 @@ pub enum BlockSignatureStrategy {
     NoVerification,
     /// Validate each signature individually, as its object is being processed.
     VerifyIndividual,
+    /// Validate only the randao reveal signature.
+    VerifyRandao,
     /// Verify all signatures in bulk at the beginning of block processing.
     VerifyBulk,
 }
@@ -115,6 +117,7 @@ pub fn per_block_processing<T: EthSpec>(
         }
         BlockSignatureStrategy::VerifyIndividual => VerifySignatures::True,
         BlockSignatureStrategy::NoVerification => VerifySignatures::False,
+        BlockSignatureStrategy::VerifyRandao => VerifySignatures::False,
     };
 
     let proposer_index = process_block_header(state, block, spec)?;
@@ -123,11 +126,16 @@ pub fn per_block_processing<T: EthSpec>(
         verify_block_signature(state, signed_block, block_root, spec)?;
     }
 
+    let verify_randao = if let BlockSignatureStrategy::VerifyRandao = block_signature_strategy {
+        VerifySignatures::True
+    } else {
+        VerifySignatures::False
+    };
     // Ensure the current and previous epoch caches are built.
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
 
-    process_randao(state, block, VerifySignatures::True, spec)?;
+    process_randao(state, block, verify_randao, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
     process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
 

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -173,7 +173,7 @@ fn invalid_randao_reveal_signature() {
         &mut state,
         &signed_block,
         None,
-        BlockSignatureStrategy::VerifyIndividual,
+        BlockSignatureStrategy::VerifyRandao,
         &spec,
     );
 

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -173,7 +173,7 @@ fn invalid_randao_reveal_signature() {
         &mut state,
         &signed_block,
         None,
-        BlockSignatureStrategy::VerifyRandao,
+        BlockSignatureStrategy::VerifyIndividual,
         &spec,
     );
 

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -259,6 +259,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
 
         let randao_reveal_ref = &randao_reveal;
         let self_ref = &self;
+        let proposer_index = self.validator_store.validator_index(&validator_pubkey);
         let validator_pubkey_ref = &validator_pubkey;
         let signed_block = self
             .beacon_nodes
@@ -273,6 +274,13 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                     .map_err(|e| format!("Error from beacon node when producing block: {:?}", e))?
                     .data;
                 drop(get_timer);
+
+                if proposer_index != Some(block.proposer_index()) {
+                    return Err(
+                        "Proposer index does not match block proposer. Beacon chain re-orged"
+                            .to_string(),
+                    );
+                }
 
                 let signed_block = self_ref
                     .validator_store


### PR DESCRIPTION
## Issue Addressed

Resolves #2612 

## Proposed Changes

Implements both the checks mentioned in the original issue. 
1. Verifies the `randao_reveal` in the beacon node
2. Cross checks the proposer index after getting back the block from the beacon node.

## Additional info
The block production time increases by ~10x because of the signature verification on the beacon node (based on the `beacon_block_production_process_seconds` metric) when running on a local testnet.