### PR TITLE
[Merged by Bors] - Fix test warnings on Rust 1.56.0

### DIFF
--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -602,7 +602,7 @@ macro_rules! assert_invalid_block {
                 $err,
                 $( ForkChoiceError::InvalidBlock($error) ) |+ $( if $guard )?
             ),
-        );
+        )
     };
 }
 
@@ -710,7 +710,7 @@ macro_rules! assert_invalid_attestation {
             ),
             "{:?}",
             $err
-        );
+        )
     };
 }
 


### PR DESCRIPTION
## Issue Addressed

Continuation of #2728, fix the fork choice tests for Rust 1.56.0 so that `unstable` is free of warnings.

CI will be broken until this PR merges, because we strictly enforce the absence of warnings (even for tests)
