### PR TITLE
[Merged by Bors] - Add note about java dependency

### DIFF
--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -1,3 +1,6 @@
+//! NOTE: These tests will fail without a java runtime environment (such as openjdk) installed and
+//! available on `$PATH`.
+//!
 //! This crate provides a series of integration tests between the Lighthouse `ValidatorStore` and
 //! Web3Signer by Consensys.
 //!


### PR DESCRIPTION
## Issue Addressed
Currently, running the Web3Signer tests locally without having a java runtime environment installed and available on your PATH will result in the tests failing. 

## Proposed Changes
Add a note regarding the Web3Signer tests being dependent on java (similar to what we have for `ganache-cli`)
