### PR TITLE
[Merged by Bors] - Fix purge-db edge case

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -36,16 +36,20 @@ pub fn get_config<E: EthSpec>(
     // If necessary, remove any existing database and configuration
     if client_config.data_dir.exists() && cli_args.is_present("purge-db") {
         // Remove the chain_db.
-        fs::remove_dir_all(client_config.get_db_path().ok_or("Failed to get db_path")?)
-            .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
+        let chain_db = client_config.get_db_path().ok_or("Failed to get db_path")?;
+        if chain_db.exists() {
+            fs::remove_dir_all(chain_db)
+                .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
+        }
 
         // Remove the freezer db.
-        fs::remove_dir_all(
-            client_config
-                .get_freezer_db_path()
-                .ok_or("Failed to get freezer db path")?,
-        )
-        .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
+        let freezer_db = client_config
+            .get_freezer_db_path()
+            .ok_or("Failed to get freezer db path")?;
+        if freezer_db.exists() {
+            fs::remove_dir_all(freezer_db)
+                .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
+        }
     }
 
     // Create `datadir` and any non-existing parent directories.


### PR DESCRIPTION
## Issue Addressed

Currently, if you launch the beacon node with the `--purge-db` flag and the `beacon` directory exists, but one (or both) of the `chain_db` or `freezer-db` directories are missing, it will error unnecessarily with: 
```
Failed to remove chain_db: No such file or directory (os error 2)
```

This is an edge case which can occur in cases of manual intervention (a user deleted the directory) or if you had previously run with the `--purge-db` flag and Lighthouse errored before it could initialize the db directories.

## Proposed Changes

Check if the `chain_db`/`freezer_db` exists before attempting to remove them. This prevents unnecessary errors.
