### PR TITLE
Config from file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ version = "2.0.1"
 dependencies = [
  "beacon_node",
  "clap",
+ "clap_utils",
  "eth2_ssz",
  "hex",
  "lighthouse_network",
@@ -685,6 +686,8 @@ dependencies = [
  "eth2_network_config",
  "eth2_ssz",
  "hex",
+ "serde_yaml",
+ "toml",
 ]
 
 [[package]]

--- a/account_manager/src/lib.rs
+++ b/account_manager/src/lib.rs
@@ -3,7 +3,7 @@ pub mod validator;
 pub mod wallet;
 
 use clap::App;
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use environment::Environment;
 use types::EthSpec;
 
@@ -23,8 +23,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
 /// Run the account manager, returning an error if the operation did not succeed.
 pub fn run<T: EthSpec>(matches: &ArgMatches<'_>, env: Environment<T>) -> Result<(), String> {
     match matches.subcommand() {
-        (wallet::CMD, Some(matches)) => wallet::cli_run(matches)?,
-        (validator::CMD, Some(matches)) => validator::cli_run(matches, env)?,
+        (wallet::CMD, Some(matches)) => wallet::cli_run(&matches)?,
+        (validator::CMD, Some(matches)) => validator::cli_run(&matches, env)?,
         (unknown, _) => {
             return Err(format!(
                 "{} is not a valid {} command. See --help.",

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -4,7 +4,8 @@ use crate::{SECRETS_DIR_FLAG, WALLETS_DIR_FLAG};
 use account_utils::{
     random_password, read_password_from_user, strip_off_newlines, validator_definitions, PlainText,
 };
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use directory::{
     ensure_dir_exists, parse_path_or_default_with_flag, DEFAULT_SECRET_DIR, DEFAULT_WALLET_DIR,
 };

--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -1,6 +1,7 @@
 use crate::wallet::create::STDIN_INPUTS_FLAG;
 use bls::{Keypair, PublicKey};
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use environment::Environment;
 use eth2::{
     types::{GenesisData, StateId, ValidatorData, ValidatorId, ValidatorStatus},

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -8,7 +8,8 @@ use account_utils::{
     },
     ZeroizeString,
 };
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use slashing_protection::{SlashingDatabase, SLASHING_PROTECTION_FILENAME};
 use std::fs;
 use std::path::PathBuf;
@@ -83,12 +84,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), String> {
-    let keystore: Option<PathBuf> = clap_utils::parse_optional(matches, KEYSTORE_FLAG)?;
-    let keystores_dir: Option<PathBuf> = clap_utils::parse_optional(matches, DIR_FLAG)?;
+    let keystore: Option<PathBuf> = clap_utils::parse_optional(&matches, KEYSTORE_FLAG)?;
+    let keystores_dir: Option<PathBuf> = clap_utils::parse_optional(&matches, DIR_FLAG)?;
     let stdin_inputs = cfg!(windows) || matches.is_present(STDIN_INPUTS_FLAG);
     let reuse_password = matches.is_present(REUSE_PASSWORD_FLAG);
     let keystore_password_path: Option<PathBuf> =
-        clap_utils::parse_optional(matches, PASSWORD_FLAG)?;
+        clap_utils::parse_optional(&matches, PASSWORD_FLAG)?;
 
     let mut defs = ValidatorDefinitions::open_or_create(&validator_dir)
         .map_err(|e| format!("Unable to open {}: {:?}", CONFIG_FILENAME, e))?;

--- a/account_manager/src/validator/mod.rs
+++ b/account_manager/src/validator/mod.rs
@@ -7,7 +7,8 @@ pub mod recover;
 pub mod slashing_protection;
 
 use crate::VALIDATOR_DIR_FLAG;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use directory::{parse_path_or_default_with_flag, DEFAULT_VALIDATOR_DIR};
 use environment::Environment;
 use std::path::PathBuf;
@@ -48,15 +49,15 @@ pub fn cli_run<T: EthSpec>(matches: &ArgMatches, env: Environment<T>) -> Result<
     eprintln!("validator-dir path: {:?}", validator_base_dir);
 
     match matches.subcommand() {
-        (create::CMD, Some(matches)) => create::cli_run::<T>(matches, env, validator_base_dir),
-        (modify::CMD, Some(matches)) => modify::cli_run(matches, validator_base_dir),
-        (import::CMD, Some(matches)) => import::cli_run(matches, validator_base_dir),
+        (create::CMD, Some(matches)) => create::cli_run::<T>(&matches, env, validator_base_dir),
+        (modify::CMD, Some(matches)) => modify::cli_run(&matches, validator_base_dir),
+        (import::CMD, Some(matches)) => import::cli_run(&matches, validator_base_dir),
         (list::CMD, Some(_)) => list::cli_run(validator_base_dir),
-        (recover::CMD, Some(matches)) => recover::cli_run(matches, validator_base_dir),
+        (recover::CMD, Some(matches)) => recover::cli_run(&matches, validator_base_dir),
         (slashing_protection::CMD, Some(matches)) => {
-            slashing_protection::cli_run(matches, env, validator_base_dir)
+            slashing_protection::cli_run(&matches, env, validator_base_dir)
         }
-        (exit::CMD, Some(matches)) => exit::cli_run(matches, env),
+        (exit::CMD, Some(matches)) => exit::cli_run(&matches, env),
         (unknown, _) => Err(format!(
             "{} does not have a {} command. See --help",
             CMD, unknown

--- a/account_manager/src/validator/modify.rs
+++ b/account_manager/src/validator/modify.rs
@@ -1,6 +1,7 @@
 use account_utils::validator_definitions::ValidatorDefinitions;
 use bls::PublicKey;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use std::{collections::HashSet, path::PathBuf};
 
 pub const CMD: &str = "modify";
@@ -76,7 +77,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             .map(|def| def.voting_public_key.clone())
             .collect::<HashSet<_>>()
     } else {
-        let public_key: PublicKey = clap_utils::parse_required(sub_matches, PUBKEY_FLAG)?;
+        let public_key: PublicKey = clap_utils::parse_required(&sub_matches, PUBKEY_FLAG)?;
         std::iter::once(public_key).collect::<HashSet<PublicKey>>()
     };
 

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -5,7 +5,8 @@ use crate::wallet::create::STDIN_INPUTS_FLAG;
 use crate::SECRETS_DIR_FLAG;
 use account_utils::eth2_keystore::{keypair_from_secret, Keystore, KeystoreBuilder};
 use account_utils::random_password;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use directory::ensure_dir_exists;
 use directory::{parse_path_or_default_with_flag, DEFAULT_SECRET_DIR};
 use eth2_wallet::bip39::Seed;
@@ -80,14 +81,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
 
 pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), String> {
     let secrets_dir = if matches.value_of("datadir").is_some() {
-        let path: PathBuf = clap_utils::parse_required(matches, "datadir")?;
+        let path: PathBuf = clap_utils::parse_required(&matches, "datadir")?;
         path.join(DEFAULT_SECRET_DIR)
     } else {
-        parse_path_or_default_with_flag(matches, SECRETS_DIR_FLAG, DEFAULT_SECRET_DIR)?
+        parse_path_or_default_with_flag(&matches, SECRETS_DIR_FLAG, DEFAULT_SECRET_DIR)?
     };
-    let first_index: u32 = clap_utils::parse_required(matches, FIRST_INDEX_FLAG)?;
-    let count: u32 = clap_utils::parse_required(matches, COUNT_FLAG)?;
-    let mnemonic_path: Option<PathBuf> = clap_utils::parse_optional(matches, MNEMONIC_FLAG)?;
+    let first_index: u32 = clap_utils::parse_required(&matches, FIRST_INDEX_FLAG)?;
+    let count: u32 = clap_utils::parse_required(&matches, COUNT_FLAG)?;
+    let mnemonic_path: Option<PathBuf> = clap_utils::parse_optional(&matches, MNEMONIC_FLAG)?;
     let stdin_inputs = cfg!(windows) || matches.is_present(STDIN_INPUTS_FLAG);
 
     eprintln!("secrets-dir path: {:?}", secrets_dir);

--- a/account_manager/src/validator/slashing_protection.rs
+++ b/account_manager/src/validator/slashing_protection.rs
@@ -1,4 +1,5 @@
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use environment::Environment;
 use slashing_protection::{
     interchange::Interchange, InterchangeError, InterchangeImportOutcome, SlashingDatabase,
@@ -98,8 +99,8 @@ pub fn cli_run<T: EthSpec>(
 
     match matches.subcommand() {
         (IMPORT_CMD, Some(matches)) => {
-            let import_filename: PathBuf = clap_utils::parse_required(matches, IMPORT_FILE_ARG)?;
-            let minify: Option<bool> = clap_utils::parse_optional(matches, MINIFY_FLAG)?;
+            let import_filename: PathBuf = clap_utils::parse_required(&matches, IMPORT_FILE_ARG)?;
+            let minify: Option<bool> = clap_utils::parse_optional(&matches, MINIFY_FLAG)?;
             let import_file = File::open(&import_filename).map_err(|e| {
                 format!(
                     "Unable to open import file at {}: {:?}",
@@ -212,11 +213,11 @@ pub fn cli_run<T: EthSpec>(
             Ok(())
         }
         (EXPORT_CMD, Some(matches)) => {
-            let export_filename: PathBuf = clap_utils::parse_required(matches, EXPORT_FILE_ARG)?;
-            let minify: bool = clap_utils::parse_required(matches, MINIFY_FLAG)?;
+            let export_filename: PathBuf = clap_utils::parse_required(&matches, EXPORT_FILE_ARG)?;
+            let minify: bool = clap_utils::parse_required(&matches, MINIFY_FLAG)?;
 
             let selected_pubkeys = if let Some(pubkeys) =
-                clap_utils::parse_optional::<String>(matches, PUBKEYS_FLAG)?
+                clap_utils::parse_optional::<String>(&matches, PUBKEYS_FLAG)?
             {
                 let pubkeys = pubkeys
                     .split(',')

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -3,7 +3,8 @@ use crate::WALLETS_DIR_FLAG;
 use account_utils::{
     is_password_sufficiently_complex, random_password, read_password_from_user, strip_off_newlines,
 };
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use eth2_wallet::{
     bip39::{Language, Mnemonic, MnemonicType},
     PlainText,
@@ -103,12 +104,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub fn cli_run(matches: &ArgMatches, wallet_base_dir: PathBuf) -> Result<(), String> {
-    let mnemonic_output_path: Option<PathBuf> = clap_utils::parse_optional(matches, MNEMONIC_FLAG)?;
+    let mnemonic_output_path: Option<PathBuf> =
+        clap_utils::parse_optional(&matches, MNEMONIC_FLAG)?;
 
     // Create a new random mnemonic.
     //
     // The `tiny-bip39` crate uses `thread_rng()` for this entropy.
-    let mnemonic_length = clap_utils::parse_required(matches, MNEMONIC_LENGTH_FLAG)?;
+    let mnemonic_length = clap_utils::parse_required(&matches, MNEMONIC_LENGTH_FLAG)?;
     let mnemonic = Mnemonic::new(
         MnemonicType::for_word_count(mnemonic_length).expect("Mnemonic length already validated"),
         Language::English,

--- a/account_manager/src/wallet/mod.rs
+++ b/account_manager/src/wallet/mod.rs
@@ -3,7 +3,8 @@ pub mod list;
 pub mod recover;
 
 use crate::WALLETS_DIR_FLAG;
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use directory::{ensure_dir_exists, parse_path_or_default_with_flag, DEFAULT_WALLET_DIR};
 use std::path::PathBuf;
 
@@ -37,9 +38,9 @@ pub fn cli_run(matches: &ArgMatches) -> Result<(), String> {
     eprintln!("wallet-dir path: {:?}", wallet_base_dir);
 
     match matches.subcommand() {
-        (create::CMD, Some(matches)) => create::cli_run(matches, wallet_base_dir),
+        (create::CMD, Some(matches)) => create::cli_run(&matches, wallet_base_dir),
         (list::CMD, Some(_)) => list::cli_run(wallet_base_dir),
-        (recover::CMD, Some(matches)) => recover::cli_run(matches, wallet_base_dir),
+        (recover::CMD, Some(matches)) => recover::cli_run(&matches, wallet_base_dir),
         (unknown, _) => Err(format!(
             "{} does not have a {} command. See --help",
             CMD, unknown

--- a/account_manager/src/wallet/recover.rs
+++ b/account_manager/src/wallet/recover.rs
@@ -1,7 +1,8 @@
 use crate::common::read_mnemonic_from_cli;
 use crate::wallet::create::{create_wallet_from_mnemonic, STDIN_INPUTS_FLAG};
 use crate::wallet::create::{HD_TYPE, NAME_FLAG, PASSWORD_FLAG, TYPE_FLAG};
-use clap::{App, Arg, ArgMatches};
+use clap::{App, Arg};
+use clap_utils::matches::Matches as ArgMatches;
 use std::path::PathBuf;
 
 pub const CMD: &str = "recover";

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::{flags::DISABLE_MALLOC_TUNING_FLAG, BAD_TESTNET_DIR_MESSAGE};
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -10,7 +10,7 @@ use beacon_chain::{
     builder::Witness, eth1_chain::CachingEth1Backend, slot_clock::SystemTimeSlotClock,
     TimeoutRwLock,
 };
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 pub use cli::cli_app;
 pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
 pub use config::{get_config, get_data_dir, get_eth2_network_config, set_network_config};

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 beacon_node = { path = "../beacon_node" }
 clap = "2.33.3"
+clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 types = { path = "../consensus/types" }
 eth2_ssz = "0.4.0"

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -1,5 +1,5 @@
 use beacon_node::{get_data_dir, get_eth2_network_config, set_network_config};
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use lighthouse_network::discv5::{enr::CombinedKey, Discv5Config, Enr};
 use lighthouse_network::{
     discovery::{create_enr_builder_from_config, load_enr_from_disk, use_or_load_enr},

--- a/boot_node/src/lib.rs
+++ b/boot_node/src/lib.rs
@@ -1,5 +1,5 @@
 //! Creates a simple DISCV5 server which can be used to bootstrap an Eth2 network.
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use slog::{o, Drain, Level, Logger};
 
 use std::convert::TryFrom;

--- a/common/clap_utils/Cargo.toml
+++ b/common/clap_utils/Cargo.toml
@@ -12,3 +12,5 @@ hex = "0.4.2"
 dirs = "3.0.1"
 eth2_network_config = { path = "../eth2_network_config" }
 eth2_ssz = "0.4.0"
+serde_yaml = "0.8.13"
+toml = "0.5.6"

--- a/common/clap_utils/src/lib.rs
+++ b/common/clap_utils/src/lib.rs
@@ -1,12 +1,13 @@
 //! A helper library for parsing values from `clap::ArgMatches`.
 
-use clap::ArgMatches;
+use crate::matches::Matches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Decode;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 pub mod flags;
+pub mod matches;
 
 pub const BAD_TESTNET_DIR_MESSAGE: &str = "The hard-coded testnet directory was invalid. \
                                         This happens when Lighthouse is migrating between spec versions \
@@ -16,7 +17,7 @@ pub const BAD_TESTNET_DIR_MESSAGE: &str = "The hard-coded testnet directory was 
 /// Attempts to load the testnet dir at the path if `name` is in `matches`, returning an error if
 /// the path cannot be found or the testnet dir is invalid.
 pub fn parse_testnet_dir(
-    matches: &ArgMatches,
+    matches: &Matches,
     name: &'static str,
 ) -> Result<Option<Eth2NetworkConfig>, String> {
     let path = parse_required::<PathBuf>(matches, name)?;
@@ -28,7 +29,7 @@ pub fn parse_testnet_dir(
 /// Attempts to load a hardcoded network config if `name` is in `matches`, returning an error if
 /// the name is not a valid network name.
 pub fn parse_hardcoded_network(
-    matches: &ArgMatches,
+    matches: &Matches,
     name: &str,
 ) -> Result<Option<Eth2NetworkConfig>, String> {
     let network_name = parse_required::<String>(matches, name)?;
@@ -38,7 +39,7 @@ pub fn parse_hardcoded_network(
 /// If `name` is in `matches`, parses the value as a path. Otherwise, attempts to find the user's
 /// home directory and appends `default` to it.
 pub fn parse_path_with_default_in_home_dir(
-    matches: &ArgMatches,
+    matches: &Matches,
     name: &'static str,
     default: PathBuf,
 ) -> Result<PathBuf, String> {
@@ -57,7 +58,7 @@ pub fn parse_path_with_default_in_home_dir(
 
 /// Returns the value of `name` or an error if it is not in `matches` or does not parse
 /// successfully using `std::string::FromStr`.
-pub fn parse_required<T>(matches: &ArgMatches, name: &str) -> Result<T, String>
+pub fn parse_required<T>(matches: &Matches, name: &str) -> Result<T, String>
 where
     T: FromStr,
     <T as FromStr>::Err: std::fmt::Display,
@@ -67,7 +68,7 @@ where
 
 /// Returns the value of `name` (if present) or an error if it does not parse successfully using
 /// `std::string::FromStr`.
-pub fn parse_optional<T>(matches: &ArgMatches, name: &str) -> Result<Option<T>, String>
+pub fn parse_optional<T>(matches: &Matches, name: &str) -> Result<Option<T>, String>
 where
     T: FromStr,
     <T as FromStr>::Err: std::fmt::Display,
@@ -85,10 +86,7 @@ where
 /// successfully using `ssz::Decode`.
 ///
 /// Expects the value of `name` to be 0x-prefixed ASCII-hex.
-pub fn parse_ssz_required<T: Decode>(
-    matches: &ArgMatches,
-    name: &'static str,
-) -> Result<T, String> {
+pub fn parse_ssz_required<T: Decode>(matches: &Matches, name: &'static str) -> Result<T, String> {
     parse_ssz_optional(matches, name)?.ok_or_else(|| format!("{} not specified", name))
 }
 
@@ -97,7 +95,7 @@ pub fn parse_ssz_required<T: Decode>(
 ///
 /// Expects the value of `name` (if any) to be 0x-prefixed ASCII-hex.
 pub fn parse_ssz_optional<T: Decode>(
-    matches: &ArgMatches,
+    matches: &Matches,
     name: &'static str,
 ) -> Result<Option<T>, String> {
     matches

--- a/common/clap_utils/src/matches.rs
+++ b/common/clap_utils/src/matches.rs
@@ -1,0 +1,77 @@
+use clap::ArgMatches;
+use std::collections::HashMap;
+use std::fs;
+
+/// This struct is a wrapper for `ArgMatches`, which is the result of consuming all cli arguments
+/// when calling `clap::App::get_matches`. This struct allowing us to to implement fallback logic
+/// for cli args when a config file is provided. Currently, `clap` makes it difficult to overwrite
+/// command line arguments.
+pub struct Matches<'a> {
+    cli: &'a ArgMatches<'a>,
+    file: Option<HashMap<String, String>>,
+}
+
+impl<'a> Matches<'a> {
+    pub fn new(cli: &'a ArgMatches<'a>, file_path: Option<&str>) -> Result<Matches<'a>, String> {
+        if let Some(file_name) = file_path {
+            let file_arg_map: HashMap<String, String> = if file_name.ends_with(".yaml") {
+                fs::read_to_string(file_name)
+                    .map_err(|e| e.to_string())
+                    .and_then(|yaml| {
+                        serde_yaml::from_str(yaml.as_str()).map_err(|e| e.to_string())
+                    })?
+            } else if file_name.ends_with(".toml") {
+                fs::read_to_string(file_name)
+                    .map_err(|e| e.to_string())
+                    .and_then(|toml| toml::from_str(toml.as_str()).map_err(|e| e.to_string()))?
+            } else {
+                return Err("config file must have extension `.yaml` or `.toml`".to_string());
+            };
+            return Ok(Matches {
+                cli,
+                file: Some(file_arg_map),
+            });
+        }
+        Ok(Matches { cli, file: None })
+    }
+
+    pub fn value_of(&self, name: &str) -> Option<&str> {
+        self.cli.value_of(name).or_else(|| self
+            .file
+            .as_ref()
+            .and_then(|file| file.get(name).map(String::as_str)))
+    }
+
+    pub fn subcommand_name(&self) -> Option<&str> {
+        self.cli.subcommand_name()
+    }
+
+    pub fn is_present(&self, name: &str) -> bool {
+        if !self.cli.is_present(name) {
+            self.file
+                .as_ref()
+                .map(|file| file.contains_key(name))
+                .unwrap_or(false)
+        } else {
+            true
+        }
+    }
+
+    pub fn subcommand_matches<S: AsRef<str>>(&self, name: S) -> Option<Matches<'a>> {
+        self.cli.subcommand_matches(name).map(|cli| Matches {
+            cli,
+            file: self.file.clone(),
+        })
+    }
+
+    pub fn subcommand(&self) -> (&str, Option<Matches<'a>>) {
+        let (name, matches) = self.cli.subcommand();
+        (
+            name,
+            matches.map(|cli| Matches {
+                cli,
+                file: self.file.clone(),
+            }),
+        )
+    }
+}

--- a/common/directory/src/lib.rs
+++ b/common/directory/src/lib.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 pub use eth2_network_config::DEFAULT_HARDCODED_NETWORK;
 use std::fs::{self, create_dir_all};
 use std::path::{Path, PathBuf};

--- a/lcli/src/change_genesis_time.rs
+++ b/lcli/src/change_genesis_time.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
 use std::fs::File;

--- a/lcli/src/check_deposit_data.rs
+++ b/lcli/src/check_deposit_data.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::{parse_required, parse_ssz_required};
 use deposit_contract::{decode_eth1_tx_data, DEPOSIT_DATA_LEN};
 use tree_hash::TreeHash;

--- a/lcli/src/deploy_deposit_contract.rs
+++ b/lcli/src/deploy_deposit_contract.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use environment::Environment;
 use types::EthSpec;
 

--- a/lcli/src/eth1_genesis.rs
+++ b/lcli/src/eth1_genesis.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use environment::Environment;
 use eth2_network_config::Eth2NetworkConfig;
 use genesis::{Eth1Config, Eth1GenesisService};

--- a/lcli/src/etl/block_efficiency.rs
+++ b/lcli/src/etl/block_efficiency.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use eth2::types::*;
 use eth2::{BeaconNodeHttpClient, Timeouts};
 use log::{error, info};

--- a/lcli/src/generate_bootnode_enr.rs
+++ b/lcli/src/generate_bootnode_enr.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use lighthouse_network::{
     discovery::{build_enr, CombinedKey, CombinedKeyExt, Keypair, ENR_FILENAME},
     NetworkConfig, NETWORK_KEY_FILENAME,

--- a/lcli/src/insecure_validators.rs
+++ b/lcli/src/insecure_validators.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use std::fs;
 use std::path::PathBuf;
 use validator_dir::Builder as ValidatorBuilder;

--- a/lcli/src/interop_genesis.rs
+++ b/lcli/src/interop_genesis.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::parse_ssz_optional;
 use eth2_network_config::Eth2NetworkConfig;
 use genesis::interop_genesis_state;

--- a/lcli/src/new_testnet.rs
+++ b/lcli/src/new_testnet.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::{parse_optional, parse_required, parse_ssz_optional};
 use eth2_network_config::Eth2NetworkConfig;
 use std::path::PathBuf;

--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::parse_required;
 use serde::Serialize;
 use ssz::Decode;

--- a/lcli/src/replace_state_pubkeys.rs
+++ b/lcli/src/replace_state_pubkeys.rs
@@ -1,5 +1,5 @@
 use account_utils::{eth2_keystore::keypair_from_secret, mnemonic_from_phrase};
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use eth2_wallet::bip39::Seed;
 use eth2_wallet::{recover_validator_secret_from_mnemonic, KeyType};

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -1,5 +1,5 @@
 use crate::transition_blocks::load_from_ssz_with;
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
 use state_processing::per_slot_processing;

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
 use state_processing::{per_block_processing, per_slot_processing, BlockSignatureStrategy};

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -1,6 +1,6 @@
 use crate::graffiti_file::GraffitiFile;
 use crate::{http_api, http_metrics};
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use clap_utils::{parse_optional, parse_required};
 use directory::{
     get_network_dir, DEFAULT_HARDCODED_NETWORK, DEFAULT_ROOT_DIR, DEFAULT_SECRET_DIR,

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -31,7 +31,7 @@ use crate::doppelganger_service::DoppelgangerService;
 use account_utils::validator_definitions::ValidatorDefinitions;
 use attestation_service::{AttestationService, AttestationServiceBuilder};
 use block_service::{BlockService, BlockServiceBuilder};
-use clap::ArgMatches;
+use clap_utils::matches::Matches as ArgMatches;
 use duties_service::DutiesService;
 use environment::RuntimeContext;
 use eth2::{reqwest::ClientBuilder, BeaconNodeHttpClient, StatusCode, Timeouts};


### PR DESCRIPTION
## Issue Addressed

Resolves: #2748

## Proposed Changes

`clap` currently makes it very difficult to overwrite cli arguments. It might be more feasible with `clap v3.0.0` which is currently in beta, because that introduces the method `App::mut_arg`, which we might be able to use to update default argument values at runtime. And `App::get_matches_mut()`, which allows you to get argument matches without consuming `App`.

So rather than using native `clap` functionality, this PR creates a wrapper struct around `ArgMatches`, with fallback logic to check a given config file for missing args (as @paulhauner suggested) . The glaring weakness of this though, is that we lose out on `clap`'s validation for any arguments we get from file.  So far I've found that our error handling is covering a lot of this validation well anyways, but it does fail with less information that `clap` would. And I haven't yet tested out all of lighthouse's flags and options.

Another potential option is to move towards a declarative style like `structopt`, which is being rolled into `clap_derive` in `clap v3.0.0` (https://github.com/clap-rs/clap/issues/1661). This style does make it simpler to update args at runtime.

