### PR TITLE
Add support for forks in the execution block generator

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -698,6 +698,19 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_forked_terminal_block() {
+        let (mock, block_hash) = MockExecutionLayer::default_params()
+            .move_to_terminal_block()
+            .produce_forked_pow_block();
+        assert!(mock
+            .el
+            .is_valid_terminal_pow_block_hash(block_hash)
+            .await
+            .unwrap()
+            .unwrap());
+    }
+
+    #[tokio::test]
     async fn finds_valid_terminal_block_hash() {
         MockExecutionLayer::default_params()
             .move_to_block_prior_to_terminal_block()

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -119,16 +119,6 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
         gen
     }
 
-    pub fn max_difficulty_block(&self, hashes: &[Hash256]) -> Option<Block<T>> {
-        let blocks: Option<Vec<Block<T>>> = hashes
-            .into_iter()
-            .map(|hash| self.block_by_hash(*hash))
-            .collect();
-        blocks?
-            .into_iter()
-            .max_by_key(|block| block.total_difficulty())
-    }
-
     pub fn latest_block(&self) -> Option<Block<T>> {
         self.head_block.clone()
     }

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -164,6 +164,21 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         self
     }
 
+    pub fn produce_forked_pow_block(self) -> (Self, Hash256) {
+        let head_block = self
+            .server
+            .execution_block_generator()
+            .latest_block()
+            .unwrap();
+
+        let block_hash = self
+            .server
+            .execution_block_generator()
+            .insert_pow_block_by_hash(head_block.parent_hash())
+            .unwrap();
+        (self, block_hash)
+    }
+
     pub async fn with_terminal_block<'a, U, V>(self, func: U) -> Self
     where
         U: Fn(ExecutionLayer, Option<ExecutionBlock>) -> V,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Refactors the block production and querying in the execution block generator to allow for forking in the PoW chain. This allows us to write tests for more complex scenarios around the merge transition.
