### PR TITLE
[Merged by Bors] - Fix linting error on Windows

### DIFF
--- a/common/filesystem/src/lib.rs
+++ b/common/filesystem/src/lib.rs
@@ -102,7 +102,7 @@ pub fn restrict_file_permissions<P: AsRef<Path>>(path: P) -> Result<(), Error> {
             .as_ref()
             .to_str()
             .ok_or(Error::UnableToObtainFilePath)?;
-        let mut acl = ACL::from_file_path(&path_str, false).map_err(Error::UnableToRetrieveACL)?;
+        let mut acl = ACL::from_file_path(path_str, false).map_err(Error::UnableToRetrieveACL)?;
 
         let owner_sid =
             windows_acl::helper::string_to_sid(OWNER_SID_STR).map_err(Error::UnableToConvertSID)?;


### PR DESCRIPTION
While testing some code on Windows, I ran into a failure when using `clippy` via (`make lint`):
```
error: this expression borrows a reference (`&str`) that is immediately dereferenced by the compiler
   --> common/filesystem/src/lib.rs:105:43
    |
105 |         let mut acl = ACL::from_file_path(&path_str, false).map_err(Error::UnableToRetrieveACL)?;
    |                                           ^^^^^^^^^ help: change this to: `path_str`
    |
    = note: `-D clippy::needless-borrow` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    
error: could not compile `filesystem` due to previous error
```

## Proposed Changes

Remove the unnecessary borrow as suggested.

## Additional Info

Since we are only running `clippy` in CI on Ubuntu, I believe we don't have any way (in CI) to detect these Windows specific lint errors (either from new code, or from linting changes from new Rust versions. 
This is because code marked as `#[cfg(windows)]` is not checked on `unix` systems and vice versa.

I'm conscious that our CI runs are already taking a long time, and that adding a new Windows `clippy` run would add a non-negligible amount of time to the runs (not sure if this topic has already been discussed), but it something to be aware of.

## Extra Note
I don't think this is the case, but it might be worth someone else running `make lint` on their Windows machines to eliminate the possibility that this is an error specific to my setup.
