### PR TITLE
[Merged by Bors] - Do not compute metrics in the network service if the cli flag is not set

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -114,6 +114,9 @@ pub struct Config {
 
     /// List of extra topics to initially subscribe to as strings.
     pub topics: Vec<GossipKind>,
+
+    /// Whether metrics are enabled.
+    pub metrics_enabled: bool,
 }
 
 impl Default for Config {
@@ -188,6 +191,7 @@ impl Default for Config {
             import_all_attestations: false,
             shutdown_after_sync: false,
             topics: Vec::new(),
+            metrics_enabled: false,
         }
     }
 }

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -137,6 +137,8 @@ pub struct NetworkService<T: BeaconChainTypes> {
     subscribe_all_subnets: bool,
     /// Shutdown beacon node after sync is complete.
     shutdown_after_sync: bool,
+    /// Whether metrics are enabled or not.
+    metrics_enabled: bool,
     /// A timer for updating various network metrics.
     metrics_update: tokio::time::Interval,
     /// gossipsub_parameter_update timer
@@ -263,6 +265,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
             next_unsubscribe,
             subscribe_all_subnets: config.subscribe_all_subnets,
             shutdown_after_sync: config.shutdown_after_sync,
+            metrics_enabled: config.metrics_enabled,
             metrics_update,
             gossipsub_parameter_update,
             fork_context,
@@ -325,7 +328,7 @@ fn spawn_service<T: BeaconChainTypes>(
         loop {
             // build the futures to check simultaneously
             tokio::select! {
-                _ = service.metrics_update.tick() => {
+                _ = service.metrics_update.tick(), if service.metrics_enabled => {
                     // update various network metrics
                     metric_update_counter +=1;
                     if metric_update_counter % T::EthSpec::default_spec().seconds_per_slot == 0 {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -705,6 +705,10 @@ pub fn set_network_config(
         config.private = true;
     }
 
+    if cli_args.is_present("metrics") {
+        config.metrics_enabled = true;
+    }
+
     Ok(())
 }
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -619,7 +619,10 @@ fn metrics_flag() {
     CommandLineTest::new()
         .flag("metrics", None)
         .run()
-        .with_config(|config| assert!(config.http_metrics.enabled));
+        .with_config(|config| {
+            assert!(config.http_metrics.enabled);
+            assert!(config.network.metrics_enabled);
+        });
 }
 #[test]
 fn metrics_address_flag() {


### PR DESCRIPTION
## Issue Addressed

The computation of metrics in the network service can be expensive. This disables the computation unless the cli flag `metrics` is set.

## Additional Info
Metrics in other parts of the network are still updated, since most are simple metrics and checking if metrics are enabled each time each metric is updated doesn't seem like a gain.
