### PR TITLE
[Merged by Bors] - De-duplicate attestations in the slasher

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -452,6 +452,18 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("slasher-slot-offset")
+                .long("slasher-slot-offset")
+                .help(
+                    "Set the delay from the start of the slot at which the slasher should ingest \
+                     attestations. Only effective if the slasher-update-period is a multiple of the \
+                     slot duration."
+                )
+                .value_name("SECONDS")
+                .requires("slasher")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("slasher-history-length")
                 .long("slasher-history-length")
                 .help(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -448,6 +448,19 @@ pub fn get_config<E: EthSpec>(
             slasher_config.update_period = update_period;
         }
 
+        if let Some(slot_offset) =
+            clap_utils::parse_optional::<f64>(cli_args, "slasher-slot-offset")?
+        {
+            if slot_offset.is_finite() {
+                slasher_config.slot_offset = slot_offset;
+            } else {
+                return Err(format!(
+                    "invalid float for slasher-slot-offset: {}",
+                    slot_offset
+                ));
+            }
+        }
+
         if let Some(history_length) =
             clap_utils::parse_optional(cli_args, "slasher-history-length")?
         {

--- a/book/src/slasher.md
+++ b/book/src/slasher.md
@@ -102,6 +102,31 @@ If the `time_taken` is substantially longer than the update period then it indic
 struggling under the load, and you should consider increasing the update period or lowering the
 resource requirements by tweaking the history length.
 
+The update period should almost always be set to a multiple of the slot duration (12
+seconds), or in rare cases a divisor (e.g. 4 seconds).
+
+### Slot Offset
+
+* Flag: `--slasher-slot-offset SECONDS`
+* Argument: number of seconds (decimal allowed)
+* Default: 10.5 seconds
+
+Set the offset from the start of the slot at which slasher processing should run. The default
+value of 10.5 seconds is chosen so that de-duplication can be maximally effective. The slasher
+will de-duplicate attestations from the same batch by storing only the attestations necessary
+to cover all seen validators. In other words, it will store aggregated attestations rather than
+unaggregated attestations if given the opportunity.
+
+Aggregated attestations are published 8 seconds into the slot, so the default allows 2.5 seconds for
+them to arrive, and 1.5 seconds for them to be processed before a potential block proposal at the
+start of the next slot. If the batch processing time on your machine is significantly longer than
+1.5 seconds then you may want to lengthen the update period to 24 seconds, or decrease the slot
+offset to a value in the range 8.5-10.5s (lower values may result in more data being stored).
+
+The slasher will run every `update-period` seconds after the first `slot_start + slot-offset`, which
+means the `slot-offset` will be ineffective if the `update-period` is not a multiple (or divisor) of
+the slot duration.
+
 ### Chunk Size and Validator Chunk Size
 
 * Flags: `--slasher-chunk-size EPOCHS`, `--slasher-validator-chunk-size NUM_VALIDATORS`

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -795,6 +795,28 @@ fn slasher_update_period_flag() {
         });
 }
 #[test]
+fn slasher_slot_offset() {
+    CommandLineTest::new()
+        .flag("slasher", None)
+        .flag("slasher-slot-offset", Some("11.25"))
+        .run()
+        .with_config(|config| {
+            if let Some(slasher_config) = &config.slasher {
+                assert_eq!(slasher_config.update_period, 11.25);
+            } else {
+                panic!("Slasher config was parsed incorrectly");
+            }
+        });
+}
+#[test]
+#[should_panic]
+fn slasher_slot_offset_nan() {
+    CommandLineTest::new()
+        .flag("slasher", None)
+        .flag("slasher-slot-offset", Some("NaN"))
+        .run();
+}
+#[test]
 fn slasher_history_length_flag() {
     CommandLineTest::new()
         .flag("slasher", None)

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -796,17 +796,12 @@ fn slasher_update_period_flag() {
 }
 #[test]
 fn slasher_slot_offset() {
+    // TODO: check that the offset is actually stored, once the config is un-hacked
+    // See: https://github.com/sigp/lighthouse/pull/2767#discussion_r741610402
     CommandLineTest::new()
         .flag("slasher", None)
         .flag("slasher-slot-offset", Some("11.25"))
-        .run()
-        .with_config(|config| {
-            if let Some(slasher_config) = &config.slasher {
-                assert_eq!(slasher_config.update_period, 11.25);
-            } else {
-                panic!("Slasher config was parsed incorrectly");
-            }
-        });
+        .run();
 }
 #[test]
 #[should_panic]

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -800,6 +800,7 @@ fn slasher_slot_offset() {
     // See: https://github.com/sigp/lighthouse/pull/2767#discussion_r741610402
     CommandLineTest::new()
         .flag("slasher", None)
+        .flag("slasher-max-db-size", Some("16"))
         .flag("slasher-slot-offset", Some("11.25"))
         .run();
 }
@@ -808,6 +809,7 @@ fn slasher_slot_offset() {
 fn slasher_slot_offset_nan() {
     CommandLineTest::new()
         .flag("slasher", None)
+        .flag("slasher-max-db-size", Some("16"))
         .flag("slasher-slot-offset", Some("NaN"))
         .run();
 }

--- a/slasher/src/attester_record.rs
+++ b/slasher/src/attester_record.rs
@@ -1,4 +1,5 @@
 use ssz_derive::{Decode, Encode};
+use std::sync::Arc;
 use tree_hash::TreeHash as _;
 use tree_hash_derive::TreeHash;
 use types::{AggregateSignature, EthSpec, Hash256, IndexedAttestation, VariableList};
@@ -9,6 +10,21 @@ pub struct AttesterRecord {
     pub attestation_data_hash: Hash256,
     /// The hash of the indexed attestation, so it can be loaded.
     pub indexed_attestation_hash: Hash256,
+}
+
+/// Bundling of an `IndexedAttestation` with an `AttesterRecord`.
+///
+/// This struct gets `Arc`d and passed around between each stage of queueing and processing.
+#[derive(Debug)]
+pub struct IndexedAttesterRecord<E: EthSpec> {
+    pub indexed: IndexedAttestation<E>,
+    pub record: AttesterRecord,
+}
+
+impl<E: EthSpec> IndexedAttesterRecord<E> {
+    pub fn new(indexed: IndexedAttestation<E>, record: AttesterRecord) -> Arc<Self> {
+        Arc::new(IndexedAttesterRecord { indexed, record })
+    }
 }
 
 #[derive(Debug, Clone, Encode, Decode, TreeHash)]

--- a/slasher/src/config.rs
+++ b/slasher/src/config.rs
@@ -7,6 +7,7 @@ pub const DEFAULT_CHUNK_SIZE: usize = 16;
 pub const DEFAULT_VALIDATOR_CHUNK_SIZE: usize = 256;
 pub const DEFAULT_HISTORY_LENGTH: usize = 4096;
 pub const DEFAULT_UPDATE_PERIOD: u64 = 12;
+pub const DEFAULT_SLOT_OFFSET: f64 = 10.5;
 pub const DEFAULT_MAX_DB_SIZE: usize = 256 * 1024; // 256 GiB
 pub const DEFAULT_BROADCAST: bool = false;
 
@@ -26,10 +27,17 @@ pub struct Config {
     pub history_length: usize,
     /// Update frequency in seconds.
     pub update_period: u64,
+    /// Offset from the start of the slot to begin processing.
+    #[serde(skip, default = "default_slot_offset")]
+    pub slot_offset: f64,
     /// Maximum size of the LMDB database in megabytes.
     pub max_db_size_mbs: usize,
     /// Whether to broadcast slashings found to the network.
     pub broadcast: bool,
+}
+
+fn default_slot_offset() -> f64 {
+    DEFAULT_SLOT_OFFSET
 }
 
 impl Config {
@@ -40,6 +48,7 @@ impl Config {
             validator_chunk_size: DEFAULT_VALIDATOR_CHUNK_SIZE,
             history_length: DEFAULT_HISTORY_LENGTH,
             update_period: DEFAULT_UPDATE_PERIOD,
+            slot_offset: DEFAULT_SLOT_OFFSET,
             max_db_size_mbs: DEFAULT_MAX_DB_SIZE,
             broadcast: DEFAULT_BROADCAST,
         }

--- a/slasher/src/lib.rs
+++ b/slasher/src/lib.rs
@@ -15,8 +15,8 @@ pub mod test_utils;
 mod utils;
 
 pub use crate::slasher::Slasher;
-pub use attestation_queue::{AttestationBatch, AttestationQueue};
-pub use attester_record::AttesterRecord;
+pub use attestation_queue::{AttestationBatch, AttestationQueue, SimpleBatch};
+pub use attester_record::{AttesterRecord, IndexedAttesterRecord};
 pub use block_queue::BlockQueue;
 pub use config::Config;
 pub use database::SlasherDB;

--- a/slasher/src/metrics.rs
+++ b/slasher/src/metrics.rs
@@ -22,6 +22,11 @@ lazy_static! {
         "slasher_num_attestations_valid",
         "Number of valid attestations per batch"
     );
+    pub static ref SLASHER_NUM_ATTESTATIONS_STORED_PER_BATCH: Result<IntGauge> =
+        try_create_int_gauge(
+            "slasher_num_attestations_stored_per_batch",
+            "Number of attestations stored per batch"
+        );
     pub static ref SLASHER_NUM_BLOCKS_PROCESSED: Result<IntGauge> = try_create_int_gauge(
         "slasher_num_blocks_processed",
         "Number of blocks processed per batch",

--- a/slasher/src/migrate.rs
+++ b/slasher/src/migrate.rs
@@ -1,4 +1,8 @@
-use crate::{database::CURRENT_SCHEMA_VERSION, Config, Error, SlasherDB};
+use crate::{
+    config::{DEFAULT_BROADCAST, DEFAULT_SLOT_OFFSET},
+    database::CURRENT_SCHEMA_VERSION,
+    Config, Error, SlasherDB,
+};
 use lmdb::RwTransaction;
 use serde_derive::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -25,8 +29,9 @@ impl Into<ConfigV2> for ConfigV1 {
             validator_chunk_size: self.validator_chunk_size,
             history_length: self.history_length,
             update_period: self.update_period,
+            slot_offset: DEFAULT_SLOT_OFFSET,
             max_db_size_mbs: self.max_db_size_mbs,
-            broadcast: false,
+            broadcast: DEFAULT_BROADCAST,
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/2112
Closes https://github.com/sigp/lighthouse/issues/1861

## Proposed Changes

Collect attestations by validator index in the slasher, and use the magic of reference counting to automatically discard redundant attestations. This results in us storing only 1-2% of the attestations observed when subscribed to all subnets, which carries over to a 50-100x reduction in data stored :tada: 

## Additional Info

There's some nuance to the configuration of the `slot-offset`. It has a profound effect on the effictiveness of de-duplication, see the docs added to the book for an explanation: https://github.com/michaelsproul/lighthouse/blob/5442e695e5256046b91d4b4f45b7d244b0d8ad12/book/src/slasher.md#slot-offset
