### PR TITLE
[Merged by Bors] - Add minimum supported version for checkpoint sync in book

### DIFF
--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -1,7 +1,7 @@
 # Checkpoint Sync
 
-Lighthouse supports syncing from a recent finalized checkpoint. This is substantially faster
-than syncing from genesis, while still providing all the same features.
+Since version 2.0.0 Lighthouse supports syncing from a recent finalized checkpoint. This is
+substantially faster than syncing from genesis, while still providing all the same features.
 
 If you would like to quickly get started with checkpoint sync, read the sections below on:
 


### PR DESCRIPTION
## Issue Addressed

No specific issue. Just some improvement in the documentation provided by the book.

## Proposed Changes

Add minimum supported version for checkpoint sync in book to make sure users who want to use this feature know they need to be using at least version 2.0.0.