### PR TITLE
Fix Uint256 deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,6 +1580,7 @@ dependencies = [
 name = "eth2_serde_utils"
 version = "0.1.0"
 dependencies = [
+ "ethereum-types 0.12.1",
  "hex",
  "serde",
  "serde_derive",
@@ -6221,7 +6222,7 @@ dependencies = [
  "derivative",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_interop_keypairs",
- "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_serde_utils 0.1.0",
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -354,12 +354,6 @@ impl<T: EthSpec> From<JsonExecutionPayload<T>> for ExecutionPayload<T> {
     }
 }
 
-fn uint256_to_hash256(u: Uint256) -> Hash256 {
-    let mut bytes = [0; 32];
-    u.to_little_endian(&mut bytes);
-    Hash256::from_slice(&bytes)
-}
-
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonConsensusValidatedRequest {

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -326,7 +326,7 @@ impl<T: EthSpec> From<ExecutionPayload<T>> for JsonExecutionPayload<T> {
             gas_used: e.gas_used,
             timestamp: e.timestamp,
             extra_data: e.extra_data,
-            base_fee_per_gas: Uint256::from_little_endian(e.base_fee_per_gas.as_bytes()),
+            base_fee_per_gas: e.base_fee_per_gas,
             block_hash: e.block_hash,
             transactions: e.transactions,
         }
@@ -347,7 +347,7 @@ impl<T: EthSpec> From<JsonExecutionPayload<T>> for ExecutionPayload<T> {
             gas_used: e.gas_used,
             timestamp: e.timestamp,
             extra_data: e.extra_data,
-            base_fee_per_gas: uint256_to_hash256(e.base_fee_per_gas),
+            base_fee_per_gas: e.base_fee_per_gas,
             block_hash: e.block_hash,
             transactions: e.transactions,
         }
@@ -797,7 +797,7 @@ mod test {
                             gas_used: 2,
                             timestamp: 42,
                             extra_data: vec![].into(),
-                            base_fee_per_gas: uint256_to_hash256(Uint256::from(1)),
+                            base_fee_per_gas: Uint256::from(1),
                             block_hash: Hash256::repeat_byte(1),
                             transactions: vec![].into(),
                         })
@@ -960,7 +960,7 @@ mod test {
                             gas_used: 0,
                             timestamp: 5,
                             extra_data: vec![].into(),
-                            base_fee_per_gas: uint256_to_hash256(Uint256::from(0)),
+                            base_fee_per_gas: Uint256::from(0),
                             block_hash: Hash256::from_str("0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174").unwrap(),
                             transactions: vec![].into(),
                         };
@@ -984,7 +984,7 @@ mod test {
                             gas_used: 0,
                             timestamp: 5,
                             extra_data: vec![].into(),
-                            base_fee_per_gas: uint256_to_hash256(Uint256::from(0)),
+                            base_fee_per_gas: Uint256::from(0),
                             block_hash: Hash256::from_str("0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174").unwrap(),
                             transactions: vec![].into(),
                         })

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -250,7 +250,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
             gas_used: GAS_USED,
             timestamp: payload.timestamp,
             extra_data: "block gen was here".as_bytes().to_vec().into(),
-            base_fee_per_gas: Hash256::from_low_u64_le(1),
+            base_fee_per_gas: Uint256::one(),
             block_hash: Hash256::zero(),
             transactions: vec![].into(),
         };

--- a/consensus/serde_utils/Cargo.toml
+++ b/consensus/serde_utils/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_derive = "1.0.116"
 hex = "0.4.2"
+ethereum-types = "0.12.1"
 
 [dev-dependencies]
 serde_json = "1.0.58"

--- a/consensus/serde_utils/src/lib.rs
+++ b/consensus/serde_utils/src/lib.rs
@@ -9,4 +9,4 @@ pub mod u32_hex;
 pub mod u64_hex_be;
 pub mod u8_hex;
 
-pub use quoted_int::{quoted_u32, quoted_u64, quoted_u8};
+pub use quoted_int::{quoted_u256, quoted_u32, quoted_u64, quoted_u8};

--- a/consensus/serde_utils/src/quoted_int.rs
+++ b/consensus/serde_utils/src/quoted_int.rs
@@ -4,6 +4,7 @@
 //!
 //! Quotes can be optional during decoding.
 
+use ethereum_types::U256;
 use serde::{Deserializer, Serializer};
 use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -54,6 +55,17 @@ macro_rules! define_mod {
                     T::try_from(v).map_err(|_| serde::de::Error::custom("invalid integer"))
                 }
             }
+        }
+
+        /// Compositional wrapper type that allows quotes or no quotes.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+        #[serde(transparent)]
+        pub struct MaybeQuoted<T>
+        where
+            T: From<$int> + Into<$int> + Copy + TryFrom<u64>,
+        {
+            #[serde(with = "self")]
+            pub value: T,
         }
 
         /// Wrapper type for requiring quotes on a `$int`-like type.
@@ -141,4 +153,41 @@ pub mod quoted_u64 {
     use super::*;
 
     define_mod!(u64, visit_u64);
+}
+
+pub mod quoted_u256 {
+    use super::*;
+
+    struct U256Visitor;
+
+    impl<'de> serde::de::Visitor<'de> for U256Visitor {
+        type Value = U256;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a quoted U256 integer")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            U256::from_dec_str(&v).map_err(serde::de::Error::custom)
+        }
+    }
+
+    /// Serialize with quotes.
+    pub fn serialize<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&format!("{}", value))
+    }
+
+    /// Deserialize with quotes.
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(U256Visitor)
+    }
 }

--- a/consensus/serde_utils/src/quoted_int.rs
+++ b/consensus/serde_utils/src/quoted_int.rs
@@ -192,7 +192,6 @@ pub mod quoted_u256 {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/consensus/serde_utils/src/quoted_int.rs
+++ b/consensus/serde_utils/src/quoted_int.rs
@@ -171,7 +171,7 @@ pub mod quoted_u256 {
         where
             E: serde::de::Error,
         {
-            U256::from_dec_str(&v).map_err(serde::de::Error::custom)
+            U256::from_dec_str(v).map_err(serde::de::Error::custom)
         }
     }
 

--- a/consensus/serde_utils/src/quoted_int.rs
+++ b/consensus/serde_utils/src/quoted_int.rs
@@ -191,3 +191,30 @@ pub mod quoted_u256 {
         deserializer.deserialize_str(U256Visitor)
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct WrappedU256(#[serde(with = "quoted_u256")] U256);
+
+    #[test]
+    fn u256_with_quotes() {
+        assert_eq!(
+            &serde_json::to_string(&WrappedU256(U256::one())).unwrap(),
+            "\"1\""
+        );
+        assert_eq!(
+            serde_json::from_str::<WrappedU256>("\"1\"").unwrap(),
+            WrappedU256(U256::one())
+        );
+    }
+
+    #[test]
+    fn u256_without_quotes() {
+        serde_json::from_str::<WrappedU256>("1").unwrap_err();
+    }
+}

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -38,7 +38,7 @@ tempfile = "3.1.0"
 derivative = "2.1.1"
 rusqlite = { version = "0.25.3", features = ["bundled"], optional = true }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
-eth2_serde_utils = "0.1.0"
+eth2_serde_utils = { path = "../serde_utils" }
 regex = "1.3.9"
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -29,6 +29,8 @@ pub struct ExecutionPayload<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
+    #[serde(serialize_with = "serialize_u256")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -29,7 +29,7 @@ pub struct ExecutionPayload<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    pub base_fee_per_gas: Hash256,
+    pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]
     pub transactions:
@@ -51,7 +51,7 @@ impl<T: EthSpec> ExecutionPayload<T> {
             gas_used: 0,
             timestamp: 0,
             extra_data: VariableList::empty(),
-            base_fee_per_gas: Hash256::zero(),
+            base_fee_per_gas: Uint256::zero(),
             block_hash: Hash256::zero(),
             transactions: VariableList::empty(),
         }

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -29,8 +29,7 @@ pub struct ExecutionPayload<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(serialize_with = "serialize_u256")]
-    #[serde(deserialize_with = "deserialize_u256")]
+    #[serde(with = "eth2_serde_utils::quoted_u256")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -26,8 +26,7 @@ pub struct ExecutionPayloadHeader<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(serialize_with = "serialize_u256")]
-    #[serde(deserialize_with = "deserialize_u256")]
+    #[serde(with = "eth2_serde_utils::quoted_u256")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     pub transactions_root: Hash256,

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -26,6 +26,8 @@ pub struct ExecutionPayloadHeader<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
+    #[serde(serialize_with = "serialize_u256")]
+    #[serde(deserialize_with = "deserialize_u256")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     pub transactions_root: Hash256,

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -26,7 +26,7 @@ pub struct ExecutionPayloadHeader<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    pub base_fee_per_gas: Hash256,
+    pub base_fee_per_gas: Uint256,
     pub block_hash: Hash256,
     pub transactions_root: Hash256,
 }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -162,24 +162,6 @@ pub type Uint256 = ethereum_types::U256;
 pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 
-use serde::{Deserializer, Serializer};
-
-pub fn serialize_u256<S>(val: &Uint256, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let val = val.to_string();
-    s.serialize_str(&val)
-}
-
-pub fn deserialize_u256<'de, D>(deserializer: D) -> Result<Uint256, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let decoded: String = serde::de::Deserialize::deserialize(deserializer)?;
-    Uint256::from_dec_str(&decoded).map_err(serde::de::Error::custom)
-}
-
 pub use bls::{
     AggregatePublicKey, AggregateSignature, Keypair, PublicKey, PublicKeyBytes, SecretKey,
     Signature, SignatureBytes,

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -162,6 +162,24 @@ pub type Uint256 = ethereum_types::U256;
 pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 
+use serde::{Deserializer, Serializer};
+
+pub fn serialize_u256<S>(val: &Uint256, s: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let val = val.to_string();
+    s.serialize_str(&val)
+}
+
+pub fn deserialize_u256<'de, D>(deserializer: D) -> Result<Uint256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded: String = serde::de::Deserialize::deserialize(deserializer)?;
+    Uint256::from_dec_str(&decoded).map_err(serde::de::Error::custom)
+}
+
 pub use bls::{
     AggregatePublicKey, AggregateSignature, Keypair, PublicKey, PublicKeyBytes, SecretKey,
     Signature, SignatureBytes,

--- a/lcli/src/create_payload_header.rs
+++ b/lcli/src/create_payload_header.rs
@@ -1,7 +1,5 @@
-use bls::Hash256;
 use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required};
-use int_to_bytes::int_to_bytes32;
 use ssz::Encode;
 use std::fs::File;
 use std::io::Write;
@@ -16,10 +14,7 @@ pub fn run<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
             .map_err(|e| format!("Unable to get time: {:?}", e))?
             .as_secs(),
     );
-    let base_fee_per_gas = Hash256::from_slice(&int_to_bytes32(parse_required(
-        matches,
-        "base-fee-per-gas",
-    )?));
+    let base_fee_per_gas = parse_required(matches, "base-fee-per-gas")?;
     let gas_limit = parse_required(matches, "gas-limit")?;
     let file_name = matches.value_of("file").ok_or("No file supplied")?;
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Builds upon @realbigsean 's merge spec test fixes from #2781. Add a `quoted_u256` module in `eth2_serde_utils`  to correctly decode Uint256 values from string.

## Additional Info

Had to add the `ethereum-types` dependency to `serde_utils` and use the local crate instead of the published version.
We could also move the  `quoted_u256` module to `types` instead if we want to use the published version.