### PR TITLE
[Merged by Bors] - Add a section on using infura as the checkpoint sync provider

### DIFF
--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -41,6 +41,17 @@ Once the checkpoint is loaded Lighthouse will sync forwards to the head of the c
 If a validator client is connected to the node then it will be able to start completing its duties
 as soon as forwards sync completes.
 
+### Use Infura as a remote beacon node provider
+
+You can use Infura as the remote beacon node provider to load the initial checkpoint state.
+
+1. Sign up for the free Infura ETH2 api using the `Create new project tab` on the [Infura dashboard](https://infura.io/dashboard).
+2. Copy the https endpoint for the required network (mainnet/prater)
+3. Use it as the url for the `--checkpoint-sync-url` flag.  e.g.
+```
+lighthouse bn --checkpoint-sync-url https://<PROJECT-ID>:<PROJECT-SECRET>@eth2-beacon-mainnet.infura.io ...
+```
+
 ## Backfilling Blocks
 
 Once forwards sync completes, Lighthouse will commence a "backfill sync" to download the blocks

--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -45,8 +45,8 @@ as soon as forwards sync completes.
 
 You can use Infura as the remote beacon node provider to load the initial checkpoint state.
 
-1. Sign up for the free Infura ETH2 api using the `Create new project tab` on the [Infura dashboard](https://infura.io/dashboard).
-2. Copy the https endpoint for the required network (mainnet/prater)
+1. Sign up for the free Infura ETH2 API using the `Create new project tab` on the [Infura dashboard](https://infura.io/dashboard).
+2. Copy the HTTPS endpoint for the required network (mainnet/Prater).
 3. Use it as the url for the `--checkpoint-sync-url` flag.  e.g.
 ```
 lighthouse bn --checkpoint-sync-url https://<PROJECT-ID>:<PROJECT-SECRET>@eth2-beacon-mainnet.infura.io ...

--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -46,7 +46,7 @@ as soon as forwards sync completes.
 You can use Infura as the remote beacon node provider to load the initial checkpoint state.
 
 1. Sign up for the free Infura ETH2 API using the `Create new project tab` on the [Infura dashboard](https://infura.io/dashboard).
-2. Copy the HTTPS endpoint for the required network (mainnet/Prater).
+2. Copy the HTTPS endpoint for the required network (Mainnet/Prater).
 3. Use it as the url for the `--checkpoint-sync-url` flag.  e.g.
 ```
 lighthouse bn --checkpoint-sync-url https://<PROJECT-ID>:<PROJECT-SECRET>@eth2-beacon-mainnet.infura.io ...


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

From discord, it seems like users are a bit unclear on how to run checkpoint sync if they don't have an existing synced beacon node. Adds a note on how to use infura for the checkpoint sync feature.
