### PR TITLE
Allocate less memory (3GB) in engine tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
- "warp 0.3.0 (git+https://github.com/paulhauner/warp?branch=cors-wildcard)",
+ "warp",
 ]
 
 [[package]]
@@ -2392,7 +2392,7 @@ dependencies = [
  "tokio-stream",
  "tree_hash",
  "types",
- "warp 0.3.0 (git+https://github.com/macladson/warp?rev=dfa259e)",
+ "warp",
  "warp_utils",
 ]
 
@@ -2413,7 +2413,7 @@ dependencies = [
  "store",
  "tokio",
  "types",
- "warp 0.3.0 (git+https://github.com/macladson/warp?rev=dfa259e)",
+ "warp",
  "warp_utils",
 ]
 
@@ -6450,7 +6450,7 @@ dependencies = [
  "types",
  "url",
  "validator_dir",
- "warp 0.3.0 (git+https://github.com/macladson/warp?rev=dfa259e)",
+ "warp",
  "warp_utils",
 ]
 
@@ -6519,35 +6519,6 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.3.0"
-source = "git+https://github.com/paulhauner/warp?branch=cors-wildcard#1f7daf462e6286fe5fd1743f7b788227efd3fa5c"
-dependencies = [
- "bytes",
- "futures",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "multipart",
- "percent-encoding",
- "pin-project 1.0.8",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-stream",
- "tokio-tungstenite",
- "tokio-util",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "warp"
-version = "0.3.0"
 source = "git+https://github.com/macladson/warp?rev=dfa259e#dfa259e19b7490e6bc4bf247e8b76f671d29a0eb"
 dependencies = [
  "bytes",
@@ -6589,7 +6560,7 @@ dependencies = [
  "state_processing",
  "tokio",
  "types",
- "warp 0.3.0 (git+https://github.com/macladson/warp?rev=dfa259e)",
+ "warp",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ dependencies = [
  "eth2_ssz",
  "eth2_ssz_derive",
  "ethereum-types 0.12.1",
+ "fork_choice",
  "fs2",
  "hex",
  "rayon",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2448,6 +2448,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     block_root,
                     &state,
                     payload_verification_status,
+                    &self.spec,
                 )
                 .map_err(|e| BlockError::BeaconChainError(e.into()))?;
         }

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -178,6 +178,7 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
                 block.canonical_root(),
                 &state,
                 payload_verification_status,
+                spec,
             )
             .map_err(|e| format!("Error applying replayed block to fork choice: {:?}", e))?;
     }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -36,7 +36,7 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, HeadSafetyStatus, StateSkipConfig, WhenSlotSkipped, HeadInfo
+    ForkChoiceError, HeadInfo, HeadSafetyStatus, StateSkipConfig, WhenSlotSkipped,
     MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -17,7 +17,7 @@ eth2_serde_utils = { path = "../../consensus/serde_utils" }
 serde_json = "1.0.58"
 serde = { version = "1.0.116", features = ["derive"] }
 eth1 = { path = "../eth1" }
-warp = { git = "https://github.com/paulhauner/warp ", branch = "cors-wildcard" }
+warp = { git = "https://github.com/macladson/warp", rev ="dfa259e", features = ["tls"] }
 environment = { path = "../../lighthouse/environment" }
 bytes = "1.1.0"
 task_executor = { path = "../../common/task_executor" }

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -569,7 +569,7 @@ mod test {
         VariableList<Transaction<E::MaxBytesPerTransaction>, E::MaxTransactionsPerPayload>,
         serde_json::Error,
     > {
-        let json = json!({
+        let mut json = json!({
             "parentHash": HASH_00,
             "coinbase": ADDRESS_01,
             "stateRoot": HASH_01,
@@ -583,8 +583,9 @@ mod test {
             "extraData": "0x",
             "baseFeePerGas": "0x1",
             "blockHash": HASH_01,
-            "transactions": transactions,
         });
+        // Take advantage of the fact that we own `transactions` and don't need to reserialize it.
+        json.as_object_mut().unwrap().insert("transactions".into(), transactions);
         let ep: JsonExecutionPayload<E> = serde_json::from_value(json)?;
         Ok(ep.transactions)
     }
@@ -673,22 +674,19 @@ mod test {
         );
 
         /*
-         * Check for transaction too large
+         * Check for transaction too large. This code is a bit weird because it's trying to avoid allocating too much memory.
+         * The transaction max size is 1GB at time of writing, so we have to allocate around 3GB: 2GB for the hex repr, and 1GB
+           for the decoded byte repr.
          */
+        let num_max_bytes = MainnetEthSpec::max_bytes_per_transaction();
 
-        use eth2_serde_utils::hex;
+        let max_bytes_str = std::iter::once("0x").chain(std::iter::repeat("00").take(num_max_bytes)).collect::<String>();
+        let max_bytes_json = serde_json::Value::Array(vec![serde_json::Value::String(max_bytes_str)]);
+        decode_transactions::<MainnetEthSpec>(max_bytes_json).unwrap();
 
-        let num_max_bytes = <MainnetEthSpec as EthSpec>::MaxBytesPerTransaction::to_usize();
-        let max_bytes = (0..num_max_bytes).map(|_| 0_u8).collect::<Vec<_>>();
-        let too_many_bytes = (0..=num_max_bytes).map(|_| 0_u8).collect::<Vec<_>>();
-        decode_transactions::<MainnetEthSpec>(
-            serde_json::to_value(&[hex::encode(&max_bytes)]).unwrap(),
-        )
-        .unwrap();
-        assert!(decode_transactions::<MainnetEthSpec>(
-            serde_json::to_value(&[hex::encode(&too_many_bytes)]).unwrap()
-        )
-        .is_err());
+        let too_many_bytes_str = std::iter::once("0x").chain(std::iter::repeat("00").take(num_max_bytes + 1)).collect::<String>();
+        let too_many_bytes_json = serde_json::Value::Array(vec![serde_json::Value::String(too_many_bytes_str)]);
+        decode_transactions::<MainnetEthSpec>(too_many_bytes_json).unwrap_err();
     }
 
     #[tokio::test]

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 use proto_array::{Block as ProtoBlock, ExecutionStatus, ProtoArrayForkChoice};
 use ssz_derive::{Decode, Encode};
 use types::{
-    AttestationShufflingId, BeaconBlock, BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec,
-    Hash256, IndexedAttestation, RelativeEpoch, SignedBeaconBlock, Slot,
+    AttestationShufflingId, BeaconBlock, BeaconState, BeaconStateError, ChainSpec, Checkpoint,
+    Epoch, EthSpec, Hash256, IndexedAttestation, RelativeEpoch, SignedBeaconBlock, Slot,
 };
 
 use crate::ForkChoiceStore;
@@ -469,6 +469,7 @@ where
         block_root: Hash256,
         state: &BeaconState<E>,
         payload_verification_status: PayloadVerificationStatus,
+        spec: &ChainSpec,
     ) -> Result<(), Error<T::Error>> {
         let current_slot = self.update_time(current_slot)?;
 

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -3,7 +3,7 @@ mod fork_choice_store;
 
 pub use crate::fork_choice::{
     Error, ForkChoice, InvalidAttestation, InvalidBlock, PayloadVerificationStatus,
-    PersistedForkChoice, QueuedAttestation, SAFE_SLOTS_TO_UPDATE_JUSTIFIED,
+    PersistedForkChoice, QueuedAttestation,
 };
 pub use fork_choice_store::ForkChoiceStore;
 pub use proto_array::Block as ProtoBlock;

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -34,3 +34,4 @@ snap = "1.0.1"
 fs2 = "0.4.3"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 store = { path = "../../beacon_node/store" }
+fork_choice = { path = "../../consensus/fork_choice" }

--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -26,6 +26,7 @@ mod ssz_generic;
 mod ssz_static;
 mod transition;
 
+pub use self::fork_choice::*;
 pub use bls_aggregate_sigs::*;
 pub use bls_aggregate_verify::*;
 pub use bls_eth_aggregate_pubkeys::*;
@@ -36,7 +37,6 @@ pub use bls_verify_msg::*;
 pub use common::SszStaticType;
 pub use epoch_processing::*;
 pub use fork::ForkTest;
-pub use fork_choice::*;
 pub use genesis_initialization::*;
 pub use genesis_validity::*;
 pub use operations::*;

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
+use ::fork_choice::PayloadVerificationStatus;
 use beacon_chain::{
     attestation_verification::{
         obtain_indexed_attestation_and_committees_per_slot, VerifiedAttestation,
@@ -319,6 +320,7 @@ impl<E: EthSpec> Tester<E> {
                     &block,
                     block_root,
                     &state,
+                    PayloadVerificationStatus::Irrelevant,
                     &self.harness.chain.spec,
                 );
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/pull/2768#discussion_r747218203

## Proposed Changes

Minimise memory usage in the max transaction size test. I couldn't get it any lower than 3GB (see the comments). If it still fails we can delete the test entirely (or question the rationale of having a 1GB transaction limit..).

## Additional Info

Blocked on https://github.com/sigp/lighthouse/pull/2799
