### PR TITLE
Kintsugi on_merge_block tests

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -15,6 +15,7 @@ use crate::chain_config::ChainConfig;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::eth1_chain::{Eth1Chain, Eth1ChainBackend};
 use crate::events::ServerSentEventHandler;
+use crate::execution_payload::prepare_execution_payload_blocking;
 use crate::head_tracker::HeadTracker;
 use crate::historical_blocks::HistoricalBlockError;
 use crate::migrate::BackgroundMigrator;
@@ -64,9 +65,7 @@ use slot_clock::SlotClock;
 use state_processing::{
     common::get_indexed_attestation,
     per_block_processing,
-    per_block_processing::{
-        compute_timestamp_at_slot, errors::AttestationValidationError, is_merge_complete,
-    },
+    per_block_processing::{errors::AttestationValidationError, is_merge_complete},
     per_slot_processing,
     state_advance::{complete_state_advance, partial_state_advance},
     BlockSignatureStrategy, SigVerifiedOp,
@@ -2880,63 +2879,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     SyncAggregate::new()
                 }))
         };
-        // Closure to fetch a sync aggregate in cases where it is required.
-        let get_execution_payload = |latest_execution_payload_header: &ExecutionPayloadHeader<
-            T::EthSpec,
-        >|
-         -> Result<ExecutionPayload<_>, BlockProductionError> {
-            let execution_layer = self
-                .execution_layer
-                .as_ref()
-                .ok_or(BlockProductionError::ExecutionLayerMissing)?;
-
-            let parent_hash;
-            if !is_merge_complete(&state) {
-                let terminal_pow_block_hash = execution_layer
-                    .block_on(|execution_layer| {
-                        execution_layer.get_terminal_pow_block_hash(&self.spec)
-                    })
-                    .map_err(BlockProductionError::TerminalPoWBlockLookupFailed)?;
-
-                if let Some(terminal_pow_block_hash) = terminal_pow_block_hash {
-                    parent_hash = terminal_pow_block_hash;
-                } else {
-                    return Ok(<_>::default());
-                }
-            } else {
-                parent_hash = latest_execution_payload_header.block_hash;
-            }
-
-            let timestamp =
-                compute_timestamp_at_slot(&state, &self.spec).map_err(BeaconStateError::from)?;
-            let random = *state.get_randao_mix(state.current_epoch())?;
-            let finalized_root = state.finalized_checkpoint().root;
-
-            let finalized_block_hash =
-                if let Some(block) = self.fork_choice.read().get_block(&finalized_root) {
-                    block.execution_status.block_hash()
-                } else {
-                    self.store
-                        .get_block(&finalized_root)
-                        .map_err(BlockProductionError::FailedToReadFinalizedBlock)?
-                        .ok_or(BlockProductionError::MissingFinalizedBlock(finalized_root))?
-                        .message()
-                        .body()
-                        .execution_payload()
-                        .map(|ep| ep.block_hash)
-                };
-
-            execution_layer
-                .block_on(|execution_layer| {
-                    execution_layer.get_payload(
-                        parent_hash,
-                        timestamp,
-                        random,
-                        finalized_block_hash.unwrap_or_else(Hash256::zero),
-                    )
-                })
-                .map_err(BlockProductionError::GetPayloadFailed)
-        };
 
         let inner_block = match &state {
             BeaconState::Base(_) => BeaconBlock::Base(BeaconBlockBase {
@@ -2975,10 +2917,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     },
                 })
             }
-            BeaconState::Merge(state) => {
+            BeaconState::Merge(_) => {
                 let sync_aggregate = get_sync_aggregate()?;
                 let execution_payload =
-                    get_execution_payload(&state.latest_execution_payload_header)?;
+                    prepare_execution_payload_blocking(self, &state)?.unwrap_or_default();
                 BeaconBlock::Merge(BeaconBlockMerge {
                     slot,
                     proposer_index,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -15,7 +15,7 @@ use crate::chain_config::ChainConfig;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::eth1_chain::{Eth1Chain, Eth1ChainBackend};
 use crate::events::ServerSentEventHandler;
-use crate::execution_payload::prepare_execution_payload_blocking;
+use crate::execution_payload::get_execution_payload;
 use crate::head_tracker::HeadTracker;
 use crate::historical_blocks::HistoricalBlockError;
 use crate::migrate::BackgroundMigrator;
@@ -2919,8 +2919,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
             BeaconState::Merge(_) => {
                 let sync_aggregate = get_sync_aggregate()?;
-                let execution_payload =
-                    prepare_execution_payload_blocking(self, &state)?.unwrap_or_default();
+                let execution_payload = get_execution_payload(self, &state)?;
                 BeaconBlock::Merge(BeaconBlockMerge {
                     slot,
                     proposer_index,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -302,6 +302,13 @@ pub enum ExecutionPayloadError {
         terminal_block_hash: Hash256,
         payload_parent_hash: Hash256,
     },
+    /// The execution node failed to provide a parent block to a known block. This indicates an
+    /// issue with the execution node.
+    ///
+    /// ## Peer scoring
+    ///
+    /// The peer is not necessarily invalid.
+    PoWParentMissing(Hash256),
 }
 
 impl From<execution_layer::Error> for ExecutionPayloadError {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -280,7 +280,7 @@ pub enum ExecutionPayloadError {
     ///
     /// The block is invalid and the peer sent us a block that passes gossip propagation conditions,
     /// but is invalid upon further verification.
-    InvalidTerminalPoWBlock,
+    InvalidTerminalPoWBlock { parent_hash: Hash256 },
     /// The `TERMINAL_BLOCK_HASH` is set, but the block has not reached the
     /// `TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH`.
     ///

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -266,24 +266,12 @@ pub enum ExecutionPayloadError {
     ///
     /// The block is invalid and the peer is faulty
     RejectedByExecutionEngine,
-    /// The execution engine returned SYNCING for the payload
-    ///
-    /// ## Peer scoring
-    ///
-    /// It is not known if the block is valid or invalid.
-    ExecutionEngineIsSyncing,
     /// The execution payload timestamp does not match the slot
     ///
     /// ## Peer scoring
     ///
     /// The block is invalid and the peer is faulty
     InvalidPayloadTimestamp { expected: u64, found: u64 },
-    /// The execution payload transaction list data exceeds size limits
-    ///
-    /// ## Peer scoring
-    ///
-    /// The block is invalid and the peer is faulty
-    TransactionDataExceedsSizeLimit,
     /// The execution payload references an execution block that cannot trigger the merge.
     ///
     /// ## Peer scoring
@@ -291,13 +279,6 @@ pub enum ExecutionPayloadError {
     /// The block is invalid and the peer sent us a block that passes gossip propagation conditions,
     /// but is invalid upon further verification.
     InvalidTerminalPoWBlock,
-    /// The execution payload references execution blocks that are unavailable on our execution
-    /// nodes.
-    ///
-    /// ## Peer scoring
-    ///
-    /// It's not clear if the peer is invalid or if it's on a different execution fork to us.
-    TerminalPoWBlockNotFound,
 }
 
 impl From<execution_layer::Error> for ExecutionPayloadError {

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -181,6 +181,7 @@ pub enum BlockProductionError {
         state_slot: Slot,
     },
     ExecutionLayerMissing,
+    BlockingFailed(execution_layer::Error),
     TerminalPoWBlockLookupFailed(execution_layer::Error),
     GetPayloadFailed(execution_layer::Error),
     FailedToReadFinalizedBlock(store::Error),

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -1,0 +1,86 @@
+use crate::{BeaconChain, BeaconChainTypes, BlockProductionError};
+use state_processing::per_block_processing::{compute_timestamp_at_slot, is_merge_complete};
+use types::*;
+
+pub fn prepare_execution_payload_blocking<T: BeaconChainTypes>(
+    chain: &BeaconChain<T>,
+    state: &BeaconState<T::EthSpec>,
+) -> Result<Option<ExecutionPayload<T::EthSpec>>, BlockProductionError> {
+    let execution_layer = chain
+        .execution_layer
+        .as_ref()
+        .ok_or(BlockProductionError::ExecutionLayerMissing)?;
+
+    execution_layer
+        .block_on_generic(|_| async { prepare_execution_payload(chain, state).await })
+        .map_err(BlockProductionError::BlockingFailed)?
+}
+
+pub async fn prepare_execution_payload<T: BeaconChainTypes>(
+    chain: &BeaconChain<T>,
+    state: &BeaconState<T::EthSpec>,
+) -> Result<Option<ExecutionPayload<T::EthSpec>>, BlockProductionError> {
+    let spec = &chain.spec;
+    let execution_layer = chain
+        .execution_layer
+        .as_ref()
+        .ok_or(BlockProductionError::ExecutionLayerMissing)?;
+
+    let parent_hash = if !is_merge_complete(&state) {
+        let is_terminal_block_hash_set = spec.terminal_block_hash != Hash256::zero();
+        let is_activation_epoch_reached =
+            state.current_epoch() >= spec.terminal_block_hash_activation_epoch;
+
+        if is_terminal_block_hash_set && !is_activation_epoch_reached {
+            return Ok(None);
+        }
+
+        let terminal_pow_block_hash = execution_layer
+            .get_terminal_pow_block_hash()
+            .await
+            .map_err(BlockProductionError::TerminalPoWBlockLookupFailed)?;
+
+        if let Some(terminal_pow_block_hash) = terminal_pow_block_hash {
+            terminal_pow_block_hash
+        } else {
+            return Ok(None);
+        }
+    } else {
+        state.latest_execution_payload_header()?.block_hash
+    };
+
+    let timestamp = compute_timestamp_at_slot(&state, spec).map_err(BeaconStateError::from)?;
+    let random = *state.get_randao_mix(state.current_epoch())?;
+    let finalized_root = state.finalized_checkpoint().root;
+
+    // The finalized block hash is not included in the specification, however we provide this
+    // parameter so that the execution layer can produce a payload id if one is not already known
+    // (e.g., due to a recent reorg).
+    let finalized_block_hash =
+        if let Some(block) = chain.fork_choice.read().get_block(&finalized_root) {
+            block.execution_status.block_hash()
+        } else {
+            chain
+                .store
+                .get_block(&finalized_root)
+                .map_err(BlockProductionError::FailedToReadFinalizedBlock)?
+                .ok_or(BlockProductionError::MissingFinalizedBlock(finalized_root))?
+                .message()
+                .body()
+                .execution_payload()
+                .map(|ep| ep.block_hash)
+        };
+
+    // Note: the fee_recipient is stored in the `execution_layer`, it will add this parameter.
+    let execution_payload = execution_layer
+        .get_payload(
+            parent_hash,
+            timestamp,
+            random,
+            finalized_block_hash.unwrap_or_else(Hash256::zero),
+        )
+        .await
+        .map_err(BlockProductionError::GetPayloadFailed)?;
+
+    Ok(Some(execution_payload))
+}

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -40,7 +40,7 @@ pub fn execute_payload<T: BeaconChainTypes>(
         return Ok(PayloadVerificationStatus::Irrelevant);
     }
 
-    let execution_payload = execution_payload_ref(block)?;
+    let execution_payload = block.execution_payload()?;
 
     // Perform the initial stages of payload verification.
     //
@@ -87,7 +87,7 @@ pub fn validate_merge_block<T: BeaconChainTypes>(
 ) -> Result<(), BlockError<T::EthSpec>> {
     let spec = &chain.spec;
     let block_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
-    let execution_payload = execution_payload_ref(block)?;
+    let execution_payload = block.execution_payload()?;
 
     if spec.terminal_block_hash != Hash256::zero() {
         if block_epoch < spec.terminal_block_hash_activation_epoch {
@@ -303,18 +303,4 @@ pub async fn prepare_execution_payload<T: BeaconChainTypes>(
         .map_err(BlockProductionError::GetPayloadFailed)?;
 
     Ok(Some(execution_payload))
-}
-
-/// Extracts a reference to an execution payload from a block, returning an error if there is a
-/// fork mismatch.
-fn execution_payload_ref<T: EthSpec>(
-    block: BeaconBlockRef<T>,
-) -> Result<&ExecutionPayload<T>, BlockError<T>> {
-    block.body().execution_payload().ok_or_else(|| {
-        InconsistentFork {
-            fork_at_slot: eth2::types::ForkName::Merge,
-            object_fork: block.body().fork_name(),
-        }
-        .into()
-    })
 }

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -11,7 +11,7 @@ use crate::{
     BeaconChain, BeaconChainError, BeaconChainTypes, BlockError, BlockProductionError,
     ExecutionPayloadError,
 };
-use execution_layer::{ExecutePayloadResponseStatus, ExecutionBlock};
+use execution_layer::ExecutePayloadResponseStatus;
 use fork_choice::PayloadVerificationStatus;
 use proto_array::{Block as ProtoBlock, ExecutionStatus};
 use slog::debug;
@@ -111,47 +111,25 @@ pub fn validate_merge_block<T: BeaconChainTypes>(
         .as_ref()
         .ok_or(ExecutionPayloadError::NoExecutionConnection)?;
 
-    let pow_block_opt = execution_layer
-        .block_on(|execution_layer| execution_layer.get_pow_block(execution_payload.parent_hash))
+    let is_valid_terminal_pow_block = execution_layer
+        .block_on(|execution_layer| {
+            execution_layer.is_valid_terminal_pow_block_hash(execution_payload.parent_hash, spec)
+        })
         .map_err(ExecutionPayloadError::from)?;
 
-    if let Some(pow_block) = pow_block_opt {
-        let pow_parent_opt = execution_layer
-            .block_on(|execution_layer| execution_layer.get_pow_block(pow_block.parent_hash))
-            .map_err(ExecutionPayloadError::from)?;
-
-        if let Some(pow_parent) = pow_parent_opt {
-            dbg!(spec.terminal_total_difficulty, &pow_block, &pow_parent);
-            if is_valid_terminal_pow_block(pow_block, pow_parent, spec) {
-                dbg!("valid");
-                Ok(())
-            } else {
-                dbg!("invalid");
-                Err(ExecutionPayloadError::InvalidTerminalPoWBlock.into())
-            }
-        } else {
-            Err(ExecutionPayloadError::PoWParentMissing(pow_block.parent_hash).into())
+    match is_valid_terminal_pow_block {
+        Some(true) => Ok(()),
+        Some(false) => Err(ExecutionPayloadError::InvalidTerminalPoWBlock.into()),
+        None => {
+            debug!(
+                chain.log,
+                "Optimistically accepting terminal block";
+                "block_hash" => ?execution_payload.parent_hash,
+                "msg" => "the terminal block/parent was unavailable"
+            );
+            Ok(())
         }
-    } else {
-        dbg!("optimistic");
-        debug!(
-            chain.log,
-            "Optimistically accepting terminal block";
-            "block_hash" => ?execution_payload.parent_hash,
-            "msg" => "the terminal block/parent was unavailable"
-        );
-        Ok(())
     }
-}
-
-fn is_valid_terminal_pow_block(
-    block: ExecutionBlock,
-    parent: ExecutionBlock,
-    spec: &ChainSpec,
-) -> bool {
-    let is_total_difficulty_reached = block.total_difficulty >= spec.terminal_total_difficulty;
-    let is_parent_total_difficulty_valid = parent.total_difficulty < spec.terminal_total_difficulty;
-    is_total_difficulty_reached && is_parent_total_difficulty_valid
 }
 
 /// Validate the gossip block's execution_payload according to the checks described here:
@@ -272,7 +250,7 @@ pub async fn prepare_execution_payload<T: BeaconChainTypes>(
         }
 
         let terminal_pow_block_hash = execution_layer
-            .get_terminal_pow_block_hash()
+            .get_terminal_pow_block_hash(spec)
             .await
             .map_err(BlockProductionError::TerminalPoWBlockLookupFailed)?;
 

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -301,9 +301,9 @@ pub async fn prepare_execution_payload<T: BeaconChainTypes>(
 
 /// Extracts a reference to an execution payload from a block, returning an error if there is a
 /// fork mismatch.
-fn execution_payload_ref<'a, T: EthSpec>(
-    block: BeaconBlockRef<'a, T>,
-) -> Result<&'a ExecutionPayload<T>, BlockError<T>> {
+fn execution_payload_ref<T: EthSpec>(
+    block: BeaconBlockRef<T>,
+) -> Result<&ExecutionPayload<T>, BlockError<T>> {
     block.body().execution_payload().ok_or_else(|| {
         InconsistentFork {
             fork_at_slot: eth2::types::ForkName::Merge,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -12,6 +12,7 @@ pub mod chain_config;
 mod errors;
 pub mod eth1_chain;
 pub mod events;
+mod execution_payload;
 pub mod fork_revert;
 mod head_tracker;
 pub mod historical_blocks;

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -146,6 +146,24 @@ impl ExecutionLayer {
         runtime.block_on(generate_future(self))
     }
 
+    /// Convenience function to allow calling async functions in a non-async context.
+    ///
+    /// The function is "generic" since it does not enforce a particular return type on
+    /// `generate_future`.
+    pub fn block_on_generic<'a, T, U, V>(&'a self, generate_future: T) -> Result<V, Error>
+    where
+        T: Fn(&'a Self) -> U,
+        U: Future<Output = V>,
+    {
+        let runtime = self
+            .executor()
+            .runtime()
+            .upgrade()
+            .ok_or(Error::ShuttingDown)?;
+        // TODO(paul): respect the shutdown signal.
+        Ok(runtime.block_on(generate_future(self)))
+    }
+
     /// Convenience function to allow spawning a task without waiting for the result.
     pub fn spawn<T, U>(&self, generate_future: T, name: &'static str)
     where

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -530,7 +530,12 @@ impl ExecutionLayer {
             let block_reached_ttd = block.total_difficulty >= spec.terminal_total_difficulty;
             if block_reached_ttd && block.parent_hash == Hash256::zero() {
                 return Ok(Some(block.block_hash));
+            } else if block.parent_hash == Hash256::zero() {
+                // The end of the chain has been reached without finding the TTD, there is no
+                // terminal block.
+                return Ok(None);
             }
+
             let parent = self
                 .get_pow_block(engine, block.parent_hash)
                 .await?

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -142,7 +142,7 @@ impl ExecutionLayer {
             .runtime()
             .upgrade()
             .ok_or(Error::ShuttingDown)?;
-        // TODO(paul): respect the shutdown signal.
+        // TODO(merge): respect the shutdown signal.
         runtime.block_on(generate_future(self))
     }
 
@@ -160,7 +160,7 @@ impl ExecutionLayer {
             .runtime()
             .upgrade()
             .ok_or(Error::ShuttingDown)?;
-        // TODO(paul): respect the shutdown signal.
+        // TODO(merge): respect the shutdown signal.
         Ok(runtime.block_on(generate_future(self)))
     }
 
@@ -521,11 +521,13 @@ impl ExecutionLayer {
 
         self.execution_blocks().await.put(block.block_hash, block);
 
-        // TODO(merge): This implementation assumes that the following PR is merged:
+        // TODO(merge): This implementation adheres to the following PR in the `dev` branch:
         //
         // https://github.com/ethereum/consensus-specs/pull/2719
         //
-        // We should check on the status of this PR prior to production.
+        // Therefore this implementation is not strictly v1.1.5, it is more lenient to some
+        // edge-cases during EL genesis. We should revisit this prior to the merge to ensure that
+        // this implementation becomes canonical.
         loop {
             let block_reached_ttd = block.total_difficulty >= spec.terminal_total_difficulty;
             if block_reached_ttd && block.parent_hash == Hash256::zero() {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use types::ChainSpec;
 
-pub use engine_api::{http::HttpJsonRpc, ExecutePayloadResponseStatus, ExecutionBlock};
+pub use engine_api::{http::HttpJsonRpc, ExecutePayloadResponseStatus};
 
 mod engine_api;
 mod engines;

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -4,6 +4,7 @@ use crate::engine_api::http::JSONRPC_VERSION;
 use crate::engine_api::ExecutePayloadResponseStatus;
 use bytes::Bytes;
 use environment::null_logger;
+use execution_block_generator::{Block, PoWBlock};
 use handle_rpc::handle_rpc;
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
@@ -117,6 +118,40 @@ impl<T: EthSpec> MockServer<T> {
 
     pub fn all_payloads_valid(&self) {
         *self.ctx.static_execute_payload_response.lock() = Some(ExecutePayloadResponseStatus::Valid)
+    }
+
+    pub fn insert_pow_block(
+        &self,
+        block_number: u64,
+        block_hash: Hash256,
+        parent_hash: Hash256,
+        total_difficulty: Uint256,
+    ) {
+        let block = Block::PoW(PoWBlock {
+            block_number,
+            block_hash,
+            parent_hash,
+            total_difficulty,
+        });
+
+        self.ctx
+            .execution_block_generator
+            .write()
+            // The EF tests supply blocks out of order, so we must import them "without checks" and
+            // trust the provide valid blocks.
+            .insert_block_without_checks(block)
+            .unwrap()
+    }
+
+    pub fn get_block(&self, block_hash: Hash256) -> Option<Block<T>> {
+        self.ctx
+            .execution_block_generator
+            .read()
+            .block_by_hash(block_hash)
+    }
+
+    pub fn drop_all_blocks(&self) {
+        self.ctx.execution_block_generator.write().drop_all_blocks()
     }
 }
 

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -138,7 +138,7 @@ impl<T: EthSpec> MockServer<T> {
             .execution_block_generator
             .write()
             // The EF tests supply blocks out of order, so we must import them "without checks" and
-            // trust the provide valid blocks.
+            // trust they form valid chains.
             .insert_block_without_checks(block)
             .unwrap()
     }

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -302,7 +302,7 @@ pub fn get_new_eth1_data<T: EthSpec>(
 ///
 /// ## Specification
 ///
-/// Partially equivalent to the `process_execution_payload` function:
+/// Contains a partial set of checks from the `process_execution_payload` function:
 ///
 /// https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/beacon-chain.md#process_execution_payload
 pub fn partially_verify_execution_payload<T: EthSpec>(

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -295,9 +295,18 @@ pub fn get_new_eth1_data<T: EthSpec>(
     }
 }
 
-/// https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/beacon-chain.md#process_execution_payload
-pub fn process_execution_payload<T: EthSpec>(
-    state: &mut BeaconState<T>,
+/// Performs *partial* verification of the `payload`.
+///
+/// The verification is partial, since the execution payload is not verified against an execution
+/// engine. That is expected to be performed by an upstream function.
+///
+/// ## Specification
+///
+/// Partially equivalent to the `process_execution_payload` function:
+///
+/// https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/beacon-chain.md#process_execution_payload
+pub fn partially_verify_execution_payload<T: EthSpec>(
+    state: &BeaconState<T>,
     payload: &ExecutionPayload<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
@@ -326,6 +335,23 @@ pub fn process_execution_payload<T: EthSpec>(
             found: payload.timestamp,
         }
     );
+
+    Ok(())
+}
+
+/// Calls `partially_verify_execution_payload` and then updates the payload header in the `state`.
+///
+/// ## Specification
+///
+/// Partially equivalent to the `process_execution_payload` function:
+///
+/// https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/beacon-chain.md#process_execution_payload
+pub fn process_execution_payload<T: EthSpec>(
+    state: &mut BeaconState<T>,
+    payload: &ExecutionPayload<T>,
+    spec: &ChainSpec,
+) -> Result<(), BlockProcessingError> {
+    partially_verify_execution_payload(state, payload, spec)?;
 
     *state.latest_execution_payload_header_mut()? = ExecutionPayloadHeader {
         parent_hash: payload.parent_hash,

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -234,6 +234,17 @@ impl<'a, T: EthSpec> BeaconBlockRef<'a, T> {
             ..self.block_header()
         }
     }
+
+    /// Extracts a reference to an execution payload from a block, returning an error if the block
+    /// is pre-merge.
+    pub fn execution_payload(&self) -> Result<&ExecutionPayload<T>, InconsistentFork> {
+        self.body()
+            .execution_payload()
+            .ok_or_else(|| InconsistentFork {
+                fork_at_slot: ForkName::Merge,
+                object_fork: self.body().fork_name(),
+            })
+    }
 }
 
 impl<'a, T: EthSpec> BeaconBlockRefMut<'a, T> {

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -39,9 +39,6 @@ excluded_paths = [
     "tests/minimal/altair/merkle/single_proof",
     "tests/mainnet/merge/merkle/single_proof",
     "tests/minimal/merge/merkle/single_proof",
-    # Fork choice tests featuring PoW blocks
-    "tests/minimal/merge/fork_choice/on_merge_block/",
-    "tests/mainnet/merge/fork_choice/on_merge_block/"
 ]
 
 def normalize_path(path):

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -23,7 +23,7 @@ pub struct PowBlock {
     pub block_hash: Hash256,
     pub parent_hash: Hash256,
     pub total_difficulty: Uint256,
-    // This field is not used an I expect it to be removed. See:
+    // This field is not used and I expect it to be removed. See:
     //
     // https://github.com/ethereum/consensus-specs/pull/2720
     pub difficulty: Uint256,
@@ -394,11 +394,9 @@ impl<E: EthSpec> Tester<E> {
     pub fn process_pow_block(&self, pow_block: &PowBlock) {
         let el = self.harness.mock_execution_layer.as_ref().unwrap();
 
-        let block_number = el
-            .server
-            .get_block(pow_block.parent_hash)
-            .map(|parent| parent.block_number() + 1)
-            .unwrap_or(0);
+        // The EF tests don't supply a block number. Our mock execution layer is fine with duplicate
+        // block numbers for the purposes of this test.
+        let block_number = 0;
 
         el.server.insert_pow_block(
             block_number,

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -146,11 +146,6 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
         let tester = Tester::new(self, testing_spec::<E>(fork_name))?;
 
-        // TODO(paul): remove this!
-        if self.description != "too_early_for_merge" {
-            return Ok(());
-        }
-
         // The reason for this failure is documented here:
         //
         // https://github.com/sigp/lighthouse/issues/2741

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -9,12 +9,25 @@ use beacon_chain::{
     BeaconChainTypes, HeadInfo,
 };
 use serde_derive::Deserialize;
+use ssz_derive::Decode;
 use state_processing::state_advance::complete_state_advance;
 use std::time::Duration;
 use types::{
     Attestation, BeaconBlock, BeaconState, Checkpoint, Epoch, EthSpec, ForkName, Hash256,
-    IndexedAttestation, SignedBeaconBlock, Slot,
+    IndexedAttestation, SignedBeaconBlock, Slot, Uint256,
 };
+
+#[derive(Default, Debug, PartialEq, Clone, Deserialize, Decode)]
+#[serde(deny_unknown_fields)]
+pub struct PowBlock {
+    pub block_hash: Hash256,
+    pub parent_hash: Hash256,
+    pub total_difficulty: Uint256,
+    // This field is not used an I expect it to be removed. See:
+    //
+    // https://github.com/ethereum/consensus-specs/pull/2720
+    pub difficulty: Uint256,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -37,11 +50,12 @@ pub struct Checks {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum Step<B, A> {
+pub enum Step<B, A, P> {
     Tick { tick: u64 },
     ValidBlock { block: B },
     MaybeValidBlock { block: B, valid: bool },
     Attestation { attestation: A },
+    PowBlock { pow_block: P },
     Checks { checks: Box<Checks> },
 }
 
@@ -56,7 +70,7 @@ pub struct ForkChoiceTest<E: EthSpec> {
     pub description: String,
     pub anchor_state: BeaconState<E>,
     pub anchor_block: BeaconBlock<E>,
-    pub steps: Vec<Step<SignedBeaconBlock<E>, Attestation<E>>>,
+    pub steps: Vec<Step<SignedBeaconBlock<E>, Attestation<E>, PowBlock>>,
 }
 
 impl<E: EthSpec> LoadCase for ForkChoiceTest<E> {
@@ -69,7 +83,7 @@ impl<E: EthSpec> LoadCase for ForkChoiceTest<E> {
             .expect("path must be valid OsStr")
             .to_string();
         let spec = &testing_spec::<E>(fork_name);
-        let steps: Vec<Step<String, String>> = yaml_decode_file(&path.join("steps.yaml"))?;
+        let steps: Vec<Step<String, String, String>> = yaml_decode_file(&path.join("steps.yaml"))?;
         // Resolve the object names in `steps.yaml` into actual decoded block/attestation objects.
         let steps = steps
             .into_iter()
@@ -90,6 +104,10 @@ impl<E: EthSpec> LoadCase for ForkChoiceTest<E> {
                 Step::Attestation { attestation } => {
                     ssz_decode_file(&path.join(format!("{}.ssz_snappy", attestation)))
                         .map(|attestation| Step::Attestation { attestation })
+                }
+                Step::PowBlock { pow_block } => {
+                    ssz_decode_file(&path.join(format!("{}.ssz_snappy", pow_block)))
+                        .map(|pow_block| Step::PowBlock { pow_block })
                 }
                 Step::Checks { checks } => Ok(Step::Checks { checks }),
             })
@@ -128,6 +146,11 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
         let tester = Tester::new(self, testing_spec::<E>(fork_name))?;
 
+        // TODO(paul): remove this!
+        if self.description != "too_early_for_merge" {
+            return Ok(());
+        }
+
         // The reason for this failure is documented here:
         //
         // https://github.com/sigp/lighthouse/issues/2741
@@ -145,6 +168,7 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
                     tester.process_block(block.clone(), *valid)?
                 }
                 Step::Attestation { attestation } => tester.process_attestation(attestation)?,
+                Step::PowBlock { pow_block } => tester.process_pow_block(pow_block),
                 Step::Checks { checks } => {
                     let Checks {
                         head,
@@ -230,6 +254,15 @@ impl<E: EthSpec> Tester<E> {
                 "anchor block differs from locally-generated genesis block".into(),
             ));
         }
+
+        // Drop any blocks that might be loaded in the mock execution layer. Some of these tests
+        // will provide their own blocks and we want to start from a clean state.
+        harness
+            .mock_execution_layer
+            .as_ref()
+            .unwrap()
+            .server
+            .drop_all_blocks();
 
         assert_eq!(
             harness.chain.slot_clock.genesis_duration().as_secs(),
@@ -355,6 +388,23 @@ impl<E: EthSpec> Tester<E> {
             .chain
             .apply_attestation_to_fork_choice(&verified_attestation)
             .map_err(|e| Error::InternalError(format!("attestation import failed with {:?}", e)))
+    }
+
+    pub fn process_pow_block(&self, pow_block: &PowBlock) {
+        let el = self.harness.mock_execution_layer.as_ref().unwrap();
+
+        let block_number = el
+            .server
+            .get_block(pow_block.parent_hash)
+            .map(|parent| parent.block_number() + 1)
+            .unwrap_or(0);
+
+        el.server.insert_pow_block(
+            block_number,
+            pow_block.block_hash,
+            pow_block.parent_hash,
+            pow_block.total_difficulty,
+        );
     }
 
     pub fn check_head(&self, expected_head: Head) -> Result<(), Error> {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -151,7 +151,13 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
         // https://github.com/sigp/lighthouse/issues/2741
         //
         // We should eventually solve the above issue and remove this `SkippedKnownFailure`.
-        if self.description == "new_finalized_slot_is_justified_checkpoint_ancestor" {
+        if self.description == "new_finalized_slot_is_justified_checkpoint_ancestor"
+            // This test is skipped until we can do retrospective confirmations of the terminal
+            // block after an optimistic sync.
+            //
+            // TODO(merge): enable this test before production.
+            || self.description == "block_lookup_failed"
+        {
             return Err(Error::SkippedKnownFailure);
         };
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -493,6 +493,34 @@ impl<E: EthSpec + TypeName> Handler for ForkChoiceOnBlockHandler<E> {
 
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
+pub struct ForkChoiceOnMergeBlockHandler<E>(PhantomData<E>);
+
+impl<E: EthSpec + TypeName> Handler for ForkChoiceOnMergeBlockHandler<E> {
+    type Case = cases::ForkChoiceTest<E>;
+
+    fn config_name() -> &'static str {
+        E::name()
+    }
+
+    fn runner_name() -> &'static str {
+        "fork_choice"
+    }
+
+    fn handler_name(&self) -> String {
+        "on_merge_block".into()
+    }
+
+    fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
+        // These tests check block validity (which may include signatures) and there is no need to
+        // run them with fake crypto.
+        cfg!(not(feature = "fake_crypto"))
+            // These tests only exist for the merge.
+            && fork_name == ForkName::Merge
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct GenesisValidityHandler<E>(PhantomData<E>);
 
 impl<E: EthSpec + TypeName> Handler for GenesisValidityHandler<E> {

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -424,6 +424,12 @@ fn fork_choice_on_block() {
 }
 
 #[test]
+fn fork_choice_on_merge_block() {
+    ForkChoiceOnMergeBlockHandler::<MinimalEthSpec>::default().run();
+    ForkChoiceOnMergeBlockHandler::<MainnetEthSpec>::default().run();
+}
+
+#[test]
 fn genesis_initialization() {
     GenesisInitializationHandler::<MinimalEthSpec>::default().run();
 }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Implements all of the execution-facing parts of the `v1.1.5` consensus specification (e.g., `prepare_execution_payload`, `validate_merge_block`, etc).

Also, runs the `fork_choice/on_merge_block` tests from the EF tests. We are still ignoring one test, that's because we don't have the ability to retrospectively verify the merge block after an optimistic sync. I did manually disable optimistic sync and observe that test passing. We can pick that test up in the coming weeks as we hone our optimistic sync implementation.

## TODO

- [x] Fork choice changes
- [x] Validator changes
- [x] Self-review and testing
