### PR TITLE
[Merged by Bors] - Inform dialing via the behaviour

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -1070,6 +1070,10 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         if let Some(event) = self.internal_events.pop_front() {
             match event {
                 InternalBehaviourMessage::DialPeer(peer_id) => {
+                    // For any dial event, inform the peer manager
+                    let enr = self.discovery_mut().enr_of_peer(&peer_id);
+                    self.peer_manager.inject_dialing(&peer_id, enr);
+                    // Submit the event
                     let handler = self.new_handler();
                     return Poll::Ready(NBAction::DialPeer {
                         peer_id,

--- a/beacon_node/lighthouse_network/src/service.rs
+++ b/beacon_node/lighthouse_network/src/service.rs
@@ -368,18 +368,7 @@ impl<TSpec: EthSpec> Service<TSpec> {
                         return Libp2pEvent::ZeroListeners;
                     }
                 }
-                SwarmEvent::Dialing(peer_id) => {
-                    // We require the ENR to inject into the peer db, if it exists.
-                    let enr = self
-                        .swarm
-                        .behaviour_mut()
-                        .discovery_mut()
-                        .enr_of_peer(&peer_id);
-                    self.swarm
-                        .behaviour_mut()
-                        .peer_manager_mut()
-                        .inject_dialing(&peer_id, enr);
-                }
+                SwarmEvent::Dialing(_peer_id) => {}
             }
         }
     }


### PR DESCRIPTION
I had this change but it seems to have been lost in chaos of network upgrades.

The swarm dialing event seems to miss some cases where we dial via the behaviour. This causes an error to be logged as the peer manager doesn't know about some dialing events. 

This shifts the logic to the behaviour to inform the peer manager.