### PR TITLE
[Merged by Bors] - Fix decoding max length

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use super::methods::*;
 use super::protocol::Protocol;
-use super::protocol::ProtocolId;
+use super::protocol::{ProtocolId, MAX_RPC_SIZE};
 use super::RPCError;
 use crate::rpc::protocol::Encoding;
 use crate::rpc::protocol::Version;
@@ -150,7 +150,7 @@ where
             Encoding::SSZSnappy => {
                 let ssz_snappy_codec = BaseOutboundCodec::new(SSZSnappyOutboundCodec::new(
                     protocol,
-                    usize::max_value(),
+                    MAX_RPC_SIZE,
                     self.fork_context.clone(),
                 ));
                 OutboundCodec::SSZSnappy(ssz_snappy_codec)

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -81,7 +81,7 @@ lazy_static! {
 }
 
 /// The maximum bytes that can be sent across the RPC.
-const MAX_RPC_SIZE: usize = 1_048_576; // 1M
+pub const MAX_RPC_SIZE: usize = 1_048_576; // 1M
 /// The protocol prefix the RPC protocol id.
 const PROTOCOL_PREFIX: &str = "/eth2/beacon_chain/req";
 /// Time allowed for the first byte of a request to arrive before we time out (Time To First Byte).


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Fix encoder max length to the correct value (`MAX_RPC_SIZE`).