### PR TITLE
[Merged by Bors] - Sync wrong dbg assertion

### DIFF
--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
 
 use lighthouse_network::rpc::StatusMessage;
@@ -21,5 +23,11 @@ impl<T: BeaconChainTypes> ToStatusMessage for BeaconChain<T> {
             head_root: head_info.block_root,
             head_slot: head_info.slot,
         })
+    }
+}
+
+impl<T: BeaconChainTypes> ToStatusMessage for Arc<BeaconChain<T>> {
+    fn status_message(&self) -> Result<StatusMessage, BeaconChainError> {
+        <BeaconChain<T> as ToStatusMessage>::status_message(&self)
     }
 }

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -28,6 +28,6 @@ impl<T: BeaconChainTypes> ToStatusMessage for BeaconChain<T> {
 
 impl<T: BeaconChainTypes> ToStatusMessage for Arc<BeaconChain<T>> {
     fn status_message(&self) -> Result<StatusMessage, BeaconChainError> {
-        <BeaconChain<T> as ToStatusMessage>::status_message(&self)
+        <BeaconChain<T> as ToStatusMessage>::status_message(self)
     }
 }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -6,7 +6,6 @@ use super::range_sync::{BatchId, ChainId};
 use super::RequestId as SyncRequestId;
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
-use beacon_chain::{BeaconChain, BeaconChainTypes};
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::{
     BlocksByRangeRequest, BlocksByRootRequest, GoodbyeReason, RequestId,
@@ -61,9 +60,9 @@ impl<T: EthSpec> SyncNetworkContext<T> {
             .unwrap_or_default()
     }
 
-    pub fn status_peers<U: BeaconChainTypes>(
+    pub fn status_peers<C: ToStatusMessage>(
         &mut self,
-        chain: Arc<BeaconChain<U>>,
+        chain: C,
         peers: impl Iterator<Item = PeerId>,
     ) {
         if let Ok(status_message) = &chain.status_message() {

--- a/beacon_node/network/src/sync/range_sync/block_storage.rs
+++ b/beacon_node/network/src/sync/range_sync/block_storage.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use types::Hash256;
+
+/// Trait that helps maintain RangeSync's implementation split from the BeaconChain
+pub trait BlockStorage {
+    fn is_block_known(&self, block_root: &Hash256) -> bool;
+}
+
+impl<T: BeaconChainTypes> BlockStorage for Arc<BeaconChain<T>> {
+    fn is_block_known(&self, block_root: &Hash256) -> bool {
+        self.fork_choice.read().contains_block(block_root)
+    }
+}

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -3,12 +3,13 @@
 //! Each chain type is stored in it's own map. A variety of helper functions are given along with
 //! this struct to simplify the logic of the other layers of sync.
 
+use super::block_storage::BlockStorage;
 use super::chain::{ChainId, ProcessingResult, RemoveChain, SyncingChain};
 use super::sync_type::RangeSyncType;
 use crate::beacon_processor::WorkEvent as BeaconWorkEvent;
 use crate::metrics;
 use crate::sync::network_context::SyncNetworkContext;
-use beacon_chain::{BeaconChain, BeaconChainTypes};
+use beacon_chain::BeaconChainTypes;
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
 use lighthouse_network::SyncInfo;
@@ -16,7 +17,6 @@ use slog::{crit, debug, error};
 use smallvec::SmallVec;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::sync::Arc;
 use tokio::sync::mpsc;
 use types::EthSpec;
 use types::{Epoch, Hash256, Slot};
@@ -39,9 +39,9 @@ pub enum RangeSyncState {
 }
 
 /// A collection of finalized and head chains currently being processed.
-pub struct ChainCollection<T: BeaconChainTypes> {
+pub struct ChainCollection<T: BeaconChainTypes, C> {
     /// The beacon chain for processing.
-    beacon_chain: Arc<BeaconChain<T>>,
+    beacon_chain: C,
     /// The set of finalized chains being synced.
     finalized_chains: FnvHashMap<ChainId, SyncingChain<T>>,
     /// The set of head chains being synced.
@@ -52,8 +52,8 @@ pub struct ChainCollection<T: BeaconChainTypes> {
     log: slog::Logger,
 }
 
-impl<T: BeaconChainTypes> ChainCollection<T> {
-    pub fn new(beacon_chain: Arc<BeaconChain<T>>, log: slog::Logger) -> Self {
+impl<T: BeaconChainTypes, C: BlockStorage> ChainCollection<T, C> {
+    pub fn new(beacon_chain: C, log: slog::Logger) -> Self {
         ChainCollection {
             beacon_chain,
             finalized_chains: FnvHashMap::default(),
@@ -413,8 +413,7 @@ impl<T: BeaconChainTypes> ChainCollection<T> {
         let log_ref = &self.log;
 
         let is_outdated = |target_slot: &Slot, target_root: &Hash256| {
-            target_slot <= &local_finalized_slot
-                || beacon_chain.fork_choice.read().contains_block(target_root)
+            target_slot <= &local_finalized_slot || beacon_chain.is_block_known(target_root)
         };
 
         // Retain only head peers that remain relevant

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -72,7 +72,7 @@ impl<T: BeaconChainTypes, C: BlockStorage> ChainCollection<T, C> {
             RangeSyncState::Finalized(ref syncing_id) => {
                 if syncing_id == id {
                     // the finalized chain that was syncing was removed
-                    debug_assert!(was_syncing);
+                    debug_assert!(was_syncing && sync_type == RangeSyncType::Finalized);
                     let syncing_head_ids: SmallVec<[u64; PARALLEL_HEAD_CHAINS]> = self
                         .head_chains
                         .iter()
@@ -85,7 +85,8 @@ impl<T: BeaconChainTypes, C: BlockStorage> ChainCollection<T, C> {
                         RangeSyncState::Head(syncing_head_ids)
                     };
                 } else {
-                    debug_assert!(!was_syncing);
+                    // we removed a head chain, or an stoped finalized chain
+                    debug_assert!(!was_syncing || sync_type != RangeSyncType::Finalized);
                 }
             }
             RangeSyncState::Head(ref mut syncing_head_ids) => {

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -6,6 +6,7 @@ mod chain;
 mod chain_collection;
 mod range;
 mod sync_type;
+mod block_storage;
 
 pub use batch::{BatchConfig, BatchInfo, BatchState};
 pub use chain::{BatchId, ChainId, EPOCHS_PER_BATCH};

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -2,11 +2,11 @@
 //! peers.
 
 mod batch;
+mod block_storage;
 mod chain;
 mod chain_collection;
 mod range;
 mod sync_type;
-mod block_storage;
 
 pub use batch::{BatchConfig, BatchInfo, BatchState};
 pub use chain::{BatchId, ChainId, EPOCHS_PER_BATCH};

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -430,6 +430,7 @@ mod tests {
         }
     }
 
+    #[allow(unused)]
     struct TestRig {
         log: slog::Logger,
         /// To check what does sync send to the beacon processor.
@@ -589,7 +590,8 @@ mod tests {
     }
 
     #[test]
-    fn sync() {
+    fn head_chain_removed_while_finalized_syncing() {
+        // NOTE: this is a regression test.
         let (mut rig, mut range) = range(true);
 
         // Get a peer with an advanced head
@@ -610,5 +612,6 @@ mod tests {
 
         // Fail the head chain by disconnecting the peer.
         range.remove_peer(&mut rig.cx, &head_peer);
+        range.assert_state(RangeSyncType::Finalized);
     }
 }

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -6,7 +6,7 @@ use lighthouse_network::SyncInfo;
 use super::block_storage::BlockStorage;
 
 /// The type of Range sync that should be done relative to our current state.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RangeSyncType {
     /// A finalized chain sync should be started with this peer.
     Finalized,

--- a/beacon_node/network/src/sync/range_sync/sync_type.rs
+++ b/beacon_node/network/src/sync/range_sync/sync_type.rs
@@ -1,9 +1,9 @@
 //! Contains logic about identifying which Sync to perform given PeerSyncInfo of ourselves and
 //! of a remote.
 
-use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::SyncInfo;
-use std::sync::Arc;
+
+use super::block_storage::BlockStorage;
 
 /// The type of Range sync that should be done relative to our current state.
 #[derive(Debug, Clone, Copy)]
@@ -17,8 +17,8 @@ pub enum RangeSyncType {
 impl RangeSyncType {
     /// Determines the type of sync given our local `PeerSyncInfo` and the remote's
     /// `PeerSyncInfo`.
-    pub fn new<T: BeaconChainTypes>(
-        chain: &Arc<BeaconChain<T>>,
+    pub fn new<C: BlockStorage>(
+        chain: &C,
         local_info: &SyncInfo,
         remote_info: &SyncInfo,
     ) -> RangeSyncType {
@@ -29,10 +29,7 @@ impl RangeSyncType {
         //    not seen the finalized hash before.
 
         if remote_info.finalized_epoch > local_info.finalized_epoch
-            && !chain
-                .fork_choice
-                .read()
-                .contains_block(&remote_info.finalized_root)
+            && !chain.is_block_known(&remote_info.finalized_root)
         {
             RangeSyncType::Finalized
         } else {


### PR DESCRIPTION
## Issue Addressed

Running a beacon node I triggered a sync debug panic. And so finally the time to create tests for sync arrived. Fortunately, te bug was not in the sync algorithm itself but a wrong assertion

## Proposed Changes

- Split Range's impl from the BeaconChain via a trait. This is needed for testing. The TestingRig/Harness is way bigger than needed and does not provide the modification functionalities that are needed to test sync. I find this simpler, tho some could disagree.
- Add a regression test for sync that fails before the changes.
- Fix the wrong assertion.