### PR TITLE
Bump crate versions for Kintsugi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
  "eth1",
  "eth2",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz_types",
  "execution_layer",
  "fork_choice",
  "futures",
@@ -333,7 +333,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "tokio",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
 ]
 
@@ -452,14 +452,14 @@ dependencies = [
  "blst",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "ethereum-types 0.12.1",
  "hex",
  "milagro_bls",
  "rand 0.7.3",
  "serde",
  "serde_derive",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "zeroize",
 ]
 
@@ -483,7 +483,7 @@ dependencies = [
  "clap",
  "clap_utils",
  "eth2_network_config",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "hex",
  "lighthouse_network",
  "log",
@@ -584,14 +584,14 @@ name = "cached_tree_hash"
 version = "0.1.0"
 dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz_types",
  "ethereum-types 0.12.1",
  "quickcheck",
  "quickcheck_macros",
  "smallvec",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ dependencies = [
  "clap",
  "dirs",
  "eth2_network_config",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "ethereum-types 0.12.1",
  "hex",
 ]
@@ -1077,13 +1077,13 @@ checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
 name = "deposit_contract"
 version = "0.2.0"
 dependencies = [
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "ethabi 12.0.0",
  "hex",
  "reqwest",
  "serde_json",
  "sha2",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
 ]
 
@@ -1275,7 +1275,7 @@ dependencies = [
  "compare_fields",
  "compare_fields_derive",
  "derivative",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.12.1",
  "fork_choice",
@@ -1290,7 +1290,7 @@ dependencies = [
  "state_processing",
  "store",
  "swap_or_not_shuffle",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "tree_hash_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "types",
 ]
@@ -1419,7 +1419,7 @@ dependencies = [
  "environment",
  "eth1_test_rig",
  "eth2",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallback",
  "futures",
@@ -1438,7 +1438,7 @@ dependencies = [
  "task_executor",
  "tokio",
  "toml",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
  "web3",
 ]
@@ -1462,7 +1462,7 @@ dependencies = [
  "bytes",
  "eth2_keystore",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "futures-util",
@@ -1567,7 +1567,7 @@ version = "0.2.0"
 dependencies = [
  "enr",
  "eth2_config",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "serde_yaml",
  "tempfile",
  "types",
@@ -1598,19 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "eth2_ssz"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.1",
- "smallvec",
-]
-
-[[package]]
-name = "eth2_ssz"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948e343aa022785c07193f41ed37adfd9dd0350368060803b8302c7f798e8306"
-dependencies = [
  "ethereum-types 0.12.1",
  "smallvec",
 ]
@@ -1639,31 +1629,16 @@ dependencies = [
 
 [[package]]
 name = "eth2_ssz_types"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "arbitrary",
  "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "serde",
  "serde_derive",
  "serde_json",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "tree_hash_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "typenum",
-]
-
-[[package]]
-name = "eth2_ssz_types"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9423ac7fb37037f828a32b724cdfa65ea62290055811731402a90fb8a5bcbb1"
-dependencies = [
- "arbitrary",
- "eth2_serde_utils 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "serde_derive",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typenum",
 ]
 
@@ -1799,7 +1774,7 @@ dependencies = [
  "environment",
  "eth1",
  "eth2_serde_utils 0.1.0",
- "eth2_ssz_types 0.2.1",
+ "eth2_ssz_types",
  "exit-future",
  "futures",
  "hex",
@@ -1813,7 +1788,7 @@ dependencies = [
  "slot_clock",
  "task_executor",
  "tokio",
- "tree_hash 0.4.0",
+ "tree_hash",
  "tree_hash_derive 0.4.0",
  "types",
  "warp 0.3.0",
@@ -1957,7 +1932,7 @@ name = "fork_choice"
 version = "0.1.0"
 dependencies = [
  "beacon_chain",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proto_array",
  "store",
@@ -2120,7 +2095,7 @@ dependencies = [
  "eth1",
  "eth1_test_rig",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "futures",
  "int_to_bytes",
  "merkle_proof",
@@ -2129,7 +2104,7 @@ dependencies = [
  "slog",
  "state_processing",
  "tokio",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
 ]
 
@@ -2402,7 +2377,7 @@ dependencies = [
  "environment",
  "eth1",
  "eth2",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "futures",
  "hex",
  "lazy_static",
@@ -2418,7 +2393,7 @@ dependencies = [
  "store",
  "tokio",
  "tokio-stream",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
  "warp 0.3.2",
  "warp_utils",
@@ -2752,7 +2727,7 @@ dependencies = [
  "eth1_test_rig",
  "eth2",
  "eth2_network_config",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_wallet",
  "genesis",
  "int_to_bytes",
@@ -2764,7 +2739,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "state_processing",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
  "validator_dir",
  "web3",
@@ -3298,9 +3273,9 @@ dependencies = [
  "dirs",
  "discv5",
  "error-chain",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz_types",
  "exit-future",
  "fnv",
  "futures",
@@ -3712,8 +3687,8 @@ dependencies = [
  "beacon_chain",
  "environment",
  "error-chain",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
+ "eth2_ssz_types",
  "exit-future",
  "fnv",
  "futures",
@@ -3977,7 +3952,7 @@ version = "0.2.0"
 dependencies = [
  "beacon_chain",
  "derivative",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools",
  "lazy_static",
@@ -4488,7 +4463,7 @@ dependencies = [
 name = "proto_array"
 version = "0.2.0"
 dependencies = [
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde",
  "serde_derive",
@@ -5330,7 +5305,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "byteorder",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "filesystem",
  "flate2",
@@ -5349,7 +5324,7 @@ dependencies = [
  "slog",
  "sloggers",
  "tempfile",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "tree_hash_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "types",
 ]
@@ -5609,8 +5584,8 @@ dependencies = [
  "bls",
  "env_logger 0.9.0",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
+ "eth2_ssz_types",
  "int_to_bytes",
  "integer-sqrt",
  "itertools",
@@ -5620,7 +5595,7 @@ dependencies = [
  "rayon",
  "safe_arith",
  "smallvec",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
 ]
 
@@ -5629,7 +5604,7 @@ name = "state_transition_vectors"
 version = "0.1.0"
 dependencies = [
  "beacon_chain",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "lazy_static",
  "state_processing",
  "types",
@@ -5648,7 +5623,7 @@ dependencies = [
  "beacon_chain",
  "db-key",
  "directory",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools",
  "lazy_static",
@@ -6213,28 +6188,17 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "beacon_chain",
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.12.1",
  "rand 0.7.3",
  "smallvec",
  "tree_hash_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "types",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9c8a86fad3169a65aad2265d3c6a8bc119d0b771046af3c1b2fb0e9b12182b"
-dependencies = [
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.1",
- "smallvec",
 ]
 
 [[package]]
@@ -6376,9 +6340,9 @@ dependencies = [
  "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth2_interop_keypairs",
  "eth2_serde_utils 0.1.0",
- "eth2_ssz 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz",
  "eth2_ssz_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "eth2_ssz_types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_ssz_types",
  "ethereum-types 0.12.1",
  "hex",
  "int_to_bytes",
@@ -6401,7 +6365,7 @@ dependencies = [
  "swap_or_not_shuffle",
  "tempfile",
  "test_random_derive",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "tree_hash_derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -6591,7 +6555,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "tokio",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
  "url",
  "validator_dir",
@@ -6612,7 +6576,7 @@ dependencies = [
  "lockfile",
  "rand 0.7.3",
  "tempfile",
- "tree_hash 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tree_hash",
  "types",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,3 +88,6 @@ members = [
 [patch.crates-io]
 fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d" }
 warp = { git = "https://github.com/macladson/warp", rev ="7e75acc" }
+eth2_ssz = { path = "consensus/ssz" }
+eth2_ssz_types = { path = "consensus/ssz_types" }
+tree_hash = { path = "consensus/tree_hash" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -30,11 +30,11 @@ slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = "2.0.2"
 slot_clock = { path = "../../common/slot_clock" }
 eth2_hashing = "0.2.0"
-eth2_ssz = "0.4.0"
-eth2_ssz_types = "0.2.1"
+eth2_ssz = "0.4.1"
+eth2_ssz_types = "0.2.2"
 eth2_ssz_derive = "0.3.0"
 state_processing = { path = "../../consensus/state_processing" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 types = { path = "../../consensus/types" }
 tokio = "1.14.0"
 eth1 = { path = "../eth1" }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -19,9 +19,9 @@ serde = { version = "1.0.116", features = ["derive"] }
 hex = "0.4.2"
 types = { path = "../../consensus/types"}
 merkle_proof = { path = "../../consensus/merkle_proof"}
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 parking_lot = "0.11.0"
 slog = "2.5.2"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -22,10 +22,10 @@ environment = { path = "../../lighthouse/environment" }
 bytes = "1.1.0"
 task_executor = { path = "../../common/task_executor" }
 hex = "0.4.2"
-eth2_ssz_types = { path = "../../consensus/ssz_types"}
+eth2_ssz_types = "0.2.2"
 lru = "0.6.0"
 exit-future = "0.2.0"
-tree_hash = { path = "../../consensus/tree_hash"}
+tree_hash = "0.4.1"
 tree_hash_derive = { path = "../../consensus/tree_hash_derive"}
 parking_lot = "0.11.0"
 slot_clock = { path = "../../common/slot_clock" }

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -16,9 +16,9 @@ eth1 = { path = "../eth1"}
 rayon = "1.4.1"
 state_processing = { path = "../../consensus/state_processing" }
 merkle_proof = { path = "../../consensus/merkle_proof" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_hashing = "0.2.0"
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 tokio = { version = "1.14.0", features = ["full"] }
 slog = "2.5.2"
 int_to_bytes = { path = "../../consensus/int_to_bytes" }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -24,14 +24,14 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
 warp_utils = { path = "../../common/warp_utils" }
 slot_clock = { path = "../../common/slot_clock" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 bs58 = "0.4.0"
 futures = "0.3.8"
 
 [dev-dependencies]
 store = { path = "../store" }
 environment = { path = "../../lighthouse/environment" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 sensitive_url = { path = "../../common/sensitive_url" }
 
 [[test]]

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -9,10 +9,10 @@ discv5 = { version = "0.1.0-beta.11", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
 hashset_delay = { path = "../../common/hashset_delay" }
-eth2_ssz_types = "0.2.1"
+eth2_ssz_types = "0.2.2"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_derive = "1.0.116"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 lighthouse_version = { path = "../../common/lighthouse_version" }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -23,8 +23,8 @@ types = { path = "../../consensus/types" }
 slot_clock = { path = "../../common/slot_clock" }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 hex = "0.4.2"
-eth2_ssz = "0.4.0"
-eth2_ssz_types = "0.2.1"
+eth2_ssz = "0.4.1"
+eth2_ssz_types = "0.2.2"
 futures = "0.3.7"
 error-chain = "0.12.4"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -12,7 +12,7 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 parking_lot = "0.11.0"
 types = { path = "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 rayon = "1.5.0"
 serde = "1.0.116"

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -13,7 +13,7 @@ db-key = "0.0.5"
 leveldb = { version = "0.8.6", default-features = false }
 parking_lot = "0.11.0"
 itertools = "0.10.0"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 types = { path =  "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -10,7 +10,7 @@ clap = "2.33.3"
 clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 types = { path = "../consensus/types" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 slog = "2.5.2"
 tokio = "1.14.0"
 log = "0.4.11"

--- a/common/clap_utils/Cargo.toml
+++ b/common/clap_utils/Cargo.toml
@@ -11,5 +11,5 @@ clap = "2.33.3"
 hex = "0.4.2"
 dirs = "3.0.1"
 eth2_network_config = { path = "../eth2_network_config" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 ethereum-types = "0.12.1"

--- a/common/deposit_contract/Cargo.toml
+++ b/common/deposit_contract/Cargo.toml
@@ -14,6 +14,6 @@ hex = "0.4.2"
 
 [dependencies]
 types = { path = "../../consensus/types"}
-eth2_ssz = "0.4.0"
-tree_hash = "0.4.0"
+eth2_ssz = "0.4.1"
+tree_hash = "0.4.1"
 ethabi = "12.0.0"

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -20,7 +20,7 @@ ring = "0.16.19"
 bytes = "1.0.1"
 account_utils = { path = "../../common/account_utils" }
 sensitive_url = { path = "../../common/sensitive_url" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 futures-util = "0.3.8"
 futures = "0.3.8"

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -16,6 +16,6 @@ tempfile = "3.1.0"
 [dependencies]
 serde_yaml = "0.8.13"
 types = { path = "../../consensus/types"}
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_config = { path = "../eth2_config"}
 enr = { version = "0.5.1", features = ["ed25519", "k256"] }

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -16,7 +16,7 @@ filesystem = { path = "../filesystem" }
 types = { path = "../../consensus/types" }
 rand = "0.7.3"
 deposit_contract = { path = "../deposit_contract" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 hex = "0.4.2"
 derivative = "2.1.1"
 lockfile = { path = "../lockfile" }

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2018"
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_ssz_types = "0.2.1"
+eth2_ssz_types = "0.2.2"
 eth2_hashing = "0.2.0"
 eth2_ssz_derive = "0.3.0"
-eth2_ssz = "0.4.0"
-tree_hash = "0.4.0"
+eth2_ssz = "0.4.1"
+tree_hash = "0.4.1"
 smallvec = "1.6.1"
 
 [dev-dependencies]

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 types = { path = "../types" }
 proto_array = { path = "../proto_array" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 
 [dev-dependencies]

--- a/consensus/proto_array/Cargo.toml
+++ b/consensus/proto_array/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/bin.rs"
 
 [dependencies]
 types = { path = "../types" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2_ssz"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Paul Hauner <paul@sigmaprime.io>"]
 edition = "2018"
 description = "SimpleSerialize (SSZ) as used in Ethereum 2.0"

--- a/consensus/ssz_types/Cargo.toml
+++ b/consensus/ssz_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2_ssz_types"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 description = "Provides types with unique properties required for SSZ serialization and Merklization."
@@ -10,11 +10,11 @@ license = "Apache-2.0"
 name = "ssz_types"
 
 [dependencies]
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.0"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 typenum = "1.12.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -12,11 +12,11 @@ beacon_chain = { path = "../../beacon_node/beacon_chain" }
 bls = { path = "../../crypto/bls" }
 integer-sqrt = "0.1.5"
 itertools = "0.10.0"
-eth2_ssz = "0.4.0"
-eth2_ssz_types = "0.2.1"
+eth2_ssz = "0.4.1"
+eth2_ssz_types = "0.2.2"
 merkle_proof = { path = "../merkle_proof" }
 safe_arith = { path = "../safe_arith" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 types = { path = "../types", default-features = false }
 rayon = "1.4.1"
 eth2_hashing = "0.2.0"

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tree_hash"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ rand = "0.7.3"
 tree_hash_derive = "0.4.0"
 types = { path = "../types" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 
 [dependencies]

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -24,12 +24,12 @@ safe_arith = { path = "../safe_arith" }
 serde = {version = "1.0.116" , features = ["rc"] }
 serde_derive = "1.0.116"
 slog = "2.5.2"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
-eth2_ssz_types = "0.2.1"
+eth2_ssz_types = "0.2.2"
 swap_or_not_shuffle = { path = "../swap_or_not_shuffle" }
 test_random_derive = { path = "../../common/test_random_derive" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 tree_hash_derive = "0.4.0"
 rand_xorshift = "0.2.0"
 cached_tree_hash = { path = "../cached_tree_hash" }

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2018"
 
 [dependencies]
-eth2_ssz = "0.4.0"
-tree_hash = "0.4.0"
+eth2_ssz = "0.4.1"
+tree_hash = "0.4.1"
 milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.2", optional = true }
 rand = "0.7.3"
 serde = "1.0.116"

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -20,12 +20,12 @@ env_logger = "0.9.0"
 types = { path = "../consensus/types" }
 state_processing = { path = "../consensus/state_processing" }
 int_to_bytes = { path = "../consensus/int_to_bytes" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 environment = { path = "../lighthouse/environment" }
 eth2_network_config = { path = "../common/eth2_network_config" }
 genesis = { path = "../beacon_node/genesis" }
 deposit_contract = { path = "../common/deposit_contract" }
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 validator_dir = { path = "../common/validator_dir", features = ["insecure_keys"] }

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }
 lazy_static = "1.4.0"
@@ -22,7 +22,7 @@ serde = "1.0"
 serde_derive = "1.0"
 slog = "2.5.2"
 sloggers = "2.0.2"
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 tree_hash_derive = "0.4.0"
 types = { path = "../consensus/types" }
 

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -22,9 +22,9 @@ serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_repr = "0.1.6"
 serde_yaml = "0.8.13"
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 tree_hash_derive = "0.4.0"
 cached_tree_hash = { path = "../../consensus/cached_tree_hash" }
 state_processing = { path = "../../consensus/state_processing" }

--- a/testing/state_transition_vectors/Cargo.toml
+++ b/testing/state_transition_vectors/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 state_processing = { path = "../../consensus/state_processing" }
 types = { path = "../../consensus/types" }
-eth2_ssz = "0.4.0"
+eth2_ssz = "0.4.1"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 lazy_static = "1.4.0"

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 tokio = { version = "1.14.0", features = ["time", "rt-multi-thread", "macros"] }
 
 [dependencies]
-tree_hash = "0.4.0"
+tree_hash = "0.4.1"
 clap = "2.33.3"
 slashing_protection = { path = "./slashing_protection" }
 slot_clock = { path = "../common/slot_clock" }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Bumps the crate versions and adds a workspace-level `patch` for:

- `eth2_ssz`
- `eth2_ssz_types`
- `tree_hash`

We can remove the `patch` after we merge to `unstable` and publish the crates.

## Additional Info

NA
