### PR TITLE
[Merged by Bors] - Optimise snapshot cache for late blocks

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1320,7 +1320,12 @@ fn load_parent<T: BeaconChainTypes>(
         .snapshot_cache
         .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
         .and_then(|mut snapshot_cache| {
-            snapshot_cache.get_state_for_block_processing(block.parent_root(), block_delay, spec)
+            snapshot_cache.get_state_for_block_processing(
+                block.parent_root(),
+                block.slot(),
+                block_delay,
+                spec,
+            )
         }) {
         if cloned {
             metrics::inc_counter(&metrics::BLOCK_PROCESSING_SNAPSHOT_CACHE_CLONES);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1331,7 +1331,7 @@ fn load_parent<T: BeaconChainTypes>(
             metrics::inc_counter(&metrics::BLOCK_PROCESSING_SNAPSHOT_CACHE_CLONES);
             debug!(
                 chain.log,
-                "Cloned snapshot for late block";
+                "Cloned snapshot for late block/skipped slot";
                 "slot" => %block.slot(),
                 "parent_slot" => %snapshot.beacon_block.slot(),
                 "parent_root" => ?block.parent_root(),

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1322,7 +1322,7 @@ fn load_parent<T: BeaconChainTypes>(
         .and_then(|mut snapshot_cache| {
             snapshot_cache.get_state_for_block_processing(block.parent_root(), block_delay, spec)
         }) {
-        Ok((snapshot.into_pre_state(), block))
+        Ok((snapshot, block))
     } else {
         // Load the blocks parent block from the database, returning invalid if that block is not
         // found.

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -18,6 +18,14 @@ lazy_static! {
         "beacon_block_processing_successes_total",
         "Count of blocks processed without error"
     );
+    pub static ref BLOCK_PROCESSING_SNAPSHOT_CACHE_MISSES: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_processing_snapshot_cache_misses",
+        "Count of snapshot cache misses"
+    );
+    pub static ref BLOCK_PROCESSING_SNAPSHOT_CACHE_CLONES: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_processing_snapshot_cache_clones",
+        "Count of snapshot cache clones"
+    );
     pub static ref BLOCK_PROCESSING_TIMES: Result<Histogram> =
         try_create_histogram("beacon_block_processing_seconds", "Full runtime of block processing");
     pub static ref BLOCK_PROCESSING_BLOCK_ROOT: Result<Histogram> = try_create_histogram(

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -114,7 +114,6 @@ pub enum StateAdvance<T: EthSpec> {
 }
 
 /// The item stored in the `SnapshotCache`.
-#[derive(Clone)]
 pub struct CacheItem<T: EthSpec> {
     beacon_block: SignedBeaconBlock<T>,
     beacon_block_root: Hash256,


### PR DESCRIPTION
## Proposed Changes

In the event of a late block, keep the block in the snapshot cache by cloning it. This helps us process new blocks quickly in the event the late block was re-org'd.
