### PR TITLE
Cleanup Comments & Fix get_pow_block_hash_at_ttd()

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -624,18 +624,6 @@ mod test {
             .await
             .with_preloaded_responses(
                 // engine_forkchoiceUpdatedV1 (prepare payload) RESPONSE validation
-                //
-                // NOTE THIS HAD TO BE MODIFIED FROM ORIGINAL RESPONSE
-                // {
-                //      "jsonrpc":"2.0",
-                //      "id":67,
-                //      "result":{
-                //          "status":"VALID", // <- This must be SUCCESS
-                //          "payloadId":"0xa247243752eb10b4"
-                //      }
-                // }
-                // see spec for engine_forkchoiceUpdatedV1 response:
-                // https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.4/src/engine/specification.md#response-1
                 vec![json!({
                     "id": STATIC_ID,
                     "jsonrpc": JSONRPC_VERSION,
@@ -779,18 +767,6 @@ mod test {
             .await
             .with_preloaded_responses(
                 // engine_executePayloadV1 RESPONSE validation
-                //
-                // NOTE THIS HAD TO BE MODIFIED FROM ORIGINAL RESPONSE
-                // {
-                //      "jsonrpc":"2.0",
-                //      "id":67,
-                //      "result":{
-                //          "status":"SUCCESS", // <- This must be VALID
-                //          "latestValidHash":"0x3559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858"
-                //      }
-                // }
-                // see spec for engine_executePayloadV1 response:
-                // https://github.com/ethereum/execution-apis/blob/v1.0.0-alpha.4/src/engine/specification.md#response
                 vec![json!({
                     "jsonrpc": JSONRPC_VERSION,
                     "id": STATIC_ID,
@@ -852,7 +828,7 @@ mod test {
                     "id": STATIC_ID,
                     "result": {
                         "status":"SUCCESS",
-                        "payloadId": serde_json::Value::Null
+                        "payloadId": JSON_NULL,
                     }
                 })],
                 |client| async move {


### PR DESCRIPTION
## Issue Addressed

The algorithm for finding the TTD block hash will not terminate until it reaches the genesis block of the chain. Given that we can't cache the entire eth1 chain, this will cause us to download the whole thing over and over every time this function is called.

## Proposed Changes

Instead of going all the way back to the genesis block, just stop the algorithm as soon as we reach a block with terminal difficulty < `TOTAL_TERMINAL_DIFFICULTY`.