### PR TITLE
Restrict network limits based on merge fork epoch

### DIFF
--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -16,7 +16,7 @@ pub mod rpc;
 mod service;
 pub mod types;
 
-pub use config::GOSSIP_MAX_SIZE;
+pub use config::gossip_max_size;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -697,9 +697,9 @@ mod tests {
         version: Version,
         message: &mut BytesMut,
     ) -> Result<Option<RPCResponse<Spec>>, RPCError> {
-        let max_packet_size = 1_048_576;
         let snappy_protocol_id = ProtocolId::new(protocol, version, Encoding::SSZSnappy);
         let fork_context = Arc::new(fork_context());
+        let max_packet_size = max_rpc_size(&fork_context);
         let mut snappy_outbound_codec =
             SSZSnappyOutboundCodec::<Spec>::new(snappy_protocol_id, max_packet_size, fork_context);
         // decode message just as snappy message
@@ -1124,7 +1124,7 @@ mod tests {
         );
     }
 
-    /// Test sending a message with encoded length prefix > MAX_RPC_SIZE.
+    /// Test sending a message with encoded length prefix > max_rpc_size.
     #[test]
     fn test_decode_invalid_length() {
         // 10 byte snappy stream identifier

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -5,7 +5,7 @@ use super::methods::{
     GoodbyeReason, RPCCodedResponse, RPCResponseErrorCode, RequestId, ResponseTermination,
 };
 use super::outbound::OutboundRequestContainer;
-use super::protocol::{InboundRequest, Protocol, RPCError, RPCProtocol};
+use super::protocol::{max_rpc_size, InboundRequest, Protocol, RPCError, RPCProtocol};
 use super::{RPCReceived, RPCSend};
 use crate::rpc::outbound::{OutboundFramed, OutboundRequest};
 use crate::rpc::protocol::InboundFramed;
@@ -951,6 +951,7 @@ where
                     OutboundRequestContainer {
                         req: req.clone(),
                         fork_context: self.fork_context.clone(),
+                        max_rpc_size: max_rpc_size(&self.fork_context),
                     },
                     (),
                 )

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -186,6 +186,7 @@ where
             SubstreamProtocol::new(
                 RPCProtocol {
                     fork_context: self.fork_context.clone(),
+                    max_rpc_size: max_rpc_size(&self.fork_context),
                     phantom: PhantomData,
                 },
                 (),

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -30,7 +30,7 @@ pub use methods::{
     RPCResponseErrorCode, RequestId, ResponseTermination, StatusMessage, MAX_REQUEST_BLOCKS,
 };
 pub(crate) use outbound::OutboundRequest;
-pub use protocol::{Protocol, RPCError, MAX_RPC_SIZE};
+pub use protocol::{max_rpc_size, Protocol, RPCError};
 
 pub(crate) mod codec;
 mod handler;

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use super::methods::*;
 use super::protocol::Protocol;
-use super::protocol::{max_rpc_size, ProtocolId};
+use super::protocol::ProtocolId;
 use super::RPCError;
 use crate::rpc::protocol::Encoding;
 use crate::rpc::protocol::Version;
@@ -29,6 +29,7 @@ use types::{EthSpec, ForkContext};
 pub struct OutboundRequestContainer<TSpec: EthSpec> {
     pub req: OutboundRequest<TSpec>,
     pub fork_context: Arc<ForkContext>,
+    pub max_rpc_size: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -150,7 +151,7 @@ where
             Encoding::SSZSnappy => {
                 let ssz_snappy_codec = BaseOutboundCodec::new(SSZSnappyOutboundCodec::new(
                     protocol,
-                    max_rpc_size(&self.fork_context),
+                    self.max_rpc_size,
                     self.fork_context.clone(),
                 ));
                 OutboundCodec::SSZSnappy(ssz_snappy_codec)

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use super::methods::*;
 use super::protocol::Protocol;
-use super::protocol::{ProtocolId, MAX_RPC_SIZE};
+use super::protocol::{max_rpc_size, ProtocolId};
 use super::RPCError;
 use crate::rpc::protocol::Encoding;
 use crate::rpc::protocol::Version;
@@ -150,7 +150,7 @@ where
             Encoding::SSZSnappy => {
                 let ssz_snappy_codec = BaseOutboundCodec::new(SSZSnappyOutboundCodec::new(
                     protocol,
-                    MAX_RPC_SIZE,
+                    max_rpc_size(&self.fork_context),
                     self.fork_context.clone(),
                 ));
                 OutboundCodec::SSZSnappy(ssz_snappy_codec)

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -181,6 +181,7 @@ impl std::fmt::Display for Version {
 #[derive(Debug, Clone)]
 pub struct RPCProtocol<TSpec: EthSpec> {
     pub fork_context: Arc<ForkContext>,
+    pub max_rpc_size: usize,
     pub phantom: PhantomData<TSpec>,
 }
 
@@ -376,7 +377,7 @@ where
                 Encoding::SSZSnappy => {
                     let ssz_snappy_codec = BaseInboundCodec::new(SSZSnappyInboundCodec::new(
                         protocol,
-                        max_rpc_size(&self.fork_context),
+                        self.max_rpc_size,
                         self.fork_context.clone(),
                     ));
                     InboundCodec::SSZSnappy(ssz_snappy_codec)

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -218,7 +218,7 @@ impl RpcLimits {
         Self { min, max }
     }
 
-    /// Returns true if the given length is greater than `MAX_RPC_SIZE` or out of
+    /// Returns true if the given length is greater than `max_rpc_size` or out of
     /// bounds for the given ssz type, returns false otherwise.
     pub fn is_out_of_bounds(&self, length: usize, max_rpc_size: usize) -> bool {
         length > std::cmp::min(self.max, max_rpc_size) || length < self.min

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -93,7 +93,7 @@ lazy_static! {
 }
 
 /// The maximum bytes that can be sent across the RPC pre-merge.
-pub(crate) const MAX_RPC_SIZE: usize = 1 * 1_048_576; // 1M
+pub(crate) const MAX_RPC_SIZE: usize = 1_048_576; // 1M
 /// The maximum bytes that can be sent across the RPC post-merge.
 pub(crate) const MAX_RPC_SIZE_POST_MERGE: usize = 10 * 1_048_576; // 10M
 /// The protocol prefix the RPC protocol id.

--- a/beacon_node/lighthouse_network/tests/common/mod.rs
+++ b/beacon_node/lighthouse_network/tests/common/mod.rs
@@ -17,7 +17,7 @@ type E = MinimalEthSpec;
 use tempfile::Builder as TempBuilder;
 
 /// Returns a dummy fork context
-fn fork_context() -> ForkContext {
+pub fn fork_context() -> ForkContext {
     let mut chain_spec = E::default_spec();
     // Set fork_epoch to `Some` to ensure that the `ForkContext` object
     // includes altair in the list of forks

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -468,7 +468,8 @@ pub fn get_config<E: EthSpec>(
         };
     }
 
-    client_config.chain.max_network_size = lighthouse_network::GOSSIP_MAX_SIZE;
+    client_config.chain.max_network_size =
+        lighthouse_network::gossip_max_size(spec.merge_fork_epoch.is_some());
 
     if cli_args.is_present("slasher") {
         let slasher_dir = if let Some(slasher_dir) = cli_args.value_of("slasher-dir") {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Specify the max rpc and gossip bytes sizes as a function of whether or not the merge fork epoch has been set.

