### PR TITLE
Ensure db paths are backwards compatible

### DIFF
--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -149,7 +149,11 @@ impl Config {
         ensure_dir_exists(freezer_db_path)
     }
 
+    /// Get the legacy path that creates db paths relative to the
+    /// home directory for a relative `data_dir` path.
     ///
+    /// Check https://github.com/sigp/lighthouse/pull/2682 for more info on
+    /// the legacy bug.
     pub fn get_data_dir_legacy(&self) -> Option<PathBuf> {
         dirs::home_dir().map(|home_dir| home_dir.join(&self.data_dir))
     }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -40,17 +40,22 @@ pub fn get_config<E: EthSpec>(
         ..Default::default()
     };
 
+    let is_legacy = client_config.data_dir.is_relative();
     // If necessary, remove any existing database and configuration
     if client_config.data_dir.exists() && cli_args.is_present("purge-db") {
         // Remove the chain_db.
-        let chain_db = client_config.get_db_path();
+        let chain_db = client_config
+            .get_db_path(is_legacy)
+            .ok_or("Failed to get db_path")?;
         if chain_db.exists() {
             fs::remove_dir_all(chain_db)
                 .map_err(|err| format!("Failed to remove chain_db: {}", err))?;
         }
 
         // Remove the freezer db.
-        let freezer_db = client_config.get_freezer_db_path();
+        let freezer_db = client_config
+            .get_freezer_db_path(is_legacy)
+            .ok_or("Failed to get freezer db path")?;
         if freezer_db.exists() {
             fs::remove_dir_all(freezer_db)
                 .map_err(|err| format!("Failed to remove freezer_db: {}", err))?;

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -40,7 +40,13 @@ pub fn get_config<E: EthSpec>(
         ..Default::default()
     };
 
-    let is_legacy = client_config.data_dir.is_relative();
+    // Use the legacy options if there is already a `chain_db` in
+    // the legacy path.
+    let is_legacy = client_config
+        .get_db_path(true)
+        .ok_or("Failed to get db path")?
+        .exists();
+
     // If necessary, remove any existing database and configuration
     if client_config.data_dir.exists() && cli_args.is_present("purge-db") {
         // Remove the chain_db.

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -62,7 +62,12 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
         let store_config = client_config.store.clone();
         let log = context.log().clone();
 
-        let is_legacy = client_config.data_dir.is_relative();
+        // Use the legacy options if there is already a `chain_db` in
+        // the legacy path.
+        let is_legacy = client_config
+            .get_db_path(true)
+            .ok_or("Failed to get db path")?
+            .exists();
 
         let datadir = client_config.create_data_dir(is_legacy)?;
         let db_path = client_config.create_db_path(is_legacy)?;

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -61,9 +61,16 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
         let client_genesis = client_config.genesis.clone();
         let store_config = client_config.store.clone();
         let log = context.log().clone();
-        let datadir = client_config.create_data_dir()?;
-        let db_path = client_config.create_db_path()?;
-        let freezer_db_path = client_config.create_freezer_db_path()?;
+
+        let is_legacy = client_config.data_dir.is_relative();
+
+        let datadir = client_config.create_data_dir(is_legacy)?;
+        let db_path = client_config.create_db_path(is_legacy)?;
+        let freezer_db_path = client_config.create_freezer_db_path(is_legacy)?;
+        if is_legacy {
+            warn!(log, "Using data_dir"; "datadir" => ?datadir);
+        }
+
         let executor = context.executor.clone();
 
         if !client_config.chain.enable_lock_timeouts {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

#2682 fixed a bug where providing a relative path for datadir resulted in the datadir db paths being created relative to the home directory. However, as @paulhauner noted in the PR, this would be a backwards incompatible change for users relying on the bug knowingly or unknowingly. 

This PR ensures backwards compatibility by keeping the db in the same place as before for users relying on the bug.
If there is no db in the existing location, then it will behave as expected (create a directory relative to the current path).

