### PR TITLE
[Merged by Bors] - Optimise balances cache in case of skipped slots

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -12,7 +12,9 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
 use superstruct::superstruct;
-use types::{BeaconBlock, BeaconState, BeaconStateError, Checkpoint, EthSpec, Hash256, Slot};
+use types::{
+    BeaconBlock, BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, Hash256, Slot,
+};
 
 #[derive(Debug)]
 pub enum Error {
@@ -56,23 +58,33 @@ pub fn get_effective_balances<T: EthSpec>(state: &BeaconState<T>) -> Vec<u64> {
         .collect()
 }
 
-/// An item that is stored in the `BalancesCache`.
-#[derive(PartialEq, Clone, Debug, Encode, Decode)]
-struct CacheItem {
-    /// The block root at which `self.balances` are valid.
-    block_root: Hash256,
-    /// The effective balances from a `BeaconState` validator registry.
-    balances: Vec<u64>,
+#[superstruct(
+    variants(V1, V8),
+    variant_attributes(derive(PartialEq, Clone, Debug, Encode, Decode)),
+    no_enum
+)]
+pub(crate) struct CacheItem {
+    pub(crate) block_root: Hash256,
+    #[superstruct(only(V8))]
+    pub(crate) epoch: Epoch,
+    pub(crate) balances: Vec<u64>,
 }
 
-/// Provides a cache to avoid reading `BeaconState` from disk when updating the current justified
-/// checkpoint.
-///
-/// It is effectively a mapping of `epoch_boundary_block_root -> state.balances`.
-#[derive(PartialEq, Clone, Default, Debug, Encode, Decode)]
+pub(crate) type CacheItem = CacheItemV8;
+
+#[superstruct(
+    variants(V1, V8),
+    variant_attributes(derive(PartialEq, Clone, Default, Debug, Encode, Decode)),
+    no_enum
+)]
 pub struct BalancesCache {
-    items: Vec<CacheItem>,
+    #[superstruct(only(V1))]
+    pub(crate) items: Vec<CacheItemV1>,
+    #[superstruct(only(V8))]
+    pub(crate) items: Vec<CacheItemV8>,
 }
+
+pub type BalancesCache = BalancesCacheV8;
 
 impl BalancesCache {
     /// Inspect the given `state` and determine the root of the block at the first slot of
@@ -83,7 +95,8 @@ impl BalancesCache {
         block_root: Hash256,
         state: &BeaconState<E>,
     ) -> Result<(), Error> {
-        let epoch_boundary_slot = state.current_epoch().start_slot(E::slots_per_epoch());
+        let epoch = state.current_epoch();
+        let epoch_boundary_slot = epoch.start_slot(E::slots_per_epoch());
         let epoch_boundary_root = if epoch_boundary_slot == state.slot() {
             block_root
         } else {
@@ -96,9 +109,10 @@ impl BalancesCache {
         // epoch. We rely on the invariant that effective balances do not change for the duration
         // of a single epoch, so even if the block on the epoch boundary itself is skipped we can
         // still update its cache entry from any subsequent state in that epoch.
-        if self.position(epoch_boundary_root).is_none() {
+        if self.position(epoch_boundary_root, epoch).is_none() {
             let item = CacheItem {
                 block_root: epoch_boundary_root,
+                epoch,
                 balances: get_effective_balances(state),
             };
 
@@ -112,17 +126,17 @@ impl BalancesCache {
         Ok(())
     }
 
-    fn position(&self, block_root: Hash256) -> Option<usize> {
+    fn position(&self, block_root: Hash256, epoch: Epoch) -> Option<usize> {
         self.items
             .iter()
-            .position(|item| item.block_root == block_root)
+            .position(|item| item.block_root == block_root && item.epoch == epoch)
     }
 
     /// Get the balances for the given `block_root`, if any.
     ///
     /// If some balances are found, they are cloned from the cache.
-    pub fn get(&mut self, block_root: Hash256) -> Option<Vec<u64>> {
-        let i = self.position(block_root)?;
+    pub fn get(&mut self, block_root: Hash256, epoch: Epoch) -> Option<Vec<u64>> {
+        let i = self.position(block_root, epoch)?;
         Some(self.items[i].balances.clone())
     }
 }
@@ -276,7 +290,10 @@ where
     fn set_justified_checkpoint(&mut self, checkpoint: Checkpoint) -> Result<(), Error> {
         self.justified_checkpoint = checkpoint;
 
-        if let Some(balances) = self.balances_cache.get(self.justified_checkpoint.root) {
+        if let Some(balances) = self.balances_cache.get(
+            self.justified_checkpoint.root,
+            self.justified_checkpoint.epoch,
+        ) {
             metrics::inc_counter(&metrics::BALANCES_CACHE_HITS);
             self.justified_balances = balances;
         } else {
@@ -311,16 +328,23 @@ where
 }
 
 /// A container which allows persisting the `BeaconForkChoiceStore` to the on-disk database.
-#[superstruct(variants(V1, V7), variant_attributes(derive(Encode, Decode)), no_enum)]
+#[superstruct(
+    variants(V1, V7, V8),
+    variant_attributes(derive(Encode, Decode)),
+    no_enum
+)]
 pub struct PersistedForkChoiceStore {
-    pub balances_cache: BalancesCache,
+    #[superstruct(only(V1, V7))]
+    pub balances_cache: BalancesCacheV1,
+    #[superstruct(only(V8))]
+    pub balances_cache: BalancesCacheV8,
     pub time: Slot,
     pub finalized_checkpoint: Checkpoint,
     pub justified_checkpoint: Checkpoint,
     pub justified_balances: Vec<u64>,
     pub best_justified_checkpoint: Checkpoint,
-    #[superstruct(only(V7))]
+    #[superstruct(only(V7, V8))]
     pub proposer_boost_root: Hash256,
 }
 
-pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV7;
+pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV8;

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -1,19 +1,27 @@
-use crate::beacon_fork_choice_store::{PersistedForkChoiceStoreV1, PersistedForkChoiceStoreV7};
+use crate::beacon_fork_choice_store::{
+    PersistedForkChoiceStoreV1, PersistedForkChoiceStoreV7, PersistedForkChoiceStoreV8,
+};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use store::{DBColumn, Error, StoreItem};
 use superstruct::superstruct;
 
 // If adding a new version you should update this type alias and fix the breakages.
-pub type PersistedForkChoice = PersistedForkChoiceV7;
+pub type PersistedForkChoice = PersistedForkChoiceV8;
 
-#[superstruct(variants(V1, V7), variant_attributes(derive(Encode, Decode)), no_enum)]
+#[superstruct(
+    variants(V1, V7, V8),
+    variant_attributes(derive(Encode, Decode)),
+    no_enum
+)]
 pub struct PersistedForkChoice {
     pub fork_choice: fork_choice::PersistedForkChoice,
     #[superstruct(only(V1))]
     pub fork_choice_store: PersistedForkChoiceStoreV1,
     #[superstruct(only(V7))]
     pub fork_choice_store: PersistedForkChoiceStoreV7,
+    #[superstruct(only(V8))]
+    pub fork_choice_store: PersistedForkChoiceStoreV8,
 }
 
 macro_rules! impl_store_item {
@@ -36,3 +44,4 @@ macro_rules! impl_store_item {
 
 impl_store_item!(PersistedForkChoiceV1);
 impl_store_item!(PersistedForkChoiceV7);
+impl_store_item!(PersistedForkChoiceV8);

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v8.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v8.rs
@@ -1,0 +1,50 @@
+use crate::beacon_chain::BeaconChainTypes;
+use crate::beacon_fork_choice_store::{
+    BalancesCacheV8, CacheItemV8, PersistedForkChoiceStoreV7, PersistedForkChoiceStoreV8,
+};
+use crate::persisted_fork_choice::{PersistedForkChoiceV7, PersistedForkChoiceV8};
+use std::sync::Arc;
+use store::{Error as StoreError, HotColdDB};
+use types::EthSpec;
+
+pub fn update_fork_choice<T: BeaconChainTypes>(
+    fork_choice: PersistedForkChoiceV7,
+    db: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
+) -> Result<PersistedForkChoiceV8, StoreError> {
+    let PersistedForkChoiceStoreV7 {
+        balances_cache,
+        time,
+        finalized_checkpoint,
+        justified_checkpoint,
+        justified_balances,
+        best_justified_checkpoint,
+        proposer_boost_root,
+    } = fork_choice.fork_choice_store;
+    let mut fork_choice_store = PersistedForkChoiceStoreV8 {
+        balances_cache: BalancesCacheV8::default(),
+        time,
+        finalized_checkpoint,
+        justified_checkpoint,
+        justified_balances,
+        best_justified_checkpoint,
+        proposer_boost_root,
+    };
+
+    // Add epochs to the balances cache. It's safe to just use the block's epoch because
+    // before schema v8 the cache would always miss on skipped slots.
+    for item in balances_cache.items {
+        // Drop any blocks that aren't found, they're presumably too old and this is only a cache.
+        if let Some(block) = db.get_block(&item.block_root)? {
+            fork_choice_store.balances_cache.items.push(CacheItemV8 {
+                block_root: item.block_root,
+                epoch: block.slot().epoch(T::EthSpec::slots_per_epoch()),
+                balances: item.balances,
+            });
+        }
+    }
+
+    Ok(PersistedForkChoiceV8 {
+        fork_choice: fork_choice.fork_choice,
+        fork_choice_store,
+    })
+}

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Checkpoint, Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(7);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(8);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //


### PR DESCRIPTION
## Proposed Changes

Remove the `is_first_block_in_epoch` logic from the balances cache update logic, as it was incorrect in the case of skipped slots. The updated code is simpler because regardless of whether the block is the first in the epoch we can check if an entry for the epoch boundary root already exists in the cache, and update the cache accordingly.

Additionally, to assist with flip-flopping justified epochs, move to cloning the balance cache rather than moving it. This should still be very fast in practice because the balances cache is a ~1.6MB `Vec`, and this operation is expected to only occur infrequently.
