### PR TITLE
[Merged by Bors] - 1.57.0 lints

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1602,7 +1602,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // This method is called for API and gossip attestations, so this covers all unaggregated attestation events
                 if let Some(event_handler) = self.event_handler.as_ref() {
                     if event_handler.has_attestation_subscribers() {
-                        event_handler.register(EventKind::Attestation(v.attestation().clone()));
+                        event_handler
+                            .register(EventKind::Attestation(Box::new(v.attestation().clone())));
                     }
                 }
                 metrics::inc_counter(&metrics::UNAGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);
@@ -1638,7 +1639,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // This method is called for API and gossip attestations, so this covers all aggregated attestation events
             if let Some(event_handler) = self.event_handler.as_ref() {
                 if event_handler.has_attestation_subscribers() {
-                    event_handler.register(EventKind::Attestation(v.attestation().clone()));
+                    event_handler
+                        .register(EventKind::Attestation(Box::new(v.attestation().clone())));
                 }
             }
             metrics::inc_counter(&metrics::AGGREGATED_ATTESTATION_PROCESSING_SUCCESSES);

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -41,9 +41,19 @@ const MAX_ADVANCE_DISTANCE: u64 = 4;
 enum Error {
     BeaconChain(BeaconChainError),
     HeadMissingFromSnapshotCache(Hash256),
-    MaxDistanceExceeded { current_slot: Slot, head_slot: Slot },
-    StateAlreadyAdvanced { block_root: Hash256 },
-    BadStateSlot { state_slot: Slot, block_slot: Slot },
+    MaxDistanceExceeded {
+        current_slot: Slot,
+        head_slot: Slot,
+    },
+    StateAlreadyAdvanced {
+        block_root: Hash256,
+    },
+    // This is actually logged out when this error is hit, the linter misses it though.
+    #[allow(dead_code)]
+    BadStateSlot {
+        state_slot: Slot,
+        block_slot: Slot,
+    },
 }
 
 impl From<BeaconChainError> for Error {

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -48,11 +48,9 @@ enum Error {
     StateAlreadyAdvanced {
         block_root: Hash256,
     },
-    // This is actually logged out when this error is hit, the linter misses it though.
-    #[allow(dead_code)]
     BadStateSlot {
-        state_slot: Slot,
-        block_slot: Slot,
+        _state_slot: Slot,
+        _block_slot: Slot,
     },
 }
 
@@ -234,8 +232,8 @@ fn advance_head<T: BeaconChainTypes>(
         // Advancing more than one slot without storing the intermediate state would corrupt the
         // database. Future works might store temporary, intermediate states inside this function.
         return Err(Error::BadStateSlot {
-            block_slot: head_slot,
-            state_slot: state.slot(),
+            _block_slot: head_slot,
+            _state_slot: state.slot(),
         });
     };
 

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -242,6 +242,8 @@ enum Error {
     PubkeyDecode(bls::Error),
     /// The file read from disk does not have a contiguous list of validator public keys. The file
     /// has become corrupted.
+    // This is actually logged out when this error is hit, the linter misses it though.
+    #[allow(dead_code)]
     InconsistentIndex {
         expected: Option<usize>,
         found: usize,

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -242,11 +242,9 @@ enum Error {
     PubkeyDecode(bls::Error),
     /// The file read from disk does not have a contiguous list of validator public keys. The file
     /// has become corrupted.
-    // This is actually logged out when this error is hit, the linter misses it though.
-    #[allow(dead_code)]
     InconsistentIndex {
-        expected: Option<usize>,
-        found: usize,
+        _expected: Option<usize>,
+        _found: usize,
     },
 }
 
@@ -298,8 +296,8 @@ impl ValidatorPubkeyCacheFile {
                 indices.insert(pubkey, index);
             } else {
                 return Err(Error::InconsistentIndex {
-                    expected,
-                    found: index,
+                    _expected: expected,
+                    _found: index,
                 });
             }
         }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2310,7 +2310,7 @@ impl ApiTester {
             self.attestations
                 .clone()
                 .into_iter()
-                .map(|attestation| EventKind::Attestation(attestation))
+                .map(|attestation| EventKind::Attestation(Box::new(attestation)))
                 .collect::<Vec<_>>()
                 .as_slice()
         );

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -72,6 +72,7 @@ mod tests;
 mod work_reprocessing_queue;
 mod worker;
 
+use crate::beacon_processor::work_reprocessing_queue::QueuedBlock;
 pub use worker::{GossipAggregatePackage, GossipAttestationPackage, ProcessId};
 
 /// The maximum size of the channel for work events to the `BeaconProcessor`.
@@ -566,12 +567,16 @@ impl<T: BeaconChainTypes> WorkEvent<T> {
 impl<T: BeaconChainTypes> std::convert::From<ReadyWork<T>> for WorkEvent<T> {
     fn from(ready_work: ReadyWork<T>) -> Self {
         match ready_work {
-            ReadyWork::Block(queued) => Self {
+            ReadyWork::Block(QueuedBlock {
+                peer_id,
+                block,
+                seen_timestamp,
+            }) => Self {
                 drop_during_sync: false,
                 work: Work::DelayedImportBlock {
-                    peer_id: queued.peer_id,
-                    block: Box::new(queued.block),
-                    seen_timestamp: queued.seen_timestamp,
+                    peer_id,
+                    block,
+                    seen_timestamp,
                 },
             },
             ReadyWork::Unaggregate(QueuedUnaggregate {

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -63,7 +63,7 @@ use types::{
     SyncCommitteeMessage, SyncSubnetId,
 };
 use work_reprocessing_queue::{
-    spawn_reprocess_scheduler, QueuedAggregate, QueuedBlock, QueuedUnaggregate, ReadyWork,
+    spawn_reprocess_scheduler, QueuedAggregate, QueuedUnaggregate, ReadyWork,
 };
 
 use worker::{Toolbox, Worker};
@@ -566,16 +566,12 @@ impl<T: BeaconChainTypes> WorkEvent<T> {
 impl<T: BeaconChainTypes> std::convert::From<ReadyWork<T>> for WorkEvent<T> {
     fn from(ready_work: ReadyWork<T>) -> Self {
         match ready_work {
-            ReadyWork::Block(QueuedBlock {
-                peer_id,
-                block,
-                seen_timestamp,
-            }) => Self {
+            ReadyWork::Block(queued) => Self {
                 drop_during_sync: false,
                 work: Work::DelayedImportBlock {
-                    peer_id,
-                    block: Box::new(block),
-                    seen_timestamp,
+                    peer_id: queued.peer_id,
+                    block: Box::new(queued.block),
+                    seen_timestamp: queued.seen_timestamp,
                 },
             },
             ReadyWork::Unaggregate(QueuedUnaggregate {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -826,11 +826,11 @@ impl<T: BeaconChainTypes> Worker<T> {
                 metrics::inc_counter(&metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_REQUEUED_TOTAL);
 
                 if reprocess_tx
-                    .try_send(ReprocessQueueMessage::EarlyBlock(Box::new(QueuedBlock {
+                    .try_send(ReprocessQueueMessage::EarlyBlock(QueuedBlock {
                         peer_id,
-                        block: verified_block,
+                        block: Box::new(verified_block),
                         seen_timestamp: seen_duration,
-                    })))
+                    }))
                     .is_err()
                 {
                     error!(

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -121,7 +121,6 @@ pub struct GossipAttestationPackage<E: EthSpec> {
     peer_id: PeerId,
     attestation: Box<Attestation<E>>,
     subnet_id: SubnetId,
-    beacon_block_root: Hash256,
     should_import: bool,
     seen_timestamp: Duration,
 }
@@ -138,7 +137,6 @@ impl<E: EthSpec> GossipAttestationPackage<E> {
         Self {
             message_id,
             peer_id,
-            beacon_block_root: attestation.data.beacon_block_root,
             attestation,
             subnet_id,
             should_import,
@@ -828,11 +826,11 @@ impl<T: BeaconChainTypes> Worker<T> {
                 metrics::inc_counter(&metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_REQUEUED_TOTAL);
 
                 if reprocess_tx
-                    .try_send(ReprocessQueueMessage::EarlyBlock(QueuedBlock {
+                    .try_send(ReprocessQueueMessage::EarlyBlock(Box::new(QueuedBlock {
                         peer_id,
                         block: verified_block,
                         seen_timestamp: seen_duration,
-                    }))
+                    })))
                     .is_err()
                 {
                     error!(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -226,7 +226,7 @@ pub fn get_config<E: EthSpec>(
         client_config.sync_eth1_chain = true;
         client_config.eth1.endpoints = endpoints
             .split(',')
-            .map(|s| SensitiveUrl::parse(s))
+            .map(SensitiveUrl::parse)
             .collect::<Result<_, _>>()
             .map_err(|e| format!("eth1-endpoints contains an invalid URL {:?}", e))?;
     }
@@ -245,7 +245,7 @@ pub fn get_config<E: EthSpec>(
         client_config.sync_eth1_chain = true;
         client_config.execution_endpoints = endpoints
             .split(',')
-            .map(|s| SensitiveUrl::parse(s))
+            .map(SensitiveUrl::parse)
             .collect::<Result<_, _>>()
             .map(Some)
             .map_err(|e| format!("execution-endpoints contains an invalid URL {:?}", e))?;

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -777,7 +777,7 @@ pub struct SseLateHead {
 #[derive(PartialEq, Debug, Serialize, Clone)]
 #[serde(bound = "T: EthSpec", untagged)]
 pub enum EventKind<T: EthSpec> {
-    Attestation(Attestation<T>),
+    Attestation(Box<Attestation<T>>),
     Block(SseBlock),
     FinalizedCheckpoint(SseFinalizedCheckpoint),
     Head(SseHead),

--- a/common/lockfile/src/lib.rs
+++ b/common/lockfile/src/lib.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 /// outage) caused the lockfile not to be deleted.
 #[derive(Debug)]
 pub struct Lockfile {
+    _file: File,
     path: PathBuf,
     file_existed: bool,
 }
@@ -41,7 +42,11 @@ impl Lockfile {
             ErrorKind::WouldBlock => LockfileError::FileLocked(path.clone(), e),
             _ => LockfileError::IoError(path.clone(), e),
         })?;
-        Ok(Self { path, file_existed })
+        Ok(Self {
+            _file: file,
+            path,
+            file_existed,
+        })
     }
 
     /// Return `true` if the lockfile existed when the lock was created.

--- a/common/lockfile/src/lib.rs
+++ b/common/lockfile/src/lib.rs
@@ -11,7 +11,6 @@ use std::path::{Path, PathBuf};
 /// outage) caused the lockfile not to be deleted.
 #[derive(Debug)]
 pub struct Lockfile {
-    file: File,
     path: PathBuf,
     file_existed: bool,
 }
@@ -42,11 +41,7 @@ impl Lockfile {
             ErrorKind::WouldBlock => LockfileError::FileLocked(path.clone(), e),
             _ => LockfileError::IoError(path.clone(), e),
         })?;
-        Ok(Self {
-            file,
-            path,
-            file_existed,
-        })
+        Ok(Self { path, file_existed })
     }
 
     /// Return `true` if the lockfile existed when the lock was created.

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -99,7 +99,7 @@ impl<'a> AlignedRecordDecorator<'a> {
 
 impl<'a> Write for AlignedRecordDecorator<'a> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        if buf.iter().any(|c| is_ascii_control(c)) {
+        if buf.iter().any(u8::is_ascii_control) {
             let filtered = buf
                 .iter()
                 .cloned()

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -62,6 +62,8 @@ pub struct MonitoringHttpClient {
     client: reqwest::Client,
     /// Path to the hot database. Required for getting db size metrics
     db_path: Option<PathBuf>,
+    /// Path to the freezer database.
+    freezer_db_path: Option<PathBuf>,
     monitoring_endpoint: SensitiveUrl,
     log: slog::Logger,
 }
@@ -71,6 +73,7 @@ impl MonitoringHttpClient {
         Ok(Self {
             client: reqwest::Client::new(),
             db_path: config.db_path.clone(),
+            freezer_db_path: config.freezer_db_path.clone(),
             monitoring_endpoint: SensitiveUrl::parse(&config.monitoring_endpoint)
                 .map_err(|e| format!("Invalid monitoring endpoint: {:?}", e))?,
             log,
@@ -125,7 +128,7 @@ impl MonitoringHttpClient {
             Error::BeaconMetricsFailed("Beacon metrics require db path".to_string())
         })?;
 
-        let freezer_db_path = self.db_path.as_ref().ok_or_else(|| {
+        let freezer_db_path = self.freezer_db_path.as_ref().ok_or_else(|| {
             Error::BeaconMetricsFailed("Beacon metrics require freezer db path".to_string())
         })?;
         let metrics =

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -62,8 +62,6 @@ pub struct MonitoringHttpClient {
     client: reqwest::Client,
     /// Path to the hot database. Required for getting db size metrics
     db_path: Option<PathBuf>,
-    /// Path to the freezer database.
-    freezer_db_path: Option<PathBuf>,
     monitoring_endpoint: SensitiveUrl,
     log: slog::Logger,
 }
@@ -73,7 +71,6 @@ impl MonitoringHttpClient {
         Ok(Self {
             client: reqwest::Client::new(),
             db_path: config.db_path.clone(),
-            freezer_db_path: config.freezer_db_path.clone(),
             monitoring_endpoint: SensitiveUrl::parse(&config.monitoring_endpoint)
                 .map_err(|e| format!("Invalid monitoring endpoint: {:?}", e))?,
             log,

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -5,7 +5,6 @@ use crate::builder::{
 use deposit_contract::decode_eth1_tx_data;
 use derivative::Derivative;
 use eth2_keystore::{Error as KeystoreError, Keystore, PlainText};
-use lockfile::{Lockfile, LockfileError};
 use std::fs::{read, write, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -18,7 +17,6 @@ pub const ETH1_DEPOSIT_TX_HASH_FILE: &str = "eth1-deposit-tx-hash.txt";
 #[derive(Debug)]
 pub enum Error {
     DirectoryDoesNotExist(PathBuf),
-    LockfileError(LockfileError),
     UnableToOpenKeystore(io::Error),
     UnableToReadKeystore(KeystoreError),
     UnableToOpenPassword(io::Error),
@@ -62,8 +60,6 @@ pub struct Eth1DepositData {
 #[derivative(PartialEq)]
 pub struct ValidatorDir {
     dir: PathBuf,
-    #[derivative(PartialEq = "ignore")]
-    lockfile: Lockfile,
 }
 
 impl ValidatorDir {
@@ -80,12 +76,7 @@ impl ValidatorDir {
             return Err(Error::DirectoryDoesNotExist(dir));
         }
 
-        // Lock the keystore file that *might* be in this directory.
-        // This is not ideal, see: https://github.com/sigp/lighthouse/issues/1978
-        let lockfile_path = dir.join(format!("{}.lock", VOTING_KEYSTORE_FILE));
-        let lockfile = Lockfile::new(lockfile_path).map_err(Error::LockfileError)?;
-
-        Ok(Self { dir, lockfile })
+        Ok(Self { dir })
     }
 
     /// Returns the `dir` provided to `Self::open`.

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -5,10 +5,10 @@ use crate::builder::{
 use deposit_contract::decode_eth1_tx_data;
 use derivative::Derivative;
 use eth2_keystore::{Error as KeystoreError, Keystore, PlainText};
+use lockfile::{Lockfile, LockfileError};
 use std::fs::{read, write, OpenOptions};
 use std::io;
 use std::path::{Path, PathBuf};
-use lockfile::{Lockfile, LockfileError};
 use tree_hash::TreeHash;
 use types::{DepositData, Hash256, Keypair};
 
@@ -85,7 +85,10 @@ impl ValidatorDir {
         let lockfile_path = dir.join(format!("{}.lock", VOTING_KEYSTORE_FILE));
         let lockfile = Lockfile::new(lockfile_path).map_err(Error::LockfileError)?;
 
-        Ok(Self { dir, _lockfile: lockfile })
+        Ok(Self {
+            dir,
+            _lockfile: lockfile,
+        })
     }
 
     /// Returns the `dir` provided to `Self::open`.

--- a/consensus/cached_tree_hash/src/cache_arena.rs
+++ b/consensus/cached_tree_hash/src/cache_arena.rs
@@ -491,8 +491,8 @@ mod tests {
             subs.push(sub);
         }
 
-        for mut sub in subs.iter_mut() {
-            test_routine(arena, &mut sub);
+        for sub in subs.iter_mut() {
+            test_routine(arena, sub);
         }
     }
 }

--- a/consensus/ssz/src/encode.rs
+++ b/consensus/ssz/src/encode.rs
@@ -113,7 +113,7 @@ impl<'a> SszEncoder<'a> {
         F: Fn(&mut Vec<u8>),
     {
         if is_ssz_fixed_len {
-            ssz_append(&mut self.buf);
+            ssz_append(self.buf);
         } else {
             self.buf
                 .extend_from_slice(&encode_length(self.offset + self.variable_bytes.len()));
@@ -129,7 +129,7 @@ impl<'a> SszEncoder<'a> {
     pub fn finalize(&mut self) -> &mut Vec<u8> {
         self.buf.append(&mut self.variable_bytes);
 
-        &mut self.buf
+        self.buf
     }
 }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -62,7 +62,7 @@ pub enum Step<B, A, P> {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Meta {
-    description: String,
+    _description: String,
 }
 
 #[derive(Debug)]

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -62,6 +62,7 @@ pub enum Step<B, A, P> {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Meta {
+    #[serde(rename(deserialize = "description"))]
     _description: String,
 }
 

--- a/testing/ef_tests/src/cases/genesis_validity.rs
+++ b/testing/ef_tests/src/cases/genesis_validity.rs
@@ -7,7 +7,7 @@ use types::{BeaconState, EthSpec, ForkName};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Metadata {
-    description: String,
+    _description: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/testing/ef_tests/src/cases/genesis_validity.rs
+++ b/testing/ef_tests/src/cases/genesis_validity.rs
@@ -7,6 +7,7 @@ use types::{BeaconState, EthSpec, ForkName};
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Metadata {
+    #[serde(rename(deserialize = "description"))]
     _description: String,
 }
 

--- a/testing/ef_tests/src/cases/ssz_generic.rs
+++ b/testing/ef_tests/src/cases/ssz_generic.rs
@@ -15,6 +15,7 @@ use types::{BitList, BitVector, FixedVector, ForkName, VariableList};
 #[derive(Debug, Clone, Deserialize)]
 struct Metadata {
     root: String,
+    #[serde(rename(deserialize = "signing_root"))]
     _signing_root: Option<String>,
 }
 

--- a/testing/ef_tests/src/cases/ssz_generic.rs
+++ b/testing/ef_tests/src/cases/ssz_generic.rs
@@ -15,7 +15,7 @@ use types::{BitList, BitVector, FixedVector, ForkName, VariableList};
 #[derive(Debug, Clone, Deserialize)]
 struct Metadata {
     root: String,
-    signing_root: Option<String>,
+    _signing_root: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/testing/ef_tests/src/cases/ssz_static.rs
+++ b/testing/ef_tests/src/cases/ssz_static.rs
@@ -10,6 +10,7 @@ use types::{BeaconBlock, BeaconState, ForkName, Hash256, SignedBeaconBlock};
 #[derive(Debug, Clone, Deserialize)]
 struct SszStaticRoots {
     root: String,
+    #[serde(rename(deserialize = "signing_root"))]
     _signing_root: Option<String>,
 }
 

--- a/testing/ef_tests/src/cases/ssz_static.rs
+++ b/testing/ef_tests/src/cases/ssz_static.rs
@@ -10,7 +10,7 @@ use types::{BeaconBlock, BeaconState, ForkName, Hash256, SignedBeaconBlock};
 #[derive(Debug, Clone, Deserialize)]
 struct SszStaticRoots {
     root: String,
-    signing_root: Option<String>,
+    _signing_root: Option<String>,
 }
 
 /// Runner for types that implement `ssz::Decode`.

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -131,7 +131,7 @@ impl Config {
         if let Some(beacon_nodes) = parse_optional::<String>(cli_args, "beacon-nodes")? {
             config.beacon_nodes = beacon_nodes
                 .split(',')
-                .map(|s| SensitiveUrl::parse(s))
+                .map(SensitiveUrl::parse)
                 .collect::<Result<_, _>>()
                 .map_err(|e| format!("Unable to parse beacon node URL: {:?}", e))?;
         }

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -84,7 +84,6 @@ pub struct ProductionValidatorClient<T: EthSpec> {
     doppelganger_service: Option<Arc<DoppelgangerService>>,
     validator_store: Arc<ValidatorStore<SystemTimeSlotClock, T>>,
     http_api_listen_addr: Option<SocketAddr>,
-    http_metrics_ctx: Option<Arc<http_metrics::Context<T>>>,
     config: Config,
 }
 
@@ -431,7 +430,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             validator_store,
             config,
             http_api_listen_addr: None,
-            http_metrics_ctx,
         })
     }
 


### PR DESCRIPTION
## Issue Addressed

New rust lints

## Proposed Changes

- Boxing some enum variants
- removing some unused fields (is the validator lockfile unused? seemed so to me)

## Additional Info

- some error fields were marked as dead code but are logged out in areas
- left some dead fields in our ef test code because I assume they are useful for debugging?