### PR TITLE
[Merged by Bors] - fix cache miss justified balances calculation

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -321,14 +321,13 @@ where
                 .deconstruct()
                 .0;
 
-            self.justified_balances = self
+            let state = self
                 .store
                 .get_state(&justified_block.state_root(), Some(justified_block.slot()))
                 .map_err(Error::FailedToReadState)?
-                .ok_or_else(|| Error::MissingState(justified_block.state_root()))?
-                .balances()
-                .clone()
-                .into();
+                .ok_or_else(|| Error::MissingState(justified_block.state_root()))?;
+
+            self.justified_balances = get_effective_balances(&state);
         }
 
         Ok(())


### PR DESCRIPTION
## Issue Addressed

We were calculating justified balances incorrectly on cache misses in `set_justified_checkpoint`

## Proposed Changes

Use the `get_effective_balances` method as opposed to `state.balances`, which returns exact balances
