### PR TITLE
[Merged by Bors] - do not count dialing peers in the connection limit

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -351,7 +351,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     /// Reports whether the peer limit is reached in which case we stop allowing new incoming
     /// connections.
     pub fn peer_limit_reached(&self) -> bool {
-        self.network_globals.connected_or_dialing_peers() >= self.max_peers()
+        self.network_globals.connected_peers() >= self.max_peers()
     }
 
     /// Updates `PeerInfo` with `identify` information.

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -350,8 +350,13 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
 
     /// Reports whether the peer limit is reached in which case we stop allowing new incoming
     /// connections.
-    pub fn peer_limit_reached(&self) -> bool {
-        self.network_globals.connected_peers() >= self.max_peers()
+    pub fn peer_limit_reached(&self, count_dialing: bool) -> bool {
+        let max_peers = self.max_peers();
+        if count_dialing {
+            self.network_globals.connected_or_dialing_peers() >= max_peers
+        } else {
+            self.network_globals.connected_peers() >= max_peers
+        }
     }
 
     /// Updates `PeerInfo` with `identify` information.

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -112,15 +112,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for PeerManager<TSpec> {
         _failed_addresses: Option<&Vec<Multiaddr>>,
     ) {
         // Log the connection
-        match &endpoint {
-            ConnectedPoint::Listener { .. } => {
-                debug!(self.log, "Connection established"; "peer_id" => %peer_id, "connection" => "Incoming");
-            }
-            ConnectedPoint::Dialer { .. } => {
-                debug!(self.log, "Connection established"; "peer_id" => %peer_id, "connection" => "Outgoing");
-                // TODO: Ensure we have that address registered.
-            }
-        }
+        debug!(self.log, "Connection established"; "peer_id" => %peer_id, "connection" => ?endpoint.to_endpoint());
 
         // Check to make sure the peer is not supposed to be banned
         match self.ban_status(peer_id) {

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -134,8 +134,10 @@ impl<TSpec: EthSpec> NetworkBehaviour for PeerManager<TSpec> {
             BanResult::NotBanned => {}
         }
 
+        // Count dialing peers in the limit if the peer dialied us.
+        let count_dialing = endpoint.is_listener();
         // Check the connection limits
-        if self.peer_limit_reached()
+        if self.peer_limit_reached(count_dialing)
             && self
                 .network_globals
                 .peers


### PR DESCRIPTION
## Issue Addressed
#2841 

## Proposed Changes
Not counting dialing peers while deciding if we have reached the target peers in case of outbound peers.

## Additional Info
Checked this running in nodes and bandwidth looks normal, peer count looks normal too
