### PR TITLE
[Merged by Bors] - Update rusqlite from yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+checksum = "5c4b1eaf239b47034fb450ee9cdedd7d0226571689d8823030c4b6c2cb407152"
 dependencies = [
  "bitflags",
  "fallible-iterator",


### PR DESCRIPTION
## Issue Addressed

The version of `rusqlite` that we were depending on has been yanked due to a vulnerability. The vulnerability only affects `update_hook`, which we don't use in Lighthouse.

There is no need to push a release -- users are safe to ignore this warning.

## Additional Info

Incoming advisory: https://github.com/rustsec/advisory-db/pull/1117
