### PR TITLE
[Merged by Bors] - Update docker images to Ubuntu latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make
 
-FROM debian:bullseye-slim
+FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,7 +1,7 @@
 # This image is meant to enable cross-architecture builds.
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
-FROM --platform=$TARGETPLATFORM debian:bullseye-slim
+FROM --platform=$TARGETPLATFORM ubuntu:latest
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,7 +1,7 @@
 # This image is meant to enable cross-architecture builds.
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
-FROM --platform=$TARGETPLATFORM debian:buster-slim
+FROM --platform=$TARGETPLATFORM debian:bullseye-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -8,6 +8,6 @@ ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make install-lcli
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -8,6 +8,6 @@ ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make install-lcli
 
-FROM debian:bullseye-slim
+FROM ubuntu:latest
 RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
## Issue Addressed

- Resolves #2778

## Proposed Changes

Updates docker images from Buster (10) to Bullseye (11), since Bullseye is [listed](https://www.debian.org/releases/) as the "current stable release".

## Additional Info

NA