### PR TITLE
[Merged by Bors] - Add configurable block replayer

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -65,7 +65,7 @@ use state_processing::{
     block_signature_verifier::{BlockSignatureVerifier, Error as BlockSignatureVerifierError},
     per_block_processing, per_slot_processing,
     state_advance::partial_state_advance,
-    BlockProcessingError, BlockSignatureStrategy, SlotProcessingError,
+    BlockProcessingError, BlockSignatureStrategy, SlotProcessingError, VerifyBlockRoot,
 };
 use std::borrow::Cow;
 use std::fs;
@@ -1185,6 +1185,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
             Some(block_root),
             // Signatures were verified earlier in this function.
             BlockSignatureStrategy::NoVerification,
+            VerifyBlockRoot::True,
             &chain.spec,
         ) {
             match err {

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -20,7 +20,7 @@ use state_processing::{
     },
     signature_sets::Error as SignatureSetError,
     state_advance::Error as StateAdvanceError,
-    BlockProcessingError, SlotProcessingError,
+    BlockProcessingError, BlockReplayError, SlotProcessingError,
 };
 use std::time::Duration;
 use task_executor::ShutdownReason;
@@ -86,6 +86,7 @@ pub enum BeaconChainError {
     ValidatorPubkeyCacheIncomplete(usize),
     SignatureSetError(SignatureSetError),
     BlockSignatureVerifierError(state_processing::block_signature_verifier::Error),
+    BlockReplayError(BlockReplayError),
     DuplicateValidatorPublicKey,
     ValidatorPubkeyCacheFileError(String),
     ValidatorIndexUnknown(usize),
@@ -160,6 +161,7 @@ easy_from_to!(ArithError, BeaconChainError);
 easy_from_to!(ForkChoiceStoreError, BeaconChainError);
 easy_from_to!(HistoricalBlockError, BeaconChainError);
 easy_from_to!(StateAdvanceError, BeaconChainError);
+easy_from_to!(BlockReplayError, BeaconChainError);
 
 #[derive(Debug)]
 pub enum BlockProductionError {

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -3,7 +3,9 @@ use fork_choice::{ForkChoice, PayloadVerificationStatus};
 use itertools::process_results;
 use slog::{info, warn, Logger};
 use state_processing::state_advance::complete_state_advance;
-use state_processing::{per_block_processing, per_block_processing::BlockSignatureStrategy};
+use state_processing::{
+    per_block_processing, per_block_processing::BlockSignatureStrategy, VerifyBlockRoot,
+};
 use std::sync::Arc;
 use std::time::Duration;
 use store::{iter::ParentRootBlockIterator, HotColdDB, ItemStore};
@@ -161,6 +163,7 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
             &block,
             None,
             BlockSignatureStrategy::NoVerification,
+            VerifyBlockRoot::True,
             spec,
         )
         .map_err(|e| format!("Error replaying block: {:?}", e))?;

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -360,13 +360,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
                 new_finalized_slot,
                 (new_finalized_block_hash, new_finalized_state_hash),
             )))
-            .chain(
-                RootsIterator::new(store.clone(), new_finalized_state).map(|res| {
-                    res.map(|(block_root, state_root, slot)| {
-                        (slot, (block_root.into(), state_root.into()))
-                    })
-                }),
-            )
+            .chain(RootsIterator::new(&store, new_finalized_state).map(|res| {
+                res.map(|(block_root, state_root, slot)| {
+                    (slot, (block_root.into(), state_root.into()))
+                })
+            }))
             .take_while(|res| {
                 res.as_ref()
                     .map_or(true, |(slot, _)| *slot >= old_finalized_slot)
@@ -416,7 +414,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
 
             // Iterate backwards from this head, staging blocks and states for deletion.
             let iter = std::iter::once(Ok((head_hash, head_state_root, head_slot)))
-                .chain(RootsIterator::from_block(store.clone(), head_hash)?);
+                .chain(RootsIterator::from_block(&store, head_hash)?);
 
             for maybe_tuple in iter {
                 let (block_root, state_root, slot) = maybe_tuple?;

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v7.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v7.rs
@@ -189,7 +189,7 @@ fn map_relevant_epochs_to_roots<T: BeaconChainTypes>(
 
     // Iterate backwards from the given `head_root` and `head_slot` and find the block root at each epoch.
     let mut iter = std::iter::once(Ok((head_root, head_slot)))
-        .chain(BlockRootsIterator::from_block(db, head_root).map_err(|e| format!("{:?}", e))?);
+        .chain(BlockRootsIterator::from_block(&db, head_root).map_err(|e| format!("{:?}", e))?);
     let mut roots_by_epoch = HashMap::new();
     for epoch in relevant_epochs {
         let start_slot = epoch.start_slot(T::EthSpec::slots_per_epoch());

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -31,13 +31,13 @@ use rayon::prelude::*;
 use sensitive_url::SensitiveUrl;
 use slog::Logger;
 use slot_clock::TestingSlotClock;
-use state_processing::state_advance::complete_state_advance;
+use state_processing::{state_advance::complete_state_advance, StateRootStrategy};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
-use store::{config::StoreConfig, BlockReplay, HotColdDB, ItemStore, LevelDB, MemoryStore};
+use store::{config::StoreConfig, HotColdDB, ItemStore, LevelDB, MemoryStore};
 use task_executor::ShutdownReason;
 use tree_hash::TreeHash;
 use types::sync_selection_proof::SyncSelectionProof;
@@ -527,7 +527,7 @@ where
     pub fn get_hot_state(&self, state_hash: BeaconStateHash) -> Option<BeaconState<E>> {
         self.chain
             .store
-            .load_hot_state(&state_hash.into(), BlockReplay::Accurate)
+            .load_hot_state(&state_hash.into(), StateRootStrategy::Accurate)
             .unwrap()
     }
 

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -10,7 +10,7 @@ use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
     common::get_indexed_attestation,
     per_block_processing::{per_block_processing, BlockSignatureStrategy},
-    per_slot_processing, BlockProcessingError,
+    per_slot_processing, BlockProcessingError, VerifyBlockRoot,
 };
 use std::sync::Arc;
 use tempfile::tempdir;
@@ -978,6 +978,7 @@ fn add_base_block_to_altair_chain() {
                 &base_block,
                 None,
                 BlockSignatureStrategy::NoVerification,
+                VerifyBlockRoot::True,
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(
@@ -1096,6 +1097,7 @@ fn add_altair_block_to_base_chain() {
                 &altair_block,
                 None,
                 BlockSignatureStrategy::NoVerification,
+                VerifyBlockRoot::True,
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -495,11 +495,14 @@ fn block_replayer_hooks() {
             pre_slots.push(state.slot());
             Ok(())
         }))
-        .post_slot_hook(Box::new(|state, is_skip_slot| {
+        .post_slot_hook(Box::new(|state, epoch_summary, is_skip_slot| {
             if is_skip_slot {
                 assert!(!block_slots.contains(&state.slot()));
             } else {
                 assert!(block_slots.contains(&state.slot()));
+            }
+            if state.slot() % E::slots_per_epoch() == 0 {
+                assert!(epoch_summary.is_some());
             }
             post_slots.push(state.slot());
             Ok(())

--- a/beacon_node/store/src/chunked_iter.rs
+++ b/beacon_node/store/src/chunked_iter.rs
@@ -1,27 +1,26 @@
 use crate::chunked_vector::{chunk_key, Chunk, Field};
 use crate::{HotColdDB, ItemStore};
 use slog::error;
-use std::sync::Arc;
 use types::{ChainSpec, EthSpec, Slot};
 
 /// Iterator over the values of a `BeaconState` vector field (like `block_roots`).
 ///
 /// Uses the freezer DB's separate table to load the values.
-pub struct ChunkedVectorIter<F, E, Hot, Cold>
+pub struct ChunkedVectorIter<'a, F, E, Hot, Cold>
 where
     F: Field<E>,
     E: EthSpec,
     Hot: ItemStore<E>,
     Cold: ItemStore<E>,
 {
-    pub(crate) store: Arc<HotColdDB<E, Hot, Cold>>,
+    pub(crate) store: &'a HotColdDB<E, Hot, Cold>,
     current_vindex: usize,
     pub(crate) end_vindex: usize,
     next_cindex: usize,
     current_chunk: Chunk<F::Value>,
 }
 
-impl<F, E, Hot, Cold> ChunkedVectorIter<F, E, Hot, Cold>
+impl<'a, F, E, Hot, Cold> ChunkedVectorIter<'a, F, E, Hot, Cold>
 where
     F: Field<E>,
     E: EthSpec,
@@ -35,7 +34,7 @@ where
     /// `HotColdDB::get_latest_restore_point_slot`. We pass it as a parameter so that the caller can
     /// maintain a stable view of the database (see `HybridForwardsBlockRootsIterator`).
     pub fn new(
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: &'a HotColdDB<E, Hot, Cold>,
         start_vindex: usize,
         last_restore_point_slot: Slot,
         spec: &ChainSpec,
@@ -57,7 +56,7 @@ where
     }
 }
 
-impl<F, E, Hot, Cold> Iterator for ChunkedVectorIter<F, E, Hot, Cold>
+impl<'a, F, E, Hot, Cold> Iterator for ChunkedVectorIter<'a, F, E, Hot, Cold>
 where
     F: Field<E>,
     E: EthSpec,

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -2,6 +2,7 @@ use crate::chunked_vector::ChunkError;
 use crate::config::StoreConfigError;
 use crate::hot_cold_store::HotColdDBError;
 use ssz::DecodeError;
+use state_processing::BlockReplayError;
 use types::{BeaconStateError, Hash256, Slot};
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -39,6 +40,7 @@ pub enum Error {
         expected: Hash256,
         computed: Hash256,
     },
+    BlockReplayError(BlockReplayError),
 }
 
 pub trait HandleUnavailable<T> {
@@ -88,6 +90,12 @@ impl From<DBError> for Error {
 impl From<StoreConfigError> for Error {
     fn from(e: StoreConfigError) -> Error {
         Error::ConfigError(e)
+    }
+}
+
+impl From<BlockReplayError> for Error {
+    fn from(e: BlockReplayError) -> Error {
+        Error::BlockReplayError(e)
     }
 }
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -434,7 +434,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         end_block_root: Hash256,
         spec: &ChainSpec,
     ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>> + '_, Error> {
-        HybridForwardsBlockRootsIterator::new(self, start_slot, end_state, end_block_root, spec)
+        HybridForwardsBlockRootsIterator::new(
+            self,
+            start_slot,
+            None,
+            || (end_state, end_block_root),
+            spec,
+        )
     }
 
     pub fn forwards_state_roots_iterator(

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -898,8 +898,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         state_root_iter: Option<impl Iterator<Item = Result<(Hash256, Slot), Error>>>,
         state_root_strategy: StateRootStrategy,
     ) -> Result<BeaconState<E>, Error> {
-        let mut block_replayer =
-            BlockReplayer::new(state, &self.spec).state_root_strategy(state_root_strategy);
+        let mut block_replayer = BlockReplayer::new(state, &self.spec)
+            .state_root_strategy(state_root_strategy)
+            .no_signature_verification()
+            .minimal_block_root_verification();
 
         let have_state_root_iterator = state_root_iter.is_some();
         if let Some(state_root_iter) = state_root_iter {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -443,6 +443,16 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         )
     }
 
+    pub fn forwards_block_roots_iterator_until(
+        &self,
+        start_slot: Slot,
+        end_slot: Slot,
+        get_state: impl FnOnce() -> (BeaconState<E>, Hash256),
+        spec: &ChainSpec,
+    ) -> Result<HybridForwardsBlockRootsIterator<E, Hot, Cold>, Error> {
+        HybridForwardsBlockRootsIterator::new(self, start_slot, Some(end_slot), get_state, spec)
+    }
+
     pub fn forwards_state_roots_iterator(
         &self,
         start_slot: Slot,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -22,12 +22,11 @@ use leveldb::iterator::LevelDBIterator;
 use lru::LruCache;
 use parking_lot::{Mutex, RwLock};
 use serde_derive::{Deserialize, Serialize};
-use slog::{debug, error, info, trace, Logger};
+use slog::{debug, error, info, trace, warn, Logger};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use state_processing::{
-    per_block_processing, per_slot_processing, BlockProcessingError, BlockSignatureStrategy,
-    SlotProcessingError,
+    BlockProcessingError, BlockReplayer, SlotProcessingError, StateRootStrategy,
 };
 use std::cmp::min;
 use std::convert::TryInto;
@@ -36,16 +35,6 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use types::*;
-
-/// Defines how blocks should be replayed on states.
-#[derive(PartialEq)]
-pub enum BlockReplay {
-    /// Perform all transitions faithfully to the specification.
-    Accurate,
-    /// Don't compute state roots, eventually computing an invalid beacon state that can only be
-    /// used for obtaining shuffling.
-    InconsistentStateRoots,
-}
 
 /// On-disk database that stores finalized states efficiently.
 ///
@@ -373,10 +362,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 // chain. This way we avoid returning a state that doesn't match `state_root`.
                 self.load_cold_state(state_root)
             } else {
-                self.load_hot_state(state_root, BlockReplay::Accurate)
+                self.load_hot_state(state_root, StateRootStrategy::Accurate)
             }
         } else {
-            match self.load_hot_state(state_root, BlockReplay::Accurate)? {
+            match self.load_hot_state(state_root, StateRootStrategy::Accurate)? {
                 Some(state) => Ok(Some(state)),
                 None => self.load_cold_state(state_root),
             }
@@ -414,7 +403,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             }
             .into())
         } else {
-            self.load_hot_state(state_root, BlockReplay::InconsistentStateRoots)
+            self.load_hot_state(state_root, StateRootStrategy::Inconsistent)
         }
     }
 
@@ -439,23 +428,39 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     pub fn forwards_block_roots_iterator(
-        store: Arc<Self>,
+        &self,
         start_slot: Slot,
         end_state: BeaconState<E>,
         end_block_root: Hash256,
         spec: &ChainSpec,
-    ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>>, Error> {
-        HybridForwardsBlockRootsIterator::new(store, start_slot, end_state, end_block_root, spec)
+    ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>> + '_, Error> {
+        HybridForwardsBlockRootsIterator::new(self, start_slot, end_state, end_block_root, spec)
     }
 
     pub fn forwards_state_roots_iterator(
-        store: Arc<Self>,
+        &self,
         start_slot: Slot,
         end_state_root: Hash256,
         end_state: BeaconState<E>,
         spec: &ChainSpec,
-    ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>>, Error> {
-        HybridForwardsStateRootsIterator::new(store, start_slot, end_state, end_state_root, spec)
+    ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>> + '_, Error> {
+        HybridForwardsStateRootsIterator::new(
+            self,
+            start_slot,
+            None,
+            || (end_state, end_state_root),
+            spec,
+        )
+    }
+
+    pub fn forwards_state_roots_iterator_until(
+        &self,
+        start_slot: Slot,
+        end_slot: Slot,
+        get_state: impl FnOnce() -> (BeaconState<E>, Hash256),
+        spec: &ChainSpec,
+    ) -> Result<HybridForwardsStateRootsIterator<E, Hot, Cold>, Error> {
+        HybridForwardsStateRootsIterator::new(self, start_slot, Some(end_slot), get_state, spec)
     }
 
     /// Load an epoch boundary state by using the hot state summary look-up.
@@ -472,10 +477,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         {
             // NOTE: minor inefficiency here because we load an unnecessary hot state summary
             //
-            // `BlockReplay` should be irrelevant here since we never replay blocks for an epoch
+            // `StateRootStrategy` should be irrelevant here since we never replay blocks for an epoch
             // boundary state in the hot DB.
             let state = self
-                .load_hot_state(&epoch_boundary_state_root, BlockReplay::Accurate)?
+                .load_hot_state(&epoch_boundary_state_root, StateRootStrategy::Accurate)?
                 .ok_or(HotColdDBError::MissingEpochBoundaryState(
                     epoch_boundary_state_root,
                 ))?;
@@ -620,7 +625,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     pub fn load_hot_state(
         &self,
         state_root: &Hash256,
-        block_replay: BlockReplay,
+        state_root_strategy: StateRootStrategy,
     ) -> Result<Option<BeaconState<E>>, Error> {
         metrics::inc_counter(&metrics::BEACON_STATE_HOT_GET_COUNT);
 
@@ -648,7 +653,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             } else {
                 let blocks =
                     self.load_blocks_to_replay(boundary_state.slot(), slot, latest_block_root)?;
-                self.replay_blocks(boundary_state, blocks, slot, block_replay)?
+                self.replay_blocks(
+                    boundary_state,
+                    blocks,
+                    slot,
+                    no_state_root_iter(),
+                    state_root_strategy,
+                )?
             };
 
             Ok(Some(state))
@@ -777,7 +788,22 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         )?;
 
         // 3. Replay the blocks on top of the low restore point.
-        self.replay_blocks(low_restore_point, blocks, slot, BlockReplay::Accurate)
+        // Use a forwards state root iterator to avoid doing any tree hashing.
+        // The state root of the high restore point should never be used, so is safely set to 0.
+        let state_root_iter = self.forwards_state_roots_iterator_until(
+            low_restore_point.slot(),
+            slot,
+            || (high_restore_point, Hash256::zero()),
+            &self.spec,
+        )?;
+
+        self.replay_blocks(
+            low_restore_point,
+            blocks,
+            slot,
+            Some(state_root_iter),
+            StateRootStrategy::Accurate,
+        )
     }
 
     /// Get the restore point with the given index, or if it is out of bounds, the split state.
@@ -860,89 +886,33 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// to have any caches built, beyond those immediately required by block processing.
     fn replay_blocks(
         &self,
-        mut state: BeaconState<E>,
-        mut blocks: Vec<SignedBeaconBlock<E>>,
+        state: BeaconState<E>,
+        blocks: Vec<SignedBeaconBlock<E>>,
         target_slot: Slot,
-        block_replay: BlockReplay,
+        state_root_iter: Option<impl Iterator<Item = Result<(Hash256, Slot), Error>>>,
+        state_root_strategy: StateRootStrategy,
     ) -> Result<BeaconState<E>, Error> {
-        if block_replay == BlockReplay::InconsistentStateRoots {
-            for i in 0..blocks.len() {
-                let prev_block_root = if i > 0 {
-                    blocks[i - 1].canonical_root()
-                } else {
-                    // Not read.
-                    Hash256::zero()
-                };
+        let mut block_replayer =
+            BlockReplayer::new(state, &self.spec).state_root_strategy(state_root_strategy);
 
-                let (state_root, parent_root) = match &mut blocks[i] {
-                    SignedBeaconBlock::Base(block) => (
-                        &mut block.message.state_root,
-                        &mut block.message.parent_root,
-                    ),
-                    SignedBeaconBlock::Altair(block) => (
-                        &mut block.message.state_root,
-                        &mut block.message.parent_root,
-                    ),
-                    SignedBeaconBlock::Merge(block) => (
-                        &mut block.message.state_root,
-                        &mut block.message.parent_root,
-                    ),
-                };
+        let have_state_root_iterator = state_root_iter.is_some();
+        if let Some(state_root_iter) = state_root_iter {
+            block_replayer = block_replayer.state_root_iter(state_root_iter);
+        }
 
-                *state_root = Hash256::zero();
-                if i > 0 {
-                    *parent_root = prev_block_root;
+        block_replayer
+            .apply_blocks(blocks, Some(target_slot))
+            .map(|block_replayer| {
+                if have_state_root_iterator && block_replayer.state_root_miss() {
+                    warn!(
+                        self.log,
+                        "State root iterator miss";
+                        "slot" => target_slot,
+                    );
                 }
-            }
-        }
 
-        let state_root_from_prev_block = |i: usize, state: &BeaconState<E>| {
-            if i > 0 {
-                let prev_block = blocks[i - 1].message();
-                if prev_block.slot() == state.slot() {
-                    Some(prev_block.state_root())
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        };
-
-        for (i, block) in blocks.iter().enumerate() {
-            if block.slot() <= state.slot() {
-                continue;
-            }
-
-            while state.slot() < block.slot() {
-                let state_root = match block_replay {
-                    BlockReplay::Accurate => state_root_from_prev_block(i, &state),
-                    BlockReplay::InconsistentStateRoots => Some(Hash256::zero()),
-                };
-                per_slot_processing(&mut state, state_root, &self.spec)
-                    .map_err(HotColdDBError::BlockReplaySlotError)?;
-            }
-
-            per_block_processing(
-                &mut state,
-                block,
-                None,
-                BlockSignatureStrategy::NoVerification,
-                &self.spec,
-            )
-            .map_err(HotColdDBError::BlockReplayBlockError)?;
-        }
-
-        while state.slot() < target_slot {
-            let state_root = match block_replay {
-                BlockReplay::Accurate => state_root_from_prev_block(blocks.len(), &state),
-                BlockReplay::InconsistentStateRoots => Some(Hash256::zero()),
-            };
-            per_slot_processing(&mut state, state_root, &self.spec)
-                .map_err(HotColdDBError::BlockReplaySlotError)?;
-        }
-
-        Ok(state)
+                block_replayer.into_state()
+            })
     }
 
     /// Fetch a copy of the current split slot from memory.
@@ -1309,7 +1279,7 @@ pub fn migrate_database<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 
     // 1. Copy all of the states between the head and the split slot, from the hot DB
     // to the cold DB.
-    let state_root_iter = StateRootsIterator::new(store.clone(), frozen_head);
+    let state_root_iter = StateRootsIterator::new(&store, frozen_head);
     for maybe_pair in state_root_iter.take_while(|result| match result {
         Ok((_, slot)) => {
             slot >= &current_split_slot
@@ -1421,6 +1391,11 @@ impl StoreItem for Split {
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
         Ok(Self::from_ssz_bytes(bytes)?)
     }
+}
+
+/// Type hint.
+fn no_state_root_iter() -> Option<std::iter::Empty<Result<(Hash256, Slot), Error>>> {
+    None
 }
 
 /// Struct for summarising a state in the hot database.

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -2,7 +2,6 @@ use crate::errors::HandleUnavailable;
 use crate::{Error, HotColdDB, ItemStore};
 use std::borrow::Cow;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use types::{
     typenum::Unsigned, BeaconState, BeaconStateError, EthSpec, Hash256, SignedBeaconBlock, Slot,
 };
@@ -13,19 +12,19 @@ use types::{
 ///
 /// It is assumed that all ancestors for this object are stored in the database. If this is not the
 /// case, the iterator will start returning `None` prior to genesis.
-pub trait AncestorIter<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>, I: Iterator> {
+pub trait AncestorIter<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>, I: Iterator> {
     /// Returns an iterator over the roots of the ancestors of `self`.
-    fn try_iter_ancestor_roots(&self, store: Arc<HotColdDB<E, Hot, Cold>>) -> Option<I>;
+    fn try_iter_ancestor_roots(&self, store: &'a HotColdDB<E, Hot, Cold>) -> Option<I>;
 }
 
 impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
-    AncestorIter<E, Hot, Cold, BlockRootsIterator<'a, E, Hot, Cold>> for SignedBeaconBlock<E>
+    AncestorIter<'a, E, Hot, Cold, BlockRootsIterator<'a, E, Hot, Cold>> for SignedBeaconBlock<E>
 {
     /// Iterates across all available prior block roots of `self`, starting at the most recent and ending
     /// at genesis.
     fn try_iter_ancestor_roots(
         &self,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: &'a HotColdDB<E, Hot, Cold>,
     ) -> Option<BlockRootsIterator<'a, E, Hot, Cold>> {
         let state = store
             .get_state(&self.message().state_root(), Some(self.slot()))
@@ -36,13 +35,13 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
 }
 
 impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
-    AncestorIter<E, Hot, Cold, StateRootsIterator<'a, E, Hot, Cold>> for BeaconState<E>
+    AncestorIter<'a, E, Hot, Cold, StateRootsIterator<'a, E, Hot, Cold>> for BeaconState<E>
 {
     /// Iterates across all available prior state roots of `self`, starting at the most recent and ending
     /// at genesis.
     fn try_iter_ancestor_roots(
         &self,
-        store: Arc<HotColdDB<E, Hot, Cold>>,
+        store: &'a HotColdDB<E, Hot, Cold>,
     ) -> Option<StateRootsIterator<'a, E, Hot, Cold>> {
         // The `self.clone()` here is wasteful.
         Some(StateRootsIterator::owned(store, self.clone()))
@@ -64,13 +63,13 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 }
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> StateRootsIterator<'a, T, Hot, Cold> {
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::new(store, beacon_state),
         }
     }
 
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::owned(store, beacon_state),
         }
@@ -113,21 +112,21 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> BlockRootsIterator<'a, T, Hot, Cold> {
     /// Create a new iterator over all block roots in the given `beacon_state` and prior states.
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::new(store, beacon_state),
         }
     }
 
     /// Create a new iterator over all block roots in the given `beacon_state` and prior states.
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             inner: RootsIterator::owned(store, beacon_state),
         }
     }
 
     pub fn from_block(
-        store: Arc<HotColdDB<T, Hot, Cold>>,
+        store: &'a HotColdDB<T, Hot, Cold>,
         block_hash: Hash256,
     ) -> Result<Self, Error> {
         Ok(Self {
@@ -150,7 +149,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Iterator
 
 /// Iterator over state and block roots that backtracks using the vectors from a `BeaconState`.
 pub struct RootsIterator<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> {
-    store: Arc<HotColdDB<T, Hot, Cold>>,
+    store: &'a HotColdDB<T, Hot, Cold>,
     beacon_state: Cow<'a, BeaconState<T>>,
     slot: Slot,
 }
@@ -160,7 +159,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 {
     fn clone(&self) -> Self {
         Self {
-            store: self.store.clone(),
+            store: self.store,
             beacon_state: self.beacon_state.clone(),
             slot: self.slot,
         }
@@ -168,7 +167,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> Clone
 }
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T, Hot, Cold> {
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             store,
             slot: beacon_state.slot(),
@@ -176,7 +175,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
         }
     }
 
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             store,
             slot: beacon_state.slot(),
@@ -185,7 +184,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
     }
 
     pub fn from_block(
-        store: Arc<HotColdDB<T, Hot, Cold>>,
+        store: &'a HotColdDB<T, Hot, Cold>,
         block_hash: Hash256,
     ) -> Result<Self, Error> {
         let block = store
@@ -310,14 +309,14 @@ pub struct BlockIterator<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> 
 
 impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> BlockIterator<'a, T, Hot, Cold> {
     /// Create a new iterator over all blocks in the given `beacon_state` and prior states.
-    pub fn new(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: &'a BeaconState<T>) -> Self {
+    pub fn new(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: &'a BeaconState<T>) -> Self {
         Self {
             roots: BlockRootsIterator::new(store, beacon_state),
         }
     }
 
     /// Create a new iterator over all blocks in the given `beacon_state` and prior states.
-    pub fn owned(store: Arc<HotColdDB<T, Hot, Cold>>, beacon_state: BeaconState<T>) -> Self {
+    pub fn owned(store: &'a HotColdDB<T, Hot, Cold>, beacon_state: BeaconState<T>) -> Self {
         Self {
             roots: BlockRootsIterator::owned(store, beacon_state),
         }
@@ -397,9 +396,8 @@ mod test {
     #[test]
     fn block_root_iter() {
         let log = NullLoggerBuilder.build().unwrap();
-        let store = Arc::new(
-            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap(),
-        );
+        let store =
+            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap();
         let slots_per_historical_root = MainnetEthSpec::slots_per_historical_root();
 
         let mut state_a: BeaconState<MainnetEthSpec> = get_state();
@@ -422,7 +420,7 @@ mod test {
         state_b.state_roots_mut()[0] = state_a_root;
         store.put_state(&state_a_root, &state_a).unwrap();
 
-        let iter = BlockRootsIterator::new(store, &state_b);
+        let iter = BlockRootsIterator::new(&store, &state_b);
 
         assert!(
             iter.clone()
@@ -445,9 +443,8 @@ mod test {
     #[test]
     fn state_root_iter() {
         let log = NullLoggerBuilder.build().unwrap();
-        let store = Arc::new(
-            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap(),
-        );
+        let store =
+            HotColdDB::open_ephemeral(Config::default(), ChainSpec::minimal(), log).unwrap();
         let slots_per_historical_root = MainnetEthSpec::slots_per_historical_root();
 
         let mut state_a: BeaconState<MainnetEthSpec> = get_state();
@@ -475,7 +472,7 @@ mod test {
         store.put_state(&state_a_root, &state_a).unwrap();
         store.put_state(&state_b_root, &state_b).unwrap();
 
-        let iter = StateRootsIterator::new(store, &state_b);
+        let iter = StateRootsIterator::new(&store, &state_b);
 
         assert!(
             iter.clone()

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -30,7 +30,7 @@ pub mod iter;
 
 pub use self::chunk_writer::ChunkWriter;
 pub use self::config::StoreConfig;
-pub use self::hot_cold_store::{BlockReplay, HotColdDB, HotStateSummary, Split};
+pub use self::hot_cold_store::{HotColdDB, HotStateSummary, Split};
 pub use self::leveldb_store::LevelDB;
 pub use self::memory_store::MemoryStore;
 pub use self::partial_beacon_state::PartialBeaconState;

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -3,7 +3,9 @@ use crate::hot_cold_store::{HotColdDB, HotColdDBError};
 use crate::{Error, ItemStore, KeyValueStore};
 use itertools::{process_results, Itertools};
 use slog::info;
-use state_processing::{per_block_processing, per_slot_processing, BlockSignatureStrategy};
+use state_processing::{
+    per_block_processing, per_slot_processing, BlockSignatureStrategy, VerifyBlockRoot,
+};
 use std::sync::Arc;
 use types::{EthSpec, Hash256};
 
@@ -48,8 +50,7 @@ where
         // Use a dummy root, as we never read the block for the upper limit state.
         let upper_limit_block_root = Hash256::repeat_byte(0xff);
 
-        let block_root_iter = Self::forwards_block_roots_iterator(
-            self.clone(),
+        let block_root_iter = self.forwards_block_roots_iterator(
             lower_limit_slot,
             upper_limit_state,
             upper_limit_block_root,
@@ -91,6 +92,7 @@ where
                         &block,
                         Some(block_root),
                         BlockSignatureStrategy::NoVerification,
+                        VerifyBlockRoot::True,
                         &self.spec,
                     )
                     .map_err(HotColdDBError::BlockReplayBlockError)?;

--- a/consensus/state_processing/src/block_replayer.rs
+++ b/consensus/state_processing/src/block_replayer.rs
@@ -1,0 +1,284 @@
+use crate::{
+    per_block_processing, per_slot_processing, BlockProcessingError, BlockSignatureStrategy,
+    SlotProcessingError, VerifyBlockRoot,
+};
+use safe_arith::{ArithError, SafeArith};
+use std::marker::PhantomData;
+use types::{BeaconState, ChainSpec, EthSpec, Hash256, SignedBeaconBlock, Slot};
+
+type PreBlockHook<'a, E, Error> =
+    Box<dyn FnMut(&mut BeaconState<E>, &SignedBeaconBlock<E>) -> Result<(), Error> + 'a>;
+type PostBlockHook<'a, E, Error> = PreBlockHook<'a, E, Error>;
+type PreSlotHook<'a, E, Error> = Box<dyn FnMut(&mut BeaconState<E>) -> Result<(), Error> + 'a>;
+type PostSlotHook<'a, E, Error> = PreSlotHook<'a, E, Error>;
+type StateRootIterDefault<Error> = std::iter::Empty<Result<(Hash256, Slot), Error>>;
+
+/// Efficiently apply blocks to a state while configuring various parameters.
+///
+/// Usage follows a builder pattern.
+pub struct BlockReplayer<
+    'a,
+    Spec: EthSpec,
+    Error = BlockReplayError,
+    StateRootIter = StateRootIterDefault<Error>,
+> {
+    state: BeaconState<Spec>,
+    spec: &'a ChainSpec,
+    state_root_strategy: StateRootStrategy,
+    block_sig_strategy: BlockSignatureStrategy,
+    pre_block_hook: Option<PreBlockHook<'a, Spec, Error>>,
+    post_block_hook: Option<PostBlockHook<'a, Spec, Error>>,
+    pre_slot_hook: Option<PreSlotHook<'a, Spec, Error>>,
+    post_slot_hook: Option<PostSlotHook<'a, Spec, Error>>,
+    state_root_iter: Option<StateRootIter>,
+    state_root_miss: bool,
+    _phantom: PhantomData<Error>,
+}
+
+#[derive(Debug)]
+pub enum BlockReplayError {
+    NoBlocks,
+    SlotProcessing(SlotProcessingError),
+    BlockProcessing(BlockProcessingError),
+    Arith(ArithError),
+}
+
+impl From<SlotProcessingError> for BlockReplayError {
+    fn from(e: SlotProcessingError) -> Self {
+        Self::SlotProcessing(e)
+    }
+}
+
+impl From<BlockProcessingError> for BlockReplayError {
+    fn from(e: BlockProcessingError) -> Self {
+        Self::BlockProcessing(e)
+    }
+}
+
+impl From<ArithError> for BlockReplayError {
+    fn from(e: ArithError) -> Self {
+        Self::Arith(e)
+    }
+}
+
+/// Defines how state roots should be computed during block replay.
+#[derive(PartialEq)]
+pub enum StateRootStrategy {
+    /// Perform all transitions faithfully to the specification.
+    Accurate,
+    /// Don't compute state roots, eventually computing an invalid beacon state that can only be
+    /// used for obtaining shuffling.
+    Inconsistent,
+}
+
+impl<'a, E, Error, StateRootIter> BlockReplayer<'a, E, Error, StateRootIter>
+where
+    E: EthSpec,
+    StateRootIter: Iterator<Item = Result<(Hash256, Slot), Error>>,
+    Error: From<BlockReplayError>,
+{
+    /// Create a new replayer that will apply blocks upon `state`.
+    ///
+    /// Defaults:
+    ///
+    /// - *No signature verification*
+    /// - Accurate state roots
+    pub fn new(state: BeaconState<E>, spec: &'a ChainSpec) -> Self {
+        Self {
+            state,
+            spec,
+            state_root_strategy: StateRootStrategy::Accurate,
+            block_sig_strategy: BlockSignatureStrategy::NoVerification,
+            pre_block_hook: None,
+            post_block_hook: None,
+            pre_slot_hook: None,
+            post_slot_hook: None,
+            state_root_iter: None,
+            state_root_miss: false,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Set the replayer's state root strategy different from the default.
+    pub fn state_root_strategy(mut self, state_root_strategy: StateRootStrategy) -> Self {
+        self.state_root_strategy = state_root_strategy;
+        self
+    }
+
+    /// Set the replayer's block signature verification strategy.
+    ///
+    /// Use this to enable signature verification if desired.
+    pub fn block_signature_strategy(mut self, block_sig_strategy: BlockSignatureStrategy) -> Self {
+        self.block_sig_strategy = block_sig_strategy;
+        self
+    }
+
+    /// Supply a state root iterator to accelerate slot processing.
+    ///
+    /// If possible the state root iterator should return a state root for every slot from
+    /// `self.state.slot` to the `target_slot` supplied to `apply_blocks` (inclusive of both
+    /// endpoints).
+    pub fn state_root_iter(mut self, iter: StateRootIter) -> Self {
+        self.state_root_iter = Some(iter);
+        self
+    }
+
+    /// Run a function immediately before each block that is applied during `apply_blocks`.
+    ///
+    /// This can be used to inspect the state as blocks are applied.
+    pub fn pre_block_hook(mut self, hook: PreBlockHook<'a, E, Error>) -> Self {
+        self.pre_block_hook = Some(hook);
+        self
+    }
+
+    /// Run a function immediately after each block that is applied during `apply_blocks`.
+    ///
+    /// This can be used to inspect the state as blocks are applied.
+    pub fn post_block_hook(mut self, hook: PostBlockHook<'a, E, Error>) -> Self {
+        self.post_block_hook = Some(hook);
+        self
+    }
+
+    /// Run a function immediately before slot processing advances the state to the next slot.
+    pub fn pre_slot_hook(mut self, hook: PreSlotHook<'a, E, Error>) -> Self {
+        self.pre_slot_hook = Some(hook);
+        self
+    }
+
+    /// Run a function immediately after slot processing has advanced the state to the next slot.
+    pub fn post_slot_hook(mut self, hook: PostSlotHook<'a, E, Error>) -> Self {
+        self.post_slot_hook = Some(hook);
+        self
+    }
+
+    /// Compute the state root for `slot` as efficiently as possible.
+    ///
+    /// The `blocks` should be the full list of blocks being applied and `i` should be the index of
+    /// the next block that will be applied, or `blocks.len()` if all blocks have already been
+    /// applied.
+    fn get_state_root(
+        &mut self,
+        slot: Slot,
+        blocks: &[SignedBeaconBlock<E>],
+        i: usize,
+    ) -> Result<Option<Hash256>, Error> {
+        // If we don't care about state roots then return immediately.
+        if self.state_root_strategy == StateRootStrategy::Inconsistent {
+            return Ok(Some(Hash256::zero()));
+        }
+
+        // If a state root iterator is configured, use it to find the root.
+        if let Some(ref mut state_root_iter) = self.state_root_iter {
+            let opt_root = state_root_iter
+                .take_while(|res| res.as_ref().map_or(true, |(_, s)| *s <= slot))
+                .find(|res| res.as_ref().map_or(true, |(_, s)| *s == slot))
+                .transpose()?;
+
+            if let Some((root, _)) = opt_root {
+                return Ok(Some(root));
+            }
+        }
+
+        // Otherwise try to source a root from the previous block.
+        if i > 0 {
+            if let Some(prev_block) = blocks.get(i.safe_sub(1).map_err(BlockReplayError::from)?) {
+                if prev_block.slot() == slot {
+                    return Ok(Some(prev_block.state_root()));
+                }
+            }
+        }
+
+        self.state_root_miss = true;
+        Ok(None)
+    }
+
+    /// Apply `blocks` atop `self.state`, taking care of slot processing.
+    ///
+    /// If `target_slot` is provided then the state will be advanced through to `target_slot`
+    /// after the blocks have been applied.
+    pub fn apply_blocks(
+        mut self,
+        blocks: Vec<SignedBeaconBlock<E>>,
+        target_slot: Option<Slot>,
+    ) -> Result<Self, Error> {
+        for (i, block) in blocks.iter().enumerate() {
+            if block.slot() <= self.state.slot() {
+                continue;
+            }
+
+            while self.state.slot() < block.slot() {
+                if let Some(ref mut pre_slot_hook) = self.pre_slot_hook {
+                    pre_slot_hook(&mut self.state)?;
+                }
+
+                let state_root = self.get_state_root(self.state.slot(), &blocks, i)?;
+                per_slot_processing(&mut self.state, state_root, self.spec)
+                    .map_err(BlockReplayError::from)?;
+
+                if let Some(ref mut post_slot_hook) = self.post_slot_hook {
+                    post_slot_hook(&mut self.state)?;
+                }
+            }
+
+            if let Some(ref mut pre_block_hook) = self.pre_block_hook {
+                pre_block_hook(&mut self.state, block)?;
+            }
+
+            // Skip block root verification: this is faster and also compatible with inaccurate
+            // state root replay.
+            per_block_processing(
+                &mut self.state,
+                block,
+                None,
+                self.block_sig_strategy,
+                VerifyBlockRoot::False,
+                self.spec,
+            )
+            .map_err(BlockReplayError::from)?;
+
+            if let Some(ref mut post_block_hook) = self.post_block_hook {
+                post_block_hook(&mut self.state, block)?;
+            }
+        }
+
+        if let Some(target_slot) = target_slot {
+            while self.state.slot() < target_slot {
+                if let Some(ref mut pre_slot_hook) = self.pre_slot_hook {
+                    pre_slot_hook(&mut self.state)?;
+                }
+
+                let state_root = self.get_state_root(self.state.slot(), &blocks, blocks.len())?;
+                per_slot_processing(&mut self.state, state_root, self.spec)
+                    .map_err(BlockReplayError::from)?;
+
+                if let Some(ref mut post_slot_hook) = self.post_slot_hook {
+                    post_slot_hook(&mut self.state)?;
+                }
+            }
+        }
+
+        Ok(self)
+    }
+
+    /// After block application, check if a state root miss occurred.
+    pub fn state_root_miss(&self) -> bool {
+        self.state_root_miss
+    }
+
+    /// Convert the replayer into the state that was built.
+    pub fn into_state(self) -> BeaconState<E> {
+        self.state
+    }
+}
+
+impl<'a, E, Error> BlockReplayer<'a, E, Error, StateRootIterDefault<Error>>
+where
+    E: EthSpec,
+    Error: From<BlockReplayError>,
+{
+    /// If type inference fails to infer the state root iterator type you can use this method
+    /// to hint that no state root iterator is desired.
+    pub fn no_state_root_iter(self) -> Self {
+        self
+    }
+}

--- a/consensus/state_processing/src/lib.rs
+++ b/consensus/state_processing/src/lib.rs
@@ -16,6 +16,7 @@
 mod macros;
 mod metrics;
 
+pub mod block_replayer;
 pub mod common;
 pub mod genesis;
 pub mod per_block_processing;
@@ -25,13 +26,14 @@ pub mod state_advance;
 pub mod upgrade;
 pub mod verify_operation;
 
+pub use block_replayer::{BlockReplayError, BlockReplayer, StateRootStrategy};
 pub use genesis::{
     eth2_genesis_time, initialize_beacon_state_from_eth1, is_valid_genesis_state,
     process_activations,
 };
 pub use per_block_processing::{
     block_signature_verifier, errors::BlockProcessingError, per_block_processing, signature_sets,
-    BlockSignatureStrategy, BlockSignatureVerifier, VerifySignatures,
+    BlockSignatureStrategy, BlockSignatureVerifier, VerifyBlockRoot, VerifySignatures,
 };
 pub use per_epoch_processing::{
     errors::EpochProcessingError, process_epoch as per_epoch_processing,

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -6,7 +6,10 @@ use crate::per_block_processing::errors::{
     DepositInvalid, HeaderInvalid, IndexedAttestationInvalid, IntoWithIndex,
     ProposerSlashingInvalid,
 };
-use crate::{per_block_processing::process_operations, BlockSignatureStrategy, VerifySignatures};
+use crate::{
+    per_block_processing::process_operations, BlockSignatureStrategy, VerifyBlockRoot,
+    VerifySignatures,
+};
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use lazy_static::lazy_static;
 use ssz_types::Bitfield;
@@ -65,6 +68,7 @@ fn valid_block_ok() {
         &block,
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         &spec,
     );
 
@@ -88,6 +92,7 @@ fn invalid_block_header_state_slot() {
         &SignedBeaconBlock::from_block(block, signature),
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         &spec,
     );
 
@@ -116,6 +121,7 @@ fn invalid_parent_block_root() {
         &SignedBeaconBlock::from_block(block, signature),
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         &spec,
     );
 
@@ -145,6 +151,7 @@ fn invalid_block_signature() {
         &SignedBeaconBlock::from_block(block, Signature::empty()),
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         &spec,
     );
 
@@ -174,6 +181,7 @@ fn invalid_randao_reveal_signature() {
         &signed_block,
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         &spec,
     );
 

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -1,7 +1,9 @@
 use clap::ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
-use state_processing::{per_block_processing, per_slot_processing, BlockSignatureStrategy};
+use state_processing::{
+    per_block_processing, per_slot_processing, BlockSignatureStrategy, VerifyBlockRoot,
+};
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -77,6 +79,7 @@ fn do_transition<T: EthSpec>(
         &block,
         None,
         BlockSignatureStrategy::VerifyIndividual,
+        VerifyBlockRoot::True,
         spec,
     )
     .map_err(|e| format!("State transition failed: {:?}", e))?;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -12,7 +12,7 @@ use state_processing::per_block_processing::{
         altair, base, process_attester_slashings, process_deposits, process_exits,
         process_proposer_slashings,
     },
-    process_sync_aggregate, VerifySignatures,
+    process_sync_aggregate, VerifyBlockRoot, VerifySignatures,
 };
 use std::fmt::Debug;
 use std::path::Path;
@@ -183,7 +183,7 @@ impl<E: EthSpec> Operation<E> for BeaconBlock<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_block_header(state, self.to_ref(), spec)?;
+        process_block_header(state, self.to_ref(), VerifyBlockRoot::True, spec)?;
         Ok(())
     }
 }

--- a/testing/ef_tests/src/cases/sanity_blocks.rs
+++ b/testing/ef_tests/src/cases/sanity_blocks.rs
@@ -5,6 +5,7 @@ use crate::decode::{ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use serde_derive::Deserialize;
 use state_processing::{
     per_block_processing, per_slot_processing, BlockProcessingError, BlockSignatureStrategy,
+    VerifyBlockRoot,
 };
 use types::{BeaconState, EthSpec, ForkName, RelativeEpoch, SignedBeaconBlock};
 
@@ -98,6 +99,7 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
                     signed_block,
                     None,
                     BlockSignatureStrategy::VerifyIndividual,
+                    VerifyBlockRoot::True,
                     spec,
                 )?;
 
@@ -106,6 +108,7 @@ impl<E: EthSpec> Case for SanityBlocks<E> {
                     signed_block,
                     None,
                     BlockSignatureStrategy::VerifyBulk,
+                    VerifyBlockRoot::True,
                     spec,
                 )?;
 

--- a/testing/ef_tests/src/cases/transition.rs
+++ b/testing/ef_tests/src/cases/transition.rs
@@ -4,6 +4,7 @@ use crate::decode::{ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use serde_derive::Deserialize;
 use state_processing::{
     per_block_processing, state_advance::complete_state_advance, BlockSignatureStrategy,
+    VerifyBlockRoot,
 };
 use std::str::FromStr;
 use types::{BeaconState, Epoch, ForkName, SignedBeaconBlock};
@@ -97,6 +98,7 @@ impl<E: EthSpec> Case for TransitionTest<E> {
                     block,
                     None,
                     BlockSignatureStrategy::VerifyBulk,
+                    VerifyBlockRoot::True,
                     spec,
                 )
                 .map_err(|e| format!("Block processing failed: {:?}", e))?;

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -2,7 +2,7 @@ use super::*;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use state_processing::{
     per_block_processing, per_block_processing::errors::ExitInvalid, BlockProcessingError,
-    BlockSignatureStrategy,
+    BlockSignatureStrategy, VerifyBlockRoot,
 };
 use types::{BeaconBlock, BeaconState, Epoch, EthSpec, SignedBeaconBlock};
 
@@ -66,6 +66,7 @@ impl ExitTest {
             block,
             None,
             BlockSignatureStrategy::VerifyIndividual,
+            VerifyBlockRoot::True,
             &E::default_spec(),
         )
     }


### PR DESCRIPTION
## Issue Addressed

Successor to #2431

## Proposed Changes

* Add a `BlockReplayer` struct to abstract over the intricacies of calling `per_slot_processing` and `per_block_processing` while avoiding unnecessary tree hashing.
* Add a variant of the forwards state root iterator that does not require an `end_state`.
* Use the `BlockReplayer` when reconstructing states in the database. Use the efficient forwards iterator for frozen states.
* Refactor the iterators to remove `Arc<HotColdDB>` (this seems to be neater than making _everything_ an `Arc<HotColdDB>` as I did in #2431).

Supplying the state roots allow us to avoid building a tree hash cache at all when reconstructing historic states, which saves around 1 second flat (regardless of `slots-per-restore-point`). This is a small percentage of worst-case state load times with 200K validators and SPRP=2048 (~15s vs ~16s) but a significant speed-up for more frequent restore points: state loads with SPRP=32 should be now consistently <500ms instead of 1.5s (a ~3x speedup).

## Additional Info

Required by https://github.com/sigp/lighthouse/pull/2628