### PR TITLE
[Merged by Bors] - Enable `mallinfo2` behind feature flag

### DIFF
--- a/common/malloc_utils/Cargo.toml
+++ b/common/malloc_utils/Cargo.toml
@@ -11,3 +11,6 @@ lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"
 libc = "0.2.79"
 parking_lot = "0.11.0"
+
+[features]
+mallinfo2 = []


### PR DESCRIPTION
## Proposed Changes

Add `mallinfo2` behind a feature flag so that we can get accurate memory metrics during debugging. It can be enabled when building Lighthouse like so (so long as the platform supports it):

```
cargo install --path lighthouse --features "malloc_utils/mallinfo2"
```
