### PR TITLE
[Merged by Bors] - Only import blocks with valid execution payloads

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -65,7 +65,7 @@ pub fn execute_payload<T: BeaconChainTypes>(
             }
             ExecutePayloadResponseStatus::Syncing => Ok(PayloadVerificationStatus::NotVerified),
         },
-        Err(_) => Ok(PayloadVerificationStatus::NotVerified),
+        Err(_) => Err(ExecutionPayloadError::RejectedByExecutionEngine.into()),
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

We are currently treating errors from the EL on `engine_executePayload` as `PayloadVerificationStatus::NotVerified`. This adds the block as a candidate head block in fork choice even if the EL explicitly rejected the block as invalid. 

`PayloadVerificationStatus::NotVerified` should be only returned when the EL explicitly returns "syncing" imo. This PR propagates an error instead of returning `NotVerified` on EL all EL errors.