### PR TITLE
[Merged by Bors] - Add early attester cache

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -993,9 +993,7 @@ fn verify_head_block_is_known<T: BeaconChainTypes>(
         .or_else(|| {
             chain
                 .early_attester_cache
-                .read()
                 .get_proto_block(attestation.data.beacon_block_root)
-                .cloned()
         });
 
     if let Some(block) = block_opt {
@@ -1251,11 +1249,7 @@ where
     //
     // We do not delay consideration for later, we simply drop the attestation.
     if !chain.fork_choice.read().contains_block(&target.root)
-        && chain
-            .early_attester_cache
-            .read()
-            .get_proto_block(target.root)
-            .is_none()
+        && chain.early_attester_cache.contains_block(target.root)
     {
         return Err(Error::UnknownTargetRoot(target.root));
     }

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -1249,7 +1249,7 @@ where
     //
     // We do not delay consideration for later, we simply drop the attestation.
     if !chain.fork_choice.read().contains_block(&target.root)
-        && chain.early_attester_cache.contains_block(target.root)
+        && !chain.early_attester_cache.contains_block(target.root)
     {
         return Err(Error::UnknownTargetRoot(target.root));
     }

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -986,11 +986,19 @@ fn verify_head_block_is_known<T: BeaconChainTypes>(
     attestation: &Attestation<T::EthSpec>,
     max_skip_slots: Option<u64>,
 ) -> Result<ProtoBlock, Error> {
-    if let Some(block) = chain
+    let block_opt = chain
         .fork_choice
         .read()
         .get_block(&attestation.data.beacon_block_root)
-    {
+        .or_else(|| {
+            chain
+                .early_attester_cache
+                .read()
+                .get_proto_block(attestation.data.beacon_block_root)
+                .cloned()
+        });
+
+    if let Some(block) = block_opt {
         // Reject any block that exceeds our limit on skipped slots.
         if let Some(max_skip_slots) = max_skip_slots {
             if attestation.data.slot > block.slot + max_skip_slots {
@@ -1242,7 +1250,13 @@ where
     // processing an attestation that does not include our latest finalized block in its chain.
     //
     // We do not delay consideration for later, we simply drop the attestation.
-    if !chain.fork_choice.read().contains_block(&target.root) {
+    if !chain.fork_choice.read().contains_block(&target.root)
+        && chain
+            .early_attester_cache
+            .read()
+            .get_proto_block(target.root)
+            .is_none()
+    {
         return Err(Error::UnknownTargetRoot(target.root));
     }
 

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -75,7 +75,7 @@ impl From<BeaconChainError> for Error {
 
 /// Stores the minimal amount of data required to compute the committee length for any committee at any
 /// slot in a given `epoch`.
-struct CommitteeLengths {
+pub struct CommitteeLengths {
     /// The `epoch` to which the lengths pertain.
     epoch: Epoch,
     /// The length of the shuffling in `self.epoch`.
@@ -84,7 +84,7 @@ struct CommitteeLengths {
 
 impl CommitteeLengths {
     /// Instantiate `Self` using `state.current_epoch()`.
-    fn new<T: EthSpec>(state: &BeaconState<T>, spec: &ChainSpec) -> Result<Self, Error> {
+    pub fn new<T: EthSpec>(state: &BeaconState<T>, spec: &ChainSpec) -> Result<Self, Error> {
         let active_validator_indices_len = if let Ok(committee_cache) =
             state.committee_cache(RelativeEpoch::Current)
         {
@@ -102,7 +102,15 @@ impl CommitteeLengths {
     }
 
     /// Get the length of the committee at the given `slot` and `committee_index`.
-    fn get<T: EthSpec>(
+    pub fn get_committee_count<T: EthSpec>(
+        &self,
+        spec: &ChainSpec,
+    ) -> Result<CommitteeLength, Error> {
+        T::get_committee_count_per_slot(self.active_validator_indices_len, spec).map_err(Into::into)
+    }
+
+    /// Get the length of the committee at the given `slot` and `committee_index`.
+    pub fn get_committee_length<T: EthSpec>(
         &self,
         slot: Slot,
         committee_index: CommitteeIndex,
@@ -172,7 +180,7 @@ impl AttesterCacheValue {
         spec: &ChainSpec,
     ) -> Result<(JustifiedCheckpoint, CommitteeLength), Error> {
         self.committee_lengths
-            .get::<T>(slot, committee_index, spec)
+            .get_committee_length::<T>(slot, committee_index, spec)
             .map(|committee_length| (self.current_justified_checkpoint, committee_length))
     }
 }

--- a/beacon_node/beacon_chain/src/attester_cache.rs
+++ b/beacon_node/beacon_chain/src/attester_cache.rs
@@ -101,11 +101,11 @@ impl CommitteeLengths {
         })
     }
 
-    /// Get the length of the committee at the given `slot` and `committee_index`.
-    pub fn get_committee_count<T: EthSpec>(
+    /// Get the count of committees per each slot of `self.epoch`.
+    pub fn get_committee_count_per_slot<T: EthSpec>(
         &self,
         spec: &ChainSpec,
-    ) -> Result<CommitteeLength, Error> {
+    ) -> Result<usize, Error> {
         T::get_committee_count_per_slot(self.active_validator_indices_len, spec).map_err(Into::into)
     }
 
@@ -128,8 +128,7 @@ impl CommitteeLengths {
         }
 
         let slots_per_epoch = slots_per_epoch as usize;
-        let committees_per_slot =
-            T::get_committee_count_per_slot(self.active_validator_indices_len, spec)?;
+        let committees_per_slot = self.get_committee_count_per_slot::<T>(spec)?;
         let index_in_epoch = compute_committee_index_in_epoch(
             slot,
             slots_per_epoch,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -108,7 +108,7 @@ pub const OP_POOL_DB_KEY: Hash256 = Hash256::zero();
 pub const ETH1_CACHE_DB_KEY: Hash256 = Hash256::zero();
 pub const FORK_CHOICE_DB_KEY: Hash256 = Hash256::zero();
 
-/// Defines how old a block can be before it's a candidate for the early attester cache.
+/// Defines how old a block can be before it's no longer a candidate for the early attester cache.
 const EARLY_ATTESTER_CACHE_HISTORIC_SLOTS: u64 = 4;
 
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.
@@ -2679,6 +2679,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             "error" => ?e
                         );
                     }
+                } else {
+                    warn!(
+                        self.log,
+                        "Early attester block missing";
+                        "block_root" => ?block_root
+                    );
                 }
             }
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -931,10 +931,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Returns the block at the given root, if any.
     ///
+    /// Will also check the early attester cache for the block.
+    ///
     /// ## Errors
     ///
     /// May return a database error.
-    pub fn get_block(
+    pub fn get_block_checking_early_attester_cache(
         &self,
         block_root: &Hash256,
     ) -> Result<Option<SignedBeaconBlock<T::EthSpec>>, Error> {
@@ -947,6 +949,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         Ok(block_opt)
+    }
+
+    /// Returns the block at the given root, if any.
+    ///
+    /// ## Errors
+    ///
+    /// May return a database error.
+    pub fn get_block(
+        &self,
+        block_root: &Hash256,
+    ) -> Result<Option<SignedBeaconBlock<T::EthSpec>>, Error> {
+        Ok(self.store.get_block(block_root)?)
     }
 
     /// Returns the state at the given root, if any.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -330,7 +330,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache used when producing attestations.
     pub(crate) attester_cache: Arc<AttesterCache>,
     /// A cache used when producing attestations whilst the head block is still being imported.
-    pub(crate) early_attester_cache: RwLock<EarlyAttesterCache<T::EthSpec>>,
+    pub early_attester_cache: RwLock<EarlyAttesterCache<T::EthSpec>>,
     /// A cache used to keep track of various block timings.
     pub block_times_cache: Arc<RwLock<BlockTimesCache>>,
     /// A list of any hard-coded forks that have been disabled.
@@ -1447,10 +1447,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<Attestation<T::EthSpec>, Error> {
         let _total_timer = metrics::start_timer(&metrics::ATTESTATION_PRODUCTION_SECONDS);
 
-        if let Some(attestation) = self
-            .early_attester_cache
-            .read()
-            .try_attest(request_slot, request_index)
+        if let Some(attestation) =
+            self.early_attester_cache
+                .read()
+                .try_attest(request_slot, request_index, &self.spec)
         {
             return Ok(attestation);
         }
@@ -2646,6 +2646,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     signed_block.clone(),
                     proto_block,
                     &state,
+                    &self.spec,
                 ) {
                     warn!(
                         self.log,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2647,7 +2647,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     proto_block,
                     &state,
                 ) {
-                    error!(
+                    warn!(
                         self.log,
                         "Early attester cache insert failed";
                         "error" => ?e

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3162,9 +3162,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(());
         }
 
-        // Clear the early attester cache so it can't conflict with `self.canonical_head`.
-        self.early_attester_cache.write().clear();
-
         let lag_timer = metrics::start_timer(&metrics::FORK_CHOICE_SET_HEAD_LAG_TIMES);
 
         // At this point we know that the new head block is not the same as the previous one
@@ -3304,6 +3301,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let is_merge_transition_complete = is_merge_transition_complete(&new_head.beacon_state);
 
         drop(lag_timer);
+
+        // Clear the early attester cache so it can't conflict with `self.canonical_head`.
+        self.early_attester_cache.write().clear();
 
         // Update the snapshot that stores the head of the chain at the time it received the
         // block.

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -763,6 +763,7 @@ where
             block_times_cache: <_>::default(),
             validator_pubkey_cache: TimeoutRwLock::new(validator_pubkey_cache),
             attester_cache: <_>::default(),
+            early_attester_cache: <_>::default(),
             disabled_forks: self.disabled_forks,
             shutdown_sender: self
                 .shutdown_sender

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -1,0 +1,105 @@
+use proto_array::Block as ProtoBlock;
+use types::*;
+
+pub struct CacheItem<E: EthSpec> {
+    /*
+     * Attesting details
+     */
+    epoch: Epoch,
+    committee_len: usize,
+    beacon_block_root: Hash256,
+    source: Checkpoint,
+    target: Checkpoint,
+    /*
+     * Cached values
+     */
+    block: SignedBeaconBlock<E>,
+    proto_block: ProtoBlock,
+}
+
+#[derive(Default)]
+pub struct EarlyAttesterCache<E: EthSpec> {
+    item: Option<CacheItem<E>>,
+}
+
+impl<E: EthSpec> EarlyAttesterCache<E> {
+    pub fn clear(&mut self) {
+        self.item = None
+    }
+
+    pub fn add_head_block(
+        &mut self,
+        beacon_block_root: Hash256,
+        block: SignedBeaconBlock<E>,
+        proto_block: ProtoBlock,
+        state: &BeaconState<E>,
+    ) -> Result<(), BeaconStateError> {
+        let epoch = state.current_epoch();
+        let committee_len = state.get_beacon_committee(state.slot(), 0)?.committee.len();
+        let source = state.current_justified_checkpoint();
+        let target_slot = epoch.start_slot(E::slots_per_epoch());
+        let target = Checkpoint {
+            epoch,
+            root: if state.slot() <= target_slot {
+                beacon_block_root
+            } else {
+                *state.get_block_root(target_slot)?
+            },
+        };
+
+        let item = CacheItem {
+            epoch,
+            committee_len,
+            beacon_block_root,
+            source,
+            target,
+            block,
+            proto_block,
+        };
+
+        self.item = Some(item);
+
+        Ok(())
+    }
+
+    pub fn try_attest(
+        &self,
+        request_slot: Slot,
+        request_index: CommitteeIndex,
+    ) -> Option<Attestation<E>> {
+        let item = self.item.as_ref()?;
+        let request_epoch = request_slot.epoch(E::slots_per_epoch());
+
+        if request_epoch != item.epoch {
+            return None;
+        }
+
+        // TODO: check committee count.
+
+        Some(Attestation {
+            aggregation_bits: BitList::with_capacity(item.committee_len).ok()?,
+            data: AttestationData {
+                slot: request_slot,
+                index: request_index,
+                beacon_block_root: item.beacon_block_root,
+                source: item.source,
+                target: item.target,
+            },
+            signature: AggregateSignature::empty(),
+        })
+    }
+
+    pub fn get_block(&self, block_root: Hash256) -> Option<&SignedBeaconBlock<E>> {
+        self.item
+            .as_ref()
+            .filter(|item| item.beacon_block_root == block_root)
+            .map(|item| &item.block)
+    }
+
+    pub fn get_proto_block(&self, block_root: Hash256) -> Option<&ProtoBlock> {
+        self.item
+            .as_ref()
+            .filter(|item| item.beacon_block_root == block_root)
+            .map(|item| &item.proto_block)
+    }
+}

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -110,6 +110,8 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             .get_committee_length::<E>(request_slot, request_index, spec)
             .ok()?;
 
+        metrics::inc_counter(&metrics::BEACON_EARLY_ATTESTER_CACHE_HITS);
+
         Some(Attestation {
             aggregation_bits: BitList::with_capacity(committee_len).ok()?,
             data: AttestationData {

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -100,7 +100,10 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             return None;
         }
 
-        let committee_count = item.committee_lengths.get_committee_count::<E>(spec).ok()?;
+        let committee_count = item
+            .committee_lengths
+            .get_committee_count_per_slot::<E>(spec)
+            .ok()?;
         if request_index >= committee_count as u64 {
             return None;
         }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -9,6 +9,7 @@ mod block_times_cache;
 mod block_verification;
 pub mod builder;
 pub mod chain_config;
+mod early_attester_cache;
 mod errors;
 pub mod eth1_chain;
 pub mod events;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -245,7 +245,7 @@ lazy_static! {
      */
     pub static ref BEACON_EARLY_ATTESTER_CACHE_HITS: Result<IntCounter> = try_create_int_counter(
         "beacon_early_attester_cache_hits",
-        "Count of times the early attester cache prevents a head miss"
+        "Count of times the early attester cache returns an attestation"
     );
 
     /*

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -241,6 +241,14 @@ lazy_static! {
         try_create_int_counter("beacon_shuffling_cache_misses_total", "Count of times shuffling cache fulfils request");
 
     /*
+     * Early attester cache
+     */
+    pub static ref BEACON_EARLY_ATTESTER_CACHE_HITS: Result<IntCounter> = try_create_int_counter(
+        "beacon_early_attester_cache_hits",
+        "Count of times the early attester cache prevents a head miss"
+    );
+
+    /*
      * Attestation Production
      */
     pub static ref ATTESTATION_PRODUCTION_SECONDS: Result<Histogram> = try_create_histogram(

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -122,6 +122,22 @@ fn produces_attestations() {
             );
             assert_eq!(data.target.epoch, state.current_epoch(), "bad target epoch");
             assert_eq!(data.target.root, target_root, "bad target root");
+
+            let early_attestation = {
+                let mut early_attester_cache = chain.early_attester_cache.write();
+                let proto_block = chain.fork_choice.read().get_block(&block_root).unwrap();
+                early_attester_cache
+                    .add_head_block(block_root, block.clone(), proto_block, &state, &chain.spec)
+                    .unwrap();
+                early_attester_cache
+                    .try_attest(slot, index, &chain.spec)
+                    .unwrap()
+            };
+
+            assert_eq!(
+                attestation, early_attestation,
+                "early attester cache inconsistent"
+            );
         }
     }
 }

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -124,12 +124,13 @@ fn produces_attestations() {
             assert_eq!(data.target.root, target_root, "bad target root");
 
             let early_attestation = {
-                let mut early_attester_cache = chain.early_attester_cache.write();
                 let proto_block = chain.fork_choice.read().get_block(&block_root).unwrap();
-                early_attester_cache
+                chain
+                    .early_attester_cache
                     .add_head_block(block_root, block.clone(), proto_block, &state, &chain.spec)
                     .unwrap();
-                early_attester_cache
+                chain
+                    .early_attester_cache
                     .try_attest(slot, index, &chain.spec)
                     .unwrap()
             };

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -133,6 +133,7 @@ fn produces_attestations() {
                     .early_attester_cache
                     .try_attest(slot, index, &chain.spec)
                     .unwrap()
+                    .unwrap()
             };
 
             assert_eq!(

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -129,7 +129,7 @@ impl<T: BeaconChainTypes> Worker<T> {
     ) {
         let mut send_block_count = 0;
         for root in request.block_roots.iter() {
-            if let Ok(Some(block)) = self.chain.store.get_block(root) {
+            if let Ok(Some(block)) = self.chain.get_block_checking_early_attester_cache(root) {
                 self.send_response(
                     peer_id,
                     Response::BlocksByRoot(Some(Box::new(block))),


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Introduces a cache to attestation to produce atop blocks which will become the head, but are not fully imported (e.g., not inserted into the database).

Whilst attesting to a block before it's imported is rather easy, if we're going to produce that attestation then we also need to be able to:

1. Verify that attestation.
1. Respond to RPC requests for the `beacon_block_root`.

Attestation verification (1) is *partially* covered. Since we prime the shuffling cache before we insert the block into the early attester cache, we should be fine for all typical use-cases. However, it is possible that the cache is washed out before we've managed to insert the state into the database and then attestation verification will fail with a "missing beacon state"-type error.

Providing the block via RPC (2) is also partially covered, since we'll check the database *and* the early attester cache when responding a blocks-by-root request. However, we'll still omit the block from blocks-by-range requests (until the block lands in the DB). I *think* this is fine, since there's no guarantee that we return all blocks for those responses.

Another important consideration is whether or not the *parent* of the early attester block is available in the databse. If it were not, we might fail to respond to blocks-by-root request that are iterating backwards to collect a chain of blocks. I argue that *we will always have the parent of the early attester block in the database.* This is because we are holding the fork-choice write-lock when inserting the block into the early attester cache and we do not drop that until the block is in the database.