### PR TITLE
Fix typo 'from Reqwest' to 'Request'

### DIFF
--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -330,12 +330,12 @@ pub struct DatabaseInfo {
 impl BeaconNodeHttpClient {
     /// Perform a HTTP GET request, returning `None` on a 404 error.
     async fn get_bytes_opt<U: IntoUrl>(&self, url: U) -> Result<Option<Vec<u8>>, Error> {
-        let response = self.client.get(url).send().await.map_err(Error::Reqwest)?;
+        let response = self.client.get(url).send().await.map_err(Error::Request)?;
         match ok_or_error(response).await {
             Ok(resp) => Ok(Some(
                 resp.bytes()
                     .await
-                    .map_err(Error::Reqwest)?
+                    .map_err(Error::Request)?
                     .into_iter()
                     .collect::<Vec<_>>(),
             )),

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -96,7 +96,7 @@ impl ValidatorClientHttpClient {
             .map_err(|_| Error::InvalidSignatureHeader)?
             .to_string();
 
-        let body = response.bytes().await.map_err(Error::Reqwest)?;
+        let body = response.bytes().await.map_err(Error::Request)?;
 
         let message =
             Message::parse_slice(digest(&SHA256, &body).as_ref()).expect("sha256 is 32 bytes");
@@ -141,7 +141,7 @@ impl ValidatorClientHttpClient {
             .headers(self.headers()?)
             .send()
             .await
-            .map_err(Error::Reqwest)?;
+            .map_err(Error::Request)?;
         let response = ok_or_error(response).await?;
         self.signed_json(response).await
     }
@@ -154,7 +154,7 @@ impl ValidatorClientHttpClient {
             .headers(self.headers()?)
             .send()
             .await
-            .map_err(Error::Reqwest)?;
+            .map_err(Error::Request)?;
         match ok_or_error(response).await {
             Ok(resp) => self.signed_json(resp).await.map(Option::Some),
             Err(err) => {
@@ -180,7 +180,7 @@ impl ValidatorClientHttpClient {
             .json(body)
             .send()
             .await
-            .map_err(Error::Reqwest)?;
+            .map_err(Error::Request)?;
         let response = ok_or_error(response).await?;
         self.signed_json(response).await
     }
@@ -194,7 +194,7 @@ impl ValidatorClientHttpClient {
             .json(body)
             .send()
             .await
-            .map_err(Error::Reqwest)?;
+            .map_err(Error::Request)?;
         let response = ok_or_error(response).await?;
         self.signed_body(response).await?;
         Ok(())

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -23,7 +23,7 @@ pub const TIMEOUT_DURATION: u64 = 5;
 #[derive(Debug)]
 pub enum Error {
     /// The `reqwest` client raised an error.
-    Reqwest(reqwest::Error),
+    Request(reqwest::Error),
     /// The supplied URL is badly formatted. It should look something like `http://127.0.0.1:5052`.
     InvalidUrl(SensitiveUrl),
     SystemMetricsFailed(String),
@@ -38,7 +38,7 @@ pub enum Error {
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            Error::Reqwest(e) => write!(f, "Reqwest error: {}", e),
+            Error::Request(e) => write!(f, "Request error: {}", e),
             // Print the debug value
             e => write!(f, "{:?}", e),
         }
@@ -89,7 +89,7 @@ impl MonitoringHttpClient {
             .timeout(Duration::from_secs(TIMEOUT_DURATION))
             .send()
             .await
-            .map_err(Error::Reqwest)?;
+            .map_err(Error::Request)?;
         ok_or_error(response).await?;
         Ok(())
     }

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -17,7 +17,7 @@ use account_utils::{
 use eth2_keystore::Keystore;
 use lighthouse_metrics::set_gauge;
 use lockfile::{Lockfile, LockfileError};
-use reqwest::{Certificate, Client, Error as ReqwestError};
+use reqwest::{Certificate, Client, Error as RequestError};
 use slog::{debug, error, info, warn, Logger};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -81,8 +81,8 @@ pub enum Error {
     InvalidWeb3SignerUrl(String),
     /// Unable to read the root certificate file for the remote signer.
     InvalidWeb3SignerRootCertificateFile(io::Error),
-    InvalidWeb3SignerRootCertificate(ReqwestError),
-    UnableToBuildWeb3SignerClient(ReqwestError),
+    InvalidWeb3SignerRootCertificate(RequestError),
+    UnableToBuildWeb3SignerClient(RequestError),
 }
 
 impl From<LockfileError> for Error {


### PR DESCRIPTION
## Issue Addressed

A typo shown when not all beacon's are up

## Proposed Changes

Rename 'from Reqwest' to 'Request'

## Additional Info

WARN Offline beacon node                     endpoint: http://192.168.1.201:6052/, error: Reqwest(reqwest::Error { kin
d: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(192.168.1.201)), port: Some(6052), path: "/eth/v1/node/version", query: None
, fragment: None }, source
