### PR TITLE
[Merged by Bors] - Update rust version in `lcli` Dockerfile

### DIFF
--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.53.0 AS builder
+FROM rust:1.56.1-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake
 COPY . lighthouse
 ARG PORTABLE


### PR DESCRIPTION
The `lcli` docker build was no longer working on the old rust version