### PR TITLE
[Merged by Bors] - Allow value for beacon_node fee-recipient argument

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -407,6 +407,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        address whilst the merge is in development stages. THE DEFAULT VALUE \
                        WILL BE REMOVED BEFORE THE MERGE ENTERS PRODUCTION")
                 .requires("merge")
+                .takes_value(true)
         )
 
         /*

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -402,6 +402,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("fee-recipient")
                 .long("fee-recipient")
+                .value_name("FEE-RECIPIENT")
                 .help("Once the merge has happened, this address will receive transaction fees \
                        collected from any blocks produced by this node. Defaults to a junk \
                        address whilst the merge is in development stages. THE DEFAULT VALUE \

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -11,7 +11,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::string::ToString;
 use tempfile::TempDir;
-use types::{Checkpoint, Epoch, Hash256};
+use types::{Address, Checkpoint, Epoch, Hash256};
 
 const DEFAULT_ETH1_ENDPOINT: &str = "http://localhost:8545/";
 
@@ -204,6 +204,16 @@ fn eth1_purge_cache_flag() {
         .flag("eth1-purge-cache", None)
         .run_with_zero_port()
         .with_config(|config| assert!(config.eth1.purge_cache));
+}
+
+// Tests for Merge flags.
+#[test] 
+fn merge_fee_recipient_flag() {
+    CommandLineTest::new()
+        .flag("merge", None)
+        .flag("fee-recipient", Some("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"))
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.suggested_fee_recipient, Some(Address::from_str("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b").unwrap())));
 }
 
 // Tests for Network flags.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -207,13 +207,21 @@ fn eth1_purge_cache_flag() {
 }
 
 // Tests for Merge flags.
-#[test] 
+#[test]
 fn merge_fee_recipient_flag() {
     CommandLineTest::new()
         .flag("merge", None)
-        .flag("fee-recipient", Some("0x00000000219ab540356cbb839cbe05303d7705fa"))
+        .flag(
+            "fee-recipient",
+            Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
+        )
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.suggested_fee_recipient, Some(Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap())));
+        .with_config(|config| {
+            assert_eq!(
+                config.suggested_fee_recipient,
+                Some(Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap())
+            )
+        });
 }
 
 // Tests for Network flags.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -211,9 +211,9 @@ fn eth1_purge_cache_flag() {
 fn merge_fee_recipient_flag() {
     CommandLineTest::new()
         .flag("merge", None)
-        .flag("fee-recipient", Some("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"))
+        .flag("fee-recipient", Some("0x00000000219ab540356cbb839cbe05303d7705fa"))
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.suggested_fee_recipient, Some(Address::from_str("0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b").unwrap())));
+        .with_config(|config| assert_eq!(config.suggested_fee_recipient, Some(Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap())));
 }
 
 // Tests for Network flags.


### PR DESCRIPTION
## Issue Addressed

The fee-recipient argument of the beacon node does not allow a value to be specified:

> $ lighthouse beacon_node --merge --fee-recipient "0x332E43696A505EF45b9319973785F837ce5267b9"
> error: Found argument '0x332E43696A505EF45b9319973785F837ce5267b9' which wasn't expected, or isn't valid in this context
> 
> USAGE:
>    lighthouse beacon_node --fee-recipient --merge
>
> For more information try --help

## Proposed Changes

Allow specifying a value for the fee-recipient argument in beacon_node/src/cli.rs

## Additional Info

I've added .takes_value(true) and successfully proposed a block in the kintsugi testnet with my own fee-recipient address instead of the hardcoded default. I think that was just missed as the argument does not make sense without a value :)
