### PR TITLE
[Merged by Bors] - Update to superstruct v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,9 +5811,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "superstruct"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecffe12af481bd0b8950f90676d61fb1e5fc33f1f1c41ce5df11e83fb509aaab"
+checksum = "78ed336741d3178d793070c48d17263c6148d13106e571049ccf6d0b3a5a5f42"
 dependencies = [
  "darling",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5811,9 +5811,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "superstruct"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ed336741d3178d793070c48d17263c6148d13106e571049ccf6d0b3a5a5f42"
+checksum = "4e623e69a04a6352677c1f892027e14e034dfc6c4aabed0a4a0be9c1a0a46cee"
 dependencies = [
  "darling",
  "itertools",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -58,7 +58,7 @@ strum = { version = "0.21.0", features = ["derive"] }
 logging = { path = "../../common/logging" }
 execution_layer = { path = "../execution_layer" }
 sensitive_url = { path = "../../common/sensitive_url" }
-superstruct = "0.3.0"
+superstruct = "0.4.0"
 
 [[test]]
 name = "beacon_chain_tests"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1099,6 +1099,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     .message()
                     .body()
                     .execution_payload()
+                    .ok()
                     .map(|ep| ep.block_hash),
             })
         })
@@ -2602,7 +2603,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // Register sync aggregate with validator monitor
-        if let Some(sync_aggregate) = block.body().sync_aggregate() {
+        if let Ok(sync_aggregate) = block.body().sync_aggregate() {
             // `SyncCommittee` for the sync_aggregate should correspond to the duty slot
             let duty_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
             let sync_committee = self.sync_committee_at_epoch(duty_epoch)?;
@@ -2643,7 +2644,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 block.body().attestations().len() as f64,
             );
 
-            if let Some(sync_aggregate) = block.body().sync_aggregate() {
+            if let Ok(sync_aggregate) = block.body().sync_aggregate() {
                 metrics::set_gauge(
                     &metrics::BLOCK_SYNC_AGGREGATE_SET_BITS,
                     sync_aggregate.num_set_bits() as i64,
@@ -3241,6 +3242,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .message()
             .body()
             .execution_payload()
+            .ok()
             .map(|ep| ep.block_hash);
         let is_merge_transition_complete = is_merge_transition_complete(&new_head.beacon_state);
 
@@ -3528,6 +3530,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .message()
             .body()
             .execution_payload()
+            .ok()
             .map(|ep| ep.block_hash)
             .unwrap_or_else(Hash256::zero);
 

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -146,7 +146,7 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
 ) -> Result<(), BlockError<T::EthSpec>> {
     // Only apply this validation if this is a merge beacon block.
-    if let Some(execution_payload) = block.body().execution_payload() {
+    if let Ok(execution_payload) = block.body().execution_payload() {
         // This logic should match `is_execution_enabled`. We use only the execution block hash of
         // the parent here in order to avoid loading the parent state during gossip verification.
 
@@ -289,6 +289,7 @@ pub async fn prepare_execution_payload<T: BeaconChainTypes>(
                 .message()
                 .body()
                 .execution_payload()
+                .ok()
                 .map(|ep| ep.block_hash)
         };
 

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -37,7 +37,7 @@ rand = "0.7.3"
 directory = { path = "../../common/directory" }
 regex = "1.3.9"
 strum = { version = "0.21.0", features = ["derive"] }
-superstruct = "0.3.0"
+superstruct = "0.4.0"
 open-metrics-client = "0.13.0"
 
 [dependencies.libp2p]

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -589,7 +589,7 @@ where
             .on_verified_block(block, block_root, state)
             .map_err(Error::AfterBlockFailed)?;
 
-        let execution_status = if let Some(execution_payload) = block.body().execution_payload() {
+        let execution_status = if let Ok(execution_payload) = block.body().execution_payload() {
             let block_hash = execution_payload.block_hash;
 
             if block_hash == Hash256::zero() {

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -148,10 +148,7 @@ pub fn per_block_processing<T: EthSpec>(
     // `process_randao` as the former depends on the `randao_mix` computed with the reveal of the
     // previous block.
     if is_execution_enabled(state, block.body()) {
-        let payload = block
-            .body()
-            .execution_payload()
-            .ok_or(BlockProcessingError::IncorrectStateType)?;
+        let payload = block.body().execution_payload()?;
         process_execution_payload(state, payload, spec)?;
     }
 
@@ -159,7 +156,7 @@ pub fn per_block_processing<T: EthSpec>(
     process_eth1_data(state, block.body().eth1_data())?;
     process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
 
-    if let Some(sync_aggregate) = block.body().sync_aggregate() {
+    if let Ok(sync_aggregate) = block.body().sync_aggregate() {
         process_sync_aggregate(
             state,
             sync_aggregate,

--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -302,7 +302,7 @@ where
 
     /// Include the signature of the block's sync aggregate (if it exists) for verification.
     pub fn include_sync_aggregate(&mut self, block: &'a SignedBeaconBlock<T>) -> Result<()> {
-        if let Some(sync_aggregate) = block.message().body().sync_aggregate() {
+        if let Ok(sync_aggregate) = block.message().body().sync_aggregate() {
             if let Some(signature_set) = sync_aggregate_signature_set(
                 &self.decompressor,
                 sync_aggregate,

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -43,7 +43,7 @@ regex = "1.3.9"
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"
 itertools = "0.10.0"
-superstruct = "0.3.0"
+superstruct = "0.4.0"
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -237,13 +237,8 @@ impl<'a, T: EthSpec> BeaconBlockRef<'a, T> {
 
     /// Extracts a reference to an execution payload from a block, returning an error if the block
     /// is pre-merge.
-    pub fn execution_payload(&self) -> Result<&ExecutionPayload<T>, InconsistentFork> {
-        self.body()
-            .execution_payload()
-            .ok_or_else(|| InconsistentFork {
-                fork_at_slot: ForkName::Merge,
-                object_fork: self.body().fork_name(),
-            })
+    pub fn execution_payload(&self) -> Result<&ExecutionPayload<T>, Error> {
+        self.body().execution_payload()
     }
 }
 

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -50,24 +50,6 @@ pub struct BeaconBlockBody<T: EthSpec> {
 }
 
 impl<'a, T: EthSpec> BeaconBlockBodyRef<'a, T> {
-    /// Access the sync aggregate from the block's body, if one exists.
-    pub fn sync_aggregate(self) -> Option<&'a SyncAggregate<T>> {
-        match self {
-            BeaconBlockBodyRef::Base(_) => None,
-            BeaconBlockBodyRef::Altair(inner) => Some(&inner.sync_aggregate),
-            BeaconBlockBodyRef::Merge(inner) => Some(&inner.sync_aggregate),
-        }
-    }
-
-    /// Access the execution payload from the block's body, if one exists.
-    pub fn execution_payload(self) -> Option<&'a ExecutionPayload<T>> {
-        match self {
-            BeaconBlockBodyRef::Base(_) => None,
-            BeaconBlockBodyRef::Altair(_) => None,
-            BeaconBlockBodyRef::Merge(inner) => Some(&inner.execution_payload),
-        }
-    }
-
     /// Get the fork_name of this object
     pub fn fork_name(self) -> ForkName {
         match self {

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -193,7 +193,7 @@ pub async fn verify_full_sync_aggregates_up_to<E: EthSpec>(
                     .map(|agg| agg.num_set_bits())
             })
             .map_err(|e| format!("Error while getting beacon block: {:?}", e))?
-            .ok_or(format!("Altair block {} should have sync aggregate", slot))?;
+            .map_err(|_| format!("Altair block {} should have sync aggregate", slot))?;
 
         if sync_aggregate_count != E::sync_committee_size() {
             return Err(format!(


### PR DESCRIPTION
## Proposed Changes

Update `superstruct` to bring in @realbigsean's fixes necessary for MEV-compatible private beacon block types (a la #2795).

The refactoring is due to another change in superstruct that allows partial getters to be auto-generated.