### PR TITLE
[Merged by Bors] - Add tests for flags `enable-enr-auto-update` and `disable-packet-filter`

### DIFF
--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -132,13 +132,15 @@ impl<T: EthSpec> BootNodeConfig<T> {
 
 /// The set of configuration parameters that can safely be (de)serialized.
 ///
-/// Its fields are a subset of the fields of `BootNodeConfig`.
+/// Its fields are a subset of the fields of `BootNodeConfig`, some of them are copied from `Discv5Config`.
 #[derive(Serialize, Deserialize)]
 pub struct BootNodeConfigSerialization {
     pub listen_socket: SocketAddr,
     // TODO: Generalise to multiaddr
     pub boot_nodes: Vec<Enr>,
     pub local_enr: Enr,
+    pub disable_packet_filter: bool,
+    pub enable_enr_auto_update: bool,
 }
 
 impl BootNodeConfigSerialization {
@@ -150,7 +152,7 @@ impl BootNodeConfigSerialization {
             boot_nodes,
             local_enr,
             local_key: _,
-            discv5_config: _,
+            discv5_config,
             phantom: _,
         } = config;
 
@@ -158,6 +160,8 @@ impl BootNodeConfigSerialization {
             listen_socket: *listen_socket,
             boot_nodes: boot_nodes.clone(),
             local_enr: local_enr.clone(),
+            disable_packet_filter: !discv5_config.enable_packet_filter,
+            enable_enr_auto_update: discv5_config.enr_update,
         }
     }
 }

--- a/lighthouse/tests/boot_node.rs
+++ b/lighthouse/tests/boot_node.rs
@@ -139,9 +139,25 @@ fn enr_port_flag() {
         })
 }
 
-// TODO add tests for flags `enable-enr-auto-update` and `disable-packet-filter`.
-//
-// These options end up in `Discv5Config`, which doesn't support serde (de)serialization.
+#[test]
+fn disable_packet_filter_flag() {
+    CommandLineTest::new()
+        .flag("disable-packet-filter", None)
+        .run_with_ip()
+        .with_config(|config| {
+            assert_eq!(config.disable_packet_filter, true);
+        });
+}
+
+#[test]
+fn enable_enr_auto_update_flag() {
+    CommandLineTest::new()
+        .flag("enable-enr-auto-update", None)
+        .run_with_ip()
+        .with_config(|config| {
+            assert_eq!(config.enable_enr_auto_update, true);
+        });
+}
 
 #[test]
 fn network_dir_flag() {


### PR DESCRIPTION
Resolves https://github.com/sigp/lighthouse/issues/2602

## Issue Addressed

https://github.com/sigp/lighthouse/pull/2749#issue-1037552417
> ## Open TODO
> Add tests for boot_node flags `enable-enr-auto-update` and `disable-packet-filter`. They end up in [Discv5Config](https://github.com/mooori/lighthouse/blob/9ed2cba6bc3e41f08207cb0eeaf9e4aee40d05dd/boot_node/src/config.rs#L29), which doesn't support serde (de)serialization.

## Proposed Changes

- Added tests for flags `enable-enr-auto-update` and `disable-packet-filter`
- Instead of (de)serialize Discv5Config, added the two fields copied from Discv5Config to BootNodeConfigSerialization.
