### PR TITLE
Run extra tests for merge fork on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PINNED_NIGHTLY ?= nightly
 
 # List of all hard forks. This list is used to set env variables for several tests so that
 # they run for different forks.
-FORKS=phase0 altair
+FORKS=phase0 altair merge
 
 # Builds the Lighthouse binary in release (optimized).
 #


### PR DESCRIPTION
## Proposed Changes

Run the `beacon_chain` and `operation_pool` tests for the merge fork on CI. If this doesn't have too much of an impact on CI run times I think we should merge it.

In future we may want to break up the jobs for different forks for better parallelism.
