### PR TITLE
log the ignored event for a disconnecting peer

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -902,7 +902,7 @@ impl<TSpec: EthSpec> NetworkBehaviourEventProcess<RPCMessage<TSpec>> for Behavio
             debug!(
                 self.log,
                 "Ignoring rpc message of disconnecting peer";
-                "peer" => %peer_id
+                "event" => ?event,
             );
             return;
         }

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -86,6 +86,7 @@ impl<T: EthSpec> std::fmt::Display for RPCSend<T> {
 }
 
 /// Messages sent to the user from the RPC protocol.
+#[derive(Debug)]
 pub struct RPCMessage<TSpec: EthSpec> {
     /// The peer that sent the message.
     pub peer_id: PeerId,


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes
When ignoring the messages of disconnecting peers we now log the ignored message too.

## Additional Info
The purpose is discard the possibility that we are ignoring the missing blocks causing the death spiral here
