### PR TITLE
[Merged by Bors] - Skip serializing proposer boost if null

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -659,6 +659,7 @@ pub struct Config {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     churn_limit_quotient: u64,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     proposer_score_boost: Option<MaybeQuoted<u64>>,
 
     #[serde(with = "eth2_serde_utils::quoted_u64")]


### PR DESCRIPTION
## Issue Addressed

Restore compatibility between Lighthouse v2.0.1 VC and `unstable` BN in preparation for the next release.

## Proposed Changes

* Don't serialize the `PROPOSER_SCORE_BOOST` as `null` because it breaks the `extra_fields: HashMap<String, String>` used by the v2.0.1 VC.
