### PR TITLE
[Merged by Bors] - Add peer score adjustment msgs

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -183,24 +183,6 @@ pub enum Error {
     /// single-participant attestation from this validator for this epoch and should not observe
     /// another.
     PriorAttestationKnown { validator_index: u64, epoch: Epoch },
-    /// The attestation is for an epoch in the future (with respect to the gossip clock disparity).
-    ///
-    /// ## Peer scoring
-    ///
-    /// Assuming the local clock is correct, the peer has sent an invalid message.
-    FutureEpoch {
-        attestation_epoch: Epoch,
-        current_epoch: Epoch,
-    },
-    /// The attestation is for an epoch in the past (with respect to the gossip clock disparity).
-    ///
-    /// ## Peer scoring
-    ///
-    /// Assuming the local clock is correct, the peer has sent an invalid message.
-    PastEpoch {
-        attestation_epoch: Epoch,
-        current_epoch: Epoch,
-    },
     /// The attestation is attesting to a state that is later than itself. (Viz., attesting to the
     /// future).
     ///

--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -887,6 +887,7 @@ impl<TSpec: EthSpec> NetworkBehaviourEventProcess<GossipsubEvent> for Behaviour<
                     PeerAction::LowToleranceError,
                     ReportSource::Gossipsub,
                     Some(GoodbyeReason::Unknown),
+                    "does_not_support_gossipsub",
                 );
             }
         }

--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -106,6 +106,15 @@ lazy_static! {
     /// The number of peers that we dialed us.
     pub static ref NETWORK_OUTBOUND_PEERS: Result<IntGauge> =
         try_create_int_gauge("network_outbound_peers","The number of peers that are currently connected that we dialed.");
+
+    /*
+     * Peer Reporting
+     */
+    pub static ref REPORT_PEER_MSGS: Result<IntCounterVec> = try_create_int_counter_vec(
+        "libp2p_report_peer_msgs_total",
+        "Number of peer reports per msg",
+        &["msg"]
+    );
 }
 
 /// Checks if we consider the NAT open.

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -155,7 +155,13 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             }
         }
 
-        self.report_peer(peer_id, PeerAction::Fatal, source, Some(reason));
+        self.report_peer(
+            peer_id,
+            PeerAction::Fatal,
+            source,
+            Some(reason),
+            "goodbye_peer",
+        );
     }
 
     /// Reports a peer for some action.
@@ -167,12 +173,13 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         action: PeerAction,
         source: ReportSource,
         reason: Option<GoodbyeReason>,
+        msg: &'static str,
     ) {
         let action = self
             .network_globals
             .peers
             .write()
-            .report_peer(peer_id, action, source);
+            .report_peer(peer_id, action, source, msg);
         self.handle_score_action(peer_id, action, reason);
     }
 
@@ -511,7 +518,13 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             RPCError::Disconnected => return, // No penalty for a graceful disconnection
         };
 
-        self.report_peer(peer_id, peer_action, ReportSource::RPC, None);
+        self.report_peer(
+            peer_id,
+            peer_action,
+            ReportSource::RPC,
+            None,
+            "handle_rpc_error",
+        );
     }
 
     /// A ping request has been received.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -492,6 +492,8 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         source: ReportSource,
         msg: &'static str,
     ) -> ScoreUpdateResult {
+        metrics::inc_counter_vec(&metrics::REPORT_PEER_MSGS, &[msg]);
+
         match self.peers.get_mut(peer_id) {
             Some(info) => {
                 let previous_state = info.score_state();

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -529,13 +529,23 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                     }
                     ScoreTransitionResult::NoAction => ScoreUpdateResult::NoAction,
                     ScoreTransitionResult::Unbanned => {
-                        error!(self.log, "Report peer action lead to an unbanning"; "peer_id" => %peer_id);
+                        error!(
+                            self.log,
+                            "msg" => %msg,
+                            "Report peer action lead to an unbanning";
+                            "peer_id" => %peer_id
+                        );
                         ScoreUpdateResult::NoAction
                     }
                 }
             }
             None => {
-                debug!(self.log, "Reporting a peer that doesn't exist"; "peer_id" =>%peer_id);
+                debug!(
+                    self.log,
+                    "Reporting a peer that doesn't exist";
+                    "msg" => %msg,
+                    "peer_id" =>%peer_id
+                );
                 ScoreUpdateResult::NoAction
             }
         }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -531,8 +531,8 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                     ScoreTransitionResult::Unbanned => {
                         error!(
                             self.log,
-                            "msg" => %msg,
                             "Report peer action lead to an unbanning";
+                            "msg" => %msg,
                             "peer_id" => %peer_id
                         );
                         ScoreUpdateResult::NoAction

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -490,6 +490,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         peer_id: &PeerId,
         action: PeerAction,
         source: ReportSource,
+        msg: &'static str,
     ) -> ScoreUpdateResult {
         match self.peers.get_mut(peer_id) {
             Some(info) => {
@@ -502,7 +503,13 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 let result =
                     Self::handle_score_transition(previous_state, peer_id, info, &self.log);
                 if previous_state == info.score_state() {
-                    debug!(self.log, "Peer score adjusted"; "peer_id" => %peer_id, "score" => %info.score());
+                    debug!(
+                        self.log,
+                        "Peer score adjusted";
+                        "msg" => %msg,
+                        "peer_id" => %peer_id,
+                        "score" => %info.score()
+                    );
                 }
                 match result {
                     ScoreTransitionResult::Banned => {
@@ -1357,7 +1364,7 @@ mod tests {
         assert_eq!(pdb.banned_peers_count.banned_peers(), 0);
 
         for p in pdb.connected_peer_ids().cloned().collect::<Vec<_>>() {
-            let _ = pdb.report_peer(&p, PeerAction::Fatal, ReportSource::PeerManager);
+            let _ = pdb.report_peer(&p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(&p);
         }
 
@@ -1426,9 +1433,19 @@ mod tests {
         pdb.inject_disconnect(&random_peer);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
 
-        let _ = pdb.report_peer(&random_peer, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         pdb.inject_disconnect(&random_peer);
-        let _ = pdb.report_peer(&random_peer, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
         pdb.inject_disconnect(&random_peer);
         assert_eq!(pdb.disconnected_peers, pdb.disconnected_peers().count());
@@ -1481,7 +1498,12 @@ mod tests {
             pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
         );
         // Disconnect and ban peer 2
-        let _ = pdb.report_peer(&random_peer2, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer2,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         // Should be 1 disconnected peer and one peer in the process of being disconnected
         println!(
             "3:{},{}",
@@ -1495,7 +1517,12 @@ mod tests {
             pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
         );
         // Now that the peer is disconnected, register the ban.
-        let _ = pdb.report_peer(&random_peer2, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer2,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         // There should be 1 disconnected peer and one banned peer.
         println!(
             "5:{},{}",
@@ -1509,7 +1536,12 @@ mod tests {
             pdb.banned_peers().count()
         );
         // Now ban peer 1.
-        let _ = pdb.report_peer(&random_peer1, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer1,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         // There should be no disconnected peers and 2 banned peers
         println!(
             "6:{},{}",
@@ -1523,7 +1555,12 @@ mod tests {
             pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
         );
         // Same thing here.
-        let _ = pdb.report_peer(&random_peer1, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer1,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         println!(
             "8:{},{}",
             pdb.disconnected_peers, pdb.banned_peers_count.banned_peers
@@ -1559,7 +1596,12 @@ mod tests {
         );
 
         // Ban peer 3
-        let _ = pdb.report_peer(&random_peer3, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         pdb.inject_disconnect(&random_peer3);
 
         // This should add a new banned peer, there should be 0 disconnected and 2 banned
@@ -1576,7 +1618,12 @@ mod tests {
         );
 
         // Ban peer 3
-        let _ = pdb.report_peer(&random_peer3, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         pdb.inject_disconnect(&random_peer3);
 
         // Should still have 2 banned peers
@@ -1606,7 +1653,12 @@ mod tests {
         );
 
         // Ban peer 3
-        let _ = pdb.report_peer(&random_peer3, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer3,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         pdb.inject_disconnect(&random_peer3);
 
         // Should have 1 disconnect (peer 2) and one banned (peer 3)
@@ -1657,7 +1709,12 @@ mod tests {
         );
 
         // Ban peer 0
-        let _ = pdb.report_peer(&random_peer, PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(
+            &random_peer,
+            PeerAction::Fatal,
+            ReportSource::PeerManager,
+            "",
+        );
         pdb.inject_disconnect(&random_peer);
 
         // Should have 1 disconnect ( peer 2) and two banned (peer0, peer 3)
@@ -1709,7 +1766,7 @@ mod tests {
         let p5 = connect_peer_with_ips(&mut pdb, vec![ip5]);
 
         for p in &peers[..BANNED_PEERS_PER_IP_THRESHOLD + 1] {
-            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager);
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(p);
         }
 
@@ -1725,6 +1782,7 @@ mod tests {
             &peers[BANNED_PEERS_PER_IP_THRESHOLD + 1],
             PeerAction::Fatal,
             ReportSource::PeerManager,
+            "",
         );
         pdb.inject_disconnect(&peers[BANNED_PEERS_PER_IP_THRESHOLD + 1]);
 
@@ -1777,7 +1835,7 @@ mod tests {
 
         // ban all peers
         for p in &peers {
-            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager);
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(p);
         }
 
@@ -1806,7 +1864,7 @@ mod tests {
         socker_addr.push(Protocol::Tcp(8080));
         for p in &peers {
             pdb.connect_ingoing(p, socker_addr.clone(), None);
-            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager);
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(p);
         }
 
@@ -1823,7 +1881,7 @@ mod tests {
 
         // reban every peer except one
         for p in &peers[1..] {
-            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager);
+            let _ = pdb.report_peer(p, PeerAction::Fatal, ReportSource::PeerManager, "");
             pdb.inject_disconnect(p);
         }
 
@@ -1832,7 +1890,7 @@ mod tests {
         assert!(!pdb.ban_status(&p2).is_banned());
 
         // reban last peer
-        let _ = pdb.report_peer(&peers[0], PeerAction::Fatal, ReportSource::PeerManager);
+        let _ = pdb.report_peer(&peers[0], PeerAction::Fatal, ReportSource::PeerManager, "");
         pdb.inject_disconnect(&peers[0]);
 
         //Ip's are banned again

--- a/beacon_node/lighthouse_network/src/service.rs
+++ b/beacon_node/lighthouse_network/src/service.rs
@@ -280,11 +280,17 @@ impl<TSpec: EthSpec> Service<TSpec> {
     }
 
     /// Report a peer's action.
-    pub fn report_peer(&mut self, peer_id: &PeerId, action: PeerAction, source: ReportSource) {
+    pub fn report_peer(
+        &mut self,
+        peer_id: &PeerId,
+        action: PeerAction,
+        source: ReportSource,
+        msg: &'static str,
+    ) {
         self.swarm
             .behaviour_mut()
             .peer_manager_mut()
-            .report_peer(peer_id, action, source, None);
+            .report_peer(peer_id, action, source, None, msg);
     }
 
     /// Disconnect and ban a peer, providing a reason.

--- a/beacon_node/lighthouse_network/tests/pm_tests.rs
+++ b/beacon_node/lighthouse_network/tests/pm_tests.rs
@@ -167,7 +167,8 @@ async fn banned_peers_consistency() {
                                 &peer_id,
                                 PeerAction::Fatal,
                                 ReportSource::Processor,
-                                None
+                                None,
+                                ""
                             );
                     },
                     _ => {}

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -741,6 +741,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     "Gossip block beacon chain error";
                     "error" => ?e,
                 );
+                self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return None;
             }
             Err(e @ BlockError::FutureSlot { .. })

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1273,7 +1273,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         let attestation_type = failed_att.kind();
         metrics::register_attestation_error(&error);
         match &error {
-            AttnError::FutureEpoch { .. } | AttnError::FutureSlot { .. } => {
+            AttnError::FutureSlot { .. } => {
                 /*
                  * These errors can be triggered by a mismatch between our slot and the peer.
                  *
@@ -1293,13 +1293,13 @@ impl<T: BeaconChainTypes> Worker<T> {
                 self.gossip_penalize_peer(
                     peer_id,
                     PeerAction::LowToleranceError,
-                    "attn_for_future",
+                    "attn_future_slot",
                 );
 
                 // Do not propagate these messages.
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
             }
-            AttnError::PastSlot { .. } | AttnError::PastEpoch { .. } => {
+            AttnError::PastSlot { .. } => {
                 // Produce a slot clock frozen at the time we received the message from the
                 // network.
                 let seen_clock = &self.chain.slot_clock.freeze_at(seen_timestamp);
@@ -1315,7 +1315,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     self.gossip_penalize_peer(
                         peer_id,
                         PeerAction::LowToleranceError,
-                        "attn_from_past",
+                        "attn_past_slot",
                     );
                 }
 

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -96,6 +96,7 @@ pub enum NetworkMessage<T: EthSpec> {
         peer_id: PeerId,
         action: PeerAction,
         source: ReportSource,
+        msg: &'static str,
     },
     /// Disconnect an ban a peer, providing a reason.
     GoodbyePeer {
@@ -445,7 +446,7 @@ fn spawn_service<T: BeaconChainTypes>(
                                 );
                                 service.libp2p.swarm.behaviour_mut().publish(messages);
                         }
-                        NetworkMessage::ReportPeer { peer_id, action, source } => service.libp2p.report_peer(&peer_id, action, source),
+                        NetworkMessage::ReportPeer { peer_id, action, source, msg } => service.libp2p.report_peer(&peer_id, action, source, msg),
                         NetworkMessage::GoodbyePeer { peer_id, reason, source } => service.libp2p.goodbye_peer(&peer_id, reason, source),
                         NetworkMessage::AttestationSubscribe { subscriptions } => {
                             if let Err(e) = service

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -788,7 +788,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                 network.report_peer(
                                     attempt.peer_id,
                                     action,
-                                    "reprocessed_backfill_original_peer",
+                                    "backfill_reprocessed_original_peer",
                                 );
                             } else {
                                 // The same peer corrected it's previous mistake. There was an error, so we
@@ -801,7 +801,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                 network.report_peer(
                                     attempt.peer_id,
                                     action,
-                                    "reprocessed_backfill_same_peer",
+                                    "backfill_reprocessed_same_peer",
                                 );
                             }
                         }

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -664,7 +664,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                         "score_adjustment" => %action,
                         "batch_epoch"=> batch_id);
                         for peer in self.participating_peers.drain() {
-                            network.report_peer(peer, action);
+                            network.report_peer(peer, action, "backfill_batch_failed");
                         }
                         self.fail_sync(BackFillError::BatchProcessingFailed(batch_id))
                             .map(|_| ProcessResult::Successful)
@@ -785,7 +785,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                     "batch_epoch" => id, "score_adjustment" => %action,
                                     "original_peer" => %attempt.peer_id, "new_peer" => %processed_attempt.peer_id
                                 );
-                                network.report_peer(attempt.peer_id, action);
+                                network.report_peer(
+                                    attempt.peer_id,
+                                    action,
+                                    "reprocessed_batch_original_peer",
+                                );
                             } else {
                                 // The same peer corrected it's previous mistake. There was an error, so we
                                 // negative score the original peer.
@@ -794,7 +798,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                     "batch_epoch" => id, "score_adjustment" => %action,
                                     "original_peer" => %attempt.peer_id, "new_peer" => %processed_attempt.peer_id
                                 );
-                                network.report_peer(attempt.peer_id, action);
+                                network.report_peer(
+                                    attempt.peer_id,
+                                    action,
+                                    "reprocessed_batch_same_peer",
+                                );
                             }
                         }
                     }

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -788,7 +788,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                 network.report_peer(
                                     attempt.peer_id,
                                     action,
-                                    "reprocessed_batch_original_peer",
+                                    "reprocessed_backfill_original_peer",
                                 );
                             } else {
                                 // The same peer corrected it's previous mistake. There was an error, so we
@@ -801,7 +801,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                                 network.report_peer(
                                     attempt.peer_id,
                                     action,
-                                    "reprocessed_batch_same_peer",
+                                    "reprocessed_backfill_same_peer",
                                 );
                             }
                         }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -366,8 +366,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     } else {
                         crit!(self.log, "Parent chain has no blocks");
                     }
-                    self.network
-                        .report_peer(peer_id, PeerAction::MidToleranceError);
+                    self.network.report_peer(
+                        peer_id,
+                        PeerAction::MidToleranceError,
+                        "bbroot_failed_chains",
+                    );
                     return;
                 }
                 // add the block to response
@@ -385,8 +388,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     // tolerate this behaviour.
                     if !single_block_request.block_returned {
                         warn!(self.log, "Peer didn't respond with a block it referenced"; "referenced_block_hash" => %single_block_request.hash, "peer_id" =>  %peer_id);
-                        self.network
-                            .report_peer(peer_id, PeerAction::MidToleranceError);
+                        self.network.report_peer(
+                            peer_id,
+                            PeerAction::MidToleranceError,
+                            "bbroot_no_block",
+                        );
                     }
                     return;
                 }
@@ -509,8 +515,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 warn!(self.log, "Single block lookup failed"; "outcome" => ?outcome);
                 // This could be a range of errors. But we couldn't process the block.
                 // For now we consider this a mid tolerance error.
-                self.network
-                    .report_peer(peer_id, PeerAction::MidToleranceError);
+                self.network.report_peer(
+                    peer_id,
+                    PeerAction::MidToleranceError,
+                    "single_block_lookup_failed",
+                );
             }
         }
     }
@@ -833,8 +842,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             self.request_parent(parent_request);
             // We do not tolerate these kinds of errors. We will accept a few but these are signs
             // of a faulty peer.
-            self.network
-                .report_peer(peer, PeerAction::LowToleranceError);
+            self.network.report_peer(
+                peer,
+                PeerAction::LowToleranceError,
+                "parent_request_bad_hash",
+            );
         } else {
             // The last block in the queue is the only one that has not attempted to be processed yet.
             //
@@ -904,6 +916,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     self.network.report_peer(
                         parent_request.last_submitted_peer,
                         PeerAction::MidToleranceError,
+                        "parent_request_err",
                     );
                 }
             }
@@ -942,6 +955,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             self.network.report_peer(
                 parent_request.last_submitted_peer,
                 PeerAction::LowToleranceError,
+                "request_parent_import_failed",
             );
             return; // drop the request
         }
@@ -1109,8 +1123,11 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         // A peer sent an object (block or attestation) that referenced a parent.
                         // The processing of this chain failed.
                         self.failed_chains.insert(chain_head);
-                        self.network
-                            .report_peer(peer_id, PeerAction::MidToleranceError);
+                        self.network.report_peer(
+                            peer_id,
+                            PeerAction::MidToleranceError,
+                            "parent_lookup_failed",
+                        );
                     }
                 }
             }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -170,13 +170,14 @@ impl<T: EthSpec> SyncNetworkContext<T> {
     }
 
     /// Reports to the scoring algorithm the behaviour of a peer.
-    pub fn report_peer(&mut self, peer_id: PeerId, action: PeerAction) {
+    pub fn report_peer(&mut self, peer_id: PeerId, action: PeerAction, msg: &'static str) {
         debug!(self.log, "Sync reporting peer"; "peer_id" => %peer_id, "action" => %action);
         self.network_send
             .send(NetworkMessage::ReportPeer {
                 peer_id,
                 action,
                 source: ReportSource::SyncService,
+                msg,
             })
             .unwrap_or_else(|e| {
                 warn!(self.log, "Could not report peer, channel failed"; "error"=> %e);

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -516,7 +516,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                         "score_adjustment" => %action,
                         "batch_epoch"=> batch_id);
                     for (peer, _) in self.peers.drain() {
-                        network.report_peer(peer, action);
+                        network.report_peer(peer, action, "batch_failed");
                     }
                     Err(RemoveChain::ChainFailed(batch_id))
                 } else {
@@ -606,7 +606,11 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                                     "batch_epoch" => id, "score_adjustment" => %action,
                                     "original_peer" => %attempt.peer_id, "new_peer" => %processed_attempt.peer_id
                                 );
-                                network.report_peer(attempt.peer_id, action);
+                                network.report_peer(
+                                    attempt.peer_id,
+                                    action,
+                                    "batch_reprocessed_original_peer",
+                                );
                             } else {
                                 // The same peer corrected it's previous mistake. There was an error, so we
                                 // negative score the original peer.
@@ -615,7 +619,11 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                                     "batch_epoch" => id, "score_adjustment" => %action,
                                     "original_peer" => %attempt.peer_id, "new_peer" => %processed_attempt.peer_id
                                 );
-                                network.report_peer(attempt.peer_id, action);
+                                network.report_peer(
+                                    attempt.peer_id,
+                                    action,
+                                    "batch_reprocessed_same_peer",
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

This PR adds the `msg` field to `Peer score adjusted` log messages. These `msg` fields help identify *why* a peer was banned.

Example:

```
Jan 11 04:18:48.096 DEBG Peer score adjusted                     score: -100.00, peer_id: 16Uiu2HAmQskxKWWGYfginwZ51n5uDbhvjHYnvASK7PZ5gBdLmzWj, msg: attn_unknown_head, service: libp2p
Jan 11 04:18:48.096 DEBG Peer score adjusted                     score: -27.86, peer_id: 16Uiu2HAmA7cCb3MemVDbK3MHZoSb7VN3cFUG3vuSZgnGesuVhPDE, msg: sync_past_slot, service: libp2p
Jan 11 04:18:48.096 DEBG Peer score adjusted                     score: -100.00, peer_id: 16Uiu2HAmQskxKWWGYfginwZ51n5uDbhvjHYnvASK7PZ5gBdLmzWj, msg: attn_unknown_head, service: libp2p
Jan 11 04:18:48.096 DEBG Peer score adjusted                     score: -28.86, peer_id: 16Uiu2HAmA7cCb3MemVDbK3MHZoSb7VN3cFUG3vuSZgnGesuVhPDE, msg: sync_past_slot, service: libp2p
Jan 11 04:18:48.096 DEBG Peer score adjusted                     score: -29.86, peer_id: 16Uiu2HAmA7cCb3MemVDbK3MHZoSb7VN3cFUG3vuSZgnGesuVhPDE, msg: sync_past_slot, service: libp2p
```

There is also a `libp2p_report_peer_msgs_total` metrics which allows us to see count of reports per `msg` tag. 

## Additional Info

NA
