### PR TITLE
[Merged by Bors] - Rust 1.58 lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ test-full: cargo-fmt test-release test-debug test-ef
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
 	cargo clippy --workspace --tests -- \
+        -D clippy::fn_to_numeric_cast_any \
         -D warnings \
         -A clippy::from-over-into \
         -A clippy::upper-case-acronyms \

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -233,8 +233,7 @@ mod test {
             if request_json != expected_json {
                 panic!(
                     "json mismatch!\n\nobserved: {}\n\nexpected: {}\n\n",
-                    request_json.to_string(),
-                    expected_json.to_string()
+                    request_json, expected_json,
                 )
             }
             self

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -714,7 +714,7 @@ pub fn set_network_config(
                         None
                     }
                 }) {
-                    addr.push_str(&format!(":{}", enr_udp_port.to_string()));
+                    addr.push_str(&format!(":{}", enr_udp_port));
                 } else {
                     return Err(
                         "enr-udp-port must be set for node to be discoverable with dns address"

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -282,10 +282,7 @@ pub fn load_pem_certificate<P: AsRef<Path>>(pem_path: P) -> Result<Certificate, 
 }
 
 fn build_web3_signer_url(base_url: &str, voting_public_key: &PublicKey) -> Result<Url, ParseError> {
-    Url::parse(base_url)?.join(&format!(
-        "api/v1/eth2/sign/{}",
-        voting_public_key.to_string()
-    ))
+    Url::parse(base_url)?.join(&format!("api/v1/eth2/sign/{}", voting_public_key))
 }
 
 /// Try to unlock `keystore` at `keystore_path` by prompting the user via `stdin`.


### PR DESCRIPTION
## Issue Addressed

Closes #2616

## Proposed Changes

* Fixes for new Rust 1.58.0 lints
* Enable the `fn_to_numeric_cast_any` (#2616)