### PR TITLE
[Merged by Bors] - Support duplicate keys in HTTP API query strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5267,7 +5267,8 @@ dependencies = [
 [[package]]
 name = "serde_array_query"
 version = "0.1.0"
-source = "git+https://github.com/sigp/serde_array_query?rev=67c3eaff7dc42d256509adad2e40a70e973248ec#67c3eaff7dc42d256509adad2e40a70e973248ec"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89c6e82b1005b33d5b2bbc47096800e5ad6b67ef5636f9c13ad29a6935734a7"
 dependencies = [
  "serde",
  "serde_urlencoded",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5265,6 +5265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_array_query"
+version = "0.1.0"
+source = "git+https://github.com/sigp/serde_array_query?rev=67c3eaff7dc42d256509adad2e40a70e973248ec#67c3eaff7dc42d256509adad2e40a70e973248ec"
+dependencies = [
+ "serde",
+ "serde_urlencoded",
+]
+
+[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6821,6 +6830,7 @@ dependencies = [
  "lighthouse_metrics",
  "safe_arith",
  "serde",
+ "serde_array_query",
  "state_processing",
  "tokio",
  "types",

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2554,7 +2554,7 @@ pub fn serve<T: BeaconChainTypes>(
                     let mut receivers = Vec::with_capacity(topics.topics.len());
 
                     if let Some(event_handler) = chain.event_handler.as_ref() {
-                        for topic in topics.topics.clone() {
+                        for topic in topics.topics {
                             let receiver = match topic {
                                 api_types::EventTopic::Head => event_handler.subscribe_head(),
                                 api_types::EventTopic::Block => event_handler.subscribe_block(),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -627,7 +627,6 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(
             |state_id: StateId, chain: Arc<BeaconChain<T>>, validator_id: ValidatorId| {
-                println!("Ran single validator endpoints");
                 blocking_json_task(move || {
                     state_id
                         .map_state(&chain, |state| {

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -429,6 +429,7 @@ pub struct AttestationPoolQuery {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ValidatorsQuery {
     #[serde(default, deserialize_with = "option_query_vec")]
     pub id: Option<Vec<ValidatorId>>,
@@ -542,7 +543,7 @@ where
 {
     let vec: Vec<QueryVec<T>> = Deserialize::deserialize(deserializer)?;
     if vec.is_empty() {
-        return Ok(None)
+        return Ok(None);
     }
 
     Ok(Some(Vec::from(QueryVec::from(vec))))
@@ -567,7 +568,7 @@ impl<T: FromStr> TryFrom<String> for QueryVec<T> {
         Ok(Self {
             values: string
                 .split(',')
-                .map(|s| s.parse().map_err(|_| "unable to parse".to_string()))
+                .map(|s| s.parse().map_err(|_| "unable to parse query".to_string()))
                 .collect::<Result<Vec<T>, String>>()?,
         })
     }
@@ -580,6 +581,7 @@ impl<T: FromStr> From<QueryVec<T>> for Vec<T> {
 }
 
 #[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ValidatorBalancesQuery {
     #[serde(default, deserialize_with = "option_query_vec")]
     pub id: Option<Vec<ValidatorId>>,
@@ -644,6 +646,7 @@ pub struct BeaconCommitteeSubscription {
 }
 
 #[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct PeersQuery {
     #[serde(default, deserialize_with = "option_query_vec")]
     pub state: Option<Vec<PeerState>>,
@@ -902,6 +905,7 @@ impl<T: EthSpec> EventKind<T> {
 }
 
 #[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct EventQuery {
     #[serde(deserialize_with = "query_vec")]
     pub topics: Vec<EventTopic>,
@@ -1006,7 +1010,9 @@ mod tests {
     fn query_vec() {
         assert_eq!(
             QueryVec::try_from("0,1,2".to_string()).unwrap(),
-            QueryVec { values: vec![0_u64, 1, 2] }
+            QueryVec {
+                values: vec![0_u64, 1, 2]
+            }
         );
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -428,10 +428,12 @@ pub struct AttestationPoolQuery {
     pub committee_index: Option<u64>,
 }
 
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 pub struct ValidatorsQuery {
-    pub id: Option<QueryVec<ValidatorId>>,
-    pub status: Option<QueryVec<ValidatorStatus>>,
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub id: Option<Vec<ValidatorId>>,
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub status: Option<Vec<ValidatorStatus>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -520,27 +522,67 @@ pub struct SyncingData {
 
 #[derive(Clone, PartialEq, Debug, Deserialize)]
 #[serde(try_from = "String", bound = "T: FromStr")]
-pub struct QueryVec<T: FromStr>(pub Vec<T>);
+pub struct QueryVec<T: FromStr> {
+    values: Vec<T>,
+}
+
+fn query_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: FromStr,
+{
+    let vec: Vec<QueryVec<T>> = Deserialize::deserialize(deserializer)?;
+    Ok(Vec::from(QueryVec::from(vec)))
+}
+
+fn option_query_vec<'de, D, T>(deserializer: D) -> Result<Option<Vec<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: FromStr,
+{
+    let vec: Vec<QueryVec<T>> = Deserialize::deserialize(deserializer)?;
+    if vec.is_empty() {
+        return Ok(None)
+    }
+
+    Ok(Some(Vec::from(QueryVec::from(vec))))
+}
+
+impl<T: FromStr> From<Vec<QueryVec<T>>> for QueryVec<T> {
+    fn from(vecs: Vec<QueryVec<T>>) -> Self {
+        Self {
+            values: vecs.into_iter().flat_map(|qv| qv.values).collect(),
+        }
+    }
+}
 
 impl<T: FromStr> TryFrom<String> for QueryVec<T> {
     type Error = String;
 
     fn try_from(string: String) -> Result<Self, Self::Error> {
         if string.is_empty() {
-            return Ok(Self(vec![]));
+            return Ok(Self { values: vec![] });
         }
 
-        string
-            .split(',')
-            .map(|s| s.parse().map_err(|_| "unable to parse".to_string()))
-            .collect::<Result<Vec<T>, String>>()
-            .map(Self)
+        Ok(Self {
+            values: string
+                .split(',')
+                .map(|s| s.parse().map_err(|_| "unable to parse".to_string()))
+                .collect::<Result<Vec<T>, String>>()?,
+        })
+    }
+}
+
+impl<T: FromStr> From<QueryVec<T>> for Vec<T> {
+    fn from(vec: QueryVec<T>) -> Vec<T> {
+        vec.values
     }
 }
 
 #[derive(Clone, Deserialize)]
 pub struct ValidatorBalancesQuery {
-    pub id: Option<QueryVec<ValidatorId>>,
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub id: Option<Vec<ValidatorId>>,
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -603,8 +645,10 @@ pub struct BeaconCommitteeSubscription {
 
 #[derive(Deserialize)]
 pub struct PeersQuery {
-    pub state: Option<QueryVec<PeerState>>,
-    pub direction: Option<QueryVec<PeerDirection>>,
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub state: Option<Vec<PeerState>>,
+    #[serde(default, deserialize_with = "option_query_vec")]
+    pub direction: Option<Vec<PeerDirection>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -859,7 +903,8 @@ impl<T: EthSpec> EventKind<T> {
 
 #[derive(Clone, Deserialize)]
 pub struct EventQuery {
-    pub topics: QueryVec<EventTopic>,
+    #[serde(deserialize_with = "query_vec")]
+    pub topics: Vec<EventTopic>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
@@ -961,7 +1006,7 @@ mod tests {
     fn query_vec() {
         assert_eq!(
             QueryVec::try_from("0,1,2".to_string()).unwrap(),
-            QueryVec(vec![0_u64, 1, 2])
+            QueryVec { values: vec![0_u64, 1, 2] }
         );
     }
 }

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -18,3 +18,4 @@ tokio = { version = "1.14.0", features = ["sync"] }
 headers = "0.3.2"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"
+serde_array_query = { git = "https://github.com/sigp/serde_array_query", rev = "67c3eaff7dc42d256509adad2e40a70e973248ec" }

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -18,4 +18,4 @@ tokio = { version = "1.14.0", features = ["sync"] }
 headers = "0.3.2"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"
-serde_array_query = { git = "https://github.com/sigp/serde_array_query", rev = "67c3eaff7dc42d256509adad2e40a70e973248ec" }
+serde_array_query = "0.1.0"

--- a/common/warp_utils/src/lib.rs
+++ b/common/warp_utils/src/lib.rs
@@ -5,3 +5,4 @@ pub mod cors;
 pub mod metrics;
 pub mod reject;
 pub mod task;
+pub mod query;

--- a/common/warp_utils/src/lib.rs
+++ b/common/warp_utils/src/lib.rs
@@ -3,6 +3,6 @@
 
 pub mod cors;
 pub mod metrics;
+pub mod query;
 pub mod reject;
 pub mod task;
-pub mod query;

--- a/common/warp_utils/src/query.rs
+++ b/common/warp_utils/src/query.rs
@@ -1,9 +1,10 @@
+use crate::reject::custom_bad_request;
 use serde::Deserialize;
 use warp::Filter;
 
 pub fn multi_key_query<'de, T: Deserialize<'de>>(
-) -> impl warp::Filter<Extract = (T,), Error = warp::Rejection> + Copy {
-    warp::filters::query::raw().and_then(|query_str: String| async move {
-        serde_array_query::from_str(&query_str).map_err(|_| warp::reject::reject())
+) -> impl warp::Filter<Extract = (Result<T, warp::Rejection>,), Error = warp::Rejection> + Copy {
+    warp::filters::query::raw().then(|query_str: String| async move {
+        serde_array_query::from_str(&query_str).map_err(|e| custom_bad_request(e.to_string()))
     })
 }

--- a/common/warp_utils/src/query.rs
+++ b/common/warp_utils/src/query.rs
@@ -1,0 +1,9 @@
+use serde::Deserialize;
+use warp::Filter;
+
+pub fn multi_key_query<'de, T: Deserialize<'de>>(
+) -> impl warp::Filter<Extract = (T,), Error = warp::Rejection> + Copy {
+    warp::filters::query::raw().and_then(|query_str: String| async move {
+        serde_array_query::from_str(&query_str).map_err(|_| warp::reject::reject())
+    })
+}

--- a/common/warp_utils/src/query.rs
+++ b/common/warp_utils/src/query.rs
@@ -2,9 +2,21 @@ use crate::reject::custom_bad_request;
 use serde::Deserialize;
 use warp::Filter;
 
+// Custom query filter using `serde_array_query`.
+// This allows duplicate keys inside query strings.
 pub fn multi_key_query<'de, T: Deserialize<'de>>(
-) -> impl warp::Filter<Extract = (Result<T, warp::Rejection>,), Error = warp::Rejection> + Copy {
-    warp::filters::query::raw().then(|query_str: String| async move {
+) -> impl warp::Filter<Extract = (Result<T, warp::Rejection>,), Error = std::convert::Infallible> + Copy
+{
+    raw_query().then(|query_str: String| async move {
         serde_array_query::from_str(&query_str).map_err(|e| custom_bad_request(e.to_string()))
     })
+}
+
+// This ensures that empty query strings are still accepted.
+// This is because warp::filters::query::raw() does not allow empty query strings
+// but warp::query::<T>() does.
+fn raw_query() -> impl Filter<Extract = (String,), Error = std::convert::Infallible> + Copy {
+    warp::filters::query::raw()
+        .or(warp::any().map(String::default))
+        .unify()
 }


### PR DESCRIPTION
## Issues Addressed

Closes #2739
Closes #2812

## Proposed Changes

Support the deserialization of query strings containing duplicate keys into their corresponding types.
As `warp` does not support this feature natively (as discussed in #2739), it relies on the external library [`serde_array_query`](https://github.com/sigp/serde_array_query) (written by @michaelsproul)

This is backwards compatible meaning that both of the following requests will produce the same output:
```
curl "http://localhost:5052/eth/v1/events?topics=head,block"
```
```
curl "http://localhost:5052/eth/v1/events?topics=head&topics=block"
```

## Additional Info

Certain error messages have changed slightly.  This only affects endpoints which accept multiple values.
For example:
```
{"code":400,"message":"BAD_REQUEST: invalid query: Invalid query string","stacktraces":[]}
```
is now
```
{"code":400,"message":"BAD_REQUEST: unable to parse query","stacktraces":[]}
```


The serve order of the endpoints `get_beacon_state_validators` and `get_beacon_state_validators_id` have flipped:
```rust
.or(get_beacon_state_validators_id.boxed())
.or(get_beacon_state_validators.boxed())
``` 
This is to ensure proper error messages when filter fallback occurs due to the use of the `and_then` filter.

## Future Work
- Cleanup / remove filter fallback behaviour by substituting `and_then` with `then` where appropriate.
- Add regression tests for HTTP API error messages.

## Credits
- @mooori for doing the ground work of investigating possible solutions within the existing Rust ecosystem.
- @michaelsproul for writing [`serde_array_query`](https://github.com/sigp/serde_array_query) and for helping debug the behaviour of the `warp` filter fallback leading to incorrect error messages.