### PR TITLE
[Merged by Bors] - Fix validator_monitor_prev_epoch_ metrics

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1344,131 +1344,131 @@ impl<T: EthSpec> ValidatorMonitor<T> {
             for (_, validator) in self.validators.iter() {
                 let id = &validator.id;
                 let summaries = validator.summaries.read();
+                let default_summary = EpochSummary::default();
+                let summary = summaries.get(&previous_epoch).unwrap_or(&default_summary);
 
-                if let Some(summary) = summaries.get(&previous_epoch) {
-                    /*
-                     * Attestations
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATIONS_TOTAL,
+                /*
+                 * Attestations
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATIONS_TOTAL,
+                    &[id],
+                    summary.attestations as i64,
+                );
+                if let Some(delay) = summary.attestation_min_delay {
+                    metrics::observe_timer_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATIONS_MIN_DELAY_SECONDS,
                         &[id],
-                        summary.attestations as i64,
-                    );
-                    if let Some(delay) = summary.attestation_min_delay {
-                        metrics::observe_timer_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATIONS_MIN_DELAY_SECONDS,
-                            &[id],
-                            delay,
-                        );
-                    }
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_AGGREGATE_INCLUSIONS,
-                        &[id],
-                        summary.attestation_aggregate_inclusions as i64,
-                    );
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_BLOCK_INCLUSIONS,
-                        &[id],
-                        summary.attestation_block_inclusions as i64,
-                    );
-                    if let Some(distance) = summary.attestation_min_block_inclusion_distance {
-                        metrics::set_gauge_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_BLOCK_MIN_INCLUSION_DISTANCE,
-                            &[id],
-                            distance.as_u64() as i64,
-                        );
-                    }
-                    /*
-                     * Sync committee messages
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_COMMITTEE_MESSAGES_TOTAL,
-                        &[id],
-                        summary.sync_committee_messages as i64,
-                    );
-                    if let Some(delay) = summary.sync_committee_message_min_delay {
-                        metrics::observe_timer_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_COMMITTEE_MESSAGES_MIN_DELAY_SECONDS,
-                            &[id],
-                            delay,
-                        );
-                    }
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTION_INCLUSIONS,
-                        &[id],
-                        summary.sync_signature_contribution_inclusions as i64,
-                    );
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_SIGNATURE_BLOCK_INCLUSIONS,
-                        &[id],
-                        summary.sync_signature_block_inclusions as i64,
-                    );
-
-                    /*
-                     * Sync contributions
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTIONS_TOTAL,
-                        &[id],
-                        summary.sync_contributions as i64,
-                    );
-                    if let Some(delay) = summary.sync_contribution_min_delay {
-                        metrics::observe_timer_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTION_MIN_DELAY_SECONDS,
-                            &[id],
-                            delay,
-                        );
-                    }
-
-                    /*
-                     * Blocks
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_BEACON_BLOCKS_TOTAL,
-                        &[id],
-                        summary.blocks as i64,
-                    );
-                    if let Some(delay) = summary.block_min_delay {
-                        metrics::observe_timer_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_BEACON_BLOCKS_MIN_DELAY_SECONDS,
-                            &[id],
-                            delay,
-                        );
-                    }
-                    /*
-                     * Aggregates
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_AGGREGATES_TOTAL,
-                        &[id],
-                        summary.aggregates as i64,
-                    );
-                    if let Some(delay) = summary.aggregate_min_delay {
-                        metrics::observe_timer_vec(
-                            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_AGGREGATES_MIN_DELAY_SECONDS,
-                            &[id],
-                            delay,
-                        );
-                    }
-                    /*
-                     * Other
-                     */
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_EXITS_TOTAL,
-                        &[id],
-                        summary.exits as i64,
-                    );
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_PROPOSER_SLASHINGS_TOTAL,
-                        &[id],
-                        summary.proposer_slashings as i64,
-                    );
-                    metrics::set_gauge_vec(
-                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTER_SLASHINGS_TOTAL,
-                        &[id],
-                        summary.attester_slashings as i64,
+                        delay,
                     );
                 }
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_AGGREGATE_INCLUSIONS,
+                    &[id],
+                    summary.attestation_aggregate_inclusions as i64,
+                );
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_BLOCK_INCLUSIONS,
+                    &[id],
+                    summary.attestation_block_inclusions as i64,
+                );
+                if let Some(distance) = summary.attestation_min_block_inclusion_distance {
+                    metrics::set_gauge_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTATION_BLOCK_MIN_INCLUSION_DISTANCE,
+                        &[id],
+                        distance.as_u64() as i64,
+                    );
+                }
+                /*
+                 * Sync committee messages
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_COMMITTEE_MESSAGES_TOTAL,
+                    &[id],
+                    summary.sync_committee_messages as i64,
+                );
+                if let Some(delay) = summary.sync_committee_message_min_delay {
+                    metrics::observe_timer_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_COMMITTEE_MESSAGES_MIN_DELAY_SECONDS,
+                        &[id],
+                        delay,
+                    );
+                }
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTION_INCLUSIONS,
+                    &[id],
+                    summary.sync_signature_contribution_inclusions as i64,
+                );
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_SIGNATURE_BLOCK_INCLUSIONS,
+                    &[id],
+                    summary.sync_signature_block_inclusions as i64,
+                );
+
+                /*
+                 * Sync contributions
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTIONS_TOTAL,
+                    &[id],
+                    summary.sync_contributions as i64,
+                );
+                if let Some(delay) = summary.sync_contribution_min_delay {
+                    metrics::observe_timer_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_SYNC_CONTRIBUTION_MIN_DELAY_SECONDS,
+                        &[id],
+                        delay,
+                    );
+                }
+
+                /*
+                 * Blocks
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_BEACON_BLOCKS_TOTAL,
+                    &[id],
+                    summary.blocks as i64,
+                );
+                if let Some(delay) = summary.block_min_delay {
+                    metrics::observe_timer_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_BEACON_BLOCKS_MIN_DELAY_SECONDS,
+                        &[id],
+                        delay,
+                    );
+                }
+                /*
+                 * Aggregates
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_AGGREGATES_TOTAL,
+                    &[id],
+                    summary.aggregates as i64,
+                );
+                if let Some(delay) = summary.aggregate_min_delay {
+                    metrics::observe_timer_vec(
+                        &metrics::VALIDATOR_MONITOR_PREV_EPOCH_AGGREGATES_MIN_DELAY_SECONDS,
+                        &[id],
+                        delay,
+                    );
+                }
+                /*
+                 * Other
+                 */
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_EXITS_TOTAL,
+                    &[id],
+                    summary.exits as i64,
+                );
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_PROPOSER_SLASHINGS_TOTAL,
+                    &[id],
+                    summary.proposer_slashings as i64,
+                );
+                metrics::set_gauge_vec(
+                    &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ATTESTER_SLASHINGS_TOTAL,
+                    &[id],
+                    summary.attester_slashings as i64,
+                );
             }
         }
     }


### PR DESCRIPTION
## Issue Addressed

#2820

## Proposed Changes

The problem is that validator_monitor_prev_epoch metrics are updated only if there is EpochSummary present in summaries map for the previous epoch and it is not the case for the offline validator. Ensure that EpochSummary is inserted into summaries map also for the offline validators.