### PR TITLE
[Merged by Bors] - Remove gitter from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ of the Lighthouse book.
 ## Contact
 
 The best place for discussion is the [Lighthouse Discord
-server](https://discord.gg/cyAszAh). Alternatively, you may use the
-[sigp/lighthouse gitter](https://gitter.im/sigp/lighthouse).
+server](https://discord.gg/cyAszAh). 
 
 Sign up to the [Lighthouse Development Updates](http://eepurl.com/dh9Lvb) mailing list for email
 notifications about releases, network status and other important information.


### PR DESCRIPTION
We dont check gitter, so shouldn't refer users to it.