### PR TITLE
[Merged by Bors] - Remove grandparents from snapshot cache

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2796,6 +2796,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         beacon_block_root: block_root,
                     },
                     None,
+                    &self.spec,
                 )
             })
             .unwrap_or_else(|e| {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3740,6 +3740,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
             .map(|mut snapshot_cache| {
                 snapshot_cache.prune(new_finalized_checkpoint.epoch);
+                debug!(
+                    self.log,
+                    "Snapshot cache pruned";
+                    "new_len" => snapshot_cache.len(),
+                    "remaining_roots" => ?snapshot_cache.beacon_block_roots(),
+                );
             })
             .unwrap_or_else(|| {
                 error!(

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -1,4 +1,4 @@
-use crate::{metrics, BeaconSnapshot};
+use crate::BeaconSnapshot;
 use std::cmp;
 use std::time::Duration;
 use types::{

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -164,6 +164,11 @@ impl<T: EthSpec> SnapshotCache<T> {
         }
     }
 
+    /// The number of snapshots contained in `self`.
+    pub fn len(&self) -> usize {
+        self.snapshots.len()
+    }
+
     /// Insert a snapshot, potentially removing an existing snapshot if `self` is at capacity (see
     /// struct-level documentation for more info).
     pub fn insert(&mut self, snapshot: BeaconSnapshot<T>, pre_state: Option<BeaconState<T>>) {

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -200,8 +200,7 @@ impl<T: EthSpec> SnapshotCache<T> {
         let grandparent_result =
             process_results(item.beacon_state.rev_iter_block_roots(spec), |iter| {
                 iter.map(|(_slot, root)| root)
-                    .skip_while(|root| *root == item.beacon_block_root || *root == parent_root)
-                    .next()
+                    .find(|root| *root != item.beacon_block_root && *root != parent_root)
             });
         if let Ok(Some(grandparent_root)) = grandparent_result {
             let head_block_root = self.head_block_root;

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -200,7 +200,8 @@ impl<T: EthSpec> SnapshotCache<T> {
         let grandparent_result =
             process_results(item.beacon_state.rev_iter_block_roots(spec), |iter| {
                 iter.map(|(_slot, root)| root)
-                    .find(|root| *root != parent_root)
+                    .skip_while(|root| *root == item.beacon_block_root || *root == parent_root)
+                    .next()
             });
         if let Ok(Some(grandparent_root)) = grandparent_result {
             let head_block_root = self.head_block_root;

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -164,6 +164,11 @@ impl<T: EthSpec> SnapshotCache<T> {
         }
     }
 
+    /// The block roots of all snapshots contained in `self`.
+    pub fn beacon_block_roots(&self) -> Vec<Hash256> {
+        self.snapshots.iter().map(|s| s.beacon_block_root).collect()
+    }
+
     /// The number of snapshots contained in `self`.
     pub fn len(&self) -> usize {
         self.snapshots.len()


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

In https://github.com/sigp/lighthouse/pull/2832 we made some changes to the `SnapshotCache` to help deal with the one-block reorgs seen on mainnet (and testnets).

I believe the change in #2832 is good and we should keep it, but I think that in its present form it is causing the `SnapshotCache` to hold onto states that it doesn't need anymore. For example, a skip slot will result in one more `BeaconSnapshot` being stored in the cache.

This PR adds a new type of pruning that happens after a block is inserted to the cache. We will remove any snapshot from the cache that is a *grandparent* of the block being imported. Since we know the grandparent has two valid blocks built atop it, it is not at risk from a one-block re-org. 

## Additional Info

NA
