### PR TITLE
[Merged by Bors] - Fix errors from local testnet scripts on MacOS

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -2,7 +2,7 @@
 name: local testnet
 
 on:
-  push:
+  pull_request:
 
 jobs:
   run-local-testnet:

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -1,0 +1,26 @@
+# Test that local testnet starts successfully.
+name: local testnet
+
+on:
+  push:
+
+jobs:
+  run-local-testnet:
+    strategy:
+      matrix:
+        os:
+          - ubuntu-18.04
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install ganache
+        run: npm install ganache-cli@latest --global
+
+      - name: Install lighthouse
+        run: make && make install-lcli
+
+      - name: Run local testnet
+        run: ./start_local_testnet.sh
+        working-directory: scripts/local_testnet

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -21,7 +21,20 @@ jobs:
       - name: Install ganache
         run: npm install ganache-cli@latest --global
 
+      # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
+      - uses: actions/cache@v2
+        id: cache-cargo
+        with:
+          path: |
+              ~/.cargo/bin/
+              ~/.cargo/registry/index/
+              ~/.cargo/registry/cache/
+              ~/.cargo/git/db/
+              target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install lighthouse
+        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: make && make install-lcli
 
       - name: Start local testnet

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -2,6 +2,9 @@
 name: local testnet
 
 on:
+  push:
+    branches:
+      - unstable
   pull_request:
 
 jobs:

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -41,6 +41,10 @@ jobs:
         run: ./start_local_testnet.sh
         working-directory: scripts/local_testnet
 
+      - name: Print logs
+        run: ./print_logs.sh
+        working-directory: scripts/local_testnet
+
       - name: Stop local testnet
         run: ./stop_local_testnet.sh
         working-directory: scripts/local_testnet

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Install lighthouse
         run: make && make install-lcli
 
-      - name: Run local testnet
+      - name: Start local testnet
         run: ./start_local_testnet.sh
+        working-directory: scripts/local_testnet
+
+      - name: Stop local testnet
+        run: ./stop_local_testnet.sh
         working-directory: scripts/local_testnet

--- a/scripts/local_testnet/beacon_node.sh
+++ b/scripts/local_testnet/beacon_node.sh
@@ -4,6 +4,8 @@
 # Starts a beacon node based upon a genesis state created by `./setup.sh`.
 #
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 SUBSCRIBE_ALL_SUBNETS=

--- a/scripts/local_testnet/bootnode.sh
+++ b/scripts/local_testnet/bootnode.sh
@@ -5,6 +5,8 @@
 # Starts a bootnode from the generated enr.
 #
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 echo "Generating bootnode enr"

--- a/scripts/local_testnet/clean.sh
+++ b/scripts/local_testnet/clean.sh
@@ -4,6 +4,8 @@
 # Deletes all files associated with the local testnet.
 #
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 if [ -d $DATADIR ]; then

--- a/scripts/local_testnet/ganache_test_node.sh
+++ b/scripts/local_testnet/ganache_test_node.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 exec ganache-cli \

--- a/scripts/local_testnet/kill_processes.sh
+++ b/scripts/local_testnet/kill_processes.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Kill processes
 
+set -Eeuo pipefail
+
 # First parameter is the file with
 # one pid per line.
 if [ -f "$1" ]; then

--- a/scripts/local_testnet/print_logs.sh
+++ b/scripts/local_testnet/print_logs.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Print the tail of all the logs output from local testnet
+
+set -Eeuo pipefail
+
+source ./vars.env
+
+for f in "$TESTNET_DIR"/*.log
+do
+  [[ -e "$f" ]] || break # handle the case of no *.log files
+  echo "============================================================================="
+  echo "$f"
+  echo "============================================================================="
+  tail "$f"
+  echo ""
+done

--- a/scripts/local_testnet/reset_genesis_time.sh
+++ b/scripts/local_testnet/reset_genesis_time.sh
@@ -4,6 +4,8 @@
 # Resets the beacon state genesis time to now.
 #
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 NOW=$(date +%s)

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -69,7 +69,7 @@ execute_command() {
     EX_NAME=$2
     shift
     shift
-    CMD="$EX_NAME $@ &>> $LOG_DIR/$LOG_NAME"
+    CMD="$EX_NAME $@ >> $LOG_DIR/$LOG_NAME 2>&1"
     echo "executing: $CMD"
     echo "$CMD" > "$LOG_DIR/$LOG_NAME"
     eval "$CMD &"

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Start all processes necessary to create a local testnet
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 # VC_COUNT is defaulted in vars.env
@@ -49,7 +51,7 @@ for (( bn=1; bn<=$BN_COUNT; bn++ )); do
 done
 for (( vc=1; vc<=$VC_COUNT; vc++ )); do
     touch $LOG_DIR/validator_node_$vc.log
-done 
+done
 
 # Sleep with a message
 sleeping() {

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -91,7 +91,7 @@ execute_command_add_PID() {
 
 # Delay to let ganache-cli to get started
 execute_command_add_PID ganache_test_node.log ./ganache_test_node.sh
-sleeping 2
+sleeping 10
 
 # Delay to get data setup
 execute_command setup.log ./setup.sh

--- a/scripts/local_testnet/stop_local_testnet.sh
+++ b/scripts/local_testnet/stop_local_testnet.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Stop all processes that were started with start_local_testnet.sh
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 PID_FILE=$TESTNET_DIR/PIDS.pid

--- a/scripts/local_testnet/validator_client.sh
+++ b/scripts/local_testnet/validator_client.sh
@@ -6,6 +6,8 @@
 #
 # Usage: ./validator_client.sh <DATADIR> <BEACON-NODE-HTTP> <OPTIONAL-DEBUG-LEVEL>
 
+set -Eeuo pipefail
+
 source ./vars.env
 
 DEBUG_LEVEL=${3:-info}

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -43,3 +43,6 @@ SECONDS_PER_SLOT=3
 
 # Seconds per Eth1 block
 SECONDS_PER_ETH1_BLOCK=1
+
+# Command line arguments for validator client
+VC_ARGS=""


### PR DESCRIPTION
## Issue Addressed

Resolves https://github.com/sigp/lighthouse/issues/2763

## Proposed Changes

- Add a workflow which tests that local testnet starts successfully
  - Added `set` option into the scripts in order to fail fast so that we can notice errors during starting local testnet.
- Fix errors on MacOS
  - The redirect `&>>` is supported since bash v4 but the version bundled in macOS(11.6.1) is v3. https://github.com/sigp/lighthouse/pull/2919/commits/a54f119c9b1839fd0909792d219858e727e120a2
