### PR TITLE
[Merged by Bors] - Allow disconnected states to introduce new peers without warning

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -666,9 +666,11 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             // connection state for an unknown peer.
             if !matches!(
                 new_state,
-                NewConnectionState::Connected { .. }
-                    | NewConnectionState::Disconnecting { .. }
-                    | NewConnectionState::Dialing { .. }
+                NewConnectionState::Connected { .. }          // We have established a new connection (peer may not have been seen before)
+                    | NewConnectionState::Disconnecting { .. }// We are disconnecting from a peer that may not have been registered before
+                    | NewConnectionState::Dialing { .. }      // We are dialing a potentially new peer
+                    | NewConnectionState::Disconnected { .. } // Dialing a peer that responds by a different ID can be immediately
+                                                              // disconnected without having being stored in the db before
             ) {
                 warn!(log_ref, "Updating state of unknown peer";
                     "peer_id" => %peer_id, "new_state" => ?new_state);


### PR DESCRIPTION
## Issue Addressed

We emit a warning to verify that all peer connection state information is consistent. A warning is given under one edge case;
We try to dial a peer with peer-id X and multiaddr Y. The peer responds to multiaddr Y with a different peer-id, Z. The dialing to the peer fails, but libp2p injects the failed attempt as peer-id Z. 

In this instance, our PeerDB tries to add a new peer in the disconnected state under a previously unknown peer-id. This is harmless and so this PR permits this behaviour without logging a warning.