### PR TITLE
[Merged by Bors] - Document why we hash downloaded blocks for both sync algs

### DIFF
--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -802,7 +802,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     for attempt in batch.attempts() {
                         // The validated batch has been re-processed
                         if attempt.hash != processed_attempt.hash {
-                            // The re-downloaded version had a different number of blocks
+                            // The re-downloaded version was different.
                             if processed_attempt.peer_id != attempt.peer_id {
                                 // A different peer sent the correct batch, the previous peer did not
                                 // We negatively score the original peer.

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -54,6 +54,9 @@ impl BatchConfig for BackFillBatchConfig {
     fn max_batch_processing_attempts() -> u8 {
         MAX_BATCH_PROCESSING_ATTEMPTS
     }
+    fn batch_attempt_hash<T: EthSpec>(blocks: &[SignedBeaconBlock<T>]) -> u64 {
+        blocks.len() as u64
+    }
 }
 
 /// Return type when attempting to start the backfill sync process.
@@ -119,7 +122,7 @@ pub struct BackFillSync<T: BeaconChainTypes> {
     /// Batches validated by this chain.
     validated_batches: u64,
 
-    /// We keep track of peer that are participating in the backfill sync. Unlike RangeSync,
+    /// We keep track of peers that are participating in the backfill sync. Unlike RangeSync,
     /// BackFillSync uses all synced peers to download the chain from. If BackFillSync fails, we don't
     /// want to penalize all our synced peers, so we use this variable to keep track of peers that
     /// have participated and only penalize these peers if backfill sync fails.
@@ -539,7 +542,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 "error" => %e, "batch" => self.processing_target);
             // This is unlikely to happen but it would stall syncing since the batch now has no
             // blocks to continue, and the chain is expecting a processing result that won't
-            // arrive.  To mitigate this, (fake) fail this processing so that the batch is
+            // arrive. To mitigate this, (fake) fail this processing so that the batch is
             // re-downloaded.
             self.on_batch_process_result(
                 network,
@@ -795,7 +798,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     for attempt in batch.attempts() {
                         // The validated batch has been re-processed
                         if attempt.hash != processed_attempt.hash {
-                            // The re-downloaded version was different
+                            // The re-downloaded version had a different number of blocks
                             if processed_attempt.peer_id != attempt.peer_id {
                                 // A different peer sent the correct batch, the previous peer did not
                                 // We negatively score the original peer.

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -55,7 +55,11 @@ impl BatchConfig for BackFillBatchConfig {
         MAX_BATCH_PROCESSING_ATTEMPTS
     }
     fn batch_attempt_hash<T: EthSpec>(blocks: &[SignedBeaconBlock<T>]) -> u64 {
-        blocks.len() as u64
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+        let mut hasher = DefaultHasher::new();
+        blocks.hash(&mut hasher);
+        hasher.finish()
     }
 }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -131,7 +131,7 @@ pub enum SyncRequestType {
     RangeSync(Epoch, ChainId),
 }
 
-/// The result of processing a multiple blocks (a chain segment).
+/// The result of processing multiple blocks (a chain segment).
 #[derive(Debug)]
 pub enum BatchProcessResult {
     /// The batch was completed successfully. It carries whether the sent batch contained blocks.

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -22,7 +22,7 @@ pub trait BatchConfig {
     /// Hashing function of a batch's attempt. Used for scoring purposes.
     ///
     /// When a batch fails processing, it is possible that the batch is wrong (faulty or incomplete) or
-    /// that a previous one is wrong. For this reason we need to re-downloaded and re-process the
+    /// that a previous one is wrong. For this reason we need to re-download and re-process the
     /// unvalidated batches and the current one. Consider this scenario:
     /// ```ignore
     /// BatchA BatchB BatchC BatchD

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -21,9 +21,10 @@ pub trait BatchConfig {
     fn max_batch_processing_attempts() -> u8;
     /// Hashing function of a batch's attempt. Used for scoring purposes.
     ///
-    /// When a batch fails processing, it is possible that the batch is wrong (faulty or incomplete) or
-    /// that a previous one is wrong. For this reason we need to re-download and re-process the
-    /// unvalidated batches and the current one. Consider this scenario:
+    /// When a batch fails processing, it is possible that the batch is wrong (faulty or
+    /// incomplete) or that a previous one is wrong. For this reason we need to re-download and
+    /// re-process the batches awaiting validation and the current one. Consider this scenario:
+    ///
     /// ```ignore
     /// BatchA BatchB BatchC BatchD
     /// -----X Empty  Empty  Y-----

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -23,13 +23,13 @@ pub trait BatchConfig {
     ///
     /// When a batch fails processing, it is possible that the batch is wrong (faulty or incomplete) or
     /// that a previous one is wrong. For this reason we need to re-downloaded and re-process the
-    /// unvalidated batches and the current one. Consider this escenario:
+    /// unvalidated batches and the current one. Consider this scenario:
     /// ```
     /// BatchA BatchB BatchC BatchD
     /// -----X Empty  Empty  Y-----
     /// ```
     ///
-    /// BatchA declares that it referes X, but BatchD declares that it's first block is Y. There is no
+    /// BatchA declares that it refers X, but BatchD declares that it's first block is Y. There is no
     /// way to know if BatchD is faulty/incomplete or if batches B and/or C are missing blocks. It is
     /// also possible that BatchA belongs to a different chain to the rest starting in some block
     /// midway in the batch's range. For this reason, the four batches would need to be re-downloaded
@@ -43,7 +43,7 @@ pub trait BatchConfig {
     /// storing the full set of blocks.
     ///
     /// Note that simpler hashing functions considered in the past (hash of first block, hash of last
-    /// block, number of received blocks) are not good enought to differentiate attempts. For this
+    /// block, number of received blocks) are not good enough to differentiate attempts. For this
     /// reason, we hash the complete set of blocks both in RangeSync and BackFillSync.
     fn batch_attempt_hash<T: EthSpec>(blocks: &[SignedBeaconBlock<T>]) -> u64;
 }

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -24,7 +24,7 @@ pub trait BatchConfig {
     /// When a batch fails processing, it is possible that the batch is wrong (faulty or incomplete) or
     /// that a previous one is wrong. For this reason we need to re-downloaded and re-process the
     /// unvalidated batches and the current one. Consider this scenario:
-    /// ```
+    /// ```ignore
     /// BatchA BatchB BatchC BatchD
     /// -----X Empty  Empty  Y-----
     /// ```


### PR DESCRIPTION
## Proposed Changes
Initially the idea was to remove hashing of blocks in backfill sync. After considering it more, we conclude that we need to do it in both (forward and backfill) anyway. But since we forgot why we were doing it in the first place, this PR documents this logic. 

Future us should find it useful 
