### PR TITLE
[Merged by Bors] - upgrade libp2p

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,12 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
-
-[[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1d36a02058e76b040de25a4464ba1c80935655595b661505c8b39b664828b95"
+checksum = "03588e54c62ae6d763e2a80090d50353b785795361b4ff5b3bf0a5097fc31c0b"
 dependencies = [
  "generic-array",
 ]
@@ -699,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -814,12 +808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
 
 [[package]]
-name = "const-oid"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -940,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -953,18 +941,6 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "crypto-common"
@@ -1131,17 +1107,8 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eeb9d92785d1facb50567852ce75d0858630630e7eabea59cf7eb7474051087"
 dependencies = [
- "const-oid 0.5.2",
+ "const-oid",
  "typenum",
-]
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
 ]
 
 [[package]]
@@ -1194,7 +1161,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b697d66081d42af4fba142d56918a3cb21dc8eb63372c6b85d14f44fb9c5979b"
 dependencies = [
- "block-buffer 0.10.0",
+ "block-buffer 0.10.1",
  "crypto-common",
  "generic-array",
 ]
@@ -1278,15 +1245,15 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uint 0.9.2",
+ "uint 0.9.3",
  "zeroize",
 ]
 
 [[package]]
 name = "dtoa"
-version = "0.4.8"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+checksum = "5caaa75cbd2b960ff1e5392d2cfb1f44717fffe12fc1f32b7b5d1267f99732a6"
 
 [[package]]
 name = "ecdsa"
@@ -1294,21 +1261,9 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34d33b390ab82f2e1481e331dbd0530895640179d2128ef9a79cc690b78d1eba"
 dependencies = [
- "der 0.3.5",
- "elliptic-curve 0.9.12",
+ "der",
+ "elliptic-curve",
  "hmac 0.11.0",
- "signature",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
-dependencies = [
- "der 0.5.1",
- "elliptic-curve 0.11.12",
- "rfc6979",
  "signature",
 ]
 
@@ -1378,29 +1333,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
  "bitvec 0.20.4",
- "ff 0.9.0",
+ "ff",
  "generic-array",
- "group 0.9.0",
+ "group",
  "pkcs8",
  "rand_core 0.6.3",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "der 0.5.1",
- "ff 0.11.0",
- "generic-array",
- "group 0.11.0",
- "rand_core 0.6.3",
- "sec1",
  "subtle",
  "zeroize",
 ]
@@ -1772,7 +1709,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
- "uint 0.9.2",
+ "uint 0.9.3",
 ]
 
 [[package]]
@@ -1826,7 +1763,7 @@ dependencies = [
  "impl-rlp 0.3.0",
  "impl-serde",
  "primitive-types 0.9.1",
- "uint 0.9.2",
+ "uint 0.9.3",
 ]
 
 [[package]]
@@ -1840,7 +1777,7 @@ dependencies = [
  "impl-rlp 0.3.0",
  "impl-serde",
  "primitive-types 0.10.1",
- "uint 0.9.2",
+ "uint 0.9.3",
 ]
 
 [[package]]
@@ -1916,16 +1853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
  "bitvec 0.20.4",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "ff"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2958d04124b9f27f175eaeb9a9f383d026098aa837eadd8ba22c11f13a05b9e"
-dependencies = [
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -2268,18 +2195,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
 dependencies = [
- "ff 0.9.0",
- "rand_core 0.6.3",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
-dependencies = [
- "ff 0.11.0",
+ "ff",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -2805,8 +2721,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3e8e491ed22bc161583a1c77e42313672c483eba6bd9d7afec0f1131d0b9ce"
 dependencies = [
  "cfg-if",
- "ecdsa 0.11.1",
- "elliptic-curve 0.9.12",
+ "ecdsa",
+ "elliptic-curve",
  "sha2 0.9.9",
 ]
 
@@ -2889,9 +2805,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
 
 [[package]]
 name = "libflate"
@@ -2948,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "libp2p"
 version = "0.42.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "atomic",
  "bytes",
@@ -3014,7 +2930,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.31.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -3030,7 +2946,6 @@ dependencies = [
  "multiaddr",
  "multihash",
  "multistream-select 0.11.0",
- "p256",
  "parking_lot",
  "pin-project 1.0.10",
  "prost",
@@ -3049,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.31.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "futures",
  "libp2p-core 0.31.0",
@@ -3061,7 +2976,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.35.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -3089,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.33.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3105,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.3.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "libp2p-core 0.31.0",
  "libp2p-gossipsub",
@@ -3117,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.31.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3134,7 +3049,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.34.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "bytes",
  "curve25519-dalek",
@@ -3155,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.31.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3171,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.33.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "either",
  "futures",
@@ -3187,7 +3102,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.26.1"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "quote",
  "syn",
@@ -3196,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.31.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3212,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.33.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "either",
  "futures",
@@ -3229,7 +3144,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.35.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "futures",
  "libp2p-core 0.31.0",
@@ -3796,7 +3711,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.11.0"
-source = "git+https://github.com/libp2p/rust-libp2p?rev=17861d9cac121f7e448585a7f052d5eab4618826#17861d9cac121f7e448585a7f052d5eab4618826"
+source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 dependencies = [
  "bytes",
  "futures",
@@ -4046,12 +3961,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open-metrics-client"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e224744b2e4da5b241857d2363a13bce60425f7b6ae2a5ff88d4d5557d9cc85"
+checksum = "f85842b073145726190373213c63f852020fb884c841a3a1f390637267a2fb8c"
 dependencies = [
  "dtoa",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "open-metrics-client-derive-text-encode",
  "owning_ref",
 ]
@@ -4137,18 +4052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "p256"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19736d80675fbe9fe33426268150b951a3fb8f5cfca2a23a17c85ef3adb24e3b"
-dependencies = [
- "ecdsa 0.13.4",
- "elliptic-curve 0.11.12",
- "sec1",
- "sha2 0.9.9",
 ]
 
 [[package]]
@@ -4333,7 +4236,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9c2f795bc591cb3384cb64082a578b89207ac92bb89c9d98c1ea2ace7cd8110"
 dependencies = [
- "der 0.3.5",
+ "der",
  "spki",
 ]
 
@@ -4429,7 +4332,7 @@ dependencies = [
  "impl-codec 0.5.1",
  "impl-rlp 0.3.0",
  "impl-serde",
- "uint 0.9.2",
+ "uint 0.9.3",
 ]
 
 [[package]]
@@ -4442,7 +4345,7 @@ dependencies = [
  "impl-codec 0.5.1",
  "impl-rlp 0.3.0",
  "impl-serde",
- "uint 0.9.2",
+ "uint 0.9.3",
 ]
 
 [[package]]
@@ -4588,9 +4491,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.26.0"
+version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d613b4fd96c0182e187734b4f8fc5cbc8c940bbf781819f7a52d42dc5922d25"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "psutil"
@@ -4925,17 +4828,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
-dependencies = [
- "crypto-bigint",
- "hmac 0.11.0",
- "zeroize",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5042,7 +4934,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.4",
+ "semver 1.0.5",
 ]
 
 [[package]]
@@ -5185,18 +5077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sec1"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
-dependencies = [
- "der 0.5.1",
- "generic-array",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5229,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57321bf8bc2362081b2599912d2961fe899c0efadf1b4b2f8d48b3e253bb96c"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5257,9 +5137,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
 
 [[package]]
 name = "semver-parser"
@@ -5745,7 +5625,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dae7e047abc519c96350e9484a96c6bf1492348af912fd3446dd2dc323f6268"
 dependencies = [
- "der 0.3.5",
+ "der",
 ]
 
 [[package]]
@@ -6262,9 +6142,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
 dependencies = [
  "cfg-if",
  "log",
@@ -6275,9 +6155,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6286,11 +6166,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
 dependencies = [
  "lazy_static",
+ "valuable",
 ]
 
 [[package]]
@@ -6316,9 +6197,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5312f325fe3588e277415f5a6cca1f4ccad0f248c4cd5a4bd33032d7286abc22"
+checksum = "74786ce43333fcf51efe947aed9718fbe46d5c7328ec3f1029e818083966d9aa"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -6388,9 +6269,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0d7f5db438199a6e2609debe3f69f808d074e0a2888ee0bccb45fe234d03f4"
+checksum = "ca94d4e9feb6a181c690c4040d7a24ef34018d8313ac5044a61d21222ae24e31"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -6413,9 +6294,9 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.3"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad17b608a64bd0735e67bde16b0636f8aa8591f831a25d18443ed00a699770"
+checksum = "ecae383baad9995efaa34ce8e57d12c3f305e545887472a492b838f4b5cfb77a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6555,9 +6436,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1b413ebfe8c2c74a69ff124699dd156a7fa41cb1d09ba6df94aa2f2b0a4a3a"
+checksum = "12f03af7ccf01dd611cc450a0d10dbc9b745770d096473e2faf0ca6e2d66d1e0"
 dependencies = [
  "arbitrary",
  "byteorder",
@@ -6746,6 +6627,12 @@ dependencies = [
  "tree_hash",
  "types",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"
@@ -7202,9 +7089,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d9028f208dd5e63c614be69f115c1b53cacc1111437d4c765185856666c107"
+checksum = "29d4c1dd079043fe673e79fe3c3a260ae2d2fb413f1062cae9e062748df0df03"
 dependencies = [
  "futures",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,8 +2863,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.42.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b2368208a825a2eee46fc5f2db54204074404f102b22b24cd7666a5e622ed8"
 dependencies = [
  "atomic",
  "bytes",
@@ -2930,7 +2931,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.31.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24250cce58fb6ccb32e26647c1c25b48b6f7bd2d6fb3d6dba72001a6694b385"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2964,7 +2966,8 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.31.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39d4a2e7efe62c738833b6be6c0f158cf7ffccba462320f4b3bebe43e1050e7b"
 dependencies = [
  "futures",
  "libp2p-core 0.31.0",
@@ -2976,7 +2979,8 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.35.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385ae5f44e84f51e17014c9f1d98464121d3b1b182c167a0b4482d6250c61926"
 dependencies = [
  "asynchronous-codec",
  "base64 0.13.0",
@@ -3004,7 +3008,8 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.33.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae5d84b4e57cb66abb9dd28ea36f69620816e004a7479c0ad76f45002820f99b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3020,7 +3025,8 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.3.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0791098ddec13b0c2f9ed37a29175f7c712ce8804ebaba7cbd8bddbc83120190"
 dependencies = [
  "libp2p-core 0.31.0",
  "libp2p-gossipsub",
@@ -3032,7 +3038,8 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.31.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d470ee73a74340e429fa278469ed274a648738e3fb8de2e8d113482441732f"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3049,7 +3056,8 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.34.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676dc2df10a7f4f6a80fbeaf2ce4168a0ca6567273e3105b21fa4c877be9017"
 dependencies = [
  "bytes",
  "curve25519-dalek",
@@ -3070,7 +3078,8 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.31.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83203abb14ae77de42c49be8dbed7ea8dfb83e76773226aa664a96e6c5e18c5d"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -3086,7 +3095,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.33.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8ae0811c7a05b6edc6684eb5cc69b055cbb715ad780e6b97872d90308503c1"
 dependencies = [
  "either",
  "futures",
@@ -3102,7 +3112,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.26.1"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b4d0acd47739fe0b570728d8d11bbb535050d84c0cf05d6477a4891fceae10"
 dependencies = [
  "quote",
  "syn",
@@ -3110,8 +3121,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.31.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52042e8796c5b58d0415bceb1bcb1bcca28b222339978e52b1a0305800bb5199"
 dependencies = [
  "futures",
  "futures-timer",
@@ -3127,7 +3139,8 @@ dependencies = [
 [[package]]
 name = "libp2p-websocket"
 version = "0.33.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d788da0ab952632d6ead2486baf38a98db92907d4bc5d0f324af0d0fab803d"
 dependencies = [
  "either",
  "futures",
@@ -3144,7 +3157,8 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.35.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053d13ce0670d29f9c5a974cf371e6cc4d2d864da1c72bf6870ac5d5e45e2036"
 dependencies = [
  "futures",
  "libp2p-core 0.31.0",
@@ -3711,7 +3725,8 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.11.0"
-source = "git+https://github.com/mxinden/rust-libp2p?rev=d5744380c2aa4c4ed7814ec456faaf8dd9152467#d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "363a84be6453a70e63513660f4894ef815daf88e3356bffcda9ca27d810ce83b"
 dependencies = [
  "bytes",
  "futures",

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ arbitrary-fuzz:
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit:
 	cargo install --force cargo-audit
-	cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159
+	cargo audit --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2022-0009
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -41,11 +41,8 @@ superstruct = "0.4.0"
 open-metrics-client = "0.14.0"
 
 [dependencies.libp2p]
-# version = "0.42.0"
+version = "0.42.1"
 default-features = false
-git = "https://github.com/mxinden/rust-libp2p"
-# Prepare release of 0.42.0
-rev = "d5744380c2aa4c4ed7814ec456faaf8dd9152467"
 features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns-tokio", "tcp-tokio", "plaintext", "secp256k1"]
 
 [dev-dependencies]

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -38,15 +38,15 @@ directory = { path = "../../common/directory" }
 regex = "1.3.9"
 strum = { version = "0.21.0", features = ["derive"] }
 superstruct = "0.4.0"
-open-metrics-client = "0.13.0"
+open-metrics-client = "0.14.0"
 
 [dependencies.libp2p]
-# version = "0.41.0"
+# version = "0.42.0"
 default-features = false
-git = "https://github.com/libp2p/rust-libp2p"
-# Latest libp2p master
-rev = "17861d9cac121f7e448585a7f052d5eab4618826"
-features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns-tokio", "tcp-tokio", "plaintext"]
+git = "https://github.com/mxinden/rust-libp2p"
+# Prepare release of 0.42.0
+rev = "d5744380c2aa4c4ed7814ec456faaf8dd9152467"
+features = ["websocket", "identify", "mplex", "yamux", "noise", "gossipsub", "dns-tokio", "tcp-tokio", "plaintext", "secp256k1"]
 
 [dev-dependencies]
 slog-term = "2.6.0"

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -963,10 +963,11 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
             match error {
                 DialError::Banned
                 | DialError::LocalPeerId
-                | DialError::InvalidPeerId
+                | DialError::InvalidPeerId(_)
                 | DialError::ConnectionIo(_)
                 | DialError::NoAddresses
-                | DialError::Transport(_) => {
+                | DialError::Transport(_)
+                | DialError::WrongPeerId { .. } => {
                     // set peer as disconnected in discovery DHT
                     debug!(self.log, "Marking peer disconnected in DHT"; "peer_id" => %peer_id);
                     self.disconnect_peer(&peer_id);

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -161,7 +161,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for PeerManager<TSpec> {
                 self.events
                     .push(PeerManagerEvent::PeerConnectedIncoming(*peer_id));
             }
-            ConnectedPoint::Dialer { address } => {
+            ConnectedPoint::Dialer { address, .. } => {
                 self.inject_connect_outgoing(peer_id, address.clone(), None);
                 self.events
                     .push(PeerManagerEvent::PeerConnectedOutgoing(*peer_id));


### PR DESCRIPTION
## Issue Addressed

Upgrades libp2p to v.0.42.0 pre release (https://github.com/libp2p/rust-libp2p/pull/2440)

