### PR TITLE
[Merged by Bors] - Make /config/spec backwards compat for VC

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -631,8 +631,12 @@ pub struct Config {
     #[serde(deserialize_with = "deserialize_fork_epoch")]
     pub altair_fork_epoch: Option<MaybeQuoted<Epoch>>,
 
+    // TODO(merge): remove this default
+    #[serde(default = "default_bellatrix_fork_version")]
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]
     bellatrix_fork_version: [u8; 4],
+    // TODO(merge): remove this default
+    #[serde(default = "default_bellatrix_fork_epoch")]
     #[serde(serialize_with = "serialize_fork_epoch")]
     #[serde(deserialize_with = "deserialize_fork_epoch")]
     pub bellatrix_fork_epoch: Option<MaybeQuoted<Epoch>>,
@@ -667,6 +671,15 @@ pub struct Config {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     deposit_network_id: u64,
     deposit_contract_address: Address,
+}
+
+fn default_bellatrix_fork_version() -> [u8; 4] {
+    // This value shouldn't be used.
+    [0xff, 0xff, 0xff, 0xff]
+}
+
+fn default_bellatrix_fork_epoch() -> Option<MaybeQuoted<Epoch>> {
+    None
 }
 
 impl Default for Config {

--- a/consensus/types/src/config_and_preset.rs
+++ b/consensus/types/src/config_and_preset.rs
@@ -14,9 +14,9 @@ pub struct ConfigAndPreset {
     pub base_preset: BasePreset,
     #[serde(flatten)]
     pub altair_preset: AltairPreset,
-    #[serde(flatten)]
-    pub bellatrix_preset: BellatrixPreset,
-
+    // TODO(merge): re-enable
+    // #[serde(flatten)]
+    // pub bellatrix_preset: BellatrixPreset,
     /// The `extra_fields` map allows us to gracefully decode fields intended for future hard forks.
     #[serde(flatten)]
     pub extra_fields: HashMap<String, String>,
@@ -27,14 +27,14 @@ impl ConfigAndPreset {
         let config = Config::from_chain_spec::<T>(spec);
         let base_preset = BasePreset::from_chain_spec::<T>(spec);
         let altair_preset = AltairPreset::from_chain_spec::<T>(spec);
-        let bellatrix_preset = BellatrixPreset::from_chain_spec::<T>(spec);
+        // TODO(merge): re-enable
+        let _bellatrix_preset = BellatrixPreset::from_chain_spec::<T>(spec);
         let extra_fields = HashMap::new();
 
         Self {
             config,
             base_preset,
             altair_preset,
-            bellatrix_preset,
             extra_fields,
         }
     }


### PR DESCRIPTION
## Proposed Changes

Restore compatibility with beacon nodes using the `MERGE` naming by:

1. Adding defaults for the Bellatrix `Config` fields
2. Not attempting to read (or serve) the Bellatrix preset on `/config/spec`.

I've confirmed that this works with Infura, and just logs a warning:

```
Jan 20 10:51:31.078 INFO Connected to beacon node                endpoint: https://eth2-beacon-mainnet.infura.io/, version: teku/v22.1.0/linux-x86_64/-eclipseadoptium-openjdk64bitservervm-java-17
Jan 20 10:51:31.344 WARN Beacon node config does not match exactly, advice: check that the BN is updated and configured for any upcoming forks, endpoint: https://eth2-beacon-mainnet.infura.io/
Jan 20 10:51:31.344 INFO Initialized beacon node connections     available: 1, total: 1
```
