### PR TITLE
[Merged by Bors] - Add default config options for transition constants

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -611,9 +611,15 @@ pub struct Config {
     #[serde(default)]
     pub preset_base: String,
 
+    // TODO(merge): remove this default
+    #[serde(default = "default_terminal_total_difficulty")]
     #[serde(with = "eth2_serde_utils::quoted_u256")]
     pub terminal_total_difficulty: Uint256,
+    // TODO(merge): remove this default
+    #[serde(default = "default_terminal_block_hash")]
     pub terminal_block_hash: Hash256,
+    // TODO(merge): remove this default
+    #[serde(default = "default_terminal_block_hash_activation_epoch")]
     pub terminal_block_hash_activation_epoch: Epoch,
 
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -680,6 +686,20 @@ fn default_bellatrix_fork_version() -> [u8; 4] {
 
 fn default_bellatrix_fork_epoch() -> Option<MaybeQuoted<Epoch>> {
     None
+}
+
+fn default_terminal_total_difficulty() -> Uint256 {
+    "115792089237316195423570985008687907853269984665640564039457584007913129638912"
+        .parse()
+        .unwrap()
+}
+
+fn default_terminal_block_hash() -> Hash256 {
+    Hash256::zero()
+}
+
+fn default_terminal_block_hash_activation_epoch() -> Epoch {
+    Epoch::new(u64::MAX)
 }
 
 impl Default for Config {


### PR DESCRIPTION
## Issue Addressed

Continuation to #2934 

## Proposed Changes

Currently, we have the transition fields in the config (`TERMINAL_TOTAL_DIFFICULTY`, `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH`) as mandatory fields. 

This is causing compatibility issues with other client BN's (nimbus and teku v22.1.0) which don't return these fields on a `eth/v1/config/spec` api call. Since we don't use this values until the merge, I think it's okay to have default values set for these fields as well to ensure compatibility.
