### PR TITLE
[Merged by Bors] - Quote validator indices when posting duties

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1256,8 +1256,12 @@ impl BeaconNodeHttpClient {
             .push("attester")
             .push(&epoch.to_string());
 
-        self.post_with_timeout_and_response(path, &indices, self.timeouts.attester_duties)
-            .await
+        self.post_with_timeout_and_response(
+            path,
+            &ValidatorIndexDataRef(indices),
+            self.timeouts.attester_duties,
+        )
+        .await
     }
 
     /// `POST validator/aggregate_and_proofs`
@@ -1356,8 +1360,12 @@ impl BeaconNodeHttpClient {
             .push("sync")
             .push(&epoch.to_string());
 
-        self.post_with_timeout_and_response(path, &indices, self.timeouts.sync_duties)
-            .await
+        self.post_with_timeout_and_response(
+            path,
+            &ValidatorIndexDataRef(indices),
+            self.timeouts.sync_duties,
+        )
+        .await
     }
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -591,6 +591,13 @@ pub struct ValidatorBalancesQuery {
 #[serde(transparent)]
 pub struct ValidatorIndexData(#[serde(with = "eth2_serde_utils::quoted_u64_vec")] pub Vec<u64>);
 
+/// Borrowed variant of `ValidatorIndexData`, for serializing/sending.
+#[derive(Clone, Copy, Serialize)]
+#[serde(transparent)]
+pub struct ValidatorIndexDataRef<'a>(
+    #[serde(serialize_with = "eth2_serde_utils::quoted_u64_vec::serialize")] pub &'a [u64],
+);
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AttesterData {
     pub pubkey: PublicKeyBytes,


### PR DESCRIPTION
## Proposed Changes

This PR establishes compatibility between Lighthouse's VC and Nimbus's BN.

Lighthouse was previously `POST`ing unquoted lists of validator indices to the attester and sync duties endpoints which were (correctly) not accepted by Nimbus. These lists had slipped through the cracks because they didn't have an explicit wrapper type to add `serde` annotations to. I've added the `ValidatorIndexDataRef` newtype in order to implement the modified serialisation behaviour.

## Testing

Combined with https://github.com/sigp/lighthouse/pull/2940, I've confirmed that this PR allows my Lighthouse VC on Prater to validate with the public Nimbus BN listed here: https://github.com/status-im/nimbus-eth2#quickly-test-your-tooling-against-nimbus. I haven't had a block proposal yet, but attestations and sync committee messages are working.

## Additional Info

This may also provide compatibility with Prysm BNs but I haven't had a chance to test that yet.
