### PR TITLE
[Merged by Bors] - Increase target subnet peers

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -53,7 +53,7 @@ use types::{
 pub mod gossipsub_scoring_parameters;
 
 /// The number of peers we target per subnet for discovery queries.
-pub const TARGET_SUBNET_PEERS: usize = 2;
+pub const TARGET_SUBNET_PEERS: usize = 4;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
 

--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -53,7 +53,7 @@ use types::{
 pub mod gossipsub_scoring_parameters;
 
 /// The number of peers we target per subnet for discovery queries.
-pub const TARGET_SUBNET_PEERS: usize = 4;
+pub const TARGET_SUBNET_PEERS: usize = 6;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
 


### PR DESCRIPTION
In the latest release we decreased the target number of subnet peers. 

It appears this could be causing issues in some cases and so reverting it back to the previous number it wise. A larger PR that follows this will address some other related discovery issues and peer management around subnet peer discovery.