### PR TITLE
[Merged by Bors] - Fix metric name for monitoring

### DIFF
--- a/common/monitoring_api/src/gather.rs
+++ b/common/monitoring_api/src/gather.rs
@@ -67,11 +67,7 @@ const BEACON_PROCESS_METRICS: &[JsonMetric] = &[
         "disk_beaconchain_bytes_total",
         JsonType::Integer,
     ),
-    JsonMetric::new(
-        "libp2p_peer_connected_peers_total",
-        "network_peers_connected",
-        JsonType::Integer,
-    ),
+    JsonMetric::new("libp2p_peers", "network_peers_connected", JsonType::Integer),
     JsonMetric::new(
         "libp2p_outbound_bytes",
         "network_libp2p_bytes_total_transmit",


### PR DESCRIPTION
## Issue Addressed

Resolves #2949 

## Proposed Changes

Fix metric naming for libp2p peer count.