### PR TITLE
[Merged by Bors] - VC: don't warn if BN config doesn't match exactly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5994,9 +5994,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -253,22 +253,19 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
                 "our_genesis_fork" => ?spec.genesis_fork_version,
             );
             return Err(CandidateError::Incompatible);
-        } else if *spec != beacon_node_spec {
+        } else if beacon_node_spec.altair_fork_epoch != spec.altair_fork_epoch {
             warn!(
                 log,
-                "Beacon node config does not match exactly";
+                "Beacon node has mismatched Altair fork epoch";
                 "endpoint" => %self.beacon_node,
-                "advice" => "check that the BN is updated and configured for any upcoming forks",
+                "endpoint_altair_fork_epoch" => ?beacon_node_spec.altair_fork_epoch,
             );
-            debug!(
+        } else if beacon_node_spec.bellatrix_fork_epoch != spec.bellatrix_fork_epoch {
+            warn!(
                 log,
-                "Beacon node config";
-                "config" => ?beacon_node_spec,
-            );
-            debug!(
-                log,
-                "Our config";
-                "config" => ?spec,
+                "Beacon node has mismatched Bellatrix fork epoch";
+                "endpoint" => %self.beacon_node,
+                "endpoint_bellatrix_fork_epoch" => ?beacon_node_spec.bellatrix_fork_epoch,
             );
         }
 


### PR DESCRIPTION
## Proposed Changes

Remove the check for exact equality on the beacon node spec when polling `/config/spec` from the VC. This check was always overzealous, and mostly served to check that the BN was configured for upcoming forks. I've replaced it by explicit checks of the `altair_fork_epoch` and `bellatrix_fork_epoch` instead.

## Additional Info

We should come back to this and clean it up so that we can retain compatibility while removing the field `default`s we installed.
