### PR TITLE
[Merged by Bors] - Gossip cache timeout adjustments

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/gossip_cache.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/gossip_cache.rs
@@ -96,19 +96,19 @@ impl GossipCacheBuilder {
     }
 
     /// Timeout for attester slashings.
-    pub fn attester_slashing(mut self, timeout: Duration) -> Self {
+    pub fn attester_slashing_timeout(mut self, timeout: Duration) -> Self {
         self.attester_slashing = Some(timeout);
         self
     }
 
     /// Timeout for aggregated sync commitee signatures.
-    pub fn signed_contribution_and_proof(mut self, timeout: Duration) -> Self {
+    pub fn signed_contribution_and_proof_timeout(mut self, timeout: Duration) -> Self {
         self.signed_contribution_and_proof = Some(timeout);
         self
     }
 
     /// Timeout for sync commitee messages.
-    pub fn sync_committee_message(mut self, timeout: Duration) -> Self {
+    pub fn sync_committee_message_timeout(mut self, timeout: Duration) -> Self {
         self.sync_committee_message = Some(timeout);
         self
     }

--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -288,13 +288,18 @@ impl<TSpec: EthSpec> Behaviour<TSpec> {
         };
 
         let slot_duration = std::time::Duration::from_secs(ctx.chain_spec.seconds_per_slot);
-        // Half an epoch
-        let gossip_max_retry_delay = std::time::Duration::from_secs(
+        let half_epoch = std::time::Duration::from_secs(
             ctx.chain_spec.seconds_per_slot * TSpec::slots_per_epoch() / 2,
         );
         let gossip_cache = GossipCache::builder()
-            .default_timeout(gossip_max_retry_delay)
             .beacon_block_timeout(slot_duration)
+            .aggregates_timeout(half_epoch)
+            .attestation_timeout(half_epoch)
+            .voluntary_exit_timeout(half_epoch * 2)
+            .proposer_slashing_timeout(half_epoch * 2)
+            .attester_slashing_timeout(half_epoch * 2)
+            // .signed_contribution_and_proof_timeout(timeout) // Do not retry
+            // .sync_committee_message_timeout(timeout) // Do not retry
             .build();
 
         Ok(Behaviour {


### PR DESCRIPTION
## Proposed Changes

- Do not retry to publish sync committee messages.
- Give a more lenient timeout to slashings and exits