### PR TITLE
[Merged by Bors] - Fix Docker run -p for both TCP and UDP

### DIFF
--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -107,7 +107,7 @@ $ docker run lighthouse:local lighthouse --help
 You can run a Docker beacon node with the following command:
 
 ```bash
-$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse --network mainnet beacon --http --http-address 0.0.0.0
+$ docker run -p 9000:9000/tcp -p 9000:9000/udp -p 127.0.0.1:5052:5052 -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse --network mainnet beacon --http --http-address 0.0.0.0
 ```
 
 > To join the Pyrmont testnet, use `--network pyrmont` instead.
@@ -130,18 +130,18 @@ $ docker run -v $HOME/.lighthouse:/root/.lighthouse sigp/lighthouse lighthouse b
 
 ### Ports
 
-In order to be a good peer and serve other peers you should expose port `9000`.
+In order to be a good peer and serve other peers you should expose port `9000` for both TCP and UDP.
 Use the `-p` flag to do this:
 
 ```bash
-$ docker run -p 9000:9000 sigp/lighthouse lighthouse beacon
+$ docker run -p 9000:9000/tcp -p 9000:9000/udp sigp/lighthouse lighthouse beacon
 ```
 
 If you use the `--http` flag you may also want to expose the HTTP port with `-p
 127.0.0.1:5052:5052`.
 
 ```bash
-$ docker run -p 9000:9000 -p 127.0.0.1:5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
+$ docker run -p 9000:9000/tcp -p 9000:9000/udp -p 127.0.0.1:5052:5052 sigp/lighthouse lighthouse beacon --http --http-address 0.0.0.0
 ```
 
 [docker_hub]: https://hub.docker.com/repository/docker/sigp/lighthouse/


### PR DESCRIPTION
## Issue Addressed

[Docker run] ... "-p 9000:9000" defaults to expose TCP only.

## Proposed Changes

Add "-p 9000:9000/udp" for UDP peer discovery.

