### PR TITLE
[Merged by Bors] - Bump crossbeam-utils to fix cargo-audit CI failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",


### PR DESCRIPTION
## Issue Addressed

Bump `crossbeam-utils` to `0.8.7` since `0.8.6` was yanked and that made `cargo audit` fail.