### PR TITLE
[Merged by Bors] - Add aliases for validator-dir flags

### DIFF
--- a/account_manager/src/lib.rs
+++ b/account_manager/src/lib.rs
@@ -10,6 +10,7 @@ use types::EthSpec;
 pub const CMD: &str = "account_manager";
 pub const SECRETS_DIR_FLAG: &str = "secrets-dir";
 pub const VALIDATOR_DIR_FLAG: &str = "validator-dir";
+pub const VALIDATOR_DIR_FLAG_ALIAS: &str = "validators-dir";
 pub const WALLETS_DIR_FLAG: &str = "wallets-dir";
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {

--- a/account_manager/src/validator/mod.rs
+++ b/account_manager/src/validator/mod.rs
@@ -6,7 +6,7 @@ pub mod modify;
 pub mod recover;
 pub mod slashing_protection;
 
-use crate::VALIDATOR_DIR_FLAG;
+use crate::{VALIDATOR_DIR_FLAG, VALIDATOR_DIR_FLAG_ALIAS};
 use clap::{App, Arg, ArgMatches};
 use directory::{parse_path_or_default_with_flag, DEFAULT_VALIDATOR_DIR};
 use environment::Environment;
@@ -21,6 +21,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name(VALIDATOR_DIR_FLAG)
                 .long(VALIDATOR_DIR_FLAG)
+                .alias(VALIDATOR_DIR_FLAG_ALIAS)
                 .value_name("VALIDATOR_DIRECTORY")
                 .help(
                     "The path to search for validator directories. \

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -67,6 +67,19 @@ fn validators_and_secrets_dir_flags() {
 }
 
 #[test]
+fn validators_dir_alias_flags() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
+    CommandLineTest::new()
+        .flag("validator-dir", dir.path().join("validators").to_str())
+        .flag("secrets-dir", dir.path().join("secrets").to_str())
+        .run_with_no_datadir()
+        .with_config(|config| {
+            assert_eq!(config.validator_dir, dir.path().join("validators"));
+            assert_eq!(config.secrets_dir, dir.path().join("secrets"));
+        });
+}
+
+#[test]
 fn beacon_nodes_flag() {
     CommandLineTest::new()
         .flag(

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -38,6 +38,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("validators-dir")
                 .long("validators-dir")
+                .alias("validator-dir")
                 .value_name("VALIDATORS_DIR")
                 .help(
                     "The directory which contains the validator keystores, deposit data for \


### PR DESCRIPTION
## Issue Addressed

#3020

## Proposed Changes

- Alias the `validators-dir` arg to `validator-dir` in the `validator_client` subcommand.
- Alias the `validator-dir` arg to `validators-dir` in the `account_manager validator` subcommand.
- Add test for the validator_client alias.

