### PR TITLE
[Merged by Bors] - Increase Bors timeout, refine target-branch-check

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-        - name: Check that pull request is targeting unstable branch
-          run: test ${{ github.base_ref }} = "unstable"
+        - name: Check that the pull request is not targeting the stable branch
+          run: test ${{ github.base_ref }} != "stable"
   cargo-fmt:
     name: cargo-fmt
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -16,5 +16,5 @@ status = [
     "cargo-udeps"
 ]
 use_squash_merge = true
-timeout_sec = 7200
+timeout_sec = 10800
 pr_status = ["license/cla", "target-branch-check"]


### PR DESCRIPTION
## Issue Addressed

Timeouts due to Windows builds running for 2h 20m.

## Proposed Changes

* Increase Bors timeout to 3h
* Refine the target branch check so that it will pass when we make PRs to feature branches. This is just an extra change I've been meaning to sneak in for a while.

## Additional Info

* I think it would also be cool to try caching for CI again, but that's a separate issue and we'll still need the long timeout on a cache miss.
