### PR TITLE
Adding lighthouse/peers methods in BeaconNodeHttpClient

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/client.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/client.rs
@@ -3,11 +3,11 @@
 //! Currently using identify to fingerprint.
 
 use libp2p::identify::IdentifyInfo;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use strum::{AsRefStr, AsStaticStr, EnumIter};
 
 /// Various client and protocol information related to a node.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Client {
     /// The client's name (Ex: lighthouse, prism, nimbus, etc)
     pub kind: ClientKind,
@@ -21,7 +21,7 @@ pub struct Client {
     pub agent_string: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, AsRefStr, AsStaticStr, EnumIter)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, AsRefStr, AsStaticStr, EnumIter)]
 pub enum ClientKind {
     /// A lighthouse node (the best kind).
     Lighthouse,

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -5,11 +5,13 @@ use crate::discovery::Eth2Enr;
 use crate::Multiaddr;
 use crate::{rpc::MetaData, types::Subnet};
 use discv5::Enr;
+use serde::de::Visitor;
 use serde::{
     ser::{SerializeStruct, Serializer},
-    Serialize,
+    Deserialize, Serialize,
 };
 use std::collections::HashSet;
+use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 use strum::AsRefStr;
@@ -17,7 +19,7 @@ use types::EthSpec;
 use PeerConnectionStatus::*;
 
 /// Information about a given connected peer.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "T: EthSpec")]
 pub struct PeerInfo<T: EthSpec> {
     /// The peers reputation
@@ -467,7 +469,7 @@ impl<T: EthSpec> PeerInfo<T> {
 }
 
 /// Connection Direction of connection.
-#[derive(Debug, Clone, Serialize, AsRefStr)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsRefStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum ConnectionDirection {
     /// The connection was established by a peer dialing us.
@@ -559,6 +561,16 @@ impl Serialize for PeerConnectionStatus {
                 s.end()
             }
         }
+    }
+}
+
+/// Deserialization for http requests.
+impl<'de> Deserialize<'de> for PeerConnectionStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        todo!()
     }
 }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -475,7 +475,7 @@ pub enum ConnectionDirection {
 
 /// Connection Status of the peer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type")]
+#[serde(tag = "status")]
 #[serde(rename_all = "lowercase")]
 pub enum PeerConnectionStatus {
     /// The peer is connected.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -6,7 +6,7 @@
 //!
 //! The scoring algorithms are currently experimental.
 use crate::behaviour::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use strum::AsRefStr;
 use tokio::time::Duration;
@@ -124,7 +124,7 @@ impl std::fmt::Display for ScoreState {
 ///
 /// This simplistic version consists of a global score per peer which decays to 0 over time. The
 /// decay rate applies equally to positive and negative scores.
-#[derive(PartialEq, Clone, Debug, Serialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct RealScore {
     /// The global score.
     // NOTE: In the future we may separate this into sub-scores involving the RPC, Gossipsub and
@@ -137,6 +137,7 @@ pub struct RealScore {
     score: f64,
     /// The time the score was last updated to perform time-based adjustments such as score-decay.
     #[serde(skip)]
+    #[serde(default = "Instant::now")]
     last_updated: Instant,
 }
 
@@ -267,7 +268,7 @@ impl RealScore {
     }
 }
 
-#[derive(PartialEq, Clone, Debug, Serialize)]
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum Score {
     Max,
     Real(RealScore),

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/sync_status.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/sync_status.rs
@@ -1,9 +1,9 @@
 //! Handles individual sync status for peers.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use types::{Epoch, Hash256, Slot};
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 /// The current sync status of the peer.
 pub enum SyncStatus {
     /// At the current state as our node or ahead of us.
@@ -19,7 +19,7 @@ pub enum SyncStatus {
 }
 
 /// A relevant peer's sync information.
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SyncInfo {
     pub head_slot: Slot,
     pub head_root: Hash256,

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -2,7 +2,7 @@
 
 use crate::types::{EnrAttestationBitfield, EnrSyncCommitteeBitfield};
 use regex::bytes::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
     typenum::{U1024, U256},
@@ -97,11 +97,11 @@ pub struct Ping {
 #[superstruct(
     variants(V1, V2),
     variant_attributes(
-        derive(Encode, Decode, Clone, Debug, PartialEq, Serialize),
+        derive(Encode, Decode, Clone, Debug, PartialEq, Serialize, Deserialize),
         serde(bound = "T: EthSpec", deny_unknown_fields),
     )
 )]
-#[derive(Clone, Debug, PartialEq, Serialize, Encode)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(bound = "T: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
 pub struct MetaData<T: EthSpec> {

--- a/beacon_node/lighthouse_network/src/types/subnet.rs
+++ b/beacon_node/lighthouse_network/src/types/subnet.rs
@@ -1,4 +1,4 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use types::{SubnetId, SyncSubnetId};
 
@@ -6,7 +6,7 @@ use types::{SubnetId, SyncSubnetId};
 ///
 /// Used for subscribing to the appropriate gossipsub subnets and mark
 /// appropriate metadata bitfields.
-#[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum Subnet {
     /// Represents a gossipsub attestation subnet and the metadata `attnets` field.
     Attestation(SubnetId),

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -383,13 +383,30 @@ impl BeaconNodeHttpClient {
         self.get(path).await
     }
 
-    /*
-     * Note:
-     *
-     * The `lighthouse/peers` endpoints do not have functions here. We are yet to implement
-     * `Deserialize` on the `PeerInfo` struct since it contains use of `Instant`. This could be
-     * fairly simply achieved, if desired.
-     */
+    /// `GET lighthouse/peers`
+    pub async fn get_lighthouse_peers<E: EthSpec>(&self) -> Result<Vec<Peer<E>>, Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("peers");
+
+        self.get(path).await
+    }
+
+    /// `GET lighthouse/peers/connected`
+    pub async fn get_lighthouse_connected_peers<E: EthSpec>(&self) -> Result<Vec<Peer<E>>, Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("peers")
+            .push("connected");
+
+        self.get(path).await
+    }
 
     /// `GET lighthouse/proto_array`
     pub async fn get_lighthouse_proto_array(&self) -> Result<GenericResponse<ProtoArray>, Error> {

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -31,8 +31,7 @@ four_byte_option_impl!(four_byte_option_u64, u64);
 four_byte_option_impl!(four_byte_option_hash256, Hash256);
 
 /// Information returned by `peers` and `connected_peers`.
-// TODO: this should be deserializable..
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(bound = "T: EthSpec")]
 pub struct Peer<T: EthSpec> {
     /// The Peer's ID


### PR DESCRIPTION
## Issue Addressed

Issue #3041

## Proposed Changes

* Add the corresponding get_lighthouse_peers() and get_lighthouse_connected_peers() methods to `BeaconNodeHttpClient`
* Impl `Deserialize` on `Peer` struct and all fields structs recursively
