### PR TITLE
[Merged by Bors] - Add log debounce to work processor

### DIFF
--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -11,7 +11,6 @@ matches = "0.1.8"
 exit-future = "0.2.0"
 slog-term = "2.6.0"
 slog-async = "2.5.0"
-logging = { path = "../../common/logging" }
 environment = { path = "../../lighthouse/environment" }
 
 [dependencies]
@@ -35,6 +34,7 @@ fnv = "1.0.7"
 rlp = "0.5.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
+logging = { path = "../../common/logging" }
 task_executor = { path = "../../common/task_executor" }
 igd = "0.11.1"
 itertools = "0.10.0"


### PR DESCRIPTION
## Issue Addressed

#3010 

## Proposed Changes

- move log debounce time latch to `./common/logging`
- add timelatch to limit logging for `attestations_delay_queue` and `queued_block_roots`

## Additional Info

- Is a separate crate for the time latch preferred? 
- `elapsed()` could take `LOG_DEBOUNCE_INTERVAL ` as an argument to allow for different granularity.
