### PR TITLE
[Merged by Bors] - Poll the `engine_exchangeTransitionConfigurationV1` endpoint

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -723,6 +723,9 @@ where
                 execution_layer.spawn_clean_proposer_preparation_routine::<TSlotClock, TEthSpec>(
                     beacon_chain.slot_clock.clone(),
                 );
+
+                // Spawns a routine that polls the `exchange_transition_configuration` endpoint.
+                execution_layer.spawn_transition_configuration_poll(beacon_chain.spec.clone());
             }
         }
 

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub const LATEST_TAG: &str = "latest";
 
 use crate::engines::ForkChoiceState;
+pub use json_structures::TransitionConfigurationV1;
 pub use types::{Address, EthSpec, ExecutionBlockHash, ExecutionPayload, Hash256, Uint256};
 
 pub mod http;
@@ -71,6 +72,11 @@ pub trait EngineApi {
         forkchoice_state: ForkChoiceState,
         payload_attributes: Option<PayloadAttributes>,
     ) -> Result<ForkchoiceUpdatedResponse, Error>;
+
+    async fn exchange_transition_configuration_v1(
+        &self,
+        transition_configuration: TransitionConfigurationV1,
+    ) -> Result<TransitionConfigurationV1, Error>;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -28,6 +28,7 @@ pub enum Error {
     ExecutionHeadBlockNotFound,
     ParentHashEqualsBlockHash(ExecutionBlockHash),
     PayloadIdUnavailable,
+    TransitionConfigurationMismatch,
 }
 
 impl From<reqwest::Error> for Error {

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -39,7 +39,7 @@ pub const ENGINE_FORKCHOICE_UPDATED_TIMEOUT: Duration = Duration::from_millis(50
 pub const ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1: &str =
     "engine_exchangeTransitionConfigurationV1";
 pub const ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1_TIMEOUT: Duration =
-    Duration::from_millis(100);
+    Duration::from_millis(500);
 
 pub struct HttpJsonRpc {
     pub client: Client,

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -36,6 +36,11 @@ pub const ENGINE_GET_PAYLOAD_TIMEOUT: Duration = Duration::from_secs(2);
 pub const ENGINE_FORKCHOICE_UPDATED_V1: &str = "engine_forkchoiceUpdatedV1";
 pub const ENGINE_FORKCHOICE_UPDATED_TIMEOUT: Duration = Duration::from_millis(500);
 
+pub const ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1: &str =
+    "engine_exchangeTransitionConfigurationV1";
+pub const ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1_TIMEOUT: Duration =
+    Duration::from_millis(100);
+
 pub struct HttpJsonRpc {
     pub client: Client,
     pub url: SensitiveUrl,
@@ -188,9 +193,9 @@ impl EngineApi for HttpJsonRpc {
 
         let response = self
             .rpc_request(
-                ENGINE_FORKCHOICE_UPDATED_V1,
+                ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1,
                 params,
-                ENGINE_FORKCHOICE_UPDATED_TIMEOUT,
+                ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1_TIMEOUT,
             )
             .await?;
 

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -179,6 +179,23 @@ impl EngineApi for HttpJsonRpc {
 
         Ok(response.into())
     }
+
+    async fn exchange_transition_configuration_v1(
+        &self,
+        transition_configuration: TransitionConfigurationV1,
+    ) -> Result<TransitionConfigurationV1, Error> {
+        let params = json!([transition_configuration]);
+
+        let response = self
+            .rpc_request(
+                ENGINE_FORKCHOICE_UPDATED_V1,
+                params,
+                ENGINE_FORKCHOICE_UPDATED_TIMEOUT,
+            )
+            .await?;
+
+        Ok(response)
+    }
 }
 
 #[cfg(test)]

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -368,7 +368,7 @@ impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedV1Response {
 pub struct TransitionConfigurationV1 {
     pub terminal_total_difficulty: Uint256,
     pub terminal_block_hash: ExecutionBlockHash,
-    #[serde(rename = "number", with = "eth2_serde_utils::u64_hex_be")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub terminal_block_number: u64,
 }
 

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -363,6 +363,15 @@ impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedV1Response {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransitionConfigurationV1 {
+    pub terminal_total_difficulty: Uint256,
+    pub terminal_block_hash: ExecutionBlockHash,
+    #[serde(rename = "number", with = "eth2_serde_utils::u64_hex_be")]
+    pub terminal_block_number: u64,
+}
+
 /// Serializes the `logs_bloom` field of an `ExecutionPayload`.
 pub mod serde_logs_bloom {
     use super::*;

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -569,11 +569,6 @@ impl ExecutionLayer {
         let local = TransitionConfigurationV1 {
             terminal_total_difficulty: spec.terminal_total_difficulty,
             terminal_block_hash: spec.terminal_block_hash,
-            // TODO(paul): confirm that we don't know this value.
-            //
-            // See:
-            //
-            // https://discord.com/channels/595666850260713488/692062809701482577/947988779203977307
             terminal_block_number: 0,
         };
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -44,6 +44,8 @@ const EXECUTION_BLOCKS_LRU_CACHE_SIZE: usize = 128;
 const DEFAULT_SUGGESTED_FEE_RECIPIENT: [u8; 20] =
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
+const CONFIG_POLL_INTERVAL: Duration = Duration::from_secs(60);
+
 #[derive(Debug)]
 pub enum Error {
     NoEngines,
@@ -303,6 +305,18 @@ impl ExecutionLayer {
         self.spawn(preparation_cleaner, "exec_preparation_cleanup");
     }
 
+    /// Spawns a routine that polls the `exchange_transition_configuration` endpoint.
+    pub fn spawn_transition_configuration_poll(&self, spec: ChainSpec) {
+        let routine = |el: ExecutionLayer| async move {
+            loop {
+                el.exchange_transition_configuration(&spec).await;
+                sleep(CONFIG_POLL_INTERVAL).await;
+            }
+        };
+
+        self.spawn(routine, "exec_config_poll");
+    }
+
     /// Returns `true` if there is at least one synced and reachable engine.
     pub async fn is_synced(&self) -> bool {
         self.engines().any_synced().await
@@ -549,6 +563,50 @@ impl ExecutionLayer {
                 .map(|result| result.map(|response| response.payload_status)),
             self.log(),
         )
+    }
+
+    pub async fn exchange_transition_configuration(&self, spec: &ChainSpec) {
+        let local = TransitionConfigurationV1 {
+            terminal_total_difficulty: spec.terminal_total_difficulty,
+            terminal_block_hash: spec.terminal_block_hash,
+            // TODO(paul): confirm that we don't know this value.
+            //
+            // See:
+            //
+            // https://discord.com/channels/595666850260713488/692062809701482577/947988779203977307
+            terminal_block_number: 0,
+        };
+
+        let broadcast_results = self
+            .engines()
+            .broadcast(|engine| engine.api.exchange_transition_configuration_v1(local))
+            .await;
+
+        for (i, result) in broadcast_results.iter().enumerate() {
+            match result {
+                Ok(remote) => {
+                    if local.terminal_total_difficulty != remote.terminal_total_difficulty
+                        || local.terminal_block_hash != remote.terminal_block_hash
+                    {
+                        error!(
+                            self.log(),
+                            "Execution client config mismatch";
+                            "msg" => "ensure lighthouse and the execution client are up-to-date and \
+                                      configured consistently",
+                            "execution_endpoint" => i,
+                            "remote" => ?remote,
+                            "local" => ?local,
+                        )
+                    }
+                }
+                Err(e) => error!(
+                    self.log(),
+                    "Unable to get transition config";
+                    "error" => ?e,
+                    "execution_endpoint" => i,
+                ),
+            }
+        }
     }
 
     /// Used during block production to determine if the merge has been triggered.

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -592,6 +592,12 @@ impl ExecutionLayer {
                             "remote" => ?remote,
                             "local" => ?local,
                         )
+                    } else {
+                        debug!(
+                            self.log(),
+                            "Execution client config is OK";
+                            "execution_endpoint" => i
+                        );
                     }
                 }
                 Err(e) => error!(

--- a/testing/execution_engine_integration/src/execution_engine.rs
+++ b/testing/execution_engine_integration/src/execution_engine.rs
@@ -109,7 +109,7 @@ impl GenericExecutionEngine for Geth {
             .arg("engine,eth")
             .arg("--http.port")
             .arg(http_port.to_string())
-            .arg("--http.authport")
+            .arg("--authrpc.port")
             .arg(http_auth_port.to_string())
             .arg("--port")
             .arg(network_port.to_string())

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -109,6 +109,16 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         self.wait_until_synced().await;
 
         /*
+         * Check the transition config endpoint.
+         */
+        for ee in [&self.ee_a, &self.ee_b] {
+            ee.execution_layer
+                .exchange_transition_configuration(&self.spec)
+                .await
+                .unwrap();
+        }
+
+        /*
          * Read the terminal block hash from both pairs, check it's equal.
          */
 


### PR DESCRIPTION
## Issue Addressed

There has been an [`engine_exchangetransitionconfigurationv1`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#engine_exchangetransitionconfigurationv1) method added to the execution API specs.

The `engine_exchangetransitionconfigurationv1` will be polled every 60s as per this PR: https://github.com/ethereum/execution-apis/pull/189. If that PR is merged as-is, then we will be matching the spec. If that PR *is not* merged, we are still fully compatible with the spec, but just doing more than we are required.

## Additional Info

- [x] ~~Blocked on #2837~~
- [x] Add method to EE integration tests