### PR TITLE
Avoid sending a zero-hash `head_block_hash` to EEs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3653,7 +3653,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // If this is a post-merge block, update the execution layer.
-        if let Some(new_head_execution_block_hash) = new_head_execution_block_hash_opt {
+        if let Some(new_head_execution_block_hash) =
+            new_head_execution_block_hash_opt.filter(|h| *h != ExecutionBlockHash::zero())
+        {
             if is_merge_transition_complete {
                 let finalized_execution_block_hash = finalized_block
                     .execution_status
@@ -3704,6 +3706,15 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         head_block_root: Hash256,
         head_execution_block_hash: ExecutionBlockHash,
     ) -> Result<(), Error> {
+        if head_execution_block_hash == ExecutionBlockHash::zero() {
+            debug!(
+                self.log,
+                "Not sending forkchoice updated";
+                "msg" => "head block hash is zero"
+            );
+            return Ok(());
+        }
+
         let forkchoice_updated_response = self
             .execution_layer
             .as_ref()

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -668,7 +668,10 @@ where
 
                 // Issue the head to the execution engine on startup. This ensures it can start
                 // syncing.
-                if let Some(block_hash) = head.execution_payload_block_hash {
+                if let Some(block_hash) = head
+                    .execution_payload_block_hash
+                    .filter(|h| *h != ExecutionBlockHash::zero())
+                {
                     let finalized_root = head.finalized_checkpoint.root;
                     let finalized_block = beacon_chain
                         .store

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -150,6 +150,16 @@ impl<T: EngineApi> Engines<T> {
         let latest_forkchoice_state = self.get_latest_forkchoice_state().await;
 
         if let Some(forkchoice_state) = latest_forkchoice_state {
+            if forkchoice_state.head_block_hash == ExecutionBlockHash::zero() {
+                debug!(
+                    self.log,
+                    "No need to call forkchoiceUpdated";
+                    "msg" => "head does not have execution enabled",
+                    "id" => &engine.id,
+                );
+                return;
+            }
+
             info!(
                 self.log,
                 "Issuing forkchoiceUpdated";


### PR DESCRIPTION
## Issue Addressed

After we up-check an EE, we will send a forkchoiceUpdated message to that EE to provide it with the latest head.

When it's pre-merge (i.e., `head_block_hash` is all-zeros), we don't want to send this message to the EE. Geth provides a warning when this happens: 

```
WARN [03-03|22:10:28.161] Forkchoice requested update to zero hash
```

I've also filtered out zero-hashes at a few other places too.

Notably, we might still send a zero-hash if we call forkchoiceUpdate during `get_payload`. I've left that in there for the time being since there's some edge cases we need to address (documented in #3058).