### PR TITLE
[Merged by Bors] - Replace `OpenOptions::new` with `File::options` to be readable

### DIFF
--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -3,7 +3,7 @@ use crate::{BeaconChainTypes, BeaconStore};
 use ssz::{Decode, DecodeError, Encode};
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
 use std::io::{self, Read, Write};
 use std::path::Path;
 use store::{DBColumn, Error as StoreError, StoreItem};
@@ -255,7 +255,7 @@ impl From<Error> for BeaconChainError {
 impl ValidatorPubkeyCacheFile {
     /// Opens an existing file for reading and writing.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        OpenOptions::new()
+        File::options()
             .read(true)
             .write(true)
             .create(false)
@@ -453,7 +453,7 @@ mod test {
         let cache = ValidatorPubkeyCache::<T>::load_from_file(&path).expect("should open cache");
         drop(cache);
 
-        let mut file = OpenOptions::new()
+        let mut file = File::options()
             .write(true)
             .append(true)
             .open(&path)

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -10,7 +10,7 @@ use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 use slog::{error, Logger};
 use std::collections::HashSet;
-use std::fs::{self, OpenOptions};
+use std::fs::{self, File};
 use std::io;
 use std::path::{Path, PathBuf};
 use types::{graffiti::GraffitiString, Address, PublicKey};
@@ -162,7 +162,7 @@ impl ValidatorDefinitions {
     /// Open an existing file, returning an error if the file does not exist.
     pub fn open<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);
-        let file = OpenOptions::new()
+        let file = File::options()
             .write(true)
             .read(true)
             .create_new(false)
@@ -219,7 +219,7 @@ impl ValidatorDefinitions {
                     return None;
                 }
 
-                let keystore_result = OpenOptions::new()
+                let keystore_result = File::options()
                     .read(true)
                     .create(false)
                     .open(&voting_keystore_path)

--- a/common/eth2_wallet_manager/src/filesystem.rs
+++ b/common/eth2_wallet_manager/src/filesystem.rs
@@ -2,7 +2,7 @@
 
 use eth2_wallet::Error as WalletError;
 use eth2_wallet::{Uuid, Wallet};
-use std::fs::{copy as copy_file, remove_file, OpenOptions};
+use std::fs::{copy as copy_file, remove_file, File};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -27,7 +27,7 @@ pub fn read<P: AsRef<Path>>(wallet_dir: P, uuid: &Uuid) -> Result<Wallet, Error>
     if !json_path.exists() {
         Err(Error::WalletDoesNotExist(json_path))
     } else {
-        OpenOptions::new()
+        File::options()
             .read(true)
             .create(false)
             .open(json_path)
@@ -79,7 +79,7 @@ pub fn create<P: AsRef<Path>>(wallet_dir: P, wallet: &Wallet) -> Result<(), Erro
     if json_path.exists() {
         Err(Error::WalletAlreadyExists(json_path))
     } else {
-        OpenOptions::new()
+        File::options()
             .write(true)
             .create_new(true)
             .open(json_path)

--- a/common/eth2_wallet_manager/src/wallet_manager.rs
+++ b/common/eth2_wallet_manager/src/wallet_manager.rs
@@ -6,7 +6,7 @@ use eth2_wallet::{bip39::Mnemonic, Error as WalletError, Uuid, Wallet, WalletBui
 use lockfile::LockfileError;
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::fs::{create_dir_all, read_dir, OpenOptions};
+use std::fs::{create_dir_all, read_dir, File};
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -172,7 +172,7 @@ impl WalletManager {
                 // Ignore any paths that don't parse as a UUID.
                 if let Ok(uuid) = Uuid::parse_str(&file_name) {
                     let wallet_path = f.path().join(format!("{}", uuid));
-                    let wallet = OpenOptions::new()
+                    let wallet = File::options()
                         .read(true)
                         .create(false)
                         .open(wallet_path)

--- a/common/lockfile/src/lib.rs
+++ b/common/lockfile/src/lib.rs
@@ -1,5 +1,5 @@
 use fs2::FileExt;
-use std::fs::{self, File, OpenOptions};
+use std::fs::{self, File};
 use std::io::{self, ErrorKind};
 use std::path::{Path, PathBuf};
 
@@ -30,7 +30,7 @@ impl Lockfile {
         let file = if file_existed {
             File::open(&path)
         } else {
-            OpenOptions::new()
+            File::options()
                 .read(true)
                 .write(true)
                 .create_new(true)

--- a/common/validator_dir/src/builder.rs
+++ b/common/validator_dir/src/builder.rs
@@ -4,7 +4,7 @@ use deposit_contract::{encode_eth1_tx_data, Error as DepositError};
 use eth2_keystore::{Error as KeystoreError, Keystore, KeystoreBuilder, PlainText};
 use filesystem::create_with_600_perms;
 use rand::{distributions::Alphanumeric, Rng};
-use std::fs::{create_dir_all, OpenOptions};
+use std::fs::{create_dir_all, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use types::{ChainSpec, DepositData, Hash256, Keypair, Signature};
@@ -197,7 +197,7 @@ impl<'a> Builder<'a> {
                     return Err(Error::DepositDataAlreadyExists(path));
                 } else {
                     let hex = format!("0x{}", hex::encode(&deposit_data));
-                    OpenOptions::new()
+                    File::options()
                         .write(true)
                         .read(true)
                         .create(true)
@@ -214,7 +214,7 @@ impl<'a> Builder<'a> {
                 if path.exists() {
                     return Err(Error::DepositAmountAlreadyExists(path));
                 } else {
-                    OpenOptions::new()
+                    File::options()
                         .write(true)
                         .read(true)
                         .create(true)
@@ -267,7 +267,7 @@ fn write_keystore_to_file(path: PathBuf, keystore: &Keystore) -> Result<(), Erro
     if path.exists() {
         Err(Error::KeystoreAlreadyExists(path))
     } else {
-        let file = OpenOptions::new()
+        let file = File::options()
             .write(true)
             .read(true)
             .create_new(true)

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -6,7 +6,7 @@ use deposit_contract::decode_eth1_tx_data;
 use derivative::Derivative;
 use eth2_keystore::{Error as KeystoreError, Keystore, PlainText};
 use lockfile::{Lockfile, LockfileError};
-use std::fs::{read, write, OpenOptions};
+use std::fs::{read, write, File};
 use std::io;
 use std::path::{Path, PathBuf};
 use tree_hash::TreeHash;
@@ -211,7 +211,7 @@ pub fn unlock_keypair<P: AsRef<Path>>(
     password_dir: P,
 ) -> Result<Keypair, Error> {
     let keystore = Keystore::from_json_reader(
-        &mut OpenOptions::new()
+        &mut File::options()
             .read(true)
             .create(false)
             .open(keystore_path)
@@ -236,7 +236,7 @@ pub fn unlock_keypair_from_password_path(
     password_path: &Path,
 ) -> Result<Keypair, Error> {
     let keystore = Keystore::from_json_reader(
-        &mut OpenOptions::new()
+        &mut File::options()
             .read(true)
             .create(false)
             .open(keystore_path)

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1163,14 +1163,13 @@ mod tests {
 #[cfg(test)]
 mod yaml_tests {
     use super::*;
-    use std::fs::OpenOptions;
     use tempfile::NamedTempFile;
 
     #[test]
     fn minimal_round_trip() {
         // create temp file
         let tmp_file = NamedTempFile::new().expect("failed to create temp file");
-        let writer = OpenOptions::new()
+        let writer = File::options()
             .read(false)
             .write(true)
             .open(tmp_file.as_ref())
@@ -1181,7 +1180,7 @@ mod yaml_tests {
         // write fresh minimal config to file
         serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
-        let reader = OpenOptions::new()
+        let reader = File::options()
             .read(true)
             .write(false)
             .open(tmp_file.as_ref())
@@ -1194,7 +1193,7 @@ mod yaml_tests {
     #[test]
     fn mainnet_round_trip() {
         let tmp_file = NamedTempFile::new().expect("failed to create temp file");
-        let writer = OpenOptions::new()
+        let writer = File::options()
             .read(false)
             .write(true)
             .open(tmp_file.as_ref())
@@ -1203,7 +1202,7 @@ mod yaml_tests {
         let yamlconfig = Config::from_chain_spec::<MainnetEthSpec>(&mainnet_spec);
         serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
-        let reader = OpenOptions::new()
+        let reader = File::options()
             .read(true)
             .write(false)
             .open(tmp_file.as_ref())

--- a/consensus/types/src/config_and_preset.rs
+++ b/consensus/types/src/config_and_preset.rs
@@ -92,13 +92,13 @@ impl ConfigAndPreset {
 mod test {
     use super::*;
     use crate::MainnetEthSpec;
-    use std::fs::OpenOptions;
+    use std::fs::File;
     use tempfile::NamedTempFile;
 
     #[test]
     fn extra_fields_round_trip() {
         let tmp_file = NamedTempFile::new().expect("failed to create temp file");
-        let writer = OpenOptions::new()
+        let writer = File::options()
             .read(false)
             .write(true)
             .open(tmp_file.as_ref())
@@ -116,7 +116,7 @@ mod test {
 
         serde_yaml::to_writer(writer, &yamlconfig).expect("failed to write or serialize");
 
-        let reader = OpenOptions::new()
+        let reader = File::options()
             .read(true)
             .write(false)
             .open(tmp_file.as_ref())

--- a/crypto/eth2_keystore/src/keystore.rs
+++ b/crypto/eth2_keystore/src/keystore.rs
@@ -21,7 +21,7 @@ use scrypt::{
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::fs::OpenOptions;
+use std::fs::File;
 use std::io::{Read, Write};
 use std::iter::FromIterator;
 use std::path::Path;
@@ -329,7 +329,7 @@ impl Keystore {
 
     /// Instantiates `self` by reading a JSON file at `path`.
     pub fn from_json_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        OpenOptions::new()
+        File::options()
             .read(true)
             .write(false)
             .create(false)

--- a/crypto/eth2_keystore/tests/tests.rs
+++ b/crypto/eth2_keystore/tests/tests.rs
@@ -7,7 +7,7 @@ use eth2_keystore::{
     json_keystore::{Kdf, Pbkdf2, Prf, Scrypt},
     Error, Keystore, KeystoreBuilder, DKLEN,
 };
-use std::fs::OpenOptions;
+use std::fs::File;
 use tempfile::tempdir;
 
 const GOOD_PASSWORD: &[u8] = &[42, 42, 42];
@@ -55,7 +55,7 @@ fn file() {
     let path = dir.path().join("keystore.json");
 
     let get_file = || {
-        OpenOptions::new()
+        File::options()
             .write(true)
             .read(true)
             .create(true)

--- a/crypto/eth2_wallet/tests/tests.rs
+++ b/crypto/eth2_wallet/tests/tests.rs
@@ -4,7 +4,7 @@ use eth2_wallet::{
     bip39::{Language, Mnemonic, Seed},
     recover_validator_secret, DerivedKey, Error, KeyType, KeystoreError, Wallet, WalletBuilder,
 };
-use std::fs::OpenOptions;
+use std::fs::File;
 use tempfile::tempdir;
 
 const NAME: &str = "Wallet McWalletface";
@@ -133,7 +133,7 @@ fn file_round_trip() {
     let path = dir.path().join("keystore.json");
 
     let get_file = || {
-        OpenOptions::new()
+        File::options()
             .write(true)
             .read(true)
             .create(true)

--- a/lcli/src/etl/block_efficiency.rs
+++ b/lcli/src/etl/block_efficiency.rs
@@ -4,7 +4,7 @@ use eth2::{BeaconNodeHttpClient, Timeouts};
 use log::{error, info};
 use sensitive_url::SensitiveUrl;
 use std::collections::{HashMap, HashSet};
-use std::fs::OpenOptions;
+use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -158,7 +158,7 @@ pub async fn run<T: EthSpec>(matches: &ArgMatches<'_>) -> Result<(), String> {
 
     let mut proposer_map: HashMap<Slot, ProposerInfo> = HashMap::new();
 
-    let mut file = OpenOptions::new()
+    let mut file = File::options()
         .read(true)
         .write(true)
         .create(true)

--- a/testing/ef_tests/src/decode.rs
+++ b/testing/ef_tests/src/decode.rs
@@ -18,7 +18,7 @@ pub fn log_file_access<P: AsRef<Path>>(file_accessed: P) {
     let passed_test_list_path =
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(ACCESSED_FILE_LOG_FILENAME);
 
-    let mut file = fs::OpenOptions::new()
+    let mut file = fs::File::options()
         .append(true)
         .create(true)
         .open(passed_test_list_path)

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -8,7 +8,7 @@ use crate::{signing_root_from_row, NotSafe, Safe, SignedAttestation, SignedBlock
 use filesystem::restrict_file_permissions;
 use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::{params, OptionalExtension, Transaction, TransactionBehavior};
-use std::fs::OpenOptions;
+use std::fs::File;
 use std::path::Path;
 use std::time::Duration;
 use types::{AttestationData, BeaconBlockHeader, Epoch, Hash256, PublicKeyBytes, SignedRoot, Slot};
@@ -50,7 +50,7 @@ impl SlashingDatabase {
     ///
     /// Error if a database (or any file) already exists at `path`.
     pub fn create(path: &Path) -> Result<Self, NotSafe> {
-        let _file = OpenOptions::new()
+        let _file = File::options()
             .write(true)
             .read(true)
             .create_new(true)

--- a/validator_client/src/key_cache.rs
+++ b/validator_client/src/key_cache.rs
@@ -11,7 +11,7 @@ use eth2_keystore::{
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::OpenOptions;
+use std::fs::File;
 use std::io;
 use std::path::{Path, PathBuf};
 
@@ -101,7 +101,7 @@ impl KeyCache {
     /// Open an existing file, returning an error if the file does not exist.
     pub fn open<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
         let cache_path = validators_dir.as_ref().join(CACHE_FILENAME);
-        let file = OpenOptions::new()
+        let file = File::options()
             .read(true)
             .create_new(false)
             .open(&cache_path)


### PR DESCRIPTION
## Issue Addressed

Closes #3049 

This PR updates widely but this replace is safe as `File::options()` is equivelent to `OpenOptions::new()`.
ref: https://doc.rust-lang.org/stable/src/std/fs.rs.html#378-380