### PR TITLE
Share Http client

### DIFF
--- a/beacon_node/eth1/src/http.rs
+++ b/beacon_node/eth1/src/http.rs
@@ -122,9 +122,16 @@ pub struct Log {
     pub(crate) block_number: u64,
     pub(crate) data: Vec<u8>,
 }
+
 #[derive(Clone)]
 pub struct Eth1Client {
     client: Client,
+}
+
+impl Default for Eth1Client {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Eth1Client {

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -460,15 +460,16 @@ impl Default for Config {
 /// - Block cache: stores some number of eth1 blocks.
 #[derive(Clone)]
 pub struct Service {
+    eth1_client: Eth1Client,
     inner: Arc<Inner>,
     pub log: Logger,
-    eth1_client: Eth1Client,
 }
 
 impl Service {
     /// Creates a new service. Does not attempt to connect to the eth1 node.
     pub fn new(config: Config, log: Logger, spec: ChainSpec) -> Self {
         Self {
+            eth1_client: Eth1Client::new(),
             inner: Arc::new(Inner {
                 block_cache: <_>::default(),
                 deposit_cache: RwLock::new(DepositUpdater::new(
@@ -480,7 +481,6 @@ impl Service {
                 spec,
             }),
             log,
-            eth1_client: Eth1Client::new(),
         }
     }
 

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -2,10 +2,7 @@ use crate::metrics;
 use crate::{
     block_cache::{BlockCache, Error as BlockCacheError, Eth1Block},
     deposit_cache::{DepositCacheInsertOutcome, Error as DepositCacheError},
-    http::{
-        get_block, get_block_number, get_chain_id, get_deposit_logs_in_range, get_network_id,
-        BlockQuery, Eth1Id,
-    },
+    http::{BlockQuery, Eth1Client, Eth1Id},
     inner::{DepositUpdater, Inner},
 };
 use fallback::{Fallback, FallbackError};
@@ -459,6 +456,7 @@ impl Default for Config {
 pub struct Service {
     inner: Arc<Inner>,
     pub log: Logger,
+    client: Eth1Client,
 }
 
 impl Service {
@@ -476,6 +474,7 @@ impl Service {
                 spec,
             }),
             log,
+            client: Eth1Client::new(),
         }
     }
 
@@ -507,6 +506,7 @@ impl Service {
         Ok(Self {
             inner: Arc::new(inner),
             log,
+            client: Eth1Client::new(),
         })
     }
 


### PR DESCRIPTION
## Issue Addressed

TODO in code

## Proposed Changes

Atm each eth1 request creates a new [client instance](https://github.com/sigp/lighthouse/blob/c3a793fd73a3b11b130b82032904d39c952869e4/beacon_node/eth1/src/http.rs#L392). Sharing the connection pool across requests is more efficient. 

## Additional Info

This is just an initial implementation that reduces the needed changes to a minimum. 

Few ideas:
- separate`EndpointCache` and `Config` from `service.rs`
- Add `download_eth1_block`, `get_remote_head_and_new_block_ranges`, `relevant_new_block_numbers_from_endpoint` to `eth1client`. The arguments of these function are similar to `eth1client` functions. Return types are different.

Thoughts?