### PR TITLE
[Merged by Bors] - Add `execution_optimistic` flag to HTTP responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "lru",
  "network",
  "parking_lot 0.12.1",
+ "proto_array",
  "safe_arith",
  "sensitive_url",
  "serde",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2883,7 +2883,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 snapshot_cache.insert(
                     BeaconSnapshot {
                         beacon_state: state,
-                        beacon_block: signed_block,
+                        beacon_block: signed_block.clone(),
                         beacon_block_root: block_root,
                     },
                     None,
@@ -2908,6 +2908,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 event_handler.register(EventKind::Block(SseBlock {
                     slot,
                     block: block_root,
+                    execution_optimistic: self.is_optimistic_block(&signed_block)?,
                 }));
             }
         }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4061,9 +4061,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns `Ok(false)` if the block is pre-Bellatrix, or has `ExecutionStatus::Valid`.
     /// Returns `Ok(true)` if the block has `ExecutionStatus::Optimistic`.
-    pub fn is_optimistic_block(
+    pub fn is_optimistic_block<Payload: ExecPayload<T::EthSpec>>(
         &self,
-        block: &SignedBeaconBlock<T::EthSpec>,
+        block: &SignedBeaconBlock<T::EthSpec, Payload>,
     ) -> Result<bool, BeaconChainError> {
         // Check if the block is pre-Bellatrix.
         if self.slot_is_prior_to_bellatrix(block.slot()) {
@@ -4087,9 +4087,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// There is a potential race condition when syncing where the block_root of `head_block` could
     /// be pruned from the fork choice store before being read.
-    pub fn is_optimistic_head_block(
+    pub fn is_optimistic_head_block<Payload: ExecPayload<T::EthSpec>>(
         &self,
-        head_block: &SignedBeaconBlock<T::EthSpec>,
+        head_block: &SignedBeaconBlock<T::EthSpec, Payload>,
     ) -> Result<bool, BeaconChainError> {
         // Check if the block is pre-Bellatrix.
         if self.slot_is_prior_to_bellatrix(head_block.slot()) {

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -37,6 +37,7 @@ use state_processing::{
 };
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1776,5 +1777,12 @@ where
         assert_ne!(honest_head, faulty_head, "forks should be distinct");
 
         (honest_head, faulty_head)
+    }
+}
+
+// Junk `Debug` impl to satistfy certain trait bounds during testing.
+impl<T: BeaconChainTypes> fmt::Debug for BeaconChainHarness<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BeaconChainHarness")
     }
 }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -40,6 +40,7 @@ tree_hash = "0.4.1"
 sensitive_url = { path = "../../common/sensitive_url" }
 logging = { path = "../../common/logging" }
 serde_json = "1.0.58"
+proto_array = { path = "../../consensus/proto_array" }
 
 [[test]]
 name = "bn_http_api_tests"

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -230,7 +230,7 @@ fn convert_to_api_response<T: BeaconChainTypes>(
 
     Ok(api_types::DutiesResponse {
         dependent_root,
-        execution_optimistic,
+        execution_optimistic: Some(execution_optimistic),
         data,
     })
 }

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -146,9 +146,9 @@ fn compute_historic_attester_duties<T: BeaconChainTypes>(
         .collect::<Result<_, _>>()
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    let execution_optimistic =
-        StateId::from_slot(request_epoch.start_slot(T::EthSpec::slots_per_epoch()))
-            .is_execution_optimistic(chain)?;
+    let execution_optimistic = chain
+        .is_optimistic_head()
+        .map_err(warp_utils::reject::beacon_chain_error)?;
 
     convert_to_api_response(
         duties,

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,5 +1,6 @@
-use beacon_chain::{BeaconChain, BeaconChainTypes, WhenSlotSkipped};
+use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use eth2::types::BlockId as CoreBlockId;
+use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 use types::{BlindedPayload, Hash256, SignedBeaconBlock, Slot};
@@ -47,7 +48,26 @@ impl BlockId {
                         ))
                     })
                 }),
-            CoreBlockId::Root(root) => Ok(*root),
+            CoreBlockId::Root(root) => {
+                if root == &Hash256::zero() {
+                    return Err(warp_utils::reject::custom_not_found(format!(
+                        "beacon block with root {}",
+                        root
+                    )));
+                };
+                chain
+                    .store
+                    .get_blinded_block(root)
+                    .map_err(BeaconChainError::DBError)
+                    .map_err(warp_utils::reject::beacon_chain_error)?
+                    .map(|block| block.canonical_root())
+                    .ok_or_else(|| {
+                        warp_utils::reject::custom_not_found(format!(
+                            "beacon block with root {}",
+                            root
+                        ))
+                    })
+            }
         }
     }
 
@@ -142,6 +162,54 @@ impl BlockId {
             }
         }
     }
+
+    /// Returns the `block` along with the `execution_optimistic` value identified by `self`.
+    pub async fn full_block_and_execution_optimistic<T: BeaconChainTypes>(
+        &self,
+        chain: &BeaconChain<T>,
+    ) -> Result<(Arc<SignedBeaconBlock<T::EthSpec>>, bool), warp::Rejection> {
+        let block = self.full_block(chain).await?;
+        let execution_optimistic = match self.0 {
+            // Genesis block is inherently verified.
+            CoreBlockId::Genesis => false,
+            // Head, Finalized and Justified are determined based on their respective statuses.
+            CoreBlockId::Head => chain
+                .is_optimistic_head_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // Note that `Justified` should always be present in fork choice,
+            // so using `is_optimistic_head_block` should be fine here. Although there is a small
+            // risk of `Justified` being pruned from the fork choice store before its status is
+            // computed.
+            CoreBlockId::Justified => chain
+                .is_optimistic_head_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // Since `is_optimistic_block` falls back to the status of the finalized block, using
+            // it should minimize the impacts of the possible race condition.
+            CoreBlockId::Finalized => chain
+                .is_optimistic_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // If the slot is supplied we cannot use `block`. Instead we compute the
+            // head and use that to determine the status.
+            CoreBlockId::Slot(_) => chain
+                .is_optimistic_head()
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // If the root is explicitly given, compute its status directly.
+            CoreBlockId::Root(_) => chain
+                .is_optimistic_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+        };
+        Ok((block, execution_optimistic))
+    }
+
+    /// Convenience function to compute `execution_optimistic` when `block` is not desired.
+    pub async fn is_execution_optimistic<T: BeaconChainTypes>(
+        &self,
+        chain: &BeaconChain<T>,
+    ) -> Result<bool, warp::Rejection> {
+        self.full_block_and_execution_optimistic(chain)
+            .await
+            .map(|(_, execution_optimistic)| execution_optimistic)
+    }
 }
 
 impl FromStr for BlockId {
@@ -149,5 +217,11 @@ impl FromStr for BlockId {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         CoreBlockId::from_str(s).map(Self)
+    }
+}
+
+impl fmt::Display for BlockId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -211,15 +211,6 @@ impl BlockId {
             }
         }
     }
-
-    /// Convenience function to compute `execution_optimistic` when `block` is not desired.
-    pub fn is_execution_optimistic<T: BeaconChainTypes>(
-        &self,
-        chain: &BeaconChain<T>,
-    ) -> Result<bool, warp::Rejection> {
-        self.blinded_block(chain)
-            .map(|(_, execution_optimistic)| execution_optimistic)
-    }
 }
 
 impl FromStr for BlockId {

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -3,7 +3,7 @@ use eth2::types::BlockId as CoreBlockId;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
-use types::{BlindedPayload, Hash256, SignedBeaconBlock, Slot};
+use types::{Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot};
 
 /// Wraps `eth2::types::BlockId` and provides a simple way to obtain a block or root for a given
 /// `BlockId`.
@@ -77,7 +77,7 @@ impl BlockId {
     pub fn blinded_block<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
-    ) -> Result<SignedBeaconBlock<T::EthSpec, BlindedPayload<T::EthSpec>>, warp::Rejection> {
+    ) -> Result<SignedBlindedBeaconBlock<T::EthSpec>, warp::Rejection> {
         match &self.0 {
             CoreBlockId::Head => Ok(chain.head_beacon_block().clone_as_blinded()),
             CoreBlockId::Slot(slot) => {
@@ -165,6 +165,44 @@ impl BlockId {
         }
     }
 
+    /// Returns the `blinded_block` along with the `execution_optimistic` value identified by `self`.
+    pub fn blinded_block_and_execution_optimistic<T: BeaconChainTypes>(
+        &self,
+        chain: &BeaconChain<T>,
+    ) -> Result<(SignedBlindedBeaconBlock<T::EthSpec>, bool), warp::Rejection> {
+        let block = self.blinded_block(chain)?;
+        let execution_optimistic = match self.0 {
+            // Genesis block is inherently verified.
+            CoreBlockId::Genesis => false,
+            // Head, Finalized and Justified are determined based on their respective statuses.
+            CoreBlockId::Head => chain
+                .is_optimistic_head_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // Note that `Justified` should always be present in fork choice,
+            // so using `is_optimistic_head_block` should be fine here. Although there is a small
+            // risk of `Justified` being pruned from the fork choice store before its status is
+            // computed.
+            CoreBlockId::Justified => chain
+                .is_optimistic_head_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // Since `is_optimistic_block` falls back to the status of the finalized block, using
+            // it should minimize the impacts of the possible race condition.
+            CoreBlockId::Finalized => chain
+                .is_optimistic_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // If the slot is supplied we cannot use `block`. Instead we compute the
+            // head and use that to determine the status.
+            CoreBlockId::Slot(_) => chain
+                .is_optimistic_head()
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+            // If the root is explicitly given, compute its status directly.
+            CoreBlockId::Root(_) => chain
+                .is_optimistic_block(&block)
+                .map_err(warp_utils::reject::beacon_chain_error)?,
+        };
+        Ok((block, execution_optimistic))
+    }
+
     /// Returns the `block` along with the `execution_optimistic` value identified by `self`.
     pub async fn full_block_and_execution_optimistic<T: BeaconChainTypes>(
         &self,
@@ -204,12 +242,11 @@ impl BlockId {
     }
 
     /// Convenience function to compute `execution_optimistic` when `block` is not desired.
-    pub async fn is_execution_optimistic<T: BeaconChainTypes>(
+    pub fn is_execution_optimistic<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
     ) -> Result<bool, warp::Rejection> {
-        self.full_block_and_execution_optimistic(chain)
-            .await
+        self.blinded_block_and_execution_optimistic(chain)
             .map(|(_, execution_optimistic)| execution_optimistic)
     }
 }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -25,7 +25,7 @@ use beacon_chain::{
     AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
     ProduceBlockVerification, WhenSlotSkipped,
 };
-use block_id::BlockId;
+pub use block_id::BlockId;
 use eth2::types::{self as api_types, EndpointVersion, ValidatorId};
 use lighthouse_network::{types::SyncState, EnrExt, NetworkGlobals, PeerId, PubsubMessage};
 use lighthouse_version::version_with_platform;
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize};
 use slog::{crit, debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
 use ssz::Encode;
-use state_id::StateId;
+pub use state_id::StateId;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::future::Future;
@@ -42,7 +42,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::{runtime::Handle, sync::mpsc::UnboundedSender};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use types::{
     Attestation, AttesterSlashing, BeaconBlockBodyMerge, BeaconBlockMerge, BeaconStateError,
@@ -53,8 +53,8 @@ use types::{
     SyncCommitteeMessage, SyncContributionData,
 };
 use version::{
-    add_consensus_version_header, fork_versioned_response, inconsistent_fork_rejection,
-    unsupported_version_rejection, V1,
+    add_consensus_version_header, execution_optimistic_fork_versioned_response,
+    fork_versioned_response, inconsistent_fork_rejection, unsupported_version_rejection, V1, V2,
 };
 use warp::http::StatusCode;
 use warp::sse::Event;
@@ -138,6 +138,12 @@ impl From<String> for Error {
     fn from(e: String) -> Self {
         Error::Other(e)
     }
+}
+
+enum HeaderComputationType {
+    UsesHeadWithBlock,
+    UsesHeadNoBlock,
+    NoHead,
 }
 
 /// Creates a `warp` logging wrapper which we use to create `slog` logs.
@@ -304,7 +310,7 @@ pub fn serve<T: BeaconChainTypes>(
             .untuple_one()
     };
 
-    let eth1_v1 = single_version(V1);
+    let eth_v1 = single_version(V1);
 
     // Create a `warp` filter that provides access to the network globals.
     let inner_network_globals = ctx.network_globals.clone();
@@ -413,7 +419,7 @@ pub fn serve<T: BeaconChainTypes>(
      */
 
     // GET beacon/genesis
-    let get_beacon_genesis = eth1_v1
+    let get_beacon_genesis = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("genesis"))
         .and(warp::path::end())
@@ -433,7 +439,7 @@ pub fn serve<T: BeaconChainTypes>(
      * beacon/states/{state_id}
      */
 
-    let beacon_states_path = eth1_v1
+    let beacon_states_path = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("states"))
         .and(warp::path::param::<StateId>().or_else(|_| async {
@@ -450,10 +456,12 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(|state_id: StateId, chain: Arc<BeaconChain<T>>| {
             blocking_json_task(move || {
+                let execution_optimistic = state_id.is_execution_optimistic(&chain)?;
                 state_id
                     .root(&chain)
                     .map(api_types::RootData::from)
                     .map(api_types::GenericResponse::from)
+                    .map(|resp| resp.add_execution_optimistic(execution_optimistic))
             })
         });
 
@@ -463,7 +471,14 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path("fork"))
         .and(warp::path::end())
         .and_then(|state_id: StateId, chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || state_id.fork(&chain).map(api_types::GenericResponse::from))
+            blocking_json_task(move || {
+                let (fork, execution_optimistic) =
+                    state_id.fork_and_execution_optimistic(&chain)?;
+                Ok(api_types::ExecutionOptimisticResponse {
+                    data: fork,
+                    execution_optimistic,
+                })
+            })
         });
 
     // GET beacon/states/{state_id}/finality_checkpoints
@@ -473,15 +488,24 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(|state_id: StateId, chain: Arc<BeaconChain<T>>| {
             blocking_json_task(move || {
-                state_id
-                    .map_state(&chain, |state| {
-                        Ok(api_types::FinalityCheckpointsData {
-                            previous_justified: state.previous_justified_checkpoint(),
-                            current_justified: state.current_justified_checkpoint(),
-                            finalized: state.finalized_checkpoint(),
-                        })
-                    })
-                    .map(api_types::GenericResponse::from)
+                let (data, execution_optimistic) = state_id.map_state_and_execution_optimistic(
+                    &chain,
+                    |state, execution_optimistic| {
+                        Ok((
+                            api_types::FinalityCheckpointsData {
+                                previous_justified: state.previous_justified_checkpoint(),
+                                current_justified: state.current_justified_checkpoint(),
+                                finalized: state.finalized_checkpoint(),
+                            },
+                            execution_optimistic,
+                        ))
+                    },
+                )?;
+
+                Ok(api_types::ExecutionOptimisticResponse {
+                    data,
+                    execution_optimistic,
+                })
             })
         });
 
@@ -497,35 +521,45 @@ pub fn serve<T: BeaconChainTypes>(
              query_res: Result<api_types::ValidatorBalancesQuery, warp::Rejection>| {
                 blocking_json_task(move || {
                     let query = query_res?;
-                    state_id
-                        .map_state(&chain, |state| {
-                            Ok(state
-                                .validators()
-                                .iter()
-                                .zip(state.balances().iter())
-                                .enumerate()
-                                // filter by validator id(s) if provided
-                                .filter(|(index, (validator, _))| {
-                                    query.id.as_ref().map_or(true, |ids| {
-                                        ids.iter().any(|id| match id {
-                                            ValidatorId::PublicKey(pubkey) => {
-                                                &validator.pubkey == pubkey
-                                            }
-                                            ValidatorId::Index(param_index) => {
-                                                *param_index == *index as u64
-                                            }
+                    let (data, execution_optimistic) = state_id
+                        .map_state_and_execution_optimistic(
+                            &chain,
+                            |state, execution_optimistic| {
+                                Ok((
+                                    state
+                                        .validators()
+                                        .iter()
+                                        .zip(state.balances().iter())
+                                        .enumerate()
+                                        // filter by validator id(s) if provided
+                                        .filter(|(index, (validator, _))| {
+                                            query.id.as_ref().map_or(true, |ids| {
+                                                ids.iter().any(|id| match id {
+                                                    ValidatorId::PublicKey(pubkey) => {
+                                                        &validator.pubkey == pubkey
+                                                    }
+                                                    ValidatorId::Index(param_index) => {
+                                                        *param_index == *index as u64
+                                                    }
+                                                })
+                                            })
                                         })
-                                    })
-                                })
-                                .map(|(index, (_, balance))| {
-                                    Some(api_types::ValidatorBalanceData {
-                                        index: index as u64,
-                                        balance: *balance,
-                                    })
-                                })
-                                .collect::<Vec<_>>())
-                        })
-                        .map(api_types::GenericResponse::from)
+                                        .map(|(index, (_, balance))| {
+                                            Some(api_types::ValidatorBalanceData {
+                                                index: index as u64,
+                                                balance: *balance,
+                                            })
+                                        })
+                                        .collect::<Vec<_>>(),
+                                    execution_optimistic,
+                                ))
+                            },
+                        )?;
+
+                    Ok(api_types::ExecutionOptimisticResponse {
+                        data,
+                        execution_optimistic,
+                    })
                 })
             },
         );
@@ -542,57 +576,67 @@ pub fn serve<T: BeaconChainTypes>(
              query_res: Result<api_types::ValidatorsQuery, warp::Rejection>| {
                 blocking_json_task(move || {
                     let query = query_res?;
-                    state_id
-                        .map_state(&chain, |state| {
-                            let epoch = state.current_epoch();
-                            let far_future_epoch = chain.spec.far_future_epoch;
+                    let (data, execution_optimistic) = state_id
+                        .map_state_and_execution_optimistic(
+                            &chain,
+                            |state, execution_optimistic| {
+                                let epoch = state.current_epoch();
+                                let far_future_epoch = chain.spec.far_future_epoch;
 
-                            Ok(state
-                                .validators()
-                                .iter()
-                                .zip(state.balances().iter())
-                                .enumerate()
-                                // filter by validator id(s) if provided
-                                .filter(|(index, (validator, _))| {
-                                    query.id.as_ref().map_or(true, |ids| {
-                                        ids.iter().any(|id| match id {
-                                            ValidatorId::PublicKey(pubkey) => {
-                                                &validator.pubkey == pubkey
-                                            }
-                                            ValidatorId::Index(param_index) => {
-                                                *param_index == *index as u64
+                                Ok((
+                                    state
+                                        .validators()
+                                        .iter()
+                                        .zip(state.balances().iter())
+                                        .enumerate()
+                                        // filter by validator id(s) if provided
+                                        .filter(|(index, (validator, _))| {
+                                            query.id.as_ref().map_or(true, |ids| {
+                                                ids.iter().any(|id| match id {
+                                                    ValidatorId::PublicKey(pubkey) => {
+                                                        &validator.pubkey == pubkey
+                                                    }
+                                                    ValidatorId::Index(param_index) => {
+                                                        *param_index == *index as u64
+                                                    }
+                                                })
+                                            })
+                                        })
+                                        // filter by status(es) if provided and map the result
+                                        .filter_map(|(index, (validator, balance))| {
+                                            let status = api_types::ValidatorStatus::from_validator(
+                                                validator,
+                                                epoch,
+                                                far_future_epoch,
+                                            );
+
+                                            let status_matches =
+                                                query.status.as_ref().map_or(true, |statuses| {
+                                                    statuses.contains(&status)
+                                                        || statuses.contains(&status.superstatus())
+                                                });
+
+                                            if status_matches {
+                                                Some(api_types::ValidatorData {
+                                                    index: index as u64,
+                                                    balance: *balance,
+                                                    status,
+                                                    validator: validator.clone(),
+                                                })
+                                            } else {
+                                                None
                                             }
                                         })
-                                    })
-                                })
-                                // filter by status(es) if provided and map the result
-                                .filter_map(|(index, (validator, balance))| {
-                                    let status = api_types::ValidatorStatus::from_validator(
-                                        validator,
-                                        epoch,
-                                        far_future_epoch,
-                                    );
+                                        .collect::<Vec<_>>(),
+                                    execution_optimistic,
+                                ))
+                            },
+                        )?;
 
-                                    let status_matches =
-                                        query.status.as_ref().map_or(true, |statuses| {
-                                            statuses.contains(&status)
-                                                || statuses.contains(&status.superstatus())
-                                        });
-
-                                    if status_matches {
-                                        Some(api_types::ValidatorData {
-                                            index: index as u64,
-                                            balance: *balance,
-                                            status,
-                                            validator: validator.clone(),
-                                        })
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .collect::<Vec<_>>())
-                        })
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::ExecutionOptimisticResponse {
+                        data,
+                        execution_optimistic,
+                    })
                 })
             },
         );
@@ -610,41 +654,51 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(
             |state_id: StateId, chain: Arc<BeaconChain<T>>, validator_id: ValidatorId| {
                 blocking_json_task(move || {
-                    state_id
-                        .map_state(&chain, |state| {
-                            let index_opt = match &validator_id {
-                                ValidatorId::PublicKey(pubkey) => {
-                                    state.validators().iter().position(|v| v.pubkey == *pubkey)
-                                }
-                                ValidatorId::Index(index) => Some(*index as usize),
-                            };
+                    let (data, execution_optimistic) = state_id
+                        .map_state_and_execution_optimistic(
+                            &chain,
+                            |state, execution_optimistic| {
+                                let index_opt = match &validator_id {
+                                    ValidatorId::PublicKey(pubkey) => {
+                                        state.validators().iter().position(|v| v.pubkey == *pubkey)
+                                    }
+                                    ValidatorId::Index(index) => Some(*index as usize),
+                                };
 
-                            index_opt
-                                .and_then(|index| {
-                                    let validator = state.validators().get(index)?;
-                                    let balance = *state.balances().get(index)?;
-                                    let epoch = state.current_epoch();
-                                    let far_future_epoch = chain.spec.far_future_epoch;
+                                Ok((
+                                    index_opt
+                                        .and_then(|index| {
+                                            let validator = state.validators().get(index)?;
+                                            let balance = *state.balances().get(index)?;
+                                            let epoch = state.current_epoch();
+                                            let far_future_epoch = chain.spec.far_future_epoch;
 
-                                    Some(api_types::ValidatorData {
-                                        index: index as u64,
-                                        balance,
-                                        status: api_types::ValidatorStatus::from_validator(
-                                            validator,
-                                            epoch,
-                                            far_future_epoch,
-                                        ),
-                                        validator: validator.clone(),
-                                    })
-                                })
-                                .ok_or_else(|| {
-                                    warp_utils::reject::custom_not_found(format!(
-                                        "unknown validator: {}",
-                                        validator_id
-                                    ))
-                                })
-                        })
-                        .map(api_types::GenericResponse::from)
+                                            Some(api_types::ValidatorData {
+                                                index: index as u64,
+                                                balance,
+                                                status: api_types::ValidatorStatus::from_validator(
+                                                    validator,
+                                                    epoch,
+                                                    far_future_epoch,
+                                                ),
+                                                validator: validator.clone(),
+                                            })
+                                        })
+                                        .ok_or_else(|| {
+                                            warp_utils::reject::custom_not_found(format!(
+                                                "unknown validator: {}",
+                                                validator_id
+                                            ))
+                                        })?,
+                                    execution_optimistic,
+                                ))
+                            },
+                        )?;
+
+                    Ok(api_types::ExecutionOptimisticResponse {
+                        data,
+                        execution_optimistic,
+                    })
                 })
             },
         );
@@ -657,87 +711,104 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(
             |state_id: StateId, chain: Arc<BeaconChain<T>>, query: api_types::CommitteesQuery| {
+                // the api spec says if the epoch is not present then the epoch of the state should be used
+                let query_state_id = query.epoch.map_or(state_id, |epoch| {
+                    StateId::from_slot(epoch.start_slot(T::EthSpec::slots_per_epoch()))
+                });
+
                 blocking_json_task(move || {
-                    state_id.map_state(&chain, |state| {
-                        let current_epoch = state.current_epoch();
-                        let epoch = query.epoch.unwrap_or(current_epoch);
+                    let (data, execution_optimistic) = query_state_id
+                        .map_state_and_execution_optimistic(
+                            &chain,
+                            |state, execution_optimistic| {
+                                let current_epoch = state.current_epoch();
+                                let epoch = query.epoch.unwrap_or(current_epoch);
 
-                        let committee_cache = match RelativeEpoch::from_epoch(current_epoch, epoch)
-                        {
-                            Ok(relative_epoch)
-                                if state.committee_cache_is_initialized(relative_epoch) =>
-                            {
-                                state.committee_cache(relative_epoch).map(Cow::Borrowed)
-                            }
-                            _ => CommitteeCache::initialized(state, epoch, &chain.spec)
-                                .map(Cow::Owned),
-                        }
-                        .map_err(|e| match e {
-                            BeaconStateError::EpochOutOfBounds => {
-                                let max_sprp = T::EthSpec::slots_per_historical_root() as u64;
-                                let first_subsequent_restore_point_slot =
-                                    ((epoch.start_slot(T::EthSpec::slots_per_epoch()) / max_sprp)
-                                        + 1)
-                                        * max_sprp;
-                                if epoch < current_epoch {
-                                    warp_utils::reject::custom_bad_request(format!(
-                                        "epoch out of bounds, try state at slot {}",
-                                        first_subsequent_restore_point_slot,
-                                    ))
-                                } else {
-                                    warp_utils::reject::custom_bad_request(
-                                        "epoch out of bounds, too far in future".into(),
-                                    )
+                                let committee_cache =
+                                    match RelativeEpoch::from_epoch(current_epoch, epoch) {
+                                        Ok(relative_epoch)
+                                            if state
+                                                .committee_cache_is_initialized(relative_epoch) =>
+                                        {
+                                            state.committee_cache(relative_epoch).map(Cow::Borrowed)
+                                        }
+                                        _ => CommitteeCache::initialized(state, epoch, &chain.spec)
+                                            .map(Cow::Owned),
+                                    }
+                                    .map_err(|e| match e {
+                                        BeaconStateError::EpochOutOfBounds => {
+                                            let max_sprp =
+                                                T::EthSpec::slots_per_historical_root() as u64;
+                                            let first_subsequent_restore_point_slot = ((epoch
+                                                .start_slot(T::EthSpec::slots_per_epoch())
+                                                / max_sprp)
+                                                + 1)
+                                                * max_sprp;
+                                            if epoch < current_epoch {
+                                                warp_utils::reject::custom_bad_request(format!(
+                                                    "epoch out of bounds, try state at slot {}",
+                                                    first_subsequent_restore_point_slot,
+                                                ))
+                                            } else {
+                                                warp_utils::reject::custom_bad_request(
+                                                    "epoch out of bounds, too far in future".into(),
+                                                )
+                                            }
+                                        }
+                                        _ => warp_utils::reject::beacon_chain_error(e.into()),
+                                    })?;
+
+                                // Use either the supplied slot or all slots in the epoch.
+                                let slots =
+                                    query.slot.map(|slot| vec![slot]).unwrap_or_else(|| {
+                                        epoch.slot_iter(T::EthSpec::slots_per_epoch()).collect()
+                                    });
+
+                                // Use either the supplied committee index or all available indices.
+                                let indices =
+                                    query.index.map(|index| vec![index]).unwrap_or_else(|| {
+                                        (0..committee_cache.committees_per_slot()).collect()
+                                    });
+
+                                let mut response = Vec::with_capacity(slots.len() * indices.len());
+
+                                for slot in slots {
+                                    // It is not acceptable to query with a slot that is not within the
+                                    // specified epoch.
+                                    if slot.epoch(T::EthSpec::slots_per_epoch()) != epoch {
+                                        return Err(warp_utils::reject::custom_bad_request(
+                                            format!("{} is not in epoch {}", slot, epoch),
+                                        ));
+                                    }
+
+                                    for &index in &indices {
+                                        let committee = committee_cache
+                                            .get_beacon_committee(slot, index)
+                                            .ok_or_else(|| {
+                                                warp_utils::reject::custom_bad_request(format!(
+                                                    "committee index {} does not exist in epoch {}",
+                                                    index, epoch
+                                                ))
+                                            })?;
+
+                                        response.push(api_types::CommitteeData {
+                                            index,
+                                            slot,
+                                            validators: committee
+                                                .committee
+                                                .iter()
+                                                .map(|i| *i as u64)
+                                                .collect(),
+                                        });
+                                    }
                                 }
-                            }
-                            _ => warp_utils::reject::beacon_chain_error(e.into()),
-                        })?;
 
-                        // Use either the supplied slot or all slots in the epoch.
-                        let slots = query.slot.map(|slot| vec![slot]).unwrap_or_else(|| {
-                            epoch.slot_iter(T::EthSpec::slots_per_epoch()).collect()
-                        });
-
-                        // Use either the supplied committee index or all available indices.
-                        let indices = query.index.map(|index| vec![index]).unwrap_or_else(|| {
-                            (0..committee_cache.committees_per_slot()).collect()
-                        });
-
-                        let mut response = Vec::with_capacity(slots.len() * indices.len());
-
-                        for slot in slots {
-                            // It is not acceptable to query with a slot that is not within the
-                            // specified epoch.
-                            if slot.epoch(T::EthSpec::slots_per_epoch()) != epoch {
-                                return Err(warp_utils::reject::custom_bad_request(format!(
-                                    "{} is not in epoch {}",
-                                    slot, epoch
-                                )));
-                            }
-
-                            for &index in &indices {
-                                let committee = committee_cache
-                                    .get_beacon_committee(slot, index)
-                                    .ok_or_else(|| {
-                                    warp_utils::reject::custom_bad_request(format!(
-                                        "committee index {} does not exist in epoch {}",
-                                        index, epoch
-                                    ))
-                                })?;
-
-                                response.push(api_types::CommitteeData {
-                                    index,
-                                    slot,
-                                    validators: committee
-                                        .committee
-                                        .iter()
-                                        .map(|i| *i as u64)
-                                        .collect(),
-                                });
-                            }
-                        }
-
-                        Ok(api_types::GenericResponse::from(response))
+                                Ok((response, execution_optimistic))
+                            },
+                        )?;
+                    Ok(api_types::ExecutionOptimisticResponse {
+                        data,
+                        execution_optimistic,
                     })
                 })
             },
@@ -754,28 +825,35 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>,
              query: api_types::SyncCommitteesQuery| {
                 blocking_json_task(move || {
-                    let sync_committee = state_id.map_state(&chain, |state| {
-                        let current_epoch = state.current_epoch();
-                        let epoch = query.epoch.unwrap_or(current_epoch);
-                        state
-                            .get_built_sync_committee(epoch, &chain.spec)
-                            .map(|committee| committee.clone())
-                            .map_err(|e| match e {
-                                BeaconStateError::SyncCommitteeNotKnown { .. } => {
-                                    warp_utils::reject::custom_bad_request(format!(
+                    let (sync_committee, execution_optimistic) = state_id
+                        .map_state_and_execution_optimistic(
+                            &chain,
+                            |state, execution_optimistic| {
+                                let current_epoch = state.current_epoch();
+                                let epoch = query.epoch.unwrap_or(current_epoch);
+                                Ok((
+                                    state
+                                        .get_built_sync_committee(epoch, &chain.spec)
+                                        .map(|committee| committee.clone())
+                                        .map_err(|e| match e {
+                                            BeaconStateError::SyncCommitteeNotKnown { .. } => {
+                                                warp_utils::reject::custom_bad_request(format!(
                                         "state at epoch {} has no sync committee for epoch {}",
                                         current_epoch, epoch
                                     ))
-                                }
-                                BeaconStateError::IncorrectStateVariant => {
-                                    warp_utils::reject::custom_bad_request(format!(
-                                        "state at epoch {} is not activated for Altair",
-                                        current_epoch,
-                                    ))
-                                }
-                                e => warp_utils::reject::beacon_state_error(e),
-                            })
-                    })?;
+                                            }
+                                            BeaconStateError::IncorrectStateVariant => {
+                                                warp_utils::reject::custom_bad_request(format!(
+                                                    "state at epoch {} is not activated for Altair",
+                                                    current_epoch,
+                                                ))
+                                            }
+                                            e => warp_utils::reject::beacon_state_error(e),
+                                        })?,
+                                    execution_optimistic,
+                                ))
+                            },
+                        )?;
 
                     let validators = chain
                         .validator_indices(sync_committee.pubkeys.iter())
@@ -793,7 +871,8 @@ pub fn serve<T: BeaconChainTypes>(
                         validator_aggregates,
                     };
 
-                    Ok(api_types::GenericResponse::from(response))
+                    Ok(api_types::GenericResponse::from(response)
+                        .add_execution_optimistic(execution_optimistic))
                 })
             },
         );
@@ -805,81 +884,100 @@ pub fn serve<T: BeaconChainTypes>(
     // things. Returning non-canonical things is hard for us since we don't already have a
     // mechanism for arbitrary forwards block iteration, we only support iterating forwards along
     // the canonical chain.
-    let get_beacon_headers = eth1_v1
+    let get_beacon_headers = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("headers"))
         .and(warp::query::<api_types::HeadersQuery>())
         .and(warp::path::end())
         .and(chain_filter.clone())
         .and_then(
-            |query: api_types::HeadersQuery, chain: Arc<BeaconChain<T>>| {
-                blocking_json_task(move || {
-                    let (root, block) = match (query.slot, query.parent_root) {
-                        // No query parameters, return the canonical head block.
-                        (None, None) => {
-                            let block = chain.head_beacon_block();
-                            (block.canonical_root(), block.clone_as_blinded())
-                        }
-                        // Only the parent root parameter, do a forwards-iterator lookup.
-                        (None, Some(parent_root)) => {
-                            let parent = BlockId::from_root(parent_root).blinded_block(&chain)?;
-                            let (root, _slot) = chain
-                                .forwards_iter_block_roots(parent.slot())
-                                .map_err(warp_utils::reject::beacon_chain_error)?
-                                // Ignore any skip-slots immediately following the parent.
-                                .find(|res| {
-                                    res.as_ref().map_or(false, |(root, _)| *root != parent_root)
-                                })
-                                .transpose()
-                                .map_err(warp_utils::reject::beacon_chain_error)?
-                                .ok_or_else(|| {
-                                    warp_utils::reject::custom_not_found(format!(
-                                        "child of block with root {}",
-                                        parent_root
-                                    ))
-                                })?;
+            |query: api_types::HeadersQuery, chain: Arc<BeaconChain<T>>| async move {
+                let (root, block, uses_head) = match (query.slot, query.parent_root) {
+                    // No query parameters, return the canonical head block.
+                    (None, None) => {
+                        let block = chain.head_beacon_block();
+                        (
+                            block.canonical_root(),
+                            block,
+                            HeaderComputationType::UsesHeadWithBlock,
+                        )
+                    }
+                    // Only the parent root parameter, do a forwards-iterator lookup.
+                    (None, Some(parent_root)) => {
+                        let parent = BlockId::from_root(parent_root).blinded_block(&chain)?;
+                        let (root, _slot) = chain
+                            .forwards_iter_block_roots(parent.slot())
+                            .map_err(warp_utils::reject::beacon_chain_error)?
+                            // Ignore any skip-slots immediately following the parent.
+                            .find(|res| {
+                                res.as_ref().map_or(false, |(root, _)| *root != parent_root)
+                            })
+                            .transpose()
+                            .map_err(warp_utils::reject::beacon_chain_error)?
+                            .ok_or_else(|| {
+                                warp_utils::reject::custom_not_found(format!(
+                                    "child of block with root {}",
+                                    parent_root
+                                ))
+                            })?;
 
-                            BlockId::from_root(root)
-                                .blinded_block(&chain)
-                                .map(|block| (root, block))?
-                        }
-                        // Slot is supplied, search by slot and optionally filter by
-                        // parent root.
-                        (Some(slot), parent_root_opt) => {
-                            let root = BlockId::from_slot(slot).root(&chain)?;
-                            let block = BlockId::from_root(root).blinded_block(&chain)?;
+                        BlockId::from_root(root)
+                            .full_block(&chain)
+                            .await
+                            .map(|block| (root, block, HeaderComputationType::NoHead))?
+                    }
+                    // Slot is supplied, search by slot and optionally filter by
+                    // parent root.
+                    (Some(slot), parent_root_opt) => {
+                        let root = BlockId::from_slot(slot).root(&chain)?;
+                        let block = BlockId::from_root(root).full_block(&chain).await?;
+                        let mut uses_head = HeaderComputationType::UsesHeadNoBlock;
 
-                            // If the parent root was supplied, check that it matches the block
-                            // obtained via a slot lookup.
-                            if let Some(parent_root) = parent_root_opt {
-                                if block.parent_root() != parent_root {
-                                    return Err(warp_utils::reject::custom_not_found(format!(
-                                        "no canonical block at slot {} with parent root {}",
-                                        slot, parent_root
-                                    )));
-                                }
+                        // If the parent root was supplied, check that it matches the block
+                        // obtained via a slot lookup.
+                        if let Some(parent_root) = parent_root_opt {
+                            if block.parent_root() != parent_root {
+                                return Err(warp_utils::reject::custom_not_found(format!(
+                                    "no canonical block at slot {} with parent root {}",
+                                    slot, parent_root
+                                )));
+                            } else {
+                                uses_head = HeaderComputationType::NoHead;
                             }
-
-                            (root, block)
                         }
-                    };
 
-                    let data = api_types::BlockHeaderData {
-                        root,
-                        canonical: true,
-                        header: api_types::BlockHeaderAndSignature {
-                            message: block.message().block_header(),
-                            signature: block.signature().clone().into(),
-                        },
-                    };
+                        (root, block, uses_head)
+                    }
+                };
 
-                    Ok(api_types::GenericResponse::from(vec![data]))
-                })
+                // The value of `execution_optimistic` depends on whether the method used to
+                // compute the response is dependent on the head block.
+                let execution_optimistic = match uses_head {
+                    HeaderComputationType::NoHead => chain.is_optimistic_block(&block),
+                    HeaderComputationType::UsesHeadWithBlock => {
+                        chain.is_optimistic_head_block(&block)
+                    }
+                    HeaderComputationType::UsesHeadNoBlock => chain.is_optimistic_head(),
+                }
+                .map_err(warp_utils::reject::beacon_chain_error)?;
+
+                let data = api_types::BlockHeaderData {
+                    root,
+                    canonical: true,
+                    header: api_types::BlockHeaderAndSignature {
+                        message: block.message().block_header(),
+                        signature: block.signature().clone().into(),
+                    },
+                };
+
+                Ok(api_types::GenericResponse::from(vec![data])
+                    .add_execution_optimistic(execution_optimistic))
+                .map(|res| warp::reply::json(&res).into_response())
             },
         );
 
     // GET beacon/headers/{block_id}
-    let get_beacon_headers_block_id = eth1_v1
+    let get_beacon_headers_block_id = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("headers"))
         .and(warp::path::param::<BlockId>().or_else(|_| async {
@@ -889,27 +987,33 @@ pub fn serve<T: BeaconChainTypes>(
         }))
         .and(warp::path::end())
         .and(chain_filter.clone())
-        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || {
-                let root = block_id.root(&chain)?;
-                let block = BlockId::from_root(root).blinded_block(&chain)?;
+        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| async move {
+            let root = block_id.root(&chain)?;
+            let (block, execution_optimistic) = BlockId::from_root(root)
+                .full_block_and_execution_optimistic(&chain)
+                .await?;
 
-                let canonical = chain
-                    .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
-                    .map_err(warp_utils::reject::beacon_chain_error)?
-                    .map_or(false, |canonical| root == canonical);
+            let canonical = chain
+                .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
+                .map_err(warp_utils::reject::beacon_chain_error)?
+                .map_or(false, |canonical| root == canonical);
 
-                let data = api_types::BlockHeaderData {
-                    root,
-                    canonical,
-                    header: api_types::BlockHeaderAndSignature {
-                        message: block.message().block_header(),
-                        signature: block.signature().clone().into(),
-                    },
-                };
+            let data = api_types::BlockHeaderData {
+                root,
+                canonical,
+                header: api_types::BlockHeaderAndSignature {
+                    message: block.message().block_header(),
+                    signature: block.signature().clone().into(),
+                },
+            };
 
-                Ok(api_types::GenericResponse::from(data))
+            let result: Result<_, warp::Rejection> = Ok(api_types::ExecutionOptimisticResponse {
+                execution_optimistic,
+                data,
             })
+            .map(|res| warp::reply::json(&res).into_response());
+
+            result
         });
 
     /*
@@ -917,7 +1021,7 @@ pub fn serve<T: BeaconChainTypes>(
      */
 
     // POST beacon/blocks
-    let post_beacon_blocks = eth1_v1
+    let post_beacon_blocks = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("blocks"))
         .and(warp::path::end())
@@ -1013,7 +1117,7 @@ pub fn serve<T: BeaconChainTypes>(
      */
 
     // POST beacon/blocks
-    let post_beacon_blinded_blocks = eth1_v1
+    let post_beacon_blinded_blocks = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("blinded_blocks"))
         .and(warp::path::end())
@@ -1115,7 +1219,7 @@ pub fn serve<T: BeaconChainTypes>(
         ))
     });
 
-    let beacon_blocks_path_v1 = eth1_v1
+    let beacon_blocks_path_v1 = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("blocks"))
         .and(block_id_or_err)
@@ -1138,10 +1242,12 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>,
              accept_header: Option<api_types::Accept>| {
                 async move {
-                    let block = block_id.full_block(&chain).await?;
+                    let (block, execution_optimistic) =
+                        block_id.full_block_and_execution_optimistic(&chain).await?;
                     let fork_name = block
                         .fork_name(&chain.spec)
                         .map_err(inconsistent_fork_rejection)?;
+
                     match accept_header {
                         Some(api_types::Accept::Ssz) => Response::builder()
                             .status(200)
@@ -1153,8 +1259,13 @@ pub fn serve<T: BeaconChainTypes>(
                                     e
                                 ))
                             }),
-                        _ => fork_versioned_response(endpoint_version, fork_name, block)
-                            .map(|res| warp::reply::json(&res).into_response()),
+                        _ => execution_optimistic_fork_versioned_response(
+                            endpoint_version,
+                            fork_name,
+                            execution_optimistic,
+                            block,
+                        )
+                        .map(|res| warp::reply::json(&res).into_response()),
                     }
                     .map(|resp| add_consensus_version_header(resp, fork_name))
                 }
@@ -1166,13 +1277,17 @@ pub fn serve<T: BeaconChainTypes>(
         .clone()
         .and(warp::path("root"))
         .and(warp::path::end())
-        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || {
-                block_id
-                    .root(&chain)
-                    .map(api_types::RootData::from)
-                    .map(api_types::GenericResponse::from)
-            })
+        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| async move {
+            let (block, execution_optimistic) =
+                block_id.full_block_and_execution_optimistic(&chain).await?;
+
+            let result: Result<_, warp::Rejection> = Ok(api_types::GenericResponse::from(
+                api_types::RootData::from(block.canonical_root()),
+            )
+            .add_execution_optimistic(execution_optimistic))
+            .map(|res| warp::reply::json(&res).into_response());
+
+            result
         });
 
     // GET beacon/blocks/{block_id}/attestations
@@ -1180,20 +1295,24 @@ pub fn serve<T: BeaconChainTypes>(
         .clone()
         .and(warp::path("attestations"))
         .and(warp::path::end())
-        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || {
-                block_id
-                    .blinded_block(&chain)
-                    .map(|block| block.message().body().attestations().clone())
-                    .map(api_types::GenericResponse::from)
-            })
+        .and_then(|block_id: BlockId, chain: Arc<BeaconChain<T>>| async move {
+            let (block, execution_optimistic) =
+                block_id.full_block_and_execution_optimistic(&chain).await?;
+
+            let result: Result<_, warp::Rejection> = Ok(api_types::GenericResponse::from(
+                block.message().body().attestations().clone(),
+            )
+            .add_execution_optimistic(execution_optimistic))
+            .map(|res| warp::reply::json(&res).into_response());
+
+            result
         });
 
     /*
      * beacon/pool
      */
 
-    let beacon_pool_path = eth1_v1
+    let beacon_pool_path = eth_v1
         .and(warp::path("beacon"))
         .and(warp::path("pool"))
         .and(chain_filter.clone());
@@ -1519,7 +1638,7 @@ pub fn serve<T: BeaconChainTypes>(
      * config
      */
 
-    let config_path = eth1_v1.and(warp::path("config"));
+    let config_path = eth_v1.and(warp::path("config"));
 
     // GET config/fork_schedule
     let get_config_fork_schedule = config_path
@@ -1609,44 +1728,73 @@ pub fn serve<T: BeaconChainTypes>(
                                 ))
                             })
                     }
-                    _ => state_id.map_state(&chain, |state| {
-                        let fork_name = state
-                            .fork_name(&chain.spec)
-                            .map_err(inconsistent_fork_rejection)?;
-                        let res = fork_versioned_response(endpoint_version, fork_name, &state)?;
-                        Ok(add_consensus_version_header(
-                            warp::reply::json(&res).into_response(),
-                            fork_name,
-                        ))
-                    }),
+                    _ => state_id.map_state_and_execution_optimistic(
+                        &chain,
+                        |state, execution_optimistic| {
+                            let fork_name = state
+                                .fork_name(&chain.spec)
+                                .map_err(inconsistent_fork_rejection)?;
+                            let res = execution_optimistic_fork_versioned_response(
+                                endpoint_version,
+                                fork_name,
+                                execution_optimistic,
+                                &state,
+                            )?;
+                            Ok(add_consensus_version_header(
+                                warp::reply::json(&res).into_response(),
+                                fork_name,
+                            ))
+                        },
+                    ),
                 })
             },
         );
 
     // GET debug/beacon/heads
-    let get_debug_beacon_heads = eth1_v1
+    let get_debug_beacon_heads = any_version
         .and(warp::path("debug"))
         .and(warp::path("beacon"))
         .and(warp::path("heads"))
         .and(warp::path::end())
         .and(chain_filter.clone())
-        .and_then(|chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || {
-                let heads = chain
-                    .heads()
-                    .into_iter()
-                    .map(|(root, slot)| api_types::ChainHeadData { slot, root })
-                    .collect::<Vec<_>>();
-                Ok(api_types::GenericResponse::from(heads))
-            })
-        });
+        .and_then(
+            |endpoint_version: EndpointVersion, chain: Arc<BeaconChain<T>>| {
+                blocking_task(move || {
+                    let heads = chain
+                        .heads()
+                        .into_iter()
+                        .map(|(root, slot)| {
+                            let execution_optimistic = if endpoint_version == V1 {
+                                None
+                            } else if endpoint_version == V2 {
+                                Handle::current().block_on(async {
+                                    BlockId::from_root(root)
+                                        .is_execution_optimistic(&chain)
+                                        .await
+                                        .ok()
+                                })
+                            } else {
+                                return Err(unsupported_version_rejection(endpoint_version));
+                            };
+                            Ok(api_types::ChainHeadData {
+                                slot,
+                                root,
+                                execution_optimistic,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, warp::Rejection>>();
+                    Ok(api_types::GenericResponse::from(heads?))
+                        .map(|res| warp::reply::json(&res).into_response())
+                })
+            },
+        );
 
     /*
      * node
      */
 
     // GET node/identity
-    let get_node_identity = eth1_v1
+    let get_node_identity = eth_v1
         .and(warp::path("node"))
         .and(warp::path("identity"))
         .and(warp::path::end())
@@ -1684,7 +1832,7 @@ pub fn serve<T: BeaconChainTypes>(
         });
 
     // GET node/version
-    let get_node_version = eth1_v1
+    let get_node_version = eth_v1
         .and(warp::path("node"))
         .and(warp::path("version"))
         .and(warp::path::end())
@@ -1697,7 +1845,7 @@ pub fn serve<T: BeaconChainTypes>(
         });
 
     // GET node/syncing
-    let get_node_syncing = eth1_v1
+    let get_node_syncing = eth_v1
         .and(warp::path("node"))
         .and(warp::path("syncing"))
         .and(warp::path::end())
@@ -1726,7 +1874,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET node/health
-    let get_node_health = eth1_v1
+    let get_node_health = eth_v1
         .and(warp::path("node"))
         .and(warp::path("health"))
         .and(warp::path::end())
@@ -1751,7 +1899,7 @@ pub fn serve<T: BeaconChainTypes>(
         });
 
     // GET node/peers/{peer_id}
-    let get_node_peers_by_id = eth1_v1
+    let get_node_peers_by_id = eth_v1
         .and(warp::path("node"))
         .and(warp::path("peers"))
         .and(warp::path::param::<String>())
@@ -1808,7 +1956,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET node/peers
-    let get_node_peers = eth1_v1
+    let get_node_peers = eth_v1
         .and(warp::path("node"))
         .and(warp::path("peers"))
         .and(warp::path::end())
@@ -1877,7 +2025,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET node/peer_count
-    let get_node_peer_count = eth1_v1
+    let get_node_peer_count = eth_v1
         .and(warp::path("node"))
         .and(warp::path("peer_count"))
         .and(warp::path::end())
@@ -1918,7 +2066,7 @@ pub fn serve<T: BeaconChainTypes>(
      */
 
     // GET validator/duties/proposer/{epoch}
-    let get_validator_duties_proposer = eth1_v1
+    let get_validator_duties_proposer = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("duties"))
         .and(warp::path("proposer"))
@@ -2061,7 +2209,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET validator/attestation_data?slot,committee_index
-    let get_validator_attestation_data = eth1_v1
+    let get_validator_attestation_data = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("attestation_data"))
         .and(warp::path::end())
@@ -2093,7 +2241,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET validator/aggregate_attestation?attestation_data_root,slot
-    let get_validator_aggregate_attestation = eth1_v1
+    let get_validator_aggregate_attestation = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("aggregate_attestation"))
         .and(warp::path::end())
@@ -2125,7 +2273,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/duties/attester/{epoch}
-    let post_validator_duties_attester = eth1_v1
+    let post_validator_duties_attester = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("duties"))
         .and(warp::path("attester"))
@@ -2147,7 +2295,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/duties/sync
-    let post_validator_duties_sync = eth1_v1
+    let post_validator_duties_sync = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("duties"))
         .and(warp::path("sync"))
@@ -2169,7 +2317,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // GET validator/sync_committee_contribution
-    let get_validator_sync_committee_contribution = eth1_v1
+    let get_validator_sync_committee_contribution = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("sync_committee_contribution"))
         .and(warp::path::end())
@@ -2192,7 +2340,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/aggregate_and_proofs
-    let post_validator_aggregate_and_proofs = eth1_v1
+    let post_validator_aggregate_and_proofs = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("aggregate_and_proofs"))
         .and(warp::path::end())
@@ -2292,7 +2440,7 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
-    let post_validator_contribution_and_proofs = eth1_v1
+    let post_validator_contribution_and_proofs = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("contribution_and_proofs"))
         .and(warp::path::end())
@@ -2319,7 +2467,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/beacon_committee_subscriptions
-    let post_validator_beacon_committee_subscriptions = eth1_v1
+    let post_validator_beacon_committee_subscriptions = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("beacon_committee_subscriptions"))
         .and(warp::path::end())
@@ -2359,7 +2507,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/prepare_beacon_proposer
-    let post_validator_prepare_beacon_proposer = eth1_v1
+    let post_validator_prepare_beacon_proposer = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("prepare_beacon_proposer"))
         .and(warp::path::end())
@@ -2407,7 +2555,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     // POST validator/register_validator
-    let post_validator_register_validator = eth1_v1
+    let post_validator_register_validator = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("register_validator"))
         .and(warp::path::end())
@@ -2480,7 +2628,7 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
     // POST validator/sync_committee_subscriptions
-    let post_validator_sync_committee_subscriptions = eth1_v1
+    let post_validator_sync_committee_subscriptions = eth_v1
         .and(warp::path("validator"))
         .and(warp::path("sync_committee_subscriptions"))
         .and(warp::path::end())
@@ -2899,7 +3047,7 @@ pub fn serve<T: BeaconChainTypes>(
             )))
         });
 
-    let get_events = eth1_v1
+    let get_events = eth_v1
         .and(warp::path("events"))
         .and(warp::path::end())
         .and(multi_key_query::<api_types::EventQuery>())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -711,14 +711,8 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and_then(
             |state_id: StateId, chain: Arc<BeaconChain<T>>, query: api_types::CommitteesQuery| {
-                // The api spec says if the epoch is not present in the request then the epoch
-                // of the state should be used.
-                let query_state_id = query.epoch.map_or(state_id, |epoch| {
-                    StateId::from_slot(epoch.start_slot(T::EthSpec::slots_per_epoch()))
-                });
-
                 blocking_json_task(move || {
-                    let (data, execution_optimistic) = query_state_id
+                    let (data, execution_optimistic) = state_id
                         .map_state_and_execution_optimistic(
                             &chain,
                             |state, execution_optimistic| {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1756,8 +1756,10 @@ pub fn serve<T: BeaconChainTypes>(
                             let execution_optimistic = if endpoint_version == V1 {
                                 None
                             } else if endpoint_version == V2 {
-                                BlockId::from_root(root)
-                                    .is_execution_optimistic(&chain)
+                                chain
+                                    .canonical_head
+                                    .fork_choice_read_lock()
+                                    .is_optimistic_block(&root)
                                     .ok()
                             } else {
                                 return Err(unsupported_version_rejection(endpoint_version));

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -476,7 +476,7 @@ pub fn serve<T: BeaconChainTypes>(
                     state_id.fork_and_execution_optimistic(&chain)?;
                 Ok(api_types::ExecutionOptimisticResponse {
                     data: fork,
-                    execution_optimistic,
+                    execution_optimistic: Some(execution_optimistic),
                 })
             })
         });
@@ -504,7 +504,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                 Ok(api_types::ExecutionOptimisticResponse {
                     data,
-                    execution_optimistic,
+                    execution_optimistic: Some(execution_optimistic),
                 })
             })
         });
@@ -558,7 +558,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     Ok(api_types::ExecutionOptimisticResponse {
                         data,
-                        execution_optimistic,
+                        execution_optimistic: Some(execution_optimistic),
                     })
                 })
             },
@@ -635,7 +635,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     Ok(api_types::ExecutionOptimisticResponse {
                         data,
-                        execution_optimistic,
+                        execution_optimistic: Some(execution_optimistic),
                     })
                 })
             },
@@ -697,7 +697,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     Ok(api_types::ExecutionOptimisticResponse {
                         data,
-                        execution_optimistic,
+                        execution_optimistic: Some(execution_optimistic),
                     })
                 })
             },
@@ -809,7 +809,7 @@ pub fn serve<T: BeaconChainTypes>(
                         )?;
                     Ok(api_types::ExecutionOptimisticResponse {
                         data,
-                        execution_optimistic,
+                        execution_optimistic: Some(execution_optimistic),
                     })
                 })
             },
@@ -1009,7 +1009,7 @@ pub fn serve<T: BeaconChainTypes>(
                 };
 
                 Ok(api_types::ExecutionOptimisticResponse {
-                    execution_optimistic,
+                    execution_optimistic: Some(execution_optimistic),
                     data,
                 })
             })

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2893,7 +2893,8 @@ pub fn serve<T: BeaconChainTypes>(
         .and(chain_filter.clone())
         .and_then(|state_id: StateId, chain: Arc<BeaconChain<T>>| {
             blocking_task(move || {
-                let state = state_id.state(&chain)?;
+                // This debug endpoint provides no indication of optimistic status.
+                let (state, _execution_optimistic) = state_id.state(&chain)?;
                 Response::builder()
                     .status(200)
                     .header("Content-Type", "application/ssz")

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -55,10 +55,16 @@ pub fn proposer_duties<T: BeaconChainTypes>(
             .safe_add(1)
             .map_err(warp_utils::reject::arith_error)?
     {
-        let (proposers, dependent_root, _execution_status, _fork) =
+        let (proposers, dependent_root, execution_status, _fork) =
             compute_proposer_duties_from_head(request_epoch, chain)
                 .map_err(warp_utils::reject::beacon_chain_error)?;
-        convert_to_api_response(chain, request_epoch, dependent_root, proposers)
+        convert_to_api_response(
+            chain,
+            request_epoch,
+            dependent_root,
+            execution_status.is_optimistic(),
+            proposers,
+        )
     } else if request_epoch
         > current_epoch
             .safe_add(1)
@@ -88,17 +94,18 @@ fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
     request_epoch: Epoch,
     chain: &BeaconChain<T>,
 ) -> Result<Option<ApiDuties>, warp::reject::Rejection> {
-    let (head_slot, head_block_root, head_decision_root) = {
-        let head = chain.canonical_head.cached_head();
-        let head_block_root = head.head_block_root();
-        let decision_root = head
-            .snapshot
-            .beacon_state
-            .proposer_shuffling_decision_root(head_block_root)
-            .map_err(warp_utils::reject::beacon_state_error)?;
-        (head.head_slot(), head_block_root, decision_root)
-    };
-    let head_epoch = head_slot.epoch(T::EthSpec::slots_per_epoch());
+    let head = chain.canonical_head.cached_head();
+    let head_block = &head.snapshot.beacon_block;
+    let head_block_root = head.head_block_root();
+    let head_decision_root = head
+        .snapshot
+        .beacon_state
+        .proposer_shuffling_decision_root(head_block_root)
+        .map_err(warp_utils::reject::beacon_state_error)?;
+    let head_epoch = head_block.slot().epoch(T::EthSpec::slots_per_epoch());
+    let execution_optimistic = chain
+        .is_optimistic_head_block(head_block)
+        .map_err(warp_utils::reject::beacon_chain_error)?;
 
     let dependent_root = match head_epoch.cmp(&request_epoch) {
         // head_epoch == request_epoch
@@ -120,7 +127,13 @@ fn try_proposer_duties_from_cache<T: BeaconChainTypes>(
         .get_epoch::<T::EthSpec>(dependent_root, request_epoch)
         .cloned()
         .map(|indices| {
-            convert_to_api_response(chain, request_epoch, dependent_root, indices.to_vec())
+            convert_to_api_response(
+                chain,
+                request_epoch,
+                dependent_root,
+                execution_optimistic,
+                indices.to_vec(),
+            )
         })
         .transpose()
 }
@@ -139,7 +152,7 @@ fn compute_and_cache_proposer_duties<T: BeaconChainTypes>(
     current_epoch: Epoch,
     chain: &BeaconChain<T>,
 ) -> Result<ApiDuties, warp::reject::Rejection> {
-    let (indices, dependent_root, _execution_status, fork) =
+    let (indices, dependent_root, execution_status, fork) =
         compute_proposer_duties_from_head(current_epoch, chain)
             .map_err(warp_utils::reject::beacon_chain_error)?;
 
@@ -151,7 +164,13 @@ fn compute_and_cache_proposer_duties<T: BeaconChainTypes>(
         .map_err(BeaconChainError::from)
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    convert_to_api_response(chain, current_epoch, dependent_root, indices)
+    convert_to_api_response(
+        chain,
+        current_epoch,
+        dependent_root,
+        execution_status.is_optimistic(),
+        indices,
+    )
 }
 
 /// Compute some proposer duties by reading a `BeaconState` from disk, completely ignoring the
@@ -184,7 +203,7 @@ fn compute_historic_proposer_duties<T: BeaconChainTypes>(
             .map_err(warp_utils::reject::beacon_chain_error)?;
         state
     } else {
-        StateId::slot(epoch.start_slot(T::EthSpec::slots_per_epoch())).state(chain)?
+        StateId::from_slot(epoch.start_slot(T::EthSpec::slots_per_epoch())).state(chain)?
     };
 
     // Ensure the state lookup was correct.
@@ -208,7 +227,10 @@ fn compute_historic_proposer_duties<T: BeaconChainTypes>(
         .map_err(BeaconChainError::from)
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    convert_to_api_response(chain, epoch, dependent_root, indices)
+    let execution_optimistic = StateId::from_slot(epoch.start_slot(T::EthSpec::slots_per_epoch()))
+        .is_execution_optimistic(chain)?;
+
+    convert_to_api_response(chain, epoch, dependent_root, execution_optimistic, indices)
 }
 
 /// Converts the internal representation of proposer duties into one that is compatible with the
@@ -217,6 +239,7 @@ fn convert_to_api_response<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     epoch: Epoch,
     dependent_root: Hash256,
+    execution_optimistic: bool,
     indices: Vec<usize>,
 ) -> Result<ApiDuties, warp::reject::Rejection> {
     let index_to_pubkey_map = chain
@@ -251,6 +274,7 @@ fn convert_to_api_response<T: BeaconChainTypes>(
     } else {
         Ok(api_types::DutiesResponse {
             dependent_root,
+            execution_optimistic,
             data: proposer_data,
         })
     }

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -275,7 +275,7 @@ fn convert_to_api_response<T: BeaconChainTypes>(
     } else {
         Ok(api_types::DutiesResponse {
             dependent_root,
-            execution_optimistic,
+            execution_optimistic: Some(execution_optimistic),
             data: proposer_data,
         })
     }

--- a/beacon_node/http_api/src/proposer_duties.rs
+++ b/beacon_node/http_api/src/proposer_duties.rs
@@ -227,8 +227,9 @@ fn compute_historic_proposer_duties<T: BeaconChainTypes>(
         .map_err(BeaconChainError::from)
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
-    let execution_optimistic = StateId::from_slot(epoch.start_slot(T::EthSpec::slots_per_epoch()))
-        .is_execution_optimistic(chain)?;
+    let execution_optimistic = chain
+        .is_optimistic_head()
+        .map_err(warp_utils::reject::beacon_chain_error)?;
 
     convert_to_api_response(chain, epoch, dependent_root, execution_optimistic, indices)
 }

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -190,16 +190,6 @@ impl StateId {
 
         func(&state, execution_optimistic)
     }
-
-    /// Convenience function to compute `execution_optimistic` when `state` is not desired.
-    pub fn is_execution_optimistic<T: BeaconChainTypes>(
-        &self,
-        chain: &BeaconChain<T>,
-    ) -> Result<bool, warp::Rejection> {
-        self.map_state_and_execution_optimistic(chain, |_, execution_optimistic| {
-            Ok(execution_optimistic)
-        })
-    }
 }
 
 impl FromStr for StateId {

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -225,7 +225,7 @@ pub fn checkpoint_slot_and_execution_optimistic<T: BeaconChainTypes>(
     };
 
     let execution_optimistic = fork_choice
-        .is_optimistic_block(root)
+        .is_optimistic_block_no_fallback(root)
         .map_err(BeaconChainError::ForkChoiceError)
         .map_err(warp_utils::reject::beacon_chain_error)?;
 

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -163,19 +163,10 @@ impl StateId {
             CoreStateId::Root(_) => {
                 let state_root = self.root(chain)?;
                 chain
-                    .is_optimistic_block(
-                        &chain
-                            .store
-                            .get_full_block(&state.get_latest_block_root(state_root))
-                            .map_err(BeaconChainError::DBError)
-                            .map_err(warp_utils::reject::beacon_chain_error)?
-                            .ok_or_else(|| {
-                                warp_utils::reject::custom_not_found(format!(
-                                    "latest block root not found for beacon state at root {}",
-                                    state_root
-                                ))
-                            })?,
-                    )
+                    .canonical_head
+                    .fork_choice_read_lock()
+                    .is_optimistic_block(&state.get_latest_block_root(state_root))
+                    .map_err(BeaconChainError::ForkChoiceError)
                     .map_err(warp_utils::reject::beacon_chain_error)?
             }
         };

--- a/beacon_node/http_api/src/validator_inclusion.rs
+++ b/beacon_node/http_api/src/validator_inclusion.rs
@@ -16,7 +16,10 @@ fn end_of_epoch_state<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
 ) -> Result<BeaconState<T::EthSpec>, warp::reject::Rejection> {
     let target_slot = epoch.end_slot(T::EthSpec::slots_per_epoch());
-    StateId::from_slot(target_slot).state(chain)
+    // The execution status is not returned, any functions which rely upon this method might return
+    // optimistic information without explicitly declaring so.
+    let (state, _execution_status) = StateId::from_slot(target_slot).state(chain)?;
+    Ok(state)
 }
 
 /// Generate an `EpochProcessingSummary` for `state`.

--- a/beacon_node/http_api/src/validator_inclusion.rs
+++ b/beacon_node/http_api/src/validator_inclusion.rs
@@ -16,7 +16,7 @@ fn end_of_epoch_state<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
 ) -> Result<BeaconState<T::EthSpec>, warp::reject::Rejection> {
     let target_slot = epoch.end_slot(T::EthSpec::slots_per_epoch());
-    StateId::slot(target_slot).state(chain)
+    StateId::from_slot(target_slot).state(chain)
 }
 
 /// Generate an `EpochProcessingSummary` for `state`.

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -1,4 +1,6 @@
-use crate::api_types::{EndpointVersion, ForkVersionedResponse};
+use crate::api_types::{
+    EndpointVersion, ExecutionOptimisticForkVersionedResponse, ForkVersionedResponse,
+};
 use eth2::CONSENSUS_VERSION_HEADER;
 use serde::Serialize;
 use types::{ForkName, InconsistentFork};
@@ -21,6 +23,26 @@ pub fn fork_versioned_response<T: Serialize>(
     };
     Ok(ForkVersionedResponse {
         version: fork_name,
+        data,
+    })
+}
+
+pub fn execution_optimistic_fork_versioned_response<T: Serialize>(
+    endpoint_version: EndpointVersion,
+    fork_name: ForkName,
+    execution_optimistic: bool,
+    data: T,
+) -> Result<ExecutionOptimisticForkVersionedResponse<T>, warp::reject::Rejection> {
+    let fork_name = if endpoint_version == V1 {
+        None
+    } else if endpoint_version == V2 {
+        Some(fork_name)
+    } else {
+        return Err(unsupported_version_rejection(endpoint_version));
+    };
+    Ok(ExecutionOptimisticForkVersionedResponse {
+        version: fork_name,
+        execution_optimistic,
         data,
     })
 }

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -42,7 +42,7 @@ pub fn execution_optimistic_fork_versioned_response<T: Serialize>(
     };
     Ok(ExecutionOptimisticForkVersionedResponse {
         version: fork_name,
-        execution_optimistic,
+        execution_optimistic: Some(execution_optimistic),
         data,
     })
 }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1702,7 +1702,7 @@ impl ApiTester {
 
             let expected = DutiesResponse {
                 data: expected_duties,
-                execution_optimistic: false,
+                execution_optimistic: Some(false),
                 dependent_root,
             };
 
@@ -2636,7 +2636,7 @@ impl ApiTester {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.execution_optimistic, false);
+        assert_eq!(result.execution_optimistic, Some(false));
 
         // Change head to be optimistic.
         self.chain
@@ -2658,7 +2658,7 @@ impl ApiTester {
             .unwrap()
             .unwrap();
 
-        assert_eq!(result.execution_optimistic, true);
+        assert_eq!(result.execution_optimistic, Some(true));
     }
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -8,13 +8,15 @@ use environment::null_logger;
 use eth2::{
     mixin::{RequestAccept, ResponseForkName, ResponseOptional},
     reqwest::RequestBuilder,
-    types::*,
+    types::{BlockId as CoreBlockId, StateId as CoreStateId, *},
     BeaconNodeHttpClient, Error, StatusCode, Timeouts,
 };
 use futures::stream::{Stream, StreamExt};
 use futures::FutureExt;
+use http_api::{BlockId, StateId};
 use lighthouse_network::{Enr, EnrExt, PeerId};
 use network::NetworkMessage;
+use proto_array::ExecutionStatus;
 use sensitive_url::SensitiveUrl;
 use slot_clock::SlotClock;
 use state_processing::per_slot_processing;
@@ -25,8 +27,8 @@ use tokio::time::Duration;
 use tree_hash::TreeHash;
 use types::application_domain::ApplicationDomain;
 use types::{
-    AggregateSignature, BeaconState, BitList, Domain, EthSpec, Hash256, Keypair, MainnetEthSpec,
-    RelativeEpoch, SelectionProof, SignedRoot, Slot,
+    AggregateSignature, BitList, Domain, EthSpec, ExecutionBlockHash, Hash256, Keypair,
+    MainnetEthSpec, RelativeEpoch, SelectionProof, SignedRoot, Slot,
 };
 
 type E = MainnetEthSpec;
@@ -210,7 +212,7 @@ impl ApiTester {
         );
 
         Self {
-            harness,
+            harness: Arc::new(harness),
             chain,
             client,
             next_block,
@@ -309,6 +311,150 @@ impl ApiTester {
         }
     }
 
+    pub async fn new_post_bellatrix() -> Self {
+        let mut spec = E::default_spec();
+        spec.altair_fork_epoch = Some(Epoch::new(0));
+        spec.bellatrix_fork_epoch = Some(Epoch::new(0));
+
+        let harness = BeaconChainHarness::builder(MainnetEthSpec)
+            .spec(spec.clone())
+            .deterministic_keypairs(VALIDATOR_COUNT)
+            .fresh_ephemeral_store()
+            .mock_execution_layer()
+            .build();
+
+        harness.advance_slot();
+
+        for _ in 0..CHAIN_LENGTH {
+            let slot = harness.chain.slot().unwrap().as_u64();
+
+            if !SKIPPED_SLOTS.contains(&slot) {
+                harness
+                    .extend_chain(
+                        1,
+                        BlockStrategy::OnCanonicalHead,
+                        AttestationStrategy::AllValidators,
+                    )
+                    .await;
+            }
+
+            harness.advance_slot();
+        }
+
+        let head = harness.chain.head_snapshot();
+
+        assert_eq!(
+            harness.chain.slot().unwrap(),
+            head.beacon_block.slot() + 1,
+            "precondition: current slot is one after head"
+        );
+
+        let (next_block, _next_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
+
+        // `make_block` adds random graffiti, so this will produce an alternate block
+        let (reorg_block, _reorg_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
+
+        let head = harness.chain.head_snapshot();
+
+        let head_state_root = head.beacon_state_root();
+        let attestations = harness
+            .get_unaggregated_attestations(
+                &AttestationStrategy::AllValidators,
+                &head.beacon_state,
+                head_state_root,
+                head.beacon_block_root,
+                harness.chain.slot().unwrap(),
+            )
+            .into_iter()
+            .flat_map(|vec| vec.into_iter().map(|(attestation, _subnet_id)| attestation))
+            .collect::<Vec<_>>();
+
+        assert!(
+            !attestations.is_empty(),
+            "precondition: attestations for testing"
+        );
+
+        let contribution_and_proofs = harness
+            .make_sync_contributions(
+                &head.beacon_state,
+                head_state_root,
+                harness.chain.slot().unwrap(),
+                RelativeSyncCommittee::Current,
+            )
+            .into_iter()
+            .filter_map(|(_, contribution)| contribution)
+            .collect::<Vec<_>>();
+
+        let attester_slashing = harness.make_attester_slashing(vec![0, 1]);
+        let proposer_slashing = harness.make_proposer_slashing(2);
+        let voluntary_exit = harness.make_voluntary_exit(3, harness.chain.epoch().unwrap());
+
+        let chain = harness.chain.clone();
+
+        assert_eq!(
+            chain
+                .canonical_head
+                .cached_head()
+                .finalized_checkpoint()
+                .epoch,
+            2,
+            "precondition: finality"
+        );
+        assert_eq!(
+            chain
+                .canonical_head
+                .cached_head()
+                .justified_checkpoint()
+                .epoch,
+            3,
+            "precondition: justification"
+        );
+
+        let log = null_logger().unwrap();
+
+        let ApiServer {
+            server,
+            listening_socket,
+            shutdown_tx,
+            network_rx,
+            local_enr,
+            external_peer_id,
+        } = create_api_server(chain.clone(), log).await;
+
+        harness.runtime.task_executor.spawn(server, "api_server");
+
+        let client = BeaconNodeHttpClient::new(
+            SensitiveUrl::parse(&format!(
+                "http://{}:{}",
+                listening_socket.ip(),
+                listening_socket.port()
+            ))
+            .unwrap(),
+            Timeouts::set_all(Duration::from_secs(SECONDS_PER_SLOT)),
+        );
+
+        Self {
+            harness: Arc::new(harness),
+            chain,
+            client,
+            next_block,
+            reorg_block,
+            attestations,
+            contribution_and_proofs,
+            attester_slashing,
+            proposer_slashing,
+            voluntary_exit,
+            _server_shutdown: shutdown_tx,
+            network_rx,
+            local_enr,
+            external_peer_id,
+        }
+    }
+
     fn validator_keypairs(&self) -> &[Keypair] {
         &self.harness.validator_keypairs
     }
@@ -325,99 +471,43 @@ impl ApiTester {
 
     fn interesting_state_ids(&self) -> Vec<StateId> {
         let mut ids = vec![
-            StateId::Head,
-            StateId::Genesis,
-            StateId::Finalized,
-            StateId::Justified,
-            StateId::Slot(Slot::new(0)),
-            StateId::Slot(Slot::new(32)),
-            StateId::Slot(Slot::from(SKIPPED_SLOTS[0])),
-            StateId::Slot(Slot::from(SKIPPED_SLOTS[1])),
-            StateId::Slot(Slot::from(SKIPPED_SLOTS[2])),
-            StateId::Slot(Slot::from(SKIPPED_SLOTS[3])),
-            StateId::Root(Hash256::zero()),
+            StateId(CoreStateId::Head),
+            StateId(CoreStateId::Genesis),
+            StateId(CoreStateId::Finalized),
+            StateId(CoreStateId::Justified),
+            StateId(CoreStateId::Slot(Slot::new(0))),
+            StateId(CoreStateId::Slot(Slot::new(32))),
+            StateId(CoreStateId::Slot(Slot::from(SKIPPED_SLOTS[0]))),
+            StateId(CoreStateId::Slot(Slot::from(SKIPPED_SLOTS[1]))),
+            StateId(CoreStateId::Slot(Slot::from(SKIPPED_SLOTS[2]))),
+            StateId(CoreStateId::Slot(Slot::from(SKIPPED_SLOTS[3]))),
+            StateId(CoreStateId::Root(Hash256::zero())),
         ];
-        ids.push(StateId::Root(
+        ids.push(StateId(CoreStateId::Root(
             self.chain.canonical_head.cached_head().head_state_root(),
-        ));
+        )));
         ids
     }
 
     fn interesting_block_ids(&self) -> Vec<BlockId> {
         let mut ids = vec![
-            BlockId::Head,
-            BlockId::Genesis,
-            BlockId::Finalized,
-            BlockId::Justified,
-            BlockId::Slot(Slot::new(0)),
-            BlockId::Slot(Slot::new(32)),
-            BlockId::Slot(Slot::from(SKIPPED_SLOTS[0])),
-            BlockId::Slot(Slot::from(SKIPPED_SLOTS[1])),
-            BlockId::Slot(Slot::from(SKIPPED_SLOTS[2])),
-            BlockId::Slot(Slot::from(SKIPPED_SLOTS[3])),
-            BlockId::Root(Hash256::zero()),
+            BlockId(CoreBlockId::Head),
+            BlockId(CoreBlockId::Genesis),
+            BlockId(CoreBlockId::Finalized),
+            BlockId(CoreBlockId::Justified),
+            BlockId(CoreBlockId::Slot(Slot::new(0))),
+            BlockId(CoreBlockId::Slot(Slot::new(32))),
+            BlockId(CoreBlockId::Slot(Slot::from(SKIPPED_SLOTS[0]))),
+            BlockId(CoreBlockId::Slot(Slot::from(SKIPPED_SLOTS[1]))),
+            BlockId(CoreBlockId::Slot(Slot::from(SKIPPED_SLOTS[2]))),
+            BlockId(CoreBlockId::Slot(Slot::from(SKIPPED_SLOTS[3]))),
+            BlockId(CoreBlockId::Root(Hash256::zero())),
         ];
-        ids.push(BlockId::Root(
+        ids.push(BlockId(CoreBlockId::Root(
             self.chain.canonical_head.cached_head().head_block_root(),
-        ));
+        )));
         ids
     }
-
-    fn get_state(&self, state_id: StateId) -> Option<BeaconState<E>> {
-        match state_id {
-            StateId::Head => Some(
-                self.chain
-                    .head_snapshot()
-                    .beacon_state
-                    .clone_with_only_committee_caches(),
-            ),
-            StateId::Genesis => self
-                .chain
-                .get_state(&self.chain.genesis_state_root, None)
-                .unwrap(),
-            StateId::Finalized => {
-                let finalized_slot = self
-                    .chain
-                    .canonical_head
-                    .cached_head()
-                    .finalized_checkpoint()
-                    .epoch
-                    .start_slot(E::slots_per_epoch());
-
-                let root = self
-                    .chain
-                    .state_root_at_slot(finalized_slot)
-                    .unwrap()
-                    .unwrap();
-
-                self.chain.get_state(&root, Some(finalized_slot)).unwrap()
-            }
-            StateId::Justified => {
-                let justified_slot = self
-                    .chain
-                    .canonical_head
-                    .cached_head()
-                    .justified_checkpoint()
-                    .epoch
-                    .start_slot(E::slots_per_epoch());
-
-                let root = self
-                    .chain
-                    .state_root_at_slot(justified_slot)
-                    .unwrap()
-                    .unwrap();
-
-                self.chain.get_state(&root, Some(justified_slot)).unwrap()
-            }
-            StateId::Slot(slot) => {
-                let root = self.chain.state_root_at_slot(slot).unwrap().unwrap();
-
-                self.chain.get_state(&root, Some(slot)).unwrap()
-            }
-            StateId::Root(root) => self.chain.get_state(&root, None).unwrap(),
-        }
-    }
-
     pub async fn test_beacon_genesis(self) -> Self {
         let result = self.client.get_beacon_genesis().await.unwrap().data;
 
@@ -437,39 +527,12 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let result = self
                 .client
-                .get_beacon_states_root(state_id)
+                .get_beacon_states_root(state_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data.root);
 
-            let expected = match state_id {
-                StateId::Head => Some(self.chain.canonical_head.cached_head().head_state_root()),
-                StateId::Genesis => Some(self.chain.genesis_state_root),
-                StateId::Finalized => {
-                    let finalized_slot = self
-                        .chain
-                        .canonical_head
-                        .cached_head()
-                        .finalized_checkpoint()
-                        .epoch
-                        .start_slot(E::slots_per_epoch());
-
-                    self.chain.state_root_at_slot(finalized_slot).unwrap()
-                }
-                StateId::Justified => {
-                    let justified_slot = self
-                        .chain
-                        .canonical_head
-                        .cached_head()
-                        .justified_checkpoint()
-                        .epoch
-                        .start_slot(E::slots_per_epoch());
-
-                    self.chain.state_root_at_slot(justified_slot).unwrap()
-                }
-                StateId::Slot(slot) => self.chain.state_root_at_slot(slot).unwrap(),
-                StateId::Root(root) => Some(root),
-            };
+            let expected = state_id.root(&self.chain).ok();
 
             assert_eq!(result, expected, "{:?}", state_id);
         }
@@ -481,12 +544,12 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let result = self
                 .client
-                .get_beacon_states_fork(state_id)
+                .get_beacon_states_fork(state_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data);
 
-            let expected = self.get_state(state_id).map(|state| state.fork());
+            let expected = state_id.fork(&self.chain).ok();
 
             assert_eq!(result, expected, "{:?}", state_id);
         }
@@ -498,13 +561,14 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let result = self
                 .client
-                .get_beacon_states_finality_checkpoints(state_id)
+                .get_beacon_states_finality_checkpoints(state_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data);
 
-            let expected = self
-                .get_state(state_id)
+            let expected = state_id
+                .state(&self.chain)
+                .ok()
                 .map(|state| FinalityCheckpointsData {
                     previous_justified: state.previous_justified_checkpoint(),
                     current_justified: state.current_justified_checkpoint(),
@@ -520,7 +584,7 @@ impl ApiTester {
     pub async fn test_beacon_states_validator_balances(self) -> Self {
         for state_id in self.interesting_state_ids() {
             for validator_indices in self.interesting_validator_indices() {
-                let state_opt = self.get_state(state_id);
+                let state_opt = state_id.state(&self.chain).ok();
                 let validators: Vec<Validator> = match state_opt.as_ref() {
                     Some(state) => state.validators().clone().into(),
                     None => vec![],
@@ -545,7 +609,7 @@ impl ApiTester {
                 let result_index_ids = self
                     .client
                     .get_beacon_states_validator_balances(
-                        state_id,
+                        state_id.0,
                         Some(validator_index_ids.as_slice()),
                     )
                     .await
@@ -554,7 +618,7 @@ impl ApiTester {
                 let result_pubkey_ids = self
                     .client
                     .get_beacon_states_validator_balances(
-                        state_id,
+                        state_id.0,
                         Some(validator_pubkey_ids.as_slice()),
                     )
                     .await
@@ -588,7 +652,7 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             for statuses in self.interesting_validator_statuses() {
                 for validator_indices in self.interesting_validator_indices() {
-                    let state_opt = self.get_state(state_id);
+                    let state_opt = state_id.state(&self.chain).ok();
                     let validators: Vec<Validator> = match state_opt.as_ref() {
                         Some(state) => state.validators().clone().into(),
                         None => vec![],
@@ -613,7 +677,7 @@ impl ApiTester {
                     let result_index_ids = self
                         .client
                         .get_beacon_states_validators(
-                            state_id,
+                            state_id.0,
                             Some(validator_index_ids.as_slice()),
                             None,
                         )
@@ -624,7 +688,7 @@ impl ApiTester {
                     let result_pubkey_ids = self
                         .client
                         .get_beacon_states_validators(
-                            state_id,
+                            state_id.0,
                             Some(validator_pubkey_ids.as_slice()),
                             None,
                         )
@@ -675,7 +739,7 @@ impl ApiTester {
 
     pub async fn test_beacon_states_validator_id(self) -> Self {
         for state_id in self.interesting_state_ids() {
-            let state_opt = self.get_state(state_id);
+            let state_opt = state_id.state(&self.chain).ok();
             let validators = match state_opt.as_ref() {
                 Some(state) => state.validators().clone().into(),
                 None => vec![],
@@ -690,7 +754,7 @@ impl ApiTester {
                 for validator_id in validator_ids {
                     let result = self
                         .client
-                        .get_beacon_states_validator_id(state_id, validator_id)
+                        .get_beacon_states_validator_id(state_id.0, validator_id)
                         .await
                         .unwrap()
                         .map(|res| res.data);
@@ -727,12 +791,12 @@ impl ApiTester {
 
     pub async fn test_beacon_states_committees(self) -> Self {
         for state_id in self.interesting_state_ids() {
-            let mut state_opt = self.get_state(state_id);
+            let mut state_opt = state_id.state(&self.chain).ok();
 
             let epoch_opt = state_opt.as_ref().map(|state| state.current_epoch());
             let results = self
                 .client
-                .get_beacon_states_committees(state_id, None, None, epoch_opt)
+                .get_beacon_states_committees(state_id.0, None, None, epoch_opt)
                 .await
                 .unwrap()
                 .map(|res| res.data);
@@ -767,37 +831,6 @@ impl ApiTester {
         }
 
         self
-    }
-
-    fn get_block_root(&self, block_id: BlockId) -> Option<Hash256> {
-        match block_id {
-            BlockId::Head => Some(self.chain.canonical_head.cached_head().head_block_root()),
-            BlockId::Genesis => Some(self.chain.genesis_block_root),
-            BlockId::Finalized => Some(
-                self.chain
-                    .canonical_head
-                    .cached_head()
-                    .finalized_checkpoint()
-                    .root,
-            ),
-            BlockId::Justified => Some(
-                self.chain
-                    .canonical_head
-                    .cached_head()
-                    .justified_checkpoint()
-                    .root,
-            ),
-            BlockId::Slot(slot) => self
-                .chain
-                .block_root_at_slot(slot, WhenSlotSkipped::None)
-                .unwrap(),
-            BlockId::Root(root) => Some(root),
-        }
-    }
-
-    async fn get_block(&self, block_id: BlockId) -> Option<SignedBeaconBlock<E>> {
-        let root = self.get_block_root(block_id)?;
-        self.chain.get_block(&root).await.unwrap()
     }
 
     pub async fn test_beacon_headers_all_slots(self) -> Self {
@@ -877,14 +910,14 @@ impl ApiTester {
         for block_id in self.interesting_block_ids() {
             let result = self
                 .client
-                .get_beacon_headers_block_id(block_id)
+                .get_beacon_headers_block_id(block_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data);
 
-            let block_root_opt = self.get_block_root(block_id);
+            let block_root_opt = block_id.root(&self.chain).ok();
 
-            if let BlockId::Slot(slot) = block_id {
+            if let CoreBlockId::Slot(slot) = block_id.0 {
                 if block_root_opt.is_none() {
                     assert!(SKIPPED_SLOTS.contains(&slot.as_u64()));
                 } else {
@@ -892,11 +925,7 @@ impl ApiTester {
                 }
             }
 
-            let block_opt = if let Some(root) = block_root_opt {
-                self.chain.get_block(&root).await.unwrap()
-            } else {
-                None
-            };
+            let block_opt = block_id.full_block(&self.chain).await.ok();
 
             if block_opt.is_none() && result.is_none() {
                 continue;
@@ -934,13 +963,13 @@ impl ApiTester {
         for block_id in self.interesting_block_ids() {
             let result = self
                 .client
-                .get_beacon_blocks_root(block_id)
+                .get_beacon_blocks_root(block_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data.root);
 
-            let expected = self.get_block_root(block_id);
-            if let BlockId::Slot(slot) = block_id {
+            let expected = block_id.root(&self.chain).ok();
+            if let CoreBlockId::Slot(slot) = block_id.0 {
                 if expected.is_none() {
                     assert!(SKIPPED_SLOTS.contains(&slot.as_u64()));
                 } else {
@@ -982,9 +1011,9 @@ impl ApiTester {
 
     pub async fn test_beacon_blocks(self) -> Self {
         for block_id in self.interesting_block_ids() {
-            let expected = self.get_block(block_id).await;
+            let expected = block_id.full_block(&self.chain).await.ok();
 
-            if let BlockId::Slot(slot) = block_id {
+            if let CoreBlockId::Slot(slot) = block_id.0 {
                 if expected.is_none() {
                     assert!(SKIPPED_SLOTS.contains(&slot.as_u64()));
                 } else {
@@ -993,10 +1022,10 @@ impl ApiTester {
             }
 
             // Check the JSON endpoint.
-            let json_result = self.client.get_beacon_blocks(block_id).await.unwrap();
+            let json_result = self.client.get_beacon_blocks(block_id.0).await.unwrap();
 
             if let (Some(json), Some(expected)) = (&json_result, &expected) {
-                assert_eq!(json.data, *expected, "{:?}", block_id);
+                assert_eq!(&json.data, expected.as_ref(), "{:?}", block_id);
                 assert_eq!(
                     json.version,
                     Some(expected.fork_name(&self.chain.spec).unwrap())
@@ -1009,23 +1038,28 @@ impl ApiTester {
             // Check the SSZ endpoint.
             let ssz_result = self
                 .client
-                .get_beacon_blocks_ssz(block_id, &self.chain.spec)
+                .get_beacon_blocks_ssz(block_id.0, &self.chain.spec)
                 .await
                 .unwrap();
-            assert_eq!(ssz_result, expected, "{:?}", block_id);
+            assert_eq!(
+                ssz_result.as_ref(),
+                expected.as_ref().map(|b| b.as_ref()),
+                "{:?}",
+                block_id
+            );
 
             // Check that the legacy v1 API still works but doesn't return a version field.
-            let v1_result = self.client.get_beacon_blocks_v1(block_id).await.unwrap();
+            let v1_result = self.client.get_beacon_blocks_v1(block_id.0).await.unwrap();
             if let (Some(v1_result), Some(expected)) = (&v1_result, &expected) {
                 assert_eq!(v1_result.version, None);
-                assert_eq!(v1_result.data, *expected);
+                assert_eq!(&v1_result.data, expected.as_ref());
             } else {
                 assert_eq!(v1_result, None);
                 assert_eq!(expected, None);
             }
 
             // Check that version headers are provided.
-            let url = self.client.get_beacon_blocks_path(block_id).unwrap();
+            let url = self.client.get_beacon_blocks_path(block_id.0).unwrap();
 
             let builders: Vec<fn(RequestBuilder) -> RequestBuilder> = vec![
                 |b| b,
@@ -1060,17 +1094,18 @@ impl ApiTester {
         for block_id in self.interesting_block_ids() {
             let result = self
                 .client
-                .get_beacon_blocks_attestations(block_id)
+                .get_beacon_blocks_attestations(block_id.0)
                 .await
                 .unwrap()
                 .map(|res| res.data);
 
-            let expected = self
-                .get_block(block_id)
+            let expected = block_id
+                .full_block(&self.chain)
                 .await
+                .ok()
                 .map(|block| block.message().body().attestations().clone().into());
 
-            if let BlockId::Slot(slot) = block_id {
+            if let CoreBlockId::Slot(slot) = block_id.0 {
                 if expected.is_none() {
                     assert!(SKIPPED_SLOTS.contains(&slot.as_u64()));
                 } else {
@@ -1473,9 +1508,13 @@ impl ApiTester {
 
     pub async fn test_get_debug_beacon_states(self) -> Self {
         for state_id in self.interesting_state_ids() {
-            let result_json = self.client.get_debug_beacon_states(state_id).await.unwrap();
+            let result_json = self
+                .client
+                .get_debug_beacon_states(state_id.0)
+                .await
+                .unwrap();
 
-            let mut expected = self.get_state(state_id);
+            let mut expected = state_id.state(&self.chain).ok();
             expected.as_mut().map(|state| state.drop_all_caches());
 
             if let (Some(json), Some(expected)) = (&result_json, &expected) {
@@ -1492,7 +1531,7 @@ impl ApiTester {
             // Check SSZ API.
             let result_ssz = self
                 .client
-                .get_debug_beacon_states_ssz(state_id, &self.chain.spec)
+                .get_debug_beacon_states_ssz(state_id.0, &self.chain.spec)
                 .await
                 .unwrap();
             assert_eq!(result_ssz, expected, "{:?}", state_id);
@@ -1500,7 +1539,7 @@ impl ApiTester {
             // Check legacy v1 API.
             let result_v1 = self
                 .client
-                .get_debug_beacon_states_v1(state_id)
+                .get_debug_beacon_states_v1(state_id.0)
                 .await
                 .unwrap();
 
@@ -1513,7 +1552,10 @@ impl ApiTester {
             }
 
             // Check that version headers are provided.
-            let url = self.client.get_debug_beacon_states_path(state_id).unwrap();
+            let url = self
+                .client
+                .get_debug_beacon_states_path(state_id.0)
+                .unwrap();
 
             let builders: Vec<fn(RequestBuilder) -> RequestBuilder> =
                 vec![|b| b, |b| b.accept(Accept::Ssz)];
@@ -1791,6 +1833,7 @@ impl ApiTester {
 
             let expected = DutiesResponse {
                 data: expected_duties,
+                execution_optimistic: false,
                 dependent_root,
             };
 
@@ -2391,11 +2434,11 @@ impl ApiTester {
         for state_id in self.interesting_state_ids() {
             let result = self
                 .client
-                .get_lighthouse_beacon_states_ssz(&state_id, &self.chain.spec)
+                .get_lighthouse_beacon_states_ssz(&state_id.0, &self.chain.spec)
                 .await
                 .unwrap();
 
-            let mut expected = self.get_state(state_id);
+            let mut expected = state_id.state(&self.chain).ok();
             expected.as_mut().map(|state| state.drop_all_caches());
 
             assert_eq!(result, expected, "{:?}", state_id);
@@ -2562,6 +2605,7 @@ impl ApiTester {
         let expected_block = EventKind::Block(SseBlock {
             block: block_root,
             slot: next_slot,
+            execution_optimistic: false,
         });
 
         let expected_head = EventKind::Head(SseHead {
@@ -2575,6 +2619,7 @@ impl ApiTester {
                 .unwrap()
                 .unwrap(),
             epoch_transition: true,
+            execution_optimistic: false,
         });
 
         let finalized_block_root = self
@@ -2593,6 +2638,7 @@ impl ApiTester {
             block: finalized_block_root,
             state: finalized_state_root,
             epoch: Epoch::new(3),
+            execution_optimistic: false,
         });
 
         self.client
@@ -2621,6 +2667,7 @@ impl ApiTester {
             new_head_block: self.reorg_block.canonical_root(),
             new_head_state: self.reorg_block.state_root(),
             epoch: self.next_block.slot().epoch(E::slots_per_epoch()),
+            execution_optimistic: false,
         });
 
         self.client
@@ -2687,6 +2734,7 @@ impl ApiTester {
         let expected_block = EventKind::Block(SseBlock {
             block: block_root,
             slot: next_slot,
+            execution_optimistic: false,
         });
 
         let expected_head = EventKind::Head(SseHead {
@@ -2696,6 +2744,7 @@ impl ApiTester {
             current_duty_dependent_root: self.chain.genesis_block_root,
             previous_duty_dependent_root: self.chain.genesis_block_root,
             epoch_transition: false,
+            execution_optimistic: false,
         });
 
         self.client
@@ -2707,6 +2756,40 @@ impl ApiTester {
         assert_eq!(block_events.as_slice(), &[expected_block, expected_head]);
 
         self
+    }
+
+    pub async fn test_check_optimistic_responses(&mut self) {
+        // Check responses are not optimistic.
+        let result = self
+            .client
+            .get_beacon_headers_block_id(CoreBlockId::Head)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.execution_optimistic, false);
+
+        // Change head to be optimistic.
+        self.chain
+            .canonical_head
+            .fork_choice_write_lock()
+            .proto_array_mut()
+            .core_proto_array_mut()
+            .nodes
+            .last_mut()
+            .map(|head_node| {
+                head_node.execution_status = ExecutionStatus::Optimistic(ExecutionBlockHash::zero())
+            });
+
+        // Check responses are now optimistic.
+        let result = self
+            .client
+            .get_beacon_headers_block_id(CoreBlockId::Head)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.execution_optimistic, true);
     }
 }
 
@@ -3103,5 +3186,13 @@ async fn lighthouse_endpoints() {
         .test_post_lighthouse_database_reconstruct()
         .await
         .test_post_lighthouse_liveness()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn optimistic_responses() {
+    ApiTester::new_post_bellatrix()
+        .await
+        .test_check_optimistic_responses()
         .await;
 }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1583,7 +1583,7 @@ fn no_state_root_iter() -> Option<std::iter::Empty<Result<(Hash256, Slot), Error
 #[derive(Debug, Clone, Copy, Default, Encode, Decode)]
 pub struct HotStateSummary {
     slot: Slot,
-    latest_block_root: Hash256,
+    pub latest_block_root: Hash256,
     epoch_boundary_state_root: Hash256,
 }
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1317,7 +1317,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     /// Load a frozen state's slot, given its root.
-    fn load_cold_state_slot(&self, state_root: &Hash256) -> Result<Option<Slot>, Error> {
+    pub fn load_cold_state_slot(&self, state_root: &Hash256) -> Result<Option<Slot>, Error> {
         Ok(self
             .cold_db
             .get(state_root)?

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -189,14 +189,14 @@ impl fmt::Display for StateId {
 #[serde(bound = "T: Serialize + serde::de::DeserializeOwned")]
 pub struct DutiesResponse<T: Serialize + serde::de::DeserializeOwned> {
     pub dependent_root: Hash256,
-    pub execution_optimistic: bool,
+    pub execution_optimistic: Option<bool>,
     pub data: T,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(bound = "T: Serialize + serde::de::DeserializeOwned")]
 pub struct ExecutionOptimisticResponse<T: Serialize + serde::de::DeserializeOwned> {
-    pub execution_optimistic: bool,
+    pub execution_optimistic: Option<bool>,
     pub data: T,
 }
 
@@ -218,7 +218,7 @@ impl<T: Serialize + serde::de::DeserializeOwned> GenericResponse<T> {
         execution_optimistic: bool,
     ) -> ExecutionOptimisticResponse<T> {
         ExecutionOptimisticResponse {
-            execution_optimistic,
+            execution_optimistic: Some(execution_optimistic),
             data: self.data,
         }
     }
@@ -240,7 +240,7 @@ impl<'a, T: Serialize> From<&'a T> for GenericResponseRef<'a, T> {
 pub struct ExecutionOptimisticForkVersionedResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ForkName>,
-    pub execution_optimistic: bool,
+    pub execution_optimistic: Option<bool>,
     pub data: T,
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -189,6 +189,14 @@ impl fmt::Display for StateId {
 #[serde(bound = "T: Serialize + serde::de::DeserializeOwned")]
 pub struct DutiesResponse<T: Serialize + serde::de::DeserializeOwned> {
     pub dependent_root: Hash256,
+    pub execution_optimistic: bool,
+    pub data: T,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(bound = "T: Serialize + serde::de::DeserializeOwned")]
+pub struct ExecutionOptimisticResponse<T: Serialize + serde::de::DeserializeOwned> {
+    pub execution_optimistic: bool,
     pub data: T,
 }
 
@@ -204,6 +212,18 @@ impl<T: Serialize + serde::de::DeserializeOwned> From<T> for GenericResponse<T> 
     }
 }
 
+impl<T: Serialize + serde::de::DeserializeOwned> GenericResponse<T> {
+    pub fn add_execution_optimistic(
+        self,
+        execution_optimistic: bool,
+    ) -> ExecutionOptimisticResponse<T> {
+        ExecutionOptimisticResponse {
+            execution_optimistic,
+            data: self.data,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[serde(bound = "T: Serialize")]
 pub struct GenericResponseRef<'a, T: Serialize> {
@@ -214,6 +234,14 @@ impl<'a, T: Serialize> From<&'a T> for GenericResponseRef<'a, T> {
     fn from(data: &'a T) -> Self {
         Self { data }
     }
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ExecutionOptimisticForkVersionedResponse<T> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<ForkName>,
+    pub execution_optimistic: bool,
+    pub data: T,
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -495,6 +523,8 @@ pub struct DepositContractData {
 pub struct ChainHeadData {
     pub slot: Slot,
     pub root: Hash256,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_optimistic: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -794,6 +824,7 @@ pub struct PeerCount {
 pub struct SseBlock {
     pub slot: Slot,
     pub block: Hash256,
+    pub execution_optimistic: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -801,6 +832,7 @@ pub struct SseFinalizedCheckpoint {
     pub block: Hash256,
     pub state: Hash256,
     pub epoch: Epoch,
+    pub execution_optimistic: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -811,6 +843,7 @@ pub struct SseHead {
     pub current_duty_dependent_root: Hash256,
     pub previous_duty_dependent_root: Hash256,
     pub epoch_transition: bool,
+    pub execution_optimistic: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -823,6 +856,7 @@ pub struct SseChainReorg {
     pub new_head_block: Hash256,
     pub new_head_state: Hash256,
     pub epoch: Epoch,
+    pub execution_optimistic: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
@@ -837,6 +871,7 @@ pub struct SseLateHead {
     pub observed_delay: Option<Duration>,
     pub imported_delay: Option<Duration>,
     pub set_as_head_delay: Option<Duration>,
+    pub execution_optimistic: bool,
 }
 
 #[derive(PartialEq, Debug, Serialize, Clone)]

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1175,6 +1175,12 @@ where
         &self.proto_array
     }
 
+    /// Returns a mutable reference to `proto_array`.
+    /// Should only be used in testing.
+    pub fn proto_array_mut(&mut self) -> &mut ProtoArrayForkChoice {
+        &mut self.proto_array
+    }
+
     /// Returns a reference to the underlying `fc_store`.
     pub fn fc_store(&self) -> &T {
         &self.fc_store


### PR DESCRIPTION
## Issue Addressed

#3031 

## Proposed Changes

Updates the following API endpoints to conform with https://github.com/ethereum/beacon-APIs/pull/190 and https://github.com/ethereum/beacon-APIs/pull/196
- [x] `beacon/states/{state_id}/root` 
- [x] `beacon/states/{state_id}/fork`
- [x] `beacon/states/{state_id}/finality_checkpoints`
- [x] `beacon/states/{state_id}/validators`
- [x] `beacon/states/{state_id}/validators/{validator_id}`
- [x] `beacon/states/{state_id}/validator_balances`
- [x] `beacon/states/{state_id}/committees`
- [x] `beacon/states/{state_id}/sync_committees`
- [x] `beacon/headers`
- [x] `beacon/headers/{block_id}`
- [x] `beacon/blocks/{block_id}`
- [x] `beacon/blocks/{block_id}/root`
- [x] `beacon/blocks/{block_id}/attestations`
- [x] `debug/beacon/states/{state_id}`
- [x] `debug/beacon/heads`
- [x] `validator/duties/attester/{epoch}`
- [x] `validator/duties/proposer/{epoch}`
- [x] `validator/duties/sync/{epoch}`

Updates the following Server-Sent Events:
- [x]  `events?topics=head`
- [x]  `events?topics=block`
- [x]  `events?topics=finalized_checkpoint`
- [x]  `events?topics=chain_reorg`

## Backwards Incompatible
There is a very minor breaking change with the way the API now handles requests to `beacon/blocks/{block_id}/root` and `beacon/states/{state_id}/root` when `block_id` or `state_id` is the `Root` variant of `BlockId` and `StateId` respectively.

Previously a request to a non-existent root would simply echo the root back to the requester:
```
curl "http://localhost:5052/eth/v1/beacon/states/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/root"
{"data":{"root":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}}
```
Now it will return a `404`:
```
curl "http://localhost:5052/eth/v1/beacon/blocks/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/root"
{"code":404,"message":"NOT_FOUND: beacon block with root 0xaaaa…aaaa","stacktraces":[]}
```

In addition to this is the block root `0x0000000000000000000000000000000000000000000000000000000000000000` previously would return the genesis block. It will now return a `404`:
```
curl "http://localhost:5052/eth/v1/beacon/blocks/0x0000000000000000000000000000000000000000000000000000000000000000"
{"code":404,"message":"NOT_FOUND: beacon block with root 0x0000…0000","stacktraces":[]}
```

## Additional Info
- `execution_optimistic` is always set, and will return `false` pre-Bellatrix. I am also open to the idea of doing something like `#[serde(skip_serializing_if = "Option::is_none")]`.
- The value of `execution_optimistic` is set to `false` where possible. Any computation that is reliant on the `head` will simply use the `ExecutionStatus` of the head (unless the head block is pre-Bellatrix).