### PR TITLE
[Merged by Bors] - Proposer preparation data quoted validator index in API

### DIFF
--- a/consensus/types/src/proposer_preparation_data.rs
+++ b/consensus/types/src/proposer_preparation_data.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
 pub struct ProposerPreparationData {
     /// The validators index.
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub validator_index: u64,
     /// The fee-recipient address.
     pub fee_recipient: Address,


### PR DESCRIPTION
## Issue Addressed

#3077

## Proposed Changes

Quotes around validator index in `prepare_beacon_proposer` endpoint
