### PR TITLE
[Merged by Bors] - Add minimum supported Rust version

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -21,6 +21,18 @@ jobs:
     steps:
         - name: Check that the pull request is not targeting the stable branch
           run: test ${{ github.base_ref }} != "stable"
+  extract-msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Extract Minimum Supported Rust Version (MSRV)
+      run: |
+        metadata=$(cargo metadata --no-deps --format-version 1)
+        msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "lighthouse")) | .[0].rust_version')
+        echo "::set-output name=MSRV::$msrv"
+      id: extract_msrv
+    outputs:
+      MSRV: ${{ steps.extract_msrv.outputs.MSRV }}
   cargo-fmt:
     name: cargo-fmt
     runs-on: ubuntu-latest
@@ -229,6 +241,16 @@ jobs:
       run: make lint
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock
+  clippy-msrv:
+    name: clippy-msrv
+    runs-on: ubuntu-latest
+    needs: [cargo-fmt, extract-msrv]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Rust @ MSRV (${{ needs.extract-msrv.outputs.MSRV }})
+      run: rustup override set ${{ needs.extract-msrv.outputs.MSRV }}
+    - name: Run Clippy
+      run: make lint
   arbitrary-check:
     name: arbitrary-check
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -249,6 +249,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Rust @ MSRV (${{ needs.extract-msrv.outputs.MSRV }})
       run: rustup override set ${{ needs.extract-msrv.outputs.MSRV }}
+    - name: Install Clippy
+      run: rustup component add clippy
     - name: Run Clippy
       run: make lint
   arbitrary-check:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -241,18 +241,16 @@ jobs:
       run: make lint
     - name: Certify Cargo.lock freshness
       run: git diff --exit-code Cargo.lock
-  clippy-msrv:
-    name: clippy-msrv
+  check-msrv:
+    name: check-msrv
     runs-on: ubuntu-latest
     needs: [cargo-fmt, extract-msrv]
     steps:
     - uses: actions/checkout@v1
     - name: Install Rust @ MSRV (${{ needs.extract-msrv.outputs.MSRV }})
       run: rustup override set ${{ needs.extract-msrv.outputs.MSRV }}
-    - name: Install Clippy
-      run: rustup component add clippy
-    - name: Run Clippy
-      run: make lint
+    - name: Run cargo check
+      run: cargo check --workspace
   arbitrary-check:
     name: arbitrary-check
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -18,7 +18,8 @@ status = [
     "op-pool-tests",
     "doppelganger-protection-test",
     "execution-engine-integration-ubuntu",
-    "cargo-vendor"
+    "cargo-vendor",
+    "check-msrv"
 ]
 use_squash_merge = true
 timeout_sec = 10800

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.1.3"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false
+rust-version = "1.58"
 
 [features]
 # Writes debugging .ssz files to /tmp during block processing.


### PR DESCRIPTION
## Proposed Changes

Set a minimum supported Rust version (MSRV) in the `Cargo.toml` for the Lighthouse binary so that attempts to compile it with an outdated compiler fail immediately with a clear error.

To ensure that the codebase builds with the MSRV I've also added a Github actions job that runs `cargo check` using the MSRV extracted from `Cargo.toml`. This will force us to keep it up to date.

I opted to use `cargo check` rather than Clippy because Clippy frequently introduces new lints that we adopt, so our MSRV for Clippy is usually the most recent Rust version, while the MSRV for building Lighthouse is older.
