### PR TITLE
[Merged by Bors] - Clarify proposers message is about current epoch

### DIFF
--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -89,7 +89,7 @@ async fn notify<T: SlotClock + 'static, E: EthSpec>(
             info!(
                 log,
                 "All validators active";
-                "proposers" => proposing_validators,
+                "proposers_this_epoch" => proposing_validators,
                 "active_validators" => attesting_validators,
                 "total_validators" => total_validators,
                 "epoch" => format!("{}", epoch),
@@ -99,7 +99,7 @@ async fn notify<T: SlotClock + 'static, E: EthSpec>(
             info!(
                 log,
                 "Some validators active";
-                "proposers" => proposing_validators,
+                "proposers_this_epoch" => proposing_validators,
                 "active_validators" => attesting_validators,
                 "total_validators" => total_validators,
                 "epoch" => format!("{}", epoch),

--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -89,7 +89,7 @@ async fn notify<T: SlotClock + 'static, E: EthSpec>(
             info!(
                 log,
                 "All validators active";
-                "proposers_this_epoch" => proposing_validators,
+                "current_epoch_proposers" => proposing_validators,
                 "active_validators" => attesting_validators,
                 "total_validators" => total_validators,
                 "epoch" => format!("{}", epoch),

--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -99,7 +99,7 @@ async fn notify<T: SlotClock + 'static, E: EthSpec>(
             info!(
                 log,
                 "Some validators active";
-                "proposers_this_epoch" => proposing_validators,
+                "current_epoch_proposers" => proposing_validators,
                 "active_validators" => attesting_validators,
                 "total_validators" => total_validators,
                 "epoch" => format!("{}", epoch),


### PR DESCRIPTION
## Issue Addressed

#3083

## Proposed Changes

Changes "proposers" to "proposers_this_epoch" in the validator log message.