### PR TITLE
[Merged by Bors] - Gracefully handle missing sync committee duties

### DIFF
--- a/validator_client/src/duties_service/sync.rs
+++ b/validator_client/src/duties_service/sync.rs
@@ -403,7 +403,7 @@ pub async fn poll_sync_committee_duties_for_period<T: SlotClock + 'static, E: Et
     if local_indices.is_empty() {
         debug!(
             duties_service.context.log(),
-            "No validators, not polling for sync comittee";
+            "No validators, not polling for sync committee duties";
             "sync_committee_period" => sync_committee_period,
         );
         return Ok(());


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/3085
Closes https://github.com/sigp/lighthouse/issues/2953

## Proposed Changes

Downgrade some of the warnings logged by the VC which were useful during development of the sync committee service but are creating trouble now that we avoid populating the `sync_duties` map with 0 active validators.
