### PR TITLE
[Merged by Bors] - Use windows-2019 in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,9 @@ jobs:
                     -   arch: x86_64-apple-darwin-portable
                         platform: macos-latest
                     -   arch: x86_64-windows
-                        platform: windows-latest
+                        platform: windows-2019
                     -   arch: x86_64-windows-portable
-                        platform: windows-latest
+                        platform: windows-2019
 
         runs-on:    ${{ matrix.platform }}
         needs: extract-version


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Address a CI failure in the release suite.

Example: https://github.com/sigp/lighthouse/actions/runs/1984266187

## Additional Info

I believe we should merge this into `unstable` and `stable`. Then, move the `v2.1.4` commit to target the commit with the updated CI. It's sad that v2.1.4 has two commits, but they're functionally equivalent for users.