### PR TITLE
[Merged by Bors] - Support IPv6 in BN and VC HTTP APIs

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -38,7 +38,7 @@ use state_id::StateId;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::future::Future;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -98,7 +98,7 @@ pub struct Context<T: BeaconChainTypes> {
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
-    pub listen_addr: Ipv4Addr,
+    pub listen_addr: IpAddr,
     pub listen_port: u16,
     pub allow_origin: Option<String>,
     pub serve_legacy_spec: bool,
@@ -110,7 +110,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             enabled: false,
-            listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+            listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5052,
             allow_origin: None,
             serve_legacy_spec: true,
@@ -2791,7 +2791,7 @@ pub fn serve<T: BeaconChainTypes>(
         .map(|reply| warp::reply::with_header(reply, "Server", &version_with_platform()))
         .with(cors_builder.build());
 
-    let http_socket: SocketAddrV4 = SocketAddrV4::new(config.listen_addr, config.listen_port);
+    let http_socket: SocketAddr = SocketAddr::new(config.listen_addr, config.listen_port);
     let http_server: HttpServer = match config.tls_config {
         Some(tls_config) => {
             let (socket, server) = warp::serve(routes)

--- a/beacon_node/http_api/tests/common.rs
+++ b/beacon_node/http_api/tests/common.rs
@@ -15,7 +15,7 @@ use network::NetworkMessage;
 use sensitive_url::SensitiveUrl;
 use slog::Logger;
 use std::future::Future;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
@@ -128,7 +128,7 @@ pub async fn create_api_server<T: BeaconChainTypes>(
     let context = Arc::new(Context {
         config: Config {
             enabled: true,
-            listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+            listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 0,
             allow_origin: None,
             serve_legacy_spec: true,

--- a/beacon_node/http_metrics/src/lib.rs
+++ b/beacon_node/http_metrics/src/lib.rs
@@ -9,7 +9,7 @@ use lighthouse_version::version_with_platform;
 use serde::{Deserialize, Serialize};
 use slog::{crit, info, Logger};
 use std::future::Future;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use warp::{http::Response, Filter};
@@ -48,7 +48,7 @@ pub struct Context<T: BeaconChainTypes> {
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
-    pub listen_addr: Ipv4Addr,
+    pub listen_addr: IpAddr,
     pub listen_port: u16,
     pub allow_origin: Option<String>,
     pub allocator_metrics_enabled: bool,
@@ -58,7 +58,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             enabled: false,
-            listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+            listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5054,
             allow_origin: None,
             allocator_metrics_enabled: true,
@@ -131,7 +131,7 @@ pub fn serve<T: BeaconChainTypes>(
         .with(cors_builder.build());
 
     let (listening_socket, server) = warp::serve(routes).try_bind_with_graceful_shutdown(
-        SocketAddrV4::new(config.listen_addr, config.listen_port),
+        SocketAddr::new(config.listen_addr, config.listen_port),
         async {
             shutdown.await;
         },

--- a/beacon_node/http_metrics/tests/tests.rs
+++ b/beacon_node/http_metrics/tests/tests.rs
@@ -2,7 +2,7 @@ use beacon_chain::test_utils::EphemeralHarnessType;
 use environment::null_logger;
 use http_metrics::Config;
 use reqwest::StatusCode;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use tokio::sync::oneshot;
 use types::MainnetEthSpec;
@@ -17,7 +17,7 @@ async fn returns_200_ok() {
         let context = Arc::new(Context {
             config: Config {
                 enabled: true,
-                listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+                listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 listen_port: 0,
                 allow_origin: None,
                 allocator_metrics_enabled: true,

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -93,8 +93,8 @@ pub fn get_config<E: EthSpec>(
 
     if let Some(address) = cli_args.value_of("http-address") {
         client_config.http_api.listen_addr = address
-            .parse::<Ipv4Addr>()
-            .map_err(|_| "http-address is not a valid IPv4 address.")?;
+            .parse::<IpAddr>()
+            .map_err(|_| "http-address is not a valid IP address.")?;
     }
 
     if let Some(port) = cli_args.value_of("http-port") {
@@ -145,8 +145,8 @@ pub fn get_config<E: EthSpec>(
 
     if let Some(address) = cli_args.value_of("metrics-address") {
         client_config.http_metrics.listen_addr = address
-            .parse::<Ipv4Addr>()
-            .map_err(|_| "metrics-address is not a valid IPv4 address.")?;
+            .parse::<IpAddr>()
+            .map_err(|_| "metrics-address is not a valid IP address.")?;
     }
 
     if let Some(port) = cli_args.value_of("metrics-port") {

--- a/common/warp_utils/src/cors.rs
+++ b/common/warp_utils/src/cors.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use warp::filters::cors::Builder;
 
 /// Configure a `cors::Builder`.
@@ -7,7 +7,7 @@ use warp::filters::cors::Builder;
 pub fn set_builder_origins(
     builder: Builder,
     allow_origin: Option<&str>,
-    default_origin: (Ipv4Addr, u16),
+    default_origin: (IpAddr, u16),
 ) -> Result<Builder, String> {
     if let Some(allow_origin) = allow_origin {
         let origins = allow_origin
@@ -65,6 +65,7 @@ mod test {
         verify_cors_origin_str("http://localhost").unwrap();
         verify_cors_origin_str("http://127.0.0.1:8000").unwrap();
         verify_cors_origin_str("http://localhost:8000").unwrap();
+        // Todo(mac) Add tests here
     }
 
     #[test]

--- a/common/warp_utils/src/cors.rs
+++ b/common/warp_utils/src/cors.rs
@@ -16,7 +16,10 @@ pub fn set_builder_origins(
             .collect::<Result<Vec<_>, _>>()?;
         Ok(builder.allow_origins(origins))
     } else {
-        let origin = format!("http://{}:{}", default_origin.0, default_origin.1);
+        let origin = match default_origin.0 {
+            IpAddr::V4(_) => format!("http://{}:{}", default_origin.0, default_origin.1),
+            IpAddr::V6(_) => format!("http://[{}]:{}", default_origin.0, default_origin.1),
+        };
         verify_cors_origin_str(&origin)?;
 
         Ok(builder.allow_origin(origin.as_str()))
@@ -65,7 +68,8 @@ mod test {
         verify_cors_origin_str("http://localhost").unwrap();
         verify_cors_origin_str("http://127.0.0.1:8000").unwrap();
         verify_cors_origin_str("http://localhost:8000").unwrap();
-        // Todo(mac) Add tests here
+        verify_cors_origin_str("http://[::1]").unwrap();
+        verify_cors_origin_str("http://[::1]:8000").unwrap();
     }
 
     #[test]
@@ -73,5 +77,6 @@ mod test {
         verify_cors_origin_str(".*").unwrap_err();
         verify_cors_origin_str("127.0.0.1").unwrap_err();
         verify_cors_origin_str("localhost").unwrap_err();
+        verify_cors_origin_str("[::1]").unwrap_err();
     }
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -4,7 +4,7 @@ use crate::exec::{CommandLineTestExec, CompletedTest};
 use lighthouse_network::PeerId;
 use std::fs::File;
 use std::io::Write;
-use std::net::{IpAddr};
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -4,7 +4,7 @@ use crate::exec::{CommandLineTestExec, CompletedTest};
 use lighthouse_network::PeerId;
 use std::fs::File;
 use std::io::Write;
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::{IpAddr};
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
@@ -395,7 +395,7 @@ fn network_shutdown_after_sync_disabled_flag() {
 }
 #[test]
 fn network_listen_address_flag() {
-    let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.2".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("listen-address", Some("127.0.0.2"))
         .run_with_zero_port()
@@ -627,9 +627,17 @@ fn http_flag() {
 }
 #[test]
 fn http_address_flag() {
-    let addr = "127.0.0.99".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("http-address", Some("127.0.0.99"))
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
+}
+#[test]
+fn http_address_ipv6_flag() {
+    let addr = "::1".parse::<IpAddr>().unwrap();
+    CommandLineTest::new()
+        .flag("http-address", Some("::1"))
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
 }
@@ -704,10 +712,19 @@ fn metrics_flag() {
 }
 #[test]
 fn metrics_address_flag() {
-    let addr = "127.0.0.99".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("metrics", None)
         .flag("metrics-address", Some("127.0.0.99"))
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.http_metrics.listen_addr, addr));
+}
+#[test]
+fn metrics_address_ipv6_flag() {
+    let addr = "::1".parse::<IpAddr>().unwrap();
+    CommandLineTest::new()
+        .flag("metrics", None)
+        .flag("metrics-address", Some("::1"))
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.http_metrics.listen_addr, addr));
 }

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -4,7 +4,7 @@ use crate::exec::CommandLineTestExec;
 use bls::{Keypair, PublicKeyBytes};
 use std::fs::File;
 use std::io::Write;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
@@ -320,7 +320,7 @@ fn http_flag() {
 }
 #[test]
 fn http_address_flag() {
-    let addr = "127.0.0.99".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("http-address", Some("127.0.0.99"))
         .flag("unencrypted-http-transport", None)
@@ -328,9 +328,18 @@ fn http_address_flag() {
         .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
 }
 #[test]
+fn http_address_ipv6_flag() {
+    let addr = "::1".parse::<IpAddr>().unwrap();
+    CommandLineTest::new()
+        .flag("http-address", Some("::1"))
+        .flag("unencrypted-http-transport", None)
+        .run()
+        .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
+}
+#[test]
 #[should_panic]
 fn missing_unencrypted_http_transport_flag() {
-    let addr = "127.0.0.99".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("http-address", Some("127.0.0.99"))
         .run()
@@ -373,9 +382,17 @@ fn metrics_flag() {
 }
 #[test]
 fn metrics_address_flag() {
-    let addr = "127.0.0.99".parse::<Ipv4Addr>().unwrap();
+    let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
         .flag("metrics-address", Some("127.0.0.99"))
+        .run()
+        .with_config(|config| assert_eq!(config.http_metrics.listen_addr, addr));
+}
+#[test]
+fn metrics_address_ipv6_flag() {
+    let addr = "::1".parse::<IpAddr>().unwrap();
+    CommandLineTest::new()
+        .flag("metrics-address", Some("::1"))
         .run()
         .with_config(|config| assert_eq!(config.http_metrics.listen_addr, addr));
 }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -12,7 +12,7 @@ use sensitive_url::SensitiveUrl;
 use serde_derive::{Deserialize, Serialize};
 use slog::{info, warn, Logger};
 use std::fs;
-use std::net::Ipv4Addr;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use types::{Address, GRAFFITI_BYTES_LEN};
 
@@ -238,8 +238,8 @@ impl Config {
         if let Some(address) = cli_args.value_of("http-address") {
             if cli_args.is_present("unencrypted-http-transport") {
                 config.http_api.listen_addr = address
-                    .parse::<Ipv4Addr>()
-                    .map_err(|_| "http-address is not a valid IPv4 address.")?;
+                    .parse::<IpAddr>()
+                    .map_err(|_| "http-address is not a valid IP address.")?;
             } else {
                 return Err(
                     "While using `--http-address`, you must also use `--unencrypted-http-transport`."
@@ -273,8 +273,8 @@ impl Config {
 
         if let Some(address) = cli_args.value_of("metrics-address") {
             config.http_metrics.listen_addr = address
-                .parse::<Ipv4Addr>()
-                .map_err(|_| "metrics-address is not a valid IPv4 address.")?;
+                .parse::<IpAddr>()
+                .map_err(|_| "metrics-address is not a valid IP address.")?;
         }
 
         if let Some(port) = cli_args.value_of("metrics-port") {

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -16,7 +16,7 @@ use slog::{crit, info, warn, Logger};
 use slot_clock::SlotClock;
 use std::future::Future;
 use std::marker::PhantomData;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::{Arc, Weak};
 use tokio::runtime::Runtime;
@@ -69,7 +69,7 @@ pub struct Context<T: SlotClock, E: EthSpec> {
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
-    pub listen_addr: Ipv4Addr,
+    pub listen_addr: IpAddr,
     pub listen_port: u16,
     pub allow_origin: Option<String>,
 }
@@ -78,7 +78,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             enabled: false,
-            listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+            listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5062,
             allow_origin: None,
         }
@@ -609,7 +609,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .with(cors_builder.build());
 
     let (listening_socket, server) = warp::serve(routes).try_bind_with_graceful_shutdown(
-        SocketAddrV4::new(config.listen_addr, config.listen_port),
+        SocketAddr::new(config.listen_addr, config.listen_port),
         async {
             shutdown.await;
         },

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -27,7 +27,7 @@ use slashing_protection::{SlashingDatabase, SLASHING_PROTECTION_FILENAME};
 use slot_clock::{SlotClock, TestingSlotClock};
 use std::future::Future;
 use std::marker::PhantomData;
-use std::net::Ipv4Addr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
 use std::time::Duration;
 use task_executor::TaskExecutor;
@@ -120,7 +120,7 @@ impl ApiTester {
             spec: E::default_spec(),
             config: HttpConfig {
                 enabled: true,
-                listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+                listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                 listen_port: 0,
                 allow_origin: None,
             },

--- a/validator_client/src/http_metrics/mod.rs
+++ b/validator_client/src/http_metrics/mod.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use slog::{crit, info, Logger};
 use slot_clock::SystemTimeSlotClock;
 use std::future::Future;
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use types::EthSpec;
 use warp::{http::Response, Filter};
@@ -53,7 +53,7 @@ pub struct Context<T: EthSpec> {
 #[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
-    pub listen_addr: Ipv4Addr,
+    pub listen_addr: IpAddr,
     pub listen_port: u16,
     pub allow_origin: Option<String>,
 }
@@ -62,7 +62,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             enabled: false,
-            listen_addr: Ipv4Addr::new(127, 0, 0, 1),
+            listen_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             listen_port: 5064,
             allow_origin: None,
         }
@@ -134,7 +134,7 @@ pub fn serve<T: EthSpec>(
         .with(cors_builder.build());
 
     let (listening_socket, server) = warp::serve(routes).try_bind_with_graceful_shutdown(
-        SocketAddrV4::new(config.listen_addr, config.listen_port),
+        SocketAddr::new(config.listen_addr, config.listen_port),
         async {
             shutdown.await;
         },


### PR DESCRIPTION
## Issue Addressed

#3103

## Proposed Changes

Parse `http-address` and `metrics-address` as `IpAddr` for both the beacon node and validator client to support IPv6 addresses.
Also adjusts parsing of CORS origins to allow for IPv6 addresses.

## Usage
You can now set  `http-address` and/or `metrics-address`  flags to IPv6 addresses.
For example, the following:
`lighthouse bn --http --http-address :: --metrics --metrics-address ::1`
will expose the beacon node HTTP server on `[::]` (equivalent of `0.0.0.0` in IPv4) and the metrics HTTP server on `localhost` (the equivalent of `127.0.0.1` in IPv4) 

The beacon node API can then be accessed by:
`curl "http://[server-ipv6-address]:5052/eth/v1/some_endpoint"`

And the metrics server api can be accessed by:
`curl "http://localhost:5054/metrics"` or by `curl "http://[::1]:5054/metrics"`

## Additional Info
On most Linux distributions the `v6only` flag is set to `false` by default (see the section for the `IPV6_V6ONLY` flag in https://www.man7.org/linux/man-pages/man7/ipv6.7.html) which means IPv4 connections will continue to function on a IPv6 address (providing it is appropriately mapped). This means that even if the Lighthouse API is running on `::` it is also possible to accept IPv4 connections.

However on Windows, this is not the case. The `v6only` flag is set to `true` so binding to `::` will only allow IPv6 connections.