### PR TITLE
[Merged by Bors] - Fix ganache in windows CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,7 +69,9 @@ jobs:
       with:
         python-version: "2.7"
     - name: Set node config to use python2.7
-      run: npm config set python %pythonLocation%
+      run: | 
+        npm config set python %pythonLocation%
+        npm config get python
     - name: Set msvs_version to 2019
       run: npm config set msvs_version 2019 --global
     - name: Install ganache

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,9 +71,7 @@ jobs:
       with:
         python-version: "2.7"
     - name: Set node config to use python2.7
-      run: | 
-        npm config set python python2.7
-        npm config get python
+      run: npm config set python %pythonLocation%
     - name: Set msvs_version to 2019
       run: npm config set msvs_version 2019 --global
     - name: Install ganache

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,7 +70,7 @@ jobs:
         python-version: "2.7"
     - name: Set node config to use python2.7
       run: | 
-        npm config set python 2.7
+        npm config set python python2.7
         npm config get python
     - name: Set msvs_version to 2019
       run: npm config set msvs_version 2019 --global

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,7 +63,9 @@ jobs:
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install windows build tools
-      run: npm install --global --production windows-build-tools
+      run: |
+        choco install python visualstudio2017-workload-vctools -y
+        npm config set msvs_version 2017
     - name: Install ganache
       run: npm install -g ganache
     - name: Install make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,7 +70,7 @@ jobs:
         python-version: "2.7"
     - name: Set node config to use python2.7
       run: | 
-        npm config set python %pythonLocation%
+        npm config set python 2.7
         npm config get python
     - name: Set msvs_version to 2019
       run: npm config set msvs_version 2019 --global

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,8 +64,8 @@ jobs:
       run: rustup update stable
     - name: Install windows build tools
       run: |
-        choco install python visualstudio2017-workload-vctools -y
-        npm config set msvs_version 2017
+        choco install python visualstudio2019-workload-vctools -y
+        npm config set msvs_version 2019
     - name: Install ganache
       run: npm install -g ganache
     - name: Install make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,6 +64,8 @@ jobs:
       run: rustup update stable
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
+    - name: Install node-gyp
+      run: npm install --global node-gyp@7.1.2
     - name: Use Python 2.7
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         python-version: "2.7"
     - name: Set node config to use python2.7
-      run: npm config set python %pythonLocation%
+      run: npm config set python python2.7
     - name: Set msvs_version to 2019
       run: npm config set msvs_version 2019 --global
     - name: Install ganache

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -62,18 +62,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest version of stable Rust
       run: rustup update stable
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Install node-gyp
-      run: npm install --global node-gyp@7.1.2
-    - name: Use Python 2.7
-      uses: actions/setup-python@v2
-      with:
-        python-version: "2.7"
-    - name: Set node config to use python2.7
-      run: npm config set python python2.7
-    - name: Set msvs_version to 2019
-      run: npm config set msvs_version 2019 --global
+    - name: Install windows build tools
+      run: npm install --global --production windows-build-tools
     - name: Install ganache
       run: npm install -g ganache
     - name: Install make


### PR DESCRIPTION
## Issue Addressed

Hopefully makes windows ganache installation more reliable.

## Proposed Changes

- use `chocolatey` to install windows build tools. This seems to often be the prescribed solution for `node gyp` issues. `chocolatey` is used here because `npm install --global --production windows-build-tools` hangs in github actions

## Additional Info
I still haven't found why the prior installation technique would sometimes work, the `windows-2019` environments seem to be identical across successes and failures.  I think this should be re-run a few times to see if it can consistently pass
