### PR TITLE
[Merged by Bors] - Fix ganache windows CI attempt 2

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -62,14 +62,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest version of stable Rust
       run: rustup update stable
-    - name: Use Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
-    - name: Set up MSBuild
-      uses: microsoft/setup-msbuild@v1.1
-    - name: Install node gyp build
-      run: npm install -g node-gyp-build --loglevel verbose
+    - name: Install windows build tools
+      run: |
+        choco install python visualstudio2019-workload-vctools -y
+        npm config set msvs_version 2019
     - name: Install ganache
       run: npm install -g ganache --loglevel verbose
     - name: Install make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -62,6 +62,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest version of stable Rust
       run: rustup update stable
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
     - name: Install windows build tools
       run: |
         choco install python visualstudio2019-workload-vctools -y

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -62,12 +62,16 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest version of stable Rust
       run: rustup update stable
-    - name: Install windows build tools
-      run: |
-        choco install python visualstudio2019-workload-vctools -y
-        npm config set msvs_version 2019
+    - name: Use Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+    - name: Set up MSBuild
+      uses: microsoft/setup-msbuild@v1.1
+    - name: Install node gyp build
+      run: npm install -g node-gyp-build --loglevel verbose
     - name: Install ganache
-      run: npm install -g ganache
+      run: npm install -g ganache --loglevel verbose
     - name: Install make
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1


### PR DESCRIPTION
## Issue Addressed

Attempt to fix CI

## Proposed Changes

- ~~install `node-gyp-build` which should look for prebuilt binaries for `@truffle-suite/bigint_buffer`. This should make it so we don't have to build it directly. See: https://github.com/trufflesuite/ganache/pull/1414~~ this didn't work
- This also uses the `setup-node` action because it includes caching. Sort of a shot in the dark, but the ganache github repo uses it and the failures seem to be for missing files in a node cache 


