### PR TITLE
[Merged by Bors] - json rpc id to value

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -75,7 +75,7 @@ impl HttpJsonRpc {
             jsonrpc: JSONRPC_VERSION,
             method,
             params,
-            id: STATIC_ID,
+            id: json!(STATIC_ID),
         };
 
         let mut request = self

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -8,7 +8,7 @@ pub struct JsonRequestBody<'a> {
     pub jsonrpc: &'a str,
     pub method: &'a str,
     pub params: serde_json::Value,
-    pub id: u32,
+    pub id: serde_json::Value,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -25,7 +25,7 @@ pub struct JsonResponseBody {
     pub error: Option<JsonError>,
     #[serde(default)]
     pub result: serde_json::Value,
-    pub id: u32,
+    pub id: serde_json::Value,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

- Update the JSON-RPC id field for both our request and response objects to be a `serde_json::Value` rather than a `u32`. This field could be a string or a number according to the JSON-RPC 2.0 spec. We only ever set it to a number, but if, for example, we get a response that wraps this number in quotes, we would fail to deserialize it. I think because we're not doing any validation around this id otherwise, we should be less strict with it in this regard. 

## Additional Info

