### PR TITLE
[Merged by Bors] - Add merge objects to lcli parse-ssz subcommand

### DIFF
--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -41,10 +41,13 @@ pub fn run_parse_ssz<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
     match type_str {
         "signed_block_base" => decode_and_print::<SignedBeaconBlockBase<T>>(&bytes, format)?,
         "signed_block_altair" => decode_and_print::<SignedBeaconBlockAltair<T>>(&bytes, format)?,
+        "signed_block_merge" => decode_and_print::<SignedBeaconBlockMerge<T>>(&bytes, format)?,
         "block_base" => decode_and_print::<BeaconBlockBase<T>>(&bytes, format)?,
         "block_altair" => decode_and_print::<BeaconBlockAltair<T>>(&bytes, format)?,
+        "block_merge" => decode_and_print::<BeaconBlockMerge<T>>(&bytes, format)?,
         "state_base" => decode_and_print::<BeaconStateBase<T>>(&bytes, format)?,
         "state_altair" => decode_and_print::<BeaconStateAltair<T>>(&bytes, format)?,
+        "state_merge" => decode_and_print::<BeaconStateMerge<T>>(&bytes, format)?,
         other => return Err(format!("Unknown type: {}", other)),
     };
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Parse merge state and blocks in parse-ssz subcommand.