### PR TITLE
[Merged by Bors] - Target geth master in integration testing

### DIFF
--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -7,8 +7,8 @@ use std::{env, fs::File};
 use tempfile::TempDir;
 use unused_port::unused_tcp_port;
 
-const GETH_BRANCH: &str = "merge-kiln-v2";
-const GETH_REPO_URL: &str = "https://github.com/MariusVanDerWijden/go-ethereum";
+const GETH_BRANCH: &str = "master";
+const GETH_REPO_URL: &str = "https://github.com/ethereum/go-ethereum";
 
 pub fn build_result(repo_dir: &Path) -> Output {
     Command::new("make")


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Target the `master` branch of the canonical Geth repo, rather than @MariusVanDerWijden's fork.

In [this tweet](https://twitter.com/vdWijden/status/1506899633741705217?s=20&t=yraR-qFAtSDCYtl_gyoeiw), Marius states:

> We merged all important changes for [#TheMerge](https://twitter.com/hashtag/TheMerge?src=hashtag_click) into [@go_ethereum](https://twitter.com/go_ethereum)
's master branch. So no need to use my fork anymore! Changes will be applied (in old geth fashion) directly to master. My merge-kiln-v2 branch is already stale, so please switch, you can also use --kiln to join Kiln

## Additional Info

NA
