### PR TITLE
[Merged by Bors] - Ensure VALID response from fcU updates protoarray

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4028,7 +4028,25 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         match forkchoice_updated_response {
             Ok(status) => match &status {
-                PayloadStatus::Valid | PayloadStatus::Syncing => Ok(()),
+                PayloadStatus::Valid => {
+                    // Ensure that fork choice knows that the block is no longer optimistic.
+                    if let Err(e) = self
+                        .fork_choice
+                        .write()
+                        .on_valid_execution_payload(head_block_root)
+                    {
+                        error!(
+                            self.log,
+                            "Failed to validate payload";
+                            "error" => ?e
+                        )
+                    };
+                    Ok(())
+                }
+                // There's nothing to be done for a syncing response. If the block is already
+                // `SYNCING` in fork choice, there's nothing to do. If already known to be `VALID`
+                // or `INVALID` then we don't want to change it to syncing.
+                PayloadStatus::Syncing => Ok(()),
                 // The specification doesn't list `ACCEPTED` as a valid response to a fork choice
                 // update. This response *seems* innocent enough, so we won't return early with an
                 // error. However, we create a log to bring attention to the issue.

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -147,6 +147,15 @@ impl InvalidPayloadRig {
             .unwrap()
     }
 
+    fn validate_manually(&self, block_root: Hash256) {
+        self.harness
+            .chain
+            .fork_choice
+            .write()
+            .on_valid_execution_payload(block_root)
+            .unwrap();
+    }
+
     fn import_block_parametric<F: Fn(&BlockError<E>) -> bool>(
         &mut self,
         is_valid: Payload,
@@ -640,6 +649,42 @@ fn invalid_after_optimistic_sync() {
     // 1 should be the head, since 2 was invalidated.
     let head = rig.harness.chain.head_info().unwrap();
     assert_eq!(head.block_root, roots[1]);
+}
+
+#[test]
+fn manually_validate_child() {
+    let mut rig = InvalidPayloadRig::new().enable_attestations();
+    rig.move_to_terminal_block();
+    rig.import_block(Payload::Valid); // Import a valid transition block.
+
+    let parent = rig.import_block(Payload::Syncing);
+    let child = rig.import_block(Payload::Syncing);
+
+    assert!(rig.execution_status(parent).is_not_verified());
+    assert!(rig.execution_status(child).is_not_verified());
+
+    rig.validate_manually(child);
+
+    assert!(rig.execution_status(parent).is_valid());
+    assert!(rig.execution_status(child).is_valid());
+}
+
+#[test]
+fn manually_validate_parent() {
+    let mut rig = InvalidPayloadRig::new().enable_attestations();
+    rig.move_to_terminal_block();
+    rig.import_block(Payload::Valid); // Import a valid transition block.
+
+    let parent = rig.import_block(Payload::Syncing);
+    let child = rig.import_block(Payload::Syncing);
+
+    assert!(rig.execution_status(parent).is_not_verified());
+    assert!(rig.execution_status(child).is_not_verified());
+
+    rig.validate_manually(parent);
+
+    assert!(rig.execution_status(parent).is_valid());
+    assert!(rig.execution_status(child).is_not_verified());
 }
 
 #[test]

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -68,6 +68,7 @@ impl<T: EthSpec> MockServer<T> {
             previous_request: <_>::default(),
             preloaded_responses,
             static_new_payload_response: <_>::default(),
+            static_forkchoice_updated_response: <_>::default(),
             _phantom: PhantomData,
         });
 
@@ -134,6 +135,7 @@ impl<T: EthSpec> MockServer<T> {
             },
             should_import: true,
         };
+        *self.ctx.static_forkchoice_updated_response.lock() = Some(response.status.clone());
         *self.ctx.static_new_payload_response.lock() = Some(response)
     }
 
@@ -148,6 +150,7 @@ impl<T: EthSpec> MockServer<T> {
             },
             should_import,
         };
+        *self.ctx.static_forkchoice_updated_response.lock() = Some(response.status.clone());
         *self.ctx.static_new_payload_response.lock() = Some(response)
     }
 
@@ -160,6 +163,7 @@ impl<T: EthSpec> MockServer<T> {
             },
             should_import: true,
         };
+        *self.ctx.static_forkchoice_updated_response.lock() = Some(response.status.clone());
         *self.ctx.static_new_payload_response.lock() = Some(response)
     }
 
@@ -248,6 +252,7 @@ pub struct Context<T: EthSpec> {
     pub preloaded_responses: Arc<Mutex<Vec<serde_json::Value>>>,
     pub previous_request: Arc<Mutex<Option<serde_json::Value>>>,
     pub static_new_payload_response: Arc<Mutex<Option<StaticNewPayloadResponse>>>,
+    pub static_forkchoice_updated_response: Arc<Mutex<Option<PayloadStatusV1>>>,
     pub _phantom: PhantomData<T>,
 }
 

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -18,6 +18,7 @@ pub enum Error<T> {
     InvalidProtoArrayBytes(String),
     InvalidLegacyProtoArrayBytes(String),
     FailedToProcessInvalidExecutionPayload(String),
+    FailedToProcessValidExecutionPayload(String),
     MissingProtoArrayBlock(Hash256),
     UnknownAncestor {
         ancestor_slot: Slot,
@@ -510,6 +511,16 @@ where
         }
 
         Ok(true)
+    }
+
+    /// See `ProtoArrayForkChoice::process_execution_payload_validation` for documentation.
+    pub fn on_valid_execution_payload(
+        &mut self,
+        block_root: Hash256,
+    ) -> Result<(), Error<T::Error>> {
+        self.proto_array
+            .process_execution_payload_validation(block_root)
+            .map_err(Error::FailedToProcessValidExecutionPayload)
     }
 
     /// See `ProtoArrayForkChoice::process_execution_payload_invalidation` for documentation.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -188,6 +188,16 @@ impl ProtoArrayForkChoice {
         })
     }
 
+    /// See `ProtoArray::propagate_execution_payload_validation` for documentation.
+    pub fn process_execution_payload_validation(
+        &mut self,
+        block_root: Hash256,
+    ) -> Result<(), String> {
+        self.proto_array
+            .propagate_execution_payload_validation(block_root)
+            .map_err(|e| format!("Failed to process valid payload: {:?}", e))
+    }
+
     /// See `ProtoArray::propagate_execution_payload_invalidation` for documentation.
     pub fn process_execution_payload_invalidation(
         &mut self,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Ensures that a `VALID` response from a `forkchoiceUpdate` call will update that block in `ProtoArray`.

I also had to modify the mock execution engine so it wouldn't return valid when all payloads were supposed to be some other static value.

## Additional Info

NA
