### PR TITLE
[Merged by Bors] - Strip newline from jwt secrets

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -177,7 +177,7 @@ impl ExecutionLayer {
                         })
                         .and_then(|ref s| {
                             let secret = JwtKey::from_slice(
-                                &hex::decode(strip_prefix(s))
+                                &hex::decode(strip_prefix(s.trim_end()))
                                     .map_err(|e| format!("Invalid hex string: {:?}", e))?,
                             )?;
                             Ok((secret, p.to_path_buf()))


### PR DESCRIPTION
## Issue Addressed

Resolves #3128 

## Proposed Changes

Strip trailing newlines from jwt secret files.