### PR TITLE
[Merged by Bors] - Fix merge rpc length limits

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -462,7 +462,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 // Our fault. Do nothing
                 return;
             }
-            RPCError::InvalidData => {
+            RPCError::InvalidData(_) => {
                 // Peer is not complying with the protocol. This is considered a malicious action
                 PeerAction::Fatal
             }

--- a/beacon_node/lighthouse_network/src/rpc/codec/base.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/base.rs
@@ -287,7 +287,10 @@ mod tests {
             max_rpc_size,
             fork_context.clone(),
         );
-        assert_eq!(codec.decode(&mut max).unwrap_err(), RPCError::InvalidData);
+        assert!(matches!(
+            codec.decode(&mut max).unwrap_err(),
+            RPCError::InvalidData(_)
+        ));
 
         let mut min = encode_len(limit.min - 1);
         let mut codec = SSZSnappyOutboundCodec::<Spec>::new(
@@ -295,7 +298,10 @@ mod tests {
             max_rpc_size,
             fork_context.clone(),
         );
-        assert_eq!(codec.decode(&mut min).unwrap_err(), RPCError::InvalidData);
+        assert!(matches!(
+            codec.decode(&mut min).unwrap_err(),
+            RPCError::InvalidData(_)
+        ));
 
         // Request limits
         let limit = protocol_id.rpc_request_limits();
@@ -305,11 +311,17 @@ mod tests {
             max_rpc_size,
             fork_context.clone(),
         );
-        assert_eq!(codec.decode(&mut max).unwrap_err(), RPCError::InvalidData);
+        assert!(matches!(
+            codec.decode(&mut max).unwrap_err(),
+            RPCError::InvalidData(_)
+        ));
 
         let mut min = encode_len(limit.min - 1);
         let mut codec =
             SSZSnappyOutboundCodec::<Spec>::new(protocol_id, max_rpc_size, fork_context);
-        assert_eq!(codec.decode(&mut min).unwrap_err(), RPCError::InvalidData);
+        assert!(matches!(
+            codec.decode(&mut min).unwrap_err(),
+            RPCError::InvalidData(_)
+        ));
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/codec/base.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/base.rs
@@ -260,9 +260,9 @@ mod tests {
             ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy);
 
         // Response limits
-        let limit = protocol_id.rpc_response_limits::<Spec>();
-        let mut max = encode_len(limit.max + 1);
         let fork_context = Arc::new(fork_context());
+        let limit = protocol_id.rpc_response_limits::<Spec>(&fork_context);
+        let mut max = encode_len(limit.max + 1);
         let mut codec = SSZSnappyOutboundCodec::<Spec>::new(
             protocol_id.clone(),
             1_048_576,

--- a/beacon_node/lighthouse_network/src/rpc/codec/base.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/base.rs
@@ -184,13 +184,25 @@ mod tests {
     use crate::rpc::protocol::*;
 
     use std::sync::Arc;
-    use types::{ForkContext, Hash256};
+    use types::{Epoch, ForkContext, ForkName, Hash256, Slot};
     use unsigned_varint::codec::Uvi;
 
     type Spec = types::MainnetEthSpec;
 
-    fn fork_context() -> ForkContext {
-        ForkContext::new::<Spec>(types::Slot::new(0), Hash256::zero(), &Spec::default_spec())
+    fn fork_context(fork_name: ForkName) -> ForkContext {
+        let mut chain_spec = Spec::default_spec();
+        let altair_fork_epoch = Epoch::new(1);
+        let merge_fork_epoch = Epoch::new(2);
+
+        chain_spec.altair_fork_epoch = Some(altair_fork_epoch);
+        chain_spec.bellatrix_fork_epoch = Some(merge_fork_epoch);
+
+        let current_slot = match fork_name {
+            ForkName::Base => Slot::new(0),
+            ForkName::Altair => altair_fork_epoch.start_slot(Spec::slots_per_epoch()),
+            ForkName::Merge => merge_fork_epoch.start_slot(Spec::slots_per_epoch()),
+        };
+        ForkContext::new::<Spec>(current_slot, Hash256::zero(), &chain_spec)
     }
 
     #[test]
@@ -202,9 +214,12 @@ mod tests {
         let snappy_protocol_id =
             ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy);
 
-        let fork_context = Arc::new(fork_context());
-        let mut snappy_outbound_codec =
-            SSZSnappyOutboundCodec::<Spec>::new(snappy_protocol_id, 1_048_576, fork_context);
+        let fork_context = Arc::new(fork_context(ForkName::Base));
+        let mut snappy_outbound_codec = SSZSnappyOutboundCodec::<Spec>::new(
+            snappy_protocol_id,
+            max_rpc_size(&fork_context),
+            fork_context,
+        );
 
         // remove response code
         let mut snappy_buf = buf.clone();
@@ -234,9 +249,12 @@ mod tests {
         let snappy_protocol_id =
             ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy);
 
-        let fork_context = Arc::new(fork_context());
-        let mut snappy_outbound_codec =
-            SSZSnappyOutboundCodec::<Spec>::new(snappy_protocol_id, 1_048_576, fork_context);
+        let fork_context = Arc::new(fork_context(ForkName::Base));
+        let mut snappy_outbound_codec = SSZSnappyOutboundCodec::<Spec>::new(
+            snappy_protocol_id,
+            max_rpc_size(&fork_context),
+            fork_context,
+        );
 
         let snappy_decoded_message = snappy_outbound_codec.decode(&mut dst).unwrap_err();
 
@@ -260,12 +278,13 @@ mod tests {
             ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy);
 
         // Response limits
-        let fork_context = Arc::new(fork_context());
+        let fork_context = Arc::new(fork_context(ForkName::Base));
+        let max_rpc_size = max_rpc_size(&fork_context);
         let limit = protocol_id.rpc_response_limits::<Spec>(&fork_context);
         let mut max = encode_len(limit.max + 1);
         let mut codec = SSZSnappyOutboundCodec::<Spec>::new(
             protocol_id.clone(),
-            1_048_576,
+            max_rpc_size,
             fork_context.clone(),
         );
         assert_eq!(codec.decode(&mut max).unwrap_err(), RPCError::InvalidData);
@@ -273,7 +292,7 @@ mod tests {
         let mut min = encode_len(limit.min - 1);
         let mut codec = SSZSnappyOutboundCodec::<Spec>::new(
             protocol_id.clone(),
-            1_048_576,
+            max_rpc_size,
             fork_context.clone(),
         );
         assert_eq!(codec.decode(&mut min).unwrap_err(), RPCError::InvalidData);
@@ -283,13 +302,14 @@ mod tests {
         let mut max = encode_len(limit.max + 1);
         let mut codec = SSZSnappyOutboundCodec::<Spec>::new(
             protocol_id.clone(),
-            1_048_576,
+            max_rpc_size,
             fork_context.clone(),
         );
         assert_eq!(codec.decode(&mut max).unwrap_err(), RPCError::InvalidData);
 
         let mut min = encode_len(limit.min - 1);
-        let mut codec = SSZSnappyOutboundCodec::<Spec>::new(protocol_id, 1_048_576, fork_context);
+        let mut codec =
+            SSZSnappyOutboundCodec::<Spec>::new(protocol_id, max_rpc_size, fork_context);
         assert_eq!(codec.decode(&mut min).unwrap_err(), RPCError::InvalidData);
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -1001,9 +1001,7 @@ mod tests {
                 ))),
                 ForkName::Merge,
             ),
-            Ok(Some(RPCResponse::BlocksByRoot(Box::new(
-                merge_block_small.clone()
-            ))))
+            Ok(Some(RPCResponse::BlocksByRoot(Box::new(merge_block_small))))
         );
 
         let mut encoded =

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -618,7 +618,7 @@ mod tests {
     use std::sync::Arc;
     use types::{
         BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockMerge, Epoch, ForkContext,
-        Hash256, Signature, SignedBeaconBlock, Slot,
+        FullPayload, Hash256, Signature, SignedBeaconBlock, Slot,
     };
 
     use snap::write::FrameEncoder;
@@ -656,11 +656,12 @@ mod tests {
 
     /// Merge block with length < max_rpc_size.
     fn merge_block_small(fork_context: &ForkContext) -> SignedBeaconBlock<Spec> {
-        let mut block = BeaconBlockMerge::empty(&Spec::default_spec());
+        let mut block: BeaconBlockMerge<_, FullPayload<Spec>> =
+            BeaconBlockMerge::empty(&Spec::default_spec());
         let tx = VariableList::from(vec![0; 1024]);
         let txs = VariableList::from(std::iter::repeat(tx).take(100).collect::<Vec<_>>());
 
-        block.body.execution_payload.transactions = txs;
+        block.body.execution_payload.execution_payload.transactions = txs;
 
         let block = BeaconBlock::Merge(block);
         assert!(block.ssz_bytes_len() <= max_rpc_size(fork_context));
@@ -671,11 +672,12 @@ mod tests {
     /// The max limit for a merge block is in the order of ~16GiB which wouldn't fit in memory.
     /// Hence, we generate a merge block just greater than `MAX_RPC_SIZE` to test rejection on the rpc layer.
     fn merge_block_large(fork_context: &ForkContext) -> SignedBeaconBlock<Spec> {
-        let mut block = BeaconBlockMerge::empty(&Spec::default_spec());
+        let mut block: BeaconBlockMerge<_, FullPayload<Spec>> =
+            BeaconBlockMerge::empty(&Spec::default_spec());
         let tx = VariableList::from(vec![0; 1024]);
         let txs = VariableList::from(std::iter::repeat(tx).take(100000).collect::<Vec<_>>());
 
-        block.body.execution_payload.transactions = txs;
+        block.body.execution_payload.execution_payload.transactions = txs;
 
         let block = BeaconBlock::Merge(block);
         assert!(block.ssz_bytes_len() > max_rpc_size(fork_context));

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -279,7 +279,9 @@ impl<TSpec: EthSpec> Decoder for SSZSnappyOutboundCodec<TSpec> {
 
         // Should not attempt to decode rpc chunks with `length > max_packet_size` or not within bounds of
         // packet size for ssz container corresponding to `self.protocol`.
-        let ssz_limits = self.protocol.rpc_response_limits::<TSpec>();
+        let ssz_limits = self
+            .protocol
+            .rpc_response_limits::<TSpec>(&self.fork_context);
         if ssz_limits.is_out_of_bounds(length, self.max_packet_size) {
             return Err(RPCError::InvalidData);
         }

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -675,7 +675,7 @@ mod tests {
         let mut block: BeaconBlockMerge<_, FullPayload<Spec>> =
             BeaconBlockMerge::empty(&Spec::default_spec());
         let tx = VariableList::from(vec![0; 1024]);
-        let txs = VariableList::from(std::iter::repeat(tx).take(10000).collect::<Vec<_>>());
+        let txs = VariableList::from(std::iter::repeat(tx).take(5000).collect::<Vec<_>>());
 
         block.body.execution_payload.execution_payload.transactions = txs;
 

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -477,7 +477,7 @@ where
                 ProtocolError::InvalidMessage | ProtocolError::TooManyProtocols => {
                     // Peer is sending invalid data during the negotiation phase, not
                     // participating in the protocol
-                    RPCError::InvalidData
+                    RPCError::InvalidData("Invalid message during negotiation".to_string())
                 }
             },
         };

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -66,15 +66,10 @@ lazy_static! {
     /// Note: This is only the theoretical upper bound. We further bound the max size we receive over the network
     /// with `MAX_RPC_SIZE_POST_MERGE`.
     pub static ref SIGNED_BEACON_BLOCK_MERGE_MAX: usize =
-    // Size of a full merge block with an empty execution payload
-    SignedBeaconBlock::<MainnetEthSpec>::from_block(
-        BeaconBlock::Merge(BeaconBlockMerge::<MainnetEthSpec>::full(&MainnetEthSpec::default_spec())),
-        Signature::empty(),
-    )
-    .as_ssz_bytes()
-    .len()
-    - types::ExecutionPayload::<MainnetEthSpec>::empty().as_ssz_bytes().len() // subtracting size of empty execution payload included above
-    + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_size(); // adding max size of execution payload (~16gb)
+    // Size of a full altair block
+    *SIGNED_BEACON_BLOCK_ALTAIR_MAX
+    + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_size() // adding max size of execution payload (~16gb)
+    + ssz::BYTES_PER_LENGTH_OFFSET; // Adding the additional ssz offset for the `ExecutionPayload` field
 
     pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize =
         VariableList::<Hash256, MaxRequestBlocks>::from(Vec::<Hash256>::new())

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -63,7 +63,10 @@ lazy_static! {
 
     /// The `BeaconBlockMerge` block has an `ExecutionPayload` field which has a max size ~16 GiB for future proofing.
     /// We calculate the value from its fields instead of constructing the block and checking the length.
-    pub static ref SIGNED_BEACON_BLOCK_MERGE_MAX: usize = types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_size();
+    pub static ref SIGNED_BEACON_BLOCK_MERGE_MAX: usize =
+        *SIGNED_BEACON_BLOCK_MERGE_MIN
+        + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_size()
+        - types::ExecutionPayload::<MainnetEthSpec>::empty().as_ssz_bytes().len();
 
     pub static ref BLOCKS_BY_ROOT_REQUEST_MIN: usize =
         VariableList::<Hash256, MaxRequestBlocks>::from(Vec::<Hash256>::new())
@@ -294,12 +297,18 @@ impl ProtocolId {
             ),
             Protocol::BlocksByRoot => RpcLimits::new(
                 std::cmp::min(
-                    *SIGNED_BEACON_BLOCK_ALTAIR_MIN,
-                    *SIGNED_BEACON_BLOCK_BASE_MIN,
+                    std::cmp::min(
+                        *SIGNED_BEACON_BLOCK_ALTAIR_MIN,
+                        *SIGNED_BEACON_BLOCK_BASE_MIN,
+                    ),
+                    *SIGNED_BEACON_BLOCK_MERGE_MIN,
                 ),
                 std::cmp::max(
-                    *SIGNED_BEACON_BLOCK_ALTAIR_MAX,
-                    *SIGNED_BEACON_BLOCK_BASE_MAX,
+                    std::cmp::max(
+                        *SIGNED_BEACON_BLOCK_ALTAIR_MAX,
+                        *SIGNED_BEACON_BLOCK_BASE_MAX,
+                    ),
+                    *SIGNED_BEACON_BLOCK_MERGE_MAX,
                 ),
             ),
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -533,7 +533,7 @@ pub enum RPCError {
     /// Stream ended unexpectedly.
     IncompleteStream,
     /// Peer sent invalid data.
-    InvalidData,
+    InvalidData(String),
     /// An error occurred due to internal reasons. Ex: timer failure.
     InternalError(&'static str),
     /// Negotiation with this peer timed out.
@@ -567,7 +567,7 @@ impl std::fmt::Display for RPCError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
             RPCError::SSZDecodeError(ref err) => write!(f, "Error while decoding ssz: {:?}", err),
-            RPCError::InvalidData => write!(f, "Peer sent unexpected data"),
+            RPCError::InvalidData(ref err) => write!(f, "Peer sent unexpected data: {}", err),
             RPCError::IoError(ref err) => write!(f, "IO Error: {}", err),
             RPCError::ErrorResponse(ref code, ref reason) => write!(
                 f,
@@ -594,7 +594,7 @@ impl std::error::Error for RPCError {
             RPCError::StreamTimeout => None,
             RPCError::UnsupportedProtocol => None,
             RPCError::IncompleteStream => None,
-            RPCError::InvalidData => None,
+            RPCError::InvalidData(_) => None,
             RPCError::InternalError(_) => None,
             RPCError::ErrorResponse(_, _) => None,
             RPCError::NegotiationTimeout => None,

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -12,7 +12,7 @@ use tokio::runtime::Runtime;
 use tokio::time::sleep;
 use types::{
     BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockMerge, Epoch, EthSpec, ForkContext,
-    Hash256, MinimalEthSpec, Signature, SignedBeaconBlock, Slot,
+    ForkName, Hash256, MinimalEthSpec, Signature, SignedBeaconBlock, Slot,
 };
 
 mod common;
@@ -61,7 +61,8 @@ fn test_status_rpc() {
 
     rt.block_on(async {
         // get sender/receiver
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Base).await;
 
         // Dummy STATUS RPC message
         let rpc_request = Request::Status(StatusMessage {
@@ -159,7 +160,8 @@ fn test_blocks_by_range_chunked_rpc() {
 
     rt.block_on(async {
         // get sender/receiver
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Merge).await;
 
         // BlocksByRange Request
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
@@ -179,7 +181,7 @@ fn test_blocks_by_range_chunked_rpc() {
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
         let rpc_response_altair = Response::BlocksByRange(Some(Box::new(signed_full_block)));
 
-        let full_block = merge_block_small(&common::fork_context());
+        let full_block = merge_block_small(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
         let rpc_response_merge_small = Response::BlocksByRange(Some(Box::new(signed_full_block)));
 
@@ -298,7 +300,8 @@ fn test_blocks_by_range_over_limit() {
 
     rt.block_on(async {
         // get sender/receiver
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Merge).await;
 
         // BlocksByRange Request
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
@@ -308,7 +311,7 @@ fn test_blocks_by_range_over_limit() {
         });
 
         // BlocksByRange Response
-        let full_block = merge_block_large(&common::fork_context());
+        let full_block = merge_block_large(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
         let rpc_response_merge_large = Response::BlocksByRange(Some(Box::new(signed_full_block)));
 
@@ -395,7 +398,8 @@ fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
 
     rt.block_on(async {
         // get sender/receiver
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Base).await;
 
         // BlocksByRange Request
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
@@ -526,7 +530,8 @@ fn test_blocks_by_range_single_empty_rpc() {
 
     rt.block_on(async {
         // get sender/receiver
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Base).await;
 
         // BlocksByRange Request
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
@@ -641,7 +646,8 @@ fn test_blocks_by_root_chunked_rpc() {
     let rt = Arc::new(Runtime::new().unwrap());
     // get sender/receiver
     rt.block_on(async {
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Merge).await;
 
         // BlocksByRoot Request
         let rpc_request = Request::BlocksByRoot(BlocksByRootRequest {
@@ -664,7 +670,7 @@ fn test_blocks_by_root_chunked_rpc() {
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
         let rpc_response_altair = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
 
-        let full_block = merge_block_small(&common::fork_context());
+        let full_block = merge_block_small(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
         let rpc_response_merge_small = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
 
@@ -779,7 +785,8 @@ fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
     let rt = Arc::new(Runtime::new().unwrap());
     // get sender/receiver
     rt.block_on(async {
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Base).await;
 
         // BlocksByRoot Request
         let rpc_request = Request::BlocksByRoot(BlocksByRootRequest {
@@ -916,7 +923,8 @@ fn test_goodbye_rpc() {
     let rt = Arc::new(Runtime::new().unwrap());
     // get sender/receiver
     rt.block_on(async {
-        let (mut sender, mut receiver) = common::build_node_pair(Arc::downgrade(&rt), &log).await;
+        let (mut sender, mut receiver) =
+            common::build_node_pair(Arc::downgrade(&rt), &log, ForkName::Base).await;
 
         // build the sender future
         let sender_future = async {

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -23,7 +23,7 @@ type E = MinimalEthSpec;
 fn merge_block_small(fork_context: &ForkContext) -> BeaconBlock<E> {
     let mut block = BeaconBlockMerge::<E>::empty(&E::default_spec());
     let tx = VariableList::from(vec![0; 1024]);
-    let txs = VariableList::from(std::iter::repeat(tx).take(100).collect::<Vec<_>>());
+    let txs = VariableList::from(std::iter::repeat(tx).take(5000).collect::<Vec<_>>());
 
     block.body.execution_payload.execution_payload.transactions = txs;
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Fix the upper bound for blocks by root responses to be equal to the max merge block size instead of altair.
Further make the rpc response limits fork aware.
