### PR TITLE
[Merged by Bors] - Update and consolidate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "eth2_keystore",
  "eth2_wallet",
  "filesystem",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "serde",
@@ -86,7 +86,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "ctr",
  "opaque-debug",
 ]
@@ -111,7 +111,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -168,12 +168,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
@@ -186,9 +180,9 @@ checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
 name = "async-trait"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -271,12 +265,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -285,13 +273,13 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "beacon_chain"
 version = "0.2.0"
 dependencies = [
- "bitvec 0.19.6",
+ "bitvec",
  "bls",
  "derivative",
  "environment",
  "eth1",
  "eth2",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
@@ -308,9 +296,9 @@ dependencies = [
  "maplit",
  "merkle_proof",
  "operation_pool",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "proto_array",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rayon",
  "safe_arith",
  "sensitive_url",
@@ -396,31 +384,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "bitvec"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
-dependencies = [
- "either",
- "radium 0.3.0",
-]
-
-[[package]]
-name = "bitvec"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
-dependencies = [
- "funty",
- "radium 0.5.3",
- "tap",
- "wyz",
-]
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -429,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
  "funty",
- "radium 0.6.2",
+ "radium",
  "tap",
  "wyz",
 ]
@@ -474,13 +440,13 @@ version = "0.2.0"
 dependencies = [
  "arbitrary",
  "blst",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_serde_utils",
  "eth2_ssz",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex",
  "milagro_bls",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_derive",
  "tree_hash",
@@ -561,12 +527,6 @@ checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
-
-[[package]]
-name = "byte-slice-cast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
@@ -608,11 +568,11 @@ dependencies = [
 name = "cached_tree_hash"
 version = "0.1.0"
 dependencies = [
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "quickcheck 0.9.2",
  "quickcheck_macros",
  "smallvec",
@@ -657,7 +617,7 @@ checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "zeroize",
 ]
 
@@ -730,7 +690,7 @@ dependencies = [
  "dirs",
  "eth2_network_config",
  "eth2_ssz",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex",
  "serde",
  "serde_json",
@@ -759,7 +719,7 @@ dependencies = [
  "lighthouse_network",
  "monitoring_api",
  "network",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "sensitive_url",
  "serde",
  "serde_derive",
@@ -845,15 +805,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1028,7 +979,7 @@ version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
- "nix 0.23.1",
+ "nix",
  "winapi",
 ]
 
@@ -1095,8 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "darwin-libproc"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/darwin-libproc?rev=73d1587cb363c00737652fdc987f1bcbaf153ef7#73d1587cb363c00737652fdc987f1bcbaf153ef7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
 dependencies = [
  "darwin-libproc-sys",
  "libc",
@@ -1105,8 +1057,12 @@ dependencies = [
 
 [[package]]
 name = "darwin-libproc-sys"
-version = "0.2.0"
-source = "git+https://github.com/agemanning/darwin-libproc?rev=73d1587cb363c00737652fdc987f1bcbaf153ef7#73d1587cb363c00737652fdc987f1bcbaf153ef7"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "data-encoding"
@@ -1125,7 +1081,7 @@ name = "deposit_contract"
 version = "0.2.0"
 dependencies = [
  "eth2_ssz",
- "ethabi 12.0.0",
+ "ethabi",
  "hex",
  "reqwest",
  "serde_json",
@@ -1257,7 +1213,7 @@ checksum = "ed8f54486179d5a7f11e1f5526f49d925a411a96c1141a707bd5f071be2ab630"
 dependencies = [
  "aes",
  "aes-gcm",
- "arrayvec 0.7.2",
+ "arrayvec",
  "digest 0.10.3",
  "enr",
  "fnv",
@@ -1270,7 +1226,7 @@ dependencies = [
  "lru",
  "parking_lot 0.11.2",
  "rand 0.8.5",
- "rlp 0.5.1",
+ "rlp",
  "sha2 0.9.9",
  "smallvec",
  "tokio",
@@ -1278,7 +1234,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
- "uint 0.9.3",
+ "uint",
  "zeroize",
 ]
 
@@ -1335,7 +1291,7 @@ dependencies = [
  "derivative",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "fork_choice",
  "fs2",
  "hex",
@@ -1365,7 +1321,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "ff",
  "generic-array",
  "group",
@@ -1390,7 +1346,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809869a1328bfb586b48c9c0f87761c47c41793a85bcb06f66074a87cafc1bcd"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bs58",
  "bytes",
  "ed25519-dalek",
@@ -1398,7 +1354,7 @@ dependencies = [
  "k256",
  "log",
  "rand 0.8.5",
- "rlp 0.5.1",
+ "rlp",
  "serde",
  "sha3",
  "zeroize",
@@ -1484,7 +1440,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "merkle_proof",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "reqwest",
  "sensitive_url",
  "serde",
@@ -1524,7 +1480,7 @@ dependencies = [
  "eth2_ssz_derive",
  "futures",
  "futures-util",
- "libsecp256k1 0.6.0",
+ "libsecp256k1",
  "lighthouse_network",
  "procinfo",
  "proto_array",
@@ -1549,35 +1505,23 @@ dependencies = [
 
 [[package]]
 name = "eth2_hashing"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "cpufeatures 0.1.5",
+ "cpufeatures",
  "lazy_static",
  "ring",
  "rustc-hex",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "wasm-bindgen-test",
-]
-
-[[package]]
-name = "eth2_hashing"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b67737df7e3769e823d9d583eb5d60bcc4b2ef97ca674d1964ef287a02f8517"
-dependencies = [
- "cpufeatures 0.1.5",
- "lazy_static",
- "ring",
- "sha2 0.9.9",
 ]
 
 [[package]]
 name = "eth2_interop_keypairs"
 version = "0.2.0"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bls",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "hex",
  "lazy_static",
  "num-bigint",
@@ -1608,7 +1552,7 @@ dependencies = [
  "hex",
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
- "rand 0.7.3",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -1637,7 +1581,7 @@ dependencies = [
 name = "eth2_serde_utils"
 version = "0.1.1"
 dependencies = [
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex",
  "serde",
  "serde_derive",
@@ -1649,7 +1593,7 @@ name = "eth2_ssz"
 version = "0.4.1"
 dependencies = [
  "eth2_ssz_derive",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "smallvec",
 ]
 
@@ -1687,7 +1631,7 @@ dependencies = [
  "eth2_key_derivation",
  "eth2_keystore",
  "hex",
- "rand 0.7.3",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1707,45 +1651,17 @@ dependencies = [
 
 [[package]]
 name = "ethabi"
-version = "12.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052a565e3de82944527d6d10a465697e6bb92476b772ca7141080c901f6a63c6"
+checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
 dependencies = [
- "ethereum-types 0.9.2",
- "rustc-hex",
- "serde",
- "serde_json",
- "tiny-keccak 1.5.0",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "ethabi"
-version = "14.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01317735d563b3bad2d5f90d2e1799f414165408251abb762510f40e790e69a"
-dependencies = [
- "anyhow",
- "ethereum-types 0.11.0",
+ "ethereum-types",
  "hex",
  "serde",
  "serde_json",
  "sha3",
  "thiserror",
- "uint 0.9.3",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a6567e6fd35589fea0c63b94b4cf2e55573e413901bdbe60ab15cf0e25e5df"
-dependencies = [
- "crunchy",
- "fixed-hash 0.6.1",
- "impl-rlp 0.2.1",
- "impl-serde",
- "tiny-keccak 2.0.2",
+ "uint",
 ]
 
 [[package]]
@@ -1755,38 +1671,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb684ac8fa8f6c5759f788862bb22ec6fe3cb392f6bfd08e3c64b603661e3f8"
 dependencies = [
  "crunchy",
- "fixed-hash 0.7.0",
- "impl-rlp 0.3.0",
+ "fixed-hash",
+ "impl-rlp",
  "impl-serde",
- "tiny-keccak 2.0.2",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473aecff686bd8e7b9db0165cbbb53562376b39bf35b427f0c60446a9e1634b0"
-dependencies = [
- "ethbloom 0.9.2",
- "fixed-hash 0.6.1",
- "impl-rlp 0.2.1",
- "impl-serde",
- "primitive-types 0.7.3",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
-dependencies = [
- "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp 0.3.0",
- "impl-serde",
- "primitive-types 0.9.1",
- "uint 0.9.3",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -1795,12 +1683,12 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom 0.11.1",
- "fixed-hash 0.7.0",
- "impl-rlp 0.3.0",
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
  "impl-serde",
- "primitive-types 0.10.1",
- "uint 0.9.3",
+ "primitive-types",
+ "uint",
 ]
 
 [[package]]
@@ -1837,8 +1725,8 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "lru",
- "parking_lot 0.11.2",
- "rand 0.7.3",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
  "reqwest",
  "sensitive_url",
  "serde",
@@ -1851,7 +1739,7 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
- "warp 0.3.0",
+ "warp",
  "zeroize",
 ]
 
@@ -1898,7 +1786,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
 dependencies = [
- "bitvec 0.20.4",
+ "bitvec",
  "rand_core 0.6.3",
  "subtle",
 ]
@@ -1925,18 +1813,6 @@ version = "0.1.0"
 dependencies = [
  "winapi",
  "windows-acl",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
-dependencies = [
- "byteorder",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
 ]
 
 [[package]]
@@ -2153,7 +2029,7 @@ dependencies = [
  "environment",
  "eth1",
  "eth1_test_rig",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_ssz",
  "futures",
  "int_to_bytes",
@@ -2182,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2304,7 +2180,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cff78e5788be1e0ab65b04d306b2ed5092c815ec97ec70f4ebd5aee158aa55d"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bitflags",
  "bytes",
  "headers-core",
@@ -2451,7 +2327,7 @@ dependencies = [
  "lighthouse_network",
  "lighthouse_version",
  "network",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "safe_arith",
  "sensitive_url",
  "serde",
@@ -2463,7 +2339,7 @@ dependencies = [
  "tokio-stream",
  "tree_hash",
  "types",
- "warp 0.3.2",
+ "warp",
  "warp_utils",
 ]
 
@@ -2484,7 +2360,7 @@ dependencies = [
  "store",
  "tokio",
  "types",
- "warp 0.3.2",
+ "warp",
  "warp_utils",
 ]
 
@@ -2606,29 +2482,11 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
-dependencies = [
- "parity-scale-codec 1.3.7",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-rlp"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
-dependencies = [
- "rlp 0.4.6",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -2637,7 +2495,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
- "rlp 0.5.1",
+ "rlp",
 ]
 
 [[package]]
@@ -2662,21 +2520,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown",
-]
-
-[[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -2775,7 +2624,7 @@ version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "012bb02250fdd38faa5feee63235f7a459974440b9b57593822414c31f92839e"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "pem",
  "ring",
  "serde",
@@ -2916,9 +2765,9 @@ checksum = "33a33a362ce288760ec6a508b94caaec573ae7d3bbbd91b87aa0bad4456839db"
 
 [[package]]
 name = "libmdbx"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3265f0f9e378bfbbd98596a3288b5909f26f3169e4f6d4a05fda8c734ce2cdd8"
+checksum = "002d7890ec770d222903165b6ba279b0fa3dba8e82610820833184066b006ce0"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2940,7 +2789,7 @@ dependencies = [
  "bytes",
  "futures",
  "futures-timer",
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "instant",
  "lazy_static",
  "libp2p-core 0.32.0",
@@ -2978,7 +2827,7 @@ dependencies = [
  "futures-timer",
  "instant",
  "lazy_static",
- "libsecp256k1 0.7.0",
+ "libsecp256k1",
  "log",
  "multiaddr 0.13.0",
  "multihash 0.14.0",
@@ -3013,10 +2862,10 @@ dependencies = [
  "futures-timer",
  "instant",
  "lazy_static",
- "libsecp256k1 0.7.0",
+ "libsecp256k1",
  "log",
  "multiaddr 0.14.0",
- "multihash 0.16.1",
+ "multihash 0.16.2",
  "multistream-select 0.11.0",
  "parking_lot 0.12.0",
  "pin-project 1.0.10",
@@ -3053,7 +2902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f62943fba0b0dae02b87868620c52a581c54ec9fb04b5e195cf20313fc510c3"
 dependencies = [
  "asynchronous-codec",
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes",
  "fnv",
@@ -3221,7 +3070,7 @@ dependencies = [
  "log",
  "quicksink",
  "rw-stream-sink",
- "soketto 0.7.1",
+ "soketto",
  "url",
  "webpki-roots",
 ]
@@ -3241,51 +3090,21 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d220bc1feda2ac231cb78c3d26f27676b8cf82c96971f7aeef3d0cf2797c73"
-dependencies = [
- "arrayref",
- "base64 0.12.3",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core 0.2.2",
- "libsecp256k1-gen-ecmult 0.2.1",
- "libsecp256k1-gen-genmult 0.2.1",
- "rand 0.7.3",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0452aac8bab02242429380e9b2f94ea20cea2b37e2c1777a1358799bbe97f37"
 dependencies = [
  "arrayref",
- "base64 0.13.0",
+ "base64",
  "digest 0.9.0",
  "hmac-drbg",
- "libsecp256k1-core 0.3.0",
- "libsecp256k1-gen-ecmult 0.3.0",
- "libsecp256k1-gen-genmult 0.3.0",
+ "libsecp256k1-core",
+ "libsecp256k1-gen-ecmult",
+ "libsecp256k1-gen-genmult",
  "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f6ab710cec28cef759c5f18671a27dae2a5f952cdaaee1d8e2908cb2478a80"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
 ]
 
 [[package]]
@@ -3301,29 +3120,11 @@ dependencies = [
 
 [[package]]
 name = "libsecp256k1-gen-ecmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccab96b584d38fac86a83f07e659f0deafd0253dc096dab5a36d53efe653c5c3"
-dependencies = [
- "libsecp256k1-core 0.2.2",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
 dependencies = [
- "libsecp256k1-core 0.3.0",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67abfe149395e3aa1c48a2beb32b068e2334402df8181f818d3aee2b304c4f5d"
-dependencies = [
- "libsecp256k1-core 0.2.2",
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3332,7 +3133,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
 dependencies = [
- "libsecp256k1-core 0.3.0",
+ "libsecp256k1-core",
 ]
 
 [[package]]
@@ -3371,7 +3172,7 @@ dependencies = [
  "directory",
  "env_logger 0.9.0",
  "environment",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_network_config",
  "futures",
  "lazy_static",
@@ -3423,9 +3224,9 @@ dependencies = [
  "lighthouse_metrics",
  "lighthouse_version",
  "lru",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "prometheus-client",
- "rand 0.7.3",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_derive",
@@ -3439,7 +3240,7 @@ dependencies = [
  "superstruct",
  "task_executor",
  "tempfile",
- "tiny-keccak 2.0.2",
+ "tiny-keccak",
  "tokio",
  "tokio-io-timeout",
  "tokio-util",
@@ -3466,10 +3267,11 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -3542,7 +3344,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "lighthouse_metrics",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -3574,9 +3376,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "mdbx-sys"
-version = "0.11.6"
+version = "0.11.6-4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb471ee10f93c8c276083d59cae56365cca92d5bb2e27959da89ced5a8adf13e"
+checksum = "9dde320ea35df4678486346065386943ed6c5920f2ab445dff8dd5d9c8cd04ad"
 dependencies = [
  "bindgen",
  "cc",
@@ -3603,8 +3405,8 @@ dependencies = [
 name = "merkle_proof"
 version = "0.2.0"
 dependencies = [
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.1",
+ "eth2_hashing",
+ "ethereum-types",
  "lazy_static",
  "quickcheck 0.9.2",
  "quickcheck_macros",
@@ -3726,7 +3528,7 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash 0.16.1",
+ "multihash 0.16.2",
  "percent-encoding",
  "serde",
  "static_assertions",
@@ -3749,9 +3551,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7392bffd88bc0c4f8297e36a777ab9f80b7127409c4a1acb8fee99c9f27addcd"
+checksum = "e3db354f401db558759dfc1e568d010a5d4146f4d3f637be1275ec4a3cf09689"
 dependencies = [
  "core2",
  "digest 0.10.3",
@@ -3793,24 +3595,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multipart"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
-dependencies = [
- "buf_redux",
- "httparse",
- "log",
- "mime",
- "mime_guess",
- "quick-error",
- "rand 0.7.3",
- "safemem",
- "tempfile",
- "twoway",
-]
 
 [[package]]
 name = "multipart"
@@ -3860,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -3901,8 +3685,8 @@ dependencies = [
  "lru_cache",
  "matches",
  "num_cpus",
- "rand 0.7.3",
- "rlp 0.5.1",
+ "rand 0.8.5",
+ "rlp",
  "slog",
  "slog-async",
  "slog-term",
@@ -3916,19 +3700,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "types",
-]
-
-[[package]]
-name = "nix"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d9f3521ea8e0641a153b3cddaf008dcbf26acd4ed739a2517295e0760d12c7"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -4149,7 +3920,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lighthouse_metrics",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "rayon",
  "serde",
  "serde_derive",
@@ -4169,25 +3940,13 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b26b16c7687c3075982af47719e481815df30bc544f7a6690763a25ca16e9d"
-dependencies = [
- "arrayvec 0.5.2",
- "bitvec 0.17.4",
- "byte-slice-cast 0.3.5",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
- "arrayvec 0.7.2",
- "bitvec 0.20.4",
- "byte-slice-cast 1.2.1",
+ "arrayvec",
+ "bitvec",
+ "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
  "serde",
@@ -4223,7 +3982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -4242,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4255,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pbkdf2"
@@ -4289,7 +4048,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
 dependencies = [
- "base64 0.13.0",
+ "base64",
 ]
 
 [[package]]
@@ -4387,15 +4146,15 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "platforms"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
+checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
 name = "plotters"
@@ -4431,7 +4190,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4443,7 +4202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4456,41 +4215,15 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "primitive-types"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
-dependencies = [
- "fixed-hash 0.6.1",
- "impl-codec 0.4.2",
- "impl-rlp 0.2.1",
- "impl-serde",
- "uint 0.8.5",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
-dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp 0.3.0",
- "impl-serde",
- "uint 0.9.3",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-rlp 0.3.0",
+ "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
  "impl-serde",
- "uint 0.9.3",
+ "uint",
 ]
 
 [[package]]
@@ -4665,15 +4398,16 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "psutil"
-version = "3.2.1"
-source = "git+https://github.com/sigp/rust-psutil?rev=b3e44bc7ec5d545b8cb8ad4e3dffe074b6e6336b#b3e44bc7ec5d545b8cb8ad4e3dffe074b6e6336b"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f866af2b0f8e4b0d2d00aad8a9c5fc48fad33466cd99a64cbb3a4c1505f1a62d"
 dependencies = [
  "cfg-if",
  "darwin-libproc",
  "derive_more",
  "glob",
  "mach",
- "nix 0.21.2",
+ "nix",
  "num_cpus",
  "once_cell",
  "platforms",
@@ -4732,9 +4466,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
 ]
@@ -4762,18 +4496,6 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
-
-[[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
-name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
@@ -4789,7 +4511,6 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
@@ -4838,7 +4559,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -4851,21 +4572,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rand_xorshift"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -4895,20 +4607,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "redox_syscall",
  "thiserror",
 ]
@@ -4954,7 +4666,7 @@ version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1f7aa4f35e5e8b4160449f51afc758f0ce6454315a9fa7d0d113e958c41eb"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -5015,15 +4727,6 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rlp"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
-dependencies = [
- "rustc-hex",
-]
 
 [[package]]
 name = "rlp"
@@ -5102,7 +4805,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.6",
+ "semver 1.0.7",
 ]
 
 [[package]]
@@ -5111,7 +4814,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "log",
  "ring",
  "sct 0.6.1",
@@ -5246,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.20.3"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d03ceae636d0fed5bae6a7f4f664354c5f4fcedf6eef053fef17e49f837d0a"
+checksum = "9c42e6f1735c5f00f51e43e28d6634141f2bcad10931b2609ddd74a86d751260"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -5264,9 +4967,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.3.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -5305,9 +5008,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "semver-parser"
@@ -5426,7 +5129,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -5438,7 +5141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "digest 0.10.3",
 ]
 
@@ -5450,7 +5153,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -5462,7 +5165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.2",
+ "cpufeatures",
  "digest 0.10.3",
 ]
 
@@ -5534,7 +5237,7 @@ dependencies = [
  "eth1_test_rig",
  "futures",
  "node_test_rig",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "rayon",
  "sensitive_url",
  "tokio",
@@ -5563,8 +5266,8 @@ dependencies = [
  "logging",
  "lru",
  "maplit",
- "parking_lot 0.11.2",
- "rand 0.7.3",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
  "rayon",
  "safe_arith",
  "serde",
@@ -5718,7 +5421,7 @@ version = "0.2.0"
 dependencies = [
  "lazy_static",
  "lighthouse_metrics",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "types",
 ]
 
@@ -5774,26 +5477,11 @@ dependencies = [
 
 [[package]]
 name = "soketto"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4919971d141dbadaa0e82b5d369e2d7666c98e4625046140615ca363e50d4daa"
-dependencies = [
- "base64 0.13.0",
- "bytes",
- "futures",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha-1 0.9.8",
-]
-
-[[package]]
-name = "soketto"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d1c5305e39e09653383c2c7244f2f78b3bcae37cf50c64cb4789c9f5096ec2"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes",
  "flate2",
  "futures",
@@ -5832,7 +5520,7 @@ dependencies = [
  "beacon_chain",
  "bls",
  "env_logger 0.9.0",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_types",
  "int_to_bytes",
@@ -5879,7 +5567,7 @@ dependencies = [
  "leveldb",
  "lighthouse_metrics",
  "lru",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "serde",
  "serde_derive",
  "slog",
@@ -5946,15 +5634,15 @@ name = "swap_or_not_shuffle"
 version = "0.2.0"
 dependencies = [
  "criterion",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types 0.12.1",
+ "eth2_hashing",
+ "ethereum-types",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6168,15 +5856,6 @@ dependencies = [
 
 [[package]]
 name = "tiny-keccak"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
-name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
@@ -6285,19 +5964,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
-dependencies = [
- "futures-util",
- "log",
- "pin-project 1.0.10",
- "tokio",
- "tungstenite 0.12.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
@@ -6306,7 +5972,7 @@ dependencies = [
  "log",
  "pin-project 1.0.10",
  "tokio",
- "tungstenite 0.14.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -6375,16 +6041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project 1.0.10",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6437,11 +6093,11 @@ name = "tree_hash"
 version = "0.4.1"
 dependencies = [
  "beacon_chain",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_ssz",
  "eth2_ssz_derive",
- "ethereum-types 0.12.1",
- "rand 0.7.3",
+ "ethereum-types",
+ "rand 0.8.5",
  "smallvec",
  "tree_hash_derive",
  "types",
@@ -6509,30 +6165,11 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
-dependencies = [
- "base64 0.13.0",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "input_buffer",
- "log",
- "rand 0.8.5",
- "sha-1 0.9.8",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "byteorder",
  "bytes",
  "http",
@@ -6572,20 +6209,20 @@ dependencies = [
  "compare_fields_derive",
  "criterion",
  "derivative",
- "eth2_hashing 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "eth2_hashing",
  "eth2_interop_keypairs",
  "eth2_serde_utils",
  "eth2_ssz",
  "eth2_ssz_derive",
  "eth2_ssz_types",
- "ethereum-types 0.12.1",
+ "ethereum-types",
  "hex",
  "int_to_bytes",
  "itertools",
  "lazy_static",
  "log",
- "parking_lot 0.11.2",
- "rand 0.7.3",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
  "rand_xorshift",
  "rayon",
  "regex",
@@ -6611,18 +6248,6 @@ name = "ucd-trie"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
-
-[[package]]
-name = "uint"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
-dependencies = [
- "byteorder",
- "crunchy",
- "rustc-hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -6749,7 +6374,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "serde",
 ]
 
@@ -6776,14 +6401,14 @@ dependencies = [
  "hyper",
  "itertools",
  "lazy_static",
- "libsecp256k1 0.6.0",
+ "libsecp256k1",
  "lighthouse_metrics",
  "lighthouse_version",
  "lockfile",
  "logging",
  "monitoring_api",
- "parking_lot 0.11.2",
- "rand 0.7.3",
+ "parking_lot 0.12.0",
+ "rand 0.8.5",
  "reqwest",
  "ring",
  "safe_arith",
@@ -6801,7 +6426,7 @@ dependencies = [
  "types",
  "url",
  "validator_dir",
- "warp 0.3.2",
+ "warp",
  "warp_utils",
 ]
 
@@ -6816,7 +6441,7 @@ dependencies = [
  "filesystem",
  "hex",
  "lockfile",
- "rand 0.7.3",
+ "rand 0.8.5",
  "tempfile",
  "tree_hash",
  "types",
@@ -6875,38 +6500,8 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.0"
-source = "git+https://github.com/macladson/warp?rev=dfa259e#dfa259e19b7490e6bc4bf247e8b76f671d29a0eb"
-dependencies = [
- "bytes",
- "futures",
- "headers",
- "http",
- "hyper",
- "log",
- "mime",
- "mime_guess",
- "multipart 0.17.1",
- "percent-encoding",
- "pin-project 1.0.10",
- "scoped-tls",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-tungstenite 0.13.0",
- "tokio-util",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "warp"
 version = "0.3.2"
-source = "git+https://github.com/macladson/warp?rev=7e75acc#7e75acc368229a46a236a8c991bf251fe7fe50ef"
+source = "git+https://github.com/macladson/warp?rev=7e75acc368229a46a236a8c991bf251fe7fe50ef#7e75acc368229a46a236a8c991bf251fe7fe50ef"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -6917,7 +6512,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multipart 0.18.0",
+ "multipart",
  "percent-encoding",
  "pin-project 1.0.10",
  "scoped-tls",
@@ -6927,7 +6522,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-tungstenite 0.15.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower-service",
  "tracing",
@@ -6948,7 +6543,7 @@ dependencies = [
  "state_processing",
  "tokio",
  "types",
- "warp 0.3.2",
+ "warp",
 ]
 
 [[package]]
@@ -7086,31 +6681,33 @@ dependencies = [
 
 [[package]]
 name = "web3"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd24abe6f2b68e0677f843059faea87bcbd4892e39f02886f366d8222c3c540d"
+checksum = "44f258e254752d210b84fe117b31f1e3cc9cbf04c0d747eb7f8cf7cf5e370f6d"
 dependencies = [
- "arrayvec 0.5.2",
- "base64 0.13.0",
+ "arrayvec",
+ "base64",
  "bytes",
  "derive_more",
- "ethabi 14.1.0",
- "ethereum-types 0.11.0",
+ "ethabi",
+ "ethereum-types",
  "futures",
  "futures-timer",
  "headers",
  "hex",
+ "idna",
  "jsonrpc-core",
  "log",
- "parking_lot 0.11.2",
+ "once_cell",
+ "parking_lot 0.12.0",
  "pin-project 1.0.10",
  "reqwest",
- "rlp 0.5.1",
+ "rlp",
  "secp256k1",
  "serde",
  "serde_json",
- "soketto 0.5.0",
- "tiny-keccak 2.0.2",
+ "soketto",
+ "tiny-keccak",
  "tokio",
  "tokio-util",
  "url",
@@ -7245,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -7258,33 +6855,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
  "ethereum-types",
  "hex",
  "milagro_bls",
- "rand 0.8.5",
+ "rand 0.7.3",
  "serde",
  "serde_derive",
  "tree_hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,10 +89,11 @@ members = [
 [patch]
 [patch.crates-io]
 fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d" }
-warp = { git = "https://github.com/macladson/warp", rev ="7e75acc" }
+warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 eth2_ssz = { path = "consensus/ssz" }
 eth2_ssz_derive = { path = "consensus/ssz_derive" }
 eth2_ssz_types = { path = "consensus/ssz_types" }
+eth2_hashing = { path = "crypto/eth2_hashing" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
 eth2_serde_utils = { path = "consensus/serde_utils" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.58"
 [dependencies]
 merkle_proof = { path = "../../consensus/merkle_proof" }
 store = { path = "../store" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 lazy_static = "1.4.0"
 smallvec = "1.6.1"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
@@ -30,7 +30,7 @@ serde_derive = "1.0.116"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = { version = "2.1.1", features = ["json"] }
 slot_clock = { path = "../../common/slot_clock" }
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 eth2_ssz = "0.4.1"
 eth2_ssz_types = "0.2.2"
 eth2_ssz_derive = "0.3.0"
@@ -42,11 +42,11 @@ eth1 = { path = "../eth1" }
 futures = "0.3.7"
 genesis = { path = "../genesis" }
 int_to_bytes = { path = "../../consensus/int_to_bytes" }
-rand = "0.7.3"
+rand = "0.8.5"
 proto_array = { path = "../../consensus/proto_array" }
 lru = "0.7.1"
 tempfile = "3.1.0"
-bitvec = "0.19.3"
+bitvec = "0.20.4"
 bls = { path = "../../crypto/bls" }
 safe_arith = { path = "../../consensus/safe_arith" }
 fork_choice = { path = "../../consensus/fork_choice" }

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -13,7 +13,7 @@ store = { path = "../store" }
 network = { path = "../network" }
 timer = { path = "../timer" }
 lighthouse_network = { path = "../lighthouse_network" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 types = { path = "../../consensus/types" }
 eth2_config = { path = "../../common/eth2_config" }
 slot_clock = { path = "../../common/slot_clock" }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dev-dependencies]
 eth1_test_rig = { path = "../../testing/eth1_test_rig" }
 toml = "0.5.6"
-web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.18.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 sloggers = { version = "2.1.1", features = ["json"] }
 environment = { path = "../../lighthouse/environment" }
 
@@ -22,7 +22,7 @@ merkle_proof = { path = "../../consensus/merkle_proof"}
 eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"
 tree_hash = "0.4.1"
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 slog = "2.5.2"
 tokio = { version = "1.14.0", features = ["full"] }
 state_processing = { path = "../../consensus/state_processing" }

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -17,7 +17,7 @@ eth2_serde_utils = "0.1.1"
 serde_json = "1.0.58"
 serde = { version = "1.0.116", features = ["derive"] }
 eth1 = { path = "../eth1" }
-warp = { git = "https://github.com/macladson/warp", rev ="dfa259e", features = ["tls"] }
+warp = { version = "0.3.2", features = ["tls"] }
 jsonwebtoken = "8"
 environment = { path = "../../lighthouse/environment" }
 bytes = "1.1.0"
@@ -28,10 +28,10 @@ lru = "0.7.1"
 exit-future = "0.2.0"
 tree_hash = "0.4.1"
 tree_hash_derive = { path = "../../consensus/tree_hash_derive"}
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 slot_clock = { path = "../../common/slot_clock" }
 tempfile = "3.1.0"
-rand = "0.7.3"
+rand = "0.8.5"
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 lazy_static = "1.4.0"

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.4.1"
 state_processing = { path = "../../consensus/state_processing" }
 merkle_proof = { path = "../../consensus/merkle_proof" }
 eth2_ssz = "0.4.1"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 tree_hash = "0.4.1"
 tokio = { version = "1.14.0", features = ["full"] }
 slog = "2.5.2"

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -28,7 +28,7 @@ eth2_ssz = "0.4.1"
 bs58 = "0.4.0"
 futures = "0.3.8"
 execution_layer = {path = "../execution_layer"}
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 safe_arith = {path = "../../consensus/safe_arith"}
 
 

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -26,14 +26,14 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 smallvec = "1.6.1"
 tokio-io-timeout = "1.1.1"
 lru = "0.7.1"
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 sha2 = "0.9.1"
 snap = "1.0.1"
 hex = "0.4.2"
 tokio-util = { version = "0.6.2", features = ["codec", "compat", "time"] }
 tiny-keccak = "2.0.2"
 task_executor = { path = "../../common/task_executor" }
-rand = "0.7.3"
+rand = "0.8.5"
 directory = { path = "../../common/directory" }
 regex = "1.5.5"
 strum = { version = "0.21.0", features = ["derive"] }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -29,7 +29,7 @@ error-chain = "0.12.4"
 tokio = { version = "1.14.0", features = ["full"] }
 tokio-stream = "0.1.3"
 smallvec = "1.6.1"
-rand = "0.7.3"
+rand = "0.8.5"
 fnv = "1.0.7"
 rlp = "0.5.0"
 lazy_static = "1.4.0"

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -9,7 +9,7 @@ derivative = "2.1.1"
 itertools = "0.10.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 types = { path = "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
 eth2_ssz = "0.4.1"

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -11,7 +11,7 @@ beacon_chain = {path = "../beacon_chain"}
 [dependencies]
 db-key = "0.0.5"
 leveldb = { version = "0.8.6", default-features = false }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 itertools = "0.10.0"
 eth2_ssz = "0.4.1"
 eth2_ssz_derive = "0.3.0"

--- a/common/account_utils/Cargo.toml
+++ b/common/account_utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.7.3"
+rand = "0.8.5"
 eth2_wallet = { path = "../../crypto/eth2_wallet" }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 filesystem = { path = "../filesystem" }

--- a/common/deposit_contract/Cargo.toml
+++ b/common/deposit_contract/Cargo.toml
@@ -16,4 +16,4 @@ hex = "0.4.2"
 types = { path = "../../consensus/types"}
 eth2_ssz = "0.4.1"
 tree_hash = "0.4.1"
-ethabi = "12.0.0"
+ethabi = "16.0.0"

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -70,13 +70,13 @@ pub fn decode_eth1_tx_data(
         };
     }
 
-    let root = decode_token!(Hash256, to_fixed_bytes);
+    let root = decode_token!(Hash256, into_fixed_bytes);
 
     let deposit_data = DepositData {
         amount,
-        signature: decode_token!(SignatureBytes, to_bytes),
-        withdrawal_credentials: decode_token!(Hash256, to_bytes),
-        pubkey: decode_token!(PublicKeyBytes, to_bytes),
+        signature: decode_token!(SignatureBytes, into_bytes),
+        withdrawal_credentials: decode_token!(Hash256, into_bytes),
+        pubkey: decode_token!(PublicKeyBytes, into_bytes),
     };
 
     Ok((deposit_data, root))

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -15,7 +15,7 @@ lighthouse_network = { path = "../../beacon_node/lighthouse_network" }
 proto_array = { path = "../../consensus/proto_array", optional = true }
 eth2_serde_utils = "0.1.1"
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
-libsecp256k1 = "0.6.0"
+libsecp256k1 = "0.7.0"
 ring = "0.16.19"
 bytes = "1.0.1"
 account_utils = { path = "../../common/account_utils" }
@@ -28,10 +28,7 @@ store = { path = "../../beacon_node/store", optional = true }
 slashing_protection = { path = "../../validator_client/slashing_protection", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-# TODO: update psutil once fix is merged: https://github.com/rust-psutil/rust-psutil/pull/93
-# TODO: Even once the above PR is corrected, there are sub-dependencies that need to be updated.
-# psutil = { version = "3.2.0", optional = true }
-psutil = { git = "https://github.com/sigp/rust-psutil", rev = "b3e44bc7ec5d545b8cb8ad4e3dffe074b6e6336b", optional = true }
+psutil = { version = "3.2.2", optional = true }
 procinfo = { version = "0.4.2", optional = true }
 
 [features]

--- a/common/eth2_interop_keypairs/Cargo.toml
+++ b/common/eth2_interop_keypairs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 lazy_static = "1.4.0"
 num-bigint = "0.4.2"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 hex = "0.4.2"
 serde_yaml = "0.8.13"
 serde = "1.0.116"

--- a/common/malloc_utils/Cargo.toml
+++ b/common/malloc_utils/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
 lazy_static = "1.4.0"
 libc = "0.2.79"
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 
 [features]
 mallinfo2 = []

--- a/common/slot_clock/Cargo.toml
+++ b/common/slot_clock/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 types = { path = "../../consensus/types" }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -14,7 +14,7 @@ bls = { path = "../../crypto/bls" }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 filesystem = { path = "../filesystem" }
 types = { path = "../../consensus/types" }
-rand = "0.7.3"
+rand = "0.8.5"
 deposit_contract = { path = "../deposit_contract" }
 tree_hash = "0.4.1"
 hex = "0.4.2"

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 ethereum-types = "0.12.1"
 eth2_ssz_types = "0.2.2"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 eth2_ssz_derive = "0.3.0"
 eth2_ssz = "0.4.1"
 tree_hash = "0.4.1"

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 lazy_static = "1.4.0"
 safe_arith = { path = "../safe_arith" }
 

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -19,7 +19,7 @@ safe_arith = { path = "../safe_arith" }
 tree_hash = "0.4.1"
 types = { path = "../types", default-features = false }
 rayon = "1.4.1"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 int_to_bytes = { path = "../int_to_bytes" }
 smallvec = "1.6.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 criterion = "0.3.3"
 
 [dependencies]
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 ethereum-types = "0.12.1"
 
 [features]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "Efficient Merkle-hashing as used in Ethereum 2.0"
 
 [dev-dependencies]
-rand = "0.7.3"
+rand = "0.8.5"
 tree_hash_derive = "0.4.0"
 types = { path = "../types" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
@@ -16,7 +16,7 @@ eth2_ssz_derive = "0.3.0"
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 smallvec = "1.6.1"
 
 [features]

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -14,12 +14,12 @@ compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 ethereum-types = "0.12.1"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }
 log = "0.4.11"
 rayon = "1.4.1"
-rand = "0.7.3"
+rand = "0.8.5"
 safe_arith = { path = "../safe_arith" }
 serde = {version = "1.0.116" , features = ["rc"] }
 serde_derive = "1.0.116"
@@ -31,7 +31,7 @@ swap_or_not_shuffle = { path = "../swap_or_not_shuffle" }
 test_random_derive = { path = "../../common/test_random_derive" }
 tree_hash = "0.4.1"
 tree_hash_derive = "0.4.0"
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 cached_tree_hash = { path = "../cached_tree_hash" }
 serde_yaml = "0.8.13"
 tempfile = "3.1.0"
@@ -41,7 +41,7 @@ arbitrary = { version = "1.0", features = ["derive"], optional = true }
 eth2_serde_utils = "0.1.1"
 regex = "1.5.5"
 lazy_static = "1.4.0"
-parking_lot = "0.11.1"
+parking_lot = "0.12.0"
 itertools = "0.10.0"
 superstruct = "0.4.1"
 serde_json = "1.0.74"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 eth2_ssz = "0.4.1"
 tree_hash = "0.4.1"
 milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.2", optional = true }
-rand = "0.8.5"
+rand = "0.7.3"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.1"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 eth2_ssz = "0.4.1"
 tree_hash = "0.4.1"
 milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.2", optional = true }
-rand = "0.7.3"
+rand = "0.8.5"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 eth2_serde_utils = "0.1.1"
 hex = "0.4.2"
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 ethereum-types = "0.12.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/crypto/eth2_hashing/Cargo.toml
+++ b/crypto/eth2_hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eth2_hashing"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,8 +9,8 @@ description = "Hashing primitives used in Ethereum 2.0"
 [dependencies]
 lazy_static = { version = "1.4.0", optional = true }
 ring = "0.16.19"
-sha2 = "0.9.5"
-cpufeatures = "0.1.5"
+sha2 = "0.10.2"
+cpufeatures = "0.2.2"
 
 [dev-dependencies]
 rustc-hex = "2.1.0"

--- a/crypto/eth2_keystore/Cargo.toml
+++ b/crypto/eth2_keystore/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.7.3"
+rand = "0.8.5"
 hmac = "0.11.0"
 pbkdf2 = { version = "0.8.0", default-features = false }
 scrypt = { version = "0.7.0", default-features = false }

--- a/crypto/eth2_wallet/Cargo.toml
+++ b/crypto/eth2_wallet/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0.116"
 serde_json = "1.0.58"
 serde_repr = "0.1.6"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
-rand = "0.7.3"
+rand = "0.8.5"
 eth2_keystore = { path = "../eth2_keystore" }
 eth2_key_derivation = { path = "../eth2_key_derivation" }
 tiny-bip39 = "0.8.1"

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -33,7 +33,7 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 directory = { path = "../common/directory" }
 account_utils = { path = "../common/account_utils" }
 eth2_wallet = { path = "../crypto/eth2_wallet" }
-web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.18.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 eth1_test_rig = { path = "../testing/eth1_test_rig" }
 sensitive_url = { path = "../common/sensitive_url" }
 eth2 = { path = "../common/eth2" }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -26,7 +26,7 @@ slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = { version = "2.1.1", features = ["json"] }
 types = { "path" = "../consensus/types" }
 bls = { path = "../crypto/bls" }
-eth2_hashing = "0.2.0"
+eth2_hashing = "0.3.0"
 clap = "2.33.3"
 env_logger = "0.9.0"
 environment = { path = "./environment" }

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -15,8 +15,8 @@ lighthouse_metrics = { path = "../common/lighthouse_metrics" }
 filesystem = { path = "../common/filesystem" }
 mdbx = { package = "libmdbx", version = "0.1.0" }
 lru = "0.7.1"
-parking_lot = "0.11.0"
-rand = "0.7.3"
+parking_lot = "0.12.0"
+rand = "0.8.5"
 safe_arith = { path = "../consensus/safe_arith" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/slasher/tests/random.rs
+++ b/slasher/tests/random.rs
@@ -42,23 +42,23 @@ fn random_test(seed: u64, test_config: TestConfig) {
     let tempdir = tempdir().unwrap();
 
     let mut config = Config::new(tempdir.path().into());
-    config.validator_chunk_size = 1 << rng.gen_range(1, 4);
+    config.validator_chunk_size = 1 << rng.gen_range(1..4);
 
-    let chunk_size_exponent = rng.gen_range(1, 4);
+    let chunk_size_exponent = rng.gen_range(1..4);
     config.chunk_size = 1 << chunk_size_exponent;
-    config.history_length = 1 << rng.gen_range(chunk_size_exponent, chunk_size_exponent + 3);
+    config.history_length = 1 << rng.gen_range(chunk_size_exponent..chunk_size_exponent + 3);
 
     let slasher = Slasher::<E>::open(config.clone(), test_logger()).unwrap();
 
     let validators = (0..num_validators as u64).collect::<Vec<u64>>();
 
-    let num_attestations = rng.gen_range(2, max_attestations + 1);
+    let num_attestations = rng.gen_range(2..max_attestations + 1);
 
     let mut current_epoch = Epoch::new(0);
     let mut attestations = vec![];
 
     for _ in 0..num_attestations {
-        let num_attesters = rng.gen_range(1, num_validators);
+        let num_attesters = rng.gen_range(1..num_validators);
         let mut attesting_indices = validators
             .choose_multiple(&mut rng, num_attesters)
             .copied()
@@ -70,17 +70,17 @@ fn random_test(seed: u64, test_config: TestConfig) {
             let source = rng.gen_range(
                 current_epoch
                     .as_u64()
-                    .saturating_sub(config.history_length as u64 - 1),
-                current_epoch.as_u64() + 1,
+                    .saturating_sub(config.history_length as u64 - 1)
+                    ..current_epoch.as_u64() + 1,
             );
-            let target = rng.gen_range(source, current_epoch.as_u64() + 1);
+            let target = rng.gen_range(source..current_epoch.as_u64() + 1);
             (source, target)
         } else {
-            let source = rng.gen_range(0, max(3 * current_epoch.as_u64(), 1));
-            let target = rng.gen_range(source, max(3 * current_epoch.as_u64(), source + 1));
+            let source = rng.gen_range(0..max(3 * current_epoch.as_u64(), 1));
+            let target = rng.gen_range(source..max(3 * current_epoch.as_u64(), source + 1));
             (source, target)
         };
-        let target_root = rng.gen_range(0, 3);
+        let target_root = rng.gen_range(0..3);
         let attestation = indexed_att(&attesting_indices, source, target, target_root);
 
         if check_slashings {
@@ -92,9 +92,9 @@ fn random_test(seed: u64, test_config: TestConfig) {
 
         // Maybe add a random block too
         if test_config.add_blocks && rng.gen_bool(0.1) {
-            let slot = rng.gen_range(0, 1 + 3 * current_epoch.as_u64() * E::slots_per_epoch() / 2);
-            let proposer = rng.gen_range(0, num_validators as u64);
-            let block_root = rng.gen_range(0, 2);
+            let slot = rng.gen_range(0..1 + 3 * current_epoch.as_u64() * E::slots_per_epoch() / 2);
+            let proposer = rng.gen_range(0..num_validators as u64);
+            let block_root = rng.gen_range(0..2);
             slasher.accept_block_header(block(slot, proposer, block_root));
         }
 

--- a/testing/eth1_test_rig/Cargo.toml
+++ b/testing/eth1_test_rig/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1.14.0", features = ["time"] }
-web3 = { version = "0.17.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
+web3 = { version = "0.18.0", default-features = false, features = ["http-tls", "signing", "ws-tls-tokio"] }
 types = { path = "../../consensus/types"}
 serde_json = "1.0.58"
 deposit_contract = { path = "../../common/deposit_contract"}

--- a/testing/eth1_test_rig/src/lib.rs
+++ b/testing/eth1_test_rig/src/lib.rs
@@ -194,6 +194,8 @@ impl DepositContract {
             to: Some(self.contract.address()),
             gas: Some(U256::from(DEPOSIT_GAS)),
             gas_price: None,
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
             value: Some(from_gwei(deposit_data.amount)),
             // Note: the reason we use this `TransactionRequest` instead of just using the
             // function in `self.contract` is so that the `eth1_tx_data` function gets used

--- a/testing/simulator/Cargo.toml
+++ b/testing/simulator/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 node_test_rig = { path = "../node_test_rig" }
 eth1 = {path = "../../beacon_node/eth1"}
 types = { path = "../../consensus/types" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 futures = "0.3.7"
 tokio = "1.14.0"
 eth1_test_rig = { path = "../eth1_test_rig" }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -30,7 +30,7 @@ dirs = "3.0.1"
 directory = { path = "../common/directory" }
 lockfile = { path = "../common/lockfile" }
 environment = { path = "../lighthouse/environment" }
-parking_lot = "0.11.0"
+parking_lot = "0.12.0"
 exit-future = "0.2.0"
 filesystem = { path = "../common/filesystem" }
 hex = "0.4.2"
@@ -47,9 +47,9 @@ warp_utils = { path = "../common/warp_utils" }
 warp = "0.3.2"
 hyper = "0.14.4"
 eth2_serde_utils = "0.1.1"
-libsecp256k1 = "0.6.0"
+libsecp256k1 = "0.7.0"
 ring = "0.16.19"
-rand = { version = "0.7.3", features = ["small_rng"] }
+rand = { version = "0.8.5", features = ["small_rng"] }
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
 itertools = "0.10.0"


### PR DESCRIPTION
## Proposed Changes

I did some gardening :deciduous_tree: in our dependency tree:

- Remove duplicate versions of `warp` (git vs patch)
- Remove duplicate versions of lots of small deps: `cpufeatures`, `ethabi`, `ethereum-types`, `bitvec`, `nix`, `libsecp256k1`.
- Update MDBX (should resolve #3028). I tested and Lighthouse compiles on Windows 11 now.
- Restore `psutil` back to upstream
- Make some progress updating everything to rand 0.8. There are a few crates stuck on 0.7.

Hopefully this puts us on a better footing for future `cargo audit` issues, and improves compile times slightly.

## Additional Info

Some crates are held back by issues with `zeroize`. libp2p-noise depends on [`chacha20poly1305`](https://crates.io/crates/chacha20poly1305) which depends on zeroize < v1.5, and we can only have one version of zeroize because it's post 1.0 (see https://github.com/rust-lang/cargo/issues/6584). The latest version of `zeroize` is v1.5.4, which is used by the new versions of many other crates (e.g. `num-bigint-dig`). Once a new version of chacha20poly1305 is released we can update libp2p-noise and upgrade everything to the latest `zeroize` version.

I've also opened a PR to `blst` related to zeroize: https://github.com/supranational/blst/pull/111