### PR TITLE
[Merged by Bors] - Update mdbook runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-upload-to-s3:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@master
 


### PR DESCRIPTION
## Issue Addressed

This resolves errors related to the glibc version of the downloaded mdbook binaries.

Currently the mdbook job is failing on `unstable`: https://github.com/sigp/lighthouse/runs/5785245715?check_suite_focus=true