### PR TITLE
[Merged by Bors] - v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -2685,7 +2685,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "account_utils",
  "bls",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "2.1.5"
+version = "2.2.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb87f3080f6d1d69e8c564c0fcfde1d7aa8cc451ce40cae89479111f03bc0eb"
+checksum = "32613e41de4c47ab04970c348ca7ae7382cf116625755af070b008a15516a889"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+checksum = "4e92cb285610dd935f60ee8b4d62dd1988bd12b7ea50579bd6a138201525318e"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+checksum = "5c29e95ab498b18131ea460b2c0baa18cbf041231d122b0b7bfebef8c8e88989"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+checksum = "b21dd6b221dd547528bd6fb15f1a3b7ab03b9a06f76bff288a8c629bcfbe7f0e"
 dependencies = [
  "darling_core",
  "quote",
@@ -1249,7 +1249,7 @@ dependencies = [
  "smallvec",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
  "tracing-subscriber",
  "uint",
@@ -2142,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -2155,7 +2155,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -2189,7 +2189,7 @@ version = "0.2.0"
 dependencies = [
  "futures",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -3262,7 +3262,7 @@ dependencies = [
  "tiny-keccak",
  "tokio",
  "tokio-io-timeout",
- "tokio-util",
+ "tokio-util 0.6.9",
  "types",
  "unsigned-varint 0.6.0",
  "unused_port",
@@ -3717,7 +3717,7 @@ dependencies = [
  "task_executor",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "types",
 ]
 
@@ -4708,7 +4708,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5265,9 +5265,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "slasher"
@@ -5980,7 +5980,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite 0.2.8",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -6010,6 +6010,20 @@ dependencies = [
  "pin-project-lite 0.2.8",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite 0.2.8",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -6053,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -6074,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -6348,7 +6362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "bytes",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -6544,7 +6558,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower-service",
  "tracing",
 ]
@@ -6730,7 +6744,7 @@ dependencies = [
  "soketto",
  "tiny-keccak",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "url",
  "web3-async-native-tls",
 ]

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "2.1.5"
+version = "2.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2021"
 

--- a/beacon_node/beacon_chain/src/observed_aggregates.rs
+++ b/beacon_node/beacon_chain/src/observed_aggregates.rs
@@ -203,6 +203,7 @@ impl<T: TreeHash + SlotData + Consts, E: EthSpec> ObservedAggregates<T, E> {
     /// Check to see if the `root` of `item` is in self.
     ///
     /// `root` must equal `a.tree_hash_root()`.
+    #[allow(clippy::wrong_self_convention)]
     pub fn is_known(&mut self, item: &T, root: Hash256) -> Result<bool, Error> {
         let index = self.get_set_index(item.get_slot())?;
 

--- a/beacon_node/eth1/src/http.rs
+++ b/beacon_node/eth1/src/http.rs
@@ -358,7 +358,7 @@ pub async fn get_deposit_logs_in_range(
     }]);
 
     let response_body = send_rpc_request(endpoint, "eth_getLogs", params, timeout).await?;
-    Ok(response_result_or_error(&response_body)
+    response_result_or_error(&response_body)
         .map_err(|e| format!("eth_getLogs failed: {}", e))?
         .as_array()
         .cloned()
@@ -383,7 +383,7 @@ pub async fn get_deposit_logs_in_range(
             })
         })
         .collect::<Result<Vec<Log>, String>>()
-        .map_err(|e| format!("Failed to get logs in range: {}", e))?)
+        .map_err(|e| format!("Failed to get logs in range: {}", e))
 }
 
 /// Sends an RPC request to `endpoint`, using a POST with the given `body`.

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -406,8 +406,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             trace!(self.log, "Single block processing succeeded"; "block" => %root);
         }
 
-        match result {
-            Err(e) => match e {
+        if let Err(e) = result {
+            match e {
                 BlockError::BlockIsAlreadyKnown => {
                     // No error here
                 }
@@ -435,9 +435,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                         }
                     }
                 }
-            },
-            Ok(()) => {
-                // No error here
             }
         }
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "2.1.5"
+version = "2.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -16,7 +16,7 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v2.1.5-",
+    prefix = "Lighthouse/v2.2.0-",
     fallback = "unknown"
 );
 

--- a/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
@@ -52,7 +52,7 @@ pub fn process_rewards_and_penalties<T: EthSpec>(
 ///
 /// Spec v1.1.0
 pub fn get_flag_index_deltas<T: EthSpec>(
-    deltas: &mut Vec<Delta>,
+    deltas: &mut [Delta],
     state: &BeaconState<T>,
     flag_index: usize,
     total_active_balance: u64,
@@ -101,7 +101,7 @@ pub fn get_flag_weight(flag_index: usize) -> Result<u64, Error> {
 }
 
 pub fn get_inactivity_penalty_deltas<T: EthSpec>(
-    deltas: &mut Vec<Delta>,
+    deltas: &mut [Delta],
     state: &BeaconState<T>,
     participation_cache: &ParticipationCache,
     spec: &ChainSpec,

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "2.1.5"
+version = "2.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "2.1.5"
+version = "2.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false


### PR DESCRIPTION
## Proposed Changes

Cut release v2.2.0 including proposer boost.

## Additional Info

I also updated the clippy lints for the imminent release of Rust 1.60, although LH v2.2.0 will continue to compile using Rust 1.58 (our MSRV).
