### PR TITLE
[Merged by Bors] - log upgrades + prevent dialing of disconnecting peers

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -991,7 +991,7 @@ where
             debug!(
                 self.log,
                 "Ignoring rpc message of disconnecting peer";
-                "peer" => %peer_id
+                event
             );
             return;
         }

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -213,6 +213,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             ScoreUpdateResult::Disconnect => {
                 // The peer has transitioned to a disconnect state and has been marked as such in
                 // the peer db. We must inform libp2p to disconnect this peer.
+                self.inbound_ping_peers.remove(peer_id);
+                self.outbound_ping_peers.remove(peer_id);
                 self.events.push(PeerManagerEvent::DisconnectPeer(
                     *peer_id,
                     GoodbyeReason::BadScore,

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -335,6 +335,19 @@ impl RPCResponseErrorCode {
     }
 }
 
+use super::Protocol;
+impl<T: EthSpec> RPCResponse<T> {
+    pub fn protocol(&self) -> Protocol {
+        match self {
+            RPCResponse::Status(_) => Protocol::Status,
+            RPCResponse::BlocksByRange(_) => Protocol::BlocksByRange,
+            RPCResponse::BlocksByRoot(_) => Protocol::BlocksByRoot,
+            RPCResponse::Pong(_) => Protocol::Ping,
+            RPCResponse::MetaData(_) => Protocol::MetaData,
+        }
+    }
+}
+
 impl std::fmt::Display for RPCResponseErrorCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let repr = match self {


### PR DESCRIPTION
## Issue Addressed
We still ping peers that are considered in a disconnecting state

## Proposed Changes

Do not ping peers once we decide they are disconnecting
Upgrade logs about ignored rpc messages

## Additional Info
--