### PR TITLE
Remove `HeadSafetyStatus`

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1459,6 +1459,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
     }
 
+    /// Returns `Ok(attestation)` if the supplied `attestation` references a valid
+    /// `beacon_block_root`.
     fn filter_optimistic_attestation(
         &self,
         attestation: Attestation<T::EthSpec>,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1165,7 +1165,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
 
         // If the payload did not validate or invalidate the block, check to see if this block is
         // valid for optimistic import.
-        if payload_verification_status == PayloadVerificationStatus::NotVerified {
+        if payload_verification_status == PayloadVerificationStatus::Optimistic {
             let current_slot = chain
                 .slot_clock
                 .now()

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1165,7 +1165,7 @@ impl<'a, T: BeaconChainTypes> FullyVerifiedBlock<'a, T> {
 
         // If the payload did not validate or invalidate the block, check to see if this block is
         // valid for optimistic import.
-        if payload_verification_status == PayloadVerificationStatus::Optimistic {
+        if payload_verification_status.is_optimistic() {
             let current_slot = chain
                 .slot_clock
                 .now()

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -162,6 +162,9 @@ pub enum BeaconChainError {
         fork_choice: Hash256,
     },
     InvalidSlot(Slot),
+    CannotAttestToOptimisticHead {
+        beacon_block_root: Hash256,
+    },
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -9,6 +9,7 @@ use crate::observed_aggregates::Error as ObservedAttestationsError;
 use crate::observed_attesters::Error as ObservedAttestersError;
 use crate::observed_block_producers::Error as ObservedBlockProducersError;
 use execution_layer::PayloadStatus;
+use fork_choice::ExecutionStatus;
 use futures::channel::mpsc::TrySendError;
 use operation_pool::OpPoolError;
 use safe_arith::ArithError;
@@ -162,7 +163,11 @@ pub enum BeaconChainError {
         fork_choice: Hash256,
     },
     InvalidSlot(Slot),
-    CannotAttestToOptimisticHead {
+    HeadBlockNotFullyVerified {
+        beacon_block_root: Hash256,
+        execution_status: ExecutionStatus,
+    },
+    CannotAttestToFinalizedBlock {
         beacon_block_root: Hash256,
     },
 }

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -61,7 +61,7 @@ pub fn notify_new_payload<T: BeaconChainTypes>(
         Ok(status) => match status {
             PayloadStatus::Valid => Ok(PayloadVerificationStatus::Verified),
             PayloadStatus::Syncing | PayloadStatus::Accepted => {
-                Ok(PayloadVerificationStatus::NotVerified)
+                Ok(PayloadVerificationStatus::Optimistic)
             }
             PayloadStatus::Invalid {
                 latest_valid_hash, ..

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -193,7 +193,7 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
 
         let is_merge_transition_complete = match parent_block.execution_status {
             // Optimistically declare that an "unknown" status block has completed the merge.
-            ExecutionStatus::Valid(_) | ExecutionStatus::Unknown(_) => true,
+            ExecutionStatus::Valid(_) | ExecutionStatus::Optimistic(_) => true,
             // It's impossible for an irrelevant block to have completed the merge. It is pre-merge
             // by definition.
             ExecutionStatus::Irrelevant(_) => false,

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -172,7 +172,7 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
         // retro-actively determine if they were valid or not.
         //
         // This scenario is so rare that it seems OK to double-verify some blocks.
-        let payload_verification_status = PayloadVerificationStatus::NotVerified;
+        let payload_verification_status = PayloadVerificationStatus::Optimistic;
 
         let (block, _) = block.deconstruct();
         fork_choice

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -41,8 +41,8 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, HeadInfo, HeadSafetyStatus, ProduceBlockVerification, StateSkipConfig,
-    WhenSlotSkipped, INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    ForkChoiceError, HeadInfo, ProduceBlockVerification, StateSkipConfig, WhenSlotSkipped,
+    INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::chain_config::ChainConfig;
@@ -53,6 +53,7 @@ pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceSto
 pub use block_verification::{BlockError, ExecutionPayloadError, GossipVerifiedBlock};
 pub use eth1_chain::{Eth1Chain, Eth1ChainBackend};
 pub use events::ServerSentEventHandler;
+pub use fork_choice::ExecutionStatus;
 pub use metrics::scrape_for_metrics;
 pub use parking_lot;
 pub use slot_clock;

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -31,7 +31,10 @@ use rayon::prelude::*;
 use sensitive_url::SensitiveUrl;
 use slog::Logger;
 use slot_clock::TestingSlotClock;
-use state_processing::{state_advance::complete_state_advance, StateRootStrategy};
+use state_processing::{
+    state_advance::{complete_state_advance, partial_state_advance},
+    StateRootStrategy,
+};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
@@ -42,15 +45,7 @@ use task_executor::ShutdownReason;
 use tree_hash::TreeHash;
 use types::sync_selection_proof::SyncSelectionProof;
 pub use types::test_utils::generate_deterministic_keypairs;
-use types::{
-    typenum::U4294967296, Address, AggregateSignature, Attestation, AttestationData,
-    AttesterSlashing, BeaconBlock, BeaconState, BeaconStateHash, ChainSpec, Checkpoint, Deposit,
-    DepositData, Domain, Epoch, EthSpec, ForkName, Graffiti, Hash256, IndexedAttestation, Keypair,
-    ProposerSlashing, PublicKeyBytes, SelectionProof, SignatureBytes, SignedAggregateAndProof,
-    SignedBeaconBlock, SignedBeaconBlockHash, SignedContributionAndProof, SignedRoot,
-    SignedVoluntaryExit, Slot, SubnetId, SyncCommittee, SyncCommitteeContribution,
-    SyncCommitteeMessage, VariableList, VoluntaryExit,
-};
+use types::{typenum::U4294967296, *};
 
 // 4th September 2019
 pub const HARNESS_GENESIS_TIME: u64 = 1_567_552_690;
@@ -685,6 +680,67 @@ where
         (signed_block, pre_state)
     }
 
+    /// Produces an "unaggregated" attestation for the given `slot` and `index` that attests to
+    /// `beacon_block_root`. The provided `state` should match the `block.state_root` for the
+    /// `block` identified by `beacon_block_root`.
+    ///
+    /// The attestation doesn't _really_ have anything about it that makes it unaggregated per say,
+    /// however this function is only required in the context of forming an unaggregated
+    /// attestation. It would be an (undetectable) violation of the protocol to create a
+    /// `SignedAggregateAndProof` based upon the output of this function.
+    ///
+    /// This function will produce attestations to optimistic blocks, which is against the
+    /// specification but useful during testing.
+    pub fn produce_unaggregated_attestation_for_block(
+        &self,
+        slot: Slot,
+        index: CommitteeIndex,
+        beacon_block_root: Hash256,
+        mut state: Cow<BeaconState<E>>,
+        state_root: Hash256,
+    ) -> Result<Attestation<E>, BeaconChainError> {
+        let epoch = slot.epoch(E::slots_per_epoch());
+
+        if state.slot() > slot {
+            return Err(BeaconChainError::CannotAttestToFutureState);
+        } else if state.current_epoch() < epoch {
+            let mut_state = state.to_mut();
+            // Only perform a "partial" state advance since we do not require the state roots to be
+            // accurate.
+            partial_state_advance(
+                mut_state,
+                Some(state_root),
+                epoch.start_slot(E::slots_per_epoch()),
+                &self.spec,
+            )?;
+            mut_state.build_committee_cache(RelativeEpoch::Current, &self.spec)?;
+        }
+
+        let committee_len = state.get_beacon_committee(slot, index)?.committee.len();
+
+        let target_slot = epoch.start_slot(E::slots_per_epoch());
+        let target_root = if state.slot() <= target_slot {
+            beacon_block_root
+        } else {
+            *state.get_block_root(target_slot)?
+        };
+
+        Ok(Attestation {
+            aggregation_bits: BitList::with_capacity(committee_len)?,
+            data: AttestationData {
+                slot,
+                index,
+                beacon_block_root,
+                source: state.current_justified_checkpoint(),
+                target: Checkpoint {
+                    epoch,
+                    root: target_root,
+                },
+            },
+            signature: AggregateSignature::empty(),
+        })
+    }
+
     /// A list of attestations for each committee for the given slot.
     ///
     /// The first layer of the Vec is organised per committee. For example, if the return value is
@@ -716,7 +772,6 @@ where
                             return None;
                         }
                         let mut attestation = self
-                            .chain
                             .produce_unaggregated_attestation_for_block(
                                 attestation_slot,
                                 bc.index,

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -954,6 +954,7 @@ where
                         let aggregate = self
                             .chain
                             .get_aggregated_attestation(&attestation.data)
+                            .unwrap()
                             .unwrap_or_else(|| {
                                 committee_attestations.iter().skip(1).fold(
                                     attestation.clone(),

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -11,7 +11,6 @@ use execution_layer::{
 use fork_choice::{Error as ForkChoiceError, InvalidationOperation, PayloadVerificationStatus};
 use proto_array::{Error as ProtoArrayError, ExecutionStatus};
 use slot_clock::SlotClock;
-use std::borrow::Cow;
 use std::time::Duration;
 use task_executor::ShutdownReason;
 use tree_hash::TreeHash;

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -200,8 +200,8 @@ impl InvalidPayloadRig {
                 let execution_status = self.execution_status(root.into());
 
                 match is_valid {
-                    Payload::Syncing => assert!(execution_status.is_not_verified()),
-                    Payload::Valid => assert!(execution_status.is_valid()),
+                    Payload::Syncing => assert!(execution_status.is_optimistic()),
+                    Payload::Valid => assert!(execution_status.is_valid_and_post_bellatrix()),
                     Payload::Invalid { .. } => unreachable!(),
                 }
 
@@ -288,7 +288,7 @@ fn invalid_payload_invalidates_parent() {
         latest_valid_hash: Some(latest_valid_hash),
     });
 
-    assert!(rig.execution_status(roots[0]).is_valid());
+    assert!(rig.execution_status(roots[0]).is_valid_and_post_bellatrix());
     assert!(rig.execution_status(roots[1]).is_invalid());
     assert!(rig.execution_status(roots[2]).is_invalid());
 
@@ -376,9 +376,9 @@ fn pre_finalized_latest_valid_hash() {
         let slot = Slot::new(i);
         let root = rig.block_root_at_slot(slot).unwrap();
         if slot == 1 {
-            assert!(rig.execution_status(root).is_valid());
+            assert!(rig.execution_status(root).is_valid_and_post_bellatrix());
         } else {
-            assert!(rig.execution_status(root).is_not_verified());
+            assert!(rig.execution_status(root).is_optimistic());
         }
     }
 }
@@ -425,7 +425,7 @@ fn latest_valid_hash_will_validate() {
         } else if slot == 0 {
             assert!(execution_status.is_irrelevant())
         } else {
-            assert!(execution_status.is_valid())
+            assert!(execution_status.is_valid_and_post_bellatrix())
         }
     }
 }
@@ -463,9 +463,9 @@ fn latest_valid_hash_is_junk() {
         let slot = Slot::new(i);
         let root = rig.block_root_at_slot(slot).unwrap();
         if slot == 1 {
-            assert!(rig.execution_status(root).is_valid());
+            assert!(rig.execution_status(root).is_valid_and_post_bellatrix());
         } else {
-            assert!(rig.execution_status(root).is_not_verified());
+            assert!(rig.execution_status(root).is_optimistic());
         }
     }
 }
@@ -535,7 +535,7 @@ fn invalidates_all_descendants() {
         let execution_status = rig.execution_status(root);
         if slot <= latest_valid_slot {
             // Blocks prior to the latest valid hash are valid.
-            assert!(execution_status.is_valid());
+            assert!(execution_status.is_valid_and_post_bellatrix());
         } else {
             // Blocks after the latest valid hash are invalid.
             assert!(execution_status.is_invalid());
@@ -586,7 +586,7 @@ fn switches_heads() {
     assert_eq!(rig.head_info().block_root, fork_block_root);
 
     // The fork block has not yet been validated.
-    assert!(rig.execution_status(fork_block_root).is_not_verified());
+    assert!(rig.execution_status(fork_block_root).is_optimistic());
 
     for root in blocks {
         let slot = rig.harness.chain.get_block(&root).unwrap().unwrap().slot();
@@ -599,7 +599,7 @@ fn switches_heads() {
         let execution_status = rig.execution_status(root);
         if slot <= latest_valid_slot {
             // Blocks prior to the latest valid hash are valid.
-            assert!(execution_status.is_valid());
+            assert!(execution_status.is_valid_and_post_bellatrix());
         } else {
             // Blocks after the latest valid hash are invalid.
             assert!(execution_status.is_invalid());
@@ -670,13 +670,13 @@ fn manually_validate_child() {
     let parent = rig.import_block(Payload::Syncing);
     let child = rig.import_block(Payload::Syncing);
 
-    assert!(rig.execution_status(parent).is_not_verified());
-    assert!(rig.execution_status(child).is_not_verified());
+    assert!(rig.execution_status(parent).is_optimistic());
+    assert!(rig.execution_status(child).is_optimistic());
 
     rig.validate_manually(child);
 
-    assert!(rig.execution_status(parent).is_valid());
-    assert!(rig.execution_status(child).is_valid());
+    assert!(rig.execution_status(parent).is_valid_and_post_bellatrix());
+    assert!(rig.execution_status(child).is_valid_and_post_bellatrix());
 }
 
 #[test]
@@ -688,13 +688,13 @@ fn manually_validate_parent() {
     let parent = rig.import_block(Payload::Syncing);
     let child = rig.import_block(Payload::Syncing);
 
-    assert!(rig.execution_status(parent).is_not_verified());
-    assert!(rig.execution_status(child).is_not_verified());
+    assert!(rig.execution_status(parent).is_optimistic());
+    assert!(rig.execution_status(child).is_optimistic());
 
     rig.validate_manually(parent);
 
-    assert!(rig.execution_status(parent).is_valid());
-    assert!(rig.execution_status(child).is_not_verified());
+    assert!(rig.execution_status(parent).is_valid_and_post_bellatrix());
+    assert!(rig.execution_status(child).is_optimistic());
 }
 
 #[test]
@@ -827,7 +827,7 @@ fn attesting_to_optimistic_head() {
         "the head should be the latest imported block"
     );
     assert!(
-        rig.execution_status(root).is_not_verified(),
+        rig.execution_status(root).is_optimistic(),
         "the head should be optimistic"
     );
 
@@ -882,17 +882,22 @@ fn attesting_to_optimistic_head() {
      * Ensure attestation production fails with an optimistic head.
      */
 
-    assert!(matches!(
-        produce_unaggregated(),
-        Err(BeaconChainError::CannotAttestToOptimisticHead {
-            beacon_block_root
-        })
-        if beacon_block_root == root
-    ));
+    macro_rules! assert_head_block_not_fully_verified {
+        ($func: expr) => {
+            assert!(matches!(
+                $func,
+                Err(BeaconChainError::HeadBlockNotFullyVerified {
+                    beacon_block_root,
+                    execution_status
+                })
+                if beacon_block_root == root && matches!(execution_status, ExecutionStatus::Optimistic(_))
+            ));
+        }
+    }
 
-    assert_eq!(get_aggregated(), None);
-
-    assert_eq!(get_aggregated_by_slot_and_root(), None);
+    assert_head_block_not_fully_verified!(produce_unaggregated());
+    assert_head_block_not_fully_verified!(get_aggregated());
+    assert_head_block_not_fully_verified!(get_aggregated_by_slot_and_root());
 
     /*
      * Ensure attestation production succeeds once the head is verified.
@@ -902,7 +907,7 @@ fn attesting_to_optimistic_head() {
 
     rig.validate_manually(root);
     assert!(
-        rig.execution_status(root).is_valid(),
+        rig.execution_status(root).is_valid_and_post_bellatrix(),
         "the head should no longer be optimistic"
     );
 

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -798,7 +798,7 @@ fn invalid_parent() {
             block_root,
             Duration::from_secs(0),
             &state,
-            PayloadVerificationStatus::NotVerified,
+            PayloadVerificationStatus::Optimistic,
             &rig.harness.chain.spec
         ),
         Err(ForkChoiceError::ProtoArrayError(message))

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -838,18 +838,6 @@ fn attesting_to_optimistic_head() {
 
     let produce_unaggregated = || rig.harness.chain.produce_unaggregated_attestation(slot, 0);
 
-    let produce_unaggregated_for_block = || {
-        rig.harness
-            .chain
-            .produce_unaggregated_attestation_for_block(
-                slot,
-                0,
-                root,
-                Cow::Owned(head.beacon_state.clone()),
-                head.beacon_state_root(),
-            )
-    };
-
     let attestation = {
         let mut attestation = rig
             .harness
@@ -898,14 +886,6 @@ fn attesting_to_optimistic_head() {
         if beacon_block_root == root
     ));
 
-    assert!(matches!(
-        produce_unaggregated_for_block(),
-        Err(BeaconChainError::CannotAttestToOptimisticHead {
-            beacon_block_root
-        })
-        if beacon_block_root == root
-    ));
-
     assert_eq!(get_aggregated(), None);
 
     assert_eq!(get_aggregated_by_slot_and_root(), None);
@@ -923,7 +903,6 @@ fn attesting_to_optimistic_head() {
     );
 
     produce_unaggregated().unwrap();
-    produce_unaggregated_for_block().unwrap();
     get_aggregated().unwrap();
     get_aggregated_by_slot_and_root().unwrap();
 }

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -833,10 +833,9 @@ fn attesting_to_optimistic_head() {
     );
 
     /*
-     * Define some closures to produce attestations.
+     * Define an attestation for use during testing. It doesn't have a valid signature, but that's
+     * not necessary here.
      */
-
-    let produce_unaggregated = || rig.harness.chain.produce_unaggregated_attestation(slot, 0);
 
     let attestation = {
         let mut attestation = rig
@@ -858,6 +857,12 @@ fn attesting_to_optimistic_head() {
 
         attestation
     };
+
+    /*
+     * Define some closures to produce attestations.
+     */
+
+    let produce_unaggregated = || rig.harness.chain.produce_unaggregated_attestation(slot, 0);
 
     let get_aggregated = || {
         rig.harness

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2138,10 +2138,11 @@ pub fn serve<T: BeaconChainTypes>(
                             query.slot,
                             &query.attestation_data_root,
                         )
-                        .map_err(|_e| {
-                            warp_utils::reject::custom_bad_request(
-                                "unable to fetch aggregate".to_string(),
-                            )
+                        .map_err(|e| {
+                            warp_utils::reject::custom_bad_request(format!(
+                                "unable to fetch aggregate: {:?}",
+                                e
+                            ))
                         })?
                         .map(api_types::GenericResponse::from)
                         .ok_or_else(|| {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2138,6 +2138,11 @@ pub fn serve<T: BeaconChainTypes>(
                             query.slot,
                             &query.attestation_data_root,
                         )
+                        .map_err(|_e| {
+                            warp_utils::reject::custom_bad_request(
+                                "unable to fetch aggregate".to_string(),
+                            )
+                        })?
                         .map(api_types::GenericResponse::from)
                         .ok_or_else(|| {
                             warp_utils::reject::custom_not_found(

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -23,7 +23,7 @@ use beacon_chain::{
     observed_operations::ObservationOutcome,
     validator_monitor::{get_block_delay_ms, timestamp_now},
     AttestationError as AttnError, BeaconChain, BeaconChainError, BeaconChainTypes,
-    HeadSafetyStatus, ProduceBlockVerification, WhenSlotSkipped,
+    ExecutionStatus, ProduceBlockVerification, WhenSlotSkipped,
 };
 use block_id::BlockId;
 use eth2::types::{self as api_types, EndpointVersion, ValidatorId};
@@ -394,24 +394,24 @@ pub fn serve<T: BeaconChainTypes>(
 
     // Create a `warp` filter that rejects requests unless the head has been verified by the
     // execution layer.
-    let only_with_safe_head = warp::any()
+    let not_while_optimistic_filter = warp::any()
         .and(chain_filter.clone())
         .and_then(move |chain: Arc<BeaconChain<T>>| async move {
-            let status = chain.head_safety_status().map_err(|e| {
+            let status = chain.head_execution_status().map_err(|e| {
                 warp_utils::reject::custom_server_error(format!(
-                    "failed to read head safety status: {:?}",
+                    "failed to read head execution status: {:?}",
                     e
                 ))
             })?;
             match status {
-                HeadSafetyStatus::Safe(_) => Ok(()),
-                HeadSafetyStatus::Unsafe(hash) => {
+                ExecutionStatus::Valid(_) | ExecutionStatus::Irrelevant(_) => Ok(()),
+                ExecutionStatus::Optimistic(hash) => {
                     Err(warp_utils::reject::custom_server_error(format!(
                         "optimistic head hash {:?} has not been verified by the execution layer",
                         hash
                     )))
                 }
-                HeadSafetyStatus::Invalid(hash) => {
+                ExecutionStatus::Invalid(hash) => {
                     Err(warp_utils::reject::custom_server_error(format!(
                         "the head block has an invalid payload {:?}, this may be unrecoverable",
                         hash
@@ -2095,7 +2095,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAttestationDataQuery>())
         .and(not_while_syncing_filter.clone())
-        .and(only_with_safe_head.clone())
+        .and(not_while_optimistic_filter.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAttestationDataQuery, chain: Arc<BeaconChain<T>>| {
@@ -2128,7 +2128,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<api_types::ValidatorAggregateAttestationQuery>())
         .and(not_while_syncing_filter.clone())
-        .and(only_with_safe_head.clone())
+        .and(not_while_optimistic_filter.clone())
         .and(chain_filter.clone())
         .and_then(
             |query: api_types::ValidatorAggregateAttestationQuery, chain: Arc<BeaconChain<T>>| {
@@ -2205,7 +2205,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::path::end())
         .and(warp::query::<SyncContributionData>())
         .and(not_while_syncing_filter.clone())
-        .and(only_with_safe_head)
+        .and(not_while_optimistic_filter)
         .and(chain_filter.clone())
         .and_then(
             |sync_committee_data: SyncContributionData, chain: Arc<BeaconChain<T>>| {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -122,7 +122,7 @@ pub enum PayloadVerificationStatus {
     /// An EL has declared the execution payload to be valid.
     Verified,
     /// An EL has not yet made a determination about the execution payload.
-    NotVerified,
+    Optimistic,
     /// The block is either pre-merge-fork, or prior to the terminal PoW block.
     Irrelevant,
 }
@@ -132,7 +132,7 @@ impl PayloadVerificationStatus {
     pub fn is_optimistic(&self) -> bool {
         match self {
             PayloadVerificationStatus::Verified => false,
-            PayloadVerificationStatus::NotVerified => true,
+            PayloadVerificationStatus::Optimistic => true,
             PayloadVerificationStatus::Irrelevant => false,
         }
     }
@@ -679,7 +679,7 @@ where
             } else {
                 match payload_verification_status {
                     PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
-                    PayloadVerificationStatus::NotVerified => {
+                    PayloadVerificationStatus::Optimistic => {
                         ExecutionStatus::Optimistic(block_hash)
                     }
                     // It would be a logic error to declare a block irrelevant if it has an

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -679,7 +679,9 @@ where
             } else {
                 match payload_verification_status {
                     PayloadVerificationStatus::Verified => ExecutionStatus::Valid(block_hash),
-                    PayloadVerificationStatus::NotVerified => ExecutionStatus::Unknown(block_hash),
+                    PayloadVerificationStatus::NotVerified => {
+                        ExecutionStatus::Optimistic(block_hash)
+                    }
                     // It would be a logic error to declare a block irrelevant if it has an
                     // execution payload with a non-zero block hash.
                     PayloadVerificationStatus::Irrelevant => {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -127,6 +127,17 @@ pub enum PayloadVerificationStatus {
     Irrelevant,
 }
 
+impl PayloadVerificationStatus {
+    /// Returns `true` if the payload was optimistically imported.
+    pub fn is_optimistic(&self) -> bool {
+        match self {
+            PayloadVerificationStatus::Verified => false,
+            PayloadVerificationStatus::NotVerified => true,
+            PayloadVerificationStatus::Irrelevant => false,
+        }
+    }
+}
+
 /// Calculate how far `slot` lies from the start of its epoch.
 ///
 /// ## Specification
@@ -939,6 +950,15 @@ where
     pub fn get_block(&self, block_root: &Hash256) -> Option<ProtoBlock> {
         if self.is_descendant_of_finalized(*block_root) {
             self.proto_array.get_block(block_root)
+        } else {
+            None
+        }
+    }
+
+    /// Returns an `ExecutionStatus` if the block is known **and** a descendant of the finalized root.
+    pub fn get_block_execution_status(&self, block_root: &Hash256) -> Option<ExecutionStatus> {
+        if self.is_descendant_of_finalized(*block_root) {
+            self.proto_array.get_block_execution_status(block_root)
         } else {
             None
         }

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -6,4 +6,4 @@ pub use crate::fork_choice::{
     PayloadVerificationStatus, PersistedForkChoice, QueuedAttestation,
 };
 pub use fork_choice_store::ForkChoiceStore;
-pub use proto_array::{Block as ProtoBlock, InvalidationOperation};
+pub use proto_array::{Block as ProtoBlock, ExecutionStatus, InvalidationOperation};

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -85,7 +85,7 @@ impl ForkChoiceTestDefinition {
             self.finalized_checkpoint,
             junk_shuffling_id.clone(),
             junk_shuffling_id,
-            ExecutionStatus::Unknown(ExecutionBlockHash::zero()),
+            ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
         )
         .expect("should create fork choice struct");
 
@@ -189,9 +189,9 @@ impl ForkChoiceTestDefinition {
                         justified_checkpoint,
                         finalized_checkpoint,
                         // All blocks are imported optimistically.
-                        execution_status: ExecutionStatus::Unknown(ExecutionBlockHash::from_root(
-                            root,
-                        )),
+                        execution_status: ExecutionStatus::Optimistic(
+                            ExecutionBlockHash::from_root(root),
+                        ),
                     };
                     fork_choice.process_block(block).unwrap_or_else(|e| {
                         panic!(

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -387,7 +387,7 @@ impl ProtoArray {
                 ExecutionStatus::Irrelevant(_) => return Ok(()),
                 // The block has an unknown status, set it to valid since any ancestor of a valid
                 // payload can be considered valid.
-                ExecutionStatus::Unknown(payload_block_hash) => {
+                ExecutionStatus::Optimistic(payload_block_hash) => {
                     node.execution_status = ExecutionStatus::Valid(payload_block_hash);
                     if let Some(parent_index) = node.parent {
                         parent_index
@@ -458,7 +458,7 @@ impl ProtoArray {
             match node.execution_status {
                 ExecutionStatus::Valid(hash)
                 | ExecutionStatus::Invalid(hash)
-                | ExecutionStatus::Unknown(hash) => {
+                | ExecutionStatus::Optimistic(hash) => {
                     // If we're no longer processing the `head_block_root` and the last valid
                     // ancestor is unknown, exit this loop and proceed to invalidate and
                     // descendants of `head_block_root`/`latest_valid_ancestor_root`.
@@ -516,7 +516,7 @@ impl ProtoArray {
                             payload_block_hash: *hash,
                         })
                     }
-                    ExecutionStatus::Unknown(hash) => {
+                    ExecutionStatus::Optimistic(hash) => {
                         invalidated_indices.insert(index);
                         node.execution_status = ExecutionStatus::Invalid(*hash);
 
@@ -580,7 +580,7 @@ impl ProtoArray {
                                 payload_block_hash: *hash,
                             })
                         }
-                        ExecutionStatus::Unknown(hash) | ExecutionStatus::Invalid(hash) => {
+                        ExecutionStatus::Optimistic(hash) | ExecutionStatus::Invalid(hash) => {
                             node.execution_status = ExecutionStatus::Invalid(*hash)
                         }
                         ExecutionStatus::Irrelevant(_) => {

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -73,7 +73,7 @@ impl ExecutionStatus {
     /// Returns `true` if the block:
     ///
     /// - Has execution enabled, AND
-    /// - Hash a valid payload
+    /// - Has a valid payload
     ///
     /// This function will return `false` for any block from a slot prior to the Bellatrix fork.
     /// This means that some blocks that are perfectly valid will still receive a `false` response.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Removes the `HeadSafetyStatus` struct, which was a relic from pre-optimistic-sync-spec days.

I've also removed some restrictions on API endpoints. The attestation endpoints now have the same restrictions applied in #3040, at the `BeaconChain` level. The sync aggregate messages should also be restricted inside the VC and at the BN via #3151.

## Additional Info

- Blocked on #3040
- Blocked on #3151
