### PR TITLE
[Merged by Bors] - Change the url of the blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ as the canonical staking deposit contract address.
 The [Lighthouse Book](https://lighthouse-book.sigmaprime.io) contains information for users and
 developers.
 
-The Lighthouse team maintains a blog at [lighthouse.sigmaprime.io][blog] which contains periodical
+The Lighthouse team maintains a blog at [lighthouse.sigp.io][blog] which contains periodical
 progress updates, roadmap insights and interesting findings.
 
 ## Branches

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ as the canonical staking deposit contract address.
 The [Lighthouse Book](https://lighthouse-book.sigmaprime.io) contains information for users and
 developers.
 
-The Lighthouse team maintains a blog at [lighthouse.sigp.io][blog] which contains periodical
+The Lighthouse team maintains a blog at [lighthouse-blog.sigmaprime.io][blog] which contains periodical
 progress updates, roadmap insights and interesting findings.
 
 ## Branches


### PR DESCRIPTION
Shifts the blog domain to lighthouse-blog.sigmaprime.io