### PR TITLE
[Merged by Bors] - Add remotekey API support

### DIFF
--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -1,3 +1,7 @@
+// TODO: Remove this
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_imports)]
 use super::{types::*, PK_LEN, SECRET_PREFIX};
 use crate::Error;
 use account_utils::ZeroizeString;
@@ -476,6 +480,16 @@ impl ValidatorClientHttpClient {
         Ok(url)
     }
 
+    fn make_remotekeys_url(&self) -> Result<Url, Error> {
+        let mut url = self.server.full.clone();
+        url.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("eth")
+            .push("v1")
+            .push("remotekeys");
+        Ok(url)
+    }
+
     /// `GET lighthouse/auth`
     pub async fn get_auth(&self) -> Result<AuthResponse, Error> {
         let mut url = self.server.full.clone();
@@ -507,6 +521,30 @@ impl ValidatorClientHttpClient {
         req: &DeleteKeystoresRequest,
     ) -> Result<DeleteKeystoresResponse, Error> {
         let url = self.make_keystores_url()?;
+        self.delete_with_unsigned_response(url, req).await
+    }
+
+    /// `GET eth/v1/remotekeys`
+    pub async fn get_remotekeys(&self) -> Result<ListRemotekeysResponse, Error> {
+        let url = self.make_remotekeys_url()?;
+        self.get_unsigned(url).await
+    }
+
+    /// `POST eth/v1/remotekeys`
+    pub async fn post_remotekeys(
+        &self,
+        req: &ImportRemotekeysRequest,
+    ) -> Result<ImportRemotekeysResponse, Error> {
+        let url = self.make_remotekeys_url()?;
+        self.post_with_unsigned_response(url, req).await
+    }
+
+    /// `DELETE eth/v1/remotekeys`
+    pub async fn delete_remotekeys(
+        &self,
+        req: &DeleteRemotekeysRequest,
+    ) -> Result<DeleteRemotekeysResponse, Error> {
+        let url = self.make_remotekeys_url()?;
         self.delete_with_unsigned_response(url, req).await
     }
 }

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -1,7 +1,3 @@
-// TODO: Remove this
-#![allow(dead_code)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
 use super::{types::*, PK_LEN, SECRET_PREFIX};
 use crate::Error;
 use account_utils::ZeroizeString;

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -111,9 +111,8 @@ pub struct ListRemotekeysResponse {
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct SingleListRemotekeysResponse {
     pub pubkey: PublicKeyBytes,
-    pub url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub readonly: Option<bool>,
+    pub url: String,
+    pub readonly: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -103,7 +103,6 @@ pub enum DeleteKeystoreStatus {
     Error,
 }
 
-// ==== GET /remotekeys/ response
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct ListRemotekeysResponse {
     pub data: Vec<SingleListRemotekeysResponse>,
@@ -117,9 +116,6 @@ pub struct SingleListRemotekeysResponse {
     pub readonly: Option<bool>,
 }
 
-//=========
-
-// ===== POST /remotekeys
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImportRemotekeysRequest {
@@ -144,8 +140,6 @@ pub enum ImportRemotekeyStatus {
 pub struct ImportRemotekeysResponse {
     pub data: Vec<Status<ImportRemotekeyStatus>>,
 }
-
-// === DELETE
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -119,7 +119,7 @@ pub struct SingleListRemotekeysResponse {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImportRemotekeysRequest {
-    pub remotekeys: Vec<SingleImportRemotekeysRequest>,
+    pub remote_keys: Vec<SingleImportRemotekeysRequest>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -102,3 +102,66 @@ pub enum DeleteKeystoreStatus {
     NotFound,
     Error,
 }
+
+// ==== GET /remotekeys/ response
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct ListRemotekeysResponse {
+    pub data: Vec<SingleListRemotekeysResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct SingleListRemotekeysResponse {
+    pub pubkey: PublicKeyBytes,
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub readonly: Option<bool>,
+}
+
+//=========
+
+// ===== POST /remotekeys
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ImportRemotekeysRequest {
+    pub remotekeys: Vec<SingleImportRemotekeysRequest>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct SingleImportRemotekeysRequest {
+    pub pubkey: PublicKeyBytes,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportRemotekeyStatus {
+    Imported,
+    Duplicate,
+    Error,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ImportRemotekeysResponse {
+    pub data: Vec<Status<ImportRemotekeyStatus>>,
+}
+
+// === DELETE
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeleteRemotekeysRequest {
+    pub pubkeys: Vec<PublicKeyBytes>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeleteRemotekeyStatus {
+    Deleted,
+    NotFound,
+    Error,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DeleteRemotekeysResponse {
+    pub data: Vec<Status<DeleteRemotekeyStatus>>,
+}

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -1,5 +1,5 @@
 use crate::ValidatorStore;
-use account_utils::validator_definitions::{SigningDefinition, ValidatorDefinition};
+use account_utils::validator_definitions::ValidatorDefinition;
 use account_utils::{
     eth2_wallet::{bip39::Mnemonic, WalletBuilder},
     random_mnemonic, random_password, ZeroizeString,
@@ -164,24 +164,12 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
 }
 
 pub async fn create_validators_web3signer<T: 'static + SlotClock, E: EthSpec>(
-    validator_requests: &[api_types::Web3SignerValidatorRequest],
+    validators: &[ValidatorDefinition],
     validator_store: &ValidatorStore<T, E>,
 ) -> Result<(), warp::Rejection> {
-    for request in validator_requests {
-        let validator_definition = ValidatorDefinition {
-            enabled: request.enable,
-            voting_public_key: request.voting_public_key.clone(),
-            graffiti: request.graffiti.clone(),
-            suggested_fee_recipient: request.suggested_fee_recipient,
-            description: request.description.clone(),
-            signing_definition: SigningDefinition::Web3Signer {
-                url: request.url.clone(),
-                root_certificate_path: request.root_certificate_path.clone(),
-                request_timeout_ms: request.request_timeout_ms,
-            },
-        };
+    for validator in validators {
         validator_store
-            .add_validator(validator_definition)
+            .add_validator(validator.clone())
             .await
             .map_err(|e| {
                 warp_utils::reject::custom_server_error(format!(

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -164,12 +164,12 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
 }
 
 pub async fn create_validators_web3signer<T: 'static + SlotClock, E: EthSpec>(
-    validators: &[ValidatorDefinition],
+    validators: Vec<ValidatorDefinition>,
     validator_store: &ValidatorStore<T, E>,
 ) -> Result<(), warp::Rejection> {
     for validator in validators {
         validator_store
-            .add_validator(validator.clone())
+            .add_validator(validator)
             .await
             .map_err(|e| {
                 warp_utils::reject::custom_server_error(format!(

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -1,10 +1,14 @@
 mod api_secret;
 mod create_validator;
 mod keystores;
+mod remotekeys;
 mod tests;
 
 use crate::ValidatorStore;
-use account_utils::mnemonic_from_phrase;
+use account_utils::{
+    mnemonic_from_phrase,
+    validator_definitions::{SigningDefinition, ValidatorDefinition},
+};
 use create_validator::{create_validators_mnemonic, create_validators_web3signer};
 use eth2::lighthouse_vc::{
     std_types::AuthResponse,
@@ -459,7 +463,25 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
              runtime: Weak<Runtime>| {
                 blocking_signed_json_task(signer, move || {
                     if let Some(runtime) = runtime.upgrade() {
-                        runtime.block_on(create_validators_web3signer(&body, &validator_store))?;
+                        let web3signers: Vec<ValidatorDefinition> = body
+                            .iter()
+                            .map(|web3signer| ValidatorDefinition {
+                                enabled: web3signer.enable,
+                                voting_public_key: web3signer.voting_public_key.clone(),
+                                graffiti: web3signer.graffiti.clone(),
+                                suggested_fee_recipient: web3signer.suggested_fee_recipient,
+                                description: web3signer.description.clone(),
+                                signing_definition: SigningDefinition::Web3Signer {
+                                    url: web3signer.url.clone(),
+                                    root_certificate_path: web3signer.root_certificate_path.clone(),
+                                    request_timeout_ms: web3signer.request_timeout_ms,
+                                },
+                            })
+                            .collect();
+                        runtime.block_on(create_validators_web3signer(
+                            &web3signers,
+                            &validator_store,
+                        ))?;
                         Ok(())
                     } else {
                         Err(warp_utils::reject::custom_server_error(
@@ -536,6 +558,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     // Standard key-manager endpoints.
     let eth_v1 = warp::path("eth").and(warp::path("v1"));
     let std_keystores = eth_v1.and(warp::path("keystores")).and(warp::path::end());
+    let std_remotekeys = eth_v1.and(warp::path("remotekeys")).and(warp::path::end());
 
     // GET /eth/v1/keystores
     let get_std_keystores = std_keystores
@@ -549,7 +572,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     let post_std_keystores = std_keystores
         .and(warp::body::json())
         .and(signer.clone())
-        .and(validator_dir_filter)
+        .and(validator_dir_filter.clone())
         .and(validator_store_filter.clone())
         .and(runtime_filter.clone())
         .and(log_filter.clone())
@@ -564,13 +587,47 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     // DELETE /eth/v1/keystores
     let delete_std_keystores = std_keystores
         .and(warp::body::json())
-        .and(signer)
-        .and(validator_store_filter)
-        .and(runtime_filter)
-        .and(log_filter)
+        .and(signer.clone())
+        .and(validator_store_filter.clone())
+        .and(runtime_filter.clone())
+        .and(log_filter.clone())
         .and_then(|request, signer, validator_store, runtime, log| {
             blocking_signed_json_task(signer, move || {
                 keystores::delete(request, validator_store, runtime, log)
+            })
+        });
+
+    // GET /eth/v1/remotekeys
+    let get_std_remotekeys = std_remotekeys
+        .and(signer.clone())
+        .and(validator_store_filter.clone())
+        .and_then(|signer, validator_store: Arc<ValidatorStore<T, E>>| {
+            blocking_signed_json_task(signer, move || Ok(remotekeys::list(validator_store)))
+        });
+
+    // POST /eth/v1/remotekeys
+    let post_std_remotekeys = std_remotekeys
+        .and(warp::body::json())
+        .and(signer.clone())
+        .and(validator_store_filter.clone())
+        .and(runtime_filter.clone())
+        .and(log_filter.clone())
+        .and_then(|request, signer, validator_store, runtime, log| {
+            blocking_signed_json_task(signer, move || {
+                remotekeys::import(request, validator_store, runtime, log)
+            })
+        });
+
+    // DELETE /eth/v1/keystores
+    let delete_std_remotekeys = std_remotekeys
+        .and(warp::body::json())
+        .and(signer.clone())
+        .and(validator_store_filter.clone())
+        .and(runtime_filter.clone())
+        .and(log_filter.clone())
+        .and_then(|request, signer, validator_store, runtime, log| {
+            blocking_signed_json_task(signer, move || {
+                remotekeys::delete(request, validator_store, runtime, log)
             })
         });
 
@@ -588,17 +645,19 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         .or(get_lighthouse_spec)
                         .or(get_lighthouse_validators)
                         .or(get_lighthouse_validators_pubkey)
-                        .or(get_std_keystores),
+                        .or(get_std_keystores)
+                        .or(get_std_remotekeys),
                 )
                 .or(warp::post().and(
                     post_validators
                         .or(post_validators_keystore)
                         .or(post_validators_mnemonic)
                         .or(post_validators_web3signer)
-                        .or(post_std_keystores),
+                        .or(post_std_keystores)
+                        .or(post_std_remotekeys),
                 ))
                 .or(warp::patch().and(patch_validators))
-                .or(warp::delete().and(delete_std_keystores)),
+                .or(warp::delete().and(delete_std_keystores.or(delete_std_remotekeys))),
         )
         // The auth route is the only route that is allowed to be accessed without the API token.
         .or(warp::get().and(get_auth))

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -572,7 +572,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     let post_std_keystores = std_keystores
         .and(warp::body::json())
         .and(signer.clone())
-        .and(validator_dir_filter.clone())
+        .and(validator_dir_filter)
         .and(validator_store_filter.clone())
         .and(runtime_filter.clone())
         .and(log_filter.clone())
@@ -621,9 +621,9 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
     // DELETE /eth/v1/remotekeys
     let delete_std_remotekeys = std_remotekeys
         .and(warp::body::json())
-        .and(signer.clone())
-        .and(validator_store_filter.clone())
-        .and(runtime_filter.clone())
+        .and(signer)
+        .and(validator_store_filter)
+        .and(runtime_filter)
         .and(log_filter.clone())
         .and_then(|request, signer, validator_store, runtime, log| {
             blocking_signed_json_task(signer, move || {

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -464,22 +464,22 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                 blocking_signed_json_task(signer, move || {
                     if let Some(runtime) = runtime.upgrade() {
                         let web3signers: Vec<ValidatorDefinition> = body
-                            .iter()
+                            .into_iter()
                             .map(|web3signer| ValidatorDefinition {
                                 enabled: web3signer.enable,
-                                voting_public_key: web3signer.voting_public_key.clone(),
-                                graffiti: web3signer.graffiti.clone(),
+                                voting_public_key: web3signer.voting_public_key,
+                                graffiti: web3signer.graffiti,
                                 suggested_fee_recipient: web3signer.suggested_fee_recipient,
-                                description: web3signer.description.clone(),
+                                description: web3signer.description,
                                 signing_definition: SigningDefinition::Web3Signer {
-                                    url: web3signer.url.clone(),
-                                    root_certificate_path: web3signer.root_certificate_path.clone(),
+                                    url: web3signer.url,
+                                    root_certificate_path: web3signer.root_certificate_path,
                                     request_timeout_ms: web3signer.request_timeout_ms,
                                 },
                             })
                             .collect();
                         runtime.block_on(create_validators_web3signer(
-                            &web3signers,
+                            web3signers,
                             &validator_store,
                         ))?;
                         Ok(())

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -618,7 +618,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
             })
         });
 
-    // DELETE /eth/v1/keystores
+    // DELETE /eth/v1/remotekeys
     let delete_std_remotekeys = std_remotekeys
         .and(warp::body::json())
         .and(signer.clone())

--- a/validator_client/src/http_api/remotekeys.rs
+++ b/validator_client/src/http_api/remotekeys.rs
@@ -1,0 +1,208 @@
+//! Implementation of the standard remotekey management API.
+use crate::{initialized_validators::Error, InitializedValidators, ValidatorStore};
+use account_utils::validator_definitions::{SigningDefinition, ValidatorDefinition};
+use eth2::lighthouse_vc::std_types::{
+    DeleteRemotekeyStatus, DeleteRemotekeysRequest, DeleteRemotekeysResponse,
+    ImportRemotekeyStatus, ImportRemotekeysRequest, ImportRemotekeysResponse,
+    ListRemotekeysResponse, SingleListRemotekeysResponse, Status,
+};
+use slog::{info, warn, Logger};
+use slot_clock::SlotClock;
+use std::sync::Arc;
+use std::sync::Weak;
+use tokio::runtime::Runtime;
+use types::{EthSpec, PublicKeyBytes};
+use url::Url;
+use warp::Rejection;
+use warp_utils::reject::custom_server_error;
+
+pub fn list<T: SlotClock + 'static, E: EthSpec>(
+    validator_store: Arc<ValidatorStore<T, E>>,
+) -> ListRemotekeysResponse {
+    let initialized_validators_rwlock = validator_store.initialized_validators();
+    let initialized_validators = initialized_validators_rwlock.read();
+
+    let keystores = initialized_validators
+        .validator_definitions()
+        .iter()
+        .filter(|def| def.enabled)
+        .map(|def| {
+            let validating_pubkey = def.voting_public_key.compress();
+            let (url, readonly) = match &def.signing_definition {
+                SigningDefinition::LocalKeystore { .. } => (None, Some(true)),
+                SigningDefinition::Web3Signer { url, .. } => (Some(url.clone()), None),
+            };
+
+            SingleListRemotekeysResponse {
+                pubkey: validating_pubkey,
+                url,
+                readonly,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    ListRemotekeysResponse { data: keystores }
+}
+
+pub fn import<T: SlotClock + 'static, E: EthSpec>(
+    request: ImportRemotekeysRequest,
+    validator_store: Arc<ValidatorStore<T, E>>,
+    runtime: Weak<Runtime>,
+    log: Logger,
+) -> Result<ImportRemotekeysResponse, Rejection> {
+    info!(
+        log,
+        "Importing remotekeys via standard HTTP API";
+        "count" => request.remotekeys.len(),
+    );
+    // Import each remotekey. Some remotekeys may fail to be imported, so we record a status for each.
+    let mut statuses = Vec::with_capacity(request.remotekeys.len());
+
+    for remotekey in request.remotekeys {
+        let status = if let Some(runtime) = runtime.upgrade() {
+            // Import the keystore.
+            match import_single_remotekey(
+                remotekey.pubkey,
+                remotekey.url,
+                &validator_store,
+                runtime,
+            ) {
+                Ok(status) => Status::ok(status),
+                Err(e) => {
+                    warn!(
+                        log,
+                        "Error importing keystore, skipped";
+                        "pubkey" => remotekey.pubkey.to_string(),
+                        "error" => ?e,
+                    );
+                    Status::error(ImportRemotekeyStatus::Error, e)
+                }
+            }
+        } else {
+            Status::error(
+                ImportRemotekeyStatus::Error,
+                "validator client shutdown".into(),
+            )
+        };
+        statuses.push(status);
+    }
+    Ok(ImportRemotekeysResponse { data: statuses })
+}
+
+fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
+    pubkey: PublicKeyBytes,
+    url: String,
+    validator_store: &ValidatorStore<T, E>,
+    runtime: Arc<Runtime>,
+) -> Result<ImportRemotekeyStatus, String> {
+    if let Err(url_err) = Url::parse(&url) {
+        return Err(format!("failed to parse remotekey URL: {}", url_err));
+    }
+
+    let pubkey = pubkey
+        .decompress()
+        .map_err(|_| format!("invalid pubkey: {}", pubkey))?;
+
+    if let Some(def) = validator_store
+        .initialized_validators()
+        .read()
+        .validator_definitions()
+        .iter()
+        .find(|def| def.voting_public_key == pubkey)
+    {
+        if def.signing_definition.is_local_keystore() {
+            return Err(
+                "cannot import duplicate of existing remote signer validator as local keystore"
+                    .into(),
+            );
+        } else if def.enabled {
+            return Ok(ImportRemotekeyStatus::Duplicate);
+        }
+    }
+
+    let web3signer_validator = ValidatorDefinition {
+        enabled: true,
+        voting_public_key: pubkey,
+        graffiti: None,
+        suggested_fee_recipient: None,
+        description: String::from("Added by remotekey API"),
+        signing_definition: SigningDefinition::Web3Signer {
+            url,
+            root_certificate_path: None,
+            request_timeout_ms: None,
+        },
+    };
+    runtime
+        .block_on(validator_store.add_validator(web3signer_validator))
+        .map_err(|e| format!("failed to initialize validator: {:?}", e))?;
+
+    Ok(ImportRemotekeyStatus::Imported)
+}
+pub fn delete<T: SlotClock + 'static, E: EthSpec>(
+    request: DeleteRemotekeysRequest,
+    validator_store: Arc<ValidatorStore<T, E>>,
+    runtime: Weak<Runtime>,
+    log: Logger,
+) -> Result<DeleteRemotekeysResponse, Rejection> {
+    // Remove from initialized validators.
+    let initialized_validators_rwlock = validator_store.initialized_validators();
+    let mut initialized_validators = initialized_validators_rwlock.write();
+
+    let statuses = request
+        .pubkeys
+        .iter()
+        .map(|pubkey_bytes| {
+            match delete_single_remotekey(
+                pubkey_bytes,
+                &mut initialized_validators,
+                runtime.clone(),
+            ) {
+                Ok(status) => Status::ok(status),
+                Err(error) => {
+                    warn!(
+                        log,
+                        "Error deleting keystore";
+                        "pubkey" => ?pubkey_bytes,
+                        "error" => ?error,
+                    );
+                    Status::error(DeleteRemotekeyStatus::Error, error)
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Use `update_validators` to update the key cache. It is safe to let the key cache get a bit out
+    // of date as it resets when it can't be decrypted. We update it just a single time to avoid
+    // continually resetting it after each key deletion.
+    if let Some(runtime) = runtime.upgrade() {
+        runtime
+            .block_on(initialized_validators.update_validators())
+            .map_err(|e| custom_server_error(format!("unable to update key cache: {:?}", e)))?;
+    }
+
+    Ok(DeleteRemotekeysResponse { data: statuses })
+}
+
+fn delete_single_remotekey(
+    pubkey_bytes: &PublicKeyBytes,
+    initialized_validators: &mut InitializedValidators,
+    runtime: Weak<Runtime>,
+) -> Result<DeleteRemotekeyStatus, String> {
+    if let Some(runtime) = runtime.upgrade() {
+        let pubkey = pubkey_bytes
+            .decompress()
+            .map_err(|e| format!("invalid pubkey, {:?}: {:?}", pubkey_bytes, e))?;
+
+        match runtime
+            .block_on(initialized_validators.delete_definition_and_keystore(&pubkey, false))
+        {
+            Ok(_) => Ok(DeleteRemotekeyStatus::Deleted),
+            Err(e) => match e {
+                Error::ValidatorNotInitialized(_) => Ok(DeleteRemotekeyStatus::NotFound),
+                _ => Err(format!("unable to disable and delete: {:?}", e)),
+            },
+        }
+    } else {
+        Err("validator client shutdown".into())
+    }
+}

--- a/validator_client/src/http_api/remotekeys.rs
+++ b/validator_client/src/http_api/remotekeys.rs
@@ -120,6 +120,8 @@ fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
         }
     }
 
+    // Remotekeys are stored as web3signers.
+    // The remotekey API provides less confgiuration option than the web3signer API.
     let web3signer_validator = ValidatorDefinition {
         enabled: true,
         voting_public_key: pubkey,
@@ -144,6 +146,11 @@ pub fn delete<T: SlotClock + 'static, E: EthSpec>(
     runtime: Weak<Runtime>,
     log: Logger,
 ) -> Result<DeleteRemotekeysResponse, Rejection> {
+    info!(
+        log,
+        "Deleting remotekeys via standard HTTP API";
+        "count" => request.pubkeys.len(),
+    );
     // Remove from initialized validators.
     let initialized_validators_rwlock = validator_store.initialized_validators();
     let mut initialized_validators = initialized_validators_rwlock.write();

--- a/validator_client/src/http_api/remotekeys.rs
+++ b/validator_client/src/http_api/remotekeys.rs
@@ -53,12 +53,12 @@ pub fn import<T: SlotClock + 'static, E: EthSpec>(
     info!(
         log,
         "Importing remotekeys via standard HTTP API";
-        "count" => request.remotekeys.len(),
+        "count" => request.remote_keys.len(),
     );
     // Import each remotekey. Some remotekeys may fail to be imported, so we record a status for each.
-    let mut statuses = Vec::with_capacity(request.remotekeys.len());
+    let mut statuses = Vec::with_capacity(request.remote_keys.len());
 
-    for remotekey in request.remotekeys {
+    for remotekey in request.remote_keys {
         let status = if let Some(runtime) = runtime.upgrade() {
             // Import the keystore.
             match import_single_remotekey(
@@ -111,10 +111,7 @@ fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
         .find(|def| def.voting_public_key == pubkey)
     {
         if def.signing_definition.is_local_keystore() {
-            return Err(
-                "cannot import duplicate of existing remote signer validator as local keystore"
-                    .into(),
-            );
+            return Err("Pubkey already present in local keystore.".into());
         } else if def.enabled {
             return Ok(ImportRemotekeyStatus::Duplicate);
         }

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![cfg(not(debug_assertions))]
+//#![cfg(not(debug_assertions))]
 
 mod keystores;
 

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1,6 +1,5 @@
 #![cfg(test)]
-// DO NOT MERGE
-//#![cfg(not(debug_assertions))]
+#![cfg(not(debug_assertions))]
 
 mod keystores;
 

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+// DO NOT MERGE
 //#![cfg(not(debug_assertions))]
 
 mod keystores;

--- a/validator_client/src/http_api/tests/keystores.rs
+++ b/validator_client/src/http_api/tests/keystores.rs
@@ -156,7 +156,7 @@ fn check_keystore_delete_response<'a>(
     }
 }
 
-fn check_remotekey_get_response<'a>(
+fn check_remotekey_get_response(
     response: &ListRemotekeysResponse,
     expected_keystores: impl IntoIterator<Item = SingleListRemotekeysResponse>,
 ) {
@@ -178,7 +178,7 @@ fn check_remotekey_import_response(
     }
 }
 
-fn check_remotekey_delete_response<'a>(
+fn check_remotekey_delete_response(
     response: &DeleteRemotekeysResponse,
     expected_statuses: impl IntoIterator<Item = DeleteRemotekeyStatus>,
 ) {

--- a/validator_client/src/http_api/tests/keystores.rs
+++ b/validator_client/src/http_api/tests/keystores.rs
@@ -1075,8 +1075,8 @@ fn import_new_remotekeys() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: None,
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .collect::<Vec<_>>();
         let get_res = tester.client.get_remotekeys().await.unwrap();
@@ -1119,8 +1119,8 @@ fn import_same_remotekey_different_url() {
             &get_res,
             vec![SingleListRemotekeysResponse {
                 pubkey: remotekeys[0].pubkey,
-                url: Some(remotekeys[0].url.clone()),
-                readonly: None,
+                url: remotekeys[0].url.clone(),
+                readonly: false,
             }],
         );
     })
@@ -1165,8 +1165,8 @@ fn import_only_duplicate_remotekeys() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: None,
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .collect::<Vec<_>>();
         let get_res = tester.client.get_remotekeys().await.unwrap();
@@ -1232,8 +1232,8 @@ fn import_some_duplicate_remotekeys() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: Some(false),
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .collect::<Vec<_>>();
         let get_res = tester.client.get_remotekeys().await.unwrap();
@@ -1290,20 +1290,15 @@ fn import_remote_and_local_keys() {
             all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
         );
 
-        // Check that both local and remote validators are returned.
+        // Check that only remote validators are returned.
         let get_res = tester.client.get_keystores().await.unwrap();
-        let expected_responses = keystores
+        let expected_responses = remotekeys
             .iter()
-            .map(|local_keystore| SingleKeystoreResponse {
-                validating_pubkey: keystore_pubkey(local_keystore),
-                derivation_path: local_keystore.path(),
-                readonly: None,
-            })
-            .chain(remotekeys.iter().map(|remotekey| SingleKeystoreResponse {
+            .map(|remotekey| SingleKeystoreResponse {
                 validating_pubkey: remotekey.pubkey,
                 derivation_path: None,
                 readonly: Some(true),
-            }))
+            })
             .collect::<Vec<_>>();
         for response in expected_responses {
             assert!(get_res.data.contains(&response), "{:?}", response);
@@ -1435,8 +1430,8 @@ fn import_same_remote_and_local_keys() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: None,
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .collect::<Vec<_>>();
         let get_res = tester.client.get_remotekeys().await.unwrap();
@@ -1572,8 +1567,8 @@ fn delete_then_reimport_remotekeys() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: None,
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .collect::<Vec<_>>();
         let get_res = tester.client.get_remotekeys().await.unwrap();
@@ -1620,16 +1615,16 @@ fn import_remotekey_web3signer() {
             .iter()
             .map(|remotekey| SingleListRemotekeysResponse {
                 pubkey: remotekey.pubkey,
-                url: Some(remotekey.url.clone()),
-                readonly: None,
+                url: remotekey.url.clone(),
+                readonly: false,
             })
             .chain(
                 web3signers
                     .iter()
                     .map(|websigner| SingleListRemotekeysResponse {
                         pubkey: websigner.voting_public_key.compress(),
-                        url: Some(websigner.url.clone()),
-                        readonly: None,
+                        url: websigner.url.clone(),
+                        readonly: false,
                     }),
             )
             .collect::<Vec<_>>();

--- a/validator_client/src/http_api/tests/keystores.rs
+++ b/validator_client/src/http_api/tests/keystores.rs
@@ -8,8 +8,7 @@ use eth2::lighthouse_vc::{
 use itertools::Itertools;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use slashing_protection::interchange::{Interchange, InterchangeMetadata};
-use std::collections::HashMap;
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 fn new_keystore(password: ZeroizeString) -> Keystore {
     let keypair = Keypair::random();
@@ -41,6 +40,19 @@ fn web3signer_validator_with_pubkey(pubkey: PublicKey) -> Web3SignerValidatorReq
         url: web3_signer_url(),
         root_certificate_path: None,
         request_timeout_ms: None,
+    }
+}
+
+fn new_remotekey_validator() -> (Keypair, SingleImportRemotekeysRequest) {
+    let keypair = Keypair::random();
+    let pk = keypair.pk.clone();
+    (keypair, remotekey_validator_with_pubkey(pk))
+}
+
+fn remotekey_validator_with_pubkey(pubkey: PublicKey) -> SingleImportRemotekeysRequest {
+    SingleImportRemotekeysRequest {
+        pubkey: pubkey.compress(),
+        url: web3_signer_url(),
     }
 }
 
@@ -107,7 +119,7 @@ fn all_delete_error(count: usize) -> impl Iterator<Item = DeleteKeystoreStatus> 
     all_with_status(count, DeleteKeystoreStatus::Error)
 }
 
-fn check_get_response<'a>(
+fn check_keystore_get_response<'a>(
     response: &ListKeystoresResponse,
     expected_keystores: impl IntoIterator<Item = &'a Keystore>,
 ) {
@@ -118,7 +130,7 @@ fn check_get_response<'a>(
     }
 }
 
-fn check_import_response(
+fn check_keystore_import_response(
     response: &ImportKeystoresResponse,
     expected_statuses: impl IntoIterator<Item = ImportKeystoreStatus>,
 ) {
@@ -131,9 +143,44 @@ fn check_import_response(
     }
 }
 
-fn check_delete_response<'a>(
+fn check_keystore_delete_response<'a>(
     response: &DeleteKeystoresResponse,
     expected_statuses: impl IntoIterator<Item = DeleteKeystoreStatus>,
+) {
+    for (status, expected_status) in response.data.iter().zip_eq(expected_statuses) {
+        assert_eq!(
+            status.status, expected_status,
+            "message: {:?}",
+            status.message
+        );
+    }
+}
+
+fn check_remotekey_get_response<'a>(
+    response: &ListRemotekeysResponse,
+    expected_keystores: impl IntoIterator<Item = SingleListRemotekeysResponse>,
+) {
+    for expected in expected_keystores {
+        response.data.contains(&expected);
+    }
+}
+
+fn check_remotekey_import_response(
+    response: &ImportRemotekeysResponse,
+    expected_statuses: impl IntoIterator<Item = ImportRemotekeyStatus>,
+) {
+    for (status, expected_status) in response.data.iter().zip_eq(expected_statuses) {
+        assert_eq!(
+            expected_status, status.status,
+            "message: {:?}",
+            status.message
+        );
+    }
+}
+
+fn check_remotekey_delete_response<'a>(
+    response: &DeleteRemotekeysResponse,
+    expected_statuses: impl IntoIterator<Item = DeleteRemotekeyStatus>,
 ) {
     for (status, expected_status) in response.data.iter().zip_eq(expected_statuses) {
         assert_eq!(
@@ -189,11 +236,11 @@ fn import_new_keystores() {
             .unwrap();
 
         // All keystores should be imported.
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // Check that GET lists all the imported keystores.
         let get_res = tester.client.get_keystores().await.unwrap();
-        check_get_response(&get_res, &keystores);
+        check_keystore_get_response(&get_res, &keystores);
     })
 }
 
@@ -214,15 +261,15 @@ fn import_only_duplicate_keystores() {
 
         // All keystores should be imported on first import.
         let import_res = tester.client.post_keystores(&req).await.unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // No keystores should be imported on repeat import.
         let import_res = tester.client.post_keystores(&req).await.unwrap();
-        check_import_response(&import_res, all_duplicate(keystores.len()));
+        check_keystore_import_response(&import_res, all_duplicate(keystores.len()));
 
         // Check that GET lists all the imported keystores.
         let get_res = tester.client.get_keystores().await.unwrap();
-        check_get_response(&get_res, &keystores);
+        check_keystore_get_response(&get_res, &keystores);
     })
 }
 
@@ -262,7 +309,7 @@ fn import_some_duplicate_keystores() {
         };
 
         let import_res = tester.client.post_keystores(&req1).await.unwrap();
-        check_import_response(&import_res, all_imported(keystores1.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores1.len()));
 
         // Check partial import.
         let expected = (0..num_keystores).map(|i| {
@@ -273,7 +320,7 @@ fn import_some_duplicate_keystores() {
             }
         });
         let import_res = tester.client.post_keystores(&req2).await.unwrap();
-        check_import_response(&import_res, expected);
+        check_keystore_import_response(&import_res, expected);
     })
 }
 
@@ -323,7 +370,7 @@ fn get_web3_signer_keystores() {
             .unwrap();
 
         // All keystores should be imported.
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // Add some web3signer validators.
         let remote_vals = (0..num_remote)
@@ -391,14 +438,14 @@ fn import_and_delete_conflicting_web3_signer_keystores() {
             slashing_protection: None,
         };
         let import_res = tester.client.post_keystores(&import_req).await.unwrap();
-        check_import_response(&import_res, all_import_error(keystores.len()));
+        check_keystore_import_response(&import_res, all_import_error(keystores.len()));
 
         // Attempt to delete the web3signer validators, which should fail.
         let delete_req = DeleteKeystoresRequest {
             pubkeys: pubkeys.clone(),
         };
         let delete_res = tester.client.delete_keystores(&delete_req).await.unwrap();
-        check_delete_response(&delete_res, all_delete_error(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_delete_error(keystores.len()));
 
         // Get should still list all the validators as `readonly`.
         let get_res = tester.client.get_keystores().await.unwrap();
@@ -418,9 +465,9 @@ fn import_and_delete_conflicting_web3_signer_keystores() {
                 .unwrap();
         }
         let import_res = tester.client.post_keystores(&import_req).await.unwrap();
-        check_import_response(&import_res, all_import_error(keystores.len()));
+        check_keystore_import_response(&import_res, all_import_error(keystores.len()));
         let delete_res = tester.client.delete_keystores(&delete_req).await.unwrap();
-        check_delete_response(&delete_res, all_delete_error(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_delete_error(keystores.len()));
     })
 }
 
@@ -464,7 +511,7 @@ fn import_keystores_wrong_password() {
                 ImportKeystoreStatus::Imported
             }
         });
-        check_import_response(&import_res, expected_statuses);
+        check_keystore_import_response(&import_res, expected_statuses);
 
         // Import again with the correct passwords and check that the statuses are as expected.
         let correct_import_req = ImportKeystoresRequest {
@@ -484,7 +531,7 @@ fn import_keystores_wrong_password() {
                 ImportKeystoreStatus::Duplicate
             }
         });
-        check_import_response(&import_res, expected_statuses);
+        check_keystore_import_response(&import_res, expected_statuses);
 
         // Import one final time, at which point all keys should be duplicates.
         let import_res = tester
@@ -492,7 +539,7 @@ fn import_keystores_wrong_password() {
             .post_keystores(&correct_import_req)
             .await
             .unwrap();
-        check_import_response(
+        check_keystore_import_response(
             &import_res,
             (0..num_keystores).map(|_| ImportKeystoreStatus::Duplicate),
         );
@@ -528,11 +575,11 @@ fn import_invalid_slashing_protection() {
             .unwrap();
 
         // All keystores should be imported.
-        check_import_response(&import_res, all_import_error(keystores.len()));
+        check_keystore_import_response(&import_res, all_import_error(keystores.len()));
 
         // Check that GET lists none of the failed keystores.
         let get_res = tester.client.get_keystores().await.unwrap();
-        check_get_response(&get_res, &[]);
+        check_keystore_get_response(&get_res, &[]);
     })
 }
 
@@ -669,7 +716,7 @@ fn generic_migration_test(
             })
             .await
             .unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // Sign attestations on VC1.
         for (validator_index, mut attestation) in first_vc_attestations {
@@ -694,7 +741,7 @@ fn generic_migration_test(
             })
             .await
             .unwrap();
-        check_delete_response(&delete_res, all_deleted(delete_indices.len()));
+        check_keystore_delete_response(&delete_res, all_deleted(delete_indices.len()));
 
         // Check that slashing protection data was returned for all selected validators.
         assert_eq!(
@@ -745,7 +792,7 @@ fn generic_migration_test(
             })
             .await
             .unwrap();
-        check_import_response(&import_res, all_imported(import_indices.len()));
+        check_keystore_import_response(&import_res, all_imported(import_indices.len()));
 
         // Sign attestations on the second VC.
         for (validator_index, mut attestation, should_succeed) in second_vc_attestations {
@@ -779,18 +826,18 @@ fn delete_keystores_twice() {
             slashing_protection: None,
         };
         let import_res = tester.client.post_keystores(&import_req).await.unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // 2. Delete all.
         let delete_req = DeleteKeystoresRequest {
             pubkeys: keystores.iter().map(keystore_pubkey).collect(),
         };
         let delete_res = tester.client.delete_keystores(&delete_req).await.unwrap();
-        check_delete_response(&delete_res, all_deleted(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_deleted(keystores.len()));
 
         // 3. Delete again.
         let delete_res = tester.client.delete_keystores(&delete_req).await.unwrap();
-        check_delete_response(&delete_res, all_not_active(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_not_active(keystores.len()));
     })
 }
 
@@ -808,7 +855,7 @@ fn delete_nonexistent_keystores() {
             pubkeys: keystores.iter().map(keystore_pubkey).collect(),
         };
         let delete_res = tester.client.delete_keystores(&delete_req).await.unwrap();
-        check_delete_response(&delete_res, all_not_found(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_not_found(keystores.len()));
     })
 }
 
@@ -868,7 +915,7 @@ fn delete_concurrent_with_signing() {
             })
             .await
             .unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // Start several threads signing attestations at sequential epochs.
         let mut join_handles = vec![];
@@ -972,7 +1019,7 @@ fn delete_then_reimport() {
             slashing_protection: None,
         };
         let import_res = tester.client.post_keystores(&import_req).await.unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
 
         // 2. Delete all.
         let delete_res = tester
@@ -982,10 +1029,475 @@ fn delete_then_reimport() {
             })
             .await
             .unwrap();
-        check_delete_response(&delete_res, all_deleted(keystores.len()));
+        check_keystore_delete_response(&delete_res, all_deleted(keystores.len()));
 
         // 3. Re-import
         let import_res = tester.client.post_keystores(&import_req).await.unwrap();
-        check_import_response(&import_res, all_imported(keystores.len()));
+        check_keystore_import_response(&import_res, all_imported(keystores.len()));
+    })
+}
+
+#[test]
+fn get_empty_remotekeys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+        let res = tester.client.get_remotekeys().await.unwrap();
+        assert_eq!(res, ListRemotekeysResponse { data: vec![] });
+    })
+}
+
+#[test]
+fn import_new_remotekeys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Generate remotekeys.
+        let remotekeys = (0..3)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+
+        // All keystores should be imported.
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // Check list response.
+        let expected_responses = remotekeys
+            .iter()
+            .map(|remotekey| SingleListRemotekeysResponse {
+                pubkey: remotekey.pubkey,
+                url: Some(remotekey.url.clone()),
+                readonly: None,
+            })
+            .collect::<Vec<_>>();
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, expected_responses);
+    })
+}
+
+#[test]
+fn import_same_remotekey_different_url() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Create two remotekeys with different urls.
+        let remotekey1 = new_remotekey_validator().1;
+        let mut remotekey2 = remotekey1.clone();
+        remotekey2.url = "http://localhost:1/this-url-hopefully-does-also-not-exist".into();
+        let remotekeys = vec![remotekey1, remotekey2];
+
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+
+        // Both remotekeys have the same public key and therefore only the first one should be imported.
+        check_remotekey_import_response(
+            &import_res,
+            vec![
+                ImportRemotekeyStatus::Imported,
+                ImportRemotekeyStatus::Duplicate,
+            ]
+            .into_iter(),
+        );
+
+        // Only first key is imported and should be returned.
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(
+            &get_res,
+            vec![SingleListRemotekeysResponse {
+                pubkey: remotekeys[0].pubkey,
+                url: Some(remotekeys[0].url.clone()),
+                readonly: None,
+            }],
+        );
+    })
+}
+
+#[test]
+fn import_only_duplicate_remotekeys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+        let remotekeys = (0..3)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // All keystores should be imported on first import.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // No keystores should be imported on repeat import.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Duplicate),
+        );
+
+        // Check list response.
+        let expected_responses = remotekeys
+            .iter()
+            .map(|remotekey| SingleListRemotekeysResponse {
+                pubkey: remotekey.pubkey,
+                url: Some(remotekey.url.clone()),
+                readonly: None,
+            })
+            .collect::<Vec<_>>();
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, expected_responses);
+    })
+}
+
+#[test]
+fn import_some_duplicate_remotekeys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+        let num_remotekeys = 5;
+        let remotekeys_all = (0..num_remotekeys)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // Select even numbered keystores.
+        let remotekeys_even = remotekeys_all
+            .iter()
+            .enumerate()
+            .filter_map(|(i, remotekey)| {
+                if i % 2 == 0 {
+                    Some(remotekey.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Only import every second remotekey.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys_even.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys_even.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // Create expected import response.
+        let expected = (0..num_remotekeys).map(|i| {
+            if i % 2 == 0 {
+                ImportRemotekeyStatus::Duplicate
+            } else {
+                ImportRemotekeyStatus::Imported
+            }
+        });
+
+        // Try to import all keys.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys_all.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(&import_res, expected);
+
+        // Check list response.
+        let expected_responses = remotekeys_all
+            .iter()
+            .map(|remotekey| SingleListRemotekeysResponse {
+                pubkey: remotekey.pubkey,
+                url: Some(remotekey.url.clone()),
+                readonly: Some(false),
+            })
+            .collect::<Vec<_>>();
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, expected_responses);
+    })
+}
+
+#[test]
+fn import_remote_and_local_keys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+        let num_local = 3;
+        let num_remote = 2;
+
+        // Generate local keystores.
+        let password = random_password_string();
+        let keystores = (0..num_local)
+            .map(|_| new_keystore(password.clone()))
+            .collect::<Vec<_>>();
+
+        // Import keystores.
+        let import_res = tester
+            .client
+            .post_keystores(&ImportKeystoresRequest {
+                keystores: keystores.clone(),
+                passwords: vec![password.clone(); keystores.len()],
+                slashing_protection: None,
+            })
+            .await
+            .unwrap();
+
+        // All keystores should be imported.
+        check_keystore_import_response(
+            &import_res,
+            all_with_status(keystores.len(), ImportKeystoreStatus::Imported),
+        );
+
+        // Add some remotekey validators.
+        let remotekeys = (0..num_remote)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+
+        // Check that both local and remote validators are returned.
+        let get_res = tester.client.get_keystores().await.unwrap();
+        let expected_responses = keystores
+            .iter()
+            .map(|local_keystore| SingleKeystoreResponse {
+                validating_pubkey: keystore_pubkey(local_keystore),
+                derivation_path: local_keystore.path(),
+                readonly: None,
+            })
+            .chain(remotekeys.iter().map(|remotekey| SingleKeystoreResponse {
+                validating_pubkey: remotekey.pubkey,
+                derivation_path: None,
+                readonly: Some(true),
+            }))
+            .collect::<Vec<_>>();
+        for response in expected_responses {
+            assert!(get_res.data.contains(&response), "{:?}", response);
+        }
+    })
+}
+
+#[test]
+fn delete_remotekeys_twice() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Generate some remotekeys.
+        let remotekeys = (0..2)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // Import all keystores.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // Delete all.
+        let delete_req = DeleteRemotekeysRequest {
+            pubkeys: remotekeys.iter().map(|k| k.pubkey).collect(),
+        };
+        let delete_res = tester.client.delete_remotekeys(&delete_req).await.unwrap();
+        check_remotekey_delete_response(
+            &delete_res,
+            all_with_status(remotekeys.len(), DeleteRemotekeyStatus::Deleted),
+        );
+
+        // Delete again.
+        let delete_res = tester.client.delete_remotekeys(&delete_req).await.unwrap();
+        check_remotekey_delete_response(
+            &delete_res,
+            all_with_status(remotekeys.len(), DeleteRemotekeyStatus::NotFound),
+        );
+
+        // Check list response.
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, Vec::new());
+    })
+}
+
+#[test]
+fn delete_nonexistent_remotekey() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Generate remotekeys.
+        let remotekeys = (0..2)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // Try to delete remotekeys.
+        let delete_req = DeleteRemotekeysRequest {
+            pubkeys: remotekeys.iter().map(|k| k.pubkey).collect(),
+        };
+        let delete_res = tester.client.delete_remotekeys(&delete_req).await.unwrap();
+        check_remotekey_delete_response(
+            &delete_res,
+            all_with_status(remotekeys.len(), DeleteRemotekeyStatus::NotFound),
+        );
+
+        // Check list response.
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, Vec::new());
+    })
+}
+
+#[test]
+fn delete_then_reimport_remotekeys() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Generate remotekey validators.
+        let mut remotekeys = (0..2)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // Import all remotekeys.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // Delete all.
+        let delete_req = DeleteRemotekeysRequest {
+            pubkeys: remotekeys.iter().map(|k| k.pubkey).collect(),
+        };
+        let delete_res = tester.client.delete_remotekeys(&delete_req).await.unwrap();
+        check_remotekey_delete_response(
+            &delete_res,
+            all_with_status(remotekeys.len(), DeleteRemotekeyStatus::Deleted),
+        );
+
+        // Change remote key url
+        for rk in remotekeys.iter_mut() {
+            rk.url = "http://localhost:1/this-url-hopefully-does-also-not-exist".into();
+        }
+
+        // Re-import
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        // Check list response.
+        let expected_responses = remotekeys
+            .iter()
+            .map(|remotekey| SingleListRemotekeysResponse {
+                pubkey: remotekey.pubkey,
+                url: Some(remotekey.url.clone()),
+                readonly: None,
+            })
+            .collect::<Vec<_>>();
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, expected_responses);
+    })
+}
+
+#[test]
+fn import_remotekey_web3signer() {
+    run_test(|tester| async move {
+        let _ = &tester;
+
+        // Generate remotekeys.
+        let remotekeys = (0..2)
+            .map(|_| new_remotekey_validator().1)
+            .collect::<Vec<_>>();
+
+        // Generate web3signers.
+        let web3signers = (0..3)
+            .map(|_| new_web3signer_validator().1)
+            .collect::<Vec<_>>();
+
+        // Import web3signers.
+        tester
+            .client
+            .post_lighthouse_validators_web3signer(&web3signers)
+            .await
+            .unwrap();
+
+        // Import remotekeys.
+        let import_res = tester
+            .client
+            .post_remotekeys(&ImportRemotekeysRequest {
+                remotekeys: remotekeys.clone(),
+            })
+            .await
+            .unwrap();
+        check_remotekey_import_response(
+            &import_res,
+            all_with_status(remotekeys.len(), ImportRemotekeyStatus::Imported),
+        );
+
+        let expected_responses = remotekeys
+            .iter()
+            .map(|remotekey| SingleListRemotekeysResponse {
+                pubkey: remotekey.pubkey,
+                url: Some(remotekey.url.clone()),
+                readonly: None,
+            })
+            .chain(
+                web3signers
+                    .iter()
+                    .map(|websigner| SingleListRemotekeysResponse {
+                        pubkey: websigner.voting_public_key.compress(),
+                        url: Some(websigner.url.clone()),
+                        readonly: None,
+                    }),
+            )
+            .collect::<Vec<_>>();
+
+        // Check remotekey list response.
+        let get_res = tester.client.get_remotekeys().await.unwrap();
+        check_remotekey_get_response(&get_res, expected_responses);
     })
 }


### PR DESCRIPTION
## Issue Addressed

#3068

## Proposed Changes

Adds support for remote key API.

## Additional Info

Needed to add `is_local_keystore`  argument to `delete_definition_and_keystore` to know if we want to delete local or remote key. Previously this wasn't necessary because remotekeys(web3signers) could be deleted.


