### PR TITLE
[Merged by Bors] - Fix: no version info in homebrew package

### DIFF
--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -4,6 +4,7 @@ use target_info::Target;
 /// Returns the current version of this build of Lighthouse.
 ///
 /// A plus-sign (`+`) is appended to the git commit if the tree is dirty.
+/// Commit hash is omitted if the sources don't include git information.
 ///
 /// ## Example
 ///
@@ -17,7 +18,7 @@ pub const VERSION: &str = git_version!(
         "--match=thiswillnevermatchlol"
     ],
     prefix = "Lighthouse/v2.2.1-",
-    fallback = "unknown"
+    fallback = "Lighthouse/v2.2.1"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.


### PR DESCRIPTION
## Issue Addressed

Resolves #3102 

## Proposed Changes

- https://github.com/sigp/lighthouse/issues/3102#issuecomment-1114835063
- This is not an ideal solution, since the commit hash is missing from version number, but I think it is sufficient.

## Additional Info

I've tested ... :

- `fallback` is updated via `change_version.sh`.

```shell
$ cd scripts/
$ ./change_version.sh 2.2.1 2.2.2
$ git diff ../common/lighthouse_version/src/lib.rs
```
```diff
@ common/lighthouse_version/src/lib.rs:20 @ pub const VERSION: &str = git_version!(
        // NOTE: using --match instead of --exclude for compatibility with old Git
        "--match=thiswillnevermatchlol"
    ],
-   prefix = "Lighthouse/v2.2.1-",
-   fallback = "Lighthouse/v2.2.1"
+   prefix = "Lighthouse/v2.2.2-",
+   fallback = "Lighthouse/v2.2.2"
);
```

- a package built without git info prints expected version number (v2.2.1).

```shell
$ git archive HEAD --output=/tmp/lighthouse.zip
$ cd /tmp
$ unzip lighthouse.zip
$ cd lighthouse
$ cargo build --release
$ target/release/lighthouse --version
Lighthouse v2.2.1
BLS library: blst
SHA256 hardware acceleration: false
Specs: mainnet (true), minimal (false), gnosis (false)
```
