### PR TITLE
[Merged by Bors] - Exclude EE build dirs from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 testing/ef_tests/consensus-spec-tests
+testing/execution_engine_integration/execution_clients
 target/
 *.data
 *.tar.gz


### PR DESCRIPTION
## Proposed Changes

Remove the bulky part of the EE integration test directory from the Docker build context so that we don't have to send 10GB of junk to the Docker daemon when building an image.