### PR TITLE
[Merged by Bors] - Allow `TaskExecutor` to be used in `async` tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "eth2_ssz_derive",
  "eth2_ssz_types",
  "execution_layer",
+ "exit-future",
  "fork_choice",
  "futures",
  "genesis",
@@ -6028,6 +6029,7 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "slog",
+ "sloggers",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,6 +2532,7 @@ dependencies = [
  "slot_clock",
  "state_processing",
  "store",
+ "task_executor",
  "tokio",
  "tokio-stream",
  "tree_hash",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -61,6 +61,7 @@ execution_layer = { path = "../execution_layer" }
 sensitive_url = { path = "../../common/sensitive_url" }
 superstruct = "0.5.0"
 hex = "0.4.2"
+exit-future = "0.2.0"
 
 [[test]]
 name = "beacon_chain_tests"

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -12,9 +12,7 @@ use crate::{
 };
 use bls::get_withdrawal_credentials;
 use execution_layer::{
-    test_utils::{
-        ExecutionBlockGenerator, ExecutionLayerRuntime, MockExecutionLayer, DEFAULT_TERMINAL_BLOCK,
-    },
+    test_utils::{ExecutionBlockGenerator, MockExecutionLayer, DEFAULT_TERMINAL_BLOCK},
     ExecutionLayer,
 };
 use futures::channel::mpsc::Receiver;
@@ -41,7 +39,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use store::{config::StoreConfig, HotColdDB, ItemStore, LevelDB, MemoryStore};
-use task_executor::ShutdownReason;
+use task_executor::{Runtime, ShutdownReason, TaskExecutor};
 use tree_hash::TreeHash;
 use types::sync_selection_proof::SyncSelectionProof;
 pub use types::test_utils::generate_deterministic_keypairs;
@@ -151,8 +149,10 @@ pub struct Builder<T: BeaconChainTypes> {
     initial_mutator: Option<BoxedMutator<T::EthSpec, T::HotStore, T::ColdStore>>,
     store_mutator: Option<BoxedMutator<T::EthSpec, T::HotStore, T::ColdStore>>,
     execution_layer: Option<ExecutionLayer>,
-    execution_layer_runtime: Option<ExecutionLayerRuntime>,
     mock_execution_layer: Option<MockExecutionLayer<T::EthSpec>>,
+    runtime: Arc<Runtime>,
+    task_executor: TaskExecutor,
+    runtime_shutdown: exit_future::Signal,
     log: Logger,
 }
 
@@ -255,6 +255,18 @@ where
     Cold: ItemStore<E>,
 {
     pub fn new(eth_spec_instance: E) -> Self {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        let (runtime_shutdown, exit) = exit_future::signal();
+        let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
+        let log = test_logger();
+        let task_executor =
+            TaskExecutor::new(Arc::downgrade(&runtime), exit, log.clone(), shutdown_tx);
+
         Self {
             eth_spec_instance,
             spec: None,
@@ -266,8 +278,10 @@ where
             store_mutator: None,
             execution_layer: None,
             mock_execution_layer: None,
-            execution_layer_runtime: None,
-            log: test_logger(),
+            runtime,
+            task_executor,
+            runtime_shutdown,
+            log,
         }
     }
 
@@ -330,8 +344,6 @@ where
             "execution layer already defined"
         );
 
-        let el_runtime = ExecutionLayerRuntime::default();
-
         let urls: Vec<SensitiveUrl> = urls
             .iter()
             .map(|s| SensitiveUrl::parse(*s))
@@ -344,21 +356,18 @@ where
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };
-        let execution_layer = ExecutionLayer::from_config(
-            config,
-            el_runtime.task_executor.clone(),
-            el_runtime.log.clone(),
-        )
-        .unwrap();
+        let execution_layer =
+            ExecutionLayer::from_config(config, self.task_executor.clone(), self.log.clone())
+                .unwrap();
 
         self.execution_layer = Some(execution_layer);
-        self.execution_layer_runtime = Some(el_runtime);
         self
     }
 
     pub fn mock_execution_layer(mut self) -> Self {
         let spec = self.spec.clone().expect("cannot build without spec");
         let mock = MockExecutionLayer::new(
+            self.task_executor.clone(),
             spec.terminal_total_difficulty,
             DEFAULT_TERMINAL_BLOCK,
             spec.terminal_block_hash,
@@ -383,7 +392,7 @@ where
     pub fn build(self) -> BeaconChainHarness<BaseHarnessType<E, Hot, Cold>> {
         let (shutdown_tx, shutdown_receiver) = futures::channel::mpsc::channel(1);
 
-        let log = test_logger();
+        let log = self.log;
         let spec = self.spec.expect("cannot build without spec");
         let seconds_per_slot = spec.seconds_per_slot;
         let validator_keypairs = self
@@ -395,6 +404,7 @@ where
             .custom_spec(spec)
             .store(self.store.expect("cannot build without store"))
             .store_migrator_config(MigratorConfig::default().blocking())
+            .task_executor(self.task_executor.clone())
             .execution_layer(self.execution_layer)
             .dummy_eth1_backend()
             .expect("should build dummy backend")
@@ -434,8 +444,10 @@ where
             chain: Arc::new(chain),
             validator_keypairs,
             shutdown_receiver: Arc::new(Mutex::new(shutdown_receiver)),
+            runtime: self.runtime,
+            task_executor: self.task_executor,
+            runtime_shutdown: self.runtime_shutdown,
             mock_execution_layer: self.mock_execution_layer,
-            execution_layer_runtime: self.execution_layer_runtime,
             rng: make_rng(),
         }
     }
@@ -451,9 +463,11 @@ pub struct BeaconChainHarness<T: BeaconChainTypes> {
     pub chain: Arc<BeaconChain<T>>,
     pub spec: ChainSpec,
     pub shutdown_receiver: Arc<Mutex<Receiver<ShutdownReason>>>,
+    pub runtime: Arc<Runtime>,
+    pub task_executor: TaskExecutor,
+    pub runtime_shutdown: exit_future::Signal,
 
     pub mock_execution_layer: Option<MockExecutionLayer<T::EthSpec>>,
-    pub execution_layer_runtime: Option<ExecutionLayerRuntime>,
 
     pub rng: Mutex<StdRng>,
 }

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -166,6 +166,7 @@ where
         let builder = BeaconChainBuilder::new(eth_spec_instance)
             .logger(context.log().clone())
             .store(store)
+            .task_executor(context.executor.clone())
             .custom_spec(spec.clone())
             .chain_config(chain_config)
             .graffiti(graffiti)

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -304,11 +304,7 @@ impl ExecutionLayer {
         T: Fn(&'a Self) -> U,
         U: Future<Output = Result<V, Error>>,
     {
-        let runtime = self
-            .executor()
-            .runtime()
-            .upgrade()
-            .ok_or(Error::ShuttingDown)?;
+        let runtime = self.executor().handle().ok_or(Error::ShuttingDown)?;
         // TODO(merge): respect the shutdown signal.
         runtime.block_on(generate_future(self))
     }
@@ -322,11 +318,7 @@ impl ExecutionLayer {
         T: Fn(&'a Self) -> U,
         U: Future<Output = V>,
     {
-        let runtime = self
-            .executor()
-            .runtime()
-            .upgrade()
-            .ok_or(Error::ShuttingDown)?;
+        let runtime = self.executor().handle().ok_or(Error::ShuttingDown)?;
         // TODO(merge): respect the shutdown signal.
         Ok(runtime.block_on(generate_future(self)))
     }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1263,13 +1263,15 @@ impl ExecutionLayer {
 mod test {
     use super::*;
     use crate::test_utils::MockExecutionLayer as GenericMockExecutionLayer;
+    use task_executor::test_utils::TestRuntime;
     use types::MainnetEthSpec;
 
     type MockExecutionLayer = GenericMockExecutionLayer<MainnetEthSpec>;
 
     #[tokio::test]
     async fn produce_three_valid_pos_execution_blocks() {
-        MockExecutionLayer::default_params()
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
             .move_to_terminal_block()
             .produce_valid_execution_payload_on_head()
             .await
@@ -1281,7 +1283,8 @@ mod test {
 
     #[tokio::test]
     async fn finds_valid_terminal_block_hash() {
-        MockExecutionLayer::default_params()
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
             .move_to_block_prior_to_terminal_block()
             .with_terminal_block(|spec, el, _| async move {
                 el.engines().upcheck_not_synced(Logging::Disabled).await;
@@ -1300,7 +1303,8 @@ mod test {
 
     #[tokio::test]
     async fn verifies_valid_terminal_block_hash() {
-        MockExecutionLayer::default_params()
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
             .move_to_terminal_block()
             .with_terminal_block(|spec, el, terminal_block| async move {
                 el.engines().upcheck_not_synced(Logging::Disabled).await;
@@ -1316,7 +1320,8 @@ mod test {
 
     #[tokio::test]
     async fn rejects_invalid_terminal_block_hash() {
-        MockExecutionLayer::default_params()
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
             .move_to_terminal_block()
             .with_terminal_block(|spec, el, terminal_block| async move {
                 el.engines().upcheck_not_synced(Logging::Disabled).await;
@@ -1334,7 +1339,8 @@ mod test {
 
     #[tokio::test]
     async fn rejects_unknown_terminal_block_hash() {
-        MockExecutionLayer::default_params()
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
             .move_to_terminal_block()
             .with_terminal_block(|spec, el, _| async move {
                 el.engines().upcheck_not_synced(Logging::Disabled).await;

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -32,8 +32,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         terminal_block_hash: ExecutionBlockHash,
         terminal_block_hash_activation_epoch: Epoch,
     ) -> Self {
-        let runtime = executor.runtime().upgrade().unwrap();
-        let handle = runtime.handle();
+        let handle = executor.handle().unwrap();
 
         let mut spec = T::default_spec();
         spec.terminal_total_difficulty = terminal_total_difficulty;
@@ -41,7 +40,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         spec.terminal_block_hash_activation_epoch = terminal_block_hash_activation_epoch;
 
         let server = MockServer::new(
-            handle,
+            &handle,
             terminal_total_difficulty,
             terminal_block,
             terminal_block_hash,

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -2,61 +2,22 @@ use crate::{
     test_utils::{MockServer, DEFAULT_TERMINAL_BLOCK, DEFAULT_TERMINAL_DIFFICULTY, JWT_SECRET},
     Config, *,
 };
-use environment::null_logger;
 use sensitive_url::SensitiveUrl;
-use std::sync::Arc;
 use task_executor::TaskExecutor;
 use tempfile::NamedTempFile;
 use types::{Address, ChainSpec, Epoch, EthSpec, FullPayload, Hash256, Uint256};
 
-pub struct ExecutionLayerRuntime {
-    pub runtime: Option<Arc<tokio::runtime::Runtime>>,
-    pub _runtime_shutdown: exit_future::Signal,
-    pub task_executor: TaskExecutor,
-    pub log: Logger,
-}
-
-impl Default for ExecutionLayerRuntime {
-    fn default() -> Self {
-        let runtime = Arc::new(
-            tokio::runtime::Builder::new_multi_thread()
-                .enable_all()
-                .build()
-                .unwrap(),
-        );
-        let (runtime_shutdown, exit) = exit_future::signal();
-        let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
-        let log = null_logger().unwrap();
-        let task_executor =
-            TaskExecutor::new(Arc::downgrade(&runtime), exit, log.clone(), shutdown_tx);
-
-        Self {
-            runtime: Some(runtime),
-            _runtime_shutdown: runtime_shutdown,
-            task_executor,
-            log,
-        }
-    }
-}
-
-impl Drop for ExecutionLayerRuntime {
-    fn drop(&mut self) {
-        if let Some(runtime) = self.runtime.take() {
-            Arc::try_unwrap(runtime).unwrap().shutdown_background()
-        }
-    }
-}
-
 pub struct MockExecutionLayer<T: EthSpec> {
     pub server: MockServer<T>,
     pub el: ExecutionLayer,
-    pub el_runtime: ExecutionLayerRuntime,
+    pub executor: TaskExecutor,
     pub spec: ChainSpec,
 }
 
 impl<T: EthSpec> MockExecutionLayer<T> {
-    pub fn default_params() -> Self {
+    pub fn default_params(executor: TaskExecutor) -> Self {
         Self::new(
+            executor,
             DEFAULT_TERMINAL_DIFFICULTY.into(),
             DEFAULT_TERMINAL_BLOCK,
             ExecutionBlockHash::zero(),
@@ -65,13 +26,14 @@ impl<T: EthSpec> MockExecutionLayer<T> {
     }
 
     pub fn new(
+        executor: TaskExecutor,
         terminal_total_difficulty: Uint256,
         terminal_block: u64,
         terminal_block_hash: ExecutionBlockHash,
         terminal_block_hash_activation_epoch: Epoch,
     ) -> Self {
-        let el_runtime = ExecutionLayerRuntime::default();
-        let handle = el_runtime.runtime.as_ref().unwrap().handle();
+        let runtime = executor.runtime().upgrade().unwrap();
+        let handle = runtime.handle();
 
         let mut spec = T::default_spec();
         spec.terminal_total_difficulty = terminal_total_difficulty;
@@ -97,17 +59,13 @@ impl<T: EthSpec> MockExecutionLayer<T> {
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };
-        let el = ExecutionLayer::from_config(
-            config,
-            el_runtime.task_executor.clone(),
-            el_runtime.log.clone(),
-        )
-        .unwrap();
+        let el =
+            ExecutionLayer::from_config(config, executor.clone(), executor.log().clone()).unwrap();
 
         Self {
             server,
             el,
-            el_runtime,
+            executor,
             spec,
         }
     }

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -22,7 +22,7 @@ use types::{EthSpec, ExecutionBlockHash, Uint256};
 use warp::{http::StatusCode, Filter, Rejection};
 
 pub use execution_block_generator::{generate_pow_block, ExecutionBlockGenerator};
-pub use mock_execution_layer::{ExecutionLayerRuntime, MockExecutionLayer};
+pub use mock_execution_layer::MockExecutionLayer;
 
 pub const DEFAULT_TERMINAL_DIFFICULTY: u64 = 6400;
 pub const DEFAULT_TERMINAL_BLOCK: u64 = 64;

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -30,6 +30,7 @@ futures = "0.3.8"
 execution_layer = {path = "../execution_layer"}
 parking_lot = "0.12.0"
 safe_arith = {path = "../../consensus/safe_arith"}
+task_executor = { path = "../../common/task_executor" }
 
 
 [dev-dependencies]

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -186,7 +186,7 @@ impl ApiTester {
             external_peer_id,
         } = create_api_server(chain.clone(), log).await;
 
-        tokio::spawn(server);
+        harness.task_executor.spawn(server, "api_server");
 
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(
@@ -265,7 +265,7 @@ impl ApiTester {
             external_peer_id,
         } = create_api_server(chain.clone(), log).await;
 
-        tokio::spawn(server);
+        harness.task_executor.spawn(server, "api_server");
 
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -20,6 +20,7 @@ use slot_clock::SlotClock;
 use state_processing::per_slot_processing;
 use std::convert::TryInto;
 use std::sync::Arc;
+use task_executor::test_utils::TestRuntime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Duration;
 use tree_hash::TreeHash;
@@ -63,6 +64,7 @@ struct ApiTester {
     network_rx: mpsc::UnboundedReceiver<NetworkMessage<E>>,
     local_enr: Enr,
     external_peer_id: PeerId,
+    _runtime: TestRuntime,
 }
 
 impl ApiTester {
@@ -186,7 +188,7 @@ impl ApiTester {
             external_peer_id,
         } = create_api_server(chain.clone(), log).await;
 
-        harness.task_executor.spawn(server, "api_server");
+        harness.runtime.task_executor.spawn(server, "api_server");
 
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(
@@ -213,6 +215,7 @@ impl ApiTester {
             network_rx,
             local_enr,
             external_peer_id,
+            _runtime: harness.runtime,
         }
     }
 
@@ -265,7 +268,7 @@ impl ApiTester {
             external_peer_id,
         } = create_api_server(chain.clone(), log).await;
 
-        harness.task_executor.spawn(server, "api_server");
+        harness.runtime.task_executor.spawn(server, "api_server");
 
         let client = BeaconNodeHttpClient::new(
             SensitiveUrl::parse(&format!(
@@ -292,6 +295,7 @@ impl ApiTester {
             network_rx,
             local_enr,
             external_peer_id,
+            _runtime: harness.runtime,
         }
     }
 

--- a/common/task_executor/Cargo.toml
+++ b/common/task_executor/Cargo.toml
@@ -5,9 +5,10 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.14.0", features = ["rt"] }
+tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread"] }
 slog = "2.5.2"
 futures = "0.3.7"
 exit-future = "0.2.0"
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../lighthouse_metrics" }
+sloggers = { version = "2.1.1", features = ["json"] }

--- a/common/task_executor/Cargo.toml
+++ b/common/task_executor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.14.0", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.14.0", features = ["rt-multi-thread"] }
 slog = "2.5.2"
 futures = "0.3.7"
 exit-future = "0.2.0"

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -1,10 +1,11 @@
 mod metrics;
+pub mod test_utils;
 
 use futures::channel::mpsc::Sender;
 use futures::prelude::*;
 use slog::{crit, debug, o, trace};
 use std::sync::Weak;
-use tokio::runtime::Runtime;
+pub use tokio::runtime::Runtime;
 
 /// Provides a reason when Lighthouse is shut down.
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/common/task_executor/src/test_utils.rs
+++ b/common/task_executor/src/test_utils.rs
@@ -7,9 +7,7 @@ use tokio::runtime;
 /// Whilst the `TestRuntime` is not necessarily useful in itself, it provides the necessary
 /// components for creating a `TaskExecutor` during tests.
 ///
-/// If created *inside* an existing runtime, it will use a handle to that. If created *outside* any
-/// existing runtime, it will create a new `Runtime` and keep it alive until the `TestRuntime` is
-/// dropped.
+/// May create its own runtime or use an existing one.
 ///
 /// ## Warning
 ///
@@ -22,6 +20,9 @@ pub struct TestRuntime {
 }
 
 impl Default for TestRuntime {
+    /// If called *inside* an existing runtime, instantiates `Self` using handle to that runtime. If
+    /// called *outside* any existing runtime, create a new `Runtime` and keep it alive until the
+    /// `Self` is dropped.
     fn default() -> Self {
         let (runtime_shutdown, exit) = exit_future::signal();
         let (shutdown_tx, _) = futures::channel::mpsc::channel(1);

--- a/common/task_executor/src/test_utils.rs
+++ b/common/task_executor/src/test_utils.rs
@@ -4,9 +4,19 @@ use sloggers::{null::NullLoggerBuilder, Build};
 use std::sync::Arc;
 use tokio::runtime;
 
+/// Whilst the `TestRuntime` is not necessarily useful in itself, it provides the necessary
+/// components for creating a `TaskExecutor` during tests.
+///
+/// If created *inside* an existing runtime, it will use a handle to that. If created *outside* any
+/// existing runtime, it will create a new `Runtime` and keep it alive until the `TestRuntime` is
+/// dropped.
+///
+/// ## Warning
+///
+/// This struct should never be used in production, only testing.
 pub struct TestRuntime {
-    pub runtime: Option<Arc<tokio::runtime::Runtime>>,
-    pub _runtime_shutdown: exit_future::Signal,
+    runtime: Option<Arc<tokio::runtime::Runtime>>,
+    _runtime_shutdown: exit_future::Signal,
     pub task_executor: TaskExecutor,
     pub log: Logger,
 }

--- a/common/task_executor/src/test_utils.rs
+++ b/common/task_executor/src/test_utils.rs
@@ -20,7 +20,7 @@ pub struct TestRuntime {
 }
 
 impl Default for TestRuntime {
-    /// If called *inside* an existing runtime, instantiates `Self` using handle to that runtime. If
+    /// If called *inside* an existing runtime, instantiates `Self` using a handle to that runtime. If
     /// called *outside* any existing runtime, create a new `Runtime` and keep it alive until the
     /// `Self` is dropped.
     fn default() -> Self {

--- a/common/task_executor/src/test_utils.rs
+++ b/common/task_executor/src/test_utils.rs
@@ -1,0 +1,49 @@
+use crate::TaskExecutor;
+use slog::Logger;
+use sloggers::{null::NullLoggerBuilder, Build};
+use std::sync::Arc;
+
+pub struct TestRuntime {
+    pub runtime: Option<Arc<tokio::runtime::Runtime>>,
+    pub _runtime_shutdown: exit_future::Signal,
+    pub task_executor: TaskExecutor,
+    pub log: Logger,
+}
+
+impl Default for TestRuntime {
+    fn default() -> Self {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        let (runtime_shutdown, exit) = exit_future::signal();
+        let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
+        let log = null_logger().unwrap();
+        let task_executor =
+            TaskExecutor::new(Arc::downgrade(&runtime), exit, log.clone(), shutdown_tx);
+
+        Self {
+            runtime: Some(runtime),
+            _runtime_shutdown: runtime_shutdown,
+            task_executor,
+            log,
+        }
+    }
+}
+
+impl Drop for TestRuntime {
+    fn drop(&mut self) {
+        if let Some(runtime) = self.runtime.take() {
+            Arc::try_unwrap(runtime).unwrap().shutdown_background()
+        }
+    }
+}
+
+pub fn null_logger() -> Result<Logger, String> {
+    let log_builder = NullLoggerBuilder;
+    log_builder
+        .build()
+        .map_err(|e| format!("Failed to start null logger: {:?}", e))
+}

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -13,9 +13,7 @@ use futures::channel::mpsc::{channel, Receiver, Sender};
 use futures::{future, StreamExt};
 
 use slog::{error, info, o, warn, Drain, Duplicate, Level, Logger};
-use sloggers::{
-    file::FileLoggerBuilder, null::NullLoggerBuilder, types::Format, types::Severity, Build,
-};
+use sloggers::{file::FileLoggerBuilder, types::Format, types::Severity, Build};
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,6 +30,8 @@ use {
 
 #[cfg(not(target_family = "unix"))]
 use {futures::channel::oneshot, std::cell::RefCell};
+
+pub use task_executor::test_utils::null_logger;
 
 const LOG_CHANNEL_SIZE: usize = 2048;
 /// The maximum time in seconds the client will wait for all internal tasks to shutdown.
@@ -504,13 +504,6 @@ impl<E: EthSpec> Environment<E> {
     pub fn eth2_config(&self) -> &Eth2Config {
         &self.eth2_config
     }
-}
-
-pub fn null_logger() -> Result<Logger, String> {
-    let log_builder = NullLoggerBuilder;
-    log_builder
-        .build()
-        .map_err(|e| format!("Failed to start null logger: {:?}", e))
 }
 
 #[cfg(target_family = "unix")]

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -316,7 +316,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         Ok(api_types::GenericResponse::from(response))
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "TaskExecutor shutdown".into(),
+                            "Lighthouse shutting down".into(),
                         ))
                     }
                 })
@@ -362,7 +362,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         Ok(api_types::GenericResponse::from(validators))
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "TaskExecutor shutdown".into(),
+                            "Lighthouse shutting down".into(),
                         ))
                     }
                 })
@@ -433,7 +433,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 })?
                         } else {
                             return Err(warp_utils::reject::custom_server_error(
-                                "TaskExecutor shutdown".into(),
+                                "Lighthouse shutting down".into(),
                             ));
                         }
                     };
@@ -485,7 +485,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         Ok(())
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "TaskExecutor shutdown".into(),
+                            "Lighthouse shutting down".into(),
                         ))
                     }
                 })
@@ -533,7 +533,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 Ok(())
                             } else {
                                 Err(warp_utils::reject::custom_server_error(
-                                    "TaskExecutor shutdown".into(),
+                                    "Lighthouse shutting down".into(),
                                 ))
                             }
                         }

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -22,8 +22,8 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
-use std::sync::{Arc, Weak};
-use tokio::runtime::Runtime;
+use std::sync::Arc;
+use task_executor::TaskExecutor;
 use types::{ChainSpec, ConfigAndPreset, EthSpec};
 use validator_dir::Builder as ValidatorDirBuilder;
 use warp::{
@@ -59,7 +59,7 @@ impl From<String> for Error {
 ///
 /// The server will gracefully handle the case where any fields are `None`.
 pub struct Context<T: SlotClock, E: EthSpec> {
-    pub runtime: Weak<Runtime>,
+    pub task_executor: TaskExecutor,
     pub api_secret: ApiSecret,
     pub validator_store: Option<Arc<ValidatorStore<T, E>>>,
     pub validator_dir: Option<PathBuf>,
@@ -161,8 +161,8 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
             })
         });
 
-    let inner_runtime = ctx.runtime.clone();
-    let runtime_filter = warp::any().map(move || inner_runtime.clone());
+    let inner_task_executor = ctx.task_executor.clone();
+    let task_executor_filter = warp::any().map(move || inner_task_executor.clone());
 
     let inner_validator_dir = ctx.validator_dir.clone();
     let validator_dir_filter = warp::any()
@@ -290,18 +290,18 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(validator_store_filter.clone())
         .and(spec_filter.clone())
         .and(signer.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and_then(
             |body: Vec<api_types::ValidatorRequest>,
              validator_dir: PathBuf,
              validator_store: Arc<ValidatorStore<T, E>>,
              spec: Arc<ChainSpec>,
              signer,
-             runtime: Weak<Runtime>| {
+             task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
-                    if let Some(runtime) = runtime.upgrade() {
+                    if let Some(handle) = task_executor.handle() {
                         let (validators, mnemonic) =
-                            runtime.block_on(create_validators_mnemonic(
+                            handle.block_on(create_validators_mnemonic(
                                 None,
                                 None,
                                 &body,
@@ -316,7 +316,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         Ok(api_types::GenericResponse::from(response))
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "Runtime shutdown".into(),
+                            "TaskExecutor shutdown".into(),
                         ))
                     }
                 })
@@ -333,16 +333,16 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(validator_store_filter.clone())
         .and(spec_filter)
         .and(signer.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and_then(
             |body: api_types::CreateValidatorsMnemonicRequest,
              validator_dir: PathBuf,
              validator_store: Arc<ValidatorStore<T, E>>,
              spec: Arc<ChainSpec>,
              signer,
-             runtime: Weak<Runtime>| {
+             task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
-                    if let Some(runtime) = runtime.upgrade() {
+                    if let Some(handle) = task_executor.handle() {
                         let mnemonic =
                             mnemonic_from_phrase(body.mnemonic.as_str()).map_err(|e| {
                                 warp_utils::reject::custom_bad_request(format!(
@@ -351,7 +351,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 ))
                             })?;
                         let (validators, _mnemonic) =
-                            runtime.block_on(create_validators_mnemonic(
+                            handle.block_on(create_validators_mnemonic(
                                 Some(mnemonic),
                                 Some(body.key_derivation_path_offset),
                                 &body.validators,
@@ -362,7 +362,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         Ok(api_types::GenericResponse::from(validators))
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "Runtime shutdown".into(),
+                            "TaskExecutor shutdown".into(),
                         ))
                     }
                 })
@@ -378,13 +378,13 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(validator_dir_filter.clone())
         .and(validator_store_filter.clone())
         .and(signer.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and_then(
             |body: api_types::KeystoreValidatorsPostRequest,
              validator_dir: PathBuf,
              validator_store: Arc<ValidatorStore<T, E>>,
              signer,
-             runtime: Weak<Runtime>| {
+             task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
                     // Check to ensure the password is correct.
                     let keypair = body
@@ -416,8 +416,8 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     let suggested_fee_recipient = body.suggested_fee_recipient;
 
                     let validator_def = {
-                        if let Some(runtime) = runtime.upgrade() {
-                            runtime
+                        if let Some(handle) = task_executor.handle() {
+                            handle
                                 .block_on(validator_store.add_validator_keystore(
                                     voting_keystore_path,
                                     voting_password,
@@ -433,7 +433,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 })?
                         } else {
                             return Err(warp_utils::reject::custom_server_error(
-                                "Runtime shutdown".into(),
+                                "TaskExecutor shutdown".into(),
                             ));
                         }
                     };
@@ -455,14 +455,14 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(validator_store_filter.clone())
         .and(signer.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and_then(
             |body: Vec<api_types::Web3SignerValidatorRequest>,
              validator_store: Arc<ValidatorStore<T, E>>,
              signer,
-             runtime: Weak<Runtime>| {
+             task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
-                    if let Some(runtime) = runtime.upgrade() {
+                    if let Some(handle) = task_executor.handle() {
                         let web3signers: Vec<ValidatorDefinition> = body
                             .into_iter()
                             .map(|web3signer| ValidatorDefinition {
@@ -478,14 +478,14 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 },
                             })
                             .collect();
-                        runtime.block_on(create_validators_web3signer(
+                        handle.block_on(create_validators_web3signer(
                             web3signers,
                             &validator_store,
                         ))?;
                         Ok(())
                     } else {
                         Err(warp_utils::reject::custom_server_error(
-                            "Runtime shutdown".into(),
+                            "TaskExecutor shutdown".into(),
                         ))
                     }
                 })
@@ -500,13 +500,13 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(validator_store_filter.clone())
         .and(signer.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and_then(
             |validator_pubkey: PublicKey,
              body: api_types::ValidatorPatchRequest,
              validator_store: Arc<ValidatorStore<T, E>>,
              signer,
-             runtime: Weak<Runtime>| {
+             task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
                     let initialized_validators_rw_lock = validator_store.initialized_validators();
                     let mut initialized_validators = initialized_validators_rw_lock.write();
@@ -518,8 +518,8 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         ))),
                         Some(enabled) if enabled == body.enabled => Ok(()),
                         Some(_) => {
-                            if let Some(runtime) = runtime.upgrade() {
-                                runtime
+                            if let Some(handle) = task_executor.handle() {
+                                handle
                                     .block_on(
                                         initialized_validators
                                             .set_validator_status(&validator_pubkey, body.enabled),
@@ -533,7 +533,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 Ok(())
                             } else {
                                 Err(warp_utils::reject::custom_server_error(
-                                    "Runtime shutdown".into(),
+                                    "TaskExecutor shutdown".into(),
                                 ))
                             }
                         }
@@ -574,12 +574,12 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(signer.clone())
         .and(validator_dir_filter)
         .and(validator_store_filter.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and(log_filter.clone())
         .and_then(
-            |request, signer, validator_dir, validator_store, runtime, log| {
+            |request, signer, validator_dir, validator_store, task_executor, log| {
                 blocking_signed_json_task(signer, move || {
-                    keystores::import(request, validator_dir, validator_store, runtime, log)
+                    keystores::import(request, validator_dir, validator_store, task_executor, log)
                 })
             },
         );
@@ -589,11 +589,11 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(signer.clone())
         .and(validator_store_filter.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and(log_filter.clone())
-        .and_then(|request, signer, validator_store, runtime, log| {
+        .and_then(|request, signer, validator_store, task_executor, log| {
             blocking_signed_json_task(signer, move || {
-                keystores::delete(request, validator_store, runtime, log)
+                keystores::delete(request, validator_store, task_executor, log)
             })
         });
 
@@ -610,11 +610,11 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(signer.clone())
         .and(validator_store_filter.clone())
-        .and(runtime_filter.clone())
+        .and(task_executor_filter.clone())
         .and(log_filter.clone())
-        .and_then(|request, signer, validator_store, runtime, log| {
+        .and_then(|request, signer, validator_store, task_executor, log| {
             blocking_signed_json_task(signer, move || {
-                remotekeys::import(request, validator_store, runtime, log)
+                remotekeys::import(request, validator_store, task_executor, log)
             })
         });
 
@@ -623,11 +623,11 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(signer)
         .and(validator_store_filter)
-        .and(runtime_filter)
+        .and(task_executor_filter)
         .and(log_filter.clone())
-        .and_then(|request, signer, validator_store, runtime, log| {
+        .and_then(|request, signer, validator_store, task_executor, log| {
             blocking_signed_json_task(signer, move || {
-                remotekeys::delete(request, validator_store, runtime, log)
+                remotekeys::delete(request, validator_store, task_executor, log)
             })
         });
 

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -102,7 +102,7 @@ impl ApiTester {
             spec,
             Some(Arc::new(DoppelgangerService::new(log.clone()))),
             slot_clock,
-            executor,
+            executor.clone(),
             log.clone(),
         ));
 
@@ -113,7 +113,7 @@ impl ApiTester {
         let initialized_validators = validator_store.initialized_validators();
 
         let context = Arc::new(Context {
-            runtime,
+            task_executor: executor,
             api_secret,
             validator_dir: Some(validator_dir.path().into()),
             validator_store: Some(validator_store.clone()),

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -498,7 +498,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
 
         self.http_api_listen_addr = if self.config.http_api.enabled {
             let ctx = Arc::new(http_api::Context {
-                runtime: self.context.executor.runtime(),
+                task_executor: self.context.executor.clone(),
                 api_secret,
                 validator_store: Some(self.validator_store.clone()),
                 validator_dir: Some(self.config.validator_dir.clone()),


### PR DESCRIPTION
# Description

Since the `TaskExecutor` currently requires a `Weak<Runtime>`, it's impossible to use it in an async test where the `Runtime` is created outside our scope. Whilst we *could* create a new `Runtime` instance inside the async test, dropping that `Runtime` would cause a panic (you can't drop a `Runtime` in an async context).

To address this issue, this PR creates the `enum Handle`, which supports either:

- A `Weak<Runtime>` (for use in our production code)
- A `Handle` to a runtime (for use in testing)

In theory, there should be no change to the behaviour of our production code (beyond some slightly different descriptions in HTTP 500 errors), or even our tests. If there is no change, you might ask *"why bother?"*. There are two PRs (#3070 and #3175) that are waiting on these fixes to introduce some new tests. Since we've added the EL to the `BeaconChain` (for the merge), we are now doing more async stuff in tests.

I've also added a `RuntimeExecutor` to the `BeaconChainTestHarness`. Whilst that's not immediately useful, it will become useful in the near future with all the new async testing.