### PR TITLE
[Merged by Bors] - Tiny improvement: PeerManager and maximum discovery query

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -841,21 +841,14 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             let outbound_only_peer_count = self.network_globals.connected_outbound_only_peers();
             let wanted_peers = if peer_count < self.target_peers.saturating_sub(dialing_peers) {
                 // We need more peers in general.
-                // The maximum discovery query is for 16 peers, but we can search for less if
-                // needed.
-                std::cmp::min(
-                    self.target_peers.saturating_sub(dialing_peers) - peer_count,
-                    16,
-                )
+                // Note: The maximum discovery query is bounded by `Discovery`.
+                self.target_peers.saturating_sub(dialing_peers) - peer_count
             } else if outbound_only_peer_count < self.min_outbound_only_peers()
                 && peer_count < self.max_outbound_dialing_peers()
             {
-                std::cmp::min(
-                    self.max_outbound_dialing_peers()
-                        .saturating_sub(dialing_peers)
-                        - peer_count,
-                    16,
-                )
+                self.max_outbound_dialing_peers()
+                    .saturating_sub(dialing_peers)
+                    - peer_count
             } else {
                 0
             };


### PR DESCRIPTION
## Issue Addressed

As [`Discovery` bounds the maximum discovery query](https://github.com/sigp/lighthouse/blob/e88b18be09c8bb00ae81d76d8d125e156b3f02c4/beacon_node/lighthouse_network/src/discovery/mod.rs#L328), `PeerManager` no need to handle it.

https://github.com/sigp/lighthouse/blob/e88b18be09c8bb00ae81d76d8d125e156b3f02c4/beacon_node/lighthouse_network/src/discovery/mod.rs#L328

