### PR TITLE
[Merged by Bors] - Prevent attestation to future blocks from early attester cache

### DIFF
--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -104,6 +104,10 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
             return Ok(None);
         }
 
+        if request_slot < item.block.slot() {
+            return Ok(None);
+        }
+
         let committee_count = item
             .committee_lengths
             .get_committee_count_per_slot::<E>(spec)?;


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Prevents the early attester cache from producing attestations to future blocks. This bug could result in a missed head vote if the BN was requested to produce an attestation for an earlier slot than the head block during the (usually) short window of time between verifying a block and setting it as the head.

This bug was noticed noticed by @infosecual and the EF Security Research team via an [Antithesis](https://andreagrieser.com/) test and diagnosed by @realbigsean. 

## Additional Info

NA
