### PR TITLE
[Merged by Bors] - Add new VC metrics for beacon node availability

### DIFF
--- a/validator_client/src/http_metrics/metrics.rs
+++ b/validator_client/src/http_metrics/metrics.rs
@@ -131,6 +131,22 @@ lazy_static::lazy_static! {
         &["endpoint"]
     );
 
+    /*
+    * Beacon node availability metrics
+    */
+    pub static ref AVAILABLE_BEACON_NODES_COUNT: Result<IntGauge> = try_create_int_gauge(
+        "vc_beacon_nodes_available_count",
+        "Number of available beacon nodes",
+    );
+    pub static ref SYNCED_BEACON_NODES_COUNT: Result<IntGauge> = try_create_int_gauge(
+        "vc_beacon_nodes_synced_count",
+        "Number of synced beacon nodes",
+    );
+    pub static ref TOTAL_BEACON_NODES_COUNT: Result<IntGauge> = try_create_int_gauge(
+        "vc_beacon_nodes_total_count",
+        "Total number of beacon nodes",
+    );
+
     pub static ref ETH2_FALLBACK_CONFIGURED: Result<IntGauge> = try_create_int_gauge(
         "sync_eth2_fallback_configured",
         "The number of configured eth2 fallbacks",

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -306,8 +306,18 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             &http_metrics::metrics::ETH2_FALLBACK_CONFIGURED,
             num_nodes.saturating_sub(1) as i64,
         );
-        // Initialize the number of connected, synced fallbacks to 0.
+        // Set the total beacon node count.
+        set_gauge(
+            &http_metrics::metrics::TOTAL_BEACON_NODES_COUNT,
+            num_nodes as i64,
+        );
+
+        // Initialize the number of connected, synced beacon nodes to 0.
         set_gauge(&http_metrics::metrics::ETH2_FALLBACK_CONNECTED, 0);
+        set_gauge(&http_metrics::metrics::SYNCED_BEACON_NODES_COUNT, 0);
+        // Initialize the number of connected, avaliable beacon nodes to 0.
+        set_gauge(&http_metrics::metrics::AVAILABLE_BEACON_NODES_COUNT, 0);
+
         let mut beacon_nodes: BeaconNodeFallback<_, T> =
             BeaconNodeFallback::new(candidates, context.eth2_config.spec.clone(), log.clone());
 

--- a/validator_client/src/notifier.rs
+++ b/validator_client/src/notifier.rs
@@ -40,8 +40,20 @@ async fn notify<T: SlotClock + 'static, E: EthSpec>(
     log: &Logger,
 ) {
     let num_available = duties_service.beacon_nodes.num_available().await;
+    set_gauge(
+        &http_metrics::metrics::AVAILABLE_BEACON_NODES_COUNT,
+        num_available as i64,
+    );
     let num_synced = duties_service.beacon_nodes.num_synced().await;
+    set_gauge(
+        &http_metrics::metrics::SYNCED_BEACON_NODES_COUNT,
+        num_synced as i64,
+    );
     let num_total = duties_service.beacon_nodes.num_total();
+    set_gauge(
+        &http_metrics::metrics::TOTAL_BEACON_NODES_COUNT,
+        num_total as i64,
+    );
     if num_synced > 0 {
         info!(
             log,


### PR DESCRIPTION
## Issue Addressed

#3154 

## Proposed Changes

Add three new metrics for the VC:
1. `vc_beacon_nodes_synced_count`
2. `vc_beacon_nodes_available_count`
3. `vc_beacon_nodes_total_count`

Their values mirror the values present in the following log line:
```
Apr 08 17:25:17.000 INFO Connected to beacon node(s) synced: 4, available: 4, total: 4, service: notifier
```
