### PR TITLE
[Merged by Bors] - Call per_slot_task from a blocking thread (v2)

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4405,6 +4405,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Called by the timer on every slot.
+    ///
+    /// Note: this function **should** be called from a non-async context since
+    /// it contains a call to `fork_choice` which may eventually call
+    /// `tokio::runtime::block_on` in certain cases.
     pub fn per_slot_task(self: &Arc<Self>) {
         trace!(self.log, "Running beacon chain per slot tasks");
         if let Some(slot) = self.slot_clock.now() {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4406,7 +4406,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Called by the timer on every slot.
     ///
-    /// Note: this function **should** be called from a non-async context since
+    /// Note: this function **MUST** be called from a non-async context since
     /// it contains a call to `fork_choice` which may eventually call
     /// `tokio::runtime::block_on` in certain cases.
     pub fn per_slot_task(self: &Arc<Self>) {

--- a/beacon_node/timer/src/lib.rs
+++ b/beacon_node/timer/src/lib.rs
@@ -3,7 +3,7 @@
 //! This service allows task execution on the beacon node for various functionality.
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
-use slog::info;
+use slog::{debug, error, info};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -26,10 +26,28 @@ pub fn spawn_timer<T: BeaconChainTypes>(
     let mut interval = interval_at(start_instant, Duration::from_secs(seconds_per_slot));
     let per_slot_executor = executor.clone();
     let timer_future = async move {
+        let log = per_slot_executor.log().clone();
         loop {
             interval.tick().await;
             let chain = beacon_chain.clone();
-            per_slot_executor.spawn_blocking(move || chain.per_slot_task(), "timer_per_slot_task");
+            if let Some(handle) = per_slot_executor
+                .spawn_blocking_handle(move || chain.per_slot_task(), "timer_per_slot_task")
+            {
+                if let Err(e) = handle.await {
+                    error!(
+                        log,
+                        "Per slot task failed";
+                        "info" => ?e
+                    );
+                }
+            } else {
+                debug!(
+                    log,
+                    "Per slot task timer stopped";
+                    "info" => "shutting down"
+                );
+                break;
+            }
         }
     };
 

--- a/beacon_node/timer/src/lib.rs
+++ b/beacon_node/timer/src/lib.rs
@@ -3,7 +3,7 @@
 //! This service allows task execution on the beacon node for various functionality.
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
-use slog::{debug, error, info};
+use slog::{debug, info, warn};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use std::time::Duration;
@@ -34,7 +34,7 @@ pub fn spawn_timer<T: BeaconChainTypes>(
                 .spawn_blocking_handle(move || chain.per_slot_task(), "timer_per_slot_task")
             {
                 if let Err(e) = handle.await {
-                    error!(
+                    warn!(
                         log,
                         "Per slot task failed";
                         "info" => ?e

--- a/beacon_node/timer/src/lib.rs
+++ b/beacon_node/timer/src/lib.rs
@@ -24,10 +24,12 @@ pub fn spawn_timer<T: BeaconChainTypes>(
 
     // Warning: `interval_at` panics if `seconds_per_slot` = 0.
     let mut interval = interval_at(start_instant, Duration::from_secs(seconds_per_slot));
+    let per_slot_executor = executor.clone();
     let timer_future = async move {
         loop {
             interval.tick().await;
-            beacon_chain.per_slot_task();
+            let chain = beacon_chain.clone();
+            per_slot_executor.spawn_blocking(move || chain.per_slot_task(), "timer_per_slot_task");
         }
     };
 


### PR DESCRIPTION
*This PR was adapted from @pawanjay176's work in #3197.*

## Issue Addressed

Fixes a regression in https://github.com/sigp/lighthouse/pull/3168

## Proposed Changes

https://github.com/sigp/lighthouse/pull/3168 added calls to `fork_choice` in  `BeaconChain::per_slot_task` function. This leads to a panic as `per_slot_task` is called from an async context which calls fork choice, which then calls `block_on`.

This PR changes the timer to call the `per_slot_task` function in a blocking thread.