### PR TITLE
[Merged by Bors] - Decrease proposer boost to 40%

### DIFF
--- a/common/eth2_network_config/built_in_network_configs/gnosis/config.yaml
+++ b/common/eth2_network_config/built_in_network_configs/gnosis/config.yaml
@@ -74,8 +74,8 @@ CHURN_LIMIT_QUOTIENT: 4096
 
 # Fork choice
 # ---------------------------------------------------------------
-# 70%
-PROPOSER_SCORE_BOOST: 70
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 # Deposit contract
 # ---------------------------------------------------------------

--- a/common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
+++ b/common/eth2_network_config/built_in_network_configs/mainnet/config.yaml
@@ -74,8 +74,8 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Fork choice
 # ---------------------------------------------------------------
-# 70%
-PROPOSER_SCORE_BOOST: 70
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 # Deposit contract
 # ---------------------------------------------------------------

--- a/common/eth2_network_config/built_in_network_configs/prater/config.yaml
+++ b/common/eth2_network_config/built_in_network_configs/prater/config.yaml
@@ -74,8 +74,8 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Fork choice
 # ---------------------------------------------------------------
-# 70%
-PROPOSER_SCORE_BOOST: 70
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 # Deposit contract
 # ---------------------------------------------------------------

--- a/common/eth2_network_config/built_in_network_configs/ropsten/config.yaml
+++ b/common/eth2_network_config/built_in_network_configs/ropsten/config.yaml
@@ -59,6 +59,11 @@ MIN_PER_EPOCH_CHURN_LIMIT: 4
 CHURN_LIMIT_QUOTIENT: 65536
 
 
+# Fork choice
+# ---------------------------------------------------------------
+# 40%
+PROPOSER_SCORE_BOOST: 40
+
 # Deposit contract
 # ---------------------------------------------------------------
 DEPOSIT_CHAIN_ID: 3

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -500,7 +500,7 @@ impl ChainSpec {
              * Fork choice
              */
             safe_slots_to_update_justified: 8,
-            proposer_score_boost: Some(70),
+            proposer_score_boost: Some(40),
 
             /*
              * Eth1
@@ -698,7 +698,7 @@ impl ChainSpec {
              * Fork choice
              */
             safe_slots_to_update_justified: 8,
-            proposer_score_boost: Some(70),
+            proposer_score_boost: Some(40),
 
             /*
              * Eth1
@@ -1261,7 +1261,7 @@ mod yaml_tests {
         EJECTION_BALANCE: 16000000000
         MIN_PER_EPOCH_CHURN_LIMIT: 4
         CHURN_LIMIT_QUOTIENT: 65536
-        PROPOSER_SCORE_BOOST: 70
+        PROPOSER_SCORE_BOOST: 40
         DEPOSIT_CHAIN_ID: 1
         DEPOSIT_NETWORK_ID: 1
         DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cBB839Cbe05303d7705Fa

--- a/lighthouse/environment/tests/testnet_dir/config.yaml
+++ b/lighthouse/environment/tests/testnet_dir/config.yaml
@@ -72,8 +72,8 @@ CHURN_LIMIT_QUOTIENT: 65536
 
 # Fork choice
 # ---------------------------------------------------------------
-# 70%
-PROPOSER_SCORE_BOOST: 70
+# 40%
+PROPOSER_SCORE_BOOST: 40
 
 # Deposit contract
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/pull/2895

## Proposed Changes

Lower the proposer boost to 40%, which is a trade-off against different types of attacks.

## Additional Info

This PR also enables proposer boost on Ropsten assuming that this PR will be merged: https://github.com/eth-clients/merge-testnets/pull/10
