### PR TITLE
[Merged by Bors] - Fix links in docs

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -43,6 +43,7 @@
     * [Running a Slasher](./slasher.md)
     * [Redundancy](./redundancy.md)
     * [Pre-Releases](./advanced-pre-releases.md)
+    * [Release Candidates](./advanced-release-candidates.md)
 * [Contributing](./contributing.md)
 	* [Development Environment](./setup.md)
 * [FAQs](./faq.md)

--- a/book/src/advanced-pre-releases.md
+++ b/book/src/advanced-pre-releases.md
@@ -1,4 +1,4 @@
 # Pre-Releases
 
-Pre-releases are now referred to as [Release Candidates][./advanced-pre-releases.md]. The terms may
+Pre-releases are now referred to as [Release Candidates](./advanced-release-candidates.md). The terms may
 be used interchangeably.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Fix the link for `advanced-release-candidates.md` in the lighthouse book and add it to the summary page.