### PR TITLE
[Merged by Bors] - Use genesis slot for node/syncing

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1737,9 +1737,9 @@ pub fn serve<T: BeaconChainTypes>(
                         .head_info()
                         .map(|info| info.slot)
                         .map_err(warp_utils::reject::beacon_chain_error)?;
-                    let current_slot = chain
-                        .slot()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_slot = chain.slot_clock.now_or_genesis().ok_or_else(|| {
+                        warp_utils::reject::custom_server_error("Unable to read slot clock".into())
+                    })?;
 
                     // Taking advantage of saturating subtraction on slot.
                     let sync_distance = current_slot - head_slot;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Resolves this error log emitted from the VC prior to genesis:

```
WARN Unable connect to beacon node           error: ServerMessage(ErrorMessage { code: 500, message: "UNHANDLED_ERROR: UnableToReadSlot", stacktraces: [] })
```

## Additional Info

NA
