### PR TITLE
[Merged by Bors] - Use a stable tag for ubuntu in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG FEATURES
 ENV FEATURES $FEATURES
 RUN cd lighthouse && make
 
-FROM ubuntu:latest
+FROM ubuntu:22.04
 RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,7 +1,7 @@
 # This image is meant to enable cross-architecture builds.
 # It assumes the lighthouse binary has already been
 # compiled for `$TARGETPLATFORM` and moved to `./bin`.
-FROM --platform=$TARGETPLATFORM ubuntu:latest
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libssl-dev \
   ca-certificates \

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -8,6 +8,6 @@ ARG PORTABLE
 ENV PORTABLE $PORTABLE
 RUN cd lighthouse && make install-lcli
 
-FROM ubuntu:latest
+FROM ubuntu:22.04
 RUN apt-get update && apt-get -y upgrade && apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Use stable version of ubuntu base image in dockerfile instead of using latest. This will help in narrowing down issues with docker images.
