### PR TITLE
Add basic cause analysis for delayed head blocks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -133,6 +133,9 @@ const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 4;
 pub const INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON: &str =
     "Justified block has an invalid execution payload.";
 
+/// Interval before the attestation deadline during which to consider blocks "borderline" late.
+const BORDERLINE_LATE_BLOCK_TOLERANCE: Duration = Duration::from_millis(50);
+
 /// Defines the behaviour when a block/block-root for a skipped slot is requested.
 pub enum WhenSlotSkipped {
     /// If the slot is a skip slot, return `None`.
@@ -2944,25 +2947,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             );
         }
 
-        // Do not store metrics if the block was > 4 slots old, this helps prevent noise during
-        // sync.
-        if block_delay_total < self.slot_clock.slot_duration() * 4 {
-            // Observe the delay between when we observed the block and when we imported it.
-            let block_delays = self.block_times_cache.read().get_block_delays(
-                block_root,
-                self.slot_clock
-                    .start_of(current_slot)
-                    .unwrap_or_else(|| Duration::from_secs(0)),
-            );
-
-            metrics::observe_duration(
-                &metrics::BEACON_BLOCK_IMPORTED_OBSERVED_DELAY_TIME,
-                block_delays
-                    .imported
-                    .unwrap_or_else(|| Duration::from_secs(0)),
-            );
-        }
-
         // Inform the unknown block cache, in case it was waiting on this block.
         self.pre_finalization_block_cache
             .block_processed(block_root);
@@ -3706,6 +3690,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 attestable_delay,
             );
             metrics::observe_duration(
+                &metrics::BEACON_BLOCK_IMPORTED_OBSERVED_DELAY_TIME,
+                import_delay,
+            );
+            metrics::observe_duration(
                 &metrics::BEACON_BLOCK_HEAD_IMPORTED_DELAY_TIME,
                 set_as_head_delay,
             );
@@ -3715,11 +3703,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let missed_attestation_deadline = attestable_delay >= attestation_deadline;
             if missed_attestation_deadline {
                 let due_to_late_block = observed_delay >= attestation_deadline;
+                let due_to_borderline_late_block =
+                    observed_delay + BORDERLINE_LATE_BLOCK_TOLERANCE >= attestation_deadline;
                 let due_to_processing = observed_delay + import_delay >= attestation_deadline;
 
                 let reason = if due_to_late_block {
                     metrics::inc_counter(&metrics::BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_LATE);
                     "late block"
+                } else if due_to_borderline_late_block {
+                    metrics::inc_counter(
+                        &metrics::BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_BORDERLINE,
+                    );
+                    "borderline late block"
                 } else if due_to_processing {
                     metrics::inc_counter(&metrics::BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_SLOW);
                     "slow to process"

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -771,7 +771,10 @@ lazy_static! {
         "Number of attester slashings seen",
         &["src", "validator"]
     );
+}
 
+// Fourth lazy-static block is used to account for macro recursion limit.
+lazy_static! {
     /*
      * Block Delay Metrics
      */
@@ -787,14 +790,25 @@ lazy_static! {
         "beacon_block_head_imported_delay_time",
         "Duration between the time the block was imported and the time when it was set as head.",
     );
+    pub static ref BEACON_BLOCK_HEAD_ATTESTABLE_DELAY_TIME: Result<Histogram> = try_create_histogram(
+        "beacon_block_head_attestable_delay_time",
+        "Duration between the start of the slot and the time at which the block could be attested to.",
+    );
     pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_TIME: Result<Histogram> = try_create_histogram(
         "beacon_block_head_slot_start_delay_time",
         "Duration between the start of the block's slot and the time when it was set as head.",
     );
-    pub static ref BEACON_BLOCK_HEAD_SLOT_START_DELAY_EXCEEDED_TOTAL: Result<IntCounter> = try_create_int_counter(
-        "beacon_block_head_slot_start_delay_exceeded_total",
-        "Triggered when the duration between the start of the block's slot and the current time \
-        will result in failed attestations.",
+    pub static ref BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_LATE: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_head_missed_att_deadline_late",
+        "Total number of delayed head blocks that arrived late"
+    );
+    pub static ref BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_SLOW: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_head_missed_att_deadline_slow",
+        "Total number of delayed head blocks that arrived on time but not processed in time"
+    );
+    pub static ref BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_OTHER: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_head_missed_att_deadline_other",
+        "Total number of delayed head blocks that were not late and not slow to process"
     );
 
     /*
@@ -805,10 +819,7 @@ lazy_static! {
             "gossip_beacon_block_skipped_slots",
             "For each gossip blocks, the number of skip slots between it and its parent"
         );
-}
 
-// Fourth lazy-static block is used to account for macro recursion limit.
-lazy_static! {
     /*
      * Sync Committee Message Verification
      */

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -802,6 +802,10 @@ lazy_static! {
         "beacon_block_head_missed_att_deadline_late",
         "Total number of delayed head blocks that arrived late"
     );
+    pub static ref BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_BORDERLINE: Result<IntCounter> = try_create_int_counter(
+        "beacon_block_head_missed_att_deadline_borderline",
+        "Total number of delayed head blocks that arrived very close to the deadline"
+    );
     pub static ref BEACON_BLOCK_HEAD_MISSED_ATT_DEADLINE_SLOW: Result<IntCounter> = try_create_int_counter(
         "beacon_block_head_missed_att_deadline_slow",
         "Total number of delayed head blocks that arrived on time but not processed in time"

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -835,6 +835,7 @@ pub struct SseLateHead {
     pub proposer_graffiti: String,
     pub block_delay: Duration,
     pub observed_delay: Option<Duration>,
+    pub attestable_delay: Option<Duration>,
     pub imported_delay: Option<Duration>,
     pub set_as_head_delay: Option<Duration>,
 }


### PR DESCRIPTION
## Proposed Changes

Add a `reason` field to the `Delayed head block` log to better help us categorise avoidable vs unavoidable attestation misses. The reason can be one of:

- late: if the block arrived on or after the attestation deadline (4s mainnet, 1.66s gnosis)
- borderline: if the block arrived less than 50ms before the attestation deadline (3.95s mainnet, 1.61s gnosis)
- slow: if the block arrived more than 50ms before the attestation deadline, but block processing pushed it over
- other: if the block was enshrined as head after the deadline but arrived on time and was processed quickly (i.e. it became head during a later re-org)

There are also 4 new metrics to count blocks in each of the above categories.

I also modified the block delay timer to be aware of the early attestation cache, so that it only considers a block late if it fails to make it to the cache before the deadline.
