### PR TITLE
[Merged by Bors] - Improve eth1 block cache sync (for Ropsten)

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -1347,11 +1347,10 @@ mod tests {
         let seconds_per_voting_period =
             <MainnetEthSpec as EthSpec>::SlotsPerEth1VotingPeriod::to_u64() * spec.seconds_per_slot;
         let eth1_blocks_per_voting_period = seconds_per_voting_period / spec.seconds_per_eth1_block;
-        let reduce_follow_distance_blocks =
-            config.follow_distance / ETH1_BLOCK_TIME_TOLERANCE_FACTOR;
+        let cache_follow_distance_blocks = config.follow_distance - config.cache_follow_distance();
 
-        let minimum_len = eth1_blocks_per_voting_period * 2 + reduce_follow_distance_blocks;
+        let minimum_len = eth1_blocks_per_voting_period * 2 + cache_follow_distance_blocks;
 
-        assert!(len > minimum_len as usize);
+        assert!(len >= minimum_len as usize);
     }
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -378,6 +378,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("eth1-cache-follow-distance")
+                .long("eth1-cache-follow-distance")
+                .value_name("BLOCKS")
+                .help("Specifies the distance between the Eth1 chain head and the last block which \
+                       should be imported into the cache. Setting this value lower can help \
+                       compensate for irregular Proof-of-Work block times, but setting it too low \
+                       can make the node vulnerable to re-orgs.")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("slots-per-restore-point")
                 .long("slots-per-restore-point")
                 .value_name("SLOT_COUNT")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -16,8 +16,6 @@ use std::str::FromStr;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 use unused_port::{unused_tcp_port, unused_udp_port};
 
-pub const ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE: u64 = 512;
-
 /// Gets the fully-initialized global client.
 ///
 /// The top-level `clap` arguments should be provided as `cli_args`.
@@ -238,6 +236,12 @@ pub fn get_config<E: EthSpec>(
         client_config.eth1.purge_cache = true;
     }
 
+    if let Some(follow_distance) =
+        clap_utils::parse_optional(cli_args, "eth1-cache-follow-distance")?
+    {
+        client_config.eth1.cache_follow_distance = Some(follow_distance);
+    }
+
     if cli_args.is_present("merge") || cli_args.is_present("execution-endpoints") {
         let mut el_config = execution_layer::Config::default();
 
@@ -343,14 +347,6 @@ pub fn get_config<E: EthSpec>(
     client_config.eth1.network_id = spec.deposit_network_id.into();
     client_config.eth1.chain_id = spec.deposit_chain_id.into();
     client_config.eth1.set_block_cache_truncation::<E>(spec);
-
-    if let Some(follow_distance) =
-        clap_utils::parse_optional(cli_args, "eth1-cache-follow-distance")?
-    {
-        client_config.eth1.cache_follow_distance = Some(follow_distance);
-    } else if spec.config_name.as_deref() == Some("ropsten") {
-        client_config.eth1.cache_follow_distance = Some(ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE);
-    }
 
     info!(
         log,

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -16,6 +16,8 @@ use std::str::FromStr;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 use unused_port::{unused_tcp_port, unused_udp_port};
 
+pub const ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE: u64 = 256;
+
 /// Gets the fully-initialized global client.
 ///
 /// The top-level `clap` arguments should be provided as `cli_args`.
@@ -341,6 +343,14 @@ pub fn get_config<E: EthSpec>(
     client_config.eth1.network_id = spec.deposit_network_id.into();
     client_config.eth1.chain_id = spec.deposit_chain_id.into();
     client_config.eth1.set_block_cache_truncation::<E>(spec);
+
+    if let Some(follow_distance) =
+        clap_utils::parse_optional(cli_args, "eth1-cache-follow-distance")?
+    {
+        client_config.eth1.cache_follow_distance = Some(follow_distance);
+    } else if spec.config_name.as_deref() == Some("ropsten") {
+        client_config.eth1.cache_follow_distance = Some(ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE);
+    }
 
     info!(
         log,

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 use unused_port::{unused_tcp_port, unused_udp_port};
 
-pub const ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE: u64 = 256;
+pub const ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE: u64 = 512;
 
 /// Gets the fully-initialized global client.
 ///

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -13,7 +13,10 @@ use beacon_chain::{
 use clap::ArgMatches;
 pub use cli::cli_app;
 pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
-pub use config::{get_config, get_data_dir, get_slots_per_restore_point, set_network_config};
+pub use config::{
+    get_config, get_data_dir, get_slots_per_restore_point, set_network_config,
+    ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE,
+};
 use environment::RuntimeContext;
 pub use eth2_config::Eth2Config;
 use slasher::Slasher;

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -13,10 +13,7 @@ use beacon_chain::{
 use clap::ArgMatches;
 pub use cli::cli_app;
 pub use client::{Client, ClientBuilder, ClientConfig, ClientGenesis};
-pub use config::{
-    get_config, get_data_dir, get_slots_per_restore_point, set_network_config,
-    ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE,
-};
+pub use config::{get_config, get_data_dir, get_slots_per_restore_point, set_network_config};
 use environment::RuntimeContext;
 pub use eth2_config::Eth2Config;
 use slasher::Slasher;

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1,4 +1,4 @@
-use beacon_node::ClientConfig as Config;
+use beacon_node::{ClientConfig as Config, ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE};
 
 use crate::exec::{CommandLineTestExec, CompletedTest};
 use lighthouse_network::PeerId;
@@ -224,6 +224,41 @@ fn eth1_purge_cache_flag() {
         .flag("eth1-purge-cache", None)
         .run_with_zero_port()
         .with_config(|config| assert!(config.eth1.purge_cache));
+}
+#[test]
+fn eth1_cache_follow_distance_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.eth1.cache_follow_distance, None);
+            assert_eq!(config.eth1.cache_follow_distance(), 3 * 2048 / 4);
+        });
+}
+#[test]
+fn eth1_cache_follow_distance_manual() {
+    CommandLineTest::new()
+        .flag("eth1-cache-follow-distance", Some("128"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.eth1.cache_follow_distance, Some(128));
+            assert_eq!(config.eth1.cache_follow_distance(), 128);
+        });
+}
+#[test]
+fn eth1_cache_follow_distance_ropsten() {
+    CommandLineTest::new()
+        .flag("network", Some("ropsten"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.eth1.cache_follow_distance,
+                Some(ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE)
+            );
+            assert_eq!(
+                config.eth1.cache_follow_distance(),
+                ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE
+            );
+        });
 }
 
 // Tests for Bellatrix flags.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1,4 +1,4 @@
-use beacon_node::{ClientConfig as Config, ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE};
+use beacon_node::ClientConfig as Config;
 
 use crate::exec::{CommandLineTestExec, CompletedTest};
 use lighthouse_network::PeerId;
@@ -242,22 +242,6 @@ fn eth1_cache_follow_distance_manual() {
         .with_config(|config| {
             assert_eq!(config.eth1.cache_follow_distance, Some(128));
             assert_eq!(config.eth1.cache_follow_distance(), 128);
-        });
-}
-#[test]
-fn eth1_cache_follow_distance_ropsten() {
-    CommandLineTest::new()
-        .flag("network", Some("ropsten"))
-        .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(
-                config.eth1.cache_follow_distance,
-                Some(ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE)
-            );
-            assert_eq!(
-                config.eth1.cache_follow_distance(),
-                ROPSTEN_DEFAULT_ETH1_CACHE_FOLLOW_DISTANCE
-            );
         });
 }
 


### PR DESCRIPTION
## Issue Addressed

Fix for the eth1 cache sync issue observed on Ropsten.

## Proposed Changes

Ropsten blocks are so infrequent that they broke our algorithm for downloading eth1 blocks. We currently try to download forwards from the last block in our cache to the block with block number [`remote_highest_block - FOLLOW_DISTANCE + FOLLOW_DISTANCE / ETH1_BLOCK_TIME_TOLERANCE_FACTOR`](https://github.com/sigp/lighthouse/blob/6f732986f1a42bec9f7ef7f57a143836f585a119/beacon_node/eth1/src/service.rs#L489-L492). With the tolerance set to 4 this is insufficient because we lag by 1536 blocks, which is more like ~14 hours on Ropsten. This results in us having an incomplete eth1 cache, because we should cache all blocks between -16h and -8h. Even if we were to set the tolerance to 2 for the largest allowance, we would only look back 1024 blocks which is still more than 8 hours.

For example consider this block https://ropsten.etherscan.io/block/12321390. The block from 1536 blocks earlier is 14 hours and 20 minutes before it: https://ropsten.etherscan.io/block/12319854. The block from 1024 blocks earlier is https://ropsten.etherscan.io/block/12320366, 8 hours and 48 minutes before.

- This PR introduces a new CLI flag called `--eth1-cache-follow-distance` which can be used to set the distance manually.
- A new dynamic catchup mechanism is added which detects when the cache is lagging the true eth1 chain and tries to download more blocks within the follow distance in order to catch up.
