### PR TITLE
[Merged by Bors] - Use async code when interacting with EL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,6 +2062,7 @@ dependencies = [
  "eth2_ssz_derive",
  "proto_array",
  "store",
+ "tokio",
  "types",
 ]
 
@@ -4173,6 +4174,7 @@ dependencies = [
  "serde_derive",
  "state_processing",
  "store",
+ "tokio",
  "types",
 ]
 
@@ -5972,6 +5974,7 @@ dependencies = [
  "rayon",
  "safe_arith",
  "smallvec",
+ "tokio",
  "tree_hash",
  "types",
 ]
@@ -5984,6 +5987,7 @@ dependencies = [
  "eth2_ssz",
  "lazy_static",
  "state_processing",
+ "tokio",
  "types",
 ]
 
@@ -6698,6 +6702,7 @@ dependencies = [
  "swap_or_not_shuffle",
  "tempfile",
  "test_random_derive",
+ "tokio",
  "tree_hash",
  "tree_hash_derive",
 ]

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -976,8 +976,8 @@ fn verify_head_block_is_known<T: BeaconChainTypes>(
     max_skip_slots: Option<u64>,
 ) -> Result<ProtoBlock, Error> {
     let block_opt = chain
-        .fork_choice
-        .read()
+        .canonical_head
+        .fork_choice_read_lock()
         .get_block(&attestation.data.beacon_block_root)
         .or_else(|| {
             chain
@@ -1245,7 +1245,10 @@ where
     // processing an attestation that does not include our latest finalized block in its chain.
     //
     // We do not delay consideration for later, we simply drop the attestation.
-    if !chain.fork_choice.read().contains_block(&target.root)
+    if !chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .contains_block(&target.root)
         && !chain.early_attester_cache.contains_block(target.root)
     {
         return Err(Error::UnknownTargetRoot(target.root));

--- a/beacon_node/beacon_chain/src/attestation_verification/batch.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification/batch.rs
@@ -65,7 +65,7 @@ where
             .try_read_for(VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT)
             .ok_or(BeaconChainError::ValidatorPubkeyCacheLockTimeout)?;
 
-        let fork = chain.with_head(|head| Ok::<_, BeaconChainError>(head.beacon_state.fork()))?;
+        let fork = chain.canonical_head.cached_head().head_fork();
 
         let mut signature_sets = Vec::with_capacity(num_indexed * 3);
 
@@ -169,12 +169,12 @@ where
             &metrics::ATTESTATION_PROCESSING_BATCH_UNAGG_SIGNATURE_SETUP_TIMES,
         );
 
+        let fork = chain.canonical_head.cached_head().head_fork();
+
         let pubkey_cache = chain
             .validator_pubkey_cache
             .try_read_for(VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT)
             .ok_or(BeaconChainError::ValidatorPubkeyCacheLockTimeout)?;
-
-        let fork = chain.with_head(|head| Ok::<_, BeaconChainError>(head.beacon_state.fork()))?;
 
         let mut signature_sets = Vec::with_capacity(num_partially_verified);
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -9,15 +9,15 @@ use crate::beacon_proposer_cache::BeaconProposerCache;
 use crate::block_times_cache::BlockTimesCache;
 use crate::block_verification::{
     check_block_is_finalized_descendant, check_block_relevancy, get_block_root,
-    signature_verify_chain_segment, BlockError, FullyVerifiedBlock, GossipVerifiedBlock,
-    IntoFullyVerifiedBlock,
+    signature_verify_chain_segment, BlockError, ExecutionPendingBlock, GossipVerifiedBlock,
+    IntoExecutionPendingBlock, PayloadVerificationOutcome, POS_PANDA_BANNER,
 };
 use crate::chain_config::ChainConfig;
 use crate::early_attester_cache::EarlyAttesterCache;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::eth1_chain::{Eth1Chain, Eth1ChainBackend};
 use crate::events::ServerSentEventHandler;
-use crate::execution_payload::get_execution_payload;
+use crate::execution_payload::{get_execution_payload, PreparePayloadHandle};
 use crate::fork_choice_signal::{ForkChoiceSignalRx, ForkChoiceSignalTx, ForkChoiceWaitResult};
 use crate::head_tracker::HeadTracker;
 use crate::historical_blocks::HistoricalBlockError;
@@ -52,17 +52,17 @@ use crate::validator_pubkey_cache::ValidatorPubkeyCache;
 use crate::BeaconForkChoiceStore;
 use crate::BeaconSnapshot;
 use crate::{metrics, BeaconChainError};
-use eth2::types::{
-    EventKind, SseBlock, SseChainReorg, SseFinalizedCheckpoint, SseHead, SseLateHead, SyncDuty,
-};
+use eth2::types::{EventKind, SseBlock, SyncDuty};
 use execution_layer::{ExecutionLayer, PayloadAttributes, PayloadStatus};
-use fork_choice::{AttestationFromBlock, ForkChoice, InvalidationOperation};
+use fork_choice::{
+    AttestationFromBlock, ExecutionStatus, ForkChoice, ForkchoiceUpdateParameters,
+    InvalidationOperation, PayloadVerificationStatus,
+};
 use futures::channel::mpsc::Sender;
 use itertools::process_results;
 use itertools::Itertools;
 use operation_pool::{OperationPool, PersistedOperationPool};
 use parking_lot::{Mutex, RwLock};
-use proto_array::ExecutionStatus;
 use safe_arith::SafeArith;
 use slasher::Slasher;
 use slog::{crit, debug, error, info, trace, warn, Logger};
@@ -71,7 +71,7 @@ use ssz::Encode;
 use state_processing::{
     common::get_indexed_attestation,
     per_block_processing,
-    per_block_processing::{errors::AttestationValidationError, is_merge_transition_complete},
+    per_block_processing::errors::AttestationValidationError,
     per_slot_processing,
     state_advance::{complete_state_advance, partial_state_advance},
     BlockSignatureStrategy, SigVerifiedOp, VerifyBlockRoot,
@@ -87,16 +87,17 @@ use store::iter::{BlockRootsIterator, ParentRootBlockIterator, StateRootsIterato
 use store::{
     DatabaseBlock, Error as DBError, HotColdDB, KeyValueStore, KeyValueStoreOp, StoreItem, StoreOp,
 };
-use task_executor::ShutdownReason;
+use task_executor::{ShutdownReason, TaskExecutor};
 use tree_hash::TreeHash;
 use types::beacon_state::CloneConfig;
 use types::*;
 
+pub use crate::canonical_head::{CanonicalHead, CanonicalHeadRwLock};
+
 pub type ForkChoiceError = fork_choice::Error<crate::ForkChoiceStoreError>;
 
-/// The time-out before failure during an operation to take a read/write RwLock on the canonical
-/// head.
-pub const HEAD_LOCK_TIMEOUT: Duration = Duration::from_secs(1);
+/// Alias to appease clippy.
+type HashBlockTuple<E> = (Hash256, Arc<SignedBeaconBlock<E>>);
 
 /// The time-out before failure during an operation to take a read/write RwLock on the block
 /// processing cache.
@@ -216,22 +217,6 @@ pub enum StateSkipConfig {
     WithoutStateRoots,
 }
 
-#[derive(Debug, PartialEq)]
-pub struct HeadInfo {
-    pub slot: Slot,
-    pub block_root: Hash256,
-    pub state_root: Hash256,
-    pub current_justified_checkpoint: types::Checkpoint,
-    pub finalized_checkpoint: types::Checkpoint,
-    pub fork: Fork,
-    pub genesis_time: u64,
-    pub genesis_validators_root: Hash256,
-    pub proposer_shuffling_decision_root: Hash256,
-    pub is_merge_transition_complete: bool,
-    pub execution_payload_block_hash: Option<ExecutionBlockHash>,
-    pub random: Hash256,
-}
-
 pub trait BeaconChainTypes: Send + Sync + 'static {
     type HotStore: store::ItemStore<Self::EthSpec>;
     type ColdStore: store::ItemStore<Self::EthSpec>;
@@ -240,23 +225,22 @@ pub trait BeaconChainTypes: Send + Sync + 'static {
     type EthSpec: types::EthSpec;
 }
 
-/// Indicates the EL payload verification status of the head beacon block.
-#[derive(Debug, PartialEq)]
-pub enum HeadSafetyStatus {
-    /// The head block has either been verified by an EL or is does not require EL verification
-    /// (e.g., it is pre-merge or pre-terminal-block).
-    ///
-    /// If the block is post-terminal-block, `Some(execution_payload.block_hash)` is included with
-    /// the variant.
-    Safe(Option<ExecutionBlockHash>),
-    /// The head block execution payload has not yet been verified by an EL.
-    ///
-    /// The `execution_payload.block_hash` of the head block is returned.
-    Unsafe(ExecutionBlockHash),
-    /// The head block execution payload was deemed to be invalid by an EL.
-    ///
-    /// The `execution_payload.block_hash` of the head block is returned.
-    Invalid(ExecutionBlockHash),
+/// Used internally to split block production into discrete functions.
+struct PartialBeaconBlock<E: EthSpec, Payload> {
+    state: BeaconState<E>,
+    slot: Slot,
+    proposer_index: u64,
+    parent_root: Hash256,
+    randao_reveal: Signature,
+    eth1_data: Eth1Data,
+    graffiti: Graffiti,
+    proposer_slashings: Vec<ProposerSlashing>,
+    attester_slashings: Vec<AttesterSlashing<E>>,
+    attestations: Vec<Attestation<E>>,
+    deposits: Vec<Deposit>,
+    voluntary_exits: Vec<SignedVoluntaryExit>,
+    sync_aggregate: Option<SyncAggregate<E>>,
+    prepare_payload_handle: Option<PreparePayloadHandle<Payload>>,
 }
 
 pub type BeaconForkChoice<T> = ForkChoice<
@@ -284,6 +268,8 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub config: ChainConfig,
     /// Persistent storage for blocks, states, etc. Typically an on-disk store, such as LevelDB.
     pub store: BeaconStore<T>,
+    /// Used for spawning async and blocking tasks.
+    pub task_executor: TaskExecutor,
     /// Database migrator for running background maintenance on the store.
     pub store_migrator: BackgroundMigrator<T::EthSpec, T::HotStore, T::ColdStore>,
     /// Reports the current slot, typically based upon the system clock.
@@ -335,21 +321,21 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub eth1_chain: Option<Eth1Chain<T::Eth1Chain, T::EthSpec>>,
     /// Interfaces with the execution client.
     pub execution_layer: Option<ExecutionLayer<T::EthSpec>>,
-    /// Stores a "snapshot" of the chain at the time the head-of-the-chain block was received.
-    pub(crate) canonical_head: TimeoutRwLock<BeaconSnapshot<T::EthSpec>>,
+    /// Stores information about the canonical head and finalized/justified checkpoints of the
+    /// chain. Also contains the fork choice struct, for computing the canonical head.
+    pub canonical_head: CanonicalHead<T>,
     /// The root of the genesis block.
     pub genesis_block_root: Hash256,
     /// The root of the genesis state.
     pub genesis_state_root: Hash256,
     /// The root of the list of genesis validators, used during syncing.
     pub genesis_validators_root: Hash256,
-    /// A state-machine that is updated with information from the network and chooses a canonical
-    /// head block.
-    pub fork_choice: RwLock<BeaconForkChoice<T>>,
     /// Transmitter used to indicate that slot-start fork choice has completed running.
     pub fork_choice_signal_tx: Option<ForkChoiceSignalTx>,
     /// Receiver used by block production to wait on slot-start fork choice.
     pub fork_choice_signal_rx: Option<ForkChoiceSignalRx>,
+    /// The genesis time of this `BeaconChain` (seconds since UNIX epoch).
+    pub genesis_time: u64,
     /// A handler for events generated by the beacon chain. This is only initialized when the
     /// HTTP server is enabled.
     pub event_handler: Option<ServerSentEventHandler<T::EthSpec>>,
@@ -358,7 +344,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache dedicated to block processing.
     pub(crate) snapshot_cache: TimeoutRwLock<SnapshotCache<T::EthSpec>>,
     /// Caches the attester shuffling for a given epoch and shuffling key root.
-    pub(crate) shuffling_cache: TimeoutRwLock<ShufflingCache>,
+    pub shuffling_cache: TimeoutRwLock<ShufflingCache>,
     /// Caches the beacon block proposer shuffling for a given epoch and shuffling key root.
     pub beacon_proposer_cache: Mutex<BeaconProposerCache>,
     /// Caches a map of `validator_index -> validator_pubkey`.
@@ -430,25 +416,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .as_kv_store_op(BEACON_CHAIN_DB_KEY)
     }
 
-    /// Return a database operation for writing fork choice to disk.
-    pub fn persist_fork_choice_in_batch(&self) -> KeyValueStoreOp {
-        let fork_choice = self.fork_choice.read();
-        Self::persist_fork_choice_in_batch_standalone(&fork_choice)
-    }
-
-    /// Return a database operation for writing fork choice to disk.
-    pub fn persist_fork_choice_in_batch_standalone(
-        fork_choice: &BeaconForkChoice<T>,
-    ) -> KeyValueStoreOp {
-        let persisted_fork_choice = PersistedForkChoice {
-            fork_choice: fork_choice.to_persisted(),
-            fork_choice_store: fork_choice.fc_store().to_persisted(),
-        };
-        persisted_fork_choice.as_kv_store_op(FORK_CHOICE_DB_KEY)
-    }
-
     /// Load fork choice from disk, returning `None` if it isn't found.
-    pub fn load_fork_choice(store: BeaconStore<T>) -> Result<Option<BeaconForkChoice<T>>, Error> {
+    pub fn load_fork_choice(
+        store: BeaconStore<T>,
+        spec: &ChainSpec,
+    ) -> Result<Option<BeaconForkChoice<T>>, Error> {
         let persisted_fork_choice =
             match store.get_item::<PersistedForkChoice>(&FORK_CHOICE_DB_KEY)? {
                 Some(fc) => fc,
@@ -461,6 +433,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(Some(ForkChoice::from_persisted(
             persisted_fork_choice.fork_choice,
             fc_store,
+            spec,
         )?))
     }
 
@@ -538,11 +511,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             ));
         }
 
-        let local_head = self.head()?;
+        let local_head = self.head_snapshot();
 
         let iter = self.store.forwards_block_roots_iterator(
             start_slot,
-            local_head.beacon_state,
+            local_head.beacon_state.clone_with(CloneConfig::none()),
             local_head.beacon_block_root,
             &self.spec,
         )?;
@@ -612,77 +585,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map(|result| result.map_err(|e| e.into())))
     }
 
-    /// Iterate through the current chain to find the slot intersecting with the given beacon state.
-    /// The maximum depth this will search is `SLOTS_PER_HISTORICAL_ROOT`, and if that depth is reached
-    /// and no intersection is found, the finalized slot will be returned.
-    pub fn find_reorg_slot(
-        &self,
-        new_state: &BeaconState<T::EthSpec>,
-        new_block_root: Hash256,
-    ) -> Result<Slot, Error> {
-        self.with_head(|snapshot| {
-            let old_state = &snapshot.beacon_state;
-            let old_block_root = snapshot.beacon_block_root;
-
-            // The earliest slot for which the two chains may have a common history.
-            let lowest_slot = std::cmp::min(new_state.slot(), old_state.slot());
-
-            // Create an iterator across `$state`, assuming that the block at `$state.slot` has the
-            // block root of `$block_root`.
-            //
-            // The iterator will be skipped until the next value returns `lowest_slot`.
-            //
-            // This is a macro instead of a function or closure due to the complex types invloved
-            // in all the iterator wrapping.
-            macro_rules! aligned_roots_iter {
-                ($state: ident, $block_root: ident) => {
-                    std::iter::once(Ok(($state.slot(), $block_root)))
-                        .chain($state.rev_iter_block_roots(&self.spec))
-                        .skip_while(|result| {
-                            result
-                                .as_ref()
-                                .map_or(false, |(slot, _)| *slot > lowest_slot)
-                        })
-                };
-            }
-
-            // Create iterators across old/new roots where iterators both start at the same slot.
-            let mut new_roots = aligned_roots_iter!(new_state, new_block_root);
-            let mut old_roots = aligned_roots_iter!(old_state, old_block_root);
-
-            // Whilst *both* of the iterators are still returning values, try and find a common
-            // ancestor between them.
-            while let (Some(old), Some(new)) = (old_roots.next(), new_roots.next()) {
-                let (old_slot, old_root) = old?;
-                let (new_slot, new_root) = new?;
-
-                // Sanity check to detect programming errors.
-                if old_slot != new_slot {
-                    return Err(Error::InvalidReorgSlotIter { new_slot, old_slot });
-                }
-
-                if old_root == new_root {
-                    // A common ancestor has been found.
-                    return Ok(old_slot);
-                }
-            }
-
-            // If no common ancestor is found, declare that the re-org happened at the previous
-            // finalized slot.
-            //
-            // Sometimes this will result in the return slot being *lower* than the actual reorg
-            // slot. However, assuming we don't re-org through a finalized slot, it will never be
-            // *higher*.
-            //
-            // We provide this potentially-inaccurate-but-safe information to avoid onerous
-            // database reads during times of deep reorgs.
-            Ok(old_state
-                .finalized_checkpoint()
-                .epoch
-                .start_slot(T::EthSpec::slots_per_epoch()))
-        })
-    }
-
     /// Iterates backwards across all `(state_root, slot)` pairs starting from
     /// an arbitrary `BeaconState` to the earliest reachable ancestor (may or may not be genesis).
     ///
@@ -713,12 +615,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         start_slot: Slot,
     ) -> Result<impl Iterator<Item = Result<(Hash256, Slot), Error>> + '_, Error> {
-        let local_head = self.head()?;
+        let local_head = self.head_snapshot();
 
         let iter = self.store.forwards_state_roots_iterator(
             start_slot,
             local_head.beacon_state_root(),
-            local_head.beacon_state,
+            local_head.beacon_state.clone_with(CloneConfig::none()),
             &self.spec,
         )?;
 
@@ -978,11 +880,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub async fn get_block_checking_early_attester_cache(
         &self,
         block_root: &Hash256,
-    ) -> Result<Option<SignedBeaconBlock<T::EthSpec>>, Error> {
+    ) -> Result<Option<Arc<SignedBeaconBlock<T::EthSpec>>>, Error> {
         if let Some(block) = self.early_attester_cache.get_block(*block_root) {
             return Ok(Some(block));
         }
-        self.get_block(block_root).await
+        Ok(self.get_block(block_root).await?.map(Arc::new))
     }
 
     /// Returns the block at the given root, if any.
@@ -1068,53 +970,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(self.store.get_state(state_root, slot)?)
     }
 
-    /// Returns a `Checkpoint` representing the head block and state. Contains the "best block";
-    /// the head of the canonical `BeaconChain`.
-    ///
-    /// It is important to note that the `beacon_state` returned may not match the present slot. It
-    /// is the state as it was when the head block was received, which could be some slots prior to
-    /// now.
-    pub fn head(&self) -> Result<BeaconSnapshot<T::EthSpec>, Error> {
-        self.with_head(|head| Ok(head.clone_with(CloneConfig::committee_caches_only())))
-    }
-
-    /// Apply a function to the canonical head without cloning it.
-    pub fn with_head<U, E, F>(&self, f: F) -> Result<U, E>
-    where
-        E: From<Error>,
-        F: FnOnce(&BeaconSnapshot<T::EthSpec>) -> Result<U, E>,
-    {
-        let head_lock = self
-            .canonical_head
-            .try_read_for(HEAD_LOCK_TIMEOUT)
-            .ok_or(Error::CanonicalHeadLockTimeout)?;
-        f(&head_lock)
-    }
-
-    /// Returns the beacon block root at the head of the canonical chain.
-    ///
-    /// See `Self::head` for more information.
-    pub fn head_beacon_block_root(&self) -> Result<Hash256, Error> {
-        self.with_head(|s| Ok(s.beacon_block_root))
-    }
-
-    /// Returns the beacon block at the head of the canonical chain.
-    ///
-    /// See `Self::head` for more information.
-    pub fn head_beacon_block(&self) -> Result<SignedBeaconBlock<T::EthSpec>, Error> {
-        self.with_head(|s| Ok(s.beacon_block.clone()))
-    }
-
-    /// Returns the beacon state at the head of the canonical chain.
-    ///
-    /// See `Self::head` for more information.
-    pub fn head_beacon_state(&self) -> Result<BeaconState<T::EthSpec>, Error> {
-        self.with_head(|s| {
-            Ok(s.beacon_state
-                .clone_with(CloneConfig::committee_caches_only()))
-        })
-    }
-
     /// Return the sync committee at `slot + 1` from the canonical chain.
     ///
     /// This is useful when dealing with sync committee messages, because messages are signed
@@ -1189,42 +1044,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         self.state_at_slot(load_slot, StateSkipConfig::WithoutStateRoots)
     }
 
-    /// Returns info representing the head block and state.
-    ///
-    /// A summarized version of `Self::head` that involves less cloning.
-    pub fn head_info(&self) -> Result<HeadInfo, Error> {
-        self.with_head(|head| {
-            let proposer_shuffling_decision_root = head
-                .beacon_state
-                .proposer_shuffling_decision_root(head.beacon_block_root)?;
-
-            // The `random` value is used whilst producing an `ExecutionPayload` atop the head.
-            let current_epoch = head.beacon_state.current_epoch();
-            let random = *head.beacon_state.get_randao_mix(current_epoch)?;
-
-            Ok(HeadInfo {
-                slot: head.beacon_block.slot(),
-                block_root: head.beacon_block_root,
-                state_root: head.beacon_state_root(),
-                current_justified_checkpoint: head.beacon_state.current_justified_checkpoint(),
-                finalized_checkpoint: head.beacon_state.finalized_checkpoint(),
-                fork: head.beacon_state.fork(),
-                genesis_time: head.beacon_state.genesis_time(),
-                genesis_validators_root: head.beacon_state.genesis_validators_root(),
-                proposer_shuffling_decision_root,
-                is_merge_transition_complete: is_merge_transition_complete(&head.beacon_state),
-                execution_payload_block_hash: head
-                    .beacon_block
-                    .message()
-                    .body()
-                    .execution_payload()
-                    .ok()
-                    .map(|ep| ep.block_hash()),
-                random,
-            })
-        })
-    }
-
     /// Returns the current heads of the `BeaconChain`. For the canonical head, see `Self::head`.
     ///
     /// Returns `(block_root, block_slot)`.
@@ -1245,7 +1064,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         slot: Slot,
         config: StateSkipConfig,
     ) -> Result<BeaconState<T::EthSpec>, Error> {
-        let head_state = self.head()?.beacon_state;
+        let head_state = self.head_beacon_state_cloned();
 
         match slot.cmp(&head_state.slot()) {
             Ordering::Equal => Ok(head_state),
@@ -1328,14 +1147,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///  be read.
     pub fn wall_clock_state(&self) -> Result<BeaconState<T::EthSpec>, Error> {
         self.state_at_slot(self.slot()?, StateSkipConfig::WithStateRoots)
-    }
-
-    /// Returns the slot of the highest block in the canonical chain.
-    pub fn best_slot(&self) -> Result<Slot, Error> {
-        self.canonical_head
-            .try_read_for(HEAD_LOCK_TIMEOUT)
-            .map(|head| head.beacon_block.slot())
-            .ok_or(Error::CanonicalHeadLockTimeout)
     }
 
     /// Returns the validator index (if any) for the given public key.
@@ -1477,7 +1288,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         validator_indices: &[u64],
         epoch: Epoch,
         head_block_root: Hash256,
-    ) -> Result<(Vec<Option<AttestationDuty>>, Hash256), Error> {
+    ) -> Result<(Vec<Option<AttestationDuty>>, Hash256, ExecutionStatus), Error> {
         self.with_committee_cache(head_block_root, epoch, |committee_cache, dependent_root| {
             let duties = validator_indices
                 .iter()
@@ -1487,7 +1298,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 })
                 .collect();
 
-            Ok((duties, dependent_root))
+            let execution_status = self
+                .canonical_head
+                .fork_choice_read_lock()
+                .get_block_execution_status(&head_block_root)
+                .ok_or(Error::AttestationHeadNotInForkChoice(head_block_root))?;
+
+            Ok((duties, dependent_root, execution_status))
         })
     }
 
@@ -1535,8 +1352,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<Attestation<T::EthSpec>, Error> {
         let beacon_block_root = attestation.data.beacon_block_root;
         match self
-            .fork_choice
-            .read()
+            .canonical_head
+            .fork_choice_read_lock()
             .get_block_execution_status(&beacon_block_root)
         {
             // The attestation references a block that is not in fork choice, it must be
@@ -1624,7 +1441,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let current_epoch_attesting_info: Option<(Checkpoint, usize)>;
         let attester_cache_key;
         let head_timer = metrics::start_timer(&metrics::ATTESTATION_PRODUCTION_HEAD_SCRAPE_SECONDS);
-        if let Some(head) = self.canonical_head.try_read_for(HEAD_LOCK_TIMEOUT) {
+        // The following braces are to prevent the `cached_head` Arc from being held for longer than
+        // required. It also helps reduce the diff for a very large PR (#3244).
+        {
+            let head = self.head_snapshot();
             let head_state = &head.beacon_state;
             head_state_slot = head_state.slot();
 
@@ -1699,15 +1519,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // routine.
             attester_cache_key =
                 AttesterCacheKey::new(request_epoch, head_state, beacon_block_root)?;
-        } else {
-            return Err(Error::CanonicalHeadLockTimeout);
         }
         drop(head_timer);
 
         // Only attest to a block if it is fully verified (i.e. not optimistic or invalid).
         match self
-            .fork_choice
-            .read()
+            .canonical_head
+            .fork_choice_read_lock()
             .get_block_execution_status(&beacon_block_root)
         {
             Some(execution_status) if execution_status.is_valid_or_irrelevant() => (),
@@ -1911,8 +1729,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<(), Error> {
         let _timer = metrics::start_timer(&metrics::FORK_CHOICE_PROCESS_ATTESTATION_TIMES);
 
-        self.fork_choice
-            .write()
+        self.canonical_head
+            .fork_choice_write_lock()
             .on_attestation(
                 self.slot()?,
                 verified.indexed_attestation(),
@@ -2047,8 +1865,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // If there's no eth1 chain then it's impossible to produce blocks and therefore
         // useless to put things in the op pool.
         if self.eth1_chain.is_some() {
-            let fork =
-                self.with_head(|head| Ok::<_, AttestationError>(head.beacon_state.fork()))?;
+            let fork = self.canonical_head.cached_head().head_fork();
 
             self.op_pool
                 .insert_attestation(
@@ -2153,7 +1970,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // pivot block is the same as the current state's pivot block. If it is, then the
         // attestation's shuffling is the same as the current state's.
         // To account for skipped slots, find the first block at *or before* the pivot slot.
-        let fork_choice_lock = self.fork_choice.read();
+        let fork_choice_lock = self.canonical_head.fork_choice_read_lock();
         let pivot_block_root = fork_choice_lock
             .proto_array()
             .core_proto_array()
@@ -2244,12 +2061,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn import_attester_slashing(
         &self,
         attester_slashing: SigVerifiedOp<AttesterSlashing<T::EthSpec>>,
-    ) -> Result<(), Error> {
+    ) {
         if self.eth1_chain.is_some() {
-            self.op_pool
-                .insert_attester_slashing(attester_slashing, self.head_info()?.fork)
+            self.op_pool.insert_attester_slashing(
+                attester_slashing,
+                self.canonical_head.cached_head().head_fork(),
+            )
         }
-        Ok(())
     }
 
     /// Attempt to obtain sync committee duties from the head.
@@ -2265,22 +2083,36 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         })
     }
 
-    /// Attempt to verify and import a chain of blocks to `self`.
+    /// A convenience method for spawning a blocking task. It maps an `Option` and
+    /// `tokio::JoinError` into a single `BeaconChainError`.
+    pub(crate) async fn spawn_blocking_handle<F, R>(
+        &self,
+        task: F,
+        name: &'static str,
+    ) -> Result<R, Error>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        let handle = self
+            .task_executor
+            .spawn_blocking_handle(task, name)
+            .ok_or(Error::RuntimeShutdown)?;
+
+        handle.await.map_err(Error::TokioJoin)
+    }
+
+    /// Accepts a `chain_segment` and filters out any uninteresting blocks (e.g., pre-finalization
+    /// or already-known).
     ///
-    /// The provided blocks _must_ each reference the previous block via `block.parent_root` (i.e.,
-    /// be a chain). An error will be returned if this is not the case.
-    ///
-    /// This operation is not atomic; if one of the blocks in the chain is invalid then some prior
-    /// blocks might be imported.
-    ///
-    /// This method is generally much more efficient than importing each block using
-    /// `Self::process_block`.
-    pub fn process_chain_segment(
+    /// This method is potentially long-running and should not run on the core executor.
+    pub fn filter_chain_segment(
         self: &Arc<Self>,
-        chain_segment: Vec<SignedBeaconBlock<T::EthSpec>>,
-    ) -> ChainSegmentResult<T::EthSpec> {
+        chain_segment: Vec<Arc<SignedBeaconBlock<T::EthSpec>>>,
+    ) -> Result<Vec<HashBlockTuple<T::EthSpec>>, ChainSegmentResult<T::EthSpec>> {
+        // This function will never import any blocks.
+        let imported_blocks = 0;
         let mut filtered_chain_segment = Vec::with_capacity(chain_segment.len());
-        let mut imported_blocks = 0;
 
         // Produce a list of the parent root and slot of the child of each block.
         //
@@ -2294,10 +2126,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         for (i, block) in chain_segment.into_iter().enumerate() {
             // Ensure the block is the correct structure for the fork at `block.slot()`.
             if let Err(e) = block.fork_name(&self.spec) {
-                return ChainSegmentResult::Failed {
+                return Err(ChainSegmentResult::Failed {
                     imported_blocks,
                     error: BlockError::InconsistentFork(e),
-                };
+                });
             }
 
             let block_root = get_block_root(&block);
@@ -2309,18 +2141,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // Without this check it would be possible to have a block verified using the
                 // incorrect shuffling. That would be bad, mmkay.
                 if block_root != *child_parent_root {
-                    return ChainSegmentResult::Failed {
+                    return Err(ChainSegmentResult::Failed {
                         imported_blocks,
                         error: BlockError::NonLinearParentRoots,
-                    };
+                    });
                 }
 
                 // Ensure that the slots are strictly increasing throughout the chain segment.
                 if *child_slot <= block.slot() {
-                    return ChainSegmentResult::Failed {
+                    return Err(ChainSegmentResult::Failed {
                         imported_blocks,
                         error: BlockError::NonLinearSlots,
-                    };
+                    });
                 }
             }
 
@@ -2348,24 +2180,60 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // The block has a known parent that does not descend from the finalized block.
                 // There is no need to process this block or any children.
                 Err(BlockError::NotFinalizedDescendant { block_parent_root }) => {
-                    return ChainSegmentResult::Failed {
+                    return Err(ChainSegmentResult::Failed {
                         imported_blocks,
                         error: BlockError::NotFinalizedDescendant { block_parent_root },
-                    };
+                    });
                 }
                 // If there was an error whilst determining if the block was invalid, return that
                 // error.
                 Err(BlockError::BeaconChainError(e)) => {
-                    return ChainSegmentResult::Failed {
+                    return Err(ChainSegmentResult::Failed {
                         imported_blocks,
                         error: BlockError::BeaconChainError(e),
-                    };
+                    });
                 }
                 // If the block was decided to be irrelevant for any other reason, don't include
                 // this block or any of it's children in the filtered chain segment.
                 _ => break,
             }
         }
+
+        Ok(filtered_chain_segment)
+    }
+
+    /// Attempt to verify and import a chain of blocks to `self`.
+    ///
+    /// The provided blocks _must_ each reference the previous block via `block.parent_root` (i.e.,
+    /// be a chain). An error will be returned if this is not the case.
+    ///
+    /// This operation is not atomic; if one of the blocks in the chain is invalid then some prior
+    /// blocks might be imported.
+    ///
+    /// This method is generally much more efficient than importing each block using
+    /// `Self::process_block`.
+    pub async fn process_chain_segment(
+        self: &Arc<Self>,
+        chain_segment: Vec<Arc<SignedBeaconBlock<T::EthSpec>>>,
+    ) -> ChainSegmentResult<T::EthSpec> {
+        let mut imported_blocks = 0;
+
+        // Filter uninteresting blocks from the chain segment in a blocking task.
+        let chain = self.clone();
+        let filtered_chain_segment_future = self.spawn_blocking_handle(
+            move || chain.filter_chain_segment(chain_segment),
+            "filter_chain_segment",
+        );
+        let mut filtered_chain_segment = match filtered_chain_segment_future.await {
+            Ok(Ok(filtered_segment)) => filtered_segment,
+            Ok(Err(segment_result)) => return segment_result,
+            Err(error) => {
+                return ChainSegmentResult::Failed {
+                    imported_blocks,
+                    error: BlockError::BeaconChainError(error),
+                }
+            }
+        };
 
         while let Some((_root, block)) = filtered_chain_segment.first() {
             // Determine the epoch of the first block in the remaining segment.
@@ -2386,20 +2254,32 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let mut blocks = filtered_chain_segment.split_off(last_index);
             std::mem::swap(&mut blocks, &mut filtered_chain_segment);
 
+            let chain = self.clone();
+            let signature_verification_future = self.spawn_blocking_handle(
+                move || signature_verify_chain_segment(blocks, &chain),
+                "signature_verify_chain_segment",
+            );
+
             // Verify the signature of the blocks, returning early if the signature is invalid.
-            let signature_verified_blocks = match signature_verify_chain_segment(blocks, self) {
-                Ok(blocks) => blocks,
-                Err(error) => {
+            let signature_verified_blocks = match signature_verification_future.await {
+                Ok(Ok(blocks)) => blocks,
+                Ok(Err(error)) => {
                     return ChainSegmentResult::Failed {
                         imported_blocks,
                         error,
+                    };
+                }
+                Err(error) => {
+                    return ChainSegmentResult::Failed {
+                        imported_blocks,
+                        error: BlockError::BeaconChainError(error),
                     };
                 }
             };
 
             // Import the blocks into the chain.
             for signature_verified_block in signature_verified_blocks {
-                match self.process_block(signature_verified_block) {
+                match self.process_block(signature_verified_block).await {
                     Ok(_) => imported_blocks += 1,
                     Err(error) => {
                         return ChainSegmentResult::Failed {
@@ -2424,43 +2304,54 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// ## Errors
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
-    pub fn verify_block_for_gossip(
-        &self,
-        block: SignedBeaconBlock<T::EthSpec>,
+    pub async fn verify_block_for_gossip(
+        self: &Arc<Self>,
+        block: Arc<SignedBeaconBlock<T::EthSpec>>,
     ) -> Result<GossipVerifiedBlock<T>, BlockError<T::EthSpec>> {
-        let slot = block.slot();
-        let graffiti_string = block.message().body().graffiti().as_utf8_lossy();
+        let chain = self.clone();
+        self.task_executor
+            .clone()
+            .spawn_blocking_handle(
+                move || {
+                    let slot = block.slot();
+                    let graffiti_string = block.message().body().graffiti().as_utf8_lossy();
 
-        match GossipVerifiedBlock::new(block, self) {
-            Ok(verified) => {
-                debug!(
-                    self.log,
-                    "Successfully processed gossip block";
-                    "graffiti" => graffiti_string,
-                    "slot" => slot,
-                    "root" => ?verified.block_root(),
-                );
+                    match GossipVerifiedBlock::new(block, &chain) {
+                        Ok(verified) => {
+                            debug!(
+                                chain.log,
+                                "Successfully processed gossip block";
+                                "graffiti" => graffiti_string,
+                                "slot" => slot,
+                                "root" => ?verified.block_root(),
+                            );
 
-                Ok(verified)
-            }
-            Err(e) => {
-                debug!(
-                    self.log,
-                    "Rejected gossip block";
-                    "error" => e.to_string(),
-                    "graffiti" => graffiti_string,
-                    "slot" => slot,
-                );
+                            Ok(verified)
+                        }
+                        Err(e) => {
+                            debug!(
+                                chain.log,
+                                "Rejected gossip block";
+                                "error" => e.to_string(),
+                                "graffiti" => graffiti_string,
+                                "slot" => slot,
+                            );
 
-                Err(e)
-            }
-        }
+                            Err(e)
+                        }
+                    }
+                },
+                "payload_verification_handle",
+            )
+            .ok_or(BeaconChainError::RuntimeShutdown)?
+            .await
+            .map_err(BeaconChainError::TokioJoin)?
     }
 
     /// Returns `Ok(block_root)` if the given `unverified_block` was successfully verified and
     /// imported into the chain.
     ///
-    /// Items that implement `IntoFullyVerifiedBlock` include:
+    /// Items that implement `IntoExecutionPendingBlock` include:
     ///
     /// - `SignedBeaconBlock`
     /// - `GossipVerifiedBlock`
@@ -2469,7 +2360,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// Returns an `Err` if the given block was invalid, or an error was encountered during
     /// verification.
-    pub fn process_block<B: IntoFullyVerifiedBlock<T>>(
+    pub async fn process_block<B: IntoExecutionPendingBlock<T>>(
         self: &Arc<Self>,
         unverified_block: B,
     ) -> Result<Hash256, BlockError<T::EthSpec>> {
@@ -2483,13 +2374,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let block = unverified_block.block().clone();
 
         // A small closure to group the verification and import errors.
-        let import_block = |unverified_block: B| -> Result<Hash256, BlockError<T::EthSpec>> {
-            let fully_verified = unverified_block.into_fully_verified_block(self)?;
-            self.import_block(fully_verified)
+        let chain = self.clone();
+        let import_block = async move {
+            let execution_pending = unverified_block.into_execution_pending_block(&chain)?;
+            chain
+                .import_execution_pending_block(execution_pending)
+                .await
         };
 
         // Verify and import the block.
-        match import_block(unverified_block) {
+        match import_block.await {
             // The block was successfully verified and imported. Yay.
             Ok(block_root) => {
                 trace!(
@@ -2503,6 +2397,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 metrics::inc_counter(&metrics::BLOCK_PROCESSING_SUCCESSES);
 
                 Ok(block_root)
+            }
+            Err(e @ BlockError::BeaconChainError(BeaconChainError::TokioJoin(_))) => {
+                debug!(
+                    self.log,
+                    "Beacon block processing cancelled";
+                    "error" => ?e,
+                );
+                Err(e)
             }
             // There was an error whilst attempting to verify and import the block. The block might
             // be partially verified or partially imported.
@@ -2531,17 +2433,91 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// An error is returned if the block was unable to be imported. It may be partially imported
     /// (i.e., this function is not atomic).
+    async fn import_execution_pending_block(
+        self: Arc<Self>,
+        execution_pending_block: ExecutionPendingBlock<T>,
+    ) -> Result<Hash256, BlockError<T::EthSpec>> {
+        let ExecutionPendingBlock {
+            block,
+            block_root,
+            state,
+            parent_block: _,
+            confirmed_state_roots,
+            payload_verification_handle,
+        } = execution_pending_block;
+
+        let PayloadVerificationOutcome {
+            payload_verification_status,
+            is_valid_merge_transition_block,
+        } = payload_verification_handle
+            .await
+            .map_err(BeaconChainError::TokioJoin)?
+            .ok_or(BeaconChainError::RuntimeShutdown)??;
+
+        // Log the PoS pandas if a merge transition just occurred.
+        if is_valid_merge_transition_block {
+            info!(self.log, "{}", POS_PANDA_BANNER);
+            info!(
+                self.log,
+                "Proof of Stake Activated";
+                "slot" => block.slot()
+            );
+            info!(
+                self.log, "";
+                "Terminal POW Block Hash" => ?block
+                    .message()
+                    .execution_payload()?
+                    .parent_hash()
+                    .into_root()
+            );
+            info!(
+                self.log, "";
+                "Merge Transition Block Root" => ?block.message().tree_hash_root()
+            );
+            info!(
+                self.log, "";
+                "Merge Transition Execution Hash" => ?block
+                    .message()
+                    .execution_payload()?
+                    .block_hash()
+                    .into_root()
+            );
+        }
+
+        let chain = self.clone();
+        let block_hash = self
+            .spawn_blocking_handle(
+                move || {
+                    chain.import_block(
+                        block,
+                        block_root,
+                        state,
+                        confirmed_state_roots,
+                        payload_verification_status,
+                    )
+                },
+                "payload_verification_handle",
+            )
+            .await??;
+
+        Ok(block_hash)
+    }
+
+    /// Accepts a fully-verified block and imports it into the chain without performing any
+    /// additional verification.
+    ///
+    /// An error is returned if the block was unable to be imported. It may be partially imported
+    /// (i.e., this function is not atomic).
     fn import_block(
         &self,
-        fully_verified_block: FullyVerifiedBlock<T>,
+        signed_block: Arc<SignedBeaconBlock<T::EthSpec>>,
+        block_root: Hash256,
+        mut state: BeaconState<T::EthSpec>,
+        confirmed_state_roots: Vec<Hash256>,
+        payload_verification_status: PayloadVerificationStatus,
     ) -> Result<Hash256, BlockError<T::EthSpec>> {
-        let signed_block = fully_verified_block.block;
-        let block_root = fully_verified_block.block_root;
-        let mut state = fully_verified_block.state;
         let current_slot = self.slot()?;
         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-        let mut ops = fully_verified_block.confirmation_db_batch;
-        let payload_verification_status = fully_verified_block.payload_verification_status;
 
         let attestation_observation_timer =
             metrics::start_timer(&metrics::BLOCK_PROCESSING_ATTESTATION_OBSERVATION);
@@ -2614,21 +2590,29 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .map_err(BeaconChainError::from)?;
         }
 
-        let mut fork_choice = self.fork_choice.write();
+        let mut fork_choice = self.canonical_head.fork_choice_write_lock();
 
         // Do not import a block that doesn't descend from the finalized root.
-        let signed_block =
-            check_block_is_finalized_descendant::<T, _>(signed_block, &fork_choice, &self.store)?;
-        let (block, block_signature) = signed_block.clone().deconstruct();
+        check_block_is_finalized_descendant(self, &fork_choice, &signed_block)?;
 
-        // compare the existing finalized checkpoint with the incoming block's finalized checkpoint
-        let old_finalized_checkpoint = fork_choice.finalized_checkpoint();
-        let new_finalized_checkpoint = state.finalized_checkpoint();
+        // Alias for readability.
+        let block = signed_block.message();
 
         // Only perform the weak subjectivity check if it was configured.
         if let Some(wss_checkpoint) = self.config.weak_subjectivity_checkpoint {
+            // Note: we're using the finalized checkpoint from the head state, rather than fork
+            // choice.
+            //
+            // We are doing this to ensure that we detect changes in finalization. It's possible
+            // that fork choice has already been updated to the finalized checkpoint in the block
+            // we're importing.
+            let current_head_finalized_checkpoint =
+                self.canonical_head.cached_head().finalized_checkpoint();
+            // Compare the existing finalized checkpoint with the incoming block's finalized checkpoint.
+            let new_finalized_checkpoint = state.finalized_checkpoint();
+
             // This ensures we only perform the check once.
-            if (old_finalized_checkpoint.epoch < wss_checkpoint.epoch)
+            if (current_head_finalized_checkpoint.epoch < wss_checkpoint.epoch)
                 && (wss_checkpoint.epoch <= new_finalized_checkpoint.epoch)
             {
                 if let Err(e) =
@@ -2640,7 +2624,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         "Weak subjectivity checkpoint verification failed while importing block!";
                         "block_root" => ?block_root,
                         "parent_root" => ?block.parent_root(),
-                        "old_finalized_epoch" => ?old_finalized_checkpoint.epoch,
+                        "old_finalized_epoch" => ?current_head_finalized_checkpoint.epoch,
                         "new_finalized_epoch" => ?new_finalized_checkpoint.epoch,
                         "weak_subjectivity_epoch" => ?wss_checkpoint.epoch,
                         "error" => ?e,
@@ -2668,7 +2652,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             fork_choice
                 .on_block(
                     current_slot,
-                    &block,
+                    block,
                     block_root,
                     block_delay,
                     &state,
@@ -2843,7 +2827,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // If the write fails, revert fork choice to the version from disk, else we can
         // end up with blocks in fork choice that are missing from disk.
         // See https://github.com/sigp/lighthouse/issues/2028
-        ops.push(StoreOp::PutBlock(block_root, Box::new(signed_block)));
+        let mut ops: Vec<_> = confirmed_state_roots
+            .into_iter()
+            .map(StoreOp::DeleteStateTemporaryFlag)
+            .collect();
+        ops.push(StoreOp::PutBlock(block_root, signed_block.clone()));
         ops.push(StoreOp::PutState(block.state_root(), &state));
         let txn_lock = self.store.hot_db.begin_rw_transaction();
 
@@ -2854,18 +2842,23 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 "msg" => "Restoring fork choice from disk",
                 "error" => ?e,
             );
-            match Self::load_fork_choice(self.store.clone())? {
-                Some(persisted_fork_choice) => {
-                    *fork_choice = persisted_fork_choice;
-                }
-                None => {
-                    crit!(
-                        self.log,
-                        "No stored fork choice found to restore from";
-                        "warning" => "The database is likely corrupt now, consider --purge-db"
-                    );
-                }
+
+            // Since the write failed, try to revert the canonical head back to what was stored
+            // in the database. This attempts to prevent inconsistency between the database and
+            // fork choice.
+            if let Err(e) =
+                self.canonical_head
+                    .restore_from_store(fork_choice, &self.store, &self.spec)
+            {
+                crit!(
+                    self.log,
+                    "No stored fork choice found to restore from";
+                    "error" => ?e,
+                    "warning" => "The database is likely corrupt now, consider --purge-db"
+                );
+                return Err(BlockError::BeaconChainError(e));
             }
+
             return Err(e.into());
         }
         drop(txn_lock);
@@ -2880,7 +2873,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let parent_root = block.parent_root();
         let slot = block.slot();
-        let signed_block = SignedBeaconBlock::from_block(block, block_signature);
 
         self.snapshot_cache
             .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
@@ -3017,7 +3009,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ///
     /// The produced block will not be inherently valid, it must be signed by a block producer.
     /// Block signing is out of the scope of this function and should be done by a separate program.
-    pub fn produce_block<Payload: ExecPayload<T::EthSpec>>(
+    pub async fn produce_block<Payload: ExecPayload<T::EthSpec>>(
         self: &Arc<Self>,
         randao_reveal: Signature,
         slot: Slot,
@@ -3029,16 +3021,51 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             validator_graffiti,
             ProduceBlockVerification::VerifyRandao,
         )
+        .await
     }
 
     /// Same as `produce_block` but allowing for configuration of RANDAO-verification.
-    pub fn produce_block_with_verification<Payload: ExecPayload<T::EthSpec>>(
+    pub async fn produce_block_with_verification<Payload: ExecPayload<T::EthSpec>>(
         self: &Arc<Self>,
         randao_reveal: Signature,
         slot: Slot,
         validator_graffiti: Option<Graffiti>,
         verification: ProduceBlockVerification,
     ) -> Result<BeaconBlockAndState<T::EthSpec, Payload>, BlockProductionError> {
+        // Part 1/2 (blocking)
+        //
+        // Load the parent state from disk.
+        let chain = self.clone();
+        let (state, state_root_opt) = self
+            .task_executor
+            .spawn_blocking_handle(
+                move || chain.load_state_for_block_production::<Payload>(slot),
+                "produce_partial_beacon_block",
+            )
+            .ok_or(BlockProductionError::ShuttingDown)?
+            .await
+            .map_err(BlockProductionError::TokioJoin)??;
+
+        // Part 2/2 (async, with some blocking components)
+        //
+        // Produce the blopck upon the state
+        self.produce_block_on_state::<Payload>(
+            state,
+            state_root_opt,
+            slot,
+            randao_reveal,
+            validator_graffiti,
+            verification,
+        )
+        .await
+    }
+
+    /// Load a beacon state from the database for block production. This is a long-running process
+    /// that should not be performed in an `async` context.
+    fn load_state_for_block_production<Payload: ExecPayload<T::EthSpec>>(
+        self: &Arc<Self>,
+        slot: Slot,
+    ) -> Result<(BeaconState<T::EthSpec>, Option<Hash256>), BlockProductionError> {
         metrics::inc_counter(&metrics::BLOCK_PRODUCTION_REQUESTS);
         let _complete_timer = metrics::start_timer(&metrics::BLOCK_PRODUCTION_TIMES);
 
@@ -3052,16 +3079,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // signed. If we miss the cache or we're producing a block that conflicts with the head,
         // fall back to getting the head from `slot - 1`.
         let state_load_timer = metrics::start_timer(&metrics::BLOCK_PRODUCTION_STATE_LOAD_TIMES);
-        let head_info = self
-            .head_info()
-            .map_err(BlockProductionError::UnableToGetHeadInfo)?;
-        let (state, state_root_opt) = if head_info.slot < slot {
+        // Atomically read some values from the head whilst avoiding holding cached head `Arc` any
+        // longer than necessary.
+        let (head_slot, head_block_root) = {
+            let head = self.canonical_head.cached_head();
+            (head.head_slot(), head.head_block_root())
+        };
+        let (state, state_root_opt) = if head_slot < slot {
             // Normal case: proposing a block atop the current head. Use the snapshot cache.
             if let Some(pre_state) = self
                 .snapshot_cache
                 .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
                 .and_then(|snapshot_cache| {
-                    snapshot_cache.get_state_for_block_production(head_info.block_root)
+                    snapshot_cache.get_state_for_block_production(head_block_root)
                 })
             {
                 (pre_state.pre_state, pre_state.state_root)
@@ -3091,16 +3121,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             (state, None)
         };
+
         drop(state_load_timer);
 
-        self.produce_block_on_state::<Payload>(
-            state,
-            state_root_opt,
-            slot,
-            randao_reveal,
-            validator_graffiti,
-            verification,
-        )
+        Ok((state, state_root_opt))
     }
 
     /// Produce a block for some `slot` upon the given `state`.
@@ -3115,15 +3139,79 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// The provided `state_root_opt` should only ever be set to `Some` if the contained value is
     /// equal to the root of `state`. Providing this value will serve as an optimization to avoid
     /// performing a tree hash in some scenarios.
-    pub fn produce_block_on_state<Payload: ExecPayload<T::EthSpec>>(
-        &self,
-        mut state: BeaconState<T::EthSpec>,
+    pub async fn produce_block_on_state<Payload: ExecPayload<T::EthSpec>>(
+        self: &Arc<Self>,
+        state: BeaconState<T::EthSpec>,
         state_root_opt: Option<Hash256>,
         produce_at_slot: Slot,
         randao_reveal: Signature,
         validator_graffiti: Option<Graffiti>,
         verification: ProduceBlockVerification,
     ) -> Result<BeaconBlockAndState<T::EthSpec, Payload>, BlockProductionError> {
+        // Part 1/3 (blocking)
+        //
+        // Perform the state advance and block-packing functions.
+        let chain = self.clone();
+        let mut partial_beacon_block = self
+            .task_executor
+            .spawn_blocking_handle(
+                move || {
+                    chain.produce_partial_beacon_block(
+                        state,
+                        state_root_opt,
+                        produce_at_slot,
+                        randao_reveal,
+                        validator_graffiti,
+                    )
+                },
+                "produce_partial_beacon_block",
+            )
+            .ok_or(BlockProductionError::ShuttingDown)?
+            .await
+            .map_err(BlockProductionError::TokioJoin)??;
+
+        // Part 2/3 (async)
+        //
+        // Wait for the execution layer to return an execution payload (if one is required).
+        let prepare_payload_handle = partial_beacon_block.prepare_payload_handle.take();
+        let execution_payload = if let Some(prepare_payload_handle) = prepare_payload_handle {
+            let execution_payload = prepare_payload_handle
+                .await
+                .map_err(BlockProductionError::TokioJoin)?
+                .ok_or(BlockProductionError::ShuttingDown)??;
+            Some(execution_payload)
+        } else {
+            None
+        };
+
+        // Part 3/3 (blocking)
+        //
+        // Perform the final steps of combining all the parts and computing the state root.
+        let chain = self.clone();
+        self.task_executor
+            .spawn_blocking_handle(
+                move || {
+                    chain.complete_partial_beacon_block(
+                        partial_beacon_block,
+                        execution_payload,
+                        verification,
+                    )
+                },
+                "complete_partial_beacon_block",
+            )
+            .ok_or(BlockProductionError::ShuttingDown)?
+            .await
+            .map_err(BlockProductionError::TokioJoin)?
+    }
+
+    fn produce_partial_beacon_block<Payload: ExecPayload<T::EthSpec>>(
+        self: &Arc<Self>,
+        mut state: BeaconState<T::EthSpec>,
+        state_root_opt: Option<Hash256>,
+        produce_at_slot: Slot,
+        randao_reveal: Signature,
+        validator_graffiti: Option<Graffiti>,
+    ) -> Result<PartialBeaconBlock<T::EthSpec, Payload>, BlockProductionError> {
         let eth1_chain = self
             .eth1_chain
             .as_ref()
@@ -3154,13 +3242,35 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             state.latest_block_header().canonical_root()
         };
 
+        let proposer_index = state.get_beacon_proposer_index(state.slot(), &self.spec)? as u64;
+
+        let pubkey_opt = state
+            .validators()
+            .get(proposer_index as usize)
+            .map(|v| v.pubkey);
+
+        // If required, start the process of loading an execution payload from the EL early. This
+        // allows it to run concurrently with things like attestation packing.
+        let prepare_payload_handle = match &state {
+            BeaconState::Base(_) | BeaconState::Altair(_) => None,
+            BeaconState::Merge(_) => {
+                let finalized_checkpoint = self.canonical_head.cached_head().finalized_checkpoint();
+                let prepare_payload_handle = get_execution_payload(
+                    self.clone(),
+                    &state,
+                    finalized_checkpoint,
+                    proposer_index,
+                    pubkey_opt,
+                )?;
+                Some(prepare_payload_handle)
+            }
+        };
+
         let (proposer_slashings, attester_slashings, voluntary_exits) =
             self.op_pool.get_slashings_and_exits(&state, &self.spec);
 
         let eth1_data = eth1_chain.eth1_data_for_block_production(&state, &self.spec)?;
-        let deposits = eth1_chain
-            .deposits_for_block_inclusion(&state, &eth1_data, &self.spec)?
-            .into();
+        let deposits = eth1_chain.deposits_for_block_inclusion(&state, &eth1_data, &self.spec)?;
 
         // Iterate through the naive aggregation pool and ensure all the attestations from there
         // are included in the operation pool.
@@ -3209,33 +3319,74 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 curr_attestation_filter,
                 &self.spec,
             )
-            .map_err(BlockProductionError::OpPoolError)?
-            .into();
+            .map_err(BlockProductionError::OpPoolError)?;
         drop(attestation_packing_timer);
 
         let slot = state.slot();
         let proposer_index = state.get_beacon_proposer_index(state.slot(), &self.spec)? as u64;
 
-        let pubkey_opt = state
-            .validators()
-            .get(proposer_index as usize)
-            .map(|v| v.pubkey);
-
-        // Closure to fetch a sync aggregate in cases where it is required.
-        let get_sync_aggregate = || -> Result<SyncAggregate<_>, BlockProductionError> {
-            Ok(self
-                .op_pool
-                .get_sync_aggregate(&state)
-                .map_err(BlockProductionError::OpPoolError)?
-                .unwrap_or_else(|| {
-                    warn!(
-                        self.log,
-                        "Producing block with no sync contributions";
-                        "slot" => state.slot(),
-                    );
-                    SyncAggregate::new()
-                }))
+        let sync_aggregate = match &state {
+            BeaconState::Base(_) => None,
+            BeaconState::Altair(_) | BeaconState::Merge(_) => {
+                let sync_aggregate = self
+                    .op_pool
+                    .get_sync_aggregate(&state)
+                    .map_err(BlockProductionError::OpPoolError)?
+                    .unwrap_or_else(|| {
+                        warn!(
+                            self.log,
+                            "Producing block with no sync contributions";
+                            "slot" => state.slot(),
+                        );
+                        SyncAggregate::new()
+                    });
+                Some(sync_aggregate)
+            }
         };
+
+        Ok(PartialBeaconBlock {
+            state,
+            slot,
+            proposer_index,
+            parent_root,
+            randao_reveal,
+            eth1_data,
+            graffiti,
+            proposer_slashings,
+            attester_slashings,
+            attestations,
+            deposits,
+            voluntary_exits,
+            sync_aggregate,
+            prepare_payload_handle,
+        })
+    }
+
+    fn complete_partial_beacon_block<Payload: ExecPayload<T::EthSpec>>(
+        &self,
+        partial_beacon_block: PartialBeaconBlock<T::EthSpec, Payload>,
+        execution_payload: Option<Payload>,
+        verification: ProduceBlockVerification,
+    ) -> Result<BeaconBlockAndState<T::EthSpec, Payload>, BlockProductionError> {
+        let PartialBeaconBlock {
+            mut state,
+            slot,
+            proposer_index,
+            parent_root,
+            randao_reveal,
+            eth1_data,
+            graffiti,
+            proposer_slashings,
+            attester_slashings,
+            attestations,
+            deposits,
+            voluntary_exits,
+            sync_aggregate,
+            // We don't need the prepare payload handle since the `execution_payload` is passed into
+            // this function. We can assume that the handle has already been consumed in order to
+            // produce said `execution_payload`.
+            prepare_payload_handle: _,
+        } = partial_beacon_block;
 
         let inner_block = match &state {
             BeaconState::Base(_) => BeaconBlock::Base(BeaconBlockBase {
@@ -3249,56 +3400,51 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     graffiti,
                     proposer_slashings: proposer_slashings.into(),
                     attester_slashings: attester_slashings.into(),
-                    attestations,
-                    deposits,
+                    attestations: attestations.into(),
+                    deposits: deposits.into(),
                     voluntary_exits: voluntary_exits.into(),
                     _phantom: PhantomData,
                 },
             }),
-            BeaconState::Altair(_) => {
-                let sync_aggregate = get_sync_aggregate()?;
-                BeaconBlock::Altair(BeaconBlockAltair {
-                    slot,
-                    proposer_index,
-                    parent_root,
-                    state_root: Hash256::zero(),
-                    body: BeaconBlockBodyAltair {
-                        randao_reveal,
-                        eth1_data,
-                        graffiti,
-                        proposer_slashings: proposer_slashings.into(),
-                        attester_slashings: attester_slashings.into(),
-                        attestations,
-                        deposits,
-                        voluntary_exits: voluntary_exits.into(),
-                        sync_aggregate,
-                        _phantom: PhantomData,
-                    },
-                })
-            }
-            BeaconState::Merge(_) => {
-                let sync_aggregate = get_sync_aggregate()?;
-                let execution_payload =
-                    get_execution_payload::<T, Payload>(self, &state, proposer_index, pubkey_opt)?;
-                BeaconBlock::Merge(BeaconBlockMerge {
-                    slot,
-                    proposer_index,
-                    parent_root,
-                    state_root: Hash256::zero(),
-                    body: BeaconBlockBodyMerge {
-                        randao_reveal,
-                        eth1_data,
-                        graffiti,
-                        proposer_slashings: proposer_slashings.into(),
-                        attester_slashings: attester_slashings.into(),
-                        attestations,
-                        deposits,
-                        voluntary_exits: voluntary_exits.into(),
-                        sync_aggregate,
-                        execution_payload,
-                    },
-                })
-            }
+            BeaconState::Altair(_) => BeaconBlock::Altair(BeaconBlockAltair {
+                slot,
+                proposer_index,
+                parent_root,
+                state_root: Hash256::zero(),
+                body: BeaconBlockBodyAltair {
+                    randao_reveal,
+                    eth1_data,
+                    graffiti,
+                    proposer_slashings: proposer_slashings.into(),
+                    attester_slashings: attester_slashings.into(),
+                    attestations: attestations.into(),
+                    deposits: deposits.into(),
+                    voluntary_exits: voluntary_exits.into(),
+                    sync_aggregate: sync_aggregate
+                        .ok_or(BlockProductionError::MissingSyncAggregate)?,
+                    _phantom: PhantomData,
+                },
+            }),
+            BeaconState::Merge(_) => BeaconBlock::Merge(BeaconBlockMerge {
+                slot,
+                proposer_index,
+                parent_root,
+                state_root: Hash256::zero(),
+                body: BeaconBlockBodyMerge {
+                    randao_reveal,
+                    eth1_data,
+                    graffiti,
+                    proposer_slashings: proposer_slashings.into(),
+                    attester_slashings: attester_slashings.into(),
+                    attestations: attestations.into(),
+                    deposits: deposits.into(),
+                    voluntary_exits: voluntary_exits.into(),
+                    sync_aggregate: sync_aggregate
+                        .ok_or(BlockProductionError::MissingSyncAggregate)?,
+                    execution_payload: execution_payload
+                        .ok_or(BlockProductionError::MissingExecutionPayload)?,
+                },
+            }),
         };
 
         let block = SignedBeaconBlock::from_block(
@@ -3362,7 +3508,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// results in the justified checkpoint being invalidated.
     ///
     /// See the documentation of `InvalidationOperation` for information about defining `op`.
-    pub fn process_invalid_execution_payload(
+    pub async fn process_invalid_execution_payload(
         self: &Arc<Self>,
         op: &InvalidationOperation,
     ) -> Result<(), Error> {
@@ -3373,8 +3519,26 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             "block_root" => ?op.block_root(),
         );
 
+        // Update the execution status in fork choice.
+        //
+        // Use a blocking task since it interacts with the `canonical_head` lock. Lock contention
+        // on the core executor is bad.
+        let chain = self.clone();
+        let inner_op = op.clone();
+        let fork_choice_result = self
+            .spawn_blocking_handle(
+                move || {
+                    chain
+                        .canonical_head
+                        .fork_choice_write_lock()
+                        .on_invalid_execution_payload(&inner_op)
+                },
+                "invalid_payload_fork_choice_update",
+            )
+            .await?;
+
         // Update fork choice.
-        if let Err(e) = self.fork_choice.write().on_invalid_execution_payload(op) {
+        if let Err(e) = fork_choice_result {
             crit!(
                 self.log,
                 "Failed to process invalid payload";
@@ -3389,7 +3553,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         //
         // Don't return early though, since invalidating the justified checkpoint might cause an
         // error here.
-        if let Err(e) = self.fork_choice() {
+        if let Err(e) = self.recompute_head_at_current_slot().await {
             crit!(
                 self.log,
                 "Failed to run fork choice routine";
@@ -3397,8 +3561,22 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             );
         }
 
-        // Atomically obtain the justified root from fork choice.
-        let justified_block = self.fork_choice.read().get_justified_block()?;
+        // Obtain the justified root from fork choice.
+        //
+        // Use a blocking task since it interacts with the `canonical_head` lock. Lock contention
+        // on the core executor is bad.
+        let chain = self.clone();
+        let justified_block = self
+            .spawn_blocking_handle(
+                move || {
+                    chain
+                        .canonical_head
+                        .fork_choice_read_lock()
+                        .get_justified_block()
+                },
+                "invalid_payload_fork_choice_get_justified",
+            )
+            .await??;
 
         if justified_block.execution_status.is_invalid() {
             crit!(
@@ -3430,452 +3608,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(())
     }
 
-    /// Execute the fork choice algorithm and enthrone the result as the canonical head.
-    pub fn fork_choice(self: &Arc<Self>) -> Result<(), Error> {
-        self.fork_choice_at_slot(self.slot()?)
-    }
-
-    /// Execute fork choice at `slot`, processing queued attestations from `slot - 1` and earlier.
-    ///
-    /// The `slot` is not verified in any way, callers should ensure it corresponds to at most
-    /// one slot ahead of the current wall-clock slot.
-    pub fn fork_choice_at_slot(self: &Arc<Self>, slot: Slot) -> Result<(), Error> {
-        metrics::inc_counter(&metrics::FORK_CHOICE_REQUESTS);
-        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_TIMES);
-
-        let result = self.fork_choice_internal(slot);
-
-        if result.is_err() {
-            metrics::inc_counter(&metrics::FORK_CHOICE_ERRORS);
-        }
-
-        result
-    }
-
-    fn fork_choice_internal(self: &Arc<Self>, slot: Slot) -> Result<(), Error> {
-        // Atomically obtain the head block root and the finalized block.
-        let (beacon_block_root, finalized_block) = {
-            let mut fork_choice = self.fork_choice.write();
-
-            // Determine the root of the block that is the head of the chain.
-            let beacon_block_root = fork_choice.get_head(slot, &self.spec)?;
-
-            (beacon_block_root, fork_choice.get_finalized_block()?)
-        };
-
-        let current_head = self.head_info()?;
-        let old_finalized_checkpoint = current_head.finalized_checkpoint;
-
-        // Exit early if the head hasn't changed.
-        if beacon_block_root == current_head.block_root {
-            return Ok(());
-        }
-
-        // Check to ensure that this finalized block hasn't been marked as invalid.
-        if let ExecutionStatus::Invalid(block_hash) = finalized_block.execution_status {
-            crit!(
-                self.log,
-                "Finalized block has an invalid payload";
-                "msg" => "You must use the `--purge-db` flag to clear the database and restart sync. \
-                You may be on a hostile network.",
-                "block_hash" => ?block_hash
-            );
-            let mut shutdown_sender = self.shutdown_sender();
-            shutdown_sender
-                .try_send(ShutdownReason::Failure(
-                    "Finalized block has an invalid execution payload.",
-                ))
-                .map_err(BeaconChainError::InvalidFinalizedPayloadShutdownError)?;
-
-            // Exit now, the node is in an invalid state.
-            return Err(Error::InvalidFinalizedPayload {
-                finalized_root: finalized_block.root,
-                execution_block_hash: block_hash,
-            });
-        }
-
-        let lag_timer = metrics::start_timer(&metrics::FORK_CHOICE_SET_HEAD_LAG_TIMES);
-
-        // At this point we know that the new head block is not the same as the previous one
-        metrics::inc_counter(&metrics::FORK_CHOICE_CHANGED_HEAD);
-
-        // Try and obtain the snapshot for `beacon_block_root` from the snapshot cache, falling
-        // back to a database read if that fails.
-        let new_head = self
-            .snapshot_cache
-            .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-            .and_then(|snapshot_cache| {
-                snapshot_cache.get_cloned(beacon_block_root, CloneConfig::committee_caches_only())
-            })
-            .map::<Result<_, Error>, _>(Ok)
-            .unwrap_or_else(|| {
-                let beacon_block = self
-                    .store
-                    .get_full_block(&beacon_block_root)?
-                    .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
-
-                let beacon_state_root = beacon_block.state_root();
-                let beacon_state: BeaconState<T::EthSpec> = self
-                    .get_state(&beacon_state_root, Some(beacon_block.slot()))?
-                    .ok_or(Error::MissingBeaconState(beacon_state_root))?;
-
-                Ok(BeaconSnapshot {
-                    beacon_block,
-                    beacon_block_root,
-                    beacon_state,
-                })
-            })
-            .and_then(|mut snapshot| {
-                // Regardless of where we got the state from, attempt to build the committee
-                // caches.
-                snapshot
-                    .beacon_state
-                    .build_all_committee_caches(&self.spec)
-                    .map_err(Into::into)
-                    .map(|()| snapshot)
-            })?;
-
-        // Attempt to detect if the new head is not on the same chain as the previous block
-        // (i.e., a re-org).
-        //
-        // Note: this will declare a re-org if we skip `SLOTS_PER_HISTORICAL_ROOT` blocks
-        // between calls to fork choice without swapping between chains. This seems like an
-        // extreme-enough scenario that a warning is fine.
-        let is_reorg = new_head
-            .beacon_state
-            .get_block_root(current_head.slot)
-            .map_or(true, |root| *root != current_head.block_root);
-
-        let mut reorg_distance = Slot::new(0);
-
-        if is_reorg {
-            match self.find_reorg_slot(&new_head.beacon_state, new_head.beacon_block_root) {
-                Ok(slot) => reorg_distance = current_head.slot.saturating_sub(slot),
-                Err(e) => {
-                    warn!(
-                        self.log,
-                        "Could not find re-org depth";
-                        "error" => format!("{:?}", e),
-                    );
-                }
-            }
-
-            metrics::inc_counter(&metrics::FORK_CHOICE_REORG_COUNT);
-            metrics::inc_counter(&metrics::FORK_CHOICE_REORG_COUNT_INTEROP);
-            warn!(
-                self.log,
-                "Beacon chain re-org";
-                "previous_head" => ?current_head.block_root,
-                "previous_slot" => current_head.slot,
-                "new_head_parent" => ?new_head.beacon_block.parent_root(),
-                "new_head" => ?beacon_block_root,
-                "new_slot" => new_head.beacon_block.slot(),
-                "reorg_distance" => reorg_distance,
-            );
-        } else {
-            debug!(
-                self.log,
-                "Head beacon block";
-                "justified_root" => ?new_head.beacon_state.current_justified_checkpoint().root,
-                "justified_epoch" => new_head.beacon_state.current_justified_checkpoint().epoch,
-                "finalized_root" => ?new_head.beacon_state.finalized_checkpoint().root,
-                "finalized_epoch" => new_head.beacon_state.finalized_checkpoint().epoch,
-                "root" => ?beacon_block_root,
-                "slot" => new_head.beacon_block.slot(),
-            );
-        };
-
-        let new_finalized_checkpoint = new_head.beacon_state.finalized_checkpoint();
-
-        // It is an error to try to update to a head with a lesser finalized epoch.
-        if new_finalized_checkpoint.epoch < old_finalized_checkpoint.epoch {
-            return Err(Error::RevertedFinalizedEpoch {
-                previous_epoch: old_finalized_checkpoint.epoch,
-                new_epoch: new_finalized_checkpoint.epoch,
-            });
-        }
-
-        let is_epoch_transition = current_head.slot.epoch(T::EthSpec::slots_per_epoch())
-            < new_head
-                .beacon_state
-                .slot()
-                .epoch(T::EthSpec::slots_per_epoch());
-
-        let update_head_timer = metrics::start_timer(&metrics::UPDATE_HEAD_TIMES);
-
-        // These fields are used for server-sent events.
-        let state_root = new_head.beacon_state_root();
-        let head_slot = new_head.beacon_state.slot();
-        let head_proposer_index = new_head.beacon_block.message().proposer_index();
-        let proposer_graffiti = new_head
-            .beacon_block
-            .message()
-            .body()
-            .graffiti()
-            .as_utf8_lossy();
-
-        // Find the dependent roots associated with this head before updating the snapshot. This
-        // is to ensure consistency when sending server sent events later in this method.
-        let dependent_root = new_head
-            .beacon_state
-            .proposer_shuffling_decision_root(self.genesis_block_root);
-        let prev_dependent_root = new_head
-            .beacon_state
-            .attester_shuffling_decision_root(self.genesis_block_root, RelativeEpoch::Current);
-
-        drop(lag_timer);
-
-        // Clear the early attester cache in case it conflicts with `self.canonical_head`.
-        self.early_attester_cache.clear();
-
-        // Update the snapshot that stores the head of the chain at the time it received the
-        // block.
-        *self
-            .canonical_head
-            .try_write_for(HEAD_LOCK_TIMEOUT)
-            .ok_or(Error::CanonicalHeadLockTimeout)? = new_head;
-
-        // The block has now been set as head so we can record times and delays.
-        metrics::stop_timer(update_head_timer);
-
-        let block_time_set_as_head = timestamp_now();
-
-        // Calculate the total delay between the start of the slot and when it was set as head.
-        let block_delay_total =
-            get_slot_delay_ms(block_time_set_as_head, head_slot, &self.slot_clock);
-
-        // Do not write to the cache for blocks older than 2 epochs, this helps reduce writes to
-        // the cache during sync.
-        if block_delay_total < self.slot_clock.slot_duration() * 64 {
-            self.block_times_cache.write().set_time_set_as_head(
-                beacon_block_root,
-                current_head.slot,
-                block_time_set_as_head,
-            );
-        }
-
-        // If a block comes in from over 4 slots ago, it is most likely a block from sync.
-        let block_from_sync = block_delay_total > self.slot_clock.slot_duration() * 4;
-
-        // Determine whether the block has been set as head too late for proper attestation
-        // production.
-        let late_head = block_delay_total >= self.slot_clock.unagg_attestation_production_delay();
-
-        // Do not store metrics if the block was > 4 slots old, this helps prevent noise during
-        // sync.
-        if !block_from_sync {
-            // Observe the total block delay. This is the delay between the time the slot started
-            // and when the block was set as head.
-            metrics::observe_duration(
-                &metrics::BEACON_BLOCK_HEAD_SLOT_START_DELAY_TIME,
-                block_delay_total,
-            );
-
-            // Observe the delay between when we imported the block and when we set the block as
-            // head.
-            let block_delays = self.block_times_cache.read().get_block_delays(
-                beacon_block_root,
-                self.slot_clock
-                    .start_of(head_slot)
-                    .unwrap_or_else(|| Duration::from_secs(0)),
-            );
-
-            metrics::observe_duration(
-                &metrics::BEACON_BLOCK_OBSERVED_SLOT_START_DELAY_TIME,
-                block_delays
-                    .observed
-                    .unwrap_or_else(|| Duration::from_secs(0)),
-            );
-
-            metrics::observe_duration(
-                &metrics::BEACON_BLOCK_HEAD_IMPORTED_DELAY_TIME,
-                block_delays
-                    .set_as_head
-                    .unwrap_or_else(|| Duration::from_secs(0)),
-            );
-
-            // If the block was enshrined as head too late for attestations to be created for it,
-            // log a debug warning and increment a metric.
-            if late_head {
-                metrics::inc_counter(&metrics::BEACON_BLOCK_HEAD_SLOT_START_DELAY_EXCEEDED_TOTAL);
-                debug!(
-                    self.log,
-                    "Delayed head block";
-                    "block_root" => ?beacon_block_root,
-                    "proposer_index" => head_proposer_index,
-                    "slot" => head_slot,
-                    "block_delay" => ?block_delay_total,
-                    "observed_delay" => ?block_delays.observed,
-                    "imported_delay" => ?block_delays.imported,
-                    "set_as_head_delay" => ?block_delays.set_as_head,
-                );
-            }
-        }
-
-        self.snapshot_cache
-            .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-            .map(|mut snapshot_cache| {
-                snapshot_cache.update_head(beacon_block_root);
-            })
-            .unwrap_or_else(|| {
-                error!(
-                    self.log,
-                    "Failed to obtain cache write lock";
-                    "lock" => "snapshot_cache",
-                    "task" => "update head"
-                );
-            });
-
-        if is_epoch_transition || is_reorg {
-            self.persist_head_and_fork_choice()?;
-            self.op_pool.prune_attestations(self.epoch()?);
-        }
-
-        if new_finalized_checkpoint.epoch != old_finalized_checkpoint.epoch {
-            // Due to race conditions, it's technically possible that the head we load here is
-            // different to the one earlier in this function.
-            //
-            // Since the head can't move backwards in terms of finalized epoch, we can only load a
-            // head with a *later* finalized state. There is no harm in this.
-            let head = self
-                .canonical_head
-                .try_read_for(HEAD_LOCK_TIMEOUT)
-                .ok_or(Error::CanonicalHeadLockTimeout)?;
-
-            // State root of the finalized state on the epoch boundary, NOT the state
-            // of the finalized block. We need to use an iterator in case the state is beyond
-            // the reach of the new head's `state_roots` array.
-            let new_finalized_slot = head
-                .beacon_state
-                .finalized_checkpoint()
-                .epoch
-                .start_slot(T::EthSpec::slots_per_epoch());
-            let new_finalized_state_root = process_results(
-                StateRootsIterator::new(&self.store, &head.beacon_state),
-                |mut iter| {
-                    iter.find_map(|(state_root, slot)| {
-                        if slot == new_finalized_slot {
-                            Some(state_root)
-                        } else {
-                            None
-                        }
-                    })
-                },
-            )?
-            .ok_or(Error::MissingFinalizedStateRoot(new_finalized_slot))?;
-
-            self.after_finalization(&head.beacon_state, new_finalized_state_root)?;
-        }
-
-        // Register a server-sent event if necessary
-        if let Some(event_handler) = self.event_handler.as_ref() {
-            if event_handler.has_head_subscribers() {
-                match (dependent_root, prev_dependent_root) {
-                    (Ok(current_duty_dependent_root), Ok(previous_duty_dependent_root)) => {
-                        event_handler.register(EventKind::Head(SseHead {
-                            slot: head_slot,
-                            block: beacon_block_root,
-                            state: state_root,
-                            current_duty_dependent_root,
-                            previous_duty_dependent_root,
-                            epoch_transition: is_epoch_transition,
-                        }));
-                    }
-                    (Err(e), _) | (_, Err(e)) => {
-                        warn!(
-                            self.log,
-                            "Unable to find dependent roots, cannot register head event";
-                            "error" => ?e
-                        );
-                    }
-                }
-            }
-
-            if is_reorg && event_handler.has_reorg_subscribers() {
-                event_handler.register(EventKind::ChainReorg(SseChainReorg {
-                    slot: head_slot,
-                    depth: reorg_distance.as_u64(),
-                    old_head_block: current_head.block_root,
-                    old_head_state: current_head.state_root,
-                    new_head_block: beacon_block_root,
-                    new_head_state: state_root,
-                    epoch: head_slot.epoch(T::EthSpec::slots_per_epoch()),
-                }));
-            }
-
-            if !block_from_sync && late_head && event_handler.has_late_head_subscribers() {
-                let peer_info = self
-                    .block_times_cache
-                    .read()
-                    .get_peer_info(beacon_block_root);
-                let block_delays = self.block_times_cache.read().get_block_delays(
-                    beacon_block_root,
-                    self.slot_clock
-                        .start_of(head_slot)
-                        .unwrap_or_else(|| Duration::from_secs(0)),
-                );
-                event_handler.register(EventKind::LateHead(SseLateHead {
-                    slot: head_slot,
-                    block: beacon_block_root,
-                    peer_id: peer_info.id,
-                    peer_client: peer_info.client,
-                    proposer_index: head_proposer_index,
-                    proposer_graffiti,
-                    block_delay: block_delay_total,
-                    observed_delay: block_delays.observed,
-                    imported_delay: block_delays.imported,
-                    set_as_head_delay: block_delays.set_as_head,
-                }));
-            }
-        }
-
-        // Update the execution layer.
-        // Always use the wall-clock slot to update the execution engine rather than the `slot`
-        // passed in.
-        if let Err(e) = self.update_execution_engine_forkchoice_blocking(self.slot()?) {
-            crit!(
-                self.log,
-                "Failed to update execution head";
-                "error" => ?e
-            );
-        }
-
-        // Performing this call immediately after
-        // `update_execution_engine_forkchoice_blocking` might result in two calls to fork
-        // choice updated, one *without* payload attributes and then a second *with*
-        // payload attributes.
-        //
-        // This seems OK. It's not a significant waste of EL<>CL bandwidth or resources, as
-        // far as I know.
-        if let Err(e) = self.prepare_beacon_proposer_blocking() {
-            crit!(
-                self.log,
-                "Failed to prepare proposers after fork choice";
-                "error" => ?e
-            );
-        }
-
-        Ok(())
-    }
-
-    pub fn prepare_beacon_proposer_blocking(self: &Arc<Self>) -> Result<(), Error> {
-        let current_slot = self.slot()?;
-
-        // Avoids raising an error before Bellatrix.
-        //
-        // See `Self::prepare_beacon_proposer_async` for more detail.
-        if self.slot_is_prior_to_bellatrix(current_slot + 1) {
-            return Ok(());
-        }
-
-        let execution_layer = self
-            .execution_layer
-            .as_ref()
-            .ok_or(Error::ExecutionLayerMissing)?;
-
-        execution_layer
-            .block_on_generic(|_| self.prepare_beacon_proposer_async(current_slot))
-            .map_err(Error::PrepareProposerBlockingFailed)?
+    pub fn block_is_known_to_fork_choice(&self, root: &Hash256) -> bool {
+        self.canonical_head
+            .fork_choice_read_lock()
+            .contains_block(root)
     }
 
     /// Determines the beacon proposer for the next slot. If that proposer is registered in the
@@ -3890,7 +3626,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// 1. We're in the tail-end of the slot (as defined by PAYLOAD_PREPARATION_LOOKAHEAD_FACTOR)
     /// 2. The head block is one slot (or less) behind the prepare slot (e.g., we're preparing for
     ///    the next slot and the block at the current slot is already known).
-    pub async fn prepare_beacon_proposer_async(
+    pub async fn prepare_beacon_proposer(
         self: &Arc<Self>,
         current_slot: Slot,
     ) -> Result<(), Error> {
@@ -3913,20 +3649,45 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Ok(());
         }
 
-        let head = self.head_info()?;
-        let head_epoch = head.slot.epoch(T::EthSpec::slots_per_epoch());
+        // Atomically read some values from the canonical head, whilst avoiding holding the cached
+        // head `Arc` any longer than necessary.
+        //
+        // Use a blocking task since blocking the core executor on the canonical head read lock can
+        // block the core tokio executor.
+        let chain = self.clone();
+        let (head_slot, head_root, head_decision_root, head_random, forkchoice_update_params) =
+            self.spawn_blocking_handle(
+                move || {
+                    let cached_head = chain.canonical_head.cached_head();
+                    let head_block_root = cached_head.head_block_root();
+                    let decision_root = cached_head
+                        .snapshot
+                        .beacon_state
+                        .proposer_shuffling_decision_root(head_block_root)?;
+                    Ok::<_, Error>((
+                        cached_head.head_slot(),
+                        head_block_root,
+                        decision_root,
+                        cached_head.head_random()?,
+                        cached_head.forkchoice_update_parameters(),
+                    ))
+                },
+                "prepare_beacon_proposer_fork_choice_read",
+            )
+            .await??;
+        let head_epoch = head_slot.epoch(T::EthSpec::slots_per_epoch());
 
         // Don't bother with proposer prep if the head is more than
         // `PREPARE_PROPOSER_HISTORIC_EPOCHS` prior to the current slot.
         //
         // This prevents the routine from running during sync.
-        if head.slot + T::EthSpec::slots_per_epoch() * PREPARE_PROPOSER_HISTORIC_EPOCHS
+        if head_slot + T::EthSpec::slots_per_epoch() * PREPARE_PROPOSER_HISTORIC_EPOCHS
             < current_slot
         {
             debug!(
                 self.log,
                 "Head too old for proposer prep";
-                "head_slot" => head.slot,
+                "head_slot" => head_slot,
                 "current_slot" => current_slot,
             );
             return Ok(());
@@ -3935,9 +3696,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // Ensure that the shuffling decision root is correct relative to the epoch we wish to
         // query.
         let shuffling_decision_root = if head_epoch == prepare_epoch {
-            head.proposer_shuffling_decision_root
+            head_decision_root
         } else {
-            head.block_root
+            head_root
         };
 
         // Read the proposer from the proposer cache.
@@ -3967,7 +3728,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 return Ok(());
             }
 
-            let (proposers, decision_root, fork) =
+            let (proposers, decision_root, _, fork) =
                 compute_proposer_duties_from_head(prepare_epoch, self)?;
 
             let proposer_index = prepare_slot.as_usize() % (T::EthSpec::slots_per_epoch() as usize);
@@ -4013,7 +3774,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .start_of(prepare_slot)
                 .ok_or(Error::InvalidSlot(prepare_slot))?
                 .as_secs(),
-            prev_randao: head.random,
+            prev_randao: head_random,
             suggested_fee_recipient: execution_layer
                 .get_suggested_fee_recipient(proposer as u64)
                 .await,
@@ -4023,18 +3784,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.log,
             "Preparing beacon proposer";
             "payload_attributes" => ?payload_attributes,
-            "head_root" => ?head.block_root,
+            "head_root" => ?head_root,
             "prepare_slot" => prepare_slot,
             "validator" => proposer,
         );
 
         let already_known = execution_layer
-            .insert_proposer(
-                prepare_slot,
-                head.block_root,
-                proposer as u64,
-                payload_attributes,
-            )
+            .insert_proposer(prepare_slot, head_root, proposer as u64, payload_attributes)
             .await;
         // Only push a log to the user if this is the first time we've seen this proposer for this
         // slot.
@@ -4076,7 +3832,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         //    known).
         if till_prepare_slot
             <= self.slot_clock.slot_duration() / PAYLOAD_PREPARATION_LOOKAHEAD_FACTOR
-            || head.slot + 1 >= prepare_slot
+            || head_slot + 1 >= prepare_slot
         {
             debug!(
                 self.log,
@@ -4085,37 +3841,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 "prepare_slot" => prepare_slot
             );
 
-            self.update_execution_engine_forkchoice_async(current_slot)
+            // Use the blocking method here so that we don't form a queue of these functions when
+            // routinely calling them.
+            self.update_execution_engine_forkchoice(current_slot, forkchoice_update_params)
                 .await?;
         }
 
         Ok(())
     }
 
-    pub fn update_execution_engine_forkchoice_blocking(
+    pub async fn update_execution_engine_forkchoice(
         self: &Arc<Self>,
         current_slot: Slot,
-    ) -> Result<(), Error> {
-        // Avoids raising an error before Bellatrix.
-        //
-        // See `Self::update_execution_engine_forkchoice_async` for more detail.
-        if self.slot_is_prior_to_bellatrix(current_slot + 1) {
-            return Ok(());
-        }
-
-        let execution_layer = self
-            .execution_layer
-            .as_ref()
-            .ok_or(Error::ExecutionLayerMissing)?;
-
-        execution_layer
-            .block_on_generic(|_| self.update_execution_engine_forkchoice_async(current_slot))
-            .map_err(Error::ForkchoiceUpdate)?
-    }
-
-    pub async fn update_execution_engine_forkchoice_async(
-        self: &Arc<Self>,
-        current_slot: Slot,
+        params: ForkchoiceUpdateParameters,
     ) -> Result<(), Error> {
         let next_slot = current_slot + 1;
 
@@ -4153,73 +3891,56 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // `execution_engine_forkchoice_lock` apart from the one here.
         let forkchoice_lock = execution_layer.execution_engine_forkchoice_lock().await;
 
-        // Deadlock warning:
-        //
-        // We are taking the `self.fork_choice` lock whilst holding the `forkchoice_lock`. This
-        // is intentional, since it allows us to ensure a consistent ordering of messages to the
-        // execution layer.
-        let forkchoice_update_parameters =
-            self.fork_choice.read().get_forkchoice_update_parameters();
-        let (head_block_root, head_hash, finalized_hash) = if let Some(params) =
-            forkchoice_update_parameters
+        let (head_block_root, head_hash, finalized_hash) = if let Some(head_hash) = params.head_hash
         {
-            if let Some(head_hash) = params.head_hash {
-                (
-                    params.head_root,
-                    head_hash,
-                    params
-                        .finalized_hash
-                        .unwrap_or_else(ExecutionBlockHash::zero),
-                )
-            } else {
-                // The head block does not have an execution block hash. We must check to see if we
-                // happen to be the proposer of the transition block, in which case we still need to
-                // send forkchoice_updated.
-                match self.spec.fork_name_at_slot::<T::EthSpec>(next_slot) {
-                    // We are pre-bellatrix; no need to update the EL.
-                    ForkName::Base | ForkName::Altair => return Ok(()),
-                    _ => {
-                        // We are post-bellatrix
-                        if execution_layer
-                            .payload_attributes(next_slot, params.head_root)
+            (
+                params.head_root,
+                head_hash,
+                params
+                    .finalized_hash
+                    .unwrap_or_else(ExecutionBlockHash::zero),
+            )
+        } else {
+            // The head block does not have an execution block hash. We must check to see if we
+            // happen to be the proposer of the transition block, in which case we still need to
+            // send forkchoice_updated.
+            match self.spec.fork_name_at_slot::<T::EthSpec>(next_slot) {
+                // We are pre-bellatrix; no need to update the EL.
+                ForkName::Base | ForkName::Altair => return Ok(()),
+                _ => {
+                    // We are post-bellatrix
+                    if execution_layer
+                        .payload_attributes(next_slot, params.head_root)
+                        .await
+                        .is_some()
+                    {
+                        // We are a proposer, check for terminal_pow_block_hash
+                        if let Some(terminal_pow_block_hash) = execution_layer
+                            .get_terminal_pow_block_hash(&self.spec)
                             .await
-                            .is_some()
+                            .map_err(Error::ForkchoiceUpdate)?
                         {
-                            // We are a proposer, check for terminal_pow_block_hash
-                            if let Some(terminal_pow_block_hash) = execution_layer
-                                .get_terminal_pow_block_hash(&self.spec)
-                                .await
-                                .map_err(Error::ForkchoiceUpdate)?
-                            {
-                                info!(
-                                    self.log,
-                                    "Prepared POS transition block proposer"; "slot" => next_slot
-                                );
-                                (
-                                    params.head_root,
-                                    terminal_pow_block_hash,
-                                    params
-                                        .finalized_hash
-                                        .unwrap_or_else(ExecutionBlockHash::zero),
-                                )
-                            } else {
-                                // TTD hasn't been reached yet, no need to update the EL.
-                                return Ok(());
-                            }
+                            info!(
+                                self.log,
+                                "Prepared POS transition block proposer"; "slot" => next_slot
+                            );
+                            (
+                                params.head_root,
+                                terminal_pow_block_hash,
+                                params
+                                    .finalized_hash
+                                    .unwrap_or_else(ExecutionBlockHash::zero),
+                            )
                         } else {
-                            // We are not a proposer, no need to update the EL.
+                            // TTD hasn't been reached yet, no need to update the EL.
                             return Ok(());
                         }
+                    } else {
+                        // We are not a proposer, no need to update the EL.
+                        return Ok(());
                     }
                 }
             }
-        } else {
-            warn!(
-                self.log,
-                "Missing forkchoice params";
-                "msg" => "please report this non-critical bug"
-            );
-            return Ok(());
         };
 
         let forkchoice_updated_response = execution_layer
@@ -4235,11 +3956,19 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             Ok(status) => match status {
                 PayloadStatus::Valid => {
                     // Ensure that fork choice knows that the block is no longer optimistic.
-                    if let Err(e) = self
-                        .fork_choice
-                        .write()
-                        .on_valid_execution_payload(head_block_root)
-                    {
+                    let chain = self.clone();
+                    let fork_choice_update_result = self
+                        .spawn_blocking_handle(
+                            move || {
+                                chain
+                                    .canonical_head
+                                    .fork_choice_write_lock()
+                                    .on_valid_execution_payload(head_block_root)
+                            },
+                            "update_execution_engine_valid_payload",
+                        )
+                        .await?;
+                    if let Err(e) = fork_choice_update_result {
                         error!(
                             self.log,
                             "Failed to validate payload";
@@ -4275,24 +4004,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     );
                     // The execution engine has stated that all blocks between the
                     // `head_execution_block_hash` and `latest_valid_hash` are invalid.
-                    let chain = self.clone();
-                    execution_layer
-                        .executor()
-                        .spawn_blocking_handle(
-                            move || {
-                                chain.process_invalid_execution_payload(
-                                    &InvalidationOperation::InvalidateMany {
-                                        head_block_root,
-                                        always_invalidate_head: true,
-                                        latest_valid_ancestor: latest_valid_hash,
-                                    },
-                                )
-                            },
-                            "process_invalid_execution_payload_many",
-                        )
-                        .ok_or(BeaconChainError::RuntimeShutdown)?
-                        .await
-                        .map_err(BeaconChainError::ProcessInvalidExecutionPayload)??;
+                    self.process_invalid_execution_payload(
+                        &InvalidationOperation::InvalidateMany {
+                            head_block_root,
+                            always_invalidate_head: true,
+                            latest_valid_ancestor: latest_valid_hash,
+                        },
+                    )
+                    .await?;
 
                     Err(BeaconChainError::ExecutionForkChoiceUpdateInvalid { status })
                 }
@@ -4308,22 +4027,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     //
                     // Using a `None` latest valid ancestor will result in only the head block
                     // being invalidated (no ancestors).
-                    let chain = self.clone();
-                    execution_layer
-                        .executor()
-                        .spawn_blocking_handle(
-                            move || {
-                                chain.process_invalid_execution_payload(
-                                    &InvalidationOperation::InvalidateOne {
-                                        block_root: head_block_root,
-                                    },
-                                )
-                            },
-                            "process_invalid_execution_payload_single",
-                        )
-                        .ok_or(BeaconChainError::RuntimeShutdown)?
-                        .await
-                        .map_err(BeaconChainError::ProcessInvalidExecutionPayload)??;
+                    self.process_invalid_execution_payload(&InvalidationOperation::InvalidateOne {
+                        block_root: head_block_root,
+                    })
+                    .await?;
 
                     Err(BeaconChainError::ExecutionForkChoiceUpdateInvalid { status })
                 }
@@ -4333,30 +4040,85 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Returns `true` if the given slot is prior to the `bellatrix_fork_epoch`.
-    fn slot_is_prior_to_bellatrix(&self, slot: Slot) -> bool {
+    pub fn slot_is_prior_to_bellatrix(&self, slot: Slot) -> bool {
         self.spec.bellatrix_fork_epoch.map_or(true, |bellatrix| {
             slot.epoch(T::EthSpec::slots_per_epoch()) < bellatrix
         })
     }
 
-    /// Returns the status of the current head block, regarding the validity of the execution
-    /// payload.
-    pub fn head_safety_status(&self) -> Result<HeadSafetyStatus, BeaconChainError> {
-        let head = self.head_info()?;
-        let head_block = self
-            .fork_choice
-            .read()
-            .get_block(&head.block_root)
-            .ok_or(BeaconChainError::HeadMissingFromForkChoice(head.block_root))?;
+    /// Returns the value of `execution_optimistic` for `block`.
+    ///
+    /// Returns `Ok(false)` if the block is pre-Bellatrix, or has `ExecutionStatus::Valid`.
+    /// Returns `Ok(true)` if the block has `ExecutionStatus::Optimistic`.
+    pub fn is_optimistic_block(
+        &self,
+        block: &SignedBeaconBlock<T::EthSpec>,
+    ) -> Result<bool, BeaconChainError> {
+        // Check if the block is pre-Bellatrix.
+        if self.slot_is_prior_to_bellatrix(block.slot()) {
+            Ok(false)
+        } else {
+            self.canonical_head
+                .fork_choice_read_lock()
+                .is_optimistic_block(&block.canonical_root())
+                .map_err(BeaconChainError::ForkChoiceError)
+        }
+    }
 
-        let status = match head_block.execution_status {
-            ExecutionStatus::Valid(block_hash) => HeadSafetyStatus::Safe(Some(block_hash)),
-            ExecutionStatus::Invalid(block_hash) => HeadSafetyStatus::Invalid(block_hash),
-            ExecutionStatus::Optimistic(block_hash) => HeadSafetyStatus::Unsafe(block_hash),
-            ExecutionStatus::Irrelevant(_) => HeadSafetyStatus::Safe(None),
-        };
+    /// Returns the value of `execution_optimistic` for `head_block`.
+    ///
+    /// Returns `Ok(false)` if the block is pre-Bellatrix, or has `ExecutionStatus::Valid`.
+    /// Returns `Ok(true)` if the block has `ExecutionStatus::Optimistic`.
+    ///
+    /// This function will return an error if `head_block` is not present in the fork choice store
+    /// and so should only be used on the head block or when the block *should* be present in the
+    /// fork choice store.
+    ///
+    /// There is a potential race condition when syncing where the block_root of `head_block` could
+    /// be pruned from the fork choice store before being read.
+    pub fn is_optimistic_head_block(
+        &self,
+        head_block: &SignedBeaconBlock<T::EthSpec>,
+    ) -> Result<bool, BeaconChainError> {
+        // Check if the block is pre-Bellatrix.
+        if self.slot_is_prior_to_bellatrix(head_block.slot()) {
+            Ok(false)
+        } else {
+            self.canonical_head
+                .fork_choice_read_lock()
+                .is_optimistic_block_no_fallback(&head_block.canonical_root())
+                .map_err(BeaconChainError::ForkChoiceError)
+        }
+    }
 
-        Ok(status)
+    /// Returns the value of `execution_optimistic` for the current head block.
+    /// You can optionally provide `head_info` if it was computed previously.
+    ///
+    /// Returns `Ok(false)` if the head block is pre-Bellatrix, or has `ExecutionStatus::Valid`.
+    /// Returns `Ok(true)` if the head block has `ExecutionStatus::Optimistic`.
+    ///
+    /// There is a potential race condition when syncing where the block root of `head_info` could
+    /// be pruned from the fork choice store before being read.
+    pub fn is_optimistic_head(&self) -> Result<bool, BeaconChainError> {
+        self.canonical_head
+            .head_execution_status()
+            .map(|status| status.is_optimistic())
+    }
+
+    pub fn is_optimistic_block_root(
+        &self,
+        block_slot: Slot,
+        block_root: &Hash256,
+    ) -> Result<bool, BeaconChainError> {
+        // Check if the block is pre-Bellatrix.
+        if self.slot_is_prior_to_bellatrix(block_slot) {
+            Ok(false)
+        } else {
+            self.canonical_head
+                .fork_choice_read_lock()
+                .is_optimistic_block_no_fallback(block_root)
+                .map_err(BeaconChainError::ForkChoiceError)
+        }
     }
 
     /// This function takes a configured weak subjectivity `Checkpoint` and the latest finalized `Checkpoint`.
@@ -4418,7 +4180,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Note: this function **MUST** be called from a non-async context since
     /// it contains a call to `fork_choice` which may eventually call
     /// `tokio::runtime::block_on` in certain cases.
-    pub fn per_slot_task(self: &Arc<Self>) {
+    pub async fn per_slot_task(self: &Arc<Self>) {
         trace!(self.log, "Running beacon chain per slot tasks");
         if let Some(slot) = self.slot_clock.now() {
             // Always run the light-weight pruning tasks (these structures should be empty during
@@ -4427,14 +4189,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.block_times_cache.write().prune(slot);
 
             // Don't run heavy-weight tasks during sync.
-            if self.best_slot().map_or(true, |head_slot| {
-                head_slot + MAX_PER_SLOT_FORK_CHOICE_DISTANCE < slot
-            }) {
+            if self.best_slot() + MAX_PER_SLOT_FORK_CHOICE_DISTANCE < slot {
                 return;
             }
 
             // Run fork choice and signal to any waiting task that it has completed.
-            if let Err(e) = self.fork_choice() {
+            if let Err(e) = self.recompute_head_at_current_slot().await {
                 error!(
                     self.log,
                     "Fork choice error at slot start";
@@ -4456,67 +4216,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 }
             }
         }
-    }
-
-    /// Called after `self` has had a new block finalized.
-    ///
-    /// Performs pruning and finality-based optimizations.
-    fn after_finalization(
-        &self,
-        head_state: &BeaconState<T::EthSpec>,
-        new_finalized_state_root: Hash256,
-    ) -> Result<(), Error> {
-        self.fork_choice.write().prune()?;
-        let new_finalized_checkpoint = head_state.finalized_checkpoint();
-
-        self.observed_block_producers.write().prune(
-            new_finalized_checkpoint
-                .epoch
-                .start_slot(T::EthSpec::slots_per_epoch()),
-        );
-
-        self.snapshot_cache
-            .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-            .map(|mut snapshot_cache| {
-                snapshot_cache.prune(new_finalized_checkpoint.epoch);
-                debug!(
-                    self.log,
-                    "Snapshot cache pruned";
-                    "new_len" => snapshot_cache.len(),
-                    "remaining_roots" => ?snapshot_cache.beacon_block_roots(),
-                );
-            })
-            .unwrap_or_else(|| {
-                error!(
-                    self.log,
-                    "Failed to obtain cache write lock";
-                    "lock" => "snapshot_cache",
-                    "task" => "prune"
-                );
-            });
-
-        self.op_pool.prune_all(head_state, self.epoch()?);
-
-        self.store_migrator.process_finalization(
-            new_finalized_state_root.into(),
-            new_finalized_checkpoint,
-            self.head_tracker.clone(),
-        )?;
-
-        self.attester_cache
-            .prune_below(new_finalized_checkpoint.epoch);
-
-        if let Some(event_handler) = self.event_handler.as_ref() {
-            if event_handler.has_finalized_subscribers() {
-                event_handler.register(EventKind::FinalizedCheckpoint(SseFinalizedCheckpoint {
-                    epoch: new_finalized_checkpoint.epoch,
-                    block: new_finalized_checkpoint.root,
-                    state: new_finalized_state_root,
-                }));
-            }
-        }
-
-        Ok(())
     }
 
     /// Runs the `map_fn` with the committee cache for `shuffling_epoch` from the chain with head
@@ -4557,8 +4256,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         F: Fn(&CommitteeCache, Hash256) -> Result<R, Error>,
     {
         let head_block = self
-            .fork_choice
-            .read()
+            .canonical_head
+            .fork_choice_read_lock()
             .get_block(&head_block_root)
             .ok_or(Error::MissingBeaconBlock(head_block_root))?;
 
@@ -4703,10 +4402,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<Vec<BeaconSnapshot<T::EthSpec, BlindedPayload<T::EthSpec>>>, Error> {
         let mut dump = vec![];
 
-        let mut last_slot = BeaconSnapshot {
-            beacon_block: self.head()?.beacon_block.into(),
-            beacon_block_root: self.head()?.beacon_block_root,
-            beacon_state: self.head()?.beacon_state,
+        let mut last_slot = {
+            let head = self.canonical_head.cached_head();
+            BeaconSnapshot {
+                beacon_block: Arc::new(head.snapshot.beacon_block.clone_as_blinded()),
+                beacon_block_root: head.snapshot.beacon_block_root,
+                beacon_state: head.snapshot.beacon_state.clone(),
+            }
         };
 
         dump.push(last_slot.clone());
@@ -4733,7 +4435,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 })?;
 
             let slot = BeaconSnapshot {
-                beacon_block,
+                beacon_block: Arc::new(beacon_block),
                 beacon_block_root,
                 beacon_state,
             };
@@ -4771,12 +4473,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     pub fn dump_as_dot<W: Write>(&self, output: &mut W) {
-        let canonical_head_hash = self
-            .canonical_head
-            .try_read_for(HEAD_LOCK_TIMEOUT)
-            .ok_or(Error::CanonicalHeadLockTimeout)
-            .unwrap()
-            .beacon_block_root;
+        let canonical_head_hash = self.canonical_head.cached_head().head_block_root();
         let mut visited: HashSet<Hash256> = HashSet::new();
         let mut finalized_blocks: HashSet<Hash256> = HashSet::new();
         let mut justified_blocks: HashSet<Hash256> = HashSet::new();

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4190,18 +4190,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self.block_times_cache.write().prune(slot);
 
             // Don't run heavy-weight tasks during sync.
-            if self.best_slot() + MAX_PER_SLOT_FORK_CHOICE_DISTANCE < slot {
-                return;
-            }
-
-            // Run fork choice and signal to any waiting task that it has completed.
-            if let Err(e) = self.recompute_head_at_current_slot().await {
-                error!(
-                    self.log,
-                    "Fork choice error at slot start";
-                    "error" => ?e,
-                    "slot" => slot,
-                );
+            if self.best_slot() + MAX_PER_SLOT_FORK_CHOICE_DISTANCE >= slot {
+                // Run fork choice and signal to any waiting task that it has completed.
+                if let Err(e) = self.recompute_head_at_current_slot().await {
+                    error!(
+                        self.log,
+                        "Fork choice error at slot start";
+                        "error" => ?e,
+                        "slot" => slot,
+                    );
+                }
             }
 
             // Send the notification regardless of fork choice success, this is a "best effort"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3330,7 +3330,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let sync_aggregate = if matches!(&state, BeaconState::Base(_)) {
             None
         } else {
-            self
+            let sync_aggregate = self
                 .op_pool
                 .get_sync_aggregate(&state)
                 .map_err(BlockProductionError::OpPoolError)?
@@ -3341,9 +3341,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         "slot" => state.slot(),
                     );
                     SyncAggregate::new()
-                })
+                });
+            Some(sync_aggregate)
         };
-
 
         Ok(PartialBeaconBlock {
             state,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3842,8 +3842,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 "prepare_slot" => prepare_slot
             );
 
-            // Use the blocking method here so that we don't form a queue of these functions when
-            // routinely calling them.
             self.update_execution_engine_forkchoice(current_slot, forkchoice_update_params)
                 .await?;
         }

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
 use superstruct::superstruct;
 use types::{
-    BeaconBlock, BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, ExecPayload, Hash256,
-    Slot,
+    BeaconBlockRef, BeaconState, BeaconStateError, Checkpoint, Epoch, EthSpec, ExecPayload,
+    Hash256, Slot,
 };
 
 #[derive(Debug)]
@@ -257,7 +257,7 @@ where
 
     fn on_verified_block<Payload: ExecPayload<E>>(
         &mut self,
-        _block: &BeaconBlock<E, Payload>,
+        _block: BeaconBlockRef<E, Payload>,
         block_root: Hash256,
         state: &BeaconState<E>,
     ) -> Result<(), Self::Error> {

--- a/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
+++ b/beacon_node/beacon_chain/src/beacon_proposer_cache.rs
@@ -9,12 +9,14 @@
 //! values it stores are very small, so this should not be an issue.
 
 use crate::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use fork_choice::ExecutionStatus;
 use lru::LruCache;
 use smallvec::SmallVec;
 use state_processing::state_advance::partial_state_advance;
 use std::cmp::Ordering;
 use types::{
-    BeaconState, BeaconStateError, ChainSpec, Epoch, EthSpec, Fork, Hash256, Slot, Unsigned,
+    BeaconState, BeaconStateError, ChainSpec, CloneConfig, Epoch, EthSpec, Fork, Hash256, Slot,
+    Unsigned,
 };
 
 /// The number of sets of proposer indices that should be cached.
@@ -135,11 +137,26 @@ impl BeaconProposerCache {
 pub fn compute_proposer_duties_from_head<T: BeaconChainTypes>(
     current_epoch: Epoch,
     chain: &BeaconChain<T>,
-) -> Result<(Vec<usize>, Hash256, Fork), BeaconChainError> {
-    // Take a copy of the head of the chain.
-    let head = chain.head()?;
-    let mut state = head.beacon_state;
-    let head_state_root = head.beacon_block.state_root();
+) -> Result<(Vec<usize>, Hash256, ExecutionStatus, Fork), BeaconChainError> {
+    // Atomically collect information about the head whilst holding the canonical head `Arc` as
+    // short as possible.
+    let (mut state, head_state_root, head_block_root) = {
+        let head = chain.canonical_head.cached_head();
+        // Take a copy of the head state.
+        let head_state = head
+            .snapshot
+            .beacon_state
+            .clone_with(CloneConfig::committee_caches_only());
+        let head_state_root = head.head_state_root();
+        let head_block_root = head.head_block_root();
+        (head_state, head_state_root, head_block_root)
+    };
+
+    let execution_status = chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .get_block_execution_status(&head_block_root)
+        .ok_or(BeaconChainError::HeadMissingFromForkChoice(head_block_root))?;
 
     // Advance the state into the requested epoch.
     ensure_state_is_in_epoch(&mut state, head_state_root, current_epoch, &chain.spec)?;
@@ -153,7 +170,7 @@ pub fn compute_proposer_duties_from_head<T: BeaconChainTypes>(
         .proposer_shuffling_decision_root(chain.genesis_block_root)
         .map_err(BeaconChainError::from)?;
 
-    Ok((indices, dependent_root, state.fork()))
+    Ok((indices, dependent_root, execution_status, state.fork()))
 }
 
 /// If required, advance `state` to `target_epoch`.

--- a/beacon_node/beacon_chain/src/beacon_snapshot.rs
+++ b/beacon_node/beacon_chain/src/beacon_snapshot.rs
@@ -1,4 +1,5 @@
 use serde_derive::Serialize;
+use std::sync::Arc;
 use types::{
     beacon_state::CloneConfig, BeaconState, EthSpec, ExecPayload, FullPayload, Hash256,
     SignedBeaconBlock,
@@ -8,7 +9,7 @@ use types::{
 /// head, justified head and finalized head.
 #[derive(Clone, Serialize, PartialEq, Debug)]
 pub struct BeaconSnapshot<E: EthSpec, Payload: ExecPayload<E> = FullPayload<E>> {
-    pub beacon_block: SignedBeaconBlock<E, Payload>,
+    pub beacon_block: Arc<SignedBeaconBlock<E, Payload>>,
     pub beacon_block_root: Hash256,
     pub beacon_state: BeaconState<E>,
 }
@@ -16,7 +17,7 @@ pub struct BeaconSnapshot<E: EthSpec, Payload: ExecPayload<E> = FullPayload<E>> 
 impl<E: EthSpec, Payload: ExecPayload<E>> BeaconSnapshot<E, Payload> {
     /// Create a new checkpoint.
     pub fn new(
-        beacon_block: SignedBeaconBlock<E, Payload>,
+        beacon_block: Arc<SignedBeaconBlock<E, Payload>>,
         beacon_block_root: Hash256,
         beacon_state: BeaconState<E>,
     ) -> Self {
@@ -39,7 +40,7 @@ impl<E: EthSpec, Payload: ExecPayload<E>> BeaconSnapshot<E, Payload> {
     /// Update all fields of the checkpoint.
     pub fn update(
         &mut self,
-        beacon_block: SignedBeaconBlock<E, Payload>,
+        beacon_block: Arc<SignedBeaconBlock<E, Payload>>,
         beacon_block_root: Hash256,
         beacon_state: BeaconState<E>,
     ) {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -88,12 +88,12 @@ pub struct CachedHead<E: EthSpec> {
     pub snapshot: Arc<BeaconSnapshot<E>>,
     /// The justified checkpoint as per `self.fork_choice`.
     ///
-    /// This value may be distinct to the `self.head_snapshot.beacon_state.justified_checkpoint`.
+    /// This value may be distinct to the `self.snapshot.beacon_state.justified_checkpoint`.
     /// This value should be used over the beacon state value in practically all circumstances.
     justified_checkpoint: Checkpoint,
     /// The finalized checkpoint as per `self.fork_choice`.
     ///
-    /// This value may be distinct to the `self.head_snapshot.beacon_state.finalized_checkpoint`.
+    /// This value may be distinct to the `self.snapshot.beacon_state.finalized_checkpoint`.
     /// This value should be used over the beacon state value in practically all circumstances.
     finalized_checkpoint: Checkpoint,
     /// The `execution_payload.block_hash` of the block at the head of the chain. Set to `None`

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1,0 +1,1307 @@
+//! This module provides all functionality for finding the canonical head, updating all necessary
+//! components (e.g. caches) and maintaining a cached head block and state.
+//!
+//! For practically all applications, the "canonical head" can be read using
+//! `beacon_chain.canonical_head.cached_head()`.
+//!
+//! The canonical head can be updated using `beacon_chain.recompute_head()`.
+//!
+//! ## Deadlock safety
+//!
+//! This module contains three locks:
+//!
+//! 1. `RwLock<BeaconForkChoice>`: Contains `proto_array` fork choice.
+//! 2. `RwLock<CachedHead>`: Contains a cached block/state from the last run of `proto_array`.
+//! 3. `Mutex<()>`: Is used to prevent concurrent execution of `BeaconChain::recompute_head`.
+//!
+//! This module has to take great efforts to avoid causing a deadlock with these three methods. Any
+//! developers working in this module should tread carefully and seek a detailed review.
+//!
+//! To encourage safe use of this module, it should **only ever return a read or write lock for the
+//! fork choice lock (lock 1)**. Whilst public functions might indirectly utilise locks (2) and (3),
+//! the fundamental `RwLockWriteGuard` or `RwLockReadGuard` should never be exposed. This prevents
+//! external functions from acquiring these locks in conflicting orders and causing a deadlock.
+//!
+//! ## Design Considerations
+//!
+//! We separate the `BeaconForkChoice` and `CachedHead` into two `RwLocks` because we want to ensure
+//! fast access to the `CachedHead`. If we were to put them both under the same lock, we would need
+//! to take an exclusive write-lock on it in order to run `ForkChoice::get_head`. This can take tens
+//! of milliseconds and would block all downstream functions that want to know simple things like
+//! the head block root. This is unacceptable for fast-responding functions like the networking
+//! stack.
+
+use crate::persisted_fork_choice::PersistedForkChoice;
+use crate::{
+    beacon_chain::{
+        BeaconForkChoice, BeaconStore, BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT, FORK_CHOICE_DB_KEY,
+    },
+    block_times_cache::BlockTimesCache,
+    events::ServerSentEventHandler,
+    metrics,
+    validator_monitor::{get_slot_delay_ms, timestamp_now},
+    BeaconChain, BeaconChainError as Error, BeaconChainTypes, BeaconSnapshot,
+};
+use eth2::types::{EventKind, SseChainReorg, SseFinalizedCheckpoint, SseHead, SseLateHead};
+use fork_choice::{ExecutionStatus, ForkChoiceView, ForkchoiceUpdateParameters, ProtoBlock};
+use itertools::process_results;
+use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use slog::{crit, debug, error, warn, Logger};
+use slot_clock::SlotClock;
+use std::sync::Arc;
+use std::time::Duration;
+use store::{iter::StateRootsIterator, KeyValueStoreOp, StoreItem};
+use task_executor::{JoinHandle, ShutdownReason};
+use types::*;
+
+/// Simple wrapper around `RwLock` that uses private visibility to prevent any other modules from
+/// accessing the contained lock without it being explicitly noted in this module.
+pub struct CanonicalHeadRwLock<T>(RwLock<T>);
+
+impl<T> From<RwLock<T>> for CanonicalHeadRwLock<T> {
+    fn from(rw_lock: RwLock<T>) -> Self {
+        Self(rw_lock)
+    }
+}
+
+impl<T> CanonicalHeadRwLock<T> {
+    fn new(item: T) -> Self {
+        Self::from(RwLock::new(item))
+    }
+
+    fn read(&self) -> RwLockReadGuard<T> {
+        self.0.read()
+    }
+
+    fn write(&self) -> RwLockWriteGuard<T> {
+        self.0.write()
+    }
+}
+
+/// Provides a series of cached values from the last time `BeaconChain::recompute_head` was run.
+///
+/// This struct is designed to be cheap-to-clone, any large fields should be wrapped in an `Arc` (or
+/// similar).
+#[derive(Clone)]
+pub struct CachedHead<E: EthSpec> {
+    /// Provides the head block and state from the last time the head was updated.
+    pub snapshot: Arc<BeaconSnapshot<E>>,
+    /// The justified checkpoint as per `self.fork_choice`.
+    ///
+    /// This value may be distinct to the `self.head_snapshot.beacon_state.justified_checkpoint`.
+    /// This value should be used over the beacon state value in practically all circumstances.
+    justified_checkpoint: Checkpoint,
+    /// The finalized checkpoint as per `self.fork_choice`.
+    ///
+    /// This value may be distinct to the `self.head_snapshot.beacon_state.finalized_checkpoint`.
+    /// This value should be used over the beacon state value in practically all circumstances.
+    finalized_checkpoint: Checkpoint,
+    /// The `execution_payload.block_hash` of the block at the head of the chain. Set to `None`
+    /// before Bellatrix.
+    head_hash: Option<ExecutionBlockHash>,
+    /// The `execution_payload.block_hash` of the finalized block. Set to `None` before Bellatrix.
+    finalized_hash: Option<ExecutionBlockHash>,
+}
+
+impl<E: EthSpec> CachedHead<E> {
+    /// Returns root of the block at the head of the beacon chain.
+    pub fn head_block_root(&self) -> Hash256 {
+        self.snapshot.beacon_block_root
+    }
+
+    /// Returns root of the `BeaconState` at the head of the beacon chain.
+    ///
+    /// ## Note
+    ///
+    /// This `BeaconState` has *not* been advanced to the current slot, it has the same slot as the
+    /// head block.
+    pub fn head_state_root(&self) -> Hash256 {
+        self.snapshot.beacon_state_root()
+    }
+
+    /// Returns slot of the block at the head of the beacon chain.
+    ///
+    /// ## Notes
+    ///
+    /// This is *not* the current slot as per the system clock. Use `BeaconChain::slot` for the
+    /// system clock (aka "wall clock") slot.
+    pub fn head_slot(&self) -> Slot {
+        self.snapshot.beacon_block.slot()
+    }
+
+    /// Returns the `Fork` from the `BeaconState` at the head of the chain.
+    pub fn head_fork(&self) -> Fork {
+        self.snapshot.beacon_state.fork()
+    }
+
+    /// Returns the randao mix for the block at the head of the chain.
+    pub fn head_random(&self) -> Result<Hash256, BeaconStateError> {
+        let state = &self.snapshot.beacon_state;
+        let root = *state.get_randao_mix(state.current_epoch())?;
+        Ok(root)
+    }
+
+    /// Returns the active validator count for the current epoch of the head state.
+    ///
+    /// Should only return `None` if the caches have not been built on the head state (this should
+    /// never happen).
+    pub fn active_validator_count(&self) -> Option<usize> {
+        self.snapshot
+            .beacon_state
+            .get_cached_active_validator_indices(RelativeEpoch::Current)
+            .map(|indices| indices.len())
+            .ok()
+    }
+
+    /// Returns the finalized checkpoint, as determined by fork choice.
+    ///
+    /// ## Note
+    ///
+    /// This is *not* the finalized checkpoint of the `head_snapshot.beacon_state`, rather it is the
+    /// best finalized checkpoint that has been observed by `self.fork_choice`. It is possible that
+    /// the `head_snapshot.beacon_state` finalized value is earlier than the one returned here.
+    pub fn finalized_checkpoint(&self) -> Checkpoint {
+        self.finalized_checkpoint
+    }
+
+    /// Returns the justified checkpoint, as determined by fork choice.
+    ///
+    /// ## Note
+    ///
+    /// This is *not* the "current justified checkpoint" of the `head_snapshot.beacon_state`, rather
+    /// it is the justified checkpoint in the view of `self.fork_choice`. It is possible that the
+    /// `head_snapshot.beacon_state` justified value is different to, but not conflicting with, the
+    /// one returned here.
+    pub fn justified_checkpoint(&self) -> Checkpoint {
+        self.justified_checkpoint
+    }
+
+    /// Returns the cached values of `ForkChoice::forkchoice_update_parameters`.
+    ///
+    /// Useful for supplying to the execution layer.
+    pub fn forkchoice_update_parameters(&self) -> ForkchoiceUpdateParameters {
+        ForkchoiceUpdateParameters {
+            head_root: self.snapshot.beacon_block_root,
+            head_hash: self.head_hash,
+            finalized_hash: self.finalized_hash,
+        }
+    }
+}
+
+/// Represents the "canonical head" of the beacon chain.
+///
+/// The `cached_head` is elected by the `fork_choice` algorithm contained in this struct.
+///
+/// There is no guarantee that the state of the `fork_choice` struct will always represent the
+/// `cached_head` (i.e. we may call `fork_choice` *without* updating the cached values), however
+/// there is a guarantee that the `cached_head` represents some past state of `fork_choice` (i.e.
+/// `fork_choice` never lags *behind* the `cached_head`).
+pub struct CanonicalHead<T: BeaconChainTypes> {
+    /// Provides an in-memory representation of the non-finalized block tree and is used to run the
+    /// fork choice algorithm and determine the canonical head.
+    pub fork_choice: CanonicalHeadRwLock<BeaconForkChoice<T>>,
+    /// Provides values cached from a previous execution of `self.fork_choice.get_head`.
+    ///
+    /// Although `self.fork_choice` might be slightly more advanced that this value, it is safe to
+    /// consider that these values represent the "canonical head" of the beacon chain.
+    pub cached_head: CanonicalHeadRwLock<CachedHead<T::EthSpec>>,
+    /// A lock used to prevent concurrent runs of `BeaconChain::recompute_head`.
+    ///
+    /// This lock **should not be made public**, it should only be used inside this module.
+    recompute_head_lock: Mutex<()>,
+}
+
+impl<T: BeaconChainTypes> CanonicalHead<T> {
+    /// Instantiate `Self`.
+    pub fn new(
+        fork_choice: BeaconForkChoice<T>,
+        snapshot: Arc<BeaconSnapshot<T::EthSpec>>,
+    ) -> Self {
+        let fork_choice_view = fork_choice.cached_fork_choice_view();
+        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
+        let cached_head = CachedHead {
+            snapshot,
+            justified_checkpoint: fork_choice_view.justified_checkpoint,
+            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
+            head_hash: forkchoice_update_params.head_hash,
+            finalized_hash: forkchoice_update_params.finalized_hash,
+        };
+
+        Self {
+            fork_choice: CanonicalHeadRwLock::new(fork_choice),
+            cached_head: CanonicalHeadRwLock::new(cached_head),
+            recompute_head_lock: Mutex::new(()),
+        }
+    }
+
+    /// Load a persisted version of `BeaconForkChoice` from the `store` and restore `self` to that
+    /// state.
+    ///
+    /// This is useful if some database corruption is expected and we wish to go back to our last
+    /// save-point.
+    pub(crate) fn restore_from_store(
+        &self,
+        // We don't actually need this value, however it's always present when we call this function
+        // and it needs to be dropped to prevent a dead-lock. Requiring it to be passed here is
+        // defensive programming.
+        mut fork_choice_write_lock: RwLockWriteGuard<BeaconForkChoice<T>>,
+        store: &BeaconStore<T>,
+        spec: &ChainSpec,
+    ) -> Result<(), Error> {
+        let fork_choice = <BeaconChain<T>>::load_fork_choice(store.clone(), spec)?
+            .ok_or(Error::MissingPersistedForkChoice)?;
+        let fork_choice_view = fork_choice.cached_fork_choice_view();
+        let beacon_block_root = fork_choice_view.head_block_root;
+        let beacon_block = store
+            .get_full_block(&beacon_block_root)?
+            .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
+        let beacon_state_root = beacon_block.state_root();
+        let beacon_state = store
+            .get_state(&beacon_state_root, Some(beacon_block.slot()))?
+            .ok_or(Error::MissingBeaconState(beacon_state_root))?;
+
+        let snapshot = BeaconSnapshot {
+            beacon_block_root,
+            beacon_block: Arc::new(beacon_block),
+            beacon_state,
+        };
+
+        let fork_choice_view = fork_choice.cached_fork_choice_view();
+        let forkchoice_update_params = fork_choice.get_forkchoice_update_parameters();
+        let cached_head = CachedHead {
+            snapshot: Arc::new(snapshot),
+            justified_checkpoint: fork_choice_view.justified_checkpoint,
+            finalized_checkpoint: fork_choice_view.finalized_checkpoint,
+            head_hash: forkchoice_update_params.head_hash,
+            finalized_hash: forkchoice_update_params.finalized_hash,
+        };
+
+        *fork_choice_write_lock = fork_choice;
+        // Avoid interleaving the fork choice and cached head locks.
+        drop(fork_choice_write_lock);
+        *self.cached_head.write() = cached_head;
+
+        Ok(())
+    }
+
+    /// Returns the execution status of the block at the head of the beacon chain.
+    ///
+    /// This will only return `Err` in the scenario where `self.fork_choice` has advanced
+    /// significantly past the cached `head_snapshot`. In such a scenario it is likely prudent to
+    /// run `BeaconChain::recompute_head` to update the cached values.
+    pub fn head_execution_status(&self) -> Result<ExecutionStatus, Error> {
+        let head_block_root = self.cached_head().head_block_root();
+        self.fork_choice_read_lock()
+            .get_block_execution_status(&head_block_root)
+            .ok_or(Error::HeadMissingFromForkChoice(head_block_root))
+    }
+
+    /// Returns a clone of `self.cached_head`.
+    ///
+    /// Takes a read-lock on `self.cached_head` for a short time (just long enough to clone it).
+    /// The `CachedHead` is designed to be fast-to-clone so this is preferred to passing back a
+    /// `RwLockReadGuard`, which may cause deadlock issues (see module-level documentation).
+    ///
+    /// This function is safe to be public since it does not expose any locks.
+    pub fn cached_head(&self) -> CachedHead<T::EthSpec> {
+        self.cached_head_read_lock().clone()
+    }
+
+    /// Access a read-lock for the cached head.
+    ///
+    /// This function is **not safe** to be public. See the module-level documentation for more
+    /// information about protecting from deadlocks.
+    fn cached_head_read_lock(&self) -> RwLockReadGuard<CachedHead<T::EthSpec>> {
+        self.cached_head.read()
+    }
+
+    /// Access a write-lock for the cached head.
+    ///
+    /// This function is **not safe** to be public. See the module-level documentation for more
+    /// information about protecting from deadlocks.
+    fn cached_head_write_lock(&self) -> RwLockWriteGuard<CachedHead<T::EthSpec>> {
+        self.cached_head.write()
+    }
+
+    /// Access a read-lock for fork choice.
+    pub fn fork_choice_read_lock(&self) -> RwLockReadGuard<BeaconForkChoice<T>> {
+        self.fork_choice.read()
+    }
+
+    /// Access a write-lock for fork choice.
+    pub fn fork_choice_write_lock(&self) -> RwLockWriteGuard<BeaconForkChoice<T>> {
+        self.fork_choice.write()
+    }
+}
+
+impl<T: BeaconChainTypes> BeaconChain<T> {
+    /// Contains the "best block"; the head of the canonical `BeaconChain`.
+    ///
+    /// It is important to note that the `snapshot.beacon_state` returned may not match the present slot. It
+    /// is the state as it was when the head block was received, which could be some slots prior to
+    /// now.
+    pub fn head(&self) -> CachedHead<T::EthSpec> {
+        self.canonical_head.cached_head()
+    }
+
+    /// Apply a function to an `Arc`-clone of the canonical head snapshot.
+    ///
+    /// This method is a relic from an old implementation where the canonical head was not behind
+    /// an `Arc` and the canonical head lock had to be held whenever it was read. This method is
+    /// fine to be left here, it just seems a bit weird.
+    pub fn with_head<U, E>(
+        &self,
+        f: impl FnOnce(&BeaconSnapshot<T::EthSpec>) -> Result<U, E>,
+    ) -> Result<U, E>
+    where
+        E: From<Error>,
+    {
+        let head_snapshot = self.head_snapshot();
+        f(&head_snapshot)
+    }
+
+    /// Returns the beacon block root at the head of the canonical chain.
+    ///
+    /// See `Self::head` for more information.
+    pub fn head_beacon_block_root(&self) -> Hash256 {
+        self.canonical_head
+            .cached_head_read_lock()
+            .snapshot
+            .beacon_block_root
+    }
+
+    /// Returns the slot of the highest block in the canonical chain.
+    pub fn best_slot(&self) -> Slot {
+        self.canonical_head
+            .cached_head_read_lock()
+            .snapshot
+            .beacon_block
+            .slot()
+    }
+
+    /// Returns a `Arc` of the `BeaconSnapshot` at the head of the canonical chain.
+    ///
+    /// See `Self::head` for more information.
+    pub fn head_snapshot(&self) -> Arc<BeaconSnapshot<T::EthSpec>> {
+        self.canonical_head.cached_head_read_lock().snapshot.clone()
+    }
+
+    /// Returns the beacon block at the head of the canonical chain.
+    ///
+    /// See `Self::head` for more information.
+    pub fn head_beacon_block(&self) -> Arc<SignedBeaconBlock<T::EthSpec>> {
+        self.head_snapshot().beacon_block.clone()
+    }
+
+    /// Returns a clone of the beacon state at the head of the canonical chain.
+    ///
+    /// Cloning the head state is expensive and should generally be avoided outside of tests.
+    ///
+    /// See `Self::head` for more information.
+    pub fn head_beacon_state_cloned(&self) -> BeaconState<T::EthSpec> {
+        // Don't clone whilst holding the read-lock, take an Arc-clone to reduce lock contention.
+        let snapshot: Arc<_> = self.head_snapshot();
+        snapshot
+            .beacon_state
+            .clone_with(CloneConfig::committee_caches_only())
+    }
+
+    /// Execute the fork choice algorithm and enthrone the result as the canonical head.
+    ///
+    /// This method replaces the old `BeaconChain::fork_choice` method.
+    pub async fn recompute_head_at_current_slot(self: &Arc<Self>) -> Result<(), Error> {
+        let current_slot = self.slot()?;
+        self.recompute_head_at_slot(current_slot).await
+    }
+
+    /// Execute the fork choice algorithm and enthrone the result as the canonical head.
+    ///
+    /// The `current_slot` is specified rather than relying on the wall-clock slot. Using a
+    /// different slot to the wall-clock can be useful for pushing fork choice into the next slot
+    /// *just* before the start of the slot. This ensures that block production can use the correct
+    /// head value without being delayed.
+    pub async fn recompute_head_at_slot(self: &Arc<Self>, current_slot: Slot) -> Result<(), Error> {
+        metrics::inc_counter(&metrics::FORK_CHOICE_REQUESTS);
+        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_TIMES);
+
+        let chain = self.clone();
+        match self
+            .task_executor
+            .spawn_blocking_handle(
+                move || chain.recompute_head_at_slot_internal(current_slot),
+                "recompute_head_internal",
+            )
+            .ok_or(Error::RuntimeShutdown)?
+            .await
+            .map_err(Error::TokioJoin)?
+        {
+            // Fork choice returned successfully and did not need to update the EL.
+            Ok(None) => Ok(()),
+            // Fork choice returned successfully and needed to update the EL. It has returned a
+            // join-handle from when it spawned some async tasks. We should await those tasks.
+            Ok(Some(join_handle)) => match join_handle.await {
+                // The async task completed successfully.
+                Ok(Some(())) => Ok(()),
+                // The async task did not complete successfully since the runtime is shutting down.
+                Ok(None) => {
+                    debug!(
+                        self.log,
+                        "Did not update EL fork choice";
+                        "info" => "shutting down"
+                    );
+                    Err(Error::RuntimeShutdown)
+                }
+                // The async task did not complete successfully, tokio returned an error.
+                Err(e) => {
+                    error!(
+                        self.log,
+                        "Did not update EL fork choice";
+                        "error" => ?e
+                    );
+                    Err(Error::TokioJoin(e))
+                }
+            },
+            // There was an error recomputing the head.
+            Err(e) => {
+                metrics::inc_counter(&metrics::FORK_CHOICE_ERRORS);
+                Err(e)
+            }
+        }
+    }
+
+    /// A non-async (blocking) function which recomputes the canonical head and spawns async tasks.
+    ///
+    /// This function performs long-running, heavy-lifting tasks which should not be performed on
+    /// the core `tokio` executor.
+    fn recompute_head_at_slot_internal(
+        self: &Arc<Self>,
+        current_slot: Slot,
+    ) -> Result<Option<JoinHandle<Option<()>>>, Error> {
+        let recompute_head_lock = self.canonical_head.recompute_head_lock.lock();
+
+        // Take a clone of the current ("old") head.
+        let old_cached_head = self.canonical_head.cached_head();
+
+        // Determine the current ("old") fork choice parameters.
+        //
+        // It is important to read the `fork_choice_view` from the cached head rather than from fork
+        // choice, since the fork choice value might have changed between calls to this function. We
+        // are interested in the changes since we last cached the head values, not since fork choice
+        // was last run.
+        let old_view = ForkChoiceView {
+            head_block_root: old_cached_head.head_block_root(),
+            justified_checkpoint: old_cached_head.justified_checkpoint(),
+            finalized_checkpoint: old_cached_head.finalized_checkpoint(),
+        };
+
+        let mut fork_choice_write_lock = self.canonical_head.fork_choice_write_lock();
+
+        // Recompute the current head via the fork choice algorithm.
+        fork_choice_write_lock.get_head(current_slot, &self.spec)?;
+
+        // Read the current head value from the fork choice algorithm.
+        let new_view = fork_choice_write_lock.cached_fork_choice_view();
+
+        // Downgrade the fork choice write-lock to a read lock, without allowing access to any
+        // other writers.
+        let fork_choice_read_lock = RwLockWriteGuard::downgrade(fork_choice_write_lock);
+
+        // Check to ensure that the finalized block hasn't been marked as invalid. If it has,
+        // shut down Lighthouse.
+        let finalized_proto_block = fork_choice_read_lock.get_finalized_block()?;
+        check_finalized_payload_validity(self, &finalized_proto_block)?;
+
+        // Sanity check the finalized checkpoint.
+        //
+        // The new finalized checkpoint must be either equal to or better than the previous
+        // finalized checkpoint.
+        check_against_finality_reversion(&old_view, &new_view)?;
+
+        let new_head_proto_block = fork_choice_read_lock
+            .get_block(&new_view.head_block_root)
+            .ok_or(Error::HeadBlockMissingFromForkChoice(
+                new_view.head_block_root,
+            ))?;
+
+        // Do not allow an invalid block to become the head.
+        //
+        // This check avoids the following infinite loop:
+        //
+        // 1. A new block is set as the head.
+        // 2. The EL is updated with the new head, and returns INVALID.
+        // 3. We call `process_invalid_execution_payload` and it calls this function.
+        // 4. This function elects an invalid block as the head.
+        // 5. GOTO 2
+        //
+        // In theory, fork choice should never select an invalid head (i.e., step #3 is impossible).
+        // However, this check is cheap.
+        if new_head_proto_block.execution_status.is_invalid() {
+            return Err(Error::HeadHasInvalidPayload {
+                block_root: new_head_proto_block.root,
+                execution_status: new_head_proto_block.execution_status,
+            });
+        }
+
+        // Exit early if the head or justified/finalized checkpoints have not changed, there's
+        // nothing to do.
+        if new_view == old_view {
+            debug!(
+                self.log,
+                "No change in canonical head";
+                "head" => ?new_view.head_block_root
+            );
+            return Ok(None);
+        }
+
+        // Get the parameters to update the execution layer since either the head or some finality
+        // parameters have changed.
+        let new_forkchoice_update_parameters =
+            fork_choice_read_lock.get_forkchoice_update_parameters();
+
+        perform_debug_logging::<T>(&old_view, &new_view, &fork_choice_read_lock, &self.log);
+
+        // Drop the read lock, it's no longer required and holding it any longer than necessary
+        // will just cause lock contention.
+        drop(fork_choice_read_lock);
+
+        // If the head has changed, update `self.canonical_head`.
+        let new_cached_head = if new_view.head_block_root != old_view.head_block_root {
+            metrics::inc_counter(&metrics::FORK_CHOICE_CHANGED_HEAD);
+
+            // Try and obtain the snapshot for `beacon_block_root` from the snapshot cache, falling
+            // back to a database read if that fails.
+            let new_snapshot = self
+                .snapshot_cache
+                .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
+                .and_then(|snapshot_cache| {
+                    snapshot_cache.get_cloned(
+                        new_view.head_block_root,
+                        CloneConfig::committee_caches_only(),
+                    )
+                })
+                .map::<Result<_, Error>, _>(Ok)
+                .unwrap_or_else(|| {
+                    let beacon_block = self
+                        .store
+                        .get_full_block(&new_view.head_block_root)?
+                        .ok_or(Error::MissingBeaconBlock(new_view.head_block_root))?;
+
+                    let beacon_state_root = beacon_block.state_root();
+                    let beacon_state: BeaconState<T::EthSpec> = self
+                        .get_state(&beacon_state_root, Some(beacon_block.slot()))?
+                        .ok_or(Error::MissingBeaconState(beacon_state_root))?;
+
+                    Ok(BeaconSnapshot {
+                        beacon_block: Arc::new(beacon_block),
+                        beacon_block_root: new_view.head_block_root,
+                        beacon_state,
+                    })
+                })
+                .and_then(|mut snapshot| {
+                    // Regardless of where we got the state from, attempt to build the committee
+                    // caches.
+                    snapshot
+                        .beacon_state
+                        .build_all_committee_caches(&self.spec)
+                        .map_err(Into::into)
+                        .map(|()| snapshot)
+                })?;
+
+            let new_cached_head = CachedHead {
+                snapshot: Arc::new(new_snapshot),
+                justified_checkpoint: new_view.justified_checkpoint,
+                finalized_checkpoint: new_view.finalized_checkpoint,
+                head_hash: new_forkchoice_update_parameters.head_hash,
+                finalized_hash: new_forkchoice_update_parameters.finalized_hash,
+            };
+
+            let new_head = {
+                // Now the new snapshot has been obtained, take a write-lock on the cached head so
+                // we can update it quickly.
+                let mut cached_head_write_lock = self.canonical_head.cached_head_write_lock();
+                // Enshrine the new head as the canonical cached head.
+                *cached_head_write_lock = new_cached_head;
+                // Take a clone of the cached head for later use. It is cloned whilst
+                // holding the write-lock to ensure we get exactly the head we just enshrined.
+                cached_head_write_lock.clone()
+            };
+
+            // Clear the early attester cache in case it conflicts with `self.canonical_head`.
+            self.early_attester_cache.clear();
+
+            new_head
+        } else {
+            let new_cached_head = CachedHead {
+                // The head hasn't changed, take a relatively cheap `Arc`-clone of the existing
+                // head.
+                snapshot: old_cached_head.snapshot.clone(),
+                justified_checkpoint: new_view.justified_checkpoint,
+                finalized_checkpoint: new_view.finalized_checkpoint,
+                head_hash: new_forkchoice_update_parameters.head_hash,
+                finalized_hash: new_forkchoice_update_parameters.finalized_hash,
+            };
+
+            let mut cached_head_write_lock = self.canonical_head.cached_head_write_lock();
+
+            // Enshrine the new head as the canonical cached head. Whilst the head block hasn't
+            // changed, the FFG checkpoints must have changed.
+            *cached_head_write_lock = new_cached_head;
+
+            // Take a clone of the cached head for later use. It is cloned whilst
+            // holding the write-lock to ensure we get exactly the head we just enshrined.
+            cached_head_write_lock.clone()
+        };
+
+        // Alias for readability.
+        let new_snapshot = &new_cached_head.snapshot;
+        let old_snapshot = &old_cached_head.snapshot;
+
+        // If the head changed, perform some updates.
+        if new_snapshot.beacon_block_root != old_snapshot.beacon_block_root {
+            if let Err(e) =
+                self.after_new_head(&old_cached_head, &new_cached_head, new_head_proto_block)
+            {
+                crit!(
+                    self.log,
+                    "Error updating canonical head";
+                    "error" => ?e
+                );
+            }
+        }
+
+        // Drop the old cache head nice and early to try and free the memory as soon as possible.
+        drop(old_cached_head);
+
+        // If the finalized checkpoint changed, perform some updates.
+        if new_view.finalized_checkpoint != old_view.finalized_checkpoint {
+            if let Err(e) =
+                self.after_finalization(&new_cached_head, new_view, finalized_proto_block)
+            {
+                crit!(
+                    self.log,
+                    "Error updating finalization";
+                    "error" => ?e
+                );
+            }
+        }
+
+        // The execution layer updates might attempt to take a write-lock on fork choice, so it's
+        // important to ensure the fork-choice lock isn't being held.
+        let el_update_handle =
+            spawn_execution_layer_updates(self.clone(), new_forkchoice_update_parameters)?;
+
+        // We have completed recomputing the head and it's now valid for another process to do the
+        // same.
+        drop(recompute_head_lock);
+
+        Ok(Some(el_update_handle))
+    }
+
+    /// Perform updates to caches and other components after the canonical head has been changed.
+    fn after_new_head(
+        self: &Arc<Self>,
+        old_cached_head: &CachedHead<T::EthSpec>,
+        new_cached_head: &CachedHead<T::EthSpec>,
+        new_head_proto_block: ProtoBlock,
+    ) -> Result<(), Error> {
+        let old_snapshot = &old_cached_head.snapshot;
+        let new_snapshot = &new_cached_head.snapshot;
+
+        // Detect and potentially report any re-orgs.
+        let reorg_distance = detect_reorg(
+            &old_snapshot.beacon_state,
+            old_snapshot.beacon_block_root,
+            &new_snapshot.beacon_state,
+            new_snapshot.beacon_block_root,
+            &self.spec,
+            &self.log,
+        );
+
+        // Determine if the new head is in a later epoch to the previous head.
+        let is_epoch_transition = old_snapshot
+            .beacon_block
+            .slot()
+            .epoch(T::EthSpec::slots_per_epoch())
+            < new_snapshot
+                .beacon_state
+                .slot()
+                .epoch(T::EthSpec::slots_per_epoch());
+
+        // These fields are used for server-sent events.
+        let state_root = new_snapshot.beacon_state_root();
+        let head_slot = new_snapshot.beacon_state.slot();
+        let dependent_root = new_snapshot
+            .beacon_state
+            .proposer_shuffling_decision_root(self.genesis_block_root);
+        let prev_dependent_root = new_snapshot
+            .beacon_state
+            .attester_shuffling_decision_root(self.genesis_block_root, RelativeEpoch::Current);
+
+        // Update the snapshot cache with the latest head value.
+        //
+        // This *could* be done inside `recompute_head`, however updating the head on the snapshot
+        // cache is not critical so we avoid placing it on a critical path. Note that this function
+        // will not return an error if the update fails, it will just log an error.
+        self.snapshot_cache
+            .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
+            .map(|mut snapshot_cache| {
+                snapshot_cache.update_head(new_snapshot.beacon_block_root);
+            })
+            .unwrap_or_else(|| {
+                error!(
+                    self.log,
+                    "Failed to obtain cache write lock";
+                    "lock" => "snapshot_cache",
+                    "task" => "update head"
+                );
+            });
+
+        observe_head_block_delays(
+            &mut self.block_times_cache.write(),
+            &new_head_proto_block,
+            new_snapshot.beacon_block.message().proposer_index(),
+            new_snapshot
+                .beacon_block
+                .message()
+                .body()
+                .graffiti()
+                .as_utf8_lossy(),
+            &self.slot_clock,
+            self.event_handler.as_ref(),
+            &self.log,
+        );
+
+        if is_epoch_transition || reorg_distance.is_some() {
+            self.persist_head_and_fork_choice()?;
+            self.op_pool.prune_attestations(self.epoch()?);
+        }
+
+        // Register server-sent-events for a new head.
+        if let Some(event_handler) = self
+            .event_handler
+            .as_ref()
+            .filter(|handler| handler.has_head_subscribers())
+        {
+            match (dependent_root, prev_dependent_root) {
+                (Ok(current_duty_dependent_root), Ok(previous_duty_dependent_root)) => {
+                    event_handler.register(EventKind::Head(SseHead {
+                        slot: head_slot,
+                        block: new_snapshot.beacon_block_root,
+                        state: state_root,
+                        current_duty_dependent_root,
+                        previous_duty_dependent_root,
+                        epoch_transition: is_epoch_transition,
+                    }));
+                }
+                (Err(e), _) | (_, Err(e)) => {
+                    warn!(
+                        self.log,
+                        "Unable to find dependent roots, cannot register head event";
+                        "error" => ?e
+                    );
+                }
+            }
+        }
+
+        // Register a server-sent-event for a reorg (if necessary).
+        if let Some(depth) = reorg_distance {
+            if let Some(event_handler) = self
+                .event_handler
+                .as_ref()
+                .filter(|handler| handler.has_reorg_subscribers())
+            {
+                event_handler.register(EventKind::ChainReorg(SseChainReorg {
+                    slot: head_slot,
+                    depth: depth.as_u64(),
+                    old_head_block: old_snapshot.beacon_block_root,
+                    old_head_state: old_snapshot.beacon_state_root(),
+                    new_head_block: new_snapshot.beacon_block_root,
+                    new_head_state: new_snapshot.beacon_state_root(),
+                    epoch: head_slot.epoch(T::EthSpec::slots_per_epoch()),
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Perform updates to caches and other components after the finalized checkpoint has been
+    /// changed.
+    fn after_finalization(
+        self: &Arc<Self>,
+        new_cached_head: &CachedHead<T::EthSpec>,
+        new_view: ForkChoiceView,
+        finalized_proto_block: ProtoBlock,
+    ) -> Result<(), Error> {
+        let new_snapshot = &new_cached_head.snapshot;
+
+        self.op_pool
+            .prune_all(&new_snapshot.beacon_state, self.epoch()?);
+
+        self.observed_block_producers.write().prune(
+            new_view
+                .finalized_checkpoint
+                .epoch
+                .start_slot(T::EthSpec::slots_per_epoch()),
+        );
+
+        self.snapshot_cache
+            .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
+            .map(|mut snapshot_cache| {
+                snapshot_cache.prune(new_view.finalized_checkpoint.epoch);
+                debug!(
+                    self.log,
+                    "Snapshot cache pruned";
+                    "new_len" => snapshot_cache.len(),
+                    "remaining_roots" => ?snapshot_cache.beacon_block_roots(),
+                );
+            })
+            .unwrap_or_else(|| {
+                error!(
+                    self.log,
+                    "Failed to obtain cache write lock";
+                    "lock" => "snapshot_cache",
+                    "task" => "prune"
+                );
+            });
+
+        self.attester_cache
+            .prune_below(new_view.finalized_checkpoint.epoch);
+
+        if let Some(event_handler) = self.event_handler.as_ref() {
+            if event_handler.has_finalized_subscribers() {
+                event_handler.register(EventKind::FinalizedCheckpoint(SseFinalizedCheckpoint {
+                    epoch: new_view.finalized_checkpoint.epoch,
+                    block: new_view.finalized_checkpoint.root,
+                    // Provide the state root of the latest finalized block, rather than the
+                    // specific state root at the first slot of the finalized epoch (which
+                    // might be a skip slot).
+                    state: finalized_proto_block.state_root,
+                }));
+            }
+        }
+
+        // The store migration task requires the *state at the slot of the finalized epoch*,
+        // rather than the state of the latest finalized block. These two values will only
+        // differ when the first slot of the finalized epoch is a skip slot.
+        //
+        // Use the `StateRootsIterator` directly rather than `BeaconChain::state_root_at_slot`
+        // to ensure we use the same state that we just set as the head.
+        let new_finalized_slot = new_view
+            .finalized_checkpoint
+            .epoch
+            .start_slot(T::EthSpec::slots_per_epoch());
+        let new_finalized_state_root = process_results(
+            StateRootsIterator::new(&self.store, &new_snapshot.beacon_state),
+            |mut iter| {
+                iter.find_map(|(state_root, slot)| {
+                    if slot == new_finalized_slot {
+                        Some(state_root)
+                    } else {
+                        None
+                    }
+                })
+            },
+        )?
+        .ok_or(Error::MissingFinalizedStateRoot(new_finalized_slot))?;
+
+        self.store_migrator.process_finalization(
+            new_finalized_state_root.into(),
+            new_view.finalized_checkpoint,
+            self.head_tracker.clone(),
+        )?;
+
+        Ok(())
+    }
+
+    /// Return a database operation for writing fork choice to disk.
+    pub fn persist_fork_choice_in_batch(&self) -> KeyValueStoreOp {
+        Self::persist_fork_choice_in_batch_standalone(&self.canonical_head.fork_choice_read_lock())
+    }
+
+    /// Return a database operation for writing fork choice to disk.
+    pub fn persist_fork_choice_in_batch_standalone(
+        fork_choice: &BeaconForkChoice<T>,
+    ) -> KeyValueStoreOp {
+        let persisted_fork_choice = PersistedForkChoice {
+            fork_choice: fork_choice.to_persisted(),
+            fork_choice_store: fork_choice.fc_store().to_persisted(),
+        };
+        persisted_fork_choice.as_kv_store_op(FORK_CHOICE_DB_KEY)
+    }
+}
+
+/// Check to see if the `finalized_proto_block` has an invalid execution payload. If so, shut down
+/// Lighthouse.
+///
+/// ## Notes
+///
+/// This function is called whilst holding a write-lock on the `canonical_head`. To ensure dead-lock
+/// safety, **do not take any other locks inside this function**.
+fn check_finalized_payload_validity<T: BeaconChainTypes>(
+    chain: &BeaconChain<T>,
+    finalized_proto_block: &ProtoBlock,
+) -> Result<(), Error> {
+    if let ExecutionStatus::Invalid(block_hash) = finalized_proto_block.execution_status {
+        crit!(
+            chain.log,
+            "Finalized block has an invalid payload";
+            "msg" => "You must use the `--purge-db` flag to clear the database and restart sync. \
+            You may be on a hostile network.",
+            "block_hash" => ?block_hash
+        );
+        let mut shutdown_sender = chain.shutdown_sender();
+        shutdown_sender
+            .try_send(ShutdownReason::Failure(
+                "Finalized block has an invalid execution payload.",
+            ))
+            .map_err(Error::InvalidFinalizedPayloadShutdownError)?;
+
+        // Exit now, the node is in an invalid state.
+        return Err(Error::InvalidFinalizedPayload {
+            finalized_root: finalized_proto_block.root,
+            execution_block_hash: block_hash,
+        });
+    }
+
+    Ok(())
+}
+
+/// Check to ensure that the transition from `old_view` to `new_view` will not revert finality.
+fn check_against_finality_reversion(
+    old_view: &ForkChoiceView,
+    new_view: &ForkChoiceView,
+) -> Result<(), Error> {
+    let finalization_equal = new_view.finalized_checkpoint == old_view.finalized_checkpoint;
+    let finalization_advanced =
+        new_view.finalized_checkpoint.epoch > old_view.finalized_checkpoint.epoch;
+
+    if finalization_equal || finalization_advanced {
+        Ok(())
+    } else {
+        Err(Error::RevertedFinalizedEpoch {
+            old: old_view.finalized_checkpoint,
+            new: new_view.finalized_checkpoint,
+        })
+    }
+}
+
+fn perform_debug_logging<T: BeaconChainTypes>(
+    old_view: &ForkChoiceView,
+    new_view: &ForkChoiceView,
+    fork_choice: &BeaconForkChoice<T>,
+    log: &Logger,
+) {
+    if new_view.head_block_root != old_view.head_block_root {
+        debug!(
+            log,
+            "Fork choice updated head";
+            "new_head_weight" => ?fork_choice
+                .get_block_weight(&new_view.head_block_root),
+            "new_head" => ?new_view.head_block_root,
+            "old_head_weight" => ?fork_choice
+                .get_block_weight(&old_view.head_block_root),
+            "old_head" => ?old_view.head_block_root,
+        )
+    }
+    if new_view.justified_checkpoint != old_view.justified_checkpoint {
+        debug!(
+            log,
+            "Fork choice justified";
+            "new_root" => ?new_view.justified_checkpoint.root,
+            "new_epoch" => new_view.justified_checkpoint.epoch,
+            "old_root" => ?old_view.justified_checkpoint.root,
+            "old_epoch" => old_view.justified_checkpoint.epoch,
+        )
+    }
+    if new_view.finalized_checkpoint != old_view.finalized_checkpoint {
+        debug!(
+            log,
+            "Fork choice finalized";
+            "new_root" => ?new_view.finalized_checkpoint.root,
+            "new_epoch" => new_view.finalized_checkpoint.epoch,
+            "old_root" => ?old_view.finalized_checkpoint.root,
+            "old_epoch" => old_view.finalized_checkpoint.epoch,
+        )
+    }
+}
+
+fn spawn_execution_layer_updates<T: BeaconChainTypes>(
+    chain: Arc<BeaconChain<T>>,
+    forkchoice_update_params: ForkchoiceUpdateParameters,
+) -> Result<JoinHandle<Option<()>>, Error> {
+    let current_slot = chain
+        .slot_clock
+        .now_or_genesis()
+        .ok_or(Error::UnableToReadSlot)?;
+
+    chain
+        .task_executor
+        .clone()
+        .spawn_handle(
+            async move {
+                // Avoids raising an error before Bellatrix.
+                //
+                // See `Self::prepare_beacon_proposer` for more detail.
+                if chain.slot_is_prior_to_bellatrix(current_slot + 1) {
+                    return;
+                }
+
+                if let Err(e) = chain
+                    .update_execution_engine_forkchoice(current_slot, forkchoice_update_params)
+                    .await
+                {
+                    crit!(
+                        chain.log,
+                        "Failed to update execution head";
+                        "error" => ?e
+                    );
+                }
+
+                // Update the mechanism for preparing for block production on the execution layer.
+                //
+                // Performing this call immediately after `update_execution_engine_forkchoice_blocking`
+                // might result in two calls to fork choice updated, one *without* payload attributes and
+                // then a second *with* payload attributes.
+                //
+                // This seems OK. It's not a significant waste of EL<>CL bandwidth or resources, as far as I
+                // know.
+                if let Err(e) = chain.prepare_beacon_proposer(current_slot).await {
+                    crit!(
+                        chain.log,
+                        "Failed to prepare proposers after fork choice";
+                        "error" => ?e
+                    );
+                }
+            },
+            "update_el_forkchoice",
+        )
+        .ok_or(Error::RuntimeShutdown)
+}
+
+/// Attempt to detect if the new head is not on the same chain as the previous block
+/// (i.e., a re-org).
+///
+/// Note: this will declare a re-org if we skip `SLOTS_PER_HISTORICAL_ROOT` blocks
+/// between calls to fork choice without swapping between chains. This seems like an
+/// extreme-enough scenario that a warning is fine.
+fn detect_reorg<E: EthSpec>(
+    old_state: &BeaconState<E>,
+    old_block_root: Hash256,
+    new_state: &BeaconState<E>,
+    new_block_root: Hash256,
+    spec: &ChainSpec,
+    log: &Logger,
+) -> Option<Slot> {
+    let is_reorg = new_state
+        .get_block_root(old_state.slot())
+        .map_or(true, |root| *root != old_block_root);
+
+    if is_reorg {
+        let reorg_distance =
+            match find_reorg_slot(old_state, old_block_root, new_state, new_block_root, spec) {
+                Ok(slot) => old_state.slot().saturating_sub(slot),
+                Err(e) => {
+                    warn!(
+                        log,
+                        "Could not find re-org depth";
+                        "error" => format!("{:?}", e),
+                    );
+                    return None;
+                }
+            };
+
+        metrics::inc_counter(&metrics::FORK_CHOICE_REORG_COUNT);
+        metrics::inc_counter(&metrics::FORK_CHOICE_REORG_COUNT_INTEROP);
+        warn!(
+            log,
+            "Beacon chain re-org";
+            "previous_head" => ?old_block_root,
+            "previous_slot" => old_state.slot(),
+            "new_head" => ?new_block_root,
+            "new_slot" => new_state.slot(),
+            "reorg_distance" => reorg_distance,
+        );
+
+        Some(reorg_distance)
+    } else {
+        None
+    }
+}
+
+/// Iterate through the current chain to find the slot intersecting with the given beacon state.
+/// The maximum depth this will search is `SLOTS_PER_HISTORICAL_ROOT`, and if that depth is reached
+/// and no intersection is found, the finalized slot will be returned.
+pub fn find_reorg_slot<E: EthSpec>(
+    old_state: &BeaconState<E>,
+    old_block_root: Hash256,
+    new_state: &BeaconState<E>,
+    new_block_root: Hash256,
+    spec: &ChainSpec,
+) -> Result<Slot, Error> {
+    // The earliest slot for which the two chains may have a common history.
+    let lowest_slot = std::cmp::min(new_state.slot(), old_state.slot());
+
+    // Create an iterator across `$state`, assuming that the block at `$state.slot` has the
+    // block root of `$block_root`.
+    //
+    // The iterator will be skipped until the next value returns `lowest_slot`.
+    //
+    // This is a macro instead of a function or closure due to the complex types invloved
+    // in all the iterator wrapping.
+    macro_rules! aligned_roots_iter {
+        ($state: ident, $block_root: ident) => {
+            std::iter::once(Ok(($state.slot(), $block_root)))
+                .chain($state.rev_iter_block_roots(spec))
+                .skip_while(|result| {
+                    result
+                        .as_ref()
+                        .map_or(false, |(slot, _)| *slot > lowest_slot)
+                })
+        };
+    }
+
+    // Create iterators across old/new roots where iterators both start at the same slot.
+    let mut new_roots = aligned_roots_iter!(new_state, new_block_root);
+    let mut old_roots = aligned_roots_iter!(old_state, old_block_root);
+
+    // Whilst *both* of the iterators are still returning values, try and find a common
+    // ancestor between them.
+    while let (Some(old), Some(new)) = (old_roots.next(), new_roots.next()) {
+        let (old_slot, old_root) = old?;
+        let (new_slot, new_root) = new?;
+
+        // Sanity check to detect programming errors.
+        if old_slot != new_slot {
+            return Err(Error::InvalidReorgSlotIter { new_slot, old_slot });
+        }
+
+        if old_root == new_root {
+            // A common ancestor has been found.
+            return Ok(old_slot);
+        }
+    }
+
+    // If no common ancestor is found, declare that the re-org happened at the previous
+    // finalized slot.
+    //
+    // Sometimes this will result in the return slot being *lower* than the actual reorg
+    // slot. However, assuming we don't re-org through a finalized slot, it will never be
+    // *higher*.
+    //
+    // We provide this potentially-inaccurate-but-safe information to avoid onerous
+    // database reads during times of deep reorgs.
+    Ok(old_state
+        .finalized_checkpoint()
+        .epoch
+        .start_slot(E::slots_per_epoch()))
+}
+
+fn observe_head_block_delays<E: EthSpec, S: SlotClock>(
+    block_times_cache: &mut BlockTimesCache,
+    head_block: &ProtoBlock,
+    head_block_proposer_index: u64,
+    head_block_graffiti: String,
+    slot_clock: &S,
+    event_handler: Option<&ServerSentEventHandler<E>>,
+    log: &Logger,
+) {
+    let block_time_set_as_head = timestamp_now();
+    let head_block_root = head_block.root;
+    let head_block_slot = head_block.slot;
+
+    // Calculate the total delay between the start of the slot and when it was set as head.
+    let block_delay_total = get_slot_delay_ms(block_time_set_as_head, head_block_slot, slot_clock);
+
+    // Do not write to the cache for blocks older than 2 epochs, this helps reduce writes to
+    // the cache during sync.
+    if block_delay_total < slot_clock.slot_duration() * 64 {
+        block_times_cache.set_time_set_as_head(
+            head_block_root,
+            head_block_slot,
+            block_time_set_as_head,
+        );
+    }
+
+    // If a block comes in from over 4 slots ago, it is most likely a block from sync.
+    let block_from_sync = block_delay_total > slot_clock.slot_duration() * 4;
+
+    // Determine whether the block has been set as head too late for proper attestation
+    // production.
+    let late_head = block_delay_total >= slot_clock.unagg_attestation_production_delay();
+
+    // Do not store metrics if the block was > 4 slots old, this helps prevent noise during
+    // sync.
+    if !block_from_sync {
+        // Observe the total block delay. This is the delay between the time the slot started
+        // and when the block was set as head.
+        metrics::observe_duration(
+            &metrics::BEACON_BLOCK_HEAD_SLOT_START_DELAY_TIME,
+            block_delay_total,
+        );
+
+        // Observe the delay between when we imported the block and when we set the block as
+        // head.
+        let block_delays = block_times_cache.get_block_delays(
+            head_block_root,
+            slot_clock
+                .start_of(head_block_slot)
+                .unwrap_or_else(|| Duration::from_secs(0)),
+        );
+
+        metrics::observe_duration(
+            &metrics::BEACON_BLOCK_OBSERVED_SLOT_START_DELAY_TIME,
+            block_delays
+                .observed
+                .unwrap_or_else(|| Duration::from_secs(0)),
+        );
+
+        metrics::observe_duration(
+            &metrics::BEACON_BLOCK_HEAD_IMPORTED_DELAY_TIME,
+            block_delays
+                .set_as_head
+                .unwrap_or_else(|| Duration::from_secs(0)),
+        );
+
+        // If the block was enshrined as head too late for attestations to be created for it,
+        // log a debug warning and increment a metric.
+        if late_head {
+            metrics::inc_counter(&metrics::BEACON_BLOCK_HEAD_SLOT_START_DELAY_EXCEEDED_TOTAL);
+            debug!(
+                log,
+                "Delayed head block";
+                "block_root" => ?head_block_root,
+                "proposer_index" => head_block_proposer_index,
+                "slot" => head_block_slot,
+                "block_delay" => ?block_delay_total,
+                "observed_delay" => ?block_delays.observed,
+                "imported_delay" => ?block_delays.imported,
+                "set_as_head_delay" => ?block_delays.set_as_head,
+            );
+        }
+    }
+
+    if let Some(event_handler) = event_handler {
+        if !block_from_sync && late_head && event_handler.has_late_head_subscribers() {
+            let peer_info = block_times_cache.get_peer_info(head_block_root);
+            let block_delays = block_times_cache.get_block_delays(
+                head_block_root,
+                slot_clock
+                    .start_of(head_block_slot)
+                    .unwrap_or_else(|| Duration::from_secs(0)),
+            );
+            event_handler.register(EventKind::LateHead(SseLateHead {
+                slot: head_block_slot,
+                block: head_block_root,
+                peer_id: peer_info.id,
+                peer_client: peer_info.client,
+                proposer_index: head_block_proposer_index,
+                proposer_graffiti: head_block_graffiti,
+                block_delay: block_delay_total,
+                observed_delay: block_delays.observed,
+                imported_delay: block_delays.imported,
+                set_as_head_delay: block_delays.set_as_head,
+            }));
+        }
+    }
+}

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use parking_lot::RwLock;
 use proto_array::Block as ProtoBlock;
+use std::sync::Arc;
 use types::*;
 
 pub struct CacheItem<E: EthSpec> {
@@ -18,7 +19,7 @@ pub struct CacheItem<E: EthSpec> {
     /*
      * Values used to make the block available.
      */
-    block: SignedBeaconBlock<E>,
+    block: Arc<SignedBeaconBlock<E>>,
     proto_block: ProtoBlock,
 }
 
@@ -48,7 +49,7 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
     pub fn add_head_block(
         &self,
         beacon_block_root: Hash256,
-        block: SignedBeaconBlock<E>,
+        block: Arc<SignedBeaconBlock<E>>,
         proto_block: ProtoBlock,
         state: &BeaconState<E>,
         spec: &ChainSpec,
@@ -146,7 +147,7 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
     }
 
     /// Returns the block, if `block_root` matches the cached item.
-    pub fn get_block(&self, block_root: Hash256) -> Option<SignedBeaconBlock<E>> {
+    pub fn get_block(&self, block_root: Hash256) -> Option<Arc<SignedBeaconBlock<E>>> {
         self.item
             .read()
             .as_ref()

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -45,8 +45,8 @@ pub enum BeaconChainError {
     UnableToReadSlot,
     UnableToComputeTimeAtSlot,
     RevertedFinalizedEpoch {
-        previous_epoch: Epoch,
-        new_epoch: Epoch,
+        old: Checkpoint,
+        new: Checkpoint,
     },
     SlotClockDidNotStart,
     NoStateForSlot(Slot),
@@ -161,6 +161,7 @@ pub enum BeaconChainError {
     BlockRewardSyncError,
     HeadMissingFromForkChoice(Hash256),
     FinalizedBlockMissingFromForkChoice(Hash256),
+    HeadBlockMissingFromForkChoice(Hash256),
     InvalidFinalizedPayload {
         finalized_root: Hash256,
         execution_block_hash: ExecutionBlockHash,
@@ -184,11 +185,19 @@ pub enum BeaconChainError {
         beacon_block_root: Hash256,
     },
     RuntimeShutdown,
+    TokioJoin(tokio::task::JoinError),
     ProcessInvalidExecutionPayload(JoinError),
     ForkChoiceSignalOutOfOrder {
         current: Slot,
         latest: Slot,
     },
+    ForkchoiceUpdateParamsMissing,
+    HeadHasInvalidPayload {
+        block_root: Hash256,
+        execution_status: ExecutionStatus,
+    },
+    AttestationHeadNotInForkChoice(Hash256),
+    MissingPersistedForkChoice,
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);
@@ -214,7 +223,6 @@ easy_from_to!(BlockReplayError, BeaconChainError);
 
 #[derive(Debug)]
 pub enum BlockProductionError {
-    UnableToGetHeadInfo(BeaconChainError),
     UnableToGetBlockRootFromState,
     UnableToReadSlot,
     UnableToProduceAtSlot(Slot),
@@ -239,6 +247,11 @@ pub enum BlockProductionError {
     MissingFinalizedBlock(Hash256),
     BlockTooLarge(usize),
     ForkChoiceError(BeaconChainError),
+    ShuttingDown,
+    MissingSyncAggregate,
+    MissingExecutionPayload,
+    TokioJoin(tokio::task::JoinError),
+    BeaconChain(BeaconChainError),
 }
 
 easy_from_to!(BlockProcessingError, BlockProductionError);

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -7,6 +7,7 @@ use state_processing::{
 };
 use std::borrow::Cow;
 use std::iter;
+use std::sync::Arc;
 use std::time::Duration;
 use store::{chunked_vector::BlockRoots, AnchorInfo, ChunkWriter, KeyValueStore};
 use types::{Hash256, SignedBlindedBeaconBlock, Slot};
@@ -58,7 +59,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// Return the number of blocks successfully imported.
     pub fn import_historical_block_batch(
         &self,
-        blocks: Vec<SignedBlindedBeaconBlock<T::EthSpec>>,
+        blocks: Vec<Arc<SignedBlindedBeaconBlock<T::EthSpec>>>,
     ) -> Result<usize, Error> {
         let anchor_info = self
             .store

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -9,6 +9,7 @@ pub mod block_reward;
 mod block_times_cache;
 mod block_verification;
 pub mod builder;
+pub mod canonical_head;
 pub mod chain_config;
 mod early_attester_cache;
 mod errors;
@@ -42,8 +43,8 @@ mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, HeadInfo, HeadSafetyStatus, ProduceBlockVerification, StateSkipConfig,
-    WhenSlotSkipped, INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
+    ForkChoiceError, ProduceBlockVerification, StateSkipConfig, WhenSlotSkipped,
+    INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
 pub use self::chain_config::ChainConfig;
@@ -52,8 +53,10 @@ pub use self::historical_blocks::HistoricalBlockError;
 pub use attestation_verification::Error as AttestationError;
 pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceStoreError};
 pub use block_verification::{BlockError, ExecutionPayloadError, GossipVerifiedBlock};
+pub use canonical_head::{CachedHead, CanonicalHead, CanonicalHeadRwLock};
 pub use eth1_chain::{Eth1Chain, Eth1ChainBackend};
 pub use events::ServerSentEventHandler;
+pub use fork_choice::ExecutionStatus;
 pub use metrics::scrape_for_metrics;
 pub use parking_lot;
 pub use slot_clock;

--- a/beacon_node/beacon_chain/src/proposer_prep_service.rs
+++ b/beacon_node/beacon_chain/src/proposer_prep_service.rs
@@ -51,9 +51,7 @@ async fn proposer_prep_service<T: BeaconChainTypes>(
                 executor.spawn(
                     async move {
                         if let Ok(current_slot) = inner_chain.slot() {
-                            if let Err(e) = inner_chain
-                                .prepare_beacon_proposer_async(current_slot)
-                                .await
+                            if let Err(e) = inner_chain.prepare_beacon_proposer(current_slot).await
                             {
                                 error!(
                                     inner_chain.log,

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -47,6 +47,12 @@ impl ShufflingCache {
     }
 }
 
+impl Default for ShufflingCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Contains the shuffling IDs for a beacon block.
 pub struct BlockShufflingIds {
     pub current: AttestationShufflingId,

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -213,16 +213,14 @@ async fn state_advance_timer<T: BeaconChainTypes>(
         let log = log.clone();
         let beacon_chain = beacon_chain.clone();
         let next_slot = current_slot + 1;
-        executor.spawn_blocking(
-            move || {
+        executor.spawn(
+            async move {
                 // Don't run fork choice during sync.
-                if beacon_chain.best_slot().map_or(true, |head_slot| {
-                    head_slot + MAX_FORK_CHOICE_DISTANCE < current_slot
-                }) {
+                if beacon_chain.best_slot() + MAX_FORK_CHOICE_DISTANCE < current_slot {
                     return;
                 }
 
-                if let Err(e) = beacon_chain.fork_choice_at_slot(next_slot) {
+                if let Err(e) = beacon_chain.recompute_head_at_slot(next_slot).await {
                     warn!(
                         log,
                         "Error updating fork choice for next slot";
@@ -231,17 +229,24 @@ async fn state_advance_timer<T: BeaconChainTypes>(
                     );
                 }
 
-                // Signal block proposal for the next slot (if it happens to be waiting).
-                if let Some(tx) = &beacon_chain.fork_choice_signal_tx {
-                    if let Err(e) = tx.notify_fork_choice_complete(next_slot) {
-                        warn!(
-                            log,
-                            "Error signalling fork choice waiter";
-                            "error" => ?e,
-                            "slot" => next_slot,
-                        );
-                    }
-                }
+                // Use a blocking task to avoid blocking the core executor whilst waiting for locks
+                // in `ForkChoiceSignalTx`.
+                beacon_chain.task_executor.clone().spawn_blocking(
+                    move || {
+                        // Signal block proposal for the next slot (if it happens to be waiting).
+                        if let Some(tx) = &beacon_chain.fork_choice_signal_tx {
+                            if let Err(e) = tx.notify_fork_choice_complete(next_slot) {
+                                warn!(
+                                    log,
+                                    "Error signalling fork choice waiter";
+                                    "error" => ?e,
+                                    "slot" => next_slot,
+                                );
+                            }
+                        }
+                    },
+                    "fork_choice_advance_signal_tx",
+                );
             },
             "fork_choice_advance",
         );
@@ -264,7 +269,7 @@ fn advance_head<T: BeaconChainTypes>(
     //
     // Fork-choice is not run *before* this function to avoid unnecessary calls whilst syncing.
     {
-        let head_slot = beacon_chain.head_info()?.slot;
+        let head_slot = beacon_chain.best_slot();
 
         // Don't run this when syncing or if lagging too far behind.
         if head_slot + MAX_ADVANCE_DISTANCE < current_slot {
@@ -275,7 +280,7 @@ fn advance_head<T: BeaconChainTypes>(
         }
     }
 
-    let head_root = beacon_chain.head_info()?.block_root;
+    let head_root = beacon_chain.head_beacon_block_root();
 
     let (head_slot, head_state_root, mut state) = match beacon_chain
         .snapshot_cache

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -56,7 +56,7 @@ fn get_harness(validator_count: usize) -> BeaconChainHarness<EphemeralHarnessTyp
 fn get_valid_unaggregated_attestation<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
 ) -> (Attestation<T::EthSpec>, usize, usize, SecretKey, SubnetId) {
-    let head = chain.head().expect("should get head");
+    let head = chain.head_snapshot();
     let current_slot = chain.slot().expect("should get slot");
 
     let mut valid_attestation = chain
@@ -106,7 +106,8 @@ fn get_valid_aggregated_attestation<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     aggregate: Attestation<T::EthSpec>,
 ) -> (SignedAggregateAndProof<T::EthSpec>, usize, SecretKey) {
-    let state = &chain.head().expect("should get head").beacon_state;
+    let head = chain.head_snapshot();
+    let state = &head.beacon_state;
     let current_slot = chain.slot().expect("should get slot");
 
     let committee = state
@@ -155,7 +156,8 @@ fn get_non_aggregator<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
     aggregate: &Attestation<T::EthSpec>,
 ) -> (usize, SecretKey) {
-    let state = &chain.head().expect("should get head").beacon_state;
+    let head = chain.head_snapshot();
+    let state = &head.beacon_state;
     let current_slot = chain.slot().expect("should get slot");
 
     let committee = state
@@ -213,15 +215,17 @@ struct GossipTester {
 }
 
 impl GossipTester {
-    pub fn new() -> Self {
+    pub async fn new() -> Self {
         let harness = get_harness(VALIDATOR_COUNT);
 
         // Extend the chain out a few epochs so we have some chain depth to play with.
-        harness.extend_chain(
-            MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
-            BlockStrategy::OnCanonicalHead,
-            AttestationStrategy::AllValidators,
-        );
+        harness
+            .extend_chain(
+                MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
+                BlockStrategy::OnCanonicalHead,
+                AttestationStrategy::AllValidators,
+            )
+            .await;
 
         // Advance into a slot where there have not been blocks or attestations produced.
         harness.advance_slot();
@@ -395,9 +399,10 @@ impl GossipTester {
     }
 }
 /// Tests verification of `SignedAggregateAndProof` from the gossip network.
-#[test]
-fn aggregated_gossip_verification() {
+#[tokio::test]
+async fn aggregated_gossip_verification() {
     GossipTester::new()
+        .await
         /*
          * The following two tests ensure:
          *
@@ -511,8 +516,7 @@ fn aggregated_gossip_verification() {
                 let committee_len = tester
                     .harness
                     .chain
-                    .head()
-                    .unwrap()
+                    .head_snapshot()
                     .beacon_state
                     .get_beacon_committee(tester.slot(), a.message.aggregate.data.index)
                     .expect("should get committees")
@@ -612,7 +616,7 @@ fn aggregated_gossip_verification() {
                     tester.valid_aggregate.message.aggregate.clone(),
                     None,
                     &sk,
-                    &chain.head_info().unwrap().fork,
+                    &chain.canonical_head.cached_head().head_fork(),
                     chain.genesis_validators_root,
                     &chain.spec,
                 )
@@ -669,9 +673,10 @@ fn aggregated_gossip_verification() {
 }
 
 /// Tests the verification conditions for an unaggregated attestation on the gossip network.
-#[test]
-fn unaggregated_gossip_verification() {
+#[tokio::test]
+async fn unaggregated_gossip_verification() {
     GossipTester::new()
+        .await
         /*
          * The following test ensures:
          *
@@ -684,8 +689,7 @@ fn unaggregated_gossip_verification() {
                 a.data.index = tester
                     .harness
                     .chain
-                    .head()
-                    .unwrap()
+                    .head_snapshot()
                     .beacon_state
                     .get_committee_count_at_slot(a.data.slot)
                     .unwrap()
@@ -924,16 +928,18 @@ fn unaggregated_gossip_verification() {
 /// Ensures that an attestation that skips epochs can still be processed.
 ///
 /// This also checks that we can do a state lookup if we don't get a hit from the shuffling cache.
-#[test]
-fn attestation_that_skips_epochs() {
+#[tokio::test]
+async fn attestation_that_skips_epochs() {
     let harness = get_harness(VALIDATOR_COUNT);
 
     // Extend the chain out a few epochs so we have some chain depth to play with.
-    harness.extend_chain(
-        MainnetEthSpec::slots_per_epoch() as usize * 3 + 1,
-        BlockStrategy::OnCanonicalHead,
-        AttestationStrategy::SomeValidators(vec![]),
-    );
+    harness
+        .extend_chain(
+            MainnetEthSpec::slots_per_epoch() as usize * 3 + 1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::SomeValidators(vec![]),
+        )
+        .await;
 
     let current_slot = harness.chain.slot().expect("should get slot");
     let current_epoch = harness.chain.epoch().expect("should get epoch");
@@ -992,16 +998,18 @@ fn attestation_that_skips_epochs() {
         .expect("should gossip verify attestation that skips slots");
 }
 
-#[test]
-fn attestation_to_finalized_block() {
+#[tokio::test]
+async fn attestation_to_finalized_block() {
     let harness = get_harness(VALIDATOR_COUNT);
 
     // Extend the chain out a few epochs so we have some chain depth to play with.
-    harness.extend_chain(
-        MainnetEthSpec::slots_per_epoch() as usize * 4 + 1,
-        BlockStrategy::OnCanonicalHead,
-        AttestationStrategy::AllValidators,
-    );
+    harness
+        .extend_chain(
+            MainnetEthSpec::slots_per_epoch() as usize * 4 + 1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
     let finalized_checkpoint = harness
         .chain
@@ -1067,16 +1075,18 @@ fn attestation_to_finalized_block() {
         .contains(earlier_block_root));
 }
 
-#[test]
-fn verify_aggregate_for_gossip_doppelganger_detection() {
+#[tokio::test]
+async fn verify_aggregate_for_gossip_doppelganger_detection() {
     let harness = get_harness(VALIDATOR_COUNT);
 
     // Extend the chain out a few epochs so we have some chain depth to play with.
-    harness.extend_chain(
-        MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
-        BlockStrategy::OnCanonicalHead,
-        AttestationStrategy::AllValidators,
-    );
+    harness
+        .extend_chain(
+            MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
     // Advance into a slot where there have not been blocks or attestations produced.
     harness.advance_slot();
@@ -1124,16 +1134,18 @@ fn verify_aggregate_for_gossip_doppelganger_detection() {
         .expect("should check if gossip aggregator was observed"));
 }
 
-#[test]
-fn verify_attestation_for_gossip_doppelganger_detection() {
+#[tokio::test]
+async fn verify_attestation_for_gossip_doppelganger_detection() {
     let harness = get_harness(VALIDATOR_COUNT);
 
     // Extend the chain out a few epochs so we have some chain depth to play with.
-    harness.extend_chain(
-        MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
-        BlockStrategy::OnCanonicalHead,
-        AttestationStrategy::AllValidators,
-    );
+    harness
+        .extend_chain(
+            MainnetEthSpec::slots_per_epoch() as usize * 3 - 1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
     // Advance into a slot where there have not been blocks or attestations produced.
     harness.advance_slot();

--- a/beacon_node/beacon_chain/tests/op_verification.rs
+++ b/beacon_node/beacon_chain/tests/op_verification.rs
@@ -46,18 +46,20 @@ fn get_harness(store: Arc<HotColdDB>, validator_count: usize) -> TestHarness {
     harness
 }
 
-#[test]
-fn voluntary_exit() {
+#[tokio::test]
+async fn voluntary_exit() {
     let db_path = tempdir().unwrap();
     let store = get_store(&db_path);
     let harness = get_harness(store.clone(), VALIDATOR_COUNT);
     let spec = &harness.chain.spec.clone();
 
-    harness.extend_chain(
-        (E::slots_per_epoch() * (spec.shard_committee_period + 1)) as usize,
-        BlockStrategy::OnCanonicalHead,
-        AttestationStrategy::AllValidators,
-    );
+    harness
+        .extend_chain(
+            (E::slots_per_epoch() * (spec.shard_committee_period + 1)) as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
 
     let validator_index1 = VALIDATOR_COUNT - 1;
     let validator_index2 = VALIDATOR_COUNT - 2;

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -2,8 +2,8 @@
 
 use beacon_chain::{
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
-    BeaconChainError, BlockError, ExecutionPayloadError, HeadInfo, StateSkipConfig,
-    WhenSlotSkipped, INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
+    BeaconChainError, BlockError, ExecutionPayloadError, StateSkipConfig, WhenSlotSkipped,
+    INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
 };
 use execution_layer::{
     json_structures::{JsonForkChoiceStateV1, JsonPayloadAttributesV1},
@@ -12,6 +12,7 @@ use execution_layer::{
 use fork_choice::{Error as ForkChoiceError, InvalidationOperation, PayloadVerificationStatus};
 use proto_array::{Error as ProtoArrayError, ExecutionStatus};
 use slot_clock::SlotClock;
+use std::sync::Arc;
 use std::time::Duration;
 use task_executor::ShutdownReason;
 use tree_hash::TreeHash;
@@ -84,19 +85,19 @@ impl InvalidPayloadRig {
     fn execution_status(&self, block_root: Hash256) -> ExecutionStatus {
         self.harness
             .chain
-            .fork_choice
-            .read()
+            .canonical_head
+            .fork_choice_read_lock()
             .get_block(&block_root)
             .unwrap()
             .execution_status
     }
 
-    fn fork_choice(&self) {
-        self.harness.chain.fork_choice().unwrap();
-    }
-
-    fn head_info(&self) -> HeadInfo {
-        self.harness.chain.head_info().unwrap()
+    async fn recompute_head(&self) {
+        self.harness
+            .chain
+            .recompute_head_at_current_slot()
+            .await
+            .unwrap();
     }
 
     fn previous_forkchoice_update_params(&self) -> (ForkChoiceState, PayloadAttributes) {
@@ -142,22 +143,24 @@ impl InvalidPayloadRig {
             .block_hash
     }
 
-    fn build_blocks(&mut self, num_blocks: u64, is_valid: Payload) -> Vec<Hash256> {
-        (0..num_blocks)
-            .map(|_| self.import_block(is_valid.clone()))
-            .collect()
+    async fn build_blocks(&mut self, num_blocks: u64, is_valid: Payload) -> Vec<Hash256> {
+        let mut roots = Vec::with_capacity(num_blocks as usize);
+        for _ in 0..num_blocks {
+            roots.push(self.import_block(is_valid.clone()).await);
+        }
+        roots
     }
 
-    fn move_to_first_justification(&mut self, is_valid: Payload) {
+    async fn move_to_first_justification(&mut self, is_valid: Payload) {
         let slots_till_justification = E::slots_per_epoch() * 3;
-        self.build_blocks(slots_till_justification, is_valid);
+        self.build_blocks(slots_till_justification, is_valid).await;
 
-        let justified_checkpoint = self.head_info().current_justified_checkpoint;
+        let justified_checkpoint = self.harness.justified_checkpoint();
         assert_eq!(justified_checkpoint.epoch, 2);
     }
 
     /// Import a block while setting the newPayload and forkchoiceUpdated responses to `is_valid`.
-    fn import_block(&mut self, is_valid: Payload) -> Hash256 {
+    async fn import_block(&mut self, is_valid: Payload) -> Hash256 {
         self.import_block_parametric(is_valid, is_valid, |error| {
             matches!(
                 error,
@@ -166,6 +169,7 @@ impl InvalidPayloadRig {
                 )
             )
         })
+        .await
     }
 
     fn block_root_at_slot(&self, slot: Slot) -> Option<Hash256> {
@@ -178,13 +182,13 @@ impl InvalidPayloadRig {
     fn validate_manually(&self, block_root: Hash256) {
         self.harness
             .chain
-            .fork_choice
-            .write()
+            .canonical_head
+            .fork_choice_write_lock()
             .on_valid_execution_payload(block_root)
             .unwrap();
     }
 
-    fn import_block_parametric<F: Fn(&BlockError<E>) -> bool>(
+    async fn import_block_parametric<F: Fn(&BlockError<E>) -> bool>(
         &mut self,
         new_payload_response: Payload,
         forkchoice_response: Payload,
@@ -192,10 +196,10 @@ impl InvalidPayloadRig {
     ) -> Hash256 {
         let mock_execution_layer = self.harness.mock_execution_layer.as_ref().unwrap();
 
-        let head = self.harness.chain.head().unwrap();
-        let state = head.beacon_state;
+        let head = self.harness.chain.head_snapshot();
+        let state = head.beacon_state.clone_with_only_committee_caches();
         let slot = state.slot() + 1;
-        let (block, post_state) = self.harness.make_block(state, slot);
+        let (block, post_state) = self.harness.make_block(state, slot).await;
         let block_root = block.canonical_root();
 
         let set_new_payload = |payload: Payload| match payload {
@@ -249,7 +253,11 @@ impl InvalidPayloadRig {
                 } else {
                     mock_execution_layer.server.full_payload_verification();
                 }
-                let root = self.harness.process_block(slot, block.clone()).unwrap();
+                let root = self
+                    .harness
+                    .process_block(slot, block.clone())
+                    .await
+                    .unwrap();
 
                 if self.enable_attestations {
                     let all_validators: Vec<usize> = (0..VALIDATOR_COUNT).collect();
@@ -294,7 +302,7 @@ impl InvalidPayloadRig {
                 set_new_payload(new_payload_response);
                 set_forkchoice_updated(forkchoice_response);
 
-                match self.harness.process_block(slot, block) {
+                match self.harness.process_block(slot, block).await {
                     Err(error) if evaluate_error(&error) => (),
                     Err(other) => {
                         panic!("evaluate_error returned false with {:?}", other)
@@ -309,8 +317,12 @@ impl InvalidPayloadRig {
                     }
                 };
 
-                let block_in_forkchoice =
-                    self.harness.chain.fork_choice.read().get_block(&block_root);
+                let block_in_forkchoice = self
+                    .harness
+                    .chain
+                    .canonical_head
+                    .fork_choice_read_lock()
+                    .get_block(&block_root);
                 if let Payload::Invalid { .. } = new_payload_response {
                     // A block found to be immediately invalid should not end up in fork choice.
                     assert_eq!(block_in_forkchoice, None);
@@ -333,106 +345,111 @@ impl InvalidPayloadRig {
         block_root
     }
 
-    fn invalidate_manually(&self, block_root: Hash256) {
+    async fn invalidate_manually(&self, block_root: Hash256) {
         self.harness
             .chain
             .process_invalid_execution_payload(&InvalidationOperation::InvalidateOne { block_root })
+            .await
             .unwrap();
     }
 }
 
 /// Simple test of the different import types.
-#[test]
-fn valid_invalid_syncing() {
+#[tokio::test]
+async fn valid_invalid_syncing() {
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
 
-    rig.import_block(Payload::Valid);
+    rig.import_block(Payload::Valid).await;
     rig.import_block(Payload::Invalid {
         latest_valid_hash: None,
-    });
-    rig.import_block(Payload::Syncing);
+    })
+    .await;
+    rig.import_block(Payload::Syncing).await;
 }
 
 /// Ensure that an invalid payload can invalidate its parent too (given the right
 /// `latest_valid_hash`.
-#[test]
-fn invalid_payload_invalidates_parent() {
+#[tokio::test]
+async fn invalid_payload_invalidates_parent() {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
-    rig.move_to_first_justification(Payload::Syncing);
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
+    rig.move_to_first_justification(Payload::Syncing).await;
 
     let roots = vec![
-        rig.import_block(Payload::Syncing),
-        rig.import_block(Payload::Syncing),
-        rig.import_block(Payload::Syncing),
+        rig.import_block(Payload::Syncing).await,
+        rig.import_block(Payload::Syncing).await,
+        rig.import_block(Payload::Syncing).await,
     ];
 
     let latest_valid_hash = rig.block_hash(roots[0]);
 
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(latest_valid_hash),
-    });
+    })
+    .await;
 
     assert!(rig.execution_status(roots[0]).is_valid_and_post_bellatrix());
     assert!(rig.execution_status(roots[1]).is_invalid());
     assert!(rig.execution_status(roots[2]).is_invalid());
 
-    assert_eq!(rig.head_info().block_root, roots[0]);
+    assert_eq!(rig.harness.head_block_root(), roots[0]);
 }
 
 /// Test invalidation of a payload via the fork choice updated message.
 ///
 /// The `invalid_payload` argument determines the type of invalid payload: `Invalid`,
 /// `InvalidBlockHash`, etc, taking the `latest_valid_hash` as an argument.
-fn immediate_forkchoice_update_invalid_test(
+async fn immediate_forkchoice_update_invalid_test(
     invalid_payload: impl FnOnce(Option<ExecutionBlockHash>) -> Payload,
 ) {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
-    rig.move_to_first_justification(Payload::Syncing);
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
+    rig.move_to_first_justification(Payload::Syncing).await;
 
-    let valid_head_root = rig.import_block(Payload::Valid);
+    let valid_head_root = rig.import_block(Payload::Valid).await;
     let latest_valid_hash = Some(rig.block_hash(valid_head_root));
 
     // Import a block which returns syncing when supplied via newPayload, and then
     // invalid when the forkchoice update is sent.
     rig.import_block_parametric(Payload::Syncing, invalid_payload(latest_valid_hash), |_| {
         false
-    });
+    })
+    .await;
 
     // The head should be the latest valid block.
-    assert_eq!(rig.head_info().block_root, valid_head_root);
+    assert_eq!(rig.harness.head_block_root(), valid_head_root);
 }
 
-#[test]
-fn immediate_forkchoice_update_payload_invalid() {
+#[tokio::test]
+async fn immediate_forkchoice_update_payload_invalid() {
     immediate_forkchoice_update_invalid_test(|latest_valid_hash| Payload::Invalid {
         latest_valid_hash,
     })
+    .await
 }
 
-#[test]
-fn immediate_forkchoice_update_payload_invalid_block_hash() {
-    immediate_forkchoice_update_invalid_test(|_| Payload::InvalidBlockHash)
+#[tokio::test]
+async fn immediate_forkchoice_update_payload_invalid_block_hash() {
+    immediate_forkchoice_update_invalid_test(|_| Payload::InvalidBlockHash).await
 }
 
-#[test]
-fn immediate_forkchoice_update_payload_invalid_terminal_block() {
-    immediate_forkchoice_update_invalid_test(|_| Payload::InvalidTerminalBlock)
+#[tokio::test]
+async fn immediate_forkchoice_update_payload_invalid_terminal_block() {
+    immediate_forkchoice_update_invalid_test(|_| Payload::InvalidTerminalBlock).await
 }
 
 /// Ensure the client tries to exit when the justified checkpoint is invalidated.
-#[test]
-fn justified_checkpoint_becomes_invalid() {
+#[tokio::test]
+async fn justified_checkpoint_becomes_invalid() {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
-    rig.move_to_first_justification(Payload::Syncing);
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
+    rig.move_to_first_justification(Payload::Syncing).await;
 
-    let justified_checkpoint = rig.head_info().current_justified_checkpoint;
+    let justified_checkpoint = rig.harness.justified_checkpoint();
     let parent_root_of_justified = rig
         .harness
         .chain
@@ -456,7 +473,8 @@ fn justified_checkpoint_becomes_invalid() {
             // is invalid.
             BlockError::BeaconChainError(BeaconChainError::JustifiedPayloadInvalid { .. })
         )
-    });
+    })
+    .await;
 
     // The beacon chain should have triggered a shutdown.
     assert_eq!(
@@ -468,18 +486,18 @@ fn justified_checkpoint_becomes_invalid() {
 }
 
 /// Ensure that a `latest_valid_hash` for a pre-finality block only reverts a single block.
-#[test]
-fn pre_finalized_latest_valid_hash() {
+#[tokio::test]
+async fn pre_finalized_latest_valid_hash() {
     let num_blocks = E::slots_per_epoch() * 4;
     let finalized_epoch = 2;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     let mut blocks = vec![];
-    blocks.push(rig.import_block(Payload::Valid)); // Import a valid transition block.
-    blocks.extend(rig.build_blocks(num_blocks - 1, Payload::Syncing));
+    blocks.push(rig.import_block(Payload::Valid).await); // Import a valid transition block.
+    blocks.extend(rig.build_blocks(num_blocks - 1, Payload::Syncing).await);
 
-    assert_eq!(rig.head_info().finalized_checkpoint.epoch, finalized_epoch);
+    assert_eq!(rig.harness.finalized_checkpoint().epoch, finalized_epoch);
 
     let pre_finalized_block_root = rig.block_root_at_slot(Slot::new(1)).unwrap();
     let pre_finalized_block_hash = rig.block_hash(pre_finalized_block_root);
@@ -490,10 +508,11 @@ fn pre_finalized_latest_valid_hash() {
     // Import a pre-finalized block.
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(pre_finalized_block_hash),
-    });
+    })
+    .await;
 
     // The latest imported block should be the head.
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     // The beacon chain should *not* have triggered a shutdown.
     assert_eq!(rig.harness.shutdown_reasons(), vec![]);
@@ -514,16 +533,16 @@ fn pre_finalized_latest_valid_hash() {
 ///
 /// - Invalidate descendants of `latest_valid_root`.
 /// - Validate `latest_valid_root` and its ancestors.
-#[test]
-fn latest_valid_hash_will_validate() {
+#[tokio::test]
+async fn latest_valid_hash_will_validate() {
     const LATEST_VALID_SLOT: u64 = 3;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
 
     let mut blocks = vec![];
-    blocks.push(rig.import_block(Payload::Valid)); // Import a valid transition block.
-    blocks.extend(rig.build_blocks(4, Payload::Syncing));
+    blocks.push(rig.import_block(Payload::Valid).await); // Import a valid transition block.
+    blocks.extend(rig.build_blocks(4, Payload::Syncing).await);
 
     let latest_valid_root = rig
         .block_root_at_slot(Slot::new(LATEST_VALID_SLOT))
@@ -532,9 +551,10 @@ fn latest_valid_hash_will_validate() {
 
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(latest_valid_hash),
-    });
+    })
+    .await;
 
-    assert_eq!(rig.head_info().slot, LATEST_VALID_SLOT);
+    assert_eq!(rig.harness.head_slot(), LATEST_VALID_SLOT);
 
     for slot in 0..=5 {
         let slot = Slot::new(slot);
@@ -558,18 +578,18 @@ fn latest_valid_hash_will_validate() {
 }
 
 /// Check behaviour when the `latest_valid_hash` is a junk value.
-#[test]
-fn latest_valid_hash_is_junk() {
+#[tokio::test]
+async fn latest_valid_hash_is_junk() {
     let num_blocks = E::slots_per_epoch() * 5;
     let finalized_epoch = 3;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
     let mut blocks = vec![];
-    blocks.push(rig.import_block(Payload::Valid)); // Import a valid transition block.
-    blocks.extend(rig.build_blocks(num_blocks, Payload::Syncing));
+    blocks.push(rig.import_block(Payload::Valid).await); // Import a valid transition block.
+    blocks.extend(rig.build_blocks(num_blocks, Payload::Syncing).await);
 
-    assert_eq!(rig.head_info().finalized_checkpoint.epoch, finalized_epoch);
+    assert_eq!(rig.harness.finalized_checkpoint().epoch, finalized_epoch);
 
     // No service should have triggered a shutdown, yet.
     assert!(rig.harness.shutdown_reasons().is_empty());
@@ -577,10 +597,11 @@ fn latest_valid_hash_is_junk() {
     let junk_hash = ExecutionBlockHash::repeat_byte(42);
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(junk_hash),
-    });
+    })
+    .await;
 
     // The latest imported block should be the head.
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     // The beacon chain should *not* have triggered a shutdown.
     assert_eq!(rig.harness.shutdown_reasons(), vec![]);
@@ -598,19 +619,19 @@ fn latest_valid_hash_is_junk() {
 }
 
 /// Check that descendants of invalid blocks are also invalidated.
-#[test]
-fn invalidates_all_descendants() {
+#[tokio::test]
+async fn invalidates_all_descendants() {
     let num_blocks = E::slots_per_epoch() * 4 + E::slots_per_epoch() / 2;
     let finalized_epoch = 2;
     let finalized_slot = E::slots_per_epoch() * 2;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
-    let blocks = rig.build_blocks(num_blocks, Payload::Syncing);
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
+    let blocks = rig.build_blocks(num_blocks, Payload::Syncing).await;
 
-    assert_eq!(rig.head_info().finalized_checkpoint.epoch, finalized_epoch);
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.finalized_checkpoint().epoch, finalized_epoch);
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     // Apply a block which conflicts with the canonical chain.
     let fork_slot = Slot::new(4 * E::slots_per_epoch() + 3);
@@ -621,9 +642,14 @@ fn invalidates_all_descendants() {
         .state_at_slot(fork_parent_slot, StateSkipConfig::WithStateRoots)
         .unwrap();
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
-    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot);
-    let fork_block_root = rig.harness.chain.process_block(fork_block).unwrap();
-    rig.fork_choice();
+    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot).await;
+    let fork_block_root = rig
+        .harness
+        .chain
+        .process_block(Arc::new(fork_block))
+        .await
+        .unwrap();
+    rig.recompute_head().await;
 
     // The latest valid hash will be set to the grandparent of the fork block. This means that the
     // parent of the fork block will become invalid.
@@ -638,14 +664,15 @@ fn invalidates_all_descendants() {
     let latest_valid_hash = rig.block_hash(latest_valid_root);
 
     // The new block should not become the head, the old head should remain.
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(latest_valid_hash),
-    });
+    })
+    .await;
 
     // The block before the fork should become the head.
-    assert_eq!(rig.head_info().block_root, latest_valid_root);
+    assert_eq!(rig.harness.head_block_root(), latest_valid_root);
 
     // The fork block should be invalidated, even though it's not an ancestor of the block that
     // triggered the INVALID response from the EL.
@@ -677,19 +704,19 @@ fn invalidates_all_descendants() {
 }
 
 /// Check that the head will switch after the canonical branch is invalidated.
-#[test]
-fn switches_heads() {
+#[tokio::test]
+async fn switches_heads() {
     let num_blocks = E::slots_per_epoch() * 4 + E::slots_per_epoch() / 2;
     let finalized_epoch = 2;
     let finalized_slot = E::slots_per_epoch() * 2;
 
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
-    let blocks = rig.build_blocks(num_blocks, Payload::Syncing);
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
+    let blocks = rig.build_blocks(num_blocks, Payload::Syncing).await;
 
-    assert_eq!(rig.head_info().finalized_checkpoint.epoch, finalized_epoch);
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.finalized_checkpoint().epoch, finalized_epoch);
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     // Apply a block which conflicts with the canonical chain.
     let fork_slot = Slot::new(4 * E::slots_per_epoch() + 3);
@@ -700,23 +727,29 @@ fn switches_heads() {
         .state_at_slot(fork_parent_slot, StateSkipConfig::WithStateRoots)
         .unwrap();
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
-    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot);
+    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot).await;
     let fork_parent_root = fork_block.parent_root();
-    let fork_block_root = rig.harness.chain.process_block(fork_block).unwrap();
-    rig.fork_choice();
+    let fork_block_root = rig
+        .harness
+        .chain
+        .process_block(Arc::new(fork_block))
+        .await
+        .unwrap();
+    rig.recompute_head().await;
 
     let latest_valid_slot = fork_parent_slot;
     let latest_valid_hash = rig.block_hash(fork_parent_root);
 
     // The new block should not become the head, the old head should remain.
-    assert_eq!(rig.head_info().block_root, *blocks.last().unwrap());
+    assert_eq!(rig.harness.head_block_root(), *blocks.last().unwrap());
 
     rig.import_block(Payload::Invalid {
         latest_valid_hash: Some(latest_valid_hash),
-    });
+    })
+    .await;
 
     // The fork block should become the head.
-    assert_eq!(rig.head_info().block_root, fork_block_root);
+    assert_eq!(rig.harness.head_block_root(), fork_block_root);
 
     // The fork block has not yet been validated.
     assert!(rig.execution_status(fork_block_root).is_optimistic());
@@ -746,17 +779,18 @@ fn switches_heads() {
     }
 }
 
-#[test]
-fn invalid_during_processing() {
+#[tokio::test]
+async fn invalid_during_processing() {
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
 
     let roots = &[
-        rig.import_block(Payload::Valid),
+        rig.import_block(Payload::Valid).await,
         rig.import_block(Payload::Invalid {
             latest_valid_hash: None,
-        }),
-        rig.import_block(Payload::Valid),
+        })
+        .await,
+        rig.import_block(Payload::Valid).await,
     ];
 
     // 0 should be present in the chain.
@@ -772,20 +806,20 @@ fn invalid_during_processing() {
         None
     );
     // 2 should be the head.
-    let head = rig.harness.chain.head_info().unwrap();
-    assert_eq!(head.block_root, roots[2]);
+    let head_block_root = rig.harness.head_block_root();
+    assert_eq!(head_block_root, roots[2]);
 }
 
-#[test]
-fn invalid_after_optimistic_sync() {
+#[tokio::test]
+async fn invalid_after_optimistic_sync() {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
 
     let mut roots = vec![
-        rig.import_block(Payload::Syncing),
-        rig.import_block(Payload::Syncing),
-        rig.import_block(Payload::Syncing),
+        rig.import_block(Payload::Syncing).await,
+        rig.import_block(Payload::Syncing).await,
+        rig.import_block(Payload::Syncing).await,
     ];
 
     for root in &roots {
@@ -793,29 +827,32 @@ fn invalid_after_optimistic_sync() {
     }
 
     // 2 should be the head.
-    let head = rig.harness.chain.head_info().unwrap();
-    assert_eq!(head.block_root, roots[2]);
+    let head = rig.harness.head_block_root();
+    assert_eq!(head, roots[2]);
 
-    roots.push(rig.import_block(Payload::Invalid {
-        latest_valid_hash: Some(rig.block_hash(roots[1])),
-    }));
+    roots.push(
+        rig.import_block(Payload::Invalid {
+            latest_valid_hash: Some(rig.block_hash(roots[1])),
+        })
+        .await,
+    );
 
     // Running fork choice is necessary since a block has been invalidated.
-    rig.fork_choice();
+    rig.recompute_head().await;
 
     // 1 should be the head, since 2 was invalidated.
-    let head = rig.harness.chain.head_info().unwrap();
-    assert_eq!(head.block_root, roots[1]);
+    let head = rig.harness.head_block_root();
+    assert_eq!(head, roots[1]);
 }
 
-#[test]
-fn manually_validate_child() {
+#[tokio::test]
+async fn manually_validate_child() {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
 
-    let parent = rig.import_block(Payload::Syncing);
-    let child = rig.import_block(Payload::Syncing);
+    let parent = rig.import_block(Payload::Syncing).await;
+    let child = rig.import_block(Payload::Syncing).await;
 
     assert!(rig.execution_status(parent).is_optimistic());
     assert!(rig.execution_status(child).is_optimistic());
@@ -826,14 +863,14 @@ fn manually_validate_child() {
     assert!(rig.execution_status(child).is_valid_and_post_bellatrix());
 }
 
-#[test]
-fn manually_validate_parent() {
+#[tokio::test]
+async fn manually_validate_parent() {
     let mut rig = InvalidPayloadRig::new().enable_attestations();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
 
-    let parent = rig.import_block(Payload::Syncing);
-    let child = rig.import_block(Payload::Syncing);
+    let parent = rig.import_block(Payload::Syncing).await;
+    let child = rig.import_block(Payload::Syncing).await;
 
     assert!(rig.execution_status(parent).is_optimistic());
     assert!(rig.execution_status(child).is_optimistic());
@@ -844,14 +881,14 @@ fn manually_validate_parent() {
     assert!(rig.execution_status(child).is_optimistic());
 }
 
-#[test]
-fn payload_preparation() {
+#[tokio::test]
+async fn payload_preparation() {
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid);
+    rig.import_block(Payload::Valid).await;
 
     let el = rig.execution_layer();
-    let head = rig.harness.chain.head().unwrap();
+    let head = rig.harness.chain.head_snapshot();
     let current_slot = rig.harness.chain.slot().unwrap();
     assert_eq!(head.beacon_state.slot(), 1);
     assert_eq!(current_slot, 1);
@@ -865,18 +902,19 @@ fn payload_preparation() {
     let fee_recipient = Address::repeat_byte(99);
 
     // Provide preparation data to the EL for `proposer`.
-    el.update_proposer_preparation_blocking(
+    el.update_proposer_preparation(
         Epoch::new(1),
         &[ProposerPreparationData {
             validator_index: proposer as u64,
             fee_recipient,
         }],
     )
-    .unwrap();
+    .await;
 
     rig.harness
         .chain
-        .prepare_beacon_proposer_blocking()
+        .prepare_beacon_proposer(rig.harness.chain.slot().unwrap())
+        .await
         .unwrap();
 
     let payload_attributes = PayloadAttributes {
@@ -896,15 +934,15 @@ fn payload_preparation() {
     assert_eq!(rig.previous_payload_attributes(), payload_attributes);
 }
 
-#[test]
-fn invalid_parent() {
+#[tokio::test]
+async fn invalid_parent() {
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
 
     // Import a syncing block atop the transition block (we'll call this the "parent block" since we
     // build another block on it later).
-    let parent_root = rig.import_block(Payload::Syncing);
+    let parent_root = rig.import_block(Payload::Syncing).await;
     let parent_block = rig.harness.get_block(parent_root.into()).unwrap();
     let parent_state = rig
         .harness
@@ -914,34 +952,34 @@ fn invalid_parent() {
     // Produce another block atop the parent, but don't import yet.
     let slot = parent_block.slot() + 1;
     rig.harness.set_current_slot(slot);
-    let (block, state) = rig.harness.make_block(parent_state, slot);
+    let (block, state) = rig.harness.make_block(parent_state, slot).await;
+    let block = Arc::new(block);
     let block_root = block.canonical_root();
     assert_eq!(block.parent_root(), parent_root);
 
     // Invalidate the parent block.
-    rig.invalidate_manually(parent_root);
+    rig.invalidate_manually(parent_root).await;
     assert!(rig.execution_status(parent_root).is_invalid());
 
     // Ensure the block built atop an invalid payload is invalid for gossip.
     assert!(matches!(
-        rig.harness.chain.verify_block_for_gossip(block.clone()),
+        rig.harness.chain.clone().verify_block_for_gossip(block.clone()).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
         if invalid_root == parent_root
     ));
 
     // Ensure the block built atop an invalid payload is invalid for import.
     assert!(matches!(
-        rig.harness.chain.process_block(block.clone()),
+        rig.harness.chain.process_block(block.clone()).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
         if invalid_root == parent_root
     ));
 
     // Ensure the block built atop an invalid payload cannot be imported to fork choice.
-    let (block, _block_signature) = block.deconstruct();
     assert!(matches!(
-        rig.harness.chain.fork_choice.write().on_block(
+        rig.harness.chain.canonical_head.fork_choice_write_lock().on_block(
             slot,
-            &block,
+            block.message(),
             block_root,
             Duration::from_secs(0),
             &state,
@@ -960,21 +998,21 @@ fn invalid_parent() {
 }
 
 /// Tests to ensure that we will still send a proposer preparation
-#[test]
-fn payload_preparation_before_transition_block() {
+#[tokio::test]
+async fn payload_preparation_before_transition_block() {
     let rig = InvalidPayloadRig::new();
     let el = rig.execution_layer();
 
-    let head = rig.harness.chain.head().unwrap();
-    let head_info = rig.head_info();
-    assert!(
-        !head_info.is_merge_transition_complete,
-        "the head block is pre-transition"
-    );
+    let head = rig.harness.chain.head_snapshot();
     assert_eq!(
-        head_info.execution_payload_block_hash,
-        Some(ExecutionBlockHash::zero()),
-        "the head block is post-bellatrix"
+        head.beacon_block
+            .message()
+            .body()
+            .execution_payload()
+            .unwrap()
+            .block_hash(),
+        ExecutionBlockHash::zero(),
+        "the head block is post-bellatrix but pre-transition"
     );
 
     let current_slot = rig.harness.chain.slot().unwrap();
@@ -986,24 +1024,32 @@ fn payload_preparation_before_transition_block() {
     let fee_recipient = Address::repeat_byte(99);
 
     // Provide preparation data to the EL for `proposer`.
-    el.update_proposer_preparation_blocking(
+    el.update_proposer_preparation(
         Epoch::new(0),
         &[ProposerPreparationData {
             validator_index: proposer as u64,
             fee_recipient,
         }],
     )
-    .unwrap();
+    .await;
 
     rig.move_to_terminal_block();
 
     rig.harness
         .chain
-        .prepare_beacon_proposer_blocking()
+        .prepare_beacon_proposer(current_slot)
+        .await
         .unwrap();
+    let forkchoice_update_params = rig
+        .harness
+        .chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .get_forkchoice_update_parameters();
     rig.harness
         .chain
-        .update_execution_engine_forkchoice_blocking(current_slot)
+        .update_execution_engine_forkchoice(current_slot, forkchoice_update_params)
+        .await
         .unwrap();
 
     let (fork_choice_state, payload_attributes) = rig.previous_forkchoice_update_params();
@@ -1012,15 +1058,15 @@ fn payload_preparation_before_transition_block() {
     assert_eq!(fork_choice_state.head_block_hash, latest_block_hash);
 }
 
-#[test]
-fn attesting_to_optimistic_head() {
+#[tokio::test]
+async fn attesting_to_optimistic_head() {
     let mut rig = InvalidPayloadRig::new();
     rig.move_to_terminal_block();
-    rig.import_block(Payload::Valid); // Import a valid transition block.
+    rig.import_block(Payload::Valid).await; // Import a valid transition block.
 
-    let root = rig.import_block(Payload::Syncing);
+    let root = rig.import_block(Payload::Syncing).await;
 
-    let head = rig.harness.chain.head().unwrap();
+    let head = rig.harness.chain.head_snapshot();
     let slot = head.beacon_block.slot();
     assert_eq!(
         head.beacon_block_root, root,

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -46,15 +46,8 @@ fn get_valid_sync_committee_message(
     slot: Slot,
     relative_sync_committee: RelativeSyncCommittee,
 ) -> (SyncCommitteeMessage, usize, SecretKey, SyncSubnetId) {
-    let head_state = harness
-        .chain
-        .head_beacon_state()
-        .expect("should get head state");
-    let head_block_root = harness
-        .chain
-        .head()
-        .expect("should get head state")
-        .beacon_block_root;
+    let head_state = harness.chain.head_beacon_state_cloned();
+    let head_block_root = harness.chain.head_snapshot().beacon_block_root;
     let (signature, _) = harness
         .make_sync_committee_messages(&head_state, head_block_root, slot, relative_sync_committee)
         .get(0)
@@ -77,16 +70,9 @@ fn get_valid_sync_contribution(
     harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
     relative_sync_committee: RelativeSyncCommittee,
 ) -> (SignedContributionAndProof<E>, usize, SecretKey) {
-    let head_state = harness
-        .chain
-        .head_beacon_state()
-        .expect("should get head state");
+    let head_state = harness.chain.head_beacon_state_cloned();
 
-    let head_block_root = harness
-        .chain
-        .head()
-        .expect("should get head state")
-        .beacon_block_root;
+    let head_block_root = harness.chain.head_snapshot().beacon_block_root;
     let sync_contributions = harness.make_sync_contributions(
         &head_state,
         head_block_root,
@@ -116,7 +102,7 @@ fn get_non_aggregator(
     harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
     slot: Slot,
 ) -> (usize, SecretKey) {
-    let state = &harness.chain.head().expect("should get head").beacon_state;
+    let state = &harness.chain.head_snapshot().beacon_state;
     let sync_subcommittee_size = E::sync_committee_size()
         .safe_div(SYNC_COMMITTEE_SUBNET_COUNT as usize)
         .expect("should determine sync subcommittee size");
@@ -162,17 +148,19 @@ fn get_non_aggregator(
 }
 
 /// Tests verification of `SignedContributionAndProof` from the gossip network.
-#[test]
-fn aggregated_gossip_verification() {
+#[tokio::test]
+async fn aggregated_gossip_verification() {
     let harness = get_harness(VALIDATOR_COUNT);
     let state = harness.get_current_state();
 
-    harness.add_attested_blocks_at_slots(
-        state,
-        Hash256::zero(),
-        &[Slot::new(1), Slot::new(2)],
-        (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
-    );
+    harness
+        .add_attested_blocks_at_slots(
+            state,
+            Hash256::zero(),
+            &[Slot::new(1), Slot::new(2)],
+            (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
+        )
+        .await;
 
     let current_slot = harness.chain.slot().expect("should get slot");
 
@@ -406,7 +394,7 @@ fn aggregated_gossip_verification() {
                 valid_aggregate.message.contribution.clone(),
                 None,
                 &non_aggregator_sk,
-                &harness.chain.head_info().expect("should get head info").fork,
+                &harness.chain.canonical_head.cached_head().head_fork(),
                 harness.chain.genesis_validators_root,
                 &harness.chain.spec,
             )
@@ -474,6 +462,7 @@ fn aggregated_gossip_verification() {
 
     harness
         .add_attested_block_at_slot(target_slot, state, Hash256::zero(), &[])
+        .await
         .expect("should add block");
 
     // **Incorrectly** create a sync contribution using the current sync committee
@@ -488,17 +477,19 @@ fn aggregated_gossip_verification() {
 }
 
 /// Tests the verification conditions for sync committee messages on the gossip network.
-#[test]
-fn unaggregated_gossip_verification() {
+#[tokio::test]
+async fn unaggregated_gossip_verification() {
     let harness = get_harness(VALIDATOR_COUNT);
     let state = harness.get_current_state();
 
-    harness.add_attested_blocks_at_slots(
-        state,
-        Hash256::zero(),
-        &[Slot::new(1), Slot::new(2)],
-        (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
-    );
+    harness
+        .add_attested_blocks_at_slots(
+            state,
+            Hash256::zero(),
+            &[Slot::new(1), Slot::new(2)],
+            (0..VALIDATOR_COUNT).collect::<Vec<_>>().as_slice(),
+        )
+        .await;
 
     let current_slot = harness.chain.slot().expect("should get slot");
 
@@ -648,6 +639,7 @@ fn unaggregated_gossip_verification() {
 
     harness
         .add_attested_block_at_slot(target_slot, state, Hash256::zero(), &[])
+        .await
         .expect("should add block");
 
     // **Incorrectly** create a sync message using the current sync committee

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -1,5 +1,5 @@
 use crate::metrics;
-use beacon_chain::{BeaconChain, BeaconChainTypes, HeadSafetyStatus};
+use beacon_chain::{BeaconChain, BeaconChainTypes, ExecutionStatus};
 use lighthouse_network::{types::SyncState, NetworkGlobals};
 use parking_lot::Mutex;
 use slog::{crit, debug, error, info, warn, Logger};
@@ -100,15 +100,10 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 current_sync_state = sync_state;
             }
 
-            let head_info = match beacon_chain.head_info() {
-                Ok(head_info) => head_info,
-                Err(e) => {
-                    error!(log, "Failed to get beacon chain head info"; "error" => format!("{:?}", e));
-                    break;
-                }
-            };
-
-            let head_slot = head_info.slot;
+            let cached_head = beacon_chain.canonical_head.cached_head();
+            let head_slot = cached_head.head_slot();
+            let head_root = cached_head.head_block_root();
+            let finalized_checkpoint = cached_head.finalized_checkpoint();
 
             metrics::set_gauge(&metrics::NOTIFIER_HEAD_SLOT, head_slot.as_u64() as i64);
 
@@ -125,9 +120,6 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
             };
 
             let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
-            let finalized_epoch = head_info.finalized_checkpoint.epoch;
-            let finalized_root = head_info.finalized_checkpoint.root;
-            let head_root = head_info.block_root;
 
             // The default is for regular sync but this gets modified if backfill sync is in
             // progress.
@@ -177,8 +169,8 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 log,
                 "Slot timer";
                 "peers" => peer_count_pretty(connected_peer_count),
-                "finalized_root" => format!("{}", finalized_root),
-                "finalized_epoch" => finalized_epoch,
+                "finalized_root" => format!("{}", finalized_checkpoint.root),
+                "finalized_epoch" => finalized_checkpoint.epoch,
                 "head_block" => format!("{}", head_root),
                 "head_slot" => head_slot,
                 "current_slot" => current_slot,
@@ -264,35 +256,29 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     head_root.to_string()
                 };
 
-                let block_hash = match beacon_chain.head_safety_status() {
-                    Ok(HeadSafetyStatus::Safe(hash_opt)) => hash_opt
-                        .map(|hash| format!("{} (verified)", hash))
-                        .unwrap_or_else(|| "n/a".to_string()),
-                    Ok(HeadSafetyStatus::Unsafe(block_hash)) => {
+                let block_hash = match beacon_chain.canonical_head.head_execution_status() {
+                    Ok(ExecutionStatus::Irrelevant(_)) => "n/a".to_string(),
+                    Ok(ExecutionStatus::Valid(hash)) => format!("{} (verified)", hash),
+                    Ok(ExecutionStatus::Optimistic(hash)) => {
                         warn!(
                             log,
-                            "Head execution payload is unverified";
-                            "execution_block_hash" => ?block_hash,
+                            "Head is optimistic";
+                            "info" => "chain not fully verified, \
+                                block and attestation production disabled until execution engine syncs",
+                            "execution_block_hash" => ?hash,
                         );
-                        format!("{} (unverified)", block_hash)
+                        format!("{} (unverified)", hash)
                     }
-                    Ok(HeadSafetyStatus::Invalid(block_hash)) => {
+                    Ok(ExecutionStatus::Invalid(hash)) => {
                         crit!(
                             log,
                             "Head execution payload is invalid";
                             "msg" => "this scenario may be unrecoverable",
-                            "execution_block_hash" => ?block_hash,
+                            "execution_block_hash" => ?hash,
                         );
-                        format!("{} (invalid)", block_hash)
+                        format!("{} (invalid)", hash)
                     }
-                    Err(e) => {
-                        error!(
-                            log,
-                            "Failed to read head safety status";
-                            "error" => ?e
-                        );
-                        "n/a".to_string()
-                    }
+                    Err(_) => "unknown".to_string(),
                 };
 
                 info!(
@@ -300,8 +286,8 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     "Synced";
                     "peers" => peer_count_pretty(connected_peer_count),
                     "exec_hash" => block_hash,
-                    "finalized_root" => format!("{}", finalized_root),
-                    "finalized_epoch" => finalized_epoch,
+                    "finalized_root" => format!("{}", finalized_checkpoint.root),
+                    "finalized_epoch" => finalized_checkpoint.epoch,
                     "epoch" => current_epoch,
                     "block" => block_info,
                     "slot" => current_slot,
@@ -312,8 +298,8 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                     log,
                     "Searching for peers";
                     "peers" => peer_count_pretty(connected_peer_count),
-                    "finalized_root" => format!("{}", finalized_root),
-                    "finalized_epoch" => finalized_epoch,
+                    "finalized_root" => format!("{}", finalized_checkpoint.root),
+                    "finalized_epoch" => finalized_checkpoint.epoch,
                     "head_slot" => head_slot,
                     "current_slot" => current_slot,
                 );
@@ -332,57 +318,52 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
 fn eth1_logging<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>, log: &Logger) {
     let current_slot_opt = beacon_chain.slot().ok();
 
-    if let Ok(head_info) = beacon_chain.head_info() {
-        // Perform some logging about the eth1 chain
-        if let Some(eth1_chain) = beacon_chain.eth1_chain.as_ref() {
-            // No need to do logging if using the dummy backend.
-            if eth1_chain.is_dummy_backend() {
-                return;
-            }
-
-            if let Some(status) =
-                eth1_chain.sync_status(head_info.genesis_time, current_slot_opt, &beacon_chain.spec)
-            {
-                debug!(
-                    log,
-                    "Eth1 cache sync status";
-                    "eth1_head_block" => status.head_block_number,
-                    "latest_cached_block_number" => status.latest_cached_block_number,
-                    "latest_cached_timestamp" => status.latest_cached_block_timestamp,
-                    "voting_target_timestamp" => status.voting_target_timestamp,
-                    "ready" => status.lighthouse_is_cached_and_ready
-                );
-
-                if !status.lighthouse_is_cached_and_ready {
-                    let voting_target_timestamp = status.voting_target_timestamp;
-
-                    let distance = status
-                        .latest_cached_block_timestamp
-                        .map(|latest| {
-                            voting_target_timestamp.saturating_sub(latest)
-                                / beacon_chain.spec.seconds_per_eth1_block
-                        })
-                        .map(|distance| distance.to_string())
-                        .unwrap_or_else(|| "initializing deposits".to_string());
-
-                    warn!(
-                        log,
-                        "Syncing eth1 block cache";
-                        "est_blocks_remaining" => distance,
-                    );
-                }
-            } else {
-                error!(
-                    log,
-                    "Unable to determine eth1 sync status";
-                );
-            }
+    // Perform some logging about the eth1 chain
+    if let Some(eth1_chain) = beacon_chain.eth1_chain.as_ref() {
+        // No need to do logging if using the dummy backend.
+        if eth1_chain.is_dummy_backend() {
+            return;
         }
-    } else {
-        error!(
-            log,
-            "Unable to get head info";
-        );
+
+        if let Some(status) = eth1_chain.sync_status(
+            beacon_chain.genesis_time,
+            current_slot_opt,
+            &beacon_chain.spec,
+        ) {
+            debug!(
+                log,
+                "Eth1 cache sync status";
+                "eth1_head_block" => status.head_block_number,
+                "latest_cached_block_number" => status.latest_cached_block_number,
+                "latest_cached_timestamp" => status.latest_cached_block_timestamp,
+                "voting_target_timestamp" => status.voting_target_timestamp,
+                "ready" => status.lighthouse_is_cached_and_ready
+            );
+
+            if !status.lighthouse_is_cached_and_ready {
+                let voting_target_timestamp = status.voting_target_timestamp;
+
+                let distance = status
+                    .latest_cached_block_timestamp
+                    .map(|latest| {
+                        voting_target_timestamp.saturating_sub(latest)
+                            / beacon_chain.spec.seconds_per_eth1_block
+                    })
+                    .map(|distance| distance.to_string())
+                    .unwrap_or_else(|| "initializing deposits".to_string());
+
+                warn!(
+                    log,
+                    "Syncing eth1 block cache";
+                    "est_blocks_remaining" => distance,
+                );
+            }
+        } else {
+            error!(
+                log,
+                "Unable to determine eth1 sync status";
+            );
+        }
     }
 }
 

--- a/beacon_node/http_api/src/attester_duties.rs
+++ b/beacon_node/http_api/src/attester_duties.rs
@@ -58,12 +58,10 @@ fn cached_attestation_duties<T: BeaconChainTypes>(
     request_indices: &[u64],
     chain: &BeaconChain<T>,
 ) -> Result<ApiDuties, warp::reject::Rejection> {
-    let head = chain
-        .head_info()
-        .map_err(warp_utils::reject::beacon_chain_error)?;
+    let head_block_root = chain.canonical_head.cached_head().head_block_root();
 
-    let (duties, dependent_root) = chain
-        .validator_attestation_duties(request_indices, request_epoch, head.block_root)
+    let (duties, dependent_root, _execution_status) = chain
+        .validator_attestation_duties(request_indices, request_epoch, head_block_root)
         .map_err(warp_utils::reject::beacon_chain_error)?;
 
     convert_to_api_response(duties, request_indices, dependent_root, chain)

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,6 +1,7 @@
 use beacon_chain::{BeaconChain, BeaconChainTypes, WhenSlotSkipped};
 use eth2::types::BlockId as CoreBlockId;
 use std::str::FromStr;
+use std::sync::Arc;
 use types::{BlindedPayload, Hash256, SignedBeaconBlock, Slot};
 
 /// Wraps `eth2::types::BlockId` and provides a simple way to obtain a block or root for a given
@@ -23,19 +24,18 @@ impl BlockId {
         chain: &BeaconChain<T>,
     ) -> Result<Hash256, warp::Rejection> {
         match &self.0 {
-            CoreBlockId::Head => chain
-                .head_info()
-                .map(|head| head.block_root)
-                .map_err(warp_utils::reject::beacon_chain_error),
+            CoreBlockId::Head => Ok(chain.canonical_head.cached_head().head_block_root()),
             CoreBlockId::Genesis => Ok(chain.genesis_block_root),
-            CoreBlockId::Finalized => chain
-                .head_info()
-                .map(|head| head.finalized_checkpoint.root)
-                .map_err(warp_utils::reject::beacon_chain_error),
-            CoreBlockId::Justified => chain
-                .head_info()
-                .map(|head| head.current_justified_checkpoint.root)
-                .map_err(warp_utils::reject::beacon_chain_error),
+            CoreBlockId::Finalized => Ok(chain
+                .canonical_head
+                .cached_head()
+                .finalized_checkpoint()
+                .root),
+            CoreBlockId::Justified => Ok(chain
+                .canonical_head
+                .cached_head()
+                .justified_checkpoint()
+                .root),
             CoreBlockId::Slot(slot) => chain
                 .block_root_at_slot(*slot, WhenSlotSkipped::None)
                 .map_err(warp_utils::reject::beacon_chain_error)
@@ -57,10 +57,7 @@ impl BlockId {
         chain: &BeaconChain<T>,
     ) -> Result<SignedBeaconBlock<T::EthSpec, BlindedPayload<T::EthSpec>>, warp::Rejection> {
         match &self.0 {
-            CoreBlockId::Head => chain
-                .head_beacon_block()
-                .map(Into::into)
-                .map_err(warp_utils::reject::beacon_chain_error),
+            CoreBlockId::Head => Ok(chain.head_beacon_block().clone_as_blinded()),
             CoreBlockId::Slot(slot) => {
                 let root = self.root(chain)?;
                 chain
@@ -103,11 +100,9 @@ impl BlockId {
     pub async fn full_block<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
-    ) -> Result<SignedBeaconBlock<T::EthSpec>, warp::Rejection> {
+    ) -> Result<Arc<SignedBeaconBlock<T::EthSpec>>, warp::Rejection> {
         match &self.0 {
-            CoreBlockId::Head => chain
-                .head_beacon_block()
-                .map_err(warp_utils::reject::beacon_chain_error),
+            CoreBlockId::Head => Ok(chain.head_beacon_block()),
             CoreBlockId::Slot(slot) => {
                 let root = self.root(chain)?;
                 chain
@@ -122,7 +117,7 @@ impl BlockId {
                                     slot
                                 )));
                             }
-                            Ok(block)
+                            Ok(Arc::new(block))
                         }
                         None => Err(warp_utils::reject::custom_not_found(format!(
                             "beacon block with root {}",
@@ -136,8 +131,8 @@ impl BlockId {
                     .get_block(&root)
                     .await
                     .map_err(warp_utils::reject::beacon_chain_error)
-                    .and_then(|root_opt| {
-                        root_opt.ok_or_else(|| {
+                    .and_then(|block_opt| {
+                        block_opt.map(Arc::new).ok_or_else(|| {
                             warp_utils::reject::custom_not_found(format!(
                                 "beacon block with root {}",
                                 root

--- a/beacon_node/http_api/src/database.rs
+++ b/beacon_node/http_api/src/database.rs
@@ -22,7 +22,7 @@ pub fn info<T: BeaconChainTypes>(
 
 pub fn historical_blocks<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
-    blocks: Vec<SignedBlindedBeaconBlock<T::EthSpec>>,
+    blocks: Vec<Arc<SignedBlindedBeaconBlock<T::EthSpec>>>,
 ) -> Result<AnchorInfo, warp::Rejection> {
     chain
         .import_historical_block_batch(blocks)

--- a/beacon_node/http_api/tests/fork_tests.rs
+++ b/beacon_node/http_api/tests/fork_tests.rs
@@ -45,6 +45,7 @@ async fn sync_committee_duties_across_fork() {
             genesis_state_root,
             &all_validators,
         )
+        .await
         .unwrap();
 
     harness.advance_slot();
@@ -61,6 +62,7 @@ async fn sync_committee_duties_across_fork() {
     let state_root = state.canonical_root();
     harness
         .add_attested_block_at_slot(fork_slot, state, state_root, &all_validators)
+        .await
         .unwrap();
 
     assert_eq!(
@@ -244,6 +246,7 @@ async fn sync_committee_indices_across_fork() {
             genesis_state_root,
             &all_validators,
         )
+        .await
         .unwrap();
 
     harness.advance_slot();
@@ -277,6 +280,7 @@ async fn sync_committee_indices_across_fork() {
     let state_root = state.canonical_root();
     harness
         .add_attested_block_at_slot(fork_slot + 1, state, state_root, &all_validators)
+        .await
         .unwrap();
 
     let current_period = fork_epoch.sync_committee_period(&spec).unwrap();

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -11,7 +11,6 @@ use eth2::{
     types::*,
     BeaconNodeHttpClient, Error, StatusCode, Timeouts,
 };
-use execution_layer::test_utils::MockExecutionLayer;
 use futures::stream::{Stream, StreamExt};
 use futures::FutureExt;
 use lighthouse_network::{Enr, EnrExt, PeerId};
@@ -2261,9 +2260,9 @@ impl ApiTester {
         let mut registrations = vec![];
         let mut fee_recipients = vec![];
 
-        let fork = self.chain.head().unwrap().beacon_state.fork();
+        let fork = self.chain.head_snapshot().beacon_state.fork();
 
-        for (val_index, keypair) in self.validator_keypairs.iter().enumerate() {
+        for (val_index, keypair) in self.validator_keypairs().iter().enumerate() {
             let pubkey = keypair.pk.compress();
             let fee_recipient = Address::from_low_u64_be(val_index as u64);
 
@@ -2296,8 +2295,7 @@ impl ApiTester {
 
         for (val_index, (_, fee_recipient)) in self
             .chain
-            .head()
-            .unwrap()
+            .head_snapshot()
             .beacon_state
             .validators()
             .into_iter()

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -21,7 +21,6 @@ use slot_clock::SlotClock;
 use state_processing::per_slot_processing;
 use std::convert::TryInto;
 use std::sync::Arc;
-use task_executor::test_utils::TestRuntime;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Duration;
 use tree_hash::TreeHash;
@@ -52,6 +51,7 @@ const SKIPPED_SLOTS: &[u64] = &[
 ];
 
 struct ApiTester {
+    harness: Arc<BeaconChainHarness<EphemeralHarnessType<E>>>,
     chain: Arc<BeaconChain<EphemeralHarnessType<E>>>,
     client: BeaconNodeHttpClient,
     next_block: SignedBeaconBlock<E>,
@@ -62,14 +62,9 @@ struct ApiTester {
     proposer_slashing: ProposerSlashing,
     voluntary_exit: SignedVoluntaryExit,
     _server_shutdown: oneshot::Sender<()>,
-    validator_keypairs: Vec<Keypair>,
     network_rx: mpsc::UnboundedReceiver<NetworkMessage<E>>,
     local_enr: Enr,
     external_peer_id: PeerId,
-    // This is never directly accessed, but adding it creates a payload cache, which we use in tests here.
-    #[allow(dead_code)]
-    mock_el: Option<MockExecutionLayer<E>>,
-    _runtime: TestRuntime,
 }
 
 impl ApiTester {
@@ -81,12 +76,14 @@ impl ApiTester {
     }
 
     pub async fn new_from_spec(spec: ChainSpec) -> Self {
-        let harness = BeaconChainHarness::builder(MainnetEthSpec)
-            .spec(spec.clone())
-            .deterministic_keypairs(VALIDATOR_COUNT)
-            .fresh_ephemeral_store()
-            .mock_execution_layer()
-            .build();
+        let harness = Arc::new(
+            BeaconChainHarness::builder(MainnetEthSpec)
+                .spec(spec.clone())
+                .deterministic_keypairs(VALIDATOR_COUNT)
+                .fresh_ephemeral_store()
+                .mock_execution_layer()
+                .build(),
+        );
 
         harness.advance_slot();
 
@@ -94,17 +91,19 @@ impl ApiTester {
             let slot = harness.chain.slot().unwrap().as_u64();
 
             if !SKIPPED_SLOTS.contains(&slot) {
-                harness.extend_chain(
-                    1,
-                    BlockStrategy::OnCanonicalHead,
-                    AttestationStrategy::AllValidators,
-                );
+                harness
+                    .extend_chain(
+                        1,
+                        BlockStrategy::OnCanonicalHead,
+                        AttestationStrategy::AllValidators,
+                    )
+                    .await;
             }
 
             harness.advance_slot();
         }
 
-        let head = harness.chain.head().unwrap();
+        let head = harness.chain.head_snapshot();
 
         assert_eq!(
             harness.chain.slot().unwrap(),
@@ -112,12 +111,14 @@ impl ApiTester {
             "precondition: current slot is one after head"
         );
 
-        let (next_block, _next_state) =
-            harness.make_block(head.beacon_state.clone(), harness.chain.slot().unwrap());
+        let (next_block, _next_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
 
         // `make_block` adds random graffiti, so this will produce an alternate block
-        let (reorg_block, _reorg_state) =
-            harness.make_block(head.beacon_state.clone(), harness.chain.slot().unwrap());
+        let (reorg_block, _reorg_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
 
         let head_state_root = head.beacon_state_root();
         let attestations = harness
@@ -168,15 +169,19 @@ impl ApiTester {
         let chain = harness.chain.clone();
 
         assert_eq!(
-            chain.head_info().unwrap().finalized_checkpoint.epoch,
+            chain
+                .canonical_head
+                .cached_head()
+                .finalized_checkpoint()
+                .epoch,
             2,
             "precondition: finality"
         );
         assert_eq!(
             chain
-                .head_info()
-                .unwrap()
-                .current_justified_checkpoint
+                .canonical_head
+                .cached_head()
+                .justified_checkpoint()
                 .epoch,
             3,
             "precondition: justification"
@@ -206,6 +211,7 @@ impl ApiTester {
         );
 
         Self {
+            harness,
             chain,
             client,
             next_block,
@@ -216,32 +222,33 @@ impl ApiTester {
             proposer_slashing,
             voluntary_exit,
             _server_shutdown: shutdown_tx,
-            validator_keypairs: harness.validator_keypairs,
             network_rx,
             local_enr,
             external_peer_id,
-            mock_el: harness.mock_execution_layer,
-            _runtime: harness.runtime,
         }
     }
 
     pub async fn new_from_genesis() -> Self {
-        let harness = BeaconChainHarness::builder(MainnetEthSpec)
-            .default_spec()
-            .deterministic_keypairs(VALIDATOR_COUNT)
-            .fresh_ephemeral_store()
-            .build();
+        let harness = Arc::new(
+            BeaconChainHarness::builder(MainnetEthSpec)
+                .default_spec()
+                .deterministic_keypairs(VALIDATOR_COUNT)
+                .fresh_ephemeral_store()
+                .build(),
+        );
 
         harness.advance_slot();
 
-        let head = harness.chain.head().unwrap();
+        let head = harness.chain.head_snapshot();
 
-        let (next_block, _next_state) =
-            harness.make_block(head.beacon_state.clone(), harness.chain.slot().unwrap());
+        let (next_block, _next_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
 
         // `make_block` adds random graffiti, so this will produce an alternate block
-        let (reorg_block, _reorg_state) =
-            harness.make_block(head.beacon_state.clone(), harness.chain.slot().unwrap());
+        let (reorg_block, _reorg_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
 
         let head_state_root = head.beacon_state_root();
         let attestations = harness
@@ -286,6 +293,7 @@ impl ApiTester {
         );
 
         Self {
+            harness,
             chain,
             client,
             next_block,
@@ -296,13 +304,14 @@ impl ApiTester {
             proposer_slashing,
             voluntary_exit,
             _server_shutdown: shutdown_tx,
-            validator_keypairs: harness.validator_keypairs,
             network_rx,
             local_enr,
             external_peer_id,
-            mock_el: None,
-            _runtime: harness.runtime,
         }
+    }
+
+    fn validator_keypairs(&self) -> &[Keypair] {
+        &self.harness.validator_keypairs
     }
 
     fn skip_slots(self, count: u64) -> Self {
@@ -329,7 +338,9 @@ impl ApiTester {
             StateId::Slot(Slot::from(SKIPPED_SLOTS[3])),
             StateId::Root(Hash256::zero()),
         ];
-        ids.push(StateId::Root(self.chain.head_info().unwrap().state_root));
+        ids.push(StateId::Root(
+            self.chain.canonical_head.cached_head().head_state_root(),
+        ));
         ids
     }
 
@@ -347,13 +358,20 @@ impl ApiTester {
             BlockId::Slot(Slot::from(SKIPPED_SLOTS[3])),
             BlockId::Root(Hash256::zero()),
         ];
-        ids.push(BlockId::Root(self.chain.head_info().unwrap().block_root));
+        ids.push(BlockId::Root(
+            self.chain.canonical_head.cached_head().head_block_root(),
+        ));
         ids
     }
 
     fn get_state(&self, state_id: StateId) -> Option<BeaconState<E>> {
         match state_id {
-            StateId::Head => Some(self.chain.head().unwrap().beacon_state),
+            StateId::Head => Some(
+                self.chain
+                    .head_snapshot()
+                    .beacon_state
+                    .clone_with_only_committee_caches(),
+            ),
             StateId::Genesis => self
                 .chain
                 .get_state(&self.chain.genesis_state_root, None)
@@ -361,9 +379,9 @@ impl ApiTester {
             StateId::Finalized => {
                 let finalized_slot = self
                     .chain
-                    .head_info()
-                    .unwrap()
-                    .finalized_checkpoint
+                    .canonical_head
+                    .cached_head()
+                    .finalized_checkpoint()
                     .epoch
                     .start_slot(E::slots_per_epoch());
 
@@ -378,9 +396,9 @@ impl ApiTester {
             StateId::Justified => {
                 let justified_slot = self
                     .chain
-                    .head_info()
-                    .unwrap()
-                    .current_justified_checkpoint
+                    .canonical_head
+                    .cached_head()
+                    .justified_checkpoint()
                     .epoch
                     .start_slot(E::slots_per_epoch());
 
@@ -404,7 +422,7 @@ impl ApiTester {
     pub async fn test_beacon_genesis(self) -> Self {
         let result = self.client.get_beacon_genesis().await.unwrap().data;
 
-        let state = self.chain.head().unwrap().beacon_state;
+        let state = &self.chain.head_snapshot().beacon_state;
         let expected = GenesisData {
             genesis_time: state.genesis_time(),
             genesis_validators_root: state.genesis_validators_root(),
@@ -426,14 +444,14 @@ impl ApiTester {
                 .map(|res| res.data.root);
 
             let expected = match state_id {
-                StateId::Head => Some(self.chain.head_info().unwrap().state_root),
+                StateId::Head => Some(self.chain.canonical_head.cached_head().head_state_root()),
                 StateId::Genesis => Some(self.chain.genesis_state_root),
                 StateId::Finalized => {
                     let finalized_slot = self
                         .chain
-                        .head_info()
-                        .unwrap()
-                        .finalized_checkpoint
+                        .canonical_head
+                        .cached_head()
+                        .finalized_checkpoint()
                         .epoch
                         .start_slot(E::slots_per_epoch());
 
@@ -442,9 +460,9 @@ impl ApiTester {
                 StateId::Justified => {
                     let justified_slot = self
                         .chain
-                        .head_info()
-                        .unwrap()
-                        .current_justified_checkpoint
+                        .canonical_head
+                        .cached_head()
+                        .justified_checkpoint()
                         .epoch
                         .start_slot(E::slots_per_epoch());
 
@@ -754,14 +772,20 @@ impl ApiTester {
 
     fn get_block_root(&self, block_id: BlockId) -> Option<Hash256> {
         match block_id {
-            BlockId::Head => Some(self.chain.head_info().unwrap().block_root),
+            BlockId::Head => Some(self.chain.canonical_head.cached_head().head_block_root()),
             BlockId::Genesis => Some(self.chain.genesis_block_root),
-            BlockId::Finalized => Some(self.chain.head_info().unwrap().finalized_checkpoint.root),
+            BlockId::Finalized => Some(
+                self.chain
+                    .canonical_head
+                    .cached_head()
+                    .finalized_checkpoint()
+                    .root,
+            ),
             BlockId::Justified => Some(
                 self.chain
-                    .head_info()
-                    .unwrap()
-                    .current_justified_checkpoint
+                    .canonical_head
+                    .cached_head()
+                    .justified_checkpoint()
                     .root,
             ),
             BlockId::Slot(slot) => self
@@ -1322,7 +1346,7 @@ impl ApiTester {
 
     pub async fn test_get_node_syncing(self) -> Self {
         let result = self.client.get_node_syncing().await.unwrap().data;
-        let head_slot = self.chain.head_info().unwrap().slot;
+        let head_slot = self.chain.canonical_head.cached_head().head_slot();
         let sync_distance = self.chain.slot().unwrap() - head_slot;
 
         let expected = SyncingData {
@@ -1536,7 +1560,7 @@ impl ApiTester {
     }
 
     fn validator_count(&self) -> usize {
-        self.chain.head().unwrap().beacon_state.validators().len()
+        self.chain.head_snapshot().beacon_state.validators().len()
     }
 
     fn interesting_validator_indices(&self) -> Vec<Vec<u64>> {
@@ -1621,7 +1645,7 @@ impl ApiTester {
                         WhenSlotSkipped::Prev,
                     )
                     .unwrap()
-                    .unwrap_or(self.chain.head_beacon_block_root().unwrap());
+                    .unwrap_or(self.chain.head_beacon_block_root());
 
                 assert_eq!(results.dependent_root, dependent_root);
 
@@ -1696,7 +1720,7 @@ impl ApiTester {
                     WhenSlotSkipped::Prev,
                 )
                 .unwrap()
-                .unwrap_or(self.chain.head_beacon_block_root().unwrap());
+                .unwrap_or(self.chain.head_beacon_block_root());
 
             // Presently, the beacon chain harness never runs the code that primes the proposer
             // cache. If this changes in the future then we'll need some smarter logic here, but
@@ -1824,7 +1848,7 @@ impl ApiTester {
                 WhenSlotSkipped::Prev,
             )
             .unwrap()
-            .unwrap_or(self.chain.head_beacon_block_root().unwrap());
+            .unwrap_or(self.chain.head_beacon_block_root());
 
         self.client
             .get_validator_duties_proposer(current_epoch)
@@ -1878,7 +1902,7 @@ impl ApiTester {
     }
 
     pub async fn test_block_production(self) -> Self {
-        let fork = self.chain.head_info().unwrap().fork;
+        let fork = self.chain.canonical_head.cached_head().head_fork();
         let genesis_validators_root = self.chain.genesis_validators_root;
 
         for _ in 0..E::slots_per_epoch() * 3 {
@@ -1898,7 +1922,7 @@ impl ApiTester {
             let proposer_pubkey = (&proposer_pubkey_bytes).try_into().unwrap();
 
             let sk = self
-                .validator_keypairs
+                .validator_keypairs()
                 .iter()
                 .find(|kp| kp.pk == proposer_pubkey)
                 .map(|kp| kp.sk.clone())
@@ -1926,7 +1950,7 @@ impl ApiTester {
 
             self.client.post_beacon_blocks(&signed_block).await.unwrap();
 
-            assert_eq!(self.chain.head_beacon_block().unwrap(), signed_block);
+            assert_eq!(self.chain.head_beacon_block().as_ref(), &signed_block);
 
             self.chain.slot_clock.set_slot(slot.as_u64() + 1);
         }
@@ -1957,7 +1981,7 @@ impl ApiTester {
     }
 
     pub async fn test_block_production_verify_randao_invalid(self) -> Self {
-        let fork = self.chain.head_info().unwrap().fork;
+        let fork = self.chain.canonical_head.cached_head().head_fork();
         let genesis_validators_root = self.chain.genesis_validators_root;
 
         for _ in 0..E::slots_per_epoch() {
@@ -1977,7 +2001,7 @@ impl ApiTester {
             let proposer_pubkey = (&proposer_pubkey_bytes).try_into().unwrap();
 
             let sk = self
-                .validator_keypairs
+                .validator_keypairs()
                 .iter()
                 .find(|kp| kp.pk == proposer_pubkey)
                 .map(|kp| kp.sk.clone())
@@ -2040,7 +2064,7 @@ impl ApiTester {
     }
 
     pub async fn test_get_validator_attestation_data(self) -> Self {
-        let mut state = self.chain.head_beacon_state().unwrap();
+        let mut state = self.chain.head_beacon_state_cloned();
         let slot = state.slot();
         state
             .build_committee_cache(RelativeEpoch::Current, &self.chain.spec)
@@ -2070,7 +2094,6 @@ impl ApiTester {
         let attestation = self
             .chain
             .head_beacon_block()
-            .unwrap()
             .message()
             .body()
             .attestations()[0]
@@ -2098,7 +2121,7 @@ impl ApiTester {
         let slot = self.chain.slot().unwrap();
         let epoch = self.chain.epoch().unwrap();
 
-        let mut head = self.chain.head().unwrap();
+        let mut head = self.chain.head_snapshot().as_ref().clone();
         while head.beacon_state.current_epoch() < epoch {
             per_slot_processing(&mut head.beacon_state, None, &self.chain.spec).unwrap();
         }
@@ -2114,7 +2137,7 @@ impl ApiTester {
             .client
             .post_validator_duties_attester(
                 epoch,
-                (0..self.validator_keypairs.len() as u64)
+                (0..self.validator_keypairs().len() as u64)
                     .collect::<Vec<u64>>()
                     .as_slice(),
             )
@@ -2123,7 +2146,7 @@ impl ApiTester {
             .data;
 
         let (i, kp, duty, proof) = self
-            .validator_keypairs
+            .validator_keypairs()
             .iter()
             .enumerate()
             .find_map(|(i, kp)| {
@@ -2416,7 +2439,7 @@ impl ApiTester {
 
     pub async fn test_post_lighthouse_liveness(self) -> Self {
         let epoch = self.chain.epoch().unwrap();
-        let head_state = self.chain.head_beacon_state().unwrap();
+        let head_state = self.chain.head_beacon_state_cloned();
         let indices = (0..head_state.validators().len())
             .map(|i| i as u64)
             .collect::<Vec<_>>();
@@ -2533,7 +2556,7 @@ impl ApiTester {
         let block_root = self.next_block.canonical_root();
 
         // current_duty_dependent_root = block root because this is the first slot of the epoch
-        let current_duty_dependent_root = self.chain.head_beacon_block_root().unwrap();
+        let current_duty_dependent_root = self.chain.head_beacon_block_root();
         let current_slot = self.chain.slot().unwrap();
         let next_slot = self.next_block.slot();
         let finalization_distance = E::slots_per_epoch() * 2;
@@ -2556,17 +2579,21 @@ impl ApiTester {
             epoch_transition: true,
         });
 
+        let finalized_block_root = self
+            .chain
+            .block_root_at_slot(next_slot - finalization_distance, WhenSlotSkipped::Prev)
+            .unwrap()
+            .unwrap();
+        let finalized_block = self
+            .chain
+            .get_blinded_block(&finalized_block_root)
+            .unwrap()
+            .unwrap();
+        let finalized_state_root = finalized_block.state_root();
+
         let expected_finalized = EventKind::FinalizedCheckpoint(SseFinalizedCheckpoint {
-            block: self
-                .chain
-                .block_root_at_slot(next_slot - finalization_distance, WhenSlotSkipped::Prev)
-                .unwrap()
-                .unwrap(),
-            state: self
-                .chain
-                .state_root_at_slot(next_slot - finalization_distance)
-                .unwrap()
-                .unwrap(),
+            block: finalized_block_root,
+            state: finalized_state_root,
             epoch: Epoch::new(3),
         });
 
@@ -2578,7 +2605,7 @@ impl ApiTester {
         let block_events = poll_events(&mut events_future, 3, Duration::from_millis(10000)).await;
         assert_eq!(
             block_events.as_slice(),
-            &[expected_block, expected_finalized, expected_head]
+            &[expected_block, expected_head, expected_finalized]
         );
 
         // Test a reorg event

--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -1358,9 +1358,9 @@ pub enum Response<TSpec: EthSpec> {
     /// A Status message.
     Status(StatusMessage),
     /// A response to a get BLOCKS_BY_RANGE request. A None response signals the end of the batch.
-    BlocksByRange(Option<Box<SignedBeaconBlock<TSpec>>>),
+    BlocksByRange(Option<Arc<SignedBeaconBlock<TSpec>>>),
     /// A response to a get BLOCKS_BY_ROOT request.
-    BlocksByRoot(Option<Box<SignedBeaconBlock<TSpec>>>),
+    BlocksByRoot(Option<Arc<SignedBeaconBlock<TSpec>>>),
 }
 
 impl<TSpec: EthSpec> std::convert::From<Response<TSpec>> for RPCCodedResponse<TSpec> {

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -532,10 +532,10 @@ fn handle_v1_response<T: EthSpec>(
         Protocol::Goodbye => Err(RPCError::InvalidData(
             "Goodbye RPC message has no valid response".to_string(),
         )),
-        Protocol::BlocksByRange => Ok(Some(RPCResponse::BlocksByRange(Box::new(
+        Protocol::BlocksByRange => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
             SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
         )))),
-        Protocol::BlocksByRoot => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
+        Protocol::BlocksByRoot => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
             SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
         )))),
         Protocol::Ping => Ok(Some(RPCResponse::Pong(Ping {
@@ -572,31 +572,31 @@ fn handle_v2_response<T: EthSpec>(
         })?;
         match protocol {
             Protocol::BlocksByRange => match fork_name {
-                ForkName::Altair => Ok(Some(RPCResponse::BlocksByRange(Box::new(
+                ForkName::Altair => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                     SignedBeaconBlock::Altair(SignedBeaconBlockAltair::from_ssz_bytes(
                         decoded_buffer,
                     )?),
                 )))),
 
-                ForkName::Base => Ok(Some(RPCResponse::BlocksByRange(Box::new(
+                ForkName::Base => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                     SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
                 )))),
-                ForkName::Merge => Ok(Some(RPCResponse::BlocksByRange(Box::new(
+                ForkName::Merge => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                     SignedBeaconBlock::Merge(SignedBeaconBlockMerge::from_ssz_bytes(
                         decoded_buffer,
                     )?),
                 )))),
             },
             Protocol::BlocksByRoot => match fork_name {
-                ForkName::Altair => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
+                ForkName::Altair => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
                     SignedBeaconBlock::Altair(SignedBeaconBlockAltair::from_ssz_bytes(
                         decoded_buffer,
                     )?),
                 )))),
-                ForkName::Base => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
+                ForkName::Base => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
                     SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
                 )))),
-                ForkName::Merge => Ok(Some(RPCResponse::BlocksByRoot(Box::new(
+                ForkName::Merge => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
                     SignedBeaconBlock::Merge(SignedBeaconBlockMerge::from_ssz_bytes(
                         decoded_buffer,
                     )?),
@@ -898,10 +898,10 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V1,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(empty_base_block()))),
                 ForkName::Base,
             ),
-            Ok(Some(RPCResponse::BlocksByRange(Box::new(
+            Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                 empty_base_block()
             ))))
         );
@@ -911,7 +911,7 @@ mod tests {
                 encode_then_decode_response(
                     Protocol::BlocksByRange,
                     Version::V1,
-                    RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(altair_block()))),
+                    RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(altair_block()))),
                     ForkName::Altair,
                 )
                 .unwrap_err(),
@@ -924,11 +924,11 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V1,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
                 ForkName::Base,
             ),
             Ok(Some(RPCResponse::BlocksByRoot(
-                Box::new(empty_base_block())
+                Arc::new(empty_base_block())
             )))
         );
 
@@ -937,7 +937,7 @@ mod tests {
                 encode_then_decode_response(
                     Protocol::BlocksByRoot,
                     Version::V1,
-                    RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
+                    RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(altair_block()))),
                     ForkName::Altair,
                 )
                 .unwrap_err(),
@@ -1013,10 +1013,10 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(empty_base_block()))),
                 ForkName::Base,
             ),
-            Ok(Some(RPCResponse::BlocksByRange(Box::new(
+            Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                 empty_base_block()
             ))))
         );
@@ -1028,10 +1028,10 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(empty_base_block()))),
                 ForkName::Altair,
             ),
-            Ok(Some(RPCResponse::BlocksByRange(Box::new(
+            Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                 empty_base_block()
             ))))
         );
@@ -1040,10 +1040,10 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(altair_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(altair_block()))),
                 ForkName::Altair,
             ),
-            Ok(Some(RPCResponse::BlocksByRange(Box::new(altair_block()))))
+            Ok(Some(RPCResponse::BlocksByRange(Arc::new(altair_block()))))
         );
 
         let merge_block_small = merge_block_small(&fork_context(ForkName::Merge));
@@ -1053,12 +1053,12 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(
+                RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(
                     merge_block_small.clone()
                 ))),
                 ForkName::Merge,
             ),
-            Ok(Some(RPCResponse::BlocksByRange(Box::new(
+            Ok(Some(RPCResponse::BlocksByRange(Arc::new(
                 merge_block_small.clone()
             ))))
         );
@@ -1085,11 +1085,11 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
                 ForkName::Base,
             ),
             Ok(Some(RPCResponse::BlocksByRoot(
-                Box::new(empty_base_block())
+                Arc::new(empty_base_block())
             ))),
         );
 
@@ -1100,11 +1100,11 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
                 ForkName::Altair,
             ),
             Ok(Some(RPCResponse::BlocksByRoot(
-                Box::new(empty_base_block())
+                Arc::new(empty_base_block())
             )))
         );
 
@@ -1112,22 +1112,22 @@ mod tests {
             encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
+                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(altair_block()))),
                 ForkName::Altair,
             ),
-            Ok(Some(RPCResponse::BlocksByRoot(Box::new(altair_block()))))
+            Ok(Some(RPCResponse::BlocksByRoot(Arc::new(altair_block()))))
         );
 
         assert_eq!(
             encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
-                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(
+                RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(
                     merge_block_small.clone()
                 ))),
                 ForkName::Merge,
             ),
-            Ok(Some(RPCResponse::BlocksByRoot(Box::new(merge_block_small))))
+            Ok(Some(RPCResponse::BlocksByRoot(Arc::new(merge_block_small))))
         );
 
         let mut encoded =
@@ -1179,7 +1179,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRange,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(empty_base_block()))),
             ForkName::Base,
         )
         .unwrap();
@@ -1200,7 +1200,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
             ForkName::Base,
         )
         .unwrap();
@@ -1222,7 +1222,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRange,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRange(Arc::new(empty_base_block()))),
             ForkName::Altair,
         )
         .unwrap();
@@ -1247,7 +1247,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(altair_block()))),
             ForkName::Altair,
         )
         .unwrap();
@@ -1292,7 +1292,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
             ForkName::Altair,
         )
         .unwrap();
@@ -1316,7 +1316,7 @@ mod tests {
         let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
-            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
+            RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Arc::new(empty_base_block()))),
             ForkName::Altair,
         )
         .unwrap();

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -9,6 +9,7 @@ use ssz_types::{
     VariableList,
 };
 use std::ops::Deref;
+use std::sync::Arc;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
 use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
@@ -237,10 +238,10 @@ pub enum RPCResponse<T: EthSpec> {
 
     /// A response to a get BLOCKS_BY_RANGE request. A None response signifies the end of the
     /// batch.
-    BlocksByRange(Box<SignedBeaconBlock<T>>),
+    BlocksByRange(Arc<SignedBeaconBlock<T>>),
 
     /// A response to a get BLOCKS_BY_ROOT request.
-    BlocksByRoot(Box<SignedBeaconBlock<T>>),
+    BlocksByRoot(Arc<SignedBeaconBlock<T>>),
 
     /// A PONG response to a PING request.
     Pong(Ping),

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -7,6 +7,7 @@ use snap::raw::{decompress_len, Decoder, Encoder};
 use ssz::{Decode, Encode};
 use std::boxed::Box;
 use std::io::{Error, ErrorKind};
+use std::sync::Arc;
 use types::{
     Attestation, AttesterSlashing, EthSpec, ForkContext, ForkName, ProposerSlashing,
     SignedAggregateAndProof, SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase,
@@ -17,7 +18,7 @@ use types::{
 #[derive(Debug, Clone, PartialEq)]
 pub enum PubsubMessage<T: EthSpec> {
     /// Gossipsub message providing notification of a new block.
-    BeaconBlock(Box<SignedBeaconBlock<T>>),
+    BeaconBlock(Arc<SignedBeaconBlock<T>>),
     /// Gossipsub message providing notification of a Aggregate attestation and associated proof.
     AggregateAndProofAttestation(Box<SignedAggregateAndProof<T>>),
     /// Gossipsub message providing notification of a raw un-aggregated attestation with its shard id.
@@ -173,7 +174,7 @@ impl<T: EthSpec> PubsubMessage<T> {
                                     ))
                                 }
                             };
-                        Ok(PubsubMessage::BeaconBlock(Box::new(beacon_block)))
+                        Ok(PubsubMessage::BeaconBlock(Arc::new(beacon_block)))
                     }
                     GossipKind::VoluntaryExit => {
                         let voluntary_exit = SignedVoluntaryExit::from_ssz_bytes(data)

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -174,15 +174,15 @@ fn test_blocks_by_range_chunked_rpc() {
         // BlocksByRange Response
         let full_block = BeaconBlock::Base(BeaconBlockBase::<E>::full(&spec));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_base = Response::BlocksByRange(Some(Box::new(signed_full_block)));
+        let rpc_response_base = Response::BlocksByRange(Some(Arc::new(signed_full_block)));
 
         let full_block = BeaconBlock::Altair(BeaconBlockAltair::<E>::full(&spec));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_altair = Response::BlocksByRange(Some(Box::new(signed_full_block)));
+        let rpc_response_altair = Response::BlocksByRange(Some(Arc::new(signed_full_block)));
 
         let full_block = merge_block_small(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_merge_small = Response::BlocksByRange(Some(Box::new(signed_full_block)));
+        let rpc_response_merge_small = Response::BlocksByRange(Some(Arc::new(signed_full_block)));
 
         // keep count of the number of messages received
         let mut messages_received = 0;
@@ -311,7 +311,7 @@ fn test_blocks_by_range_over_limit() {
         // BlocksByRange Response
         let full_block = merge_block_large(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_merge_large = Response::BlocksByRange(Some(Box::new(signed_full_block)));
+        let rpc_response_merge_large = Response::BlocksByRange(Some(Arc::new(signed_full_block)));
 
         let request_id = messages_to_send as usize;
         // build the sender future
@@ -409,7 +409,7 @@ fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
         let spec = E::default_spec();
         let empty_block = BeaconBlock::empty(&spec);
         let empty_signed = SignedBeaconBlock::from_block(empty_block, Signature::empty());
-        let rpc_response = Response::BlocksByRange(Some(Box::new(empty_signed)));
+        let rpc_response = Response::BlocksByRange(Some(Arc::new(empty_signed)));
 
         // keep count of the number of messages received
         let mut messages_received: u64 = 0;
@@ -540,7 +540,7 @@ fn test_blocks_by_range_single_empty_rpc() {
         let spec = E::default_spec();
         let empty_block = BeaconBlock::empty(&spec);
         let empty_signed = SignedBeaconBlock::from_block(empty_block, Signature::empty());
-        let rpc_response = Response::BlocksByRange(Some(Box::new(empty_signed)));
+        let rpc_response = Response::BlocksByRange(Some(Arc::new(empty_signed)));
 
         let messages_to_send = 1;
 
@@ -660,15 +660,15 @@ fn test_blocks_by_root_chunked_rpc() {
         // BlocksByRoot Response
         let full_block = BeaconBlock::Base(BeaconBlockBase::<E>::full(&spec));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_base = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
+        let rpc_response_base = Response::BlocksByRoot(Some(Arc::new(signed_full_block)));
 
         let full_block = BeaconBlock::Altair(BeaconBlockAltair::<E>::full(&spec));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_altair = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
+        let rpc_response_altair = Response::BlocksByRoot(Some(Arc::new(signed_full_block)));
 
         let full_block = merge_block_small(&common::fork_context(ForkName::Merge));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response_merge_small = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
+        let rpc_response_merge_small = Response::BlocksByRoot(Some(Arc::new(signed_full_block)));
 
         // keep count of the number of messages received
         let mut messages_received = 0;
@@ -803,7 +803,7 @@ fn test_blocks_by_root_chunked_rpc_terminates_correctly() {
         // BlocksByRoot Response
         let full_block = BeaconBlock::Base(BeaconBlockBase::<E>::full(&spec));
         let signed_full_block = SignedBeaconBlock::from_block(full_block, Signature::empty());
-        let rpc_response = Response::BlocksByRoot(Some(Box::new(signed_full_block)));
+        let rpc_response = Response::BlocksByRoot(Some(Arc::new(signed_full_block)));
 
         // keep count of the number of messages received
         let mut messages_received = 0;

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -8,7 +8,6 @@ use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
 };
 use beacon_chain::{BeaconChain, MAXIMUM_GOSSIP_CLOCK_DISPARITY};
-use environment::{null_logger, Environment, EnvironmentBuilder};
 use lighthouse_network::{
     discv5::enr::{CombinedKey, EnrBuilder},
     rpc::methods::{MetaData, MetaDataV2},
@@ -20,7 +19,6 @@ use std::cmp;
 use std::iter::Iterator;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use types::{
     Attestation, AttesterSlashing, EthSpec, MainnetEthSpec, ProposerSlashing, SignedBeaconBlock,
@@ -45,7 +43,7 @@ const STANDARD_TIMEOUT: Duration = Duration::from_secs(10);
 /// Provides utilities for testing the `BeaconProcessor`.
 struct TestRig {
     chain: Arc<BeaconChain<T>>,
-    next_block: SignedBeaconBlock<E>,
+    next_block: Arc<SignedBeaconBlock<E>>,
     attestations: Vec<(Attestation<E>, SubnetId)>,
     next_block_attestations: Vec<(Attestation<E>, SubnetId)>,
     next_block_aggregate_attestations: Vec<SignedAggregateAndProof<E>>,
@@ -56,7 +54,7 @@ struct TestRig {
     work_journal_rx: mpsc::Receiver<&'static str>,
     _network_rx: mpsc::UnboundedReceiver<NetworkMessage<E>>,
     _sync_rx: mpsc::UnboundedReceiver<SyncMessage<E>>,
-    environment: Option<Environment<E>>,
+    _harness: BeaconChainHarness<T>,
 }
 
 /// This custom drop implementation ensures that we shut down the tokio runtime gracefully. Without
@@ -65,12 +63,11 @@ impl Drop for TestRig {
     fn drop(&mut self) {
         // Causes the beacon processor to shutdown.
         self.beacon_processor_tx = mpsc::channel(MAX_WORK_EVENT_QUEUE_LEN).0;
-        self.environment.take().unwrap().shutdown_on_idle();
     }
 }
 
 impl TestRig {
-    pub fn new(chain_length: u64) -> Self {
+    pub async fn new(chain_length: u64) -> Self {
         // This allows for testing voluntary exits without building out a massive chain.
         let mut spec = E::default_spec();
         spec.shard_committee_period = 2;
@@ -84,16 +81,18 @@ impl TestRig {
         harness.advance_slot();
 
         for _ in 0..chain_length {
-            harness.extend_chain(
-                1,
-                BlockStrategy::OnCanonicalHead,
-                AttestationStrategy::AllValidators,
-            );
+            harness
+                .extend_chain(
+                    1,
+                    BlockStrategy::OnCanonicalHead,
+                    AttestationStrategy::AllValidators,
+                )
+                .await;
 
             harness.advance_slot();
         }
 
-        let head = harness.chain.head().unwrap();
+        let head = harness.chain.head_snapshot();
 
         assert_eq!(
             harness.chain.slot().unwrap(),
@@ -101,8 +100,9 @@ impl TestRig {
             "precondition: current slot is one after head"
         );
 
-        let (next_block, next_state) =
-            harness.make_block(head.beacon_state.clone(), harness.chain.slot().unwrap());
+        let (next_block, next_state) = harness
+            .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
+            .await;
 
         let head_state_root = head.beacon_state_root();
         let attestations = harness
@@ -155,11 +155,11 @@ impl TestRig {
         let proposer_slashing = harness.make_proposer_slashing(2);
         let voluntary_exit = harness.make_voluntary_exit(3, harness.chain.epoch().unwrap());
 
-        let chain = harness.chain;
+        let chain = harness.chain.clone();
 
         let (network_tx, _network_rx) = mpsc::unbounded_channel();
 
-        let log = null_logger().unwrap();
+        let log = harness.logger().clone();
 
         let (beacon_processor_tx, beacon_processor_rx) = mpsc::channel(MAX_WORK_EVENT_QUEUE_LEN);
         let (sync_tx, _sync_rx) = mpsc::unbounded_channel();
@@ -181,15 +181,7 @@ impl TestRig {
             &log,
         ));
 
-        let mut environment = EnvironmentBuilder::mainnet()
-            .null_logger()
-            .unwrap()
-            .multi_threaded_tokio_runtime()
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let executor = environment.core_context().executor;
+        let executor = harness.runtime.task_executor.clone();
 
         let (work_journal_tx, work_journal_rx) = mpsc::channel(16_364);
 
@@ -208,7 +200,7 @@ impl TestRig {
 
         Self {
             chain,
-            next_block,
+            next_block: Arc::new(next_block),
             attestations,
             next_block_attestations,
             next_block_aggregate_attestations,
@@ -219,12 +211,16 @@ impl TestRig {
             work_journal_rx,
             _network_rx,
             _sync_rx,
-            environment: Some(environment),
+            _harness: harness,
         }
     }
 
+    pub async fn recompute_head(&self) {
+        self.chain.recompute_head_at_current_slot().await.unwrap()
+    }
+
     pub fn head_root(&self) -> Hash256 {
-        self.chain.head().unwrap().beacon_block_root
+        self.chain.head_snapshot().beacon_block_root
     }
 
     pub fn enqueue_gossip_block(&self) {
@@ -233,7 +229,7 @@ impl TestRig {
                 junk_message_id(),
                 junk_peer_id(),
                 Client::default(),
-                Box::new(self.next_block.clone()),
+                self.next_block.clone(),
                 Duration::from_secs(0),
             ))
             .unwrap();
@@ -241,7 +237,7 @@ impl TestRig {
 
     pub fn enqueue_rpc_block(&self) {
         let event = WorkEvent::rpc_beacon_block(
-            Box::new(self.next_block.clone()),
+            self.next_block.clone(),
             std::time::Duration::default(),
             BlockProcessType::ParentLookup {
                 chain_hash: Hash256::random(),
@@ -324,28 +320,16 @@ impl TestRig {
             .unwrap();
     }
 
-    fn handle(&mut self) -> Handle {
-        self.environment
-            .as_mut()
-            .unwrap()
-            .core_context()
-            .executor
-            .handle()
-            .unwrap()
-    }
-
     /// Assert that the `BeaconProcessor` doesn't produce any events in the given `duration`.
-    pub fn assert_no_events_for(&mut self, duration: Duration) {
-        self.handle().block_on(async {
-            tokio::select! {
-                _ = tokio::time::sleep(duration) => (),
-                event = self.work_journal_rx.recv() => panic!(
-                    "received {:?} within {:?} when expecting no events",
-                    event,
-                    duration
-                ),
-            }
-        })
+    pub async fn assert_no_events_for(&mut self, duration: Duration) {
+        tokio::select! {
+            _ = tokio::time::sleep(duration) => (),
+            event = self.work_journal_rx.recv() => panic!(
+                "received {:?} within {:?} when expecting no events",
+                event,
+                duration
+            ),
+        }
     }
 
     /// Checks that the `BeaconProcessor` event journal contains the `expected` events in the given
@@ -354,57 +338,54 @@ impl TestRig {
     ///
     /// Given the described logic, `expected` must not contain `WORKER_FREED` or `NOTHING_TO_DO`
     /// events.
-    pub fn assert_event_journal_contains_ordered(&mut self, expected: &[&str]) {
+    pub async fn assert_event_journal_contains_ordered(&mut self, expected: &[&str]) {
         assert!(expected
             .iter()
             .all(|ev| ev != &WORKER_FREED && ev != &NOTHING_TO_DO));
 
-        let (events, worker_freed_remaining) = self.handle().block_on(async {
-            let mut events = Vec::with_capacity(expected.len());
-            let mut worker_freed_remaining = expected.len();
+        let mut events = Vec::with_capacity(expected.len());
+        let mut worker_freed_remaining = expected.len();
 
-            let drain_future = async {
-                loop {
-                    match self.work_journal_rx.recv().await {
-                        Some(event) if event == WORKER_FREED => {
-                            worker_freed_remaining -= 1;
-                            if worker_freed_remaining == 0 {
-                                // Break when all expected events are finished.
-                                break;
-                            }
+        let drain_future = async {
+            loop {
+                match self.work_journal_rx.recv().await {
+                    Some(event) if event == WORKER_FREED => {
+                        worker_freed_remaining -= 1;
+                        if worker_freed_remaining == 0 {
+                            // Break when all expected events are finished.
+                            break;
                         }
-                        Some(event) if event == NOTHING_TO_DO => {
-                            // Ignore these.
-                        }
-                        Some(event) => {
-                            events.push(event);
-                        }
-                        None => break,
                     }
+                    Some(event) if event == NOTHING_TO_DO => {
+                        // Ignore these.
+                    }
+                    Some(event) => {
+                        events.push(event);
+                    }
+                    None => break,
                 }
-            };
-
-            // Drain the expected number of events from the channel, or time out and give up.
-            tokio::select! {
-                _ = tokio::time::sleep(STANDARD_TIMEOUT) => panic!(
-                    "Timeout ({:?}) expired waiting for events. Expected {:?} but got {:?} waiting for {} `WORKER_FREED` events.",
-                    STANDARD_TIMEOUT,
-                    expected,
-                    events,
-                    worker_freed_remaining,
-                ),
-                _ = drain_future => {},
             }
+        };
 
-            (events, worker_freed_remaining)
-        });
+        // Drain the expected number of events from the channel, or time out and give up.
+        tokio::select! {
+            _ = tokio::time::sleep(STANDARD_TIMEOUT) => panic!(
+                "Timeout ({:?}) expired waiting for events. Expected {:?} but got {:?} waiting for {} `WORKER_FREED` events.",
+                STANDARD_TIMEOUT,
+                expected,
+                events,
+                worker_freed_remaining,
+            ),
+            _ = drain_future => {},
+        }
 
         assert_eq!(events, expected);
         assert_eq!(worker_freed_remaining, 0);
     }
 
-    pub fn assert_event_journal(&mut self, expected: &[&str]) {
-        self.assert_event_journal_with_timeout(expected, STANDARD_TIMEOUT);
+    pub async fn assert_event_journal(&mut self, expected: &[&str]) {
+        self.assert_event_journal_with_timeout(expected, STANDARD_TIMEOUT)
+            .await
     }
 
     /// Assert that the `BeaconProcessor` event journal is as `expected`.
@@ -413,34 +394,34 @@ impl TestRig {
     ///
     /// We won't attempt to listen for any more than `expected.len()` events. As such, it makes sense
     /// to use the `NOTHING_TO_DO` event to ensure that execution has completed.
-    pub fn assert_event_journal_with_timeout(&mut self, expected: &[&str], timeout: Duration) {
-        let events = self.handle().block_on(async {
-            let mut events = Vec::with_capacity(expected.len());
+    pub async fn assert_event_journal_with_timeout(
+        &mut self,
+        expected: &[&str],
+        timeout: Duration,
+    ) {
+        let mut events = Vec::with_capacity(expected.len());
 
-            let drain_future = async {
-                while let Some(event) = self.work_journal_rx.recv().await {
-                    events.push(event);
+        let drain_future = async {
+            while let Some(event) = self.work_journal_rx.recv().await {
+                events.push(event);
 
-                    // Break as soon as we collect the desired number of events.
-                    if events.len() >= expected.len() {
-                        break;
-                    }
+                // Break as soon as we collect the desired number of events.
+                if events.len() >= expected.len() {
+                    break;
                 }
-            };
-
-            // Drain the expected number of events from the channel, or time out and give up.
-            tokio::select! {
-                _ = tokio::time::sleep(timeout) => panic!(
-                    "Timeout ({:?}) expired waiting for events. Expected {:?} but got {:?}",
-                    timeout,
-                    expected,
-                    events
-                ),
-                _ = drain_future => {},
             }
+        };
 
-            events
-        });
+        // Drain the expected number of events from the channel, or time out and give up.
+        tokio::select! {
+            _ = tokio::time::sleep(timeout) => panic!(
+                "Timeout ({:?}) expired waiting for events. Expected {:?} but got {:?}",
+                timeout,
+                expected,
+                events
+            ),
+            _ = drain_future => {},
+        }
 
         assert_eq!(events, expected);
     }
@@ -455,9 +436,9 @@ fn junk_message_id() -> MessageId {
 }
 
 /// Blocks that arrive early should be queued for later processing.
-#[test]
-fn import_gossip_block_acceptably_early() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn import_gossip_block_acceptably_early() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     let slot_start = rig
         .chain
@@ -477,7 +458,8 @@ fn import_gossip_block_acceptably_early() {
 
     rig.enqueue_gossip_block();
 
-    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     // Note: this section of the code is a bit race-y. We're assuming that we can set the slot clock
     // and check the head in the time between the block arrived early and when its due for
@@ -492,7 +474,8 @@ fn import_gossip_block_acceptably_early() {
         "block not yet imported"
     );
 
-    rig.assert_event_journal(&[DELAYED_IMPORT_BLOCK, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[DELAYED_IMPORT_BLOCK, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.head_root(),
@@ -502,9 +485,9 @@ fn import_gossip_block_acceptably_early() {
 }
 
 /// Blocks that are *too* early shouldn't get into the delay queue.
-#[test]
-fn import_gossip_block_unacceptably_early() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn import_gossip_block_unacceptably_early() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     let slot_start = rig
         .chain
@@ -524,11 +507,12 @@ fn import_gossip_block_unacceptably_early() {
 
     rig.enqueue_gossip_block();
 
-    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     // Waiting for 5 seconds is a bit arbitrary, however it *should* be long enough to ensure the
     // block isn't imported.
-    rig.assert_no_events_for(Duration::from_secs(5));
+    rig.assert_no_events_for(Duration::from_secs(5)).await;
 
     assert!(
         rig.head_root() != rig.next_block.canonical_root(),
@@ -537,9 +521,9 @@ fn import_gossip_block_unacceptably_early() {
 }
 
 /// Blocks that arrive on-time should be processed normally.
-#[test]
-fn import_gossip_block_at_current_slot() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn import_gossip_block_at_current_slot() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     assert_eq!(
         rig.chain.slot().unwrap(),
@@ -549,7 +533,8 @@ fn import_gossip_block_at_current_slot() {
 
     rig.enqueue_gossip_block();
 
-    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_BLOCK, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.head_root(),
@@ -559,15 +544,16 @@ fn import_gossip_block_at_current_slot() {
 }
 
 /// Ensure a valid attestation can be imported.
-#[test]
-fn import_gossip_attestation() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn import_gossip_attestation() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     let initial_attns = rig.chain.naive_aggregation_pool.read().num_items();
 
     rig.enqueue_unaggregated_attestation();
 
-    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.naive_aggregation_pool.read().num_items(),
@@ -583,8 +569,8 @@ enum BlockImportMethod {
 
 /// Ensure that attestations that reference an unknown block get properly re-queued and
 /// re-processed upon importing the block.
-fn attestation_to_unknown_block_processed(import_method: BlockImportMethod) {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+async fn attestation_to_unknown_block_processed(import_method: BlockImportMethod) {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Send the attestation but not the block, and check that it was not imported.
 
@@ -592,7 +578,8 @@ fn attestation_to_unknown_block_processed(import_method: BlockImportMethod) {
 
     rig.enqueue_next_block_unaggregated_attestation();
 
-    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.naive_aggregation_pool.read().num_items(),
@@ -613,11 +600,12 @@ fn attestation_to_unknown_block_processed(import_method: BlockImportMethod) {
         }
     };
 
-    rig.assert_event_journal_contains_ordered(&[block_event, UNKNOWN_BLOCK_ATTESTATION]);
+    rig.assert_event_journal_contains_ordered(&[block_event, UNKNOWN_BLOCK_ATTESTATION])
+        .await;
 
     // Run fork choice, since it isn't run when processing an RPC block. At runtime it is the
     // responsibility of the sync manager to do this.
-    rig.chain.fork_choice().unwrap();
+    rig.recompute_head().await;
 
     assert_eq!(
         rig.head_root(),
@@ -632,20 +620,20 @@ fn attestation_to_unknown_block_processed(import_method: BlockImportMethod) {
     );
 }
 
-#[test]
-fn attestation_to_unknown_block_processed_after_gossip_block() {
-    attestation_to_unknown_block_processed(BlockImportMethod::Gossip)
+#[tokio::test]
+async fn attestation_to_unknown_block_processed_after_gossip_block() {
+    attestation_to_unknown_block_processed(BlockImportMethod::Gossip).await
 }
 
-#[test]
-fn attestation_to_unknown_block_processed_after_rpc_block() {
-    attestation_to_unknown_block_processed(BlockImportMethod::Rpc)
+#[tokio::test]
+async fn attestation_to_unknown_block_processed_after_rpc_block() {
+    attestation_to_unknown_block_processed(BlockImportMethod::Rpc).await
 }
 
 /// Ensure that attestations that reference an unknown block get properly re-queued and
 /// re-processed upon importing the block.
-fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod) {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+async fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod) {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Empty the op pool.
     rig.chain
@@ -659,7 +647,8 @@ fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod) {
 
     rig.enqueue_next_block_aggregated_attestation();
 
-    rig.assert_event_journal(&[GOSSIP_AGGREGATE, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_AGGREGATE, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.op_pool.num_attestations(),
@@ -680,11 +669,12 @@ fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod) {
         }
     };
 
-    rig.assert_event_journal_contains_ordered(&[block_event, UNKNOWN_BLOCK_AGGREGATE]);
+    rig.assert_event_journal_contains_ordered(&[block_event, UNKNOWN_BLOCK_AGGREGATE])
+        .await;
 
     // Run fork choice, since it isn't run when processing an RPC block. At runtime it is the
     // responsibility of the sync manager to do this.
-    rig.chain.fork_choice().unwrap();
+    rig.recompute_head().await;
 
     assert_eq!(
         rig.head_root(),
@@ -699,21 +689,21 @@ fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod) {
     );
 }
 
-#[test]
-fn aggregate_attestation_to_unknown_block_processed_after_gossip_block() {
-    aggregate_attestation_to_unknown_block(BlockImportMethod::Gossip)
+#[tokio::test]
+async fn aggregate_attestation_to_unknown_block_processed_after_gossip_block() {
+    aggregate_attestation_to_unknown_block(BlockImportMethod::Gossip).await
 }
 
-#[test]
-fn aggregate_attestation_to_unknown_block_processed_after_rpc_block() {
-    aggregate_attestation_to_unknown_block(BlockImportMethod::Rpc)
+#[tokio::test]
+async fn aggregate_attestation_to_unknown_block_processed_after_rpc_block() {
+    aggregate_attestation_to_unknown_block(BlockImportMethod::Rpc).await
 }
 
 /// Ensure that attestations that reference an unknown block get properly re-queued and re-processed
 /// when the block is not seen.
-#[test]
-fn requeue_unknown_block_gossip_attestation_without_import() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn requeue_unknown_block_gossip_attestation_without_import() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Send the attestation but not the block, and check that it was not imported.
 
@@ -721,7 +711,8 @@ fn requeue_unknown_block_gossip_attestation_without_import() {
 
     rig.enqueue_next_block_unaggregated_attestation();
 
-    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_ATTESTATION, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.naive_aggregation_pool.read().num_items(),
@@ -734,7 +725,8 @@ fn requeue_unknown_block_gossip_attestation_without_import() {
     rig.assert_event_journal_with_timeout(
         &[UNKNOWN_BLOCK_ATTESTATION, WORKER_FREED, NOTHING_TO_DO],
         Duration::from_secs(1) + QUEUED_ATTESTATION_DELAY,
-    );
+    )
+    .await;
 
     assert_eq!(
         rig.chain.naive_aggregation_pool.read().num_items(),
@@ -745,9 +737,9 @@ fn requeue_unknown_block_gossip_attestation_without_import() {
 
 /// Ensure that aggregate that reference an unknown block get properly re-queued and re-processed
 /// when the block is not seen.
-#[test]
-fn requeue_unknown_block_gossip_aggregated_attestation_without_import() {
-    let mut rig = TestRig::new(SMALL_CHAIN);
+#[tokio::test]
+async fn requeue_unknown_block_gossip_aggregated_attestation_without_import() {
+    let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Send the attestation but not the block, and check that it was not imported.
 
@@ -755,7 +747,8 @@ fn requeue_unknown_block_gossip_aggregated_attestation_without_import() {
 
     rig.enqueue_next_block_aggregated_attestation();
 
-    rig.assert_event_journal(&[GOSSIP_AGGREGATE, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_AGGREGATE, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.naive_aggregation_pool.read().num_items(),
@@ -768,7 +761,8 @@ fn requeue_unknown_block_gossip_aggregated_attestation_without_import() {
     rig.assert_event_journal_with_timeout(
         &[UNKNOWN_BLOCK_AGGREGATE, WORKER_FREED, NOTHING_TO_DO],
         Duration::from_secs(1) + QUEUED_ATTESTATION_DELAY,
-    );
+    )
+    .await;
 
     assert_eq!(
         rig.chain.op_pool.num_attestations(),
@@ -778,10 +772,10 @@ fn requeue_unknown_block_gossip_aggregated_attestation_without_import() {
 }
 
 /// Ensure a bunch of valid operations can be imported.
-#[test]
-fn import_misc_gossip_ops() {
+#[tokio::test]
+async fn import_misc_gossip_ops() {
     // Exits need the long chain so validators aren't too young to exit.
-    let mut rig = TestRig::new(LONG_CHAIN);
+    let mut rig = TestRig::new(LONG_CHAIN).await;
 
     /*
      * Attester slashing
@@ -791,7 +785,8 @@ fn import_misc_gossip_ops() {
 
     rig.enqueue_gossip_attester_slashing();
 
-    rig.assert_event_journal(&[GOSSIP_ATTESTER_SLASHING, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_ATTESTER_SLASHING, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.op_pool.num_attester_slashings(),
@@ -807,7 +802,8 @@ fn import_misc_gossip_ops() {
 
     rig.enqueue_gossip_proposer_slashing();
 
-    rig.assert_event_journal(&[GOSSIP_PROPOSER_SLASHING, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_PROPOSER_SLASHING, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.op_pool.num_proposer_slashings(),
@@ -823,7 +819,8 @@ fn import_misc_gossip_ops() {
 
     rig.enqueue_gossip_voluntary_exit();
 
-    rig.assert_event_journal(&[GOSSIP_VOLUNTARY_EXIT, WORKER_FREED, NOTHING_TO_DO]);
+    rig.assert_event_journal(&[GOSSIP_VOLUNTARY_EXIT, WORKER_FREED, NOTHING_TO_DO])
+        .await;
 
     assert_eq!(
         rig.chain.op_pool.num_voluntary_exits(),

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -143,10 +143,6 @@ lazy_static! {
         "beacon_processor_attester_slashing_imported_total",
         "Total number of attester slashings imported to the op pool."
     );
-    pub static ref BEACON_PROCESSOR_ATTESTER_SLASHING_ERROR_TOTAL: Result<IntCounter> = try_create_int_counter(
-        "beacon_processor_attester_slashing_error_total",
-        "Total number of attester slashings that raised an error during processing."
-    );
     // Rpc blocks.
     pub static ref BEACON_PROCESSOR_RPC_BLOCK_QUEUE_TOTAL: Result<IntGauge> = try_create_int_gauge(
         "beacon_processor_rpc_block_queue_total",

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -7,7 +7,7 @@ use crate::{
     subnet_service::{AttestationService, SubnetServiceMessage},
     NetworkConfig,
 };
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainTypes};
 use futures::channel::mpsc::Sender;
 use futures::future::OptionFuture;
 use futures::prelude::*;
@@ -30,8 +30,8 @@ use task_executor::ShutdownReason;
 use tokio::sync::mpsc;
 use tokio::time::Sleep;
 use types::{
-    ChainSpec, EthSpec, ForkContext, RelativeEpoch, Slot, SubnetId, SyncCommitteeSubscription,
-    SyncSubnetId, Unsigned, ValidatorSubscription,
+    ChainSpec, EthSpec, ForkContext, Slot, SubnetId, SyncCommitteeSubscription, SyncSubnetId,
+    Unsigned, ValidatorSubscription,
 };
 
 mod tests;
@@ -706,29 +706,12 @@ impl<T: BeaconChainTypes> NetworkService<T> {
 
     fn update_gossipsub_parameters(&mut self) {
         if let Ok(slot) = self.beacon_chain.slot() {
-            if let Some(active_validators) = self
+            let active_validators_opt = self
                 .beacon_chain
-                .with_head(|head| {
-                    Ok::<_, BeaconChainError>(
-                        head.beacon_state
-                            .get_cached_active_validator_indices(RelativeEpoch::Current)
-                            .map(|indices| indices.len())
-                            .ok()
-                            .or_else(|| {
-                                // if active validator cached was not build we count the
-                                // active validators
-                                self.beacon_chain.epoch().ok().map(|current_epoch| {
-                                    head.beacon_state
-                                        .validators()
-                                        .iter()
-                                        .filter(|validator| validator.is_active_at(current_epoch))
-                                        .count()
-                                })
-                            }),
-                    )
-                })
-                .unwrap_or(None)
-            {
+                .canonical_head
+                .cached_head()
+                .active_validator_count();
+            if let Some(active_validators) = active_validators_opt {
                 if self
                     .libp2p
                     .swarm
@@ -742,6 +725,14 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                         "active_validators" => active_validators
                     );
                 }
+            } else {
+                // This scenario will only happen if the caches on the cached canonical head aren't
+                // built. That should never be the case.
+                error!(
+                    self.log,
+                    "Active validator count unavailable";
+                    "info" => "please report this bug"
+                );
             }
         }
     }

--- a/beacon_node/network/src/status.rs
+++ b/beacon_node/network/src/status.rs
@@ -1,4 +1,5 @@
-use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use types::{EthSpec, Hash256};
 
 use lighthouse_network::rpc::StatusMessage;
 /// Trait to produce a `StatusMessage` representing the state of the given `beacon_chain`.
@@ -6,20 +7,33 @@ use lighthouse_network::rpc::StatusMessage;
 /// NOTE: The purpose of this is simply to obtain a `StatusMessage` from the `BeaconChain` without
 /// polluting/coupling the type with RPC concepts.
 pub trait ToStatusMessage {
-    fn status_message(&self) -> Result<StatusMessage, BeaconChainError>;
+    fn status_message(&self) -> StatusMessage;
 }
 
 impl<T: BeaconChainTypes> ToStatusMessage for BeaconChain<T> {
-    fn status_message(&self) -> Result<StatusMessage, BeaconChainError> {
-        let head_info = self.head_info()?;
-        let fork_digest = self.enr_fork_id().fork_digest;
+    fn status_message(&self) -> StatusMessage {
+        status_message(self)
+    }
+}
 
-        Ok(StatusMessage {
-            fork_digest,
-            finalized_root: head_info.finalized_checkpoint.root,
-            finalized_epoch: head_info.finalized_checkpoint.epoch,
-            head_root: head_info.block_root,
-            head_slot: head_info.slot,
-        })
+/// Build a `StatusMessage` representing the state of the given `beacon_chain`.
+pub(crate) fn status_message<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) -> StatusMessage {
+    let fork_digest = beacon_chain.enr_fork_id().fork_digest;
+    let cached_head = beacon_chain.canonical_head.cached_head();
+    let mut finalized_checkpoint = cached_head.finalized_checkpoint();
+
+    // Alias the genesis checkpoint root to `0x00`.
+    let spec = &beacon_chain.spec;
+    let genesis_epoch = spec.genesis_slot.epoch(T::EthSpec::slots_per_epoch());
+    if finalized_checkpoint.epoch == genesis_epoch {
+        finalized_checkpoint.root = Hash256::zero();
+    }
+
+    StatusMessage {
+        fork_digest,
+        finalized_root: finalized_checkpoint.root,
+        finalized_epoch: finalized_checkpoint.epoch,
+        head_root: cached_head.head_block_root(),
+        head_slot: cached_head.head_slot(),
     }
 }

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use store::config::StoreConfig;
 use store::{HotColdDB, MemoryStore};
+use task_executor::test_utils::TestRuntime;
 use types::{
     CommitteeIndex, Epoch, EthSpec, Hash256, MainnetEthSpec, Slot, SubnetId,
     SyncCommitteeSubscription, SyncSubnetId, ValidatorSubscription,
@@ -32,6 +33,7 @@ type TestBeaconChainType = Witness<
 
 pub struct TestBeaconChain {
     chain: Arc<BeaconChain<TestBeaconChainType>>,
+    _test_runtime: TestRuntime,
 }
 
 impl TestBeaconChain {
@@ -46,11 +48,14 @@ impl TestBeaconChain {
 
         let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
 
+        let test_runtime = TestRuntime::default();
+
         let chain = Arc::new(
             BeaconChainBuilder::new(MainnetEthSpec)
                 .logger(log.clone())
                 .custom_spec(spec.clone())
                 .store(Arc::new(store))
+                .task_executor(test_runtime.task_executor.clone())
                 .genesis_state(
                     interop_genesis_state::<MainnetEthSpec>(
                         &keypairs,
@@ -74,7 +79,10 @@ impl TestBeaconChain {
                 .build()
                 .expect("should build"),
         );
-        Self { chain }
+        Self {
+            chain,
+            _test_runtime: test_runtime,
+        }
     }
 }
 

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -53,7 +53,7 @@ impl BatchConfig for BackFillBatchConfig {
     fn max_batch_processing_attempts() -> u8 {
         MAX_BATCH_PROCESSING_ATTEMPTS
     }
-    fn batch_attempt_hash<T: EthSpec>(blocks: &[SignedBeaconBlock<T>]) -> u64 {
+    fn batch_attempt_hash<T: EthSpec>(blocks: &[Arc<SignedBeaconBlock<T>>]) -> u64 {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
         let mut hasher = DefaultHasher::new();
@@ -392,7 +392,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         batch_id: BatchId,
         peer_id: &PeerId,
         request_id: Id,
-        beacon_block: Option<SignedBeaconBlock<T::EthSpec>>,
+        beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) -> Result<ProcessResult, BackFillError> {
         // check if we have this batch
         let batch = match self.batches.get_mut(&batch_id) {

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use lighthouse_network::{rpc::BlocksByRootRequest, PeerId};
 use rand::seq::IteratorRandom;
@@ -82,8 +83,8 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
     /// Returns the block for processing if the response is what we expected.
     pub fn verify_block<T: EthSpec>(
         &mut self,
-        block: Option<Box<SignedBeaconBlock<T>>>,
-    ) -> Result<Option<Box<SignedBeaconBlock<T>>>, VerifyError> {
+        block: Option<Arc<SignedBeaconBlock<T>>>,
+    ) -> Result<Option<Arc<SignedBeaconBlock<T>>>, VerifyError> {
         match self.state {
             State::AwaitingDownload => {
                 self.register_failure();
@@ -195,7 +196,7 @@ mod tests {
 
         let mut sl = SingleBlockRequest::<4>::new(block.canonical_root(), peer_id);
         sl.request_block().unwrap();
-        sl.verify_block(Some(Box::new(block))).unwrap().unwrap();
+        sl.verify_block(Some(Arc::new(block))).unwrap().unwrap();
     }
 
     #[test]

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -158,7 +158,7 @@ fn test_single_block_lookup_happy_path() {
 
     // The peer provides the correct block, should not be penalized. Now the block should be sent
     // for processing.
-    bl.single_block_lookup_response(id, peer_id, Some(Box::new(block)), D, &mut cx);
+    bl.single_block_lookup_response(id, peer_id, Some(Arc::new(block)), D, &mut cx);
     rig.expect_empty_network();
     rig.expect_block_process();
 
@@ -204,7 +204,7 @@ fn test_single_block_lookup_wrong_response() {
 
     // Peer sends something else. It should be penalized.
     let bad_block = rig.rand_block();
-    bl.single_block_lookup_response(id, peer_id, Some(Box::new(bad_block)), D, &mut cx);
+    bl.single_block_lookup_response(id, peer_id, Some(Arc::new(bad_block)), D, &mut cx);
     rig.expect_penalty();
     rig.expect_block_request(); // should be retried
 
@@ -243,7 +243,7 @@ fn test_single_block_lookup_becomes_parent_request() {
 
     // The peer provides the correct block, should not be penalized. Now the block should be sent
     // for processing.
-    bl.single_block_lookup_response(id, peer_id, Some(Box::new(block.clone())), D, &mut cx);
+    bl.single_block_lookup_response(id, peer_id, Some(Arc::new(block.clone())), D, &mut cx);
     rig.expect_empty_network();
     rig.expect_block_process();
 
@@ -252,7 +252,7 @@ fn test_single_block_lookup_becomes_parent_request() {
 
     // Send the stream termination. Peer should have not been penalized, and the request moved to a
     // parent request after processing.
-    bl.single_block_processed(id, Err(BlockError::ParentUnknown(Box::new(block))), &mut cx);
+    bl.single_block_processed(id, Err(BlockError::ParentUnknown(Arc::new(block))), &mut cx);
     assert_eq!(bl.single_block_lookups.len(), 0);
     rig.expect_parent_request();
     rig.expect_empty_network();
@@ -269,11 +269,11 @@ fn test_parent_lookup_happy_path() {
     let peer_id = PeerId::random();
 
     // Trigger the request
-    bl.search_parent(Box::new(block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(block), peer_id, &mut cx);
     let id = rig.expect_parent_request();
 
     // Peer sends the right block, it should be sent for processing. Peer should not be penalized.
-    bl.parent_lookup_response(id, peer_id, Some(Box::new(parent)), D, &mut cx);
+    bl.parent_lookup_response(id, peer_id, Some(Arc::new(parent)), D, &mut cx);
     rig.expect_block_process();
     rig.expect_empty_network();
 
@@ -294,12 +294,12 @@ fn test_parent_lookup_wrong_response() {
     let peer_id = PeerId::random();
 
     // Trigger the request
-    bl.search_parent(Box::new(block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(block), peer_id, &mut cx);
     let id1 = rig.expect_parent_request();
 
     // Peer sends the wrong block, peer should be penalized and the block re-requested.
     let bad_block = rig.rand_block();
-    bl.parent_lookup_response(id1, peer_id, Some(Box::new(bad_block)), D, &mut cx);
+    bl.parent_lookup_response(id1, peer_id, Some(Arc::new(bad_block)), D, &mut cx);
     rig.expect_penalty();
     let id2 = rig.expect_parent_request();
 
@@ -308,7 +308,7 @@ fn test_parent_lookup_wrong_response() {
     rig.expect_empty_network();
 
     // Send the right block this time.
-    bl.parent_lookup_response(id2, peer_id, Some(Box::new(parent)), D, &mut cx);
+    bl.parent_lookup_response(id2, peer_id, Some(Arc::new(parent)), D, &mut cx);
     rig.expect_block_process();
 
     // Processing succeeds, now the rest of the chain should be sent for processing.
@@ -328,7 +328,7 @@ fn test_parent_lookup_empty_response() {
     let peer_id = PeerId::random();
 
     // Trigger the request
-    bl.search_parent(Box::new(block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(block), peer_id, &mut cx);
     let id1 = rig.expect_parent_request();
 
     // Peer sends an empty response, peer should be penalized and the block re-requested.
@@ -337,7 +337,7 @@ fn test_parent_lookup_empty_response() {
     let id2 = rig.expect_parent_request();
 
     // Send the right block this time.
-    bl.parent_lookup_response(id2, peer_id, Some(Box::new(parent)), D, &mut cx);
+    bl.parent_lookup_response(id2, peer_id, Some(Arc::new(parent)), D, &mut cx);
     rig.expect_block_process();
 
     // Processing succeeds, now the rest of the chain should be sent for processing.
@@ -357,7 +357,7 @@ fn test_parent_lookup_rpc_failure() {
     let peer_id = PeerId::random();
 
     // Trigger the request
-    bl.search_parent(Box::new(block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(block), peer_id, &mut cx);
     let id1 = rig.expect_parent_request();
 
     // The request fails. It should be tried again.
@@ -365,7 +365,7 @@ fn test_parent_lookup_rpc_failure() {
     let id2 = rig.expect_parent_request();
 
     // Send the right block this time.
-    bl.parent_lookup_response(id2, peer_id, Some(Box::new(parent)), D, &mut cx);
+    bl.parent_lookup_response(id2, peer_id, Some(Arc::new(parent)), D, &mut cx);
     rig.expect_block_process();
 
     // Processing succeeds, now the rest of the chain should be sent for processing.
@@ -385,7 +385,7 @@ fn test_parent_lookup_too_many_attempts() {
     let peer_id = PeerId::random();
 
     // Trigger the request
-    bl.search_parent(Box::new(block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(block), peer_id, &mut cx);
     for i in 1..=parent_lookup::PARENT_FAIL_TOLERANCE + 1 {
         let id = rig.expect_parent_request();
         match i % 2 {
@@ -397,7 +397,7 @@ fn test_parent_lookup_too_many_attempts() {
             _ => {
                 // Send a bad block this time. It should be tried again.
                 let bad_block = rig.rand_block();
-                bl.parent_lookup_response(id, peer_id, Some(Box::new(bad_block)), D, &mut cx);
+                bl.parent_lookup_response(id, peer_id, Some(Arc::new(bad_block)), D, &mut cx);
                 rig.expect_penalty();
             }
         }
@@ -427,12 +427,12 @@ fn test_parent_lookup_too_deep() {
     let peer_id = PeerId::random();
     let trigger_block = blocks.pop().unwrap();
     let chain_hash = trigger_block.canonical_root();
-    bl.search_parent(Box::new(trigger_block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(trigger_block), peer_id, &mut cx);
 
     for block in blocks.into_iter().rev() {
         let id = rig.expect_parent_request();
         // the block
-        bl.parent_lookup_response(id, peer_id, Some(Box::new(block.clone())), D, &mut cx);
+        bl.parent_lookup_response(id, peer_id, Some(Arc::new(block.clone())), D, &mut cx);
         // the stream termination
         bl.parent_lookup_response(id, peer_id, None, D, &mut cx);
         // the processing request
@@ -440,7 +440,7 @@ fn test_parent_lookup_too_deep() {
         // the processing result
         bl.parent_block_processed(
             chain_hash,
-            Err(BlockError::ParentUnknown(Box::new(block))),
+            Err(BlockError::ParentUnknown(Arc::new(block))),
             &mut cx,
         )
     }
@@ -454,7 +454,7 @@ fn test_parent_lookup_disconnection() {
     let (mut bl, mut cx, mut rig) = TestRig::test_setup(None);
     let peer_id = PeerId::random();
     let trigger_block = rig.rand_block();
-    bl.search_parent(Box::new(trigger_block), peer_id, &mut cx);
+    bl.search_parent(Arc::new(trigger_block), peer_id, &mut cx);
     bl.peer_disconnected(&peer_id, &mut cx);
     assert!(bl.parent_queue.is_empty());
 }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -65,27 +65,26 @@ impl<T: EthSpec> SyncNetworkContext<T> {
         chain: &C,
         peers: impl Iterator<Item = PeerId>,
     ) {
-        if let Ok(status_message) = chain.status_message() {
-            for peer_id in peers {
-                debug!(
-                    self.log,
-                    "Sending Status Request";
-                    "peer" => %peer_id,
-                    "fork_digest" => ?status_message.fork_digest,
-                    "finalized_root" => ?status_message.finalized_root,
-                    "finalized_epoch" => ?status_message.finalized_epoch,
-                    "head_root" => %status_message.head_root,
-                    "head_slot" => %status_message.head_slot,
-                );
+        let status_message = chain.status_message();
+        for peer_id in peers {
+            debug!(
+                self.log,
+                "Sending Status Request";
+                "peer" => %peer_id,
+                "fork_digest" => ?status_message.fork_digest,
+                "finalized_root" => ?status_message.finalized_root,
+                "finalized_epoch" => ?status_message.finalized_epoch,
+                "head_root" => %status_message.head_root,
+                "head_slot" => %status_message.head_slot,
+            );
 
-                let request = Request::Status(status_message.clone());
-                let request_id = RequestId::Router;
-                let _ = self.send_network_msg(NetworkMessage::SendRequest {
-                    peer_id,
-                    request,
-                    request_id,
-                });
-            }
+            let request = Request::Status(status_message.clone());
+            let request_id = RequestId::Router;
+            let _ = self.send_network_msg(NetworkMessage::SendRequest {
+                peer_id,
+                request,
+                request_id,
+            });
         }
     }
 

--- a/beacon_node/network/src/sync/peer_sync_info.rs
+++ b/beacon_node/network/src/sync/peer_sync_info.rs
@@ -59,7 +59,7 @@ pub fn remote_sync_type<T: BeaconChainTypes>(
             if remote.head_slot < near_range_start {
                 PeerSyncType::Behind
             } else if remote.head_slot > near_range_end
-                && !chain.fork_choice.read().contains_block(&remote.head_root)
+                && !chain.block_is_known_to_fork_choice(&remote.head_root)
             {
                 // This peer has a head ahead enough of ours and we have no knowledge of their best
                 // block.
@@ -74,7 +74,7 @@ pub fn remote_sync_type<T: BeaconChainTypes>(
             if (local.finalized_epoch + 1 == remote.finalized_epoch
                 && near_range_start <= remote.head_slot
                 && remote.head_slot <= near_range_end)
-                || chain.fork_choice.read().contains_block(&remote.head_root)
+                || chain.block_is_known_to_fork_choice(&remote.head_root)
             {
                 // This peer is near enough to us to be considered synced, or
                 // we have already synced up to this peer's head

--- a/beacon_node/network/src/sync/range_sync/block_storage.rs
+++ b/beacon_node/network/src/sync/range_sync/block_storage.rs
@@ -8,6 +8,6 @@ pub trait BlockStorage {
 
 impl<T: BeaconChainTypes> BlockStorage for BeaconChain<T> {
     fn is_block_known(&self, block_root: &Hash256) -> bool {
-        self.fork_choice.read().contains_block(block_root)
+        self.block_is_known_to_fork_choice(block_root)
     }
 }

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -9,6 +9,7 @@ use rand::seq::SliceRandom;
 use slog::{crit, debug, o, warn};
 use std::collections::{btree_map::Entry, BTreeMap, HashSet};
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
 
@@ -216,7 +217,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         batch_id: BatchId,
         peer_id: &PeerId,
         request_id: Id,
-        beacon_block: Option<SignedBeaconBlock<T::EthSpec>>,
+        beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) -> ProcessingResult {
         // check if we have this batch
         let batch = match self.batches.get_mut(&batch_id) {

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -53,7 +53,7 @@ use lighthouse_network::rpc::GoodbyeReason;
 use lighthouse_network::PeerId;
 use lighthouse_network::SyncInfo;
 use lru_cache::LRUTimeCache;
-use slog::{crit, debug, error, trace, warn};
+use slog::{crit, debug, trace, warn};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -221,7 +221,7 @@ where
         chain_id: ChainId,
         batch_id: BatchId,
         request_id: Id,
-        beacon_block: Option<SignedBeaconBlock<T::EthSpec>>,
+        beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) {
         // check if this chunk removes the chain
         match self.chains.call_by_id(chain_id, |chain| {
@@ -365,17 +365,12 @@ where
 
         network.status_peers(self.beacon_chain.as_ref(), chain.peers());
 
-        let local = match self.beacon_chain.status_message() {
-            Ok(status) => SyncInfo {
-                head_slot: status.head_slot,
-                head_root: status.head_root,
-                finalized_epoch: status.finalized_epoch,
-                finalized_root: status.finalized_root,
-            },
-            Err(e) => {
-                return error!(self.log, "Failed to get peer sync info";
-                    "msg" => "likely due to head lock contention", "err" => ?e)
-            }
+        let status = self.beacon_chain.status_message();
+        let local = SyncInfo {
+            head_slot: status.head_slot,
+            head_root: status.head_root,
+            finalized_epoch: status.finalized_epoch,
+            finalized_root: status.finalized_root,
         };
 
         // update the state of the collection
@@ -447,8 +442,8 @@ mod tests {
     }
 
     impl ToStatusMessage for FakeStorage {
-        fn status_message(&self) -> Result<StatusMessage, beacon_chain::BeaconChainError> {
-            Ok(self.status.read().clone())
+        fn status_message(&self) -> StatusMessage {
+            self.status.read().clone()
         }
     }
 

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -21,3 +21,4 @@ store = { path = "../store" }
 
 [dev-dependencies]
 beacon_chain =  { path = "../beacon_chain" }
+tokio = { version = "1.14.0", features = ["rt-multi-thread"] }

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -710,7 +710,7 @@ mod release_tests {
     }
 
     /// Test state for sync contribution-related tests.
-    fn sync_contribution_test_state<E: EthSpec>(
+    async fn sync_contribution_test_state<E: EthSpec>(
         num_committees: usize,
     ) -> (BeaconChainHarness<EphemeralHarnessType<E>>, ChainSpec) {
         let mut spec = E::default_spec();
@@ -722,12 +722,14 @@ mod release_tests {
         let harness = get_harness::<E>(num_validators, Some(spec.clone()));
 
         let state = harness.get_current_state();
-        harness.add_attested_blocks_at_slots(
-            state,
-            Hash256::zero(),
-            &[Slot::new(1)],
-            (0..num_validators).collect::<Vec<_>>().as_slice(),
-        );
+        harness
+            .add_attested_blocks_at_slots(
+                state,
+                Hash256::zero(),
+                &[Slot::new(1)],
+                (0..num_validators).collect::<Vec<_>>().as_slice(),
+            )
+            .await;
 
         (harness, spec)
     }
@@ -1454,9 +1456,9 @@ mod release_tests {
     }
 
     /// End-to-end test of basic sync contribution handling.
-    #[test]
-    fn sync_contribution_aggregation_insert_get_prune() {
-        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1);
+    #[tokio::test]
+    async fn sync_contribution_aggregation_insert_get_prune() {
+        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1).await;
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
         let state = harness.get_current_state();
@@ -1514,9 +1516,9 @@ mod release_tests {
     }
 
     /// Adding a sync contribution already in the pool should not increase the size of the pool.
-    #[test]
-    fn sync_contribution_duplicate() {
-        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1);
+    #[tokio::test]
+    async fn sync_contribution_duplicate() {
+        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1).await;
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
         let state = harness.get_current_state();
@@ -1551,9 +1553,9 @@ mod release_tests {
 
     /// Adding a sync contribution already in the pool with more bits set should increase the
     /// number of bits set in the aggregate.
-    #[test]
-    fn sync_contribution_with_more_bits() {
-        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1);
+    #[tokio::test]
+    async fn sync_contribution_with_more_bits() {
+        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1).await;
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
         let state = harness.get_current_state();
@@ -1631,9 +1633,9 @@ mod release_tests {
 
     /// Adding a sync contribution already in the pool with fewer bits set should not increase the
     /// number of bits set in the aggregate.
-    #[test]
-    fn sync_contribution_with_fewer_bits() {
-        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1);
+    #[tokio::test]
+    async fn sync_contribution_with_fewer_bits() {
+        let (harness, _) = sync_contribution_test_state::<MainnetEthSpec>(1).await;
 
         let op_pool = OperationPool::<MainnetEthSpec>::new();
         let state = harness.get_current_state();

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -669,7 +669,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         for op in batch {
             match op {
                 StoreOp::PutBlock(block_root, block) => {
-                    self.block_as_kv_store_ops(&block_root, *block, &mut key_value_batch)?;
+                    self.block_as_kv_store_ops(
+                        &block_root,
+                        block.as_ref().clone(),
+                        &mut key_value_batch,
+                    )?;
                 }
 
                 StoreOp::PutState(state_root, state) => {

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -39,6 +39,7 @@ pub use impls::beacon_state::StorageContainer as BeaconStateStorageContainer;
 pub use metadata::AnchorInfo;
 pub use metrics::scrape_for_metrics;
 use parking_lot::MutexGuard;
+use std::sync::Arc;
 use strum::{EnumString, IntoStaticStr};
 pub use types::*;
 
@@ -152,7 +153,7 @@ pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'stati
 /// Reified key-value storage operation.  Helps in modifying the storage atomically.
 /// See also https://github.com/sigp/lighthouse/issues/692
 pub enum StoreOp<'a, E: EthSpec> {
-    PutBlock(Hash256, Box<SignedBeaconBlock<E>>),
+    PutBlock(Hash256, Arc<SignedBeaconBlock<E>>),
     PutState(Hash256, &'a BeaconState<E>),
     PutStateSummary(Hash256, HotStateSummary),
     PutStateTemporaryFlag(Hash256),

--- a/beacon_node/timer/src/lib.rs
+++ b/beacon_node/timer/src/lib.rs
@@ -3,7 +3,7 @@
 //! This service allows task execution on the beacon node for various functionality.
 
 use beacon_chain::{BeaconChain, BeaconChainTypes};
-use slog::{debug, info, warn};
+use slog::{info, warn};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use tokio::time::sleep;
@@ -13,11 +13,8 @@ pub fn spawn_timer<T: BeaconChainTypes>(
     executor: task_executor::TaskExecutor,
     beacon_chain: Arc<BeaconChain<T>>,
 ) -> Result<(), &'static str> {
-    let log = executor.log();
-    let per_slot_executor = executor.clone();
-
+    let log = executor.log().clone();
     let timer_future = async move {
-        let log = per_slot_executor.log().clone();
         loop {
             let duration_to_next_slot = match beacon_chain.slot_clock.duration_to_next_slot() {
                 Some(duration) => duration,
@@ -28,31 +25,12 @@ pub fn spawn_timer<T: BeaconChainTypes>(
             };
 
             sleep(duration_to_next_slot).await;
-
-            let chain = beacon_chain.clone();
-            if let Some(handle) = per_slot_executor
-                .spawn_blocking_handle(move || chain.per_slot_task(), "timer_per_slot_task")
-            {
-                if let Err(e) = handle.await {
-                    warn!(
-                        log,
-                        "Per slot task failed";
-                        "info" => ?e
-                    );
-                }
-            } else {
-                debug!(
-                    log,
-                    "Per slot task timer stopped";
-                    "info" => "shutting down"
-                );
-                break;
-            }
+            beacon_chain.per_slot_task().await;
         }
     };
 
     executor.spawn(timer_future, "timer");
-    info!(log, "Timer service started");
+    info!(executor.log(), "Timer service started");
 
     Ok(())
 }

--- a/common/task_executor/Cargo.toml
+++ b/common/task_executor/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 
 [dependencies]
-tokio = { version = "1.14.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.14.0", features = ["rt-multi-thread", "macros"] }
 slog = "2.5.2"
 futures = "0.3.7"
 exit-future = "0.2.0"

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -331,8 +331,7 @@ impl TaskExecutor {
         &self,
         future: F,
         name: &'static str,
-    ) -> Option<F::Output>
-where {
+    ) -> Option<F::Output> {
         let timer = metrics::start_timer_vec(&metrics::BLOCK_ON_TASKS_HISTOGRAM, &[name]);
         metrics::inc_gauge_vec(&metrics::BLOCK_ON_TASKS_COUNT, &[name]);
         let log = self.log.clone();

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -7,6 +7,8 @@ use slog::{crit, debug, o, trace};
 use std::sync::Weak;
 use tokio::runtime::{Handle, Runtime};
 
+pub use tokio::task::JoinHandle;
+
 /// Provides a reason when Lighthouse is shut down.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum ShutdownReason {
@@ -310,6 +312,62 @@ impl TaskExecutor {
         };
 
         Some(future)
+    }
+
+    /// Block the current (non-async) thread on the completion of some future.
+    ///
+    /// ## Warning
+    ///
+    /// This method is "dangerous" since calling it from an async thread will result in a panic! Any
+    /// use of this outside of testing should be very deeply considered as Lighthouse has been
+    /// burned by this function in the past.
+    ///
+    /// Determining what is an "async thread" is rather challenging; just because a function isn't
+    /// marked as `async` doesn't mean it's not being called from an `async` function or there isn't
+    /// a `tokio` context present in the thread-local storage due to some `rayon` funkiness. Talk to
+    /// @paulhauner if you plan to use this function in production. He has put metrics in here to
+    /// track any use of it, so don't think you can pull a sneaky one on him.
+    pub fn block_on_dangerous<F: Future>(
+        &self,
+        future: F,
+        name: &'static str,
+    ) -> Option<F::Output>
+where {
+        let timer = metrics::start_timer_vec(&metrics::BLOCK_ON_TASKS_HISTOGRAM, &[name]);
+        metrics::inc_gauge_vec(&metrics::BLOCK_ON_TASKS_COUNT, &[name]);
+        let log = self.log.clone();
+        let handle = self.handle()?;
+        let exit = self.exit.clone();
+
+        debug!(
+            log,
+            "Starting block_on task";
+            "name" => name
+        );
+
+        handle.block_on(async {
+            let output = tokio::select! {
+                output = future => {
+                    debug!(
+                        log,
+                        "Completed block_on task";
+                        "name" => name
+                    );
+                    Some(output)
+                },
+                _ = exit => {
+                    debug!(
+                        log,
+                        "Cancelled block_on task";
+                        "name" => name,
+                    );
+                    None
+                }
+            };
+            metrics::dec_gauge_vec(&metrics::BLOCK_ON_TASKS_COUNT, &[name]);
+            drop(timer);
+            output
+        })
     }
 
     /// Returns a `Handle` to the current runtime.

--- a/common/task_executor/src/metrics.rs
+++ b/common/task_executor/src/metrics.rs
@@ -20,7 +20,7 @@ lazy_static! {
     );
     pub static ref BLOCK_ON_TASKS_COUNT: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "block_on_tasks_count",
-        "Total number of block_on_dangers tasks spawned",
+        "Total number of block_on_dangerous tasks spawned",
         &["name"]
     );
     pub static ref BLOCK_ON_TASKS_HISTOGRAM: Result<HistogramVec> = try_create_histogram_vec(

--- a/common/task_executor/src/metrics.rs
+++ b/common/task_executor/src/metrics.rs
@@ -18,6 +18,16 @@ lazy_static! {
         "Time taken by blocking tasks",
         &["blocking_task_hist"]
     );
+    pub static ref BLOCK_ON_TASKS_COUNT: Result<IntGaugeVec> = try_create_int_gauge_vec(
+        "block_on_tasks_count",
+        "Total number of block_on_dangers tasks spawned",
+        &["name"]
+    );
+    pub static ref BLOCK_ON_TASKS_HISTOGRAM: Result<HistogramVec> = try_create_histogram_vec(
+        "block_on_tasks_histogram",
+        "Time taken by block_on_dangerous tasks",
+        &["name"]
+    );
     pub static ref TASKS_HISTOGRAM: Result<HistogramVec> = try_create_histogram_vec(
         "async_tasks_time_histogram",
         "Time taken by async tasks",

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -15,3 +15,4 @@ eth2_ssz_derive = "0.3.0"
 [dev-dependencies]
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 store = { path = "../../beacon_node/store" }
+tokio = { version = "1.14.0", features = ["rt-multi-thread"] }

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -1,4 +1,4 @@
-use types::{BeaconBlock, BeaconState, Checkpoint, EthSpec, ExecPayload, Hash256, Slot};
+use types::{BeaconBlockRef, BeaconState, Checkpoint, EthSpec, ExecPayload, Hash256, Slot};
 
 /// Approximates the `Store` in "Ethereum 2.0 Phase 0 -- Beacon Chain Fork Choice":
 ///
@@ -33,7 +33,7 @@ pub trait ForkChoiceStore<T: EthSpec>: Sized {
     /// choice. Allows the implementer to performing caching or other housekeeping duties.
     fn on_verified_block<Payload: ExecPayload<T>>(
         &mut self,
-        block: &BeaconBlock<T, Payload>,
+        block: BeaconBlockRef<T, Payload>,
         block_root: Hash256,
         state: &BeaconState<T>,
     ) -> Result<(), Self::Error>;

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -2,8 +2,9 @@ mod fork_choice;
 mod fork_choice_store;
 
 pub use crate::fork_choice::{
-    AttestationFromBlock, Error, ForkChoice, InvalidAttestation, InvalidBlock,
-    PayloadVerificationStatus, PersistedForkChoice, QueuedAttestation,
+    AttestationFromBlock, Error, ForkChoice, ForkChoiceView, ForkchoiceUpdateParameters,
+    InvalidAttestation, InvalidBlock, PayloadVerificationStatus, PersistedForkChoice,
+    QueuedAttestation,
 };
 pub use fork_choice_store::ForkChoiceStore;
 pub use proto_array::{Block as ProtoBlock, ExecutionStatus, InvalidationOperation};

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -16,6 +16,7 @@ four_byte_option_impl!(four_byte_option_usize, usize);
 four_byte_option_impl!(four_byte_option_checkpoint, Checkpoint);
 
 /// Defines an operation which may invalidate the `execution_status` of some nodes.
+#[derive(Clone)]
 pub enum InvalidationOperation {
     /// Invalidate only `block_root` and it's descendants. Don't invalidate any ancestors.
     InvalidateOne { block_root: Hash256 },

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dev-dependencies]
 env_logger = "0.9.0"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
+tokio = { version = "1.14.0", features = ["rt-multi-thread"] }
 
 [dependencies]
 bls = { path = "../../crypto/bls" }

--- a/consensus/tree_hash/examples/flamegraph_beacon_state.rs
+++ b/consensus/tree_hash/examples/flamegraph_beacon_state.rs
@@ -17,7 +17,7 @@ fn get_harness<T: EthSpec>() -> BeaconChainHarness<EphemeralHarnessType<T>> {
 }
 
 fn build_state<T: EthSpec>() -> BeaconState<T> {
-    let state = get_harness::<T>().chain.head_beacon_state().unwrap();
+    let state = get_harness::<T>().chain.head_beacon_state_cloned();
 
     assert_eq!(state.as_base().unwrap().validators.len(), VALIDATOR_COUNT);
     assert_eq!(state.as_base().unwrap().balances.len(), VALIDATOR_COUNT);

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -53,6 +53,7 @@ criterion = "0.3.3"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 state_processing = { path = "../state_processing" }
+tokio = "1.14.0"
 
 [features]
 default = ["sqlite", "legacy-arith"]

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -579,11 +579,9 @@ impl<'a, E: EthSpec> From<BeaconBlockRef<'a, E, FullPayload<E>>>
     fn from(
         full_block: BeaconBlockRef<'a, E, FullPayload<E>>,
     ) -> BeaconBlock<E, BlindedPayload<E>> {
-        match full_block {
-            BeaconBlockRef::Base(block) => BeaconBlock::Base(block.clone_as_blinded()),
-            BeaconBlockRef::Altair(block) => BeaconBlock::Altair(block.clone_as_blinded()),
-            BeaconBlockRef::Merge(block) => BeaconBlock::Merge(block.clone_as_blinded()),
-        }
+        map_beacon_block_ref_into_beacon_block!(&'a _, full_block, |inner, cons| {
+            cons(inner.clone_as_blinded())
+        })
     }
 }
 

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -38,7 +38,7 @@ use tree_hash_derive::TreeHash;
         derive(Debug, PartialEq, TreeHash),
         tree_hash(enum_behaviour = "transparent")
     ),
-    map_ref_into(BeaconBlockBodyRef),
+    map_ref_into(BeaconBlockBodyRef, BeaconBlock),
     map_ref_mut_into(BeaconBlockBodyRefMut)
 )]
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -251,6 +251,97 @@ impl<E: EthSpec> From<BeaconBlockBodyMerge<E, FullPayload<E>>>
     }
 }
 
+// We can clone a full block into a blinded block, without cloning the payload.
+impl<E: EthSpec> BeaconBlockBodyBase<E, FullPayload<E>> {
+    pub fn clone_as_blinded(&self) -> BeaconBlockBodyBase<E, BlindedPayload<E>> {
+        let BeaconBlockBodyBase {
+            randao_reveal,
+            eth1_data,
+            graffiti,
+            proposer_slashings,
+            attester_slashings,
+            attestations,
+            deposits,
+            voluntary_exits,
+            _phantom,
+        } = self;
+
+        BeaconBlockBodyBase {
+            randao_reveal: randao_reveal.clone(),
+            eth1_data: eth1_data.clone(),
+            graffiti: *graffiti,
+            proposer_slashings: proposer_slashings.clone(),
+            attester_slashings: attester_slashings.clone(),
+            attestations: attestations.clone(),
+            deposits: deposits.clone(),
+            voluntary_exits: voluntary_exits.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E: EthSpec> BeaconBlockBodyAltair<E, FullPayload<E>> {
+    pub fn clone_as_blinded(&self) -> BeaconBlockBodyAltair<E, BlindedPayload<E>> {
+        let BeaconBlockBodyAltair {
+            randao_reveal,
+            eth1_data,
+            graffiti,
+            proposer_slashings,
+            attester_slashings,
+            attestations,
+            deposits,
+            voluntary_exits,
+            sync_aggregate,
+            _phantom,
+        } = self;
+
+        BeaconBlockBodyAltair {
+            randao_reveal: randao_reveal.clone(),
+            eth1_data: eth1_data.clone(),
+            graffiti: *graffiti,
+            proposer_slashings: proposer_slashings.clone(),
+            attester_slashings: attester_slashings.clone(),
+            attestations: attestations.clone(),
+            deposits: deposits.clone(),
+            voluntary_exits: voluntary_exits.clone(),
+            sync_aggregate: sync_aggregate.clone(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E: EthSpec> BeaconBlockBodyMerge<E, FullPayload<E>> {
+    pub fn clone_as_blinded(&self) -> BeaconBlockBodyMerge<E, BlindedPayload<E>> {
+        let BeaconBlockBodyMerge {
+            randao_reveal,
+            eth1_data,
+            graffiti,
+            proposer_slashings,
+            attester_slashings,
+            attestations,
+            deposits,
+            voluntary_exits,
+            sync_aggregate,
+            execution_payload: FullPayload { execution_payload },
+        } = self;
+
+        BeaconBlockBodyMerge {
+            randao_reveal: randao_reveal.clone(),
+            eth1_data: eth1_data.clone(),
+            graffiti: *graffiti,
+            proposer_slashings: proposer_slashings.clone(),
+            attester_slashings: attester_slashings.clone(),
+            attestations: attestations.clone(),
+            deposits: deposits.clone(),
+            voluntary_exits: voluntary_exits.clone(),
+            sync_aggregate: sync_aggregate.clone(),
+            execution_payload: BlindedPayload {
+                execution_payload_header: From::from(execution_payload),
+            },
+        }
+    }
+}
+
 impl<E: EthSpec> From<BeaconBlockBody<E, FullPayload<E>>>
     for (
         BeaconBlockBody<E, BlindedPayload<E>>,

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -254,59 +254,13 @@ impl<E: EthSpec> From<BeaconBlockBodyMerge<E, FullPayload<E>>>
 // We can clone a full block into a blinded block, without cloning the payload.
 impl<E: EthSpec> BeaconBlockBodyBase<E, FullPayload<E>> {
     pub fn clone_as_blinded(&self) -> BeaconBlockBodyBase<E, BlindedPayload<E>> {
-        let BeaconBlockBodyBase {
-            randao_reveal,
-            eth1_data,
-            graffiti,
-            proposer_slashings,
-            attester_slashings,
-            attestations,
-            deposits,
-            voluntary_exits,
-            _phantom,
-        } = self;
-
-        BeaconBlockBodyBase {
-            randao_reveal: randao_reveal.clone(),
-            eth1_data: eth1_data.clone(),
-            graffiti: *graffiti,
-            proposer_slashings: proposer_slashings.clone(),
-            attester_slashings: attester_slashings.clone(),
-            attestations: attestations.clone(),
-            deposits: deposits.clone(),
-            voluntary_exits: voluntary_exits.clone(),
-            _phantom: PhantomData,
-        }
+        self.clone().into()
     }
 }
 
 impl<E: EthSpec> BeaconBlockBodyAltair<E, FullPayload<E>> {
     pub fn clone_as_blinded(&self) -> BeaconBlockBodyAltair<E, BlindedPayload<E>> {
-        let BeaconBlockBodyAltair {
-            randao_reveal,
-            eth1_data,
-            graffiti,
-            proposer_slashings,
-            attester_slashings,
-            attestations,
-            deposits,
-            voluntary_exits,
-            sync_aggregate,
-            _phantom,
-        } = self;
-
-        BeaconBlockBodyAltair {
-            randao_reveal: randao_reveal.clone(),
-            eth1_data: eth1_data.clone(),
-            graffiti: *graffiti,
-            proposer_slashings: proposer_slashings.clone(),
-            attester_slashings: attester_slashings.clone(),
-            attestations: attestations.clone(),
-            deposits: deposits.clone(),
-            voluntary_exits: voluntary_exits.clone(),
-            sync_aggregate: sync_aggregate.clone(),
-            _phantom: PhantomData,
-        }
+        self.clone().into()
     }
 }
 

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -254,13 +254,15 @@ impl<E: EthSpec> From<BeaconBlockBodyMerge<E, FullPayload<E>>>
 // We can clone a full block into a blinded block, without cloning the payload.
 impl<E: EthSpec> BeaconBlockBodyBase<E, FullPayload<E>> {
     pub fn clone_as_blinded(&self) -> BeaconBlockBodyBase<E, BlindedPayload<E>> {
-        self.clone().into()
+        let (block_body, _payload) = self.clone().into();
+        block_body
     }
 }
 
 impl<E: EthSpec> BeaconBlockBodyAltair<E, FullPayload<E>> {
     pub fn clone_as_blinded(&self) -> BeaconBlockBodyAltair<E, BlindedPayload<E>> {
-        self.clone().into()
+        let (block_body, _payload) = self.clone().into();
+        block_body
     }
 }
 

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -28,6 +28,8 @@ pub trait ExecPayload<T: EthSpec>:
     + Hash
     + TryFrom<ExecutionPayloadHeader<T>>
     + From<ExecutionPayload<T>>
+    + Send
+    + 'static
 {
     fn block_type() -> BlockType;
 

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -346,6 +346,14 @@ impl<E: EthSpec> From<SignedBeaconBlock<E>> for SignedBlindedBeaconBlock<E> {
     }
 }
 
+// We can blind borrowed blocks with payloads by converting the payload into a header (without
+// cloning the payload contents).
+impl<E: EthSpec> SignedBeaconBlock<E> {
+    pub fn clone_as_blinded(&self) -> SignedBlindedBeaconBlock<E> {
+        SignedBeaconBlock::from_block(self.message().into(), self.signature().clone())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -222,7 +222,7 @@ pub fn migrate_db<E: EthSpec>(
     runtime_context: &RuntimeContext<E>,
     log: Logger,
 ) -> Result<(), Error> {
-    let spec = runtime_context.eth2_config.spec.clone();
+    let spec = &runtime_context.eth2_config.spec;
     let hot_path = client_config.get_db_path();
     let cold_path = client_config.get_freezer_db_path();
 
@@ -236,7 +236,7 @@ pub fn migrate_db<E: EthSpec>(
             Ok(())
         },
         client_config.store.clone(),
-        spec,
+        spec.clone(),
         log.clone(),
     )?;
 
@@ -253,6 +253,7 @@ pub fn migrate_db<E: EthSpec>(
         from,
         to,
         log,
+        spec,
     )
 }
 

--- a/slasher/service/src/service.rs
+++ b/slasher/service/src/service.rs
@@ -216,14 +216,7 @@ impl<T: BeaconChainTypes> SlasherService<T> {
             };
 
             // Add to local op pool.
-            if let Err(e) = beacon_chain.import_attester_slashing(verified_slashing) {
-                error!(
-                    log,
-                    "Beacon chain refused attester slashing";
-                    "error" => ?e,
-                    "slashing" => ?slashing,
-                );
-            }
+            beacon_chain.import_attester_slashing(verified_slashing);
 
             // Publish to the network if broadcast is enabled.
             if slasher.config().broadcast {

--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -81,11 +81,23 @@ pub struct Cases<T> {
 }
 
 impl<T: Case> Cases<T> {
-    pub fn test_results(&self, fork_name: ForkName) -> Vec<CaseResult> {
-        self.test_cases
-            .into_par_iter()
-            .enumerate()
-            .map(|(i, (ref path, ref tc))| CaseResult::new(i, path, tc, tc.result(i, fork_name)))
-            .collect()
+    pub fn test_results(&self, fork_name: ForkName, use_rayon: bool) -> Vec<CaseResult> {
+        if use_rayon {
+            self.test_cases
+                .into_par_iter()
+                .enumerate()
+                .map(|(i, (ref path, ref tc))| {
+                    CaseResult::new(i, path, tc, tc.result(i, fork_name))
+                })
+                .collect()
+        } else {
+            self.test_cases
+                .iter()
+                .enumerate()
+                .map(|(i, (ref path, ref tc))| {
+                    CaseResult::new(i, path, tc, tc.result(i, fork_name))
+                })
+                .collect()
+        }
     }
 }

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -7,15 +7,17 @@ use beacon_chain::{
         obtain_indexed_attestation_and_committees_per_slot, VerifiedAttestation,
     },
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
-    BeaconChainTypes, HeadInfo,
+    BeaconChainTypes, CachedHead,
 };
 use serde_derive::Deserialize;
 use ssz_derive::Decode;
 use state_processing::state_advance::complete_state_advance;
+use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 use types::{
-    Attestation, BeaconBlock, BeaconState, Checkpoint, Epoch, EthSpec, ExecutionBlockHash,
-    ForkName, Hash256, IndexedAttestation, SignedBeaconBlock, Slot, Uint256,
+    Attestation, BeaconBlock, BeaconState, Checkpoint, EthSpec, ExecutionBlockHash, ForkName,
+    Hash256, IndexedAttestation, SignedBeaconBlock, Slot, Uint256,
 };
 
 #[derive(Default, Debug, PartialEq, Clone, Deserialize, Decode)]
@@ -287,19 +289,20 @@ impl<E: EthSpec> Tester<E> {
         Ok(self.spec.genesis_slot + slots_since_genesis)
     }
 
-    fn find_head(&self) -> Result<HeadInfo, Error> {
+    fn block_on_dangerous<F: Future>(&self, future: F) -> Result<F::Output, Error> {
         self.harness
             .chain
-            .fork_choice()
-            .map_err(|e| Error::InternalError(format!("failed to find head with {:?}", e)))?;
-        self.harness
-            .chain
-            .head_info()
-            .map_err(|e| Error::InternalError(format!("failed to read head with {:?}", e)))
+            .task_executor
+            .clone()
+            .block_on_dangerous(future, "ef_tests_block_on")
+            .ok_or_else(|| Error::InternalError("runtime shutdown".into()))
     }
 
-    fn genesis_epoch(&self) -> Epoch {
-        self.spec.genesis_slot.epoch(E::slots_per_epoch())
+    fn find_head(&self) -> Result<CachedHead<E>, Error> {
+        let chain = self.harness.chain.clone();
+        self.block_on_dangerous(chain.recompute_head_at_current_slot())?
+            .map_err(|e| Error::InternalError(format!("failed to find head with {:?}", e)))?;
+        Ok(self.harness.chain.canonical_head.cached_head())
     }
 
     pub fn set_tick(&self, tick: u64) {
@@ -314,15 +317,16 @@ impl<E: EthSpec> Tester<E> {
 
         self.harness
             .chain
-            .fork_choice
-            .write()
+            .canonical_head
+            .fork_choice_write_lock()
             .update_time(slot)
             .unwrap();
     }
 
     pub fn process_block(&self, block: SignedBeaconBlock<E>, valid: bool) -> Result<(), Error> {
-        let result = self.harness.chain.process_block(block.clone());
         let block_root = block.canonical_root();
+        let block = Arc::new(block);
+        let result = self.block_on_dangerous(self.harness.chain.process_block(block.clone()))?;
         if result.is_ok() != valid {
             return Err(Error::DidntFail(format!(
                 "block with root {} was valid={} whilst test expects valid={}. result: {:?}",
@@ -367,16 +371,20 @@ impl<E: EthSpec> Tester<E> {
                     .seconds_from_current_slot_start(self.spec.seconds_per_slot)
                     .unwrap();
 
-                let (block, _) = block.deconstruct();
-                let result = self.harness.chain.fork_choice.write().on_block(
-                    self.harness.chain.slot().unwrap(),
-                    &block,
-                    block_root,
-                    block_delay,
-                    &state,
-                    PayloadVerificationStatus::Irrelevant,
-                    &self.harness.chain.spec,
-                );
+                let result = self
+                    .harness
+                    .chain
+                    .canonical_head
+                    .fork_choice_write_lock()
+                    .on_block(
+                        self.harness.chain.slot().unwrap(),
+                        block.message(),
+                        block_root,
+                        block_delay,
+                        &state,
+                        PayloadVerificationStatus::Irrelevant,
+                        &self.harness.chain.spec,
+                    );
 
                 if result.is_ok() {
                     return Err(Error::DidntFail(format!(
@@ -424,10 +432,11 @@ impl<E: EthSpec> Tester<E> {
     }
 
     pub fn check_head(&self, expected_head: Head) -> Result<(), Error> {
-        let chain_head = self.find_head().map(|head| Head {
-            slot: head.slot,
-            root: head.block_root,
-        })?;
+        let head = self.find_head()?;
+        let chain_head = Head {
+            slot: head.head_slot(),
+            root: head.head_block_root(),
+        };
 
         check_equal("head", chain_head, expected_head)
     }
@@ -446,15 +455,15 @@ impl<E: EthSpec> Tester<E> {
     }
 
     pub fn check_justified_checkpoint(&self, expected_checkpoint: Checkpoint) -> Result<(), Error> {
-        let head_checkpoint = self.find_head()?.current_justified_checkpoint;
-        let fc_checkpoint = self.harness.chain.fork_choice.read().justified_checkpoint();
+        let head_checkpoint = self.find_head()?.justified_checkpoint();
+        let fc_checkpoint = self
+            .harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .justified_checkpoint();
 
-        assert_checkpoints_eq(
-            "justified_checkpoint",
-            self.genesis_epoch(),
-            head_checkpoint,
-            fc_checkpoint,
-        );
+        assert_checkpoints_eq("justified_checkpoint", head_checkpoint, fc_checkpoint);
 
         check_equal("justified_checkpoint", fc_checkpoint, expected_checkpoint)
     }
@@ -463,15 +472,15 @@ impl<E: EthSpec> Tester<E> {
         &self,
         expected_checkpoint_root: Hash256,
     ) -> Result<(), Error> {
-        let head_checkpoint = self.find_head()?.current_justified_checkpoint;
-        let fc_checkpoint = self.harness.chain.fork_choice.read().justified_checkpoint();
+        let head_checkpoint = self.find_head()?.justified_checkpoint();
+        let fc_checkpoint = self
+            .harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .justified_checkpoint();
 
-        assert_checkpoints_eq(
-            "justified_checkpoint_root",
-            self.genesis_epoch(),
-            head_checkpoint,
-            fc_checkpoint,
-        );
+        assert_checkpoints_eq("justified_checkpoint_root", head_checkpoint, fc_checkpoint);
 
         check_equal(
             "justified_checkpoint_root",
@@ -481,15 +490,15 @@ impl<E: EthSpec> Tester<E> {
     }
 
     pub fn check_finalized_checkpoint(&self, expected_checkpoint: Checkpoint) -> Result<(), Error> {
-        let head_checkpoint = self.find_head()?.finalized_checkpoint;
-        let fc_checkpoint = self.harness.chain.fork_choice.read().finalized_checkpoint();
+        let head_checkpoint = self.find_head()?.finalized_checkpoint();
+        let fc_checkpoint = self
+            .harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .finalized_checkpoint();
 
-        assert_checkpoints_eq(
-            "finalized_checkpoint",
-            self.genesis_epoch(),
-            head_checkpoint,
-            fc_checkpoint,
-        );
+        assert_checkpoints_eq("finalized_checkpoint", head_checkpoint, fc_checkpoint);
 
         check_equal("finalized_checkpoint", fc_checkpoint, expected_checkpoint)
     }
@@ -501,8 +510,8 @@ impl<E: EthSpec> Tester<E> {
         let best_justified_checkpoint = self
             .harness
             .chain
-            .fork_choice
-            .read()
+            .canonical_head
+            .fork_choice_read_lock()
             .best_justified_checkpoint();
         check_equal(
             "best_justified_checkpoint",
@@ -515,7 +524,12 @@ impl<E: EthSpec> Tester<E> {
         &self,
         expected_proposer_boost_root: Hash256,
     ) -> Result<(), Error> {
-        let proposer_boost_root = self.harness.chain.fork_choice.read().proposer_boost_root();
+        let proposer_boost_root = self
+            .harness
+            .chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .proposer_boost_root();
         check_equal(
             "proposer_boost_root",
             proposer_boost_root,
@@ -530,20 +544,8 @@ impl<E: EthSpec> Tester<E> {
 /// This function is necessary due to a quirk documented in this issue:
 ///
 /// https://github.com/ethereum/consensus-specs/issues/2566
-fn assert_checkpoints_eq(name: &str, genesis_epoch: Epoch, head: Checkpoint, fc: Checkpoint) {
-    if fc.epoch == genesis_epoch {
-        assert_eq!(
-            head,
-            Checkpoint {
-                epoch: genesis_epoch,
-                root: Hash256::zero()
-            },
-            "{} (genesis)",
-            name
-        )
-    } else {
-        assert_eq!(head, fc, "{} (non-genesis)", name)
-    }
+fn assert_checkpoints_eq(name: &str, head: Checkpoint, fc: Checkpoint) {
+    assert_eq!(head, fc, "{}", name)
 }
 
 /// Convenience function to create `Error` messages.

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -30,6 +30,10 @@ pub trait Handler {
         }
     }
 
+    fn use_rayon() -> bool {
+        true
+    }
+
     fn run_for_fork(&self, fork_name: ForkName) {
         let fork_name_str = fork_name.to_string();
 
@@ -59,7 +63,7 @@ pub trait Handler {
             })
             .collect();
 
-        let results = Cases { test_cases }.test_results(fork_name);
+        let results = Cases { test_cases }.test_results(fork_name, Self::use_rayon());
 
         let name = format!(
             "{}/{}/{}",
@@ -458,6 +462,11 @@ impl<E: EthSpec + TypeName> Handler for ForkChoiceHandler<E> {
 
     fn handler_name(&self) -> String {
         self.handler_name.clone()
+    }
+
+    fn use_rayon() -> bool {
+        // The fork choice tests use `block_on` which can cause panics with rayon.
+        false
     }
 
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -98,10 +98,9 @@ impl<E: GenericExecutionEngine> TestRig<E> {
     }
 
     pub fn perform_tests_blocking(&self) {
-        self.ee_a
-            .execution_layer
-            .block_on_generic(|_| async { self.perform_tests().await })
-            .unwrap()
+        self.runtime
+            .handle()
+            .block_on(async { self.perform_tests().await });
     }
 
     pub async fn wait_until_synced(&self) {

--- a/testing/state_transition_vectors/Cargo.toml
+++ b/testing/state_transition_vectors/Cargo.toml
@@ -12,3 +12,4 @@ types = { path = "../../consensus/types" }
 eth2_ssz = "0.4.1"
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 lazy_static = "1.4.0"
+tokio = { version = "1.14.0", features = ["rt-multi-thread"] }

--- a/testing/state_transition_vectors/src/macros.rs
+++ b/testing/state_transition_vectors/src/macros.rs
@@ -4,11 +4,11 @@
 /// - `mod tests`: runs all the test vectors locally.
 macro_rules! vectors_and_tests {
     ($($name: ident, $test: expr),*) => {
-        pub fn vectors() -> Vec<TestVector> {
+        pub async fn vectors() -> Vec<TestVector> {
             let mut vec = vec![];
 
             $(
-                vec.push($test.test_vector(stringify!($name).into()));
+                vec.push($test.test_vector(stringify!($name).into()).await);
             )*
 
             vec
@@ -18,9 +18,9 @@ macro_rules! vectors_and_tests {
         mod tests {
             use super::*;
             $(
-                #[test]
-                fn $name() {
-                    $test.run();
+                #[tokio::test]
+                async fn $name() {
+                    $test.run().await;
                 }
             )*
         }


### PR DESCRIPTION
## Overview

This rather extensive PR achieves two primary goals:

1. Uses the finalized/justified checkpoints of fork choice (FC), rather than that of the head state.
2. Refactors fork choice, block production and block processing to `async` functions.

Additionally, it achieves:

- Concurrent forkchoice updates to the EL and cache pruning after a new head is selected.
- Concurrent "block packing" (attestations, etc) and execution payload retrieval during block production.
- Concurrent per-block-processing and execution payload verification during block processing.
- The `Arc`-ification of `SignedBeaconBlock` during block processing (it's never mutated, so why not?):
    - I had to do this to deal with sending blocks into spawned tasks.
    - Previously we were cloning the beacon block at least 2 times during each block processing, these clones are either removed or turned into cheaper `Arc` clones.
    - We were also `Box`-ing and un-`Box`-ing beacon blocks as they moved throughout the networking crate. This is not a big deal, but it's nice to avoid shifting things between the stack and heap.
    - Avoids cloning *all the blocks* in *every chain segment* during sync.
    - It also has the potential to clean up our code where we need to pass an *owned* block around so we can send it back in the case of an error (I didn't do much of this, my PR is already big enough :sweat_smile:)
- The `BeaconChain::HeadSafetyStatus` struct was removed. It was an old relic from prior merge specs.

For motivation for this change, see https://github.com/sigp/lighthouse/pull/3244#issuecomment-1160963273

## Changes to `canonical_head` and `fork_choice`

Previously, the `BeaconChain` had two separate fields:

```
canonical_head: RwLock<Snapshot>,
fork_choice: RwLock<BeaconForkChoice>
```

Now, we have grouped these values under a single struct:

```
canonical_head: CanonicalHead {
  cached_head: RwLock<Arc<Snapshot>>,
  fork_choice: RwLock<BeaconForkChoice>
} 
```

Apart from ergonomics, the only *actual* change here is wrapping the canonical head snapshot in an `Arc`. This means that we no longer need to hold the `cached_head` (`canonical_head`, in old terms) lock when we want to pull some values from it. This was done to avoid deadlock risks by preventing functions from acquiring (and holding) the `cached_head` and `fork_choice` locks simultaneously.

## Breaking Changes

### The `state` (root) field in the `finalized_checkpoint` SSE event

Consider the scenario where epoch `n` is just finalized, but `start_slot(n)` is skipped. There are two state roots we might in the `finalized_checkpoint` SSE event:

1. The state root of the finalized block, which is `get_block(finalized_checkpoint.root).state_root`.
4. The state root at slot of `start_slot(n)`, which would be the state from (1), but "skipped forward" through any skip slots.

Previously, Lighthouse would choose (2). However, we can see that when [Teku generates that event](https://github.com/ConsenSys/teku/blob/de2b2801c89ef5abf983d6bf37867c37fc47121f/data/beaconrestapi/src/main/java/tech/pegasys/teku/beaconrestapi/handlers/v1/events/EventSubscriptionManager.java#L171-L182) it uses [`getStateRootFromBlockRoot`](https://github.com/ConsenSys/teku/blob/de2b2801c89ef5abf983d6bf37867c37fc47121f/data/provider/src/main/java/tech/pegasys/teku/api/ChainDataProvider.java#L336-L341) which uses (1).

I have switched Lighthouse from (2) to (1). I think it's a somewhat arbitrary choice between the two, where (1) is easier to compute and is consistent with Teku.

## Notes for Reviewers

I've renamed `BeaconChain::fork_choice` to `BeaconChain::recompute_head`. Doing this helped ensure I broke all previous uses of fork choice and I also find it more descriptive. It describes an action and can't be confused with trying to get a reference to the `ForkChoice` struct.

I've changed the ordering of SSE events when a block is received. It used to be `[block, finalized, head]` and now it's `[block, head, finalized]`. It was easier this way and I don't think we were making any promises about SSE event ordering so it's not "breaking".

I've made it so fork choice will run when it's first constructed. I did this because I wanted to have a cached version of the last call to `get_head`. Ensuring `get_head` has been run *at least once* means that the cached values doesn't need to wrapped in an `Option`. This was fairly simple, it just involved passing a `slot` to the constructor so it knows *when* it's being run. When loading a fork choice from the store and a slot clock isn't handy I've just used the `slot` that was saved in the `fork_choice_store`. That seems like it would be a faithful representation of the slot when we saved it.

I added the `genesis_time: u64` to the `BeaconChain`. It's small, constant and nice to have around.

Since we're using FC for the fin/just checkpoints, we no longer get the `0x00..00` roots at genesis. You can see I had to remove a work-around in `ef-tests` here: b56be3bc2. I can't find any reason why this would be an issue, if anything I think it'll be better since the genesis-alias has caught us out a few times (0x00..00 isn't actually a real root). Edit: I did find a case where the `network` expected the 0x00..00 alias and patched it here: 3f26ac3e2.

You'll notice a lot of changes in tests. Generally, tests should be functionally equivalent. Here are the things creating the most diff-noise in tests:
- Changing tests to be `tokio::async` tests.
- Adding `.await` to fork choice, block processing and block production functions.
- Refactor of the `canonical_head` "API" provided by the `BeaconChain`. E.g., `chain.canonical_head.cached_head()` instead of `chain.canonical_head.read()`.
- Wrapping `SignedBeaconBlock` in an `Arc`.
- In the `beacon_chain/tests/block_verification`, we can't use the `lazy_static` `CHAIN_SEGMENT` variable anymore since it's generated with an async function. We just generate it in each test, not so efficient but hopefully insignificant.

I had to disable `rayon` concurrent tests in the `fork_choice` tests. This is because the use of `rayon` and `block_on` was causing a panic.