### PR TITLE
[Merged by Bors] - Pin MDBX at last version with Win/Mac support

### DIFF
--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -13,7 +13,8 @@ flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
 filesystem = { path = "../common/filesystem" }
-mdbx = { package = "libmdbx", version = "0.1.0" }
+# MDBX is pinned at the last version with Windows and macOS support. This is only viable short-term.
+mdbx = { package = "libmdbx", version = "=0.1.4" }
 lru = "0.7.1"
 parking_lot = "0.12.0"
 rand = "0.8.5"


### PR DESCRIPTION
## Issue Addressed

Newer versions of MDBX have removed Windows and macOS support, so this PR pins MDBX at the last working version to prevent an accidental regression via `cargo update`.

## Additional Info

This is a short-term solution, if our pinned version of MDBX turns out to be buggy we will need to consider backporting patches from upstream to our own fork.
