### PR TITLE
[Merged by Bors] - Only use authenticated endpoints during EE integration testing

### DIFF
--- a/testing/execution_engine_integration/src/execution_engine.rs
+++ b/testing/execution_engine_integration/src/execution_engine.rs
@@ -22,7 +22,6 @@ pub struct ExecutionEngine<E> {
     engine: E,
     #[allow(dead_code)]
     datadir: TempDir,
-    http_port: u16,
     http_auth_port: u16,
     child: Child,
 }
@@ -46,14 +45,9 @@ impl<E: GenericExecutionEngine> ExecutionEngine<E> {
         Self {
             engine,
             datadir,
-            http_port,
             http_auth_port,
             child,
         }
-    }
-
-    pub fn http_url(&self) -> SensitiveUrl {
-        SensitiveUrl::parse(&format!("http://127.0.0.1:{}", self.http_port)).unwrap()
     }
 
     pub fn http_auth_url(&self) -> SensitiveUrl {

--- a/testing/execution_engine_integration/src/main.rs
+++ b/testing/execution_engine_integration/src/main.rs
@@ -15,7 +15,7 @@ use nethermind::NethermindEngine;
 use test_rig::TestRig;
 
 /// Set to `false` to send logs to the console during tests. Logs are useful when debugging.
-const SUPPRESS_LOGS: bool = true;
+const SUPPRESS_LOGS: bool = false;
 
 fn main() {
     if cfg!(windows) {

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -75,7 +75,7 @@ impl GenericExecutionEngine for NethermindEngine {
 
     fn start_client(
         datadir: &TempDir,
-        http_port: u16,
+        _http_port: u16,
         http_auth_port: u16,
         jwt_secret_path: PathBuf,
     ) -> Child {
@@ -89,11 +89,14 @@ impl GenericExecutionEngine for NethermindEngine {
             .arg("--Merge.TerminalTotalDifficulty")
             .arg("0")
             .arg("--JsonRpc.AdditionalRpcUrls")
-            .arg(format!("http://localhost:{}|http;ws|net;eth;subscribe;engine;web3;client|no-auth,http://localhost:{}|http;ws|net;eth;subscribe;engine;web3;client", http_port, http_auth_port))
+            .arg(format!(
+                "http://localhost:{}|http;ws|net;eth;subscribe;engine;web3;client",
+                http_auth_port
+            ))
             .arg("--JsonRpc.EnabledModules")
             .arg("net,eth,subscribe,web3,admin,engine")
             .arg("--JsonRpc.Port")
-            .arg(http_port.to_string())
+            .arg(http_auth_port.to_string())
             .arg("--Network.DiscoveryPort")
             .arg(network_port.to_string())
             .arg("--Network.P2PPort")

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -68,7 +68,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         let ee_b = {
             let execution_engine = ExecutionEngine::new(generic_engine);
-            let urls = vec![execution_engine.http_url()];
+            let urls = vec![execution_engine.http_auth_url()];
 
             let config = execution_layer::Config {
                 execution_endpoints: urls,


### PR DESCRIPTION
## Issue Addressed

Failures in our CI integration tests for Geth.

## Proposed Changes

Only connect to the authenticated execution endpoints during execution tests.
This is necessary now that it is impossible to connect to the `engine` api on an unauthenticated endpoint.
See https://github.com/ethereum/go-ethereum/pull/24997

## Additional Info

As these tests break semi-regularly, I have kept logs enabled to ease future debugging.
I've also updated the Nethermind tests, although these weren't broken. This should future-proof us if Nethermind decides to follow suit with Geth
