### PR TITLE
Use `Vec` in `SingleEpochParticipationCache` rather than `HashMap`

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
@@ -12,7 +12,6 @@
 //! to get useful summaries about the validator participation in an epoch.
 
 use safe_arith::{ArithError, SafeArith};
-use std::collections::HashMap;
 use types::{
     consts::altair::{
         NUM_FLAG_INDICES, TIMELY_HEAD_FLAG_INDEX, TIMELY_SOURCE_FLAG_INDEX,
@@ -24,6 +23,7 @@ use types::{
 #[derive(Debug, PartialEq)]
 pub enum Error {
     InvalidFlagIndex(usize),
+    InvalidValidatorIndex(usize),
 }
 
 /// A balance which will never be below the specified `minimum`.
@@ -64,7 +64,7 @@ struct SingleEpochParticipationCache {
     /// It would be ideal to maintain a reference to the `BeaconState` here rather than copying the
     /// `ParticipationFlags`, however that would cause us to run into mutable reference limitations
     /// upstream.
-    unslashed_participating_indices: HashMap<usize, ParticipationFlags>,
+    unslashed_participating_indices: Vec<Option<ParticipationFlags>>,
     /// Stores the sum of the balances for all validators in `self.unslashed_participating_indices`
     /// for all flags in `NUM_FLAG_INDICES`.
     ///
@@ -76,11 +76,11 @@ struct SingleEpochParticipationCache {
 }
 
 impl SingleEpochParticipationCache {
-    fn new(hashmap_len: usize, spec: &ChainSpec) -> Self {
+    fn instantiate(num_validators: usize, spec: &ChainSpec) -> Self {
         let zero_balance = Balance::zero(spec.effective_balance_increment);
 
         Self {
-            unslashed_participating_indices: HashMap::with_capacity(hashmap_len),
+            unslashed_participating_indices: vec![None; num_validators],
             total_flag_balances: [zero_balance; NUM_FLAG_INDICES],
             total_active_balance: zero_balance,
         }
@@ -100,7 +100,11 @@ impl SingleEpochParticipationCache {
     ///
     /// May return an error if `flag_index` is out-of-bounds.
     fn has_flag(&self, val_index: usize, flag_index: usize) -> Result<bool, Error> {
-        if let Some(participation_flags) = self.unslashed_participating_indices.get(&val_index) {
+        let participation_flags = self
+            .unslashed_participating_indices
+            .get(val_index)
+            .ok_or(Error::InvalidValidatorIndex(val_index))?;
+        if let Some(participation_flags) = participation_flags {
             participation_flags
                 .has_flag(flag_index)
                 .map_err(|_| Error::InvalidFlagIndex(flag_index))
@@ -149,8 +153,10 @@ impl SingleEpochParticipationCache {
         }
 
         // Add their `ParticipationFlags` to the map.
-        self.unslashed_participating_indices
-            .insert(val_index, *epoch_participation);
+        *self
+            .unslashed_participating_indices
+            .get_mut(val_index)
+            .ok_or(BeaconStateError::UnknownValidator(val_index))? = Some(*epoch_participation);
 
         // Iterate through all the flags and increment the total flag balances for whichever flags
         // are set for `val_index`.
@@ -190,19 +196,12 @@ impl ParticipationCache {
         let current_epoch = state.current_epoch();
         let previous_epoch = state.previous_epoch();
 
-        let num_previous_epoch_active_vals = state
-            .get_cached_active_validator_indices(RelativeEpoch::Previous)?
-            .len();
-        let num_current_epoch_active_vals = state
-            .get_cached_active_validator_indices(RelativeEpoch::Current)?
-            .len();
-
         // Both the current/previous epoch participations are set to a capacity that is slightly
         // larger than required. The difference will be due slashed-but-active validators.
         let mut current_epoch_participation =
-            SingleEpochParticipationCache::new(num_current_epoch_active_vals, spec);
+            SingleEpochParticipationCache::instantiate(state.validators().len(), spec);
         let mut previous_epoch_participation =
-            SingleEpochParticipationCache::new(num_previous_epoch_active_vals, spec);
+            SingleEpochParticipationCache::instantiate(state.validators().len(), spec);
         // Contains the set of validators which are either:
         //
         // - Active in the previous epoch.
@@ -316,13 +315,17 @@ impl ParticipationCache {
     pub fn is_active_unslashed_in_previous_epoch(&self, val_index: usize) -> bool {
         self.previous_epoch_participation
             .unslashed_participating_indices
-            .contains_key(&val_index)
+            .get(val_index)
+            // TODO(paul): map_or should be an Err.
+            .map_or(false, |flags| flags.is_some())
     }
 
     pub fn is_active_unslashed_in_current_epoch(&self, val_index: usize) -> bool {
         self.current_epoch_participation
             .unslashed_participating_indices
-            .contains_key(&val_index)
+            .get(val_index)
+            // TODO(paul): map_or should be an Err.
+            .map_or(false, |flags| flags.is_some())
     }
 
     /*


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Uses a `Vec` in `SingleEpochParticipationCache` rather than `HashMap` to speed up processing times at the cost of memory usage.

### Benchmarks

Benchmarks on a recent mainnet state using #3252 to get timing.

#### Without this PR

```
lcli skip-slots --state-path /tmp/state-0x3cdc.ssz --partial-state-advance --slots 32 --state-root 0x3cdc33cd02713d8d6cc33a6dbe2d3a5bf9af1d357de0d175a403496486ff845e --runs 10
[2022-06-09T08:21:03Z INFO  lcli::skip_slots] Run 0: 245.718794ms
[2022-06-09T08:21:03Z INFO  lcli::skip_slots] Run 1: 245.364782ms
[2022-06-09T08:21:03Z INFO  lcli::skip_slots] Run 2: 255.866179ms
[2022-06-09T08:21:04Z INFO  lcli::skip_slots] Run 3: 243.838909ms
[2022-06-09T08:21:04Z INFO  lcli::skip_slots] Run 4: 250.431425ms
[2022-06-09T08:21:04Z INFO  lcli::skip_slots] Run 5: 248.68765ms
[2022-06-09T08:21:04Z INFO  lcli::skip_slots] Run 6: 262.051113ms
[2022-06-09T08:21:05Z INFO  lcli::skip_slots] Run 7: 264.293967ms
[2022-06-09T08:21:05Z INFO  lcli::skip_slots] Run 8: 293.202007ms
[2022-06-09T08:21:05Z INFO  lcli::skip_slots] Run 9: 264.552017ms
```

#### With this PR:

```
lcli skip-slots --state-path /tmp/state-0x3cdc.ssz --partial-state-advance --slots 32 --state-root 0x3cdc33cd02713d8d6cc33a6dbe2d3a5bf9af1d357de0d175a403496486ff845e --runs 10
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 0: 73.898678ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 1: 75.536978ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 2: 75.176104ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 3: 76.460828ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 4: 75.904195ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 5: 75.53077ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 6: 74.745572ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 7: 75.823489ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 8: 74.892055ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 9: 76.333569ms
```

## TODO

- [ ] Quantify additional memory costs.
- [ ] Fix `todo(paul)` in code
