### PR TITLE
Avoid recomputing `state.previous_epoch`

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/inactivity_updates.rs
@@ -14,6 +14,7 @@ pub fn process_inactivity_updates<T: EthSpec>(
     participation_cache: &ParticipationCache,
     spec: &ChainSpec,
 ) -> Result<(), EpochProcessingError> {
+    let previous_epoch = state.previous_epoch();
     // Score updates based on previous epoch participation, skip genesis epoch
     if state.current_epoch() == T::genesis_epoch() {
         return Ok(());
@@ -33,7 +34,7 @@ pub fn process_inactivity_updates<T: EthSpec>(
                 .safe_add_assign(spec.inactivity_score_bias)?;
         }
         // Decrease the score of all validators for forgiveness when not during a leak
-        if !state.is_in_inactivity_leak(spec) {
+        if !state.is_in_inactivity_leak(previous_epoch, spec) {
             let inactivity_score = state.get_inactivity_score_mut(index)?;
             inactivity_score
                 .safe_sub_assign(min(spec.inactivity_score_recovery_rate, *inactivity_score))?;

--- a/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
@@ -238,7 +238,7 @@ impl ParticipationCache {
 
             // Note: a validator might still be "eligible" whilst returning `false` to
             // `Validator::is_active_at`.
-            if state.is_eligible_validator(val_index)? {
+            if state.is_eligible_validator(previous_epoch, val_index)? {
                 eligible_indices.push(val_index)
             }
         }

--- a/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/rewards_and_penalties.rs
@@ -73,7 +73,7 @@ pub fn get_flag_index_deltas<T: EthSpec>(
         let mut delta = Delta::default();
 
         if unslashed_participating_indices.contains(index as usize)? {
-            if !state.is_in_inactivity_leak(spec) {
+            if !state.is_in_inactivity_leak(previous_epoch, spec) {
                 let reward_numerator = base_reward
                     .safe_mul(weight)?
                     .safe_mul(unslashed_participating_increments)?;

--- a/consensus/state_processing/src/per_epoch_processing/base/rewards_and_penalties.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/rewards_and_penalties.rs
@@ -78,6 +78,7 @@ pub fn get_attestation_deltas<T: EthSpec>(
     validator_statuses: &ValidatorStatuses,
     spec: &ChainSpec,
 ) -> Result<Vec<AttestationDelta>, Error> {
+    let previous_epoch = state.previous_epoch();
     let finality_delay = state
         .previous_epoch()
         .safe_sub(state.finalized_checkpoint().epoch)?
@@ -92,7 +93,7 @@ pub fn get_attestation_deltas<T: EthSpec>(
         // `get_inclusion_delay_deltas`. It's safe to do so here because any validator that is in
         // the unslashed indices of the matching source attestations is active, and therefore
         // eligible.
-        if !state.is_eligible_validator(index)? {
+        if !state.is_eligible_validator(previous_epoch, index)? {
             continue;
         }
 

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1602,17 +1602,23 @@ impl<T: EthSpec> BeaconState<T> {
         self.clone_with(CloneConfig::committee_caches_only())
     }
 
-    pub fn is_eligible_validator(&self, val_index: usize) -> Result<bool, Error> {
-        let previous_epoch = self.previous_epoch();
+    /// Passing `previous_epoch` to this function rather than computing it internally provides
+    /// a tangible speed improvement in state processing.
+    pub fn is_eligible_validator(
+        &self,
+        previous_epoch: Epoch,
+        val_index: usize,
+    ) -> Result<bool, Error> {
         self.get_validator(val_index).map(|val| {
             val.is_active_at(previous_epoch)
                 || (val.slashed && previous_epoch + Epoch::new(1) < val.withdrawable_epoch)
         })
     }
 
-    pub fn is_in_inactivity_leak(&self, spec: &ChainSpec) -> bool {
-        (self.previous_epoch() - self.finalized_checkpoint().epoch)
-            > spec.min_epochs_to_inactivity_penalty
+    /// Passing `previous_epoch` to this function rather than computing it internally provides
+    /// a tangible speed improvement in state processing.
+    pub fn is_in_inactivity_leak(&self, previous_epoch: Epoch, spec: &ChainSpec) -> bool {
+        (previous_epoch - self.finalized_checkpoint().epoch) > spec.min_epochs_to_inactivity_penalty
     }
 
     /// Get the `SyncCommittee` associated with the next slot. Useful because sync committees


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Much to my surprise, `BeaconState::previous_epoch` has been showing up in flamegraphs! This PR removes repeated calls to it.

### Benchmarks

Benchmarks on a recent mainnet state using #3252 to get timing.

These tests were run with optimisations #3254 and #3255  already applied.

#### Without this PR

```
lcli skip-slots --state-path /tmp/state-0x3cdc.ssz --partial-state-advance --slots 32 --state-root 0x3cdc33cd02713d8d6cc33a6dbe2d3a5bf9af1d357de0d175a403496486ff845e --runs 10
[2022-06-09T08:56:29Z INFO  lcli::skip_slots] Run 0: 104.628252ms
[2022-06-09T08:56:29Z INFO  lcli::skip_slots] Run 1: 83.104139ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 2: 84.025086ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 3: 84.747254ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 4: 83.197275ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 5: 83.390297ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 6: 83.057175ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 7: 85.289398ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 8: 83.081438ms
[2022-06-09T08:56:30Z INFO  lcli::skip_slots] Run 9: 82.661783ms
```


#### With this PR

```
lcli skip-slots --state-path /tmp/state-0x3cdc.ssz --partial-state-advance --slots 32 --state-root 0x3cdc33cd02713d8d6cc33a6dbe2d3a5bf9af1d357de0d175a403496486ff845e --runs 10
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 0: 73.898678ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 1: 75.536978ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 2: 75.176104ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 3: 76.460828ms
[2022-06-09T08:57:59Z INFO  lcli::skip_slots] Run 4: 75.904195ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 5: 75.53077ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 6: 74.745572ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 7: 75.823489ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 8: 74.892055ms
[2022-06-09T08:58:00Z INFO  lcli::skip_slots] Run 9: 76.333569ms
```

## Additional Info

- Blocked on #3254 and #3255
