### PR TITLE
Optimise proposer index calculation in block processing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3405,7 +3405,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         drop(attestation_packing_timer);
 
         let slot = state.slot();
-        let proposer_index = state.get_beacon_proposer_index(state.slot(), &self.spec)? as u64;
+        let proposer_index =
+            state.get_beacon_proposer_index_using_committee_cache(state.slot(), &self.spec)? as u64;
 
         let sync_aggregate = if matches!(&state, BeaconState::Base(_)) {
             None

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -535,7 +535,10 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     let mut signature_verifier = get_signature_verifier(&state, &pubkey_cache, &chain.spec);
 
     for (block_root, block) in &chain_segment {
-        signature_verifier.include_all_signatures(block, Some(*block_root))?;
+        let proposer_index = state
+            .get_beacon_proposer_index_using_committee_cache(block.slot(), &chain.spec)?
+            as u64;
+        signature_verifier.include_all_signatures(block, Some(*block_root), proposer_index)?;
     }
 
     if signature_verifier.verify().is_err() {
@@ -909,7 +912,11 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
 
         let mut signature_verifier = get_signature_verifier(&state, &pubkey_cache, &chain.spec);
 
-        signature_verifier.include_all_signatures(&block, Some(block_root))?;
+        let proposer_index = state
+            .get_beacon_proposer_index_using_committee_cache(block.slot(), &chain.spec)?
+            as u64;
+
+        signature_verifier.include_all_signatures(&block, Some(block_root), proposer_index)?;
 
         if signature_verifier.verify().is_ok() {
             Ok(Self {
@@ -955,7 +962,11 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
 
         let mut signature_verifier = get_signature_verifier(&state, &pubkey_cache, &chain.spec);
 
-        signature_verifier.include_all_signatures_except_proposal(&block)?;
+        // Assume that the proposer index is accurate since gossip processing has checked the
+        // proposer index.
+        let proposer_index = block.message().proposer_index();
+
+        signature_verifier.include_all_signatures_except_proposal(&block, proposer_index)?;
 
         if signature_verifier.verify().is_ok() {
             Ok(Self {

--- a/consensus/state_processing/src/common/slash_validator.rs
+++ b/consensus/state_processing/src/common/slash_validator.rs
@@ -10,7 +10,7 @@ use types::{
 pub fn slash_validator<T: EthSpec>(
     state: &mut BeaconState<T>,
     slashed_index: usize,
-    opt_whistleblower_index: Option<usize>,
+    proposer_index: usize,
     spec: &ChainSpec,
 ) -> Result<(), Error> {
     let epoch = state.current_epoch();
@@ -39,8 +39,7 @@ pub fn slash_validator<T: EthSpec>(
     )?;
 
     // Apply proposer and whistleblower rewards
-    let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)?;
-    let whistleblower_index = opt_whistleblower_index.unwrap_or(proposer_index);
+    let whistleblower_index = proposer_index;
     let whistleblower_reward =
         validator_effective_balance.safe_div(spec.whistleblower_reward_quotient)?;
     let proposer_reward = match state {

--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -74,6 +74,7 @@ where
     state: &'a BeaconState<T>,
     spec: &'a ChainSpec,
     sets: ParallelSignatureSets<'a>,
+    proposer_index: Option<usize>,
 }
 
 #[derive(Default)]
@@ -107,6 +108,30 @@ where
             state,
             spec,
             sets: ParallelSignatureSets::default(),
+            proposer_index: None,
+        }
+    }
+
+    pub fn proposer_index<Payload: ExecPayload<T>>(
+        &mut self,
+        block: &'a SignedBeaconBlock<T, Payload>,
+    ) -> Result<usize> {
+        if let Some(index) = self.proposer_index {
+            Ok(index)
+        } else {
+            let proposer_index = self
+                .state
+                .get_beacon_proposer_index_using_committee_cache(block.slot(), self.spec)?;
+
+            if proposer_index != block.message().proposer_index() as usize {
+                return Err(Error::IncorrectBlockProposer {
+                    block: block.message().proposer_index(),
+                    local_shuffling: proposer_index as u64,
+                });
+            }
+
+            self.proposer_index = Some(proposer_index);
+            Ok(proposer_index)
         }
     }
 
@@ -136,7 +161,8 @@ where
         block: &'a SignedBeaconBlock<T, Payload>,
         block_root: Option<Hash256>,
     ) -> Result<()> {
-        self.include_block_proposal(block, block_root)?;
+        let proposer_index = self.proposer_index(block)?;
+        self.include_block_proposal(block, block_root, proposer_index)?;
         self.include_all_signatures_except_proposal(block)?;
 
         Ok(())
@@ -148,7 +174,8 @@ where
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
     ) -> Result<()> {
-        self.include_randao_reveal(block)?;
+        let proposer_index = self.proposer_index(block)?;
+        self.include_randao_reveal(block, proposer_index)?;
         self.include_proposer_slashings(block)?;
         self.include_attester_slashings(block)?;
         self.include_attestations(block)?;
@@ -164,12 +191,14 @@ where
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
         block_root: Option<Hash256>,
+        proposer_index: usize,
     ) -> Result<()> {
         let set = block_proposal_signature_set(
             self.state,
             self.get_pubkey.clone(),
             block,
             block_root,
+            proposer_index as u64,
             self.spec,
         )?;
         self.sets.push(set);
@@ -180,11 +209,13 @@ where
     pub fn include_randao_reveal<Payload: ExecPayload<T>>(
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
+        proposer_index: usize,
     ) -> Result<()> {
         let set = randao_signature_set(
             self.state,
             self.get_pubkey.clone(),
             block.message(),
+            proposer_index as u64,
             self.spec,
         )?;
         self.sets.push(set);

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -19,15 +19,15 @@ pub fn process_operations<'a, T: EthSpec, Payload: ExecPayload<T>>(
     process_proposer_slashings(
         state,
         block_body.proposer_slashings(),
-        verify_signatures,
         proposer_index as usize,
+        verify_signatures,
         spec,
     )?;
     process_attester_slashings(
         state,
         block_body.attester_slashings(),
-        verify_signatures,
         proposer_index as usize,
+        verify_signatures,
         spec,
     )?;
     process_attestations(state, block_body, proposer_index, verify_signatures, spec)?;
@@ -46,8 +46,8 @@ pub mod base {
     pub fn process_attestations<T: EthSpec>(
         state: &mut BeaconState<T>,
         attestations: &[Attestation<T>],
-        verify_signatures: VerifySignatures,
         proposer_index: u64,
+        verify_signatures: VerifySignatures,
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
         // Ensure the previous epoch cache exists.
@@ -170,8 +170,8 @@ pub mod altair {
 pub fn process_proposer_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     proposer_slashings: &[ProposerSlashing],
-    verify_signatures: VerifySignatures,
     proposer_index: usize,
+    verify_signatures: VerifySignatures,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     // Verify and apply proposer slashings in series.
@@ -202,8 +202,8 @@ pub fn process_proposer_slashings<T: EthSpec>(
 pub fn process_attester_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     attester_slashings: &[AttesterSlashing<T>],
-    verify_signatures: VerifySignatures,
     proposer_index: usize,
+    verify_signatures: VerifySignatures,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     for (i, attester_slashing) in attester_slashings.iter().enumerate() {
@@ -234,8 +234,8 @@ pub fn process_attestations<'a, T: EthSpec, Payload: ExecPayload<T>>(
             base::process_attestations(
                 state,
                 block_body.attestations(),
-                verify_signatures,
                 proposer_index,
+                verify_signatures,
                 spec,
             )?;
         }

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -640,10 +640,14 @@ async fn valid_insert_attester_slashing() {
     let attester_slashing = harness.make_attester_slashing(vec![1, 2]);
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -660,10 +664,14 @@ async fn invalid_attester_slashing_not_slashable() {
     attester_slashing.attestation_1 = attester_slashing.attestation_2.clone();
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -686,10 +694,14 @@ async fn invalid_attester_slashing_1_invalid() {
     attester_slashing.attestation_1.attesting_indices = VariableList::from(vec![2, 1]);
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -715,10 +727,14 @@ async fn invalid_attester_slashing_2_invalid() {
     attester_slashing.attestation_2.attesting_indices = VariableList::from(vec![2, 1]);
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -741,10 +757,14 @@ async fn valid_insert_proposer_slashing() {
     let harness = get_harness::<MainnetEthSpec>(EPOCH_OFFSET, VALIDATOR_COUNT).await;
     let proposer_slashing = harness.make_proposer_slashing(1);
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
     // Expecting Ok(_) because we inserted a valid proposer slashing
@@ -760,10 +780,14 @@ async fn invalid_proposer_slashing_proposals_identical() {
     proposer_slashing.signed_header_1.message = proposer_slashing.signed_header_2.message.clone();
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -787,10 +811,14 @@ async fn invalid_proposer_slashing_proposer_unknown() {
     proposer_slashing.signed_header_2.message.proposer_index = 3_141_592;
 
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -811,10 +839,14 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
 
     let proposer_slashing = harness.make_proposer_slashing(1);
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result_1 = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing.clone()],
         VerifySignatures::False,
+        proposer_index,
         &spec,
     );
     assert!(result_1.is_ok());
@@ -823,6 +855,7 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
         &mut state,
         &[proposer_slashing],
         VerifySignatures::False,
+        proposer_index,
         &spec,
     );
     // Expecting ProposerNotSlashable because we've already slashed the validator
@@ -842,10 +875,14 @@ async fn invalid_bad_proposal_1_signature() {
     let mut proposer_slashing = harness.make_proposer_slashing(1);
     proposer_slashing.signed_header_1.signature = Signature::empty();
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -866,10 +903,14 @@ async fn invalid_bad_proposal_2_signature() {
     let mut proposer_slashing = harness.make_proposer_slashing(1);
     proposer_slashing.signed_header_2.signature = Signature::empty();
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        proposer_index,
         &spec,
     );
 
@@ -891,10 +932,14 @@ async fn invalid_proposer_slashing_proposal_epoch_mismatch() {
     proposer_slashing.signed_header_1.message.slot = Slot::new(0);
     proposer_slashing.signed_header_2.message.slot = Slot::new(128);
     let mut state = harness.get_current_state();
+    let proposer_index = state
+        .get_beacon_proposer_index(state.slot(), &spec)
+        .unwrap();
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::False,
+        proposer_index,
         &spec,
     );
 

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -646,8 +646,8 @@ async fn valid_insert_attester_slashing() {
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -670,8 +670,8 @@ async fn invalid_attester_slashing_not_slashable() {
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -700,8 +700,8 @@ async fn invalid_attester_slashing_1_invalid() {
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -733,8 +733,8 @@ async fn invalid_attester_slashing_2_invalid() {
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -763,8 +763,8 @@ async fn valid_insert_proposer_slashing() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
     // Expecting Ok(_) because we inserted a valid proposer slashing
@@ -786,8 +786,8 @@ async fn invalid_proposer_slashing_proposals_identical() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -817,8 +817,8 @@ async fn invalid_proposer_slashing_proposer_unknown() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -845,8 +845,8 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
     let result_1 = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing.clone()],
-        VerifySignatures::False,
         proposer_index,
+        VerifySignatures::False,
         &spec,
     );
     assert!(result_1.is_ok());
@@ -854,8 +854,8 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
     let result_2 = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::False,
         proposer_index,
+        VerifySignatures::False,
         &spec,
     );
     // Expecting ProposerNotSlashable because we've already slashed the validator
@@ -881,8 +881,8 @@ async fn invalid_bad_proposal_1_signature() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -909,8 +909,8 @@ async fn invalid_bad_proposal_2_signature() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::True,
         proposer_index,
+        VerifySignatures::True,
         &spec,
     );
 
@@ -938,8 +938,8 @@ async fn invalid_proposer_slashing_proposal_epoch_mismatch() {
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
-        VerifySignatures::False,
         proposer_index,
+        VerifySignatures::False,
         &spec,
     );
 

--- a/consensus/swap_or_not_shuffle/src/lib.rs
+++ b/consensus/swap_or_not_shuffle/src/lib.rs
@@ -17,7 +17,7 @@
 mod compute_shuffled_index;
 mod shuffle_list;
 
-pub use compute_shuffled_index::compute_shuffled_index;
+pub use compute_shuffled_index::{compute_shuffled_index, compute_unshuffled_index};
 pub use shuffle_list::shuffle_list;
 
 type Hash256 = ethereum_types::H256;

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -743,11 +743,6 @@ impl<T: EthSpec> BeaconState<T> {
             let validator_index = indices.get(position_in_shuffling).copied().ok_or(
                 Error::ShuffleIndexOutOfBounds(position_in_active_validators),
             )?;
-            dbg!(
-                position_in_active_validators,
-                position_in_shuffling,
-                validator_index
-            );
             Ok(validator_index)
         };
 

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -114,6 +114,24 @@ impl CommitteeCache {
         &self.shuffling
     }
 
+    /// Returns the **unshuffled** list of active validator indices for the initialized epoch.
+    ///
+    /// The validator indices are in ascending order, this is useful for computing the proposer
+    /// index.
+    ///
+    /// Always returns `&[]` for a non-initialized epoch.
+    ///
+    /// Spec v0.12.1
+    pub fn unshuffled_active_validator_indices(&self) -> Vec<usize> {
+        let mut indices = Vec::with_capacity(self.shuffling.len());
+        for (val_index, position) in self.shuffling_positions.iter().enumerate() {
+            if position.0.is_some() {
+                indices.push(val_index)
+            }
+        }
+        indices
+    }
+
     /// Returns the shuffled list of active validator indices for the initialized epoch.
     ///
     /// Always returns `&[]` for a non-initialized epoch.

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -350,6 +350,11 @@ fn do_transition<T: EthSpec>(
             get_pubkey(validator_index)
         };
 
+        // Compute the proposer index outside the timer.
+        let proposer_index = pre_state
+            .get_beacon_proposer_index(block.slot(), spec)
+            .map_err(|e| format!("Unable to determine proposer index: {:?}", e))?;
+
         let t = Instant::now();
         BlockSignatureVerifier::verify_entire_block(
             &pre_state,
@@ -357,6 +362,7 @@ fn do_transition<T: EthSpec>(
             decompressor,
             &block,
             Some(block_root),
+            proposer_index as u64,
             spec,
         )
         .map_err(|e| format!("Invalid block signature: {:?}", e))?;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -78,9 +78,13 @@ impl<E: EthSpec> Operation<E> for Attestation<E> {
     ) -> Result<(), BlockProcessingError> {
         let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
         match state {
-            BeaconState::Base(_) => {
-                base::process_attestations(state, &[self.clone()], VerifySignatures::True, spec)
-            }
+            BeaconState::Base(_) => base::process_attestations(
+                state,
+                &[self.clone()],
+                proposer_index,
+                VerifySignatures::True,
+                spec,
+            ),
             BeaconState::Altair(_) | BeaconState::Merge(_) => altair::process_attestation(
                 state,
                 self,
@@ -108,7 +112,14 @@ impl<E: EthSpec> Operation<E> for AttesterSlashing<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_attester_slashings(state, &[self.clone()], VerifySignatures::True, spec)
+        let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
+        process_attester_slashings(
+            state,
+            &[self.clone()],
+            proposer_index as usize,
+            VerifySignatures::True,
+            spec,
+        )
     }
 }
 
@@ -142,7 +153,14 @@ impl<E: EthSpec> Operation<E> for ProposerSlashing {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_proposer_slashings(state, &[self.clone()], VerifySignatures::True, spec)
+        let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
+        process_proposer_slashings(
+            state,
+            &[self.clone()],
+            proposer_index as usize,
+            VerifySignatures::True,
+            spec,
+        )
     }
 }
 

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -53,15 +53,16 @@ impl ExitTest {
         let validator_index = self.validator_index;
         let exit_epoch = self.exit_epoch;
 
-        let (signed_block, state) =
-            harness.make_block_with_modifier(state.clone(), state.slot() + 1, |block| {
+        let (signed_block, state) = harness
+            .make_block_with_modifier(state.clone(), state.slot() + 1, |block| {
                 // Drop any attestations included in the block. The irregular change to the state
                 // via `self.state_modifier` might have invalidated attestations floating around in
                 // the op pool.
                 *block.body_mut().attestations_mut() = vec![].into();
                 harness.add_voluntary_exit(block, validator_index, exit_epoch);
                 block_modifier(&harness, block);
-            });
+            })
+            .await;
 
         (signed_block, state)
     }

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -46,16 +46,23 @@ impl ExitTest {
         let mut state = harness.get_current_state();
         (self.state_modifier)(&mut state);
 
+        // The irregular changes to the state via `self.state_modifier` might invalidate the caches.
+        state.drop_all_caches().unwrap();
+
         let block_modifier = self.block_modifier;
         let validator_index = self.validator_index;
         let exit_epoch = self.exit_epoch;
 
-        let (signed_block, state) = harness
-            .make_block_with_modifier(state.clone(), state.slot() + 1, |block| {
+        let (signed_block, state) =
+            harness.make_block_with_modifier(state.clone(), state.slot() + 1, |block| {
+                // Drop any attestations included in the block. The irregular change to the state
+                // via `self.state_modifier` might have invalidated attestations floating around in
+                // the op pool.
+                *block.body_mut().attestations_mut() = vec![].into();
                 harness.add_voluntary_exit(block, validator_index, exit_epoch);
                 block_modifier(&harness, block);
-            })
-            .await;
+            });
+
         (signed_block, state)
     }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Avoid recomputing the active validator indices when computing the proposer index. Since we only have the *shuffled* active validator indices in our committee cache, this function maps an index in the *unshuffled active validators* to the *shuffled active validators* using unshuffling.

This is probably not a *huge* saving in the current scheme of block processing when we consider how long the THC takes, but I thought that this might be nice for `tree-states`. It avoids the iteration of computing the active validator indices, which I understand is more expensive with tree-states.

### Benchmarks

Benchmarks on a [recent mainnet block](https://beaconcha.in/block/0x6c69cf50a451f1ec905e954bf1fa22970f371a72a5aa9f8e3a43a18fdd980bec) using #3252 to get timing.

#### Without this PR

```
lcli transition-blocks --block-path /tmp/block-0x6c69.ssz --pre-state-path /tmp/pre-state-0x6c69.ssz --runs 15 --exclude-cache-builds --exclude-post-block-thc --no-signature-verification 2>&1 | grep "Process block"
[2022-06-12T01:23:01Z DEBUG lcli::transition_blocks] Process block: 5.976771ms
[2022-06-12T01:23:01Z DEBUG lcli::transition_blocks] Process block: 5.956646ms
[2022-06-12T01:23:01Z DEBUG lcli::transition_blocks] Process block: 6.010116ms
[2022-06-12T01:23:01Z DEBUG lcli::transition_blocks] Process block: 5.975266ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 6.02316ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 6.034038ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 6.037002ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 5.97694ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 5.934441ms
[2022-06-12T01:23:02Z DEBUG lcli::transition_blocks] Process block: 5.943318ms
[2022-06-12T01:23:03Z DEBUG lcli::transition_blocks] Process block: 6.365686ms
[2022-06-12T01:23:03Z DEBUG lcli::transition_blocks] Process block: 5.890999ms
[2022-06-12T01:23:03Z DEBUG lcli::transition_blocks] Process block: 6.002739ms
[2022-06-12T01:23:03Z DEBUG lcli::transition_blocks] Process block: 5.989115ms
[2022-06-12T01:23:03Z DEBUG lcli::transition_blocks] Process block: 8.056736ms
```

#### With this PR:

```
lcli transition-blocks --block-path /tmp/block-0x6c69.ssz --pre-state-path /tmp/pre-state-0x6c69.ssz --runs 15 --exclude-cache-builds --exclude-post-block-thc --no-signature-verification 2>&1 | grep "Process block"
[2022-06-12T01:22:04Z DEBUG lcli::transition_blocks] Process block: 2.988006ms
[2022-06-12T01:22:04Z DEBUG lcli::transition_blocks] Process block: 3.044924ms
[2022-06-12T01:22:04Z DEBUG lcli::transition_blocks] Process block: 3.378032ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 3.015221ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 3.012321ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 3.068026ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 2.990344ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 4.755704ms
[2022-06-12T01:22:05Z DEBUG lcli::transition_blocks] Process block: 3.004696ms
[2022-06-12T01:22:06Z DEBUG lcli::transition_blocks] Process block: 3.127911ms
[2022-06-12T01:22:06Z DEBUG lcli::transition_blocks] Process block: 3.162573ms
[2022-06-12T01:22:06Z DEBUG lcli::transition_blocks] Process block: 3.3767ms
[2022-06-12T01:22:06Z DEBUG lcli::transition_blocks] Process block: 3.1083ms
[2022-06-12T01:22:06Z DEBUG lcli::transition_blocks] Process block: 3.038865ms
[2022-06-12T01:22:07Z DEBUG lcli::transition_blocks] Process block: 3.382932ms
```

## Additional Info

NA
