### PR TITLE
[Merged by Bors] - Deprecate step param in BlocksByRange RPC request

### DIFF
--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -1065,11 +1065,33 @@ where
                         // propagate the STATUS message upwards
                         self.propagate_request(peer_request_id, peer_id, Request::Status(msg))
                     }
-                    InboundRequest::BlocksByRange(req) => self.propagate_request(
-                        peer_request_id,
-                        peer_id,
-                        Request::BlocksByRange(req),
-                    ),
+                    InboundRequest::BlocksByRange(req) => {
+                        let methods::OldBlocksByRangeRequest {
+                            start_slot,
+                            mut count,
+                            step,
+                        } = req;
+                        // Still disconnect the peer if the request is naughty.
+                        if step == 0 {
+                            self.peer_manager.handle_rpc_error(
+                                &peer_id,
+                                Protocol::BlocksByRange,
+                                &RPCError::InvalidData(
+                                    "Blocks by range with 0 step parameter".into(),
+                                ),
+                                ConnectionDirection::Incoming,
+                            );
+                        }
+                        // return just one block in case the step parameter is used. https://github.com/ethereum/consensus-specs/pull/2856
+                        if step > 1 {
+                            count = 1;
+                        }
+                        self.propagate_request(
+                            peer_request_id,
+                            peer_id,
+                            Request::BlocksByRange(BlocksByRangeRequest { start_slot, count }),
+                        );
+                    }
                     InboundRequest::BlocksByRoot(req) => {
                         self.propagate_request(peer_request_id, peer_id, Request::BlocksByRoot(req))
                     }
@@ -1313,7 +1335,13 @@ impl<TSpec: EthSpec> std::convert::From<Request> for OutboundRequest<TSpec> {
     fn from(req: Request) -> OutboundRequest<TSpec> {
         match req {
             Request::BlocksByRoot(r) => OutboundRequest::BlocksByRoot(r),
-            Request::BlocksByRange(r) => OutboundRequest::BlocksByRange(r),
+            Request::BlocksByRange(BlocksByRangeRequest { start_slot, count }) => {
+                OutboundRequest::BlocksByRange(methods::OldBlocksByRangeRequest {
+                    start_slot,
+                    count,
+                    step: 1,
+                })
+            }
             Request::Status(s) => OutboundRequest::Status(s),
         }
     }

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -137,6 +137,9 @@ impl<TSpec: EthSpec> Decoder for SSZSnappyInboundCodec<TSpec> {
     type Error = RPCError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if self.protocol.message_name == Protocol::MetaData {
+            return Ok(Some(InboundRequest::MetaData(PhantomData)));
+        }
         let length = match handle_length(&mut self.inner, &mut self.len, src)? {
             Some(len) => len,
             None => return Ok(None),

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -461,7 +461,7 @@ fn handle_v1_request<T: EthSpec>(
             GoodbyeReason::from_ssz_bytes(decoded_buffer)?,
         ))),
         Protocol::BlocksByRange => Ok(Some(InboundRequest::BlocksByRange(
-            BlocksByRangeRequest::from_ssz_bytes(decoded_buffer)?,
+            OldBlocksByRangeRequest::from_ssz_bytes(decoded_buffer)?,
         ))),
         Protocol::BlocksByRoot => Ok(Some(InboundRequest::BlocksByRoot(BlocksByRootRequest {
             block_roots: VariableList::from_ssz_bytes(decoded_buffer)?,
@@ -493,7 +493,7 @@ fn handle_v2_request<T: EthSpec>(
 ) -> Result<Option<InboundRequest<T>>, RPCError> {
     match protocol {
         Protocol::BlocksByRange => Ok(Some(InboundRequest::BlocksByRange(
-            BlocksByRangeRequest::from_ssz_bytes(decoded_buffer)?,
+            OldBlocksByRangeRequest::from_ssz_bytes(decoded_buffer)?,
         ))),
         Protocol::BlocksByRoot => Ok(Some(InboundRequest::BlocksByRoot(BlocksByRootRequest {
             block_roots: VariableList::from_ssz_bytes(decoded_buffer)?,

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -842,10 +842,12 @@ mod tests {
                 fork_context.clone(),
             );
 
-            let decoded = inbound_codec.decode(&mut buf).unwrap().expect(&format!(
-                "Should correctly decode the request {} over protocol {:?} and fork {}",
-                req, protocol, fork_name
-            ));
+            let decoded = inbound_codec.decode(&mut buf).unwrap().unwrap_or_else(|| {
+                panic!(
+                    "Should correctly decode the request {} over protocol {:?} and fork {}",
+                    req, protocol, fork_name
+                )
+            });
             match req.clone() {
                 OutboundRequest::Status(status) => {
                     assert_eq!(decoded, InboundRequest::Status(status))

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -1342,7 +1342,7 @@ mod tests {
             OutboundRequest::BlocksByRoot(bbroot_request()),
             OutboundRequest::MetaData(PhantomData::<Spec>),
         ];
-        for req in requests.into_iter() {
+        for req in requests.iter() {
             for fork_name in ForkName::list_all() {
                 encode_then_decode_request(req.clone(), fork_name);
             }

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -712,6 +712,20 @@ mod tests {
         }
     }
 
+    fn bbrange_request() -> OldBlocksByRangeRequest {
+        OldBlocksByRangeRequest {
+            start_slot: 0,
+            count: 10,
+            step: 1,
+        }
+    }
+
+    fn bbroot_request() -> BlocksByRootRequest {
+        BlocksByRootRequest {
+            block_roots: VariableList::from(vec![Hash256::zero()]),
+        }
+    }
+
     fn ping_message() -> Ping {
         Ping { data: 1 }
     }
@@ -732,7 +746,7 @@ mod tests {
     }
 
     /// Encodes the given protocol response as bytes.
-    fn encode(
+    fn encode_response(
         protocol: Protocol,
         version: Version,
         message: RPCCodedResponse<Spec>,
@@ -779,7 +793,7 @@ mod tests {
     }
 
     /// Attempts to decode the given protocol bytes as an rpc response
-    fn decode(
+    fn decode_response(
         protocol: Protocol,
         version: Version,
         message: &mut BytesMut,
@@ -795,21 +809,68 @@ mod tests {
     }
 
     /// Encodes the provided protocol message as bytes and tries to decode the encoding bytes.
-    fn encode_then_decode(
+    fn encode_then_decode_response(
         protocol: Protocol,
         version: Version,
         message: RPCCodedResponse<Spec>,
         fork_name: ForkName,
     ) -> Result<Option<RPCResponse<Spec>>, RPCError> {
-        let mut encoded = encode(protocol, version.clone(), message, fork_name)?;
-        decode(protocol, version, &mut encoded, fork_name)
+        let mut encoded = encode_response(protocol, version.clone(), message, fork_name)?;
+        decode_response(protocol, version, &mut encoded, fork_name)
+    }
+
+    /// Verifies that requests we send are encoded in a way that we would correctly decode too.
+    fn encode_then_decode_request(req: OutboundRequest<Spec>, fork_name: ForkName) {
+        let fork_context = Arc::new(fork_context(fork_name));
+        let max_packet_size = max_rpc_size(&fork_context);
+        for protocol in req.supported_protocols() {
+            // Encode a request we send
+            let mut buf = BytesMut::new();
+            let mut outbound_codec = SSZSnappyOutboundCodec::<Spec>::new(
+                protocol.clone(),
+                max_packet_size,
+                fork_context.clone(),
+            );
+            outbound_codec.encode(req.clone(), &mut buf).unwrap();
+
+            let mut inbound_codec = SSZSnappyInboundCodec::<Spec>::new(
+                protocol.clone(),
+                max_packet_size,
+                fork_context.clone(),
+            );
+
+            let decoded = inbound_codec.decode(&mut buf).unwrap().expect(&format!(
+                "Should correctly decode the request {} over protocol {:?} and fork {}",
+                req, protocol, fork_name
+            ));
+            match req.clone() {
+                OutboundRequest::Status(status) => {
+                    assert_eq!(decoded, InboundRequest::Status(status))
+                }
+                OutboundRequest::Goodbye(goodbye) => {
+                    assert_eq!(decoded, InboundRequest::Goodbye(goodbye))
+                }
+                OutboundRequest::BlocksByRange(bbrange) => {
+                    assert_eq!(decoded, InboundRequest::BlocksByRange(bbrange))
+                }
+                OutboundRequest::BlocksByRoot(bbroot) => {
+                    assert_eq!(decoded, InboundRequest::BlocksByRoot(bbroot))
+                }
+                OutboundRequest::Ping(ping) => {
+                    assert_eq!(decoded, InboundRequest::Ping(ping))
+                }
+                OutboundRequest::MetaData(metadata) => {
+                    assert_eq!(decoded, InboundRequest::MetaData(metadata))
+                }
+            }
+        }
     }
 
     // Test RPCResponse encoding/decoding for V1 messages
     #[test]
     fn test_encode_then_decode_v1() {
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::Status,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::Status(status_message())),
@@ -819,7 +880,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::Ping,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::Pong(ping_message())),
@@ -829,7 +890,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
@@ -842,7 +903,7 @@ mod tests {
 
         assert!(
             matches!(
-                encode_then_decode(
+                encode_then_decode_response(
                     Protocol::BlocksByRange,
                     Version::V1,
                     RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(altair_block()))),
@@ -855,7 +916,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -868,7 +929,7 @@ mod tests {
 
         assert!(
             matches!(
-                encode_then_decode(
+                encode_then_decode_response(
                     Protocol::BlocksByRoot,
                     Version::V1,
                     RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
@@ -881,7 +942,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::MetaData,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata())),
@@ -891,7 +952,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::MetaData,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata())),
@@ -902,7 +963,7 @@ mod tests {
 
         // A MetaDataV2 still encodes as a MetaDataV1 since version is Version::V1
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::MetaData,
                 Version::V1,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata_v2())),
@@ -917,7 +978,7 @@ mod tests {
     fn test_encode_then_decode_v2() {
         assert!(
             matches!(
-                encode_then_decode(
+                encode_then_decode_response(
                     Protocol::Status,
                     Version::V2,
                     RPCCodedResponse::Success(RPCResponse::Status(status_message())),
@@ -931,7 +992,7 @@ mod tests {
 
         assert!(
             matches!(
-                encode_then_decode(
+                encode_then_decode_response(
                     Protocol::Ping,
                     Version::V2,
                     RPCCodedResponse::Success(RPCResponse::Pong(ping_message())),
@@ -944,7 +1005,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
@@ -959,7 +1020,7 @@ mod tests {
         // This is useful for checking that we allow for blocks smaller than
         // the current_fork's rpc limit
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
@@ -971,7 +1032,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(altair_block()))),
@@ -984,7 +1045,7 @@ mod tests {
         let merge_block_large = merge_block_large(&fork_context(ForkName::Merge));
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(
@@ -1003,7 +1064,7 @@ mod tests {
 
         assert!(
             matches!(
-                decode(
+                decode_response(
                     Protocol::BlocksByRange,
                     Version::V2,
                     &mut encoded,
@@ -1016,7 +1077,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -1031,7 +1092,7 @@ mod tests {
         // This is useful for checking that we allow for blocks smaller than
         // the current_fork's rpc limit
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -1043,7 +1104,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
@@ -1053,7 +1114,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::BlocksByRoot,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(
@@ -1070,7 +1131,7 @@ mod tests {
 
         assert!(
             matches!(
-                decode(
+                decode_response(
                     Protocol::BlocksByRoot,
                     Version::V2,
                     &mut encoded,
@@ -1084,7 +1145,7 @@ mod tests {
 
         // A MetaDataV1 still encodes as a MetaDataV2 since version is Version::V2
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::MetaData,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata())),
@@ -1094,7 +1155,7 @@ mod tests {
         );
 
         assert_eq!(
-            encode_then_decode(
+            encode_then_decode_response(
                 Protocol::MetaData,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata_v2())),
@@ -1110,7 +1171,7 @@ mod tests {
         let fork_context = fork_context(ForkName::Altair);
 
         // Removing context bytes for v2 messages should error
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRange,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
@@ -1121,7 +1182,7 @@ mod tests {
         let _ = encoded_bytes.split_to(4);
 
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut encoded_bytes,
@@ -1131,7 +1192,7 @@ mod tests {
             RPCError::ErrorResponse(RPCResponseErrorCode::InvalidRequest, _),
         ));
 
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -1142,7 +1203,7 @@ mod tests {
         let _ = encoded_bytes.split_to(4);
 
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut encoded_bytes,
@@ -1153,7 +1214,7 @@ mod tests {
         ));
 
         // Trying to decode a base block with altair context bytes should give ssz decoding error
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRange,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRange(Box::new(empty_base_block()))),
@@ -1167,7 +1228,7 @@ mod tests {
         wrong_fork_bytes.extend_from_slice(&encoded_bytes.split_off(4));
 
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut wrong_fork_bytes,
@@ -1178,7 +1239,7 @@ mod tests {
         ));
 
         // Trying to decode an altair block with base context bytes should give ssz decoding error
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(altair_block()))),
@@ -1191,7 +1252,7 @@ mod tests {
         wrong_fork_bytes.extend_from_slice(&encoded_bytes.split_off(4));
 
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut wrong_fork_bytes,
@@ -1205,7 +1266,7 @@ mod tests {
         let mut encoded_bytes = BytesMut::new();
         encoded_bytes.extend_from_slice(&fork_context.to_context_bytes(ForkName::Altair).unwrap());
         encoded_bytes.extend_from_slice(
-            &encode(
+            &encode_response(
                 Protocol::MetaData,
                 Version::V2,
                 RPCCodedResponse::Success(RPCResponse::MetaData(metadata())),
@@ -1214,7 +1275,7 @@ mod tests {
             .unwrap(),
         );
 
-        assert!(decode(
+        assert!(decode_response(
             Protocol::MetaData,
             Version::V2,
             &mut encoded_bytes,
@@ -1223,7 +1284,7 @@ mod tests {
         .is_err());
 
         // Sending context bytes which do not correspond to any fork should return an error
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -1236,7 +1297,7 @@ mod tests {
         wrong_fork_bytes.extend_from_slice(&encoded_bytes.split_off(4));
 
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut wrong_fork_bytes,
@@ -1247,7 +1308,7 @@ mod tests {
         ));
 
         // Sending bytes less than context bytes length should wait for more bytes by returning `Ok(None)`
-        let mut encoded_bytes = encode(
+        let mut encoded_bytes = encode_response(
             Protocol::BlocksByRoot,
             Version::V2,
             RPCCodedResponse::Success(RPCResponse::BlocksByRoot(Box::new(empty_base_block()))),
@@ -1258,7 +1319,7 @@ mod tests {
         let mut part = encoded_bytes.split_to(3);
 
         assert_eq!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut part,
@@ -1266,6 +1327,23 @@ mod tests {
             ),
             Ok(None)
         )
+    }
+
+    #[test]
+    fn test_encode_then_decode_request() {
+        let requests: &[OutboundRequest<Spec>] = &[
+            OutboundRequest::Ping(ping_message()),
+            OutboundRequest::Status(status_message()),
+            OutboundRequest::Goodbye(GoodbyeReason::Fault),
+            OutboundRequest::BlocksByRange(bbrange_request()),
+            OutboundRequest::BlocksByRoot(bbroot_request()),
+            OutboundRequest::MetaData(PhantomData::<Spec>),
+        ];
+        for req in requests.into_iter() {
+            for fork_name in ForkName::list_all() {
+                encode_then_decode_request(req.clone(), fork_name);
+            }
+        }
     }
 
     /// Test a malicious snappy encoding for a V1 `Status` message where the attacker
@@ -1319,7 +1397,7 @@ mod tests {
 
         // 10 (for stream identifier) + 80 + 42 = 132 > `max_compressed_len`. Hence, decoding should fail with `InvalidData`.
         assert!(matches!(
-            decode(Protocol::Status, Version::V1, &mut dst, ForkName::Base).unwrap_err(),
+            decode_response(Protocol::Status, Version::V1, &mut dst, ForkName::Base).unwrap_err(),
             RPCError::InvalidData(_)
         ));
     }
@@ -1376,7 +1454,7 @@ mod tests {
 
         // 10 (for stream identifier) + 176156 + 8103 = 184269 > `max_compressed_len`. Hence, decoding should fail with `InvalidData`.
         assert!(matches!(
-            decode(
+            decode_response(
                 Protocol::BlocksByRange,
                 Version::V2,
                 &mut dst,
@@ -1421,7 +1499,7 @@ mod tests {
         dst.extend_from_slice(writer.get_ref());
 
         assert!(matches!(
-            decode(Protocol::Status, Version::V1, &mut dst, ForkName::Base).unwrap_err(),
+            decode_response(Protocol::Status, Version::V1, &mut dst, ForkName::Base).unwrap_err(),
             RPCError::InvalidData(_)
         ));
     }

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -201,6 +201,16 @@ pub struct BlocksByRangeRequest {
 
     /// The number of blocks from the start slot.
     pub count: u64,
+}
+
+/// Request a number of beacon block roots from a peer.
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub struct OldBlocksByRangeRequest {
+    /// The starting slot to request blocks.
+    pub start_slot: u64,
+
+    /// The number of blocks from the start slot.
+    pub count: u64,
 
     /// The step increment to receive blocks.
     ///
@@ -410,6 +420,12 @@ impl std::fmt::Display for GoodbyeReason {
 }
 
 impl std::fmt::Display for BlocksByRangeRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Start Slot: {}, Count: {}", self.start_slot, self.count)
+    }
+}
+
+impl std::fmt::Display for OldBlocksByRangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -36,7 +36,7 @@ pub struct OutboundRequestContainer<TSpec: EthSpec> {
 pub enum OutboundRequest<TSpec: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),
-    BlocksByRange(BlocksByRangeRequest),
+    BlocksByRange(OldBlocksByRangeRequest),
     BlocksByRoot(BlocksByRootRequest),
     Ping(Ping),
     MetaData(PhantomData<TSpec>),

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -415,7 +415,7 @@ where
 pub enum InboundRequest<TSpec: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),
-    BlocksByRange(BlocksByRangeRequest),
+    BlocksByRange(OldBlocksByRangeRequest),
     BlocksByRoot(BlocksByRootRequest),
     Ping(Ping),
     MetaData(PhantomData<TSpec>),

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -279,8 +279,8 @@ impl ProtocolId {
                 <GoodbyeReason as Encode>::ssz_fixed_len(),
             ),
             Protocol::BlocksByRange => RpcLimits::new(
-                <BlocksByRangeRequest as Encode>::ssz_fixed_len(),
-                <BlocksByRangeRequest as Encode>::ssz_fixed_len(),
+                <OldBlocksByRangeRequest as Encode>::ssz_fixed_len(),
+                <OldBlocksByRangeRequest as Encode>::ssz_fixed_len(),
             ),
             Protocol::BlocksByRoot => {
                 RpcLimits::new(*BLOCKS_BY_ROOT_REQUEST_MIN, *BLOCKS_BY_ROOT_REQUEST_MAX)

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -167,7 +167,6 @@ fn test_blocks_by_range_chunked_rpc() {
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
             start_slot: 0,
             count: messages_to_send,
-            step: 0,
         });
 
         let spec = E::default_spec();
@@ -307,7 +306,6 @@ fn test_blocks_by_range_over_limit() {
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
             start_slot: 0,
             count: messages_to_send,
-            step: 0,
         });
 
         // BlocksByRange Response
@@ -405,7 +403,6 @@ fn test_blocks_by_range_chunked_rpc_terminates_correctly() {
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
             start_slot: 0,
             count: messages_to_send,
-            step: 0,
         });
 
         // BlocksByRange Response
@@ -537,7 +534,6 @@ fn test_blocks_by_range_single_empty_rpc() {
         let rpc_request = Request::BlocksByRange(BlocksByRangeRequest {
             start_slot: 0,
             count: 10,
-            step: 0,
         });
 
         // BlocksByRange Response

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -7,7 +7,7 @@ use itertools::process_results;
 use lighthouse_network::rpc::StatusMessage;
 use lighthouse_network::rpc::*;
 use lighthouse_network::{PeerId, PeerRequestId, ReportSource, Response, SyncInfo};
-use slog::{debug, error, warn};
+use slog::{debug, error};
 use slot_clock::SlotClock;
 use task_executor::TaskExecutor;
 use types::{Epoch, EthSpec, Hash256, Slot};
@@ -196,15 +196,11 @@ impl<T: BeaconChainTypes> Worker<T> {
             "peer_id" => %peer_id,
             "count" => req.count,
             "start_slot" => req.start_slot,
-            "step" => req.step);
+        );
 
         // Should not send more than max request blocks
         if req.count > MAX_REQUEST_BLOCKS {
             req.count = MAX_REQUEST_BLOCKS;
-        }
-        if req.step == 0 {
-            self.goodbye_peer(peer_id, GoodbyeReason::Fault);
-            return warn!(self.log, "Peer sent invalid range request"; "error" => "Step sent was 0");
         }
 
         let forwards_block_root_iter = match self
@@ -229,29 +225,21 @@ impl<T: BeaconChainTypes> Worker<T> {
             Err(e) => return error!(self.log, "Unable to obtain root iter"; "error" => ?e),
         };
 
-        // Pick out the required blocks, ignoring skip-slots and stepping by the step parameter.
-        //
-        // NOTE: We don't mind if req.count * req.step overflows as it just ends the iterator early and
-        // the peer will get less blocks.
-        // The step parameter is quadratically weighted in the filter, so large values should be
-        // prevented before reaching this point.
+        // Pick out the required blocks, ignoring skip-slots.
         let mut last_block_root = None;
         let maybe_block_roots = process_results(forwards_block_root_iter, |iter| {
-            iter.take_while(|(_, slot)| {
-                slot.as_u64() < req.start_slot.saturating_add(req.count * req.step)
-            })
-            // map skip slots to None
-            .map(|(root, _)| {
-                let result = if Some(root) == last_block_root {
-                    None
-                } else {
-                    Some(root)
-                };
-                last_block_root = Some(root);
-                result
-            })
-            .step_by(req.step as usize)
-            .collect::<Vec<Option<Hash256>>>()
+            iter.take_while(|(_, slot)| slot.as_u64() < req.start_slot.saturating_add(req.count))
+                // map skip slots to None
+                .map(|(root, _)| {
+                    let result = if Some(root) == last_block_root {
+                        None
+                    } else {
+                        Some(root)
+                    };
+                    last_block_root = Some(root);
+                    result
+                })
+                .collect::<Vec<Option<Hash256>>>()
         });
 
         let block_roots = match maybe_block_roots {
@@ -273,7 +261,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                             // Due to skip slots, blocks could be out of the range, we ensure they
                             // are in the range before sending
                             if block.slot() >= req.start_slot
-                                && block.slot() < req.start_slot + req.count * req.step
+                                && block.slot() < req.start_slot + req.count
                             {
                                 blocks_sent += 1;
                                 self.send_network_message(NetworkMessage::SendResponse {

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -199,7 +199,6 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
         BlocksByRangeRequest {
             start_slot: self.start_slot.into(),
             count: self.end_slot.sub(self.start_slot).into(),
-            step: 1,
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

Deprecates the step parameter in the blocks by range request

## Proposed Changes

- Modifies the BlocksByRangeRequest type to remove the step parameter and everywhere we took it into account before
- Adds a new type to still handle coding and decoding of requests that use the parameter

## Additional Info
I went with a deprecation over the type itself so that requests received outside `lighthouse_network` don't even need to deal with this parameter. After the deprecation period just removing the Old blocks by range request should be straightforward 