### PR TITLE
[Merged by Bors] - Simplify error handling after engines fallback removal

### DIFF
--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -266,7 +266,8 @@ impl Engines {
     {
         match self.first_success_without_retry(func).await {
             Ok(result) => Ok(result),
-            Err(_e) => {
+            Err(e) => {
+                debug!(self.log, "First engine call failed. Retrying"; "err" => ?e);
                 // Try to recover the node.
                 self.upcheck_not_synced(Logging::Enabled).await;
                 // Try again.

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -267,9 +267,9 @@ impl Engines {
         match self.first_success_without_retry(func).await {
             Ok(result) => Ok(result),
             Err(_e) => {
-                // Try to recover some nodes.
+                // Try to recover the node.
                 self.upcheck_not_synced(Logging::Enabled).await;
-                // Retry again.
+                // Try again.
                 self.first_success_without_retry(func).await
             }
         }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -68,7 +68,7 @@ pub enum Error {
     NoPayloadBuilder,
     ApiError(ApiError),
     Builder(builder_client::Error),
-    EngineError(EngineError),
+    EngineError(Box<EngineError>),
     NotSynced,
     ShuttingDown,
     FeeRecipientUnspecified,
@@ -745,6 +745,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     })
             })
             .await
+            .map_err(Box::new)
             .map_err(Error::EngineError)
     }
 
@@ -784,6 +785,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             .await;
 
         process_payload_status(execution_payload.block_hash, broadcast_result, self.log())
+            .map_err(Box::new)
             .map_err(Error::EngineError)
     }
 
@@ -926,6 +928,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             broadcast_result.map(|response| response.payload_status),
             self.log(),
         )
+        .map_err(Box::new)
         .map_err(Error::EngineError)
     }
 
@@ -957,10 +960,10 @@ impl<T: EthSpec> ExecutionLayer<T> {
                         "remote" => ?remote,
                         "local" => ?local,
                     );
-                    Err(Error::EngineError(EngineError::Api {
+                    Err(Error::EngineError(Box::new(EngineError::Api {
                         id: i.to_string(),
                         error: ApiError::TransitionConfigurationMismatch,
-                    }))
+                    })))
                 } else {
                     debug!(
                         self.log(),
@@ -977,7 +980,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     "error" => ?e,
                     "execution_endpoint" => i,
                 );
-                Err(Error::EngineError(e))
+                Err(Error::EngineError(Box::new(e)))
             }
         }
     }
@@ -1018,6 +1021,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     .await
             })
             .await
+            .map_err(Box::new)
             .map_err(Error::EngineError)?;
 
         if let Some(hash) = &hash_opt {
@@ -1128,6 +1132,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 Ok(None)
             })
             .await
+            .map_err(Box::new)
             .map_err(Error::EngineError)
     }
 
@@ -1186,6 +1191,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     .await
             })
             .await
+            .map_err(Box::new)
             .map_err(Error::EngineError)
     }
 

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -23,25 +23,7 @@ pub enum PayloadStatus {
     },
 }
 
-/// Processes the responses from multiple execution engines, finding the "best" status and returning
-/// it (if any).
-///
-/// This function has the following basic goals:
-///
-/// - Detect a consensus failure between nodes.
-/// - Find the most-synced node by preferring a definite response (valid/invalid) over a
-///     syncing/accepted response or error.
-///
-/// # Details
-///
-/// - If there are conflicting valid/invalid responses, always return an error.
-/// - If there are syncing/accepted responses but valid/invalid responses exist, return the
-///     valid/invalid responses since they're definite.
-/// - If there are multiple valid responses, return the first one processed.
-/// - If there are multiple invalid responses, return the first one processed.
-/// - Syncing/accepted responses are grouped, if there are multiple of them, return the first one
-///     processed.
-/// - If there are no responses (only errors or nothing), return an error.
+/// Processes the response the execution engine.
 pub fn process_payload_status(
     head_block_hash: ExecutionBlockHash,
     status: Result<PayloadStatusV1, EngineError>,
@@ -50,9 +32,9 @@ pub fn process_payload_status(
     match status {
         Err(error) => {
             warn!(
-                log,
-                "Error whilst processing payload status";
-                "error" => ?error,
+            log,
+            "Error whilst processing payload status";
+            "error" => ?error,
             );
             Err(error)
         }
@@ -66,16 +48,14 @@ pub fn process_payload_status(
                     // equal to the provided `block_hash`.
                     Ok(PayloadStatus::Valid)
                 } else {
-                    let e =EngineError::Api {
-                            error: ApiError::BadResponse(
-                                format!(
-                                    "new_payload: response.status = VALID but invalid latest_valid_hash. Expected({:?}) Found({:?})",
-                                    head_block_hash,
-                                    response.latest_valid_hash,
-                                )
-                            ),
-                        };
-                    Err(e)
+                    let error = format!(
+                        "new_payload: response.status = VALID but invalid latest_valid_hash. Expected({:?}) Found({:?})",
+                        head_block_hash,
+                        response.latest_valid_hash
+                    );
+                    Err(EngineError::Api {
+                        error: ApiError::BadResponse(error),
+                    })
                 }
             }
             PayloadStatusV1Status::Invalid => {
@@ -99,10 +79,10 @@ pub fn process_payload_status(
                 // warning here.
                 if response.latest_valid_hash.is_some() {
                     warn!(
-                        log,
-                        "Malformed response from execution engine";
-                        "msg" => "expected a null latest_valid_hash",
-                        "status" => ?response.status
+                    log,
+                    "Malformed response from execution engine";
+                    "msg" => "expected a null latest_valid_hash",
+                    "status" => ?response.status
                     )
                 }
 
@@ -115,10 +95,10 @@ pub fn process_payload_status(
                 // warning here.
                 if response.latest_valid_hash.is_some() {
                     warn!(
-                        log,
-                        "Malformed response from execution engine";
-                        "msg" => "expected a null latest_valid_hash",
-                        "status" => ?response.status
+                    log,
+                    "Malformed response from execution engine";
+                    "msg" => "expected a null latest_valid_hash",
+                    "status" => ?response.status
                     )
                 }
 
@@ -131,10 +111,10 @@ pub fn process_payload_status(
                 // warning here.
                 if response.latest_valid_hash.is_some() {
                     warn!(
-                        log,
-                        "Malformed response from execution engine";
-                        "msg" => "expected a null latest_valid_hash",
-                        "status" => ?response.status
+                    log,
+                    "Malformed response from execution engine";
+                    "msg" => "expected a null latest_valid_hash",
+                    "status" => ?response.status
                     )
                 }
 
@@ -145,10 +125,10 @@ pub fn process_payload_status(
                 // warning here.
                 if response.latest_valid_hash.is_some() {
                     warn!(
-                        log,
-                        "Malformed response from execution engine";
-                        "msg" => "expected a null latest_valid_hash",
-                        "status" => ?response.status
+                    log,
+                    "Malformed response from execution engine";
+                    "msg" => "expected a null latest_valid_hash",
+                    "status" => ?response.status
                     )
                 }
 

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -23,7 +23,7 @@ pub enum PayloadStatus {
     },
 }
 
-/// Processes the response the execution engine.
+/// Processes the response from the execution engine.
 pub fn process_payload_status(
     head_block_hash: ExecutionBlockHash,
     status: Result<PayloadStatusV1, EngineError>,

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -1,7 +1,6 @@
 use crate::engine_api::{Error as ApiError, PayloadStatusV1, PayloadStatusV1Status};
 use crate::engines::EngineError;
-use crate::Error;
-use slog::{crit, warn, Logger};
+use slog::{warn, Logger};
 use types::ExecutionBlockHash;
 
 /// Provides a simpler, easier to parse version of `PayloadStatusV1` for upstream users.
@@ -43,30 +42,31 @@ pub enum PayloadStatus {
 /// - Syncing/accepted responses are grouped, if there are multiple of them, return the first one
 ///     processed.
 /// - If there are no responses (only errors or nothing), return an error.
-pub fn process_multiple_payload_statuses(
+pub fn process_payload_status(
     head_block_hash: ExecutionBlockHash,
-    statuses: impl Iterator<Item = Result<PayloadStatusV1, EngineError>>,
+    status: Result<PayloadStatusV1, EngineError>,
     log: &Logger,
-) -> Result<PayloadStatus, Error> {
-    let mut errors = vec![];
-    let mut valid_statuses = vec![];
-    let mut invalid_statuses = vec![];
-    let mut other_statuses = vec![];
-
-    for status in statuses {
-        match status {
-            Err(e) => errors.push(e),
-            Ok(response) => match &response.status {
-                PayloadStatusV1Status::Valid => {
-                    if response
-                        .latest_valid_hash
-                        .map_or(false, |h| h == head_block_hash)
-                    {
-                        // The response is only valid if `latest_valid_hash` is not `null` and
-                        // equal to the provided `block_hash`.
-                        valid_statuses.push(PayloadStatus::Valid)
-                    } else {
-                        errors.push(EngineError::Api {
+) -> Result<PayloadStatus, EngineError> {
+    match status {
+        Err(error) => {
+            warn!(
+                log,
+                "Error whilst processing payload status";
+                "error" => ?error,
+            );
+            Err(error)
+        }
+        Ok(response) => match &response.status {
+            PayloadStatusV1Status::Valid => {
+                if response
+                    .latest_valid_hash
+                    .map_or(false, |h| h == head_block_hash)
+                {
+                    // The response is only valid if `latest_valid_hash` is not `null` and
+                    // equal to the provided `block_hash`.
+                    Ok(PayloadStatus::Valid)
+                } else {
+                    Err(EngineError::Api {
                                 id: "unknown".to_string(),
                                 error: ApiError::BadResponse(
                                     format!(
@@ -75,117 +75,86 @@ pub fn process_multiple_payload_statuses(
                                         response.latest_valid_hash,
                                     )
                                 ),
-                            });
-                    }
+                            })
                 }
-                PayloadStatusV1Status::Invalid => {
-                    if let Some(latest_valid_hash) = response.latest_valid_hash {
-                        // The response is only valid if `latest_valid_hash` is not `null`.
-                        invalid_statuses.push(PayloadStatus::Invalid {
-                            latest_valid_hash,
-                            validation_error: response.validation_error.clone(),
-                        })
-                    } else {
-                        errors.push(EngineError::Api {
-                            id: "unknown".to_string(),
-                            error: ApiError::BadResponse(
-                                "new_payload: response.status = INVALID but null latest_valid_hash"
-                                    .to_string(),
-                            ),
-                        });
-                    }
-                }
-                PayloadStatusV1Status::InvalidBlockHash => {
-                    // In the interests of being liberal with what we accept, only raise a
-                    // warning here.
-                    if response.latest_valid_hash.is_some() {
-                        warn!(
-                            log,
-                            "Malformed response from execution engine";
-                            "msg" => "expected a null latest_valid_hash",
-                            "status" => ?response.status
-                        )
-                    }
-
-                    invalid_statuses.push(PayloadStatus::InvalidBlockHash {
+            }
+            PayloadStatusV1Status::Invalid => {
+                if let Some(latest_valid_hash) = response.latest_valid_hash {
+                    // The response is only valid if `latest_valid_hash` is not `null`.
+                    Ok(PayloadStatus::Invalid {
+                        latest_valid_hash,
                         validation_error: response.validation_error.clone(),
-                    });
+                    })
+                } else {
+                    Err(EngineError::Api {
+                        id: "unknown".to_string(),
+                        error: ApiError::BadResponse(
+                            "new_payload: response.status = INVALID but null latest_valid_hash"
+                                .to_string(),
+                        ),
+                    })
                 }
-                PayloadStatusV1Status::InvalidTerminalBlock => {
-                    // In the interests of being liberal with what we accept, only raise a
-                    // warning here.
-                    if response.latest_valid_hash.is_some() {
-                        warn!(
-                            log,
-                            "Malformed response from execution engine";
-                            "msg" => "expected a null latest_valid_hash",
-                            "status" => ?response.status
-                        )
-                    }
+            }
+            PayloadStatusV1Status::InvalidBlockHash => {
+                // In the interests of being liberal with what we accept, only raise a
+                // warning here.
+                if response.latest_valid_hash.is_some() {
+                    warn!(
+                        log,
+                        "Malformed response from execution engine";
+                        "msg" => "expected a null latest_valid_hash",
+                        "status" => ?response.status
+                    )
+                }
 
-                    invalid_statuses.push(PayloadStatus::InvalidTerminalBlock {
-                        validation_error: response.validation_error.clone(),
-                    });
+                Ok(PayloadStatus::InvalidBlockHash {
+                    validation_error: response.validation_error.clone(),
+                })
+            }
+            PayloadStatusV1Status::InvalidTerminalBlock => {
+                // In the interests of being liberal with what we accept, only raise a
+                // warning here.
+                if response.latest_valid_hash.is_some() {
+                    warn!(
+                        log,
+                        "Malformed response from execution engine";
+                        "msg" => "expected a null latest_valid_hash",
+                        "status" => ?response.status
+                    )
                 }
-                PayloadStatusV1Status::Syncing => {
-                    // In the interests of being liberal with what we accept, only raise a
-                    // warning here.
-                    if response.latest_valid_hash.is_some() {
-                        warn!(
-                            log,
-                            "Malformed response from execution engine";
-                            "msg" => "expected a null latest_valid_hash",
-                            "status" => ?response.status
-                        )
-                    }
 
-                    other_statuses.push(PayloadStatus::Syncing)
+                Ok(PayloadStatus::InvalidTerminalBlock {
+                    validation_error: response.validation_error.clone(),
+                })
+            }
+            PayloadStatusV1Status::Syncing => {
+                // In the interests of being liberal with what we accept, only raise a
+                // warning here.
+                if response.latest_valid_hash.is_some() {
+                    warn!(
+                        log,
+                        "Malformed response from execution engine";
+                        "msg" => "expected a null latest_valid_hash",
+                        "status" => ?response.status
+                    )
                 }
-                PayloadStatusV1Status::Accepted => {
-                    // In the interests of being liberal with what we accept, only raise a
-                    // warning here.
-                    if response.latest_valid_hash.is_some() {
-                        warn!(
-                            log,
-                            "Malformed response from execution engine";
-                            "msg" => "expected a null latest_valid_hash",
-                            "status" => ?response.status
-                        )
-                    }
 
-                    other_statuses.push(PayloadStatus::Accepted)
+                Ok(PayloadStatus::Syncing)
+            }
+            PayloadStatusV1Status::Accepted => {
+                // In the interests of being liberal with what we accept, only raise a
+                // warning here.
+                if response.latest_valid_hash.is_some() {
+                    warn!(
+                        log,
+                        "Malformed response from execution engine";
+                        "msg" => "expected a null latest_valid_hash",
+                        "status" => ?response.status
+                    )
                 }
-            },
-        }
+
+                Ok(PayloadStatus::Accepted)
+            }
+        },
     }
-
-    if !valid_statuses.is_empty() && !invalid_statuses.is_empty() {
-        crit!(
-            log,
-            "Consensus failure between execution nodes";
-            "invalid_statuses" => ?invalid_statuses,
-            "valid_statuses" => ?valid_statuses,
-        );
-
-        // Choose to exit and ignore the valid response. This preferences correctness over
-        // liveness.
-        return Err(Error::ConsensusFailure);
-    }
-
-    // Log any errors to assist with troubleshooting.
-    for error in &errors {
-        warn!(
-            log,
-            "Error whilst processing payload status";
-            "error" => ?error,
-        );
-    }
-
-    valid_statuses
-        .first()
-        .or_else(|| invalid_statuses.first())
-        .or_else(|| other_statuses.first())
-        .cloned()
-        .map(Result::Ok)
-        .unwrap_or_else(|| Err(Error::EngineErrors(errors)))
 }

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -66,16 +66,16 @@ pub fn process_payload_status(
                     // equal to the provided `block_hash`.
                     Ok(PayloadStatus::Valid)
                 } else {
-                    Err(EngineError::Api {
-                                id: "unknown".to_string(),
-                                error: ApiError::BadResponse(
-                                    format!(
-                                        "new_payload: response.status = VALID but invalid latest_valid_hash. Expected({:?}) Found({:?})",
-                                        head_block_hash,
-                                        response.latest_valid_hash,
-                                    )
-                                ),
-                            })
+                    let e =EngineError::Api {
+                            error: ApiError::BadResponse(
+                                format!(
+                                    "new_payload: response.status = VALID but invalid latest_valid_hash. Expected({:?}) Found({:?})",
+                                    head_block_hash,
+                                    response.latest_valid_hash,
+                                )
+                            ),
+                        };
+                    Err(e)
                 }
             }
             PayloadStatusV1Status::Invalid => {
@@ -87,7 +87,6 @@ pub fn process_payload_status(
                     })
                 } else {
                     Err(EngineError::Api {
-                        id: "unknown".to_string(),
                         error: ApiError::BadResponse(
                             "new_payload: response.status = INVALID but null latest_valid_hash"
                                 .to_string(),


### PR DESCRIPTION
## Issue Addressed
Part of #3118, continuation of #3257

## Proposed Changes
- the [ `first_success_without_retry` ](https://github.com/sigp/lighthouse/blob/9c429d0764ed91cf56efb8a47a35a556b54a86a4/beacon_node/execution_layer/src/engines.rs#L348-L351) function returns a single error.
- the [`first_success`](https://github.com/sigp/lighthouse/blob/9c429d0764ed91cf56efb8a47a35a556b54a86a4/beacon_node/execution_layer/src/engines.rs#L324) function returns a single error.
- [ `EngineErrors` ](https://github.com/sigp/lighthouse/blob/9c429d0764ed91cf56efb8a47a35a556b54a86a4/beacon_node/execution_layer/src/lib.rs#L69) carries a single error.
- [`EngineError`](https://github.com/sigp/lighthouse/blob/9c429d0764ed91cf56efb8a47a35a556b54a86a4/beacon_node/execution_layer/src/engines.rs#L173-L177) now does not need to carry an Id
- [`process_multiple_payload_statuses`](https://github.com/sigp/lighthouse/blob/9c429d0764ed91cf56efb8a47a35a556b54a86a4/beacon_node/execution_layer/src/payload_status.rs#L46-L50) now doesn't need to receive an iterator of statuses and weight in different errors

## Additional Info
This is built on top of #3294 
