### PR TITLE
[Merged by Bors] - Update Cross config for v0.2.2

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,15 +1,5 @@
-[build.env]
-passthrough = [
-    "RUSTFLAGS",
-]
-
-# These custom images are required to work around the lack of Clang in the default `cross` images.
-# We need Clang to run `bindgen` for MDBX, and the `BINDGEN_EXTRA_CLANG_ARGS` flags must also be set
-# while cross-compiling for ARM to prevent bindgen from attempting to include headers from the host.
-#
-# For more information see https://github.com/rust-embedded/cross/pull/608
 [target.x86_64-unknown-linux-gnu]
-image = "michaelsproul/cross-clang:x86_64-latest"
+pre-build = ["apt-get install -y cmake clang-3.9"]
 
 [target.aarch64-unknown-linux-gnu]
-image = "michaelsproul/cross-clang:aarch64-latest"
+pre-build = ["apt-get install -y cmake clang-3.9"]


### PR DESCRIPTION
## Proposed Changes

Update `Cross.toml` for the recently released Cross v0.2.2. This allows us to remove the dependency on my fork of the Cross Docker image, which was a maintenance burden and prone to bit-rot. This PR puts us back in sync with upstream Cross.

## Additional Info

Due to some bindgen errors on the default Cross images we seemingly need a full `clang-3.9` install. The `libclang-3.9-dev` package was found to be insufficient due to `stdarg.h` being missing.

In order to continue building locally all Lighthouse devs should update their local cross version with `cargo install cross`.
