### PR TITLE
[Merged by Bors] - Fix clippy lints for rust 1.62

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1079,12 +1079,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Apply a function to the canonical head without cloning it.
-    pub fn with_head<U, E>(
-        &self,
-        f: impl FnOnce(&BeaconSnapshot<T::EthSpec>) -> Result<U, E>,
-    ) -> Result<U, E>
+    pub fn with_head<U, E, F>(&self, f: F) -> Result<U, E>
     where
         E: From<Error>,
+        F: FnOnce(&BeaconSnapshot<T::EthSpec>) -> Result<U, E>,
     {
         let head_lock = self
             .canonical_head

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1717,14 +1717,13 @@ fn verify_header_signature<T: BeaconChainTypes>(
         .get(header.message.proposer_index as usize)
         .cloned()
         .ok_or(BlockError::UnknownValidator(header.message.proposer_index))?;
-    let (fork, genesis_validators_root) = chain
-        .with_head(|head| {
+    let (fork, genesis_validators_root) =
+        chain.with_head::<_, BlockError<T::EthSpec>, _>(|head| {
             Ok((
                 head.beacon_state.fork(),
                 head.beacon_state.genesis_validators_root(),
             ))
-        })
-        .map_err(|e: BlockError<T::EthSpec>| e)?;
+        })?;
 
     if header.verify_signature::<T::EthSpec>(
         &proposer_pubkey,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -45,7 +45,7 @@ struct VerifiedUnaggregate<T: BeaconChainTypes> {
 
 /// This implementation allows `Self` to be imported to fork choice and other functions on the
 /// `BeaconChain`.
-impl<'a, T: BeaconChainTypes> VerifiedAttestation<T> for VerifiedUnaggregate<T> {
+impl<T: BeaconChainTypes> VerifiedAttestation<T> for VerifiedUnaggregate<T> {
     fn attestation(&self) -> &Attestation<T::EthSpec> {
         &self.attestation
     }
@@ -72,7 +72,7 @@ struct VerifiedAggregate<T: BeaconChainTypes> {
 
 /// This implementation allows `Self` to be imported to fork choice and other functions on the
 /// `BeaconChain`.
-impl<'a, T: BeaconChainTypes> VerifiedAttestation<T> for VerifiedAggregate<T> {
+impl<T: BeaconChainTypes> VerifiedAttestation<T> for VerifiedAggregate<T> {
     fn attestation(&self) -> &Attestation<T::EthSpec> {
         &self.signed_aggregate.message.aggregate
     }

--- a/beacon_node/network/src/subnet_service/attestation_subnets.rs
+++ b/beacon_node/network/src/subnet_service/attestation_subnets.rs
@@ -623,7 +623,7 @@ impl<T: BeaconChainTypes> Stream for AttestationService<T> {
         // process any known validator expiries
         match self.known_validators.poll_next_unpin(cx) {
             Poll::Ready(Some(Ok(_validator_index))) => {
-                let _ = self.handle_known_validator_expiry();
+                self.handle_known_validator_expiry();
             }
             Poll::Ready(Some(Err(e))) => {
                 error!(self.log, "Failed to check for random subnet cycles"; "error"=> e);

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -11,6 +11,7 @@ use slog::{info, warn, Logger};
 use std::cmp;
 use std::cmp::max;
 use std::fmt::Debug;
+use std::fmt::Write;
 use std::fs;
 use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
@@ -784,7 +785,8 @@ pub fn set_network_config(
                             None
                         })
                 {
-                    addr.push_str(&format!(":{}", enr_udp_port));
+                    write!(addr, ":{}", enr_udp_port)
+                        .map_err(|e| format!("Failed to write enr address {}", e))?;
                 } else {
                     return Err(
                         "enr-udp-port must be set for node to be discoverable with dns address"

--- a/boot_node/src/lib.rs
+++ b/boot_node/src/lib.rs
@@ -50,7 +50,7 @@ pub fn run(
 
     let logger = Logger::root(drain.fuse(), o!());
     let _scope_guard = slog_scope::set_global_logger(logger);
-    let _log_guard = slog_stdlog::init_with_level(debug_level).unwrap();
+    slog_stdlog::init_with_level(debug_level).unwrap();
 
     let log = slog_scope::logger();
     // Run the main function emitting any errors

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -105,7 +105,6 @@ impl ForkChoiceTestDefinition {
                             Hash256::zero(),
                             &spec,
                         )
-                        .map_err(|e| e)
                         .unwrap_or_else(|e| {
                             panic!("find_head op at index {} returned error {}", op_index, e)
                         });
@@ -132,7 +131,6 @@ impl ForkChoiceTestDefinition {
                             proposer_boost_root,
                             &spec,
                         )
-                        .map_err(|e| e)
                         .unwrap_or_else(|e| {
                             panic!("find_head op at index {} returned error {}", op_index, e)
                         });

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -240,7 +240,7 @@ impl ProtoArray {
                 // not exist.
                 node.weight = node
                     .weight
-                    .checked_sub(node_delta.abs() as u64)
+                    .checked_sub(node_delta.unsigned_abs())
                     .ok_or(Error::DeltaOverflow(node_index))?;
             } else {
                 node.weight = node

--- a/consensus/types/src/test_utils/macros.rs
+++ b/consensus/types/src/test_utils/macros.rs
@@ -13,8 +13,8 @@ macro_rules! ssz_tests {
     ($type: ty) => {
         #[test]
         pub fn test_ssz_round_trip() {
-            use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
             use ssz::{ssz_encode, Decode};
+            use $crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
 
             let mut rng = XorShiftRng::from_seed([42; 16]);
             let original = <$type>::random_for_test(&mut rng);
@@ -33,8 +33,8 @@ macro_rules! tree_hash_tests {
     ($type: ty) => {
         #[test]
         pub fn test_tree_hash_root() {
-            use crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
             use tree_hash::TreeHash;
+            use $crate::test_utils::{SeedableRng, TestRandom, XorShiftRng};
 
             let mut rng = XorShiftRng::from_seed([42; 16]);
             let original = <$type>::random_for_test(&mut rng);


### PR DESCRIPTION
## Issue Addressed

Fixes some new clippy lints after the last rust release
### Lints fixed for the curious:
- [cast_abs_to_unsigned](https://rust-lang.github.io/rust-clippy/master/index.html#cast_abs_to_unsigned)
- [map_identity](https://rust-lang.github.io/rust-clippy/master/index.html#map_identity) 
- [let_unit_value](https://rust-lang.github.io/rust-clippy/master/index.html#let_unit_value)
- [crate_in_macro_def](https://rust-lang.github.io/rust-clippy/master/index.html#crate_in_macro_def) 
- [extra_unused_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes)
- [format_push_string](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string)
