### PR TITLE
[Merged by Bors] - Bump the MSRV to 1.62 and using `#[derive(Default)]` on enums

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Get latest version of stable Rust
+        run: rustup update stable
+
       - name: Install ganache
         run: npm install ganache@latest --global
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.58.1-bullseye AS builder
+FROM rust:1.62.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG FEATURES

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -10,7 +10,7 @@ use types::{Graffiti, PublicKeyBytes};
 const DEFAULT_FREEZER_DB_DIR: &str = "freezer_db";
 
 /// Defines how the client should initialize the `BeaconChain` and other components.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub enum ClientGenesis {
     /// Creates a genesis state as per the 2019 Canada interop specifications.
     Interop {
@@ -21,6 +21,7 @@ pub enum ClientGenesis {
     FromStore,
     /// Connects to an eth1 node and waits until it can create the genesis state from the deposit
     /// contract.
+    #[default]
     DepositContract,
     /// Loads the genesis state from SSZ-encoded `BeaconState` bytes.
     ///
@@ -36,12 +37,6 @@ pub enum ClientGenesis {
         genesis_state_bytes: Vec<u8>,
         url: SensitiveUrl,
     },
-}
-
-impl Default for ClientGenesis {
-    fn default() -> Self {
-        Self::DepositContract
-    }
 }
 
 /// The core configuration of a Lighthouse beacon node.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -477,7 +477,7 @@ pub enum ConnectionDirection {
 }
 
 /// Connection Status of the peer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum PeerConnectionStatus {
     /// The peer is connected.
     Connected {
@@ -507,6 +507,7 @@ pub enum PeerConnectionStatus {
         since: Instant,
     },
     /// The connection status has not been specified.
+    #[default]
     Unknown,
 }
 
@@ -559,11 +560,5 @@ impl Serialize for PeerConnectionStatus {
                 s.end()
             }
         }
-    }
-}
-
-impl Default for PeerConnectionStatus {
-    fn default() -> Self {
-        PeerConnectionStatus::Unknown
     }
 }

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -78,16 +78,11 @@ impl std::fmt::Display for GossipKind {
 }
 
 /// The known encoding types for gossipsub messages.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Default)]
 pub enum GossipEncoding {
     /// Messages are encoded with SSZSnappy.
+    #[default]
     SSZSnappy,
-}
-
-impl Default for GossipEncoding {
-    fn default() -> Self {
-        GossipEncoding::SSZSnappy
-    }
 }
 
 impl GossipTopic {

--- a/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
@@ -58,9 +58,10 @@ impl Kdf {
 }
 
 /// PRF for use in `pbkdf2`.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Default)]
 pub enum Prf {
     #[serde(rename = "hmac-sha256")]
+    #[default]
     HmacSha256,
 }
 
@@ -70,12 +71,6 @@ impl Prf {
             Prf::HmacSha256 => Hmac::<Sha256>::new_from_slice(password)
                 .expect("Could not derive HMAC using SHA256."),
         }
-    }
-}
-
-impl Default for Prf {
-    fn default() -> Self {
-        Prf::HmacSha256
     }
 }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.3.2-rc.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false
-rust-version = "1.58"
+rust-version = "1.62"
 
 [features]
 # Writes debugging .ssz files to /tmp during block processing.

--- a/testing/ef_tests/src/bls_setting.rs
+++ b/testing/ef_tests/src/bls_setting.rs
@@ -2,18 +2,13 @@ use self::BlsSetting::*;
 use crate::error::Error;
 use serde_repr::Deserialize_repr;
 
-#[derive(Deserialize_repr, Debug, Clone, Copy)]
+#[derive(Deserialize_repr, Debug, Clone, Copy, Default)]
 #[repr(u8)]
 pub enum BlsSetting {
+    #[default]
     Flexible = 0,
     Required = 1,
     Ignored = 2,
-}
-
-impl Default for BlsSetting {
-    fn default() -> Self {
-        Flexible
-    }
 }
 
 impl BlsSetting {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Since Rust 1.62, we can use `#[derive(Default)]` on enums. ✨ 

https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#default-enum-variants

There are no changes to functionality in this PR, just replaced the `Default` trait implementation with `#[derive(Default)]`.


