### PR TITLE
[Merged by Bors] - eth2_hashing: make `cpufeatures` dep optional

### DIFF
--- a/crypto/eth2_hashing/Cargo.toml
+++ b/crypto/eth2_hashing/Cargo.toml
@@ -19,6 +19,6 @@ rustc-hex = "2.1.0"
 wasm-bindgen-test = "0.3.18"
 
 [features]
-default = ["zero_hash_cache", "cpufeatures"]
+default = ["zero_hash_cache", "detect-cpufeatures"]
 zero_hash_cache = ["lazy_static"]
-cpufeatures = ["dep:cpufeatures"]
+detect-cpufeatures = ["cpufeatures"]

--- a/crypto/eth2_hashing/Cargo.toml
+++ b/crypto/eth2_hashing/Cargo.toml
@@ -8,9 +8,9 @@ description = "Hashing primitives used in Ethereum 2.0"
 
 [dependencies]
 lazy_static = { version = "1.4.0", optional = true }
+cpufeatures = { version = "0.2.2", optional = true }
 ring = "0.16.19"
 sha2 = "0.10.2"
-cpufeatures = "0.2.2"
 
 [dev-dependencies]
 rustc-hex = "2.1.0"
@@ -19,5 +19,6 @@ rustc-hex = "2.1.0"
 wasm-bindgen-test = "0.3.18"
 
 [features]
-default = ["zero_hash_cache"]
+default = ["zero_hash_cache", "cpufeatures"]
 zero_hash_cache = ["lazy_static"]
+cpufeatures = ["dep:cpufeatures"]

--- a/crypto/eth2_hashing/src/lib.rs
+++ b/crypto/eth2_hashing/src/lib.rs
@@ -135,7 +135,8 @@ pub fn have_sha_extensions() -> bool {
     #[cfg(all(feature = "detect-cpufeatures", target_arch = "x86_64"))]
     return x86_sha_extensions::get();
 
-    false
+    #[cfg(not(all(feature = "detect-cpufeatures", target_arch = "x86_64")))]
+    return false;
 }
 
 impl DynamicImpl {

--- a/crypto/eth2_hashing/src/lib.rs
+++ b/crypto/eth2_hashing/src/lib.rs
@@ -127,16 +127,15 @@ pub enum DynamicImpl {
 // Runtime latch for detecting the availability of SHA extensions on x86_64.
 //
 // Inspired by the runtime switch within the `sha2` crate itself.
-#[cfg(all(feature = "cpufeatures", target_arch = "x86_64"))]
+#[cfg(all(feature = "detect-cpufeatures", target_arch = "x86_64"))]
 cpufeatures::new!(x86_sha_extensions, "sha", "sse2", "ssse3", "sse4.1");
 
 #[inline(always)]
 pub fn have_sha_extensions() -> bool {
-    #[cfg(all(feature = "cpufeatures", target_arch = "x86_64"))]
+    #[cfg(all(feature = "detect-cpufeatures", target_arch = "x86_64"))]
     return x86_sha_extensions::get();
 
-    #[cfg(not(target_arch = "x86_64"))]
-    return false;
+    false
 }
 
 impl DynamicImpl {

--- a/crypto/eth2_hashing/src/lib.rs
+++ b/crypto/eth2_hashing/src/lib.rs
@@ -127,12 +127,12 @@ pub enum DynamicImpl {
 // Runtime latch for detecting the availability of SHA extensions on x86_64.
 //
 // Inspired by the runtime switch within the `sha2` crate itself.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(feature = "cpufeatures", target_arch = "x86_64"))]
 cpufeatures::new!(x86_sha_extensions, "sha", "sse2", "ssse3", "sse4.1");
 
 #[inline(always)]
 pub fn have_sha_extensions() -> bool {
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(feature = "cpufeatures", target_arch = "x86_64"))]
     return x86_sha_extensions::get();
 
     #[cfg(not(target_arch = "x86_64"))]


### PR DESCRIPTION
## Issue Addressed

#3308 

## Proposed Changes

* add `cpufeatures` feature.
* make `cpufeature` default feature to preserve the compatibility;
* hide all `cpufeature`-related code with `cpufeatures` feature.