### PR TITLE
[Merged by Bors] - Document min CMake version

### DIFF
--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -19,6 +19,10 @@ Install the following packages:
 sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
 ```
 
+> Note: Lighthouse requires CMake v3.12 or newer, which isn't available in the package repositories
+> of Ubuntu 18.04 or earlier. On these distributions CMake can still be installed via PPA:
+> [https://apt.kitware.com/](https://apt.kitware.com)
+
 #### macOS
 
 1. Install the [Homebrew][] package manager.


### PR DESCRIPTION
## Proposed Changes

Add a tip about the minimum CMake version to make it more obvious what it takes to compile on Ubuntu 18.04.
