### PR TITLE
[Merged by Bors] - Add Merge support to web3signer validators

### DIFF
--- a/validator_client/src/signing_method/web3signer.rs
+++ b/validator_client/src/signing_method/web3signer.rs
@@ -25,6 +25,7 @@ pub enum MessageType {
 pub enum ForkName {
     Phase0,
     Altair,
+    Bellatrix,
 }
 
 #[derive(Debug, PartialEq, Serialize)]
@@ -43,7 +44,10 @@ pub enum Web3SignerObject<'a, T: EthSpec, Payload: ExecPayload<T>> {
     Attestation(&'a AttestationData),
     BeaconBlock {
         version: ForkName,
-        block: &'a BeaconBlock<T, Payload>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        block: Option<&'a BeaconBlock<T, Payload>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        block_header: Option<BeaconBlockHeader>,
     },
     #[allow(dead_code)]
     Deposit {
@@ -70,13 +74,23 @@ pub enum Web3SignerObject<'a, T: EthSpec, Payload: ExecPayload<T>> {
 
 impl<'a, T: EthSpec, Payload: ExecPayload<T>> Web3SignerObject<'a, T, Payload> {
     pub fn beacon_block(block: &'a BeaconBlock<T, Payload>) -> Result<Self, Error> {
-        let version = match block {
-            BeaconBlock::Base(_) => ForkName::Phase0,
-            BeaconBlock::Altair(_) => ForkName::Altair,
-            BeaconBlock::Merge(_) => return Err(Error::MergeForkNotSupported),
-        };
-
-        Ok(Web3SignerObject::BeaconBlock { version, block })
+        match block {
+            BeaconBlock::Base(_) => Ok(Web3SignerObject::BeaconBlock {
+                version: ForkName::Phase0,
+                block: Some(block),
+                block_header: None,
+            }),
+            BeaconBlock::Altair(_) => Ok(Web3SignerObject::BeaconBlock {
+                version: ForkName::Altair,
+                block: Some(block),
+                block_header: None,
+            }),
+            BeaconBlock::Merge(_) => Ok(Web3SignerObject::BeaconBlock {
+                version: ForkName::Bellatrix,
+                block: None,
+                block_header: Some(block.block_header()),
+            }),
+        }
     }
 
     pub fn message_type(&self) -> MessageType {


### PR DESCRIPTION
## Issue Addressed

Web3signer validators can't produce post-Bellatrix blocks.

## Proposed Changes

Add support for Bellatrix to web3signer validators.

## Additional Info

I am running validators with this code on Ropsten, but it may be a while for them to get a proposal.
