### PR TITLE
[Merged by Bors] - Add a u256_hex_be module to encode/decode U256 types 

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -78,6 +78,7 @@ pub struct JsonExecutionPayloadHeaderV1<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: ExecutionBlockHash,
     pub transactions_root: Hash256,
@@ -142,6 +143,7 @@ pub struct JsonExecutionPayloadV1<T: EthSpec> {
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: ExecutionBlockHash,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -488,6 +488,7 @@ impl From<ProposeBlindedBlockResponseStatus> for JsonProposeBlindedBlockResponse
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransitionConfigurationV1 {
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub terminal_total_difficulty: Uint256,
     pub terminal_block_hash: ExecutionBlockHash,
     #[serde(with = "eth2_serde_utils::u64_hex_be")]

--- a/consensus/serde_utils/src/lib.rs
+++ b/consensus/serde_utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod list_of_bytes_lists;
 pub mod quoted_u64_vec;
 pub mod u32_hex;
 pub mod u64_hex_be;
+pub mod u256_hex_be;
 pub mod u8_hex;
 
 pub use fixed_bytes_hex::{bytes_4_hex, bytes_8_hex};

--- a/consensus/serde_utils/src/lib.rs
+++ b/consensus/serde_utils/src/lib.rs
@@ -6,9 +6,9 @@ pub mod hex_vec;
 pub mod json_str;
 pub mod list_of_bytes_lists;
 pub mod quoted_u64_vec;
+pub mod u256_hex_be;
 pub mod u32_hex;
 pub mod u64_hex_be;
-pub mod u256_hex_be;
 pub mod u8_hex;
 
 pub use fixed_bytes_hex::{bytes_4_hex, bytes_8_hex};

--- a/consensus/serde_utils/src/u256_hex_be.rs
+++ b/consensus/serde_utils/src/u256_hex_be.rs
@@ -1,0 +1,115 @@
+use ethereum_types::U256;
+
+use crate::u64_hex_be::QuantityVisitor;
+use serde::de::Error;
+use serde::{Deserializer, Serializer};
+
+const BYTES_LEN: usize = 32;
+
+pub fn serialize<S>(num: &U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut bytes = [0; BYTES_LEN];
+    num.to_big_endian(&mut bytes);
+    let raw = hex::encode(bytes);
+    let trimmed = raw.trim_start_matches('0');
+
+    let hex = if trimmed.is_empty() { "0" } else { trimmed };
+
+    serializer.serialize_str(&format!("0x{}", &hex))
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded = deserializer.deserialize_str(QuantityVisitor)?;
+
+    // TODO: this is not strict about byte length like other methods.
+    if decoded.len() > BYTES_LEN {
+        return Err(D::Error::custom(format!(
+            "expected max {} bytes for array, got {}",
+            BYTES_LEN,
+            decoded.len()
+        )));
+    }
+
+    let mut array = [0; BYTES_LEN];
+    array[BYTES_LEN - decoded.len()..].copy_from_slice(&decoded);
+    Ok(U256::from_big_endian(&array))
+}
+
+#[cfg(test)]
+mod test {
+    use ethereum_types::U256;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct Wrapper {
+        #[serde(with = "super")]
+        val: U256,
+    }
+
+    #[test]
+    fn encoding() {
+        assert_eq!(
+            &serde_json::to_string(&Wrapper { val: 0.into() }).unwrap(),
+            "\"0x0\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper { val: 1.into() }).unwrap(),
+            "\"0x1\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper { val: 256.into() }).unwrap(),
+            "\"0x100\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper { val: 65.into() }).unwrap(),
+            "\"0x41\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper { val: 1024.into() }).unwrap(),
+            "\"0x400\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: U256::max_value()
+            })
+            .unwrap(),
+            "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+        );
+    }
+
+    #[test]
+    fn decoding() {
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x0\"").unwrap(),
+            Wrapper { val: 0.into() },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x41\"").unwrap(),
+            Wrapper { val: 65.into() },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x400\"").unwrap(),
+            Wrapper { val: 1024.into() },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>(
+                "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+            )
+            .unwrap(),
+            Wrapper {
+                val: U256::max_value()
+            },
+        );
+        serde_json::from_str::<Wrapper>("\"0x\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"0x0400\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"400\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"ff\"").unwrap_err();
+    }
+}

--- a/consensus/serde_utils/src/u256_hex_be.rs
+++ b/consensus/serde_utils/src/u256_hex_be.rs
@@ -90,6 +90,13 @@ mod test {
         );
         assert_eq!(
             &serde_json::to_string(&Wrapper {
+                val: U256::max_value() - 1
+            })
+            .unwrap(),
+            "\"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
                 val: U256::max_value()
             })
             .unwrap(),
@@ -110,6 +117,15 @@ mod test {
         assert_eq!(
             serde_json::from_str::<Wrapper>("\"0x400\"").unwrap(),
             Wrapper { val: 1024.into() },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>(
+                "\"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe\""
+            )
+            .unwrap(),
+            Wrapper {
+                val: U256::max_value() - 1
+            },
         );
         assert_eq!(
             serde_json::from_str::<Wrapper>(

--- a/consensus/serde_utils/src/u256_hex_be.rs
+++ b/consensus/serde_utils/src/u256_hex_be.rs
@@ -28,18 +28,18 @@ impl<'de> Visitor<'de> for U256Visitor {
         if !value.starts_with("0x") {
             return Err(de::Error::custom("must start with 0x"));
         }
-        let stripped = value.trim_start_matches("0x");
+        let stripped = &value[2..];
         if stripped.is_empty() {
             Err(de::Error::custom(format!(
                 "quantity cannot be {}",
                 stripped
             )))
         } else if stripped == "0" {
-            Ok(stripped.to_string())
+            Ok(value.to_string())
         } else if stripped.starts_with('0') {
             Err(de::Error::custom("cannot have leading zero"))
         } else {
-            Ok(format!("0x{}", stripped))
+            Ok(value.to_string())
         }
     }
 }

--- a/consensus/serde_utils/src/u256_hex_be.rs
+++ b/consensus/serde_utils/src/u256_hex_be.rs
@@ -31,7 +31,7 @@ impl<'de> Visitor<'de> for U256Visitor {
         let stripped = &value[2..];
         if stripped.is_empty() {
             Err(de::Error::custom(format!(
-                "quantity cannot be {}",
+                "quantity cannot be {:?}",
                 stripped
             )))
         } else if stripped == "0" {


### PR DESCRIPTION
## Issue Addressed

Resolves #3314 

## Proposed Changes

Add a module to encode/decode u256 types according to the execution layer encoding/decoding standards
https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#structures

Updates `JsonExecutionPayloadV1.base_fee_per_gas`, `JsonExecutionPayloadHeaderV1.base_fee_per_gas`  and `TransitionConfigurationV1.terminal_total_difficulty` to encode/decode according to standards