### PR TITLE
[Merged by Bors] - Further remove EE redundancy

### DIFF
--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -1003,6 +1003,11 @@ async fn payload_preparation_before_transition_block() {
     let rig = InvalidPayloadRig::new();
     let el = rig.execution_layer();
 
+    // Run the watchdog routine so that the status of the execution engine is set. This ensures
+    // that we don't end up with `eth_syncing` requests later in this function that will impede
+    // testing.
+    el.watchdog_task().await;
+
     let head = rig.harness.chain.head_snapshot();
     assert_eq!(
         head.beacon_block

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -230,6 +230,11 @@ impl Engine {
     }
 
     /// Run `func` on the node regardless of the node's current state.
+    ///
+    /// ## Note
+    ///
+    /// This function takes locks on `self.state`, holding a conflicting lock might cause a
+    /// deadlock.
     pub async fn request<'a, F, G, H>(self: &'a Arc<Self>, func: F) -> Result<H, EngineError>
     where
         F: Fn(&'a Engine) -> G,

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -171,7 +171,7 @@ impl Engine {
     /// Run the `EngineApi::upcheck` function if the node's last known state is not synced. This
     /// might be used to recover the node if offline.
     pub async fn upcheck(&self) {
-        let state = match self.api.upcheck().await {
+        let state: EngineState = match self.api.upcheck().await {
             Ok(()) => {
                 let mut state = self.state.write().await;
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -147,7 +147,7 @@ pub struct ExecutionLayer<T: EthSpec> {
 }
 
 impl<T: EthSpec> ExecutionLayer<T> {
-    /// Instantiate `Self` with a Execution engine specified using `Config`, all using the JSON-RPC via HTTP.
+    /// Instantiate `Self` with an Execution engine specified in `Config`, using JSON-RPC via HTTP.
     pub fn from_config(config: Config, executor: TaskExecutor, log: Logger) -> Result<Self, Error> {
         let Config {
             execution_endpoints: urls,
@@ -357,7 +357,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
         self.spawn(routine, "exec_config_poll");
     }
 
-    /// Returns `true` if there is at least one synced and reachable engine.
+    /// Returns `true` if the execution engine is synced and reachable.
     pub async fn is_synced(&self) -> bool {
         self.engine().is_synced().await
     }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -132,15 +132,8 @@ pub struct Config {
     pub default_datadir: PathBuf,
 }
 
-/// Provides access to one execution engine and provides a neat interface for consumption
-/// by the `BeaconChain`.
-///
-/// When there is more than one execution node specified, the others will be used in a "fallback"
-/// fashion. Some requests may be broadcast to all nodes and others might only be sent to the first
-/// node that returns a valid response. Ultimately, the purpose of fallback nodes is to provide
-/// redundancy in the case where one node is offline.
-///
-/// The fallback nodes have an ordering. The first supplied will be the first contacted, and so on.
+/// Provides access to one execution engine and provides a neat interface for consumption by the
+/// `BeaconChain`.
 #[derive(Clone)]
 pub struct ExecutionLayer<T: EthSpec> {
     inner: Arc<Inner<T>>,


### PR DESCRIPTION
## Issue Addressed

Resolves #3176

## Proposed Changes

Continues from PRs by @divagant-martian to gradually remove EL redundancy (see #3284, #3257).

This PR achieves:

- Removes the `broadcast` and `first_success` methods. The functional impact is that every request to the EE will always be tried immediately, regardless of the cached `EngineState` (this resolves #3176). Previously we would check the engine state before issuing requests, this doesn't make sense in a single-EE world; there's only one EE so we might as well try it for every request.
- Runs the upcheck/watchdog routine once per slot rather than thrice. When we had multiple EEs frequent polling was useful to try and detect when the primary EE had come back online and we could switch to it. That's not as relevant now.
- Always creates logs in the `Engines::upcheck` function. Previously we would mute some logs since they could get really noisy when one EE was down but others were functioning fine. Now we only have one EE and are upcheck-ing it less, it makes sense to always produce logs.

This PR purposefully does not achieve:

- Updating all occurances of "engines" to "engine". I'm trying to keep the diff small and manageable. We can come back for this.

## Additional Info

NA
