### PR TITLE
[Merged by Bors] - Add `--release` to disallowed-from-async lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,9 @@ lint:
 		-A clippy::upper-case-acronyms \
 		-A clippy::vec-init-then-push
 
-# FIXME: fails if --release is added due to broken HTTP API tests
 nightly-lint:
 	cp .github/custom/clippy.toml .
-	cargo +$(CLIPPY_PINNED_NIGHTLY) clippy --workspace --tests -- \
+	cargo +$(CLIPPY_PINNED_NIGHTLY) clippy --workspace --tests --release -- \
 		-A clippy::all \
 		-D clippy::disallowed_from_async
 	rm clippy.toml


### PR DESCRIPTION
## Issue Addressed

- #3251

## Proposed Changes

Adds the release tag to the `disallowed_from_async` lint.

## Additional Info

~~I haven't run this locally yet due to (minor) complexity of running the lint, I'm seeing if it will work via Github.~~
