### PR TITLE
[Merged by Bors] - Don't create a execution payload with same timestamp as terminal block

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3908,14 +3908,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 ForkName::Base | ForkName::Altair => return Ok(()),
                 _ => {
                     // We are post-bellatrix
-                    if execution_layer
+                    if let Some(payload_attributes) = execution_layer
                         .payload_attributes(next_slot, params.head_root)
                         .await
-                        .is_some()
                     {
                         // We are a proposer, check for terminal_pow_block_hash
                         if let Some(terminal_pow_block_hash) = execution_layer
-                            .get_terminal_pow_block_hash(&self.spec)
+                            .get_terminal_pow_block_hash(&self.spec, payload_attributes.timestamp)
                             .await
                             .map_err(Error::ForkchoiceUpdate)?
                         {

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -393,7 +393,7 @@ where
         }
 
         let terminal_pow_block_hash = execution_layer
-            .get_terminal_pow_block_hash(spec)
+            .get_terminal_pow_block_hash(spec, timestamp)
             .await
             .map_err(BlockProductionError::TerminalPoWBlockLookupFailed)?;
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -28,6 +28,7 @@ use rayon::prelude::*;
 use sensitive_url::SensitiveUrl;
 use slog::Logger;
 use slot_clock::TestingSlotClock;
+use state_processing::per_block_processing::compute_timestamp_at_slot;
 use state_processing::{
     state_advance::{complete_state_advance, partial_state_advance},
     StateRootStrategy,
@@ -516,6 +517,11 @@ where
 
     pub fn get_current_state(&self) -> BeaconState<E> {
         self.chain.head_beacon_state_cloned()
+    }
+
+    pub fn get_timestamp_at_slot(&self) -> u64 {
+        let state = self.get_current_state();
+        compute_timestamp_at_slot(&state, &self.spec).unwrap()
     }
 
     pub fn get_current_state_and_root(&self) -> (BeaconState<E>, Hash256) {

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -106,6 +106,8 @@ pub struct ExecutionBlock {
     pub block_number: u64,
     pub parent_hash: ExecutionBlockHash,
     pub total_difficulty: Uint256,
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
+    pub timestamp: u64,
 }
 
 /// Representation of an exection block with enough detail to reconstruct a payload.

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -235,7 +235,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     }
 
     /// Note: this function returns a mutex guard, be careful to avoid deadlocks.
-    async fn execution_blocks(
+    pub async fn execution_blocks(
         &self,
     ) -> MutexGuard<'_, LruCache<ExecutionBlockHash, ExecutionBlock>> {
         self.inner.execution_blocks.lock().await
@@ -902,6 +902,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     pub async fn get_terminal_pow_block_hash(
         &self,
         spec: &ChainSpec,
+        timestamp: u64,
     ) -> Result<Option<ExecutionBlockHash>, Error> {
         let _timer = metrics::start_timer_vec(
             &metrics::EXECUTION_LAYER_REQUEST_TIMES,
@@ -924,8 +925,15 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     }
                 }
 
-                self.get_pow_block_hash_at_total_difficulty(engine, spec)
-                    .await
+                let block = self
+                    .get_pow_block_hash_at_total_difficulty(engine, spec)
+                    .await?;
+                if let Some(pow_block) = block {
+                    if pow_block.timestamp >= timestamp {
+                        return Ok(None);
+                    }
+                }
+                Ok(block.map(|b| b.block_hash))
             })
             .await
             .map_err(Box::new)
@@ -957,7 +965,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
         &self,
         engine: &Engine,
         spec: &ChainSpec,
-    ) -> Result<Option<ExecutionBlockHash>, ApiError> {
+    ) -> Result<Option<ExecutionBlock>, ApiError> {
         let mut block = engine
             .api
             .get_block_by_number(BlockByNumberQuery::Tag(LATEST_TAG))
@@ -970,7 +978,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             let block_reached_ttd = block.total_difficulty >= spec.terminal_total_difficulty;
             if block_reached_ttd {
                 if block.parent_hash == ExecutionBlockHash::zero() {
-                    return Ok(Some(block.block_hash));
+                    return Ok(Some(block));
                 }
                 let parent = self
                     .get_pow_block(engine, block.parent_hash)
@@ -979,7 +987,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 let parent_reached_ttd = parent.total_difficulty >= spec.terminal_total_difficulty;
 
                 if block_reached_ttd && !parent_reached_ttd {
-                    return Ok(Some(block.block_hash));
+                    return Ok(Some(block));
                 } else {
                     block = parent;
                 }
@@ -1197,14 +1205,49 @@ mod test {
             .move_to_block_prior_to_terminal_block()
             .with_terminal_block(|spec, el, _| async move {
                 el.engine().upcheck().await;
-                assert_eq!(el.get_terminal_pow_block_hash(&spec).await.unwrap(), None)
+                assert_eq!(
+                    el.get_terminal_pow_block_hash(&spec, timestamp_now())
+                        .await
+                        .unwrap(),
+                    None
+                )
             })
             .await
             .move_to_terminal_block()
             .with_terminal_block(|spec, el, terminal_block| async move {
                 assert_eq!(
-                    el.get_terminal_pow_block_hash(&spec).await.unwrap(),
+                    el.get_terminal_pow_block_hash(&spec, timestamp_now())
+                        .await
+                        .unwrap(),
                     Some(terminal_block.unwrap().block_hash)
+                )
+            })
+            .await;
+    }
+
+    #[tokio::test]
+    async fn rejects_terminal_block_with_equal_timestamp() {
+        let runtime = TestRuntime::default();
+        MockExecutionLayer::default_params(runtime.task_executor.clone())
+            .move_to_block_prior_to_terminal_block()
+            .with_terminal_block(|spec, el, _| async move {
+                el.engine().upcheck().await;
+                assert_eq!(
+                    el.get_terminal_pow_block_hash(&spec, timestamp_now())
+                        .await
+                        .unwrap(),
+                    None
+                )
+            })
+            .await
+            .move_to_terminal_block()
+            .with_terminal_block(|spec, el, terminal_block| async move {
+                let timestamp = terminal_block.as_ref().map(|b| b.timestamp).unwrap();
+                assert_eq!(
+                    el.get_terminal_pow_block_hash(&spec, timestamp)
+                        .await
+                        .unwrap(),
+                    None
                 )
             })
             .await;
@@ -1268,4 +1311,12 @@ mod test {
 
 fn noop<T: EthSpec>(_: &ExecutionLayer<T>, _: &ExecutionPayload<T>) -> Option<ExecutionPayload<T>> {
     None
+}
+
+/// Returns the duration since the unix epoch.
+pub fn timestamp_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_secs()
 }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -929,6 +929,12 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     .get_pow_block_hash_at_total_difficulty(engine, spec)
                     .await?;
                 if let Some(pow_block) = block {
+                    // If `terminal_block.timestamp == transition_block.timestamp`,
+                    // we violate the invariant that a block's timestamp must be
+                    // strictly greater than its parent's timestamp.
+                    // The execution layer will reject a fcu call with such payload
+                    // attributes leading to a missed block.
+                    // Hence, we return `None` in such a case.
                     if pow_block.timestamp >= timestamp {
                         return Ok(None);
                     }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -925,9 +925,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     }
                 }
 
-                let block = self
-                    .get_pow_block_hash_at_total_difficulty(engine, spec)
-                    .await?;
+                let block = self.get_pow_block_at_total_difficulty(engine, spec).await?;
                 if let Some(pow_block) = block {
                     // If `terminal_block.timestamp == transition_block.timestamp`,
                     // we violate the invariant that a block's timestamp must be
@@ -967,7 +965,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     /// `get_pow_block_at_terminal_total_difficulty`
     ///
     /// https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/validator.md
-    async fn get_pow_block_hash_at_total_difficulty(
+    async fn get_pow_block_at_total_difficulty(
         &self,
         engine: &Engine,
         spec: &ChainSpec,
@@ -1319,8 +1317,9 @@ fn noop<T: EthSpec>(_: &ExecutionLayer<T>, _: &ExecutionPayload<T>) -> Option<Ex
     None
 }
 
+#[cfg(test)]
 /// Returns the duration since the unix epoch.
-pub fn timestamp_now() -> u64 {
+fn timestamp_now() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_else(|_| Duration::from_secs(0))

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -235,7 +235,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     }
 
     /// Note: this function returns a mutex guard, be careful to avoid deadlocks.
-    pub async fn execution_blocks(
+    async fn execution_blocks(
         &self,
     ) -> MutexGuard<'_, LruCache<ExecutionBlockHash, ExecutionBlock>> {
         self.inner.execution_blocks.lock().await

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -57,12 +57,14 @@ impl<T: EthSpec> Block<T> {
                 block_number: block.block_number,
                 parent_hash: block.parent_hash,
                 total_difficulty: block.total_difficulty,
+                timestamp: block.timestamp,
             },
             Block::PoS(payload) => ExecutionBlock {
                 block_hash: payload.block_hash,
                 block_number: payload.block_number,
                 parent_hash: payload.parent_hash,
                 total_difficulty,
+                timestamp: payload.timestamp,
             },
         }
     }
@@ -75,6 +77,7 @@ pub struct PoWBlock {
     pub block_hash: ExecutionBlockHash,
     pub parent_hash: ExecutionBlockHash,
     pub total_difficulty: Uint256,
+    pub timestamp: u64,
 }
 
 pub struct ExecutionBlockGenerator<T: EthSpec> {
@@ -231,6 +234,26 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
         self.blocks.insert(block.block_hash(), block);
 
         Ok(())
+    }
+
+    pub fn modify_last_block(&mut self, block_modifier: impl FnOnce(&mut Block<T>)) {
+        if let Some((last_block_hash, block_number)) =
+            self.block_hashes.keys().max().and_then(|block_number| {
+                self.block_hashes
+                    .get(block_number)
+                    .map(|block| (block, *block_number))
+            })
+        {
+            let mut block = self.blocks.remove(last_block_hash).unwrap();
+            block_modifier(&mut block);
+            // Update the block hash after modifying the block
+            match &mut block {
+                Block::PoW(b) => b.block_hash = ExecutionBlockHash::from_root(b.tree_hash_root()),
+                Block::PoS(b) => b.block_hash = ExecutionBlockHash::from_root(b.tree_hash_root()),
+            }
+            self.block_hashes.insert(block_number, block.block_hash());
+            self.blocks.insert(block.block_hash(), block);
+        }
     }
 
     pub fn get_payload(&mut self, id: &PayloadId) -> Option<ExecutionPayload<T>> {
@@ -390,6 +413,7 @@ pub fn generate_pow_block(
         block_hash: ExecutionBlockHash::zero(),
         parent_hash,
         total_difficulty,
+        timestamp: block_number,
     };
 
     block.block_hash = ExecutionBlockHash::from_root(block.tree_hash_root());

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -6,7 +6,7 @@ use crate::engine_api::{
 };
 use bytes::Bytes;
 use environment::null_logger;
-use execution_block_generator::{Block, PoWBlock};
+use execution_block_generator::PoWBlock;
 use handle_rpc::handle_rpc;
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
@@ -21,7 +21,7 @@ use tokio::{runtime, sync::oneshot};
 use types::{EthSpec, ExecutionBlockHash, Uint256};
 use warp::{http::StatusCode, Filter, Rejection};
 
-pub use execution_block_generator::{generate_pow_block, ExecutionBlockGenerator};
+pub use execution_block_generator::{generate_pow_block, Block, ExecutionBlockGenerator};
 pub use mock_execution_layer::MockExecutionLayer;
 
 pub const DEFAULT_TERMINAL_DIFFICULTY: u64 = 6400;
@@ -290,6 +290,7 @@ impl<T: EthSpec> MockServer<T> {
             block_hash,
             parent_hash,
             total_difficulty,
+            timestamp: block_number,
         });
 
         self.ctx

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -142,7 +142,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let terminal_pow_block_hash = self
             .ee_a
             .execution_layer
-            .get_terminal_pow_block_hash(&self.spec)
+            .get_terminal_pow_block_hash(&self.spec, timestamp_now())
             .await
             .unwrap()
             .unwrap();
@@ -151,7 +151,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             terminal_pow_block_hash,
             self.ee_b
                 .execution_layer
-                .get_terminal_pow_block_hash(&self.spec)
+                .get_terminal_pow_block_hash(&self.spec, timestamp_now())
                 .await
                 .unwrap()
                 .unwrap()


### PR DESCRIPTION
## Issue Addressed

Resolves #3316 

## Proposed Changes

This PR fixes an issue where lighthouse created a transition block with `block.execution_payload().timestamp == terminal_block.timestamp` if the terminal block was created at the slot boundary.
