### PR TITLE
[builder API] Add/update relay timeouts

### DIFF
--- a/beacon_node/builder_client/src/lib.rs
+++ b/beacon_node/builder_client/src/lib.rs
@@ -12,17 +12,26 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::time::Duration;
 
-pub const DEFAULT_GET_HEADER_TIMEOUT_MILLIS: u64 = 500;
+pub const DEFAULT_TIMEOUT_MILLIS: u64 = 15000;
+
+/// This timeout is in accordance with v0.2.0 of the [builder specs](https://github.com/flashbots/mev-boost/pull/20).
+pub const DEFAULT_GET_HEADER_TIMEOUT_MILLIS: u64 = 1000;
 
 #[derive(Clone)]
 pub struct Timeouts {
     get_header: Duration,
+    post_validators: Duration,
+    post_blinded_blocks: Duration,
+    get_builder_status: Duration,
 }
 
 impl Default for Timeouts {
     fn default() -> Self {
         Self {
             get_header: Duration::from_millis(DEFAULT_GET_HEADER_TIMEOUT_MILLIS),
+            post_validators: Duration::from_millis(DEFAULT_TIMEOUT_MILLIS),
+            post_blinded_blocks: Duration::from_millis(DEFAULT_TIMEOUT_MILLIS),
+            get_builder_status: Duration::from_millis(DEFAULT_TIMEOUT_MILLIS),
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed

#3319

## Proposed Changes

Add the Builder Spec v0.2.0's suggested timeout, and set timouts for all other requests. Set to 15 seconds for now. Interested to see how this works with a large number of validators. We may need to consider batching validator registrations if there are issues (I think Prysm has run into trouble with the performance of this endpoint and lots of validators). 

Blocked on #3134 