### PR TITLE
[Merged by Bors] - Upstream local testnet improvements

### DIFF
--- a/scripts/local_testnet/kill_processes.sh
+++ b/scripts/local_testnet/kill_processes.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Kill processes
 
-set -Eeuo pipefail
+set -Euo pipefail
 
 # First parameter is the file with
 # one pid per line.

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -5,6 +5,9 @@ set -Eeuo pipefail
 
 source ./vars.env
 
+# Set a higher ulimit in case we want to import 1000s of validators.
+ulimit -n 65536
+
 # VC_COUNT is defaulted in vars.env
 DEBUG_LEVEL=${DEBUG_LEVEL:-info}
 


### PR DESCRIPTION
## Proposed Changes

Adds some improvements I found when playing around with local testnets in #3335:
- When trying to kill processes, do not exit on a failure. (If a node fails to start due to a bug, the PID associated with it no longer exists. When trying to tear down the testnets, an error will be raised when it tries that PID and then will not try any PIDs following it. This change means it will continue and tear down the rest of the network.
- When starting the testnet, set `ulimit` to a high number. This allows the VCs to import 1000s of validators without running into limitations.