### PR TITLE
[builder API] Make gas limit configurable, and add per-validator builderAPI usage

### DIFF
--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -280,6 +280,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             password_opt,
             graffiti,
             suggested_fee_recipient,
+            None,
         )
         .map_err(|e| format!("Unable to create new validator definition: {:?}", e))?;
 

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -281,6 +281,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
             graffiti,
             suggested_fee_recipient,
             None,
+            None,
         )
         .map_err(|e| format!("Unable to create new validator definition: {:?}", e))?;
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -594,7 +594,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
 
                             let header = relay.data.message.header;
                             if header.fee_recipient() != suggested_fee_recipient {
-                                warn!(self.log(), "Incorrect fee recipient from connected builder, falling back to local execution engine.");
+                                info!(self.log(), "Fee recipient from connected builder does not match, using it anyways.");
                                 Ok(local)
                             } else if header.parent_hash() != parent_hash {
                                 warn!(self.log(), "Invalid parent hash from connected builder, falling back to local execution engine.");

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -106,6 +106,9 @@ pub struct ValidatorDefinition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_recipient: Option<Address>,
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<u64>,
+    #[serde(default)]
     pub description: String,
     #[serde(flatten)]
     pub signing_definition: SigningDefinition,
@@ -123,6 +126,7 @@ impl ValidatorDefinition {
         voting_keystore_password: Option<ZeroizeString>,
         graffiti: Option<GraffitiString>,
         suggested_fee_recipient: Option<Address>,
+        gas_limit: Option<u64>,
     ) -> Result<Self, Error> {
         let voting_keystore_path = voting_keystore_path.as_ref().into();
         let keystore =
@@ -135,6 +139,7 @@ impl ValidatorDefinition {
             description: keystore.description().unwrap_or("").to_string(),
             graffiti,
             suggested_fee_recipient,
+            gas_limit,
             signing_definition: SigningDefinition::LocalKeystore {
                 voting_keystore_path,
                 voting_keystore_password_path: None,
@@ -281,6 +286,7 @@ impl ValidatorDefinitions {
                     description: keystore.description().unwrap_or("").to_string(),
                     graffiti: None,
                     suggested_fee_recipient: None,
+                    gas_limit: None,
                     signing_definition: SigningDefinition::LocalKeystore {
                         voting_keystore_path,
                         voting_keystore_password_path,
@@ -522,5 +528,45 @@ mod tests {
             def.suggested_fee_recipient,
             Some(Address::from_str("0xa2e334e71511686bcfe38bb3ee1ad8f6babcc03d").unwrap())
         );
+    }
+
+    #[test]
+    fn gas_limit_checks() {
+        let no_gas_limit = r#"---
+        description: ""
+        enabled: true
+        type: local_keystore
+        suggested_fee_recipient: "0xa2e334e71511686bcfe38bb3ee1ad8f6babcc03d"
+        voting_keystore_path: ""
+        voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
+        "#;
+        let def: ValidatorDefinition = serde_yaml::from_str(no_gas_limit).unwrap();
+        assert!(def.gas_limit.is_none());
+
+        let invalid_gas_limit = r#"---
+        description: ""
+        enabled: true
+        type: local_keystore
+        suggested_fee_recipient: "0xa2e334e71511686bcfe38bb3ee1ad8f6babcc03d"
+        gas_limit: "banana"
+        voting_keystore_path: ""
+        voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
+        "#;
+
+        let def: Result<ValidatorDefinition, _> = serde_yaml::from_str(invalid_gas_limit);
+        assert!(def.is_err());
+
+        let valid_gas_limit = r#"---
+        description: ""
+        enabled: true
+        type: local_keystore
+        suggested_fee_recipient: "0xa2e334e71511686bcfe38bb3ee1ad8f6babcc03d"
+        gas_limit: 35000000
+        voting_keystore_path: ""
+        voting_public_key: "0xaf3c7ddab7e293834710fca2d39d068f884455ede270e0d0293dc818e4f2f0f975355067e8437955cb29aec674e5c9e7"
+        "#;
+
+        let def: ValidatorDefinition = serde_yaml::from_str(valid_gas_limit).unwrap();
+        assert_eq!(def.gas_limit, Some(35000000));
     }
 }

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -464,6 +464,7 @@ impl ValidatorClientHttpClient {
         voting_pubkey: &PublicKeyBytes,
         enabled: Option<bool>,
         gas_limit: Option<u64>,
+        builder_proposals: Option<bool>,
     ) -> Result<(), Error> {
         let mut path = self.server.full.clone();
 
@@ -473,8 +474,15 @@ impl ValidatorClientHttpClient {
             .push("validators")
             .push(&voting_pubkey.to_string());
 
-        self.patch(path, &ValidatorPatchRequest { enabled, gas_limit })
-            .await
+        self.patch(
+            path,
+            &ValidatorPatchRequest {
+                enabled,
+                gas_limit,
+                builder_proposals,
+            },
+        )
+        .await
     }
 
     fn make_keystores_url(&self) -> Result<Url, Error> {

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -462,7 +462,8 @@ impl ValidatorClientHttpClient {
     pub async fn patch_lighthouse_validators(
         &self,
         voting_pubkey: &PublicKeyBytes,
-        enabled: bool,
+        enabled: Option<bool>,
+        gas_limit: Option<u64>,
     ) -> Result<(), Error> {
         let mut path = self.server.full.clone();
 
@@ -472,7 +473,8 @@ impl ValidatorClientHttpClient {
             .push("validators")
             .push(&voting_pubkey.to_string());
 
-        self.patch(path, &ValidatorPatchRequest { enabled }).await
+        self.patch(path, &ValidatorPatchRequest { enabled, gas_limit })
+            .await
     }
 
     fn make_keystores_url(&self) -> Result<Url, Error> {

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -29,6 +29,9 @@ pub struct ValidatorRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_proposals: Option<bool>,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub deposit_gwei: u64,
 }
@@ -52,6 +55,12 @@ pub struct CreatedValidator {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_recipient: Option<Address>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<u64>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_proposals: Option<bool>,
     pub eth1_deposit_tx_data: String,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub deposit_gwei: u64,
@@ -71,6 +80,9 @@ pub struct ValidatorPatchRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_proposals: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -81,6 +93,7 @@ pub struct KeystoreValidatorsPostRequest {
     pub graffiti: Option<GraffitiString>,
     pub suggested_fee_recipient: Option<Address>,
     pub gas_limit: Option<u64>,
+    pub builder_proposals: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -96,6 +109,9 @@ pub struct Web3SignerValidatorRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gas_limit: Option<u64>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub builder_proposals: Option<bool>,
     pub voting_public_key: PublicKey,
     pub url: String,
     #[serde(default)]

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -26,6 +26,9 @@ pub struct ValidatorRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_recipient: Option<Address>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<u64>,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub deposit_gwei: u64,
 }
@@ -62,7 +65,12 @@ pub struct PostValidatorsResponseData {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorPatchRequest {
-    pub enabled: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<u64>,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -72,6 +80,7 @@ pub struct KeystoreValidatorsPostRequest {
     pub keystore: Keystore,
     pub graffiti: Option<GraffitiString>,
     pub suggested_fee_recipient: Option<Address>,
+    pub gas_limit: Option<u64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -84,6 +93,9 @@ pub struct Web3SignerValidatorRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_recipient: Option<Address>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gas_limit: Option<u64>,
     pub voting_public_key: PublicKey,
     pub url: String,
     #[serde(default)]

--- a/lighthouse/tests/account_manager.rs
+++ b/lighthouse/tests/account_manager.rs
@@ -494,6 +494,7 @@ fn validator_import_launchpad() {
         description: "".into(),
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         voting_public_key: keystore.public_key().unwrap(),
         signing_definition: SigningDefinition::LocalKeystore {
             voting_keystore_path,
@@ -614,6 +615,7 @@ fn validator_import_launchpad_no_password_then_add_password() {
         description: "".into(),
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         voting_public_key: keystore.public_key().unwrap(),
         signing_definition: SigningDefinition::LocalKeystore {
             voting_keystore_path,
@@ -638,6 +640,7 @@ fn validator_import_launchpad_no_password_then_add_password() {
         description: "".into(),
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         voting_public_key: keystore.public_key().unwrap(),
         signing_definition: SigningDefinition::LocalKeystore {
             voting_keystore_path: dst_keystore_dir.join(KEYSTORE_NAME),
@@ -738,6 +741,7 @@ fn validator_import_launchpad_password_file() {
         voting_public_key: keystore.public_key().unwrap(),
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         signing_definition: SigningDefinition::LocalKeystore {
             voting_keystore_path,
             voting_keystore_password_path: None,

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -388,3 +388,30 @@ fn no_doppelganger_protection_flag() {
         .run()
         .with_config(|config| assert!(!config.enable_doppelganger_protection));
 }
+#[test]
+fn no_gas_limit_flag() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert!(config.gas_limit.is_none()));
+}
+#[test]
+fn gas_limit_flag() {
+    CommandLineTest::new()
+        .flag("gas-limit", Some("600"))
+        .flag("builder-proposals", None)
+        .run()
+        .with_config(|config| assert_eq!(config.gas_limit, Some(600)));
+}
+#[test]
+fn no_builder_proposals_flag() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert!(!config.builder_proposals));
+}
+#[test]
+fn builder_proposals_flag() {
+    CommandLineTest::new()
+        .flag("builder-proposals", None)
+        .run()
+        .with_config(|config| assert!(config.builder_proposals));
+}

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -10,14 +10,14 @@ ulimit -n 65536
 
 # VC_COUNT is defaulted in vars.env
 DEBUG_LEVEL=${DEBUG_LEVEL:-info}
-PRIVATE_TX_PROPOSALS=
+BUILDER_PROPOSALS=
 
 # Get options
 while getopts "v:d:ph" flag; do
   case "${flag}" in
     v) VC_COUNT=${OPTARG};;
     d) DEBUG_LEVEL=${OPTARG};;
-    p) PRIVATE_TX_PROPOSALS="-p";;
+    p) BUILDER_PROPOSALS="-p";;
     h)
         validators=$(( $VALIDATOR_COUNT / $BN_COUNT ))
         echo "Start local testnet, defaults: 1 eth1 node, $BN_COUNT beacon nodes,"
@@ -119,7 +119,7 @@ done
 
 # Start requested number of validator clients
 for (( vc=1; vc<=$VC_COUNT; vc++ )); do
-    execute_command_add_PID validator_node_$vc.log ./validator_client.sh $PRIVATE_TX_PROPOSALS -d $DEBUG_LEVEL $DATADIR/node_$vc http://localhost:$((BN_http_port_base + $vc))
+    execute_command_add_PID validator_node_$vc.log ./validator_client.sh $BUILDER_PROPOSALS -d $DEBUG_LEVEL $DATADIR/node_$vc http://localhost:$((BN_http_port_base + $vc))
 done
 
 echo "Started!"

--- a/scripts/local_testnet/validator_client.sh
+++ b/scripts/local_testnet/validator_client.sh
@@ -12,12 +12,12 @@ source ./vars.env
 
 DEBUG_LEVEL=info
 
-PRIVATE_TX_PROPOSALS=
+BUILDER_PROPOSALS=
 
 # Get options
 while getopts "pd:" flag; do
   case "${flag}" in
-    p) PRIVATE_TX_PROPOSALS="--builder-proposals";;
+    p) BUILDER_PROPOSALS="--builder-proposals";;
     d) DEBUG_LEVEL=${OPTARG};;
   esac
 done
@@ -25,7 +25,7 @@ done
 exec lighthouse \
 	--debug-level $DEBUG_LEVEL \
 	vc \
-	$PRIVATE_TX_PROPOSALS \
+	$BUILDER_PROPOSALS \
 	--datadir ${@:$OPTIND:1} \
 	--testnet-dir $TESTNET_DIR \
 	--init-slashing-protection \

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -311,6 +311,7 @@ mod tests {
                 None,
                 slot_clock,
                 None,
+                None,
                 executor,
                 log.clone(),
             );
@@ -359,6 +360,7 @@ mod tests {
                     voting_public_key: validator_pubkey.clone(),
                     graffiti: None,
                     suggested_fee_recipient: None,
+                    gas_limit: None,
                     description: String::default(),
                     signing_definition: SigningDefinition::LocalKeystore {
                         voting_keystore_path: signer_rig.keystore_path.clone(),
@@ -375,6 +377,7 @@ mod tests {
                     voting_public_key: validator_pubkey.clone(),
                     graffiti: None,
                     suggested_fee_recipient: None,
+                    gas_limit: None,
                     description: String::default(),
                     signing_definition: SigningDefinition::Web3Signer {
                         url: signer_rig.url.to_string(),

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -42,7 +42,6 @@ pub struct BlockServiceBuilder<T, E: EthSpec> {
     context: Option<RuntimeContext<E>>,
     graffiti: Option<Graffiti>,
     graffiti_file: Option<GraffitiFile>,
-    private_tx_proposals: bool,
 }
 
 impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
@@ -54,7 +53,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
             context: None,
             graffiti: None,
             graffiti_file: None,
-            private_tx_proposals: false,
         }
     }
 
@@ -88,11 +86,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
         self
     }
 
-    pub fn private_tx_proposals(mut self, private_tx_proposals: bool) -> Self {
-        self.private_tx_proposals = private_tx_proposals;
-        self
-    }
-
     pub fn build(self) -> Result<BlockService<T, E>, String> {
         Ok(BlockService {
             inner: Arc::new(Inner {
@@ -110,7 +103,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
                     .ok_or("Cannot build BlockService without runtime_context")?,
                 graffiti: self.graffiti,
                 graffiti_file: self.graffiti_file,
-                private_tx_proposals: self.private_tx_proposals,
             }),
         })
     }
@@ -124,7 +116,6 @@ pub struct Inner<T, E: EthSpec> {
     context: RuntimeContext<E>,
     graffiti: Option<Graffiti>,
     graffiti_file: Option<GraffitiFile>,
-    private_tx_proposals: bool,
 }
 
 /// Attempts to produce attestations for any block producer(s) at the start of the epoch.
@@ -233,13 +224,15 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
             )
         }
 
-        let private_tx_proposals = self.private_tx_proposals;
         for validator_pubkey in proposers {
+            let builder_proposals = self
+                .validator_store
+                .get_builder_proposals(&validator_pubkey);
             let service = self.clone();
             let log = log.clone();
             self.inner.context.executor.spawn(
                 async move {
-                    let publish_result = if private_tx_proposals {
+                    let publish_result = if builder_proposals {
                         let mut result = service.clone()
                             .publish_block::<BlindedPayload<E>>(slot, validator_pubkey)
                             .await;

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -357,15 +357,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                 };
                 drop(get_timer);
 
-                // Ensure the correctness of the execution payload's fee recipient.
-                if let Ok(execution_payload) = block.body().execution_payload() {
-                    if Some(execution_payload.fee_recipient()) != fee_recipient {
-                        return Err(BlockError::Recoverable(
-                            "Incorrect fee recipient used by builder".to_string(),
-                        ));
-                    }
-                }
-
                 if proposer_index != Some(block.proposer_index()) {
                     return Err(BlockError::Recoverable(
                         "Proposer index does not match block proposer. Beacon chain re-orged"

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -259,4 +259,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     execution payload construction during proposals.")
                 .takes_value(false),
         )
+        .arg(
+            Arg::with_name("gas-limit")
+                .long("gas-limit")
+                .value_name("INTEGER")
+                .takes_value(true)
+                .help("The gas limit to be used in all builder proposals for all validators managed \
+                    by this validator client. Note this will not necessarily be used if the gas limit \
+                    set here moves too far from the previous block's gas limit. [default: 30,000,000]")
+                .requires("builder-proposals"),
+    )
 }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -52,7 +52,10 @@ pub struct Config {
     /// If true, enable functionality that monitors the network for attestations or proposals from
     /// any of the validators managed by this client before starting up.
     pub enable_doppelganger_protection: bool,
-    pub private_tx_proposals: bool,
+    /// Enable use of the blinded block endpoints during proposals.
+    pub builder_proposals: bool,
+    /// Fallback gas limit.
+    pub gas_limit: Option<u64>,
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to a beacon node over SSL/TLS.
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
@@ -88,7 +91,8 @@ impl Default for Config {
             monitoring_api: None,
             enable_doppelganger_protection: false,
             beacon_nodes_tls_certs: None,
-            private_tx_proposals: false,
+            builder_proposals: false,
+            gas_limit: None,
         }
     }
 }
@@ -297,8 +301,17 @@ impl Config {
         }
 
         if cli_args.is_present("builder-proposals") {
-            config.private_tx_proposals = true;
+            config.builder_proposals = true;
         }
+
+        config.gas_limit = cli_args
+            .value_of("gas-limit")
+            .map(|gas_limit| {
+                gas_limit
+                    .parse::<u64>()
+                    .map_err(|_| "gas-limit is not a valid u64.")
+            })
+            .transpose()?;
 
         Ok(config)
     }

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -140,6 +140,7 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
                 request.enable,
                 request.graffiti.clone(),
                 request.suggested_fee_recipient,
+                request.gas_limit,
             )
             .await
             .map_err(|e| {

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -141,6 +141,7 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
                 request.graffiti.clone(),
                 request.suggested_fee_recipient,
                 request.gas_limit,
+                request.builder_proposals,
             )
             .await
             .map_err(|e| {
@@ -155,6 +156,8 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
             description: request.description.clone(),
             graffiti: request.graffiti.clone(),
             suggested_fee_recipient: request.suggested_fee_recipient,
+            gas_limit: request.gas_limit,
+            builder_proposals: request.builder_proposals,
             voting_pubkey,
             eth1_deposit_tx_data: eth2_serde_utils::hex::encode(&eth1_deposit_data.rlp),
             deposit_gwei: request.deposit_gwei,

--- a/validator_client/src/http_api/keystores.rs
+++ b/validator_client/src/http_api/keystores.rs
@@ -205,6 +205,7 @@ fn import_single_keystore<T: SlotClock + 'static, E: EthSpec>(
             true,
             None,
             None,
+            None,
         ))
         .map_err(|e| format!("failed to initialize validator: {:?}", e))?;
 

--- a/validator_client/src/http_api/keystores.rs
+++ b/validator_client/src/http_api/keystores.rs
@@ -206,6 +206,7 @@ fn import_single_keystore<T: SlotClock + 'static, E: EthSpec>(
             None,
             None,
             None,
+            None,
         ))
         .map_err(|e| format!("failed to initialize validator: {:?}", e))?;
 

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -414,6 +414,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     let graffiti = body.graffiti.clone();
                     let suggested_fee_recipient = body.suggested_fee_recipient;
                     let gas_limit = body.gas_limit;
+                    let builder_proposals = body.builder_proposals;
 
                     let validator_def = {
                         if let Some(handle) = task_executor.handle() {
@@ -425,6 +426,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                     graffiti,
                                     suggested_fee_recipient,
                                     gas_limit,
+                                    builder_proposals,
                                 ))
                                 .map_err(|e| {
                                     warp_utils::reject::custom_server_error(format!(
@@ -472,6 +474,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 graffiti: web3signer.graffiti,
                                 suggested_fee_recipient: web3signer.suggested_fee_recipient,
                                 gas_limit: web3signer.gas_limit,
+                                builder_proposals: web3signer.builder_proposals,
                                 description: web3signer.description,
                                 signing_definition: SigningDefinition::Web3Signer {
                                     url: web3signer.url,

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -413,6 +413,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     let voting_password = body.password.clone();
                     let graffiti = body.graffiti.clone();
                     let suggested_fee_recipient = body.suggested_fee_recipient;
+                    let gas_limit = body.gas_limit;
 
                     let validator_def = {
                         if let Some(handle) = task_executor.handle() {
@@ -423,6 +424,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                     body.enable,
                                     graffiti,
                                     suggested_fee_recipient,
+                                    gas_limit,
                                 ))
                                 .map_err(|e| {
                                     warp_utils::reject::custom_server_error(format!(
@@ -469,6 +471,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                                 voting_public_key: web3signer.voting_public_key,
                                 graffiti: web3signer.graffiti,
                                 suggested_fee_recipient: web3signer.suggested_fee_recipient,
+                                gas_limit: web3signer.gas_limit,
                                 description: web3signer.description,
                                 signing_definition: SigningDefinition::Web3Signer {
                                     url: web3signer.url,
@@ -512,18 +515,29 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     let initialized_validators_rw_lock = validator_store.initialized_validators();
                     let mut initialized_validators = initialized_validators_rw_lock.write();
 
-                    match initialized_validators.is_enabled(&validator_pubkey) {
-                        None => Err(warp_utils::reject::custom_not_found(format!(
+                    match (
+                        initialized_validators.is_enabled(&validator_pubkey),
+                        initialized_validators.gas_limit(&validator_pubkey.compress()),
+                    ) {
+                        (None, _) => Err(warp_utils::reject::custom_not_found(format!(
                             "no validator for {:?}",
                             validator_pubkey
                         ))),
-                        Some(enabled) if enabled == body.enabled => Ok(()),
-                        Some(_) => {
+                        (Some(enabled), Some(gas_limit))
+                            if Some(enabled) == body.enabled
+                                && Some(gas_limit) == body.gas_limit =>
+                        {
+                            Ok(())
+                        }
+                        (Some(_), _) => {
                             if let Some(handle) = task_executor.handle() {
                                 handle
                                     .block_on(
-                                        initialized_validators
-                                            .set_validator_status(&validator_pubkey, body.enabled),
+                                        initialized_validators.set_validator_definition_fields(
+                                            &validator_pubkey,
+                                            body.enabled,
+                                            body.gas_limit,
+                                        ),
                                     )
                                     .map_err(|e| {
                                         warp_utils::reject::custom_server_error(format!(

--- a/validator_client/src/http_api/remotekeys.rs
+++ b/validator_client/src/http_api/remotekeys.rs
@@ -120,6 +120,7 @@ fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
         graffiti: None,
         suggested_fee_recipient: None,
         gas_limit: None,
+        builder_proposals: None,
         description: String::from("Added by remotekey API"),
         signing_definition: SigningDefinition::Web3Signer {
             url,

--- a/validator_client/src/http_api/remotekeys.rs
+++ b/validator_client/src/http_api/remotekeys.rs
@@ -119,6 +119,7 @@ fn import_single_remotekey<T: SlotClock + 'static, E: EthSpec>(
         voting_public_key: pubkey,
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         description: String::from("Added by remotekey API"),
         signing_definition: SigningDefinition::Web3Signer {
             url,

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -104,6 +104,7 @@ impl ApiTester {
             Some(Arc::new(DoppelgangerService::new(log.clone()))),
             slot_clock,
             Some(TEST_DEFAULT_FEE_RECIPIENT),
+            None,
             executor.clone(),
             log.clone(),
         ));
@@ -270,6 +271,7 @@ impl ApiTester {
                 description: format!("boi #{}", i),
                 graffiti: None,
                 suggested_fee_recipient: None,
+                gas_limit: None,
                 deposit_gwei: E::default_spec().max_effective_balance,
             })
             .collect::<Vec<_>>();
@@ -401,6 +403,7 @@ impl ApiTester {
                 keystore,
                 graffiti: None,
                 suggested_fee_recipient: None,
+                gas_limit: None,
             };
 
             self.client
@@ -419,6 +422,7 @@ impl ApiTester {
             keystore,
             graffiti: None,
             suggested_fee_recipient: None,
+            gas_limit: None,
         };
 
         let response = self
@@ -455,6 +459,7 @@ impl ApiTester {
                     description: format!("{}", i),
                     graffiti: None,
                     suggested_fee_recipient: None,
+                    gas_limit: None,
                     voting_public_key: kp.pk,
                     url: format!("http://signer_{}.com/", i),
                     root_certificate_path: None,
@@ -484,7 +489,7 @@ impl ApiTester {
         let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
 
         self.client
-            .patch_lighthouse_validators(&validator.voting_pubkey, enabled)
+            .patch_lighthouse_validators(&validator.voting_pubkey, Some(enabled), None)
             .await
             .unwrap();
 
@@ -517,6 +522,25 @@ impl ApiTester {
                 .data
                 .enabled,
             enabled
+        );
+
+        self
+    }
+
+    pub async fn set_gas_limit(self, index: usize, gas_limit: u64) -> Self {
+        let validator = &self.client.get_lighthouse_validators().await.unwrap().data[index];
+
+        self.client
+            .patch_lighthouse_validators(&validator.voting_pubkey, None, Some(gas_limit))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            self.initialized_validators
+                .read()
+                .gas_limit(&validator.voting_pubkey)
+                .unwrap(),
+            gas_limit
         );
 
         self
@@ -583,6 +607,7 @@ fn routes_with_invalid_auth() {
                         description: <_>::default(),
                         graffiti: <_>::default(),
                         suggested_fee_recipient: <_>::default(),
+                        gas_limit: <_>::default(),
                         deposit_gwei: <_>::default(),
                     }])
                     .await
@@ -612,13 +637,14 @@ fn routes_with_invalid_auth() {
                         keystore,
                         graffiti: <_>::default(),
                         suggested_fee_recipient: <_>::default(),
+                        gas_limit: <_>::default(),
                     })
                     .await
             })
             .await
             .test_with_invalid_auth(|client| async move {
                 client
-                    .patch_lighthouse_validators(&PublicKeyBytes::empty(), false)
+                    .patch_lighthouse_validators(&PublicKeyBytes::empty(), Some(false), None)
                     .await
             })
             .await
@@ -732,6 +758,33 @@ fn validator_enabling() {
             .await
             .assert_enabled_validators_count(2)
             .assert_validators_count(2);
+    });
+}
+
+#[test]
+fn validator_gas_limit() {
+    let runtime = build_runtime();
+    let weak_runtime = Arc::downgrade(&runtime);
+    runtime.block_on(async {
+        ApiTester::new(weak_runtime)
+            .await
+            .create_hd_validators(HdValidatorScenario {
+                count: 2,
+                specify_mnemonic: false,
+                key_derivation_path_offset: 0,
+                disabled: vec![],
+            })
+            .await
+            .assert_enabled_validators_count(2)
+            .assert_validators_count(2)
+            .set_gas_limit(0, 500)
+            .await
+            .set_validator_enabled(0, false)
+            .await
+            .assert_enabled_validators_count(1)
+            .assert_validators_count(2)
+            .set_gas_limit(0, 1000)
+            .await
     });
 }
 

--- a/validator_client/src/http_api/tests/keystores.rs
+++ b/validator_client/src/http_api/tests/keystores.rs
@@ -39,6 +39,7 @@ fn web3signer_validator_with_pubkey(pubkey: PublicKey) -> Web3SignerValidatorReq
         description: "".into(),
         graffiti: None,
         suggested_fee_recipient: None,
+        gas_limit: None,
         voting_public_key: pubkey,
         url: web3_signer_url(),
         root_certificate_path: None,
@@ -465,7 +466,7 @@ fn import_and_delete_conflicting_web3_signer_keystores() {
         for pubkey in &pubkeys {
             tester
                 .client
-                .patch_lighthouse_validators(pubkey, false)
+                .patch_lighthouse_validators(pubkey, Some(false), None)
                 .await
                 .unwrap();
         }

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -110,6 +110,7 @@ pub struct InitializedValidator {
     graffiti: Option<Graffiti>,
     suggested_fee_recipient: Option<Address>,
     gas_limit: Option<u64>,
+    builder_proposals: Option<bool>,
     /// The validators index in `state.validators`, to be updated by an external service.
     index: Option<u64>,
 }
@@ -128,6 +129,22 @@ impl InitializedValidator {
             // Web3Signer validators do not have any lockfiles.
             SigningMethod::Web3Signer { .. } => None,
         }
+    }
+
+    pub fn get_suggested_fee_recipient(&self) -> Option<Address> {
+        self.suggested_fee_recipient
+    }
+
+    pub fn get_gas_limit(&self) -> Option<u64> {
+        self.gas_limit
+    }
+
+    pub fn get_builder_proposals(&self) -> Option<bool> {
+        self.builder_proposals
+    }
+
+    pub fn get_index(&self) -> Option<u64> {
+        self.index
     }
 }
 
@@ -293,6 +310,7 @@ impl InitializedValidator {
             graffiti: def.graffiti.map(Into::into),
             suggested_fee_recipient: def.suggested_fee_recipient,
             gas_limit: def.gas_limit,
+            builder_proposals: def.builder_proposals,
             index: None,
         })
     }
@@ -591,6 +609,18 @@ impl InitializedValidators {
     /// `ValidatorDefinitions`.
     pub fn gas_limit(&self, public_key: &PublicKeyBytes) -> Option<u64> {
         self.validators.get(public_key).and_then(|v| v.gas_limit)
+    }
+
+    /// Returns the `builder_proposals` for a given public key specified in the
+    /// `ValidatorDefinitions`.
+    pub fn builder_proposals(&self, public_key: &PublicKeyBytes) -> Option<bool> {
+        self.validators
+            .get(public_key)
+            .and_then(|v| v.builder_proposals)
+    }
+
+    pub fn validator(&self, public_key: &PublicKeyBytes) -> Option<&InitializedValidator> {
+        self.validators.get(public_key)
     }
 
     /// Sets the `InitializedValidator` and `ValidatorDefinition` `enabled` and `gas_limit` values.

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -362,8 +362,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             context.eth2_config.spec.clone(),
             doppelganger_service.clone(),
             slot_clock.clone(),
-            config.fee_recipient,
-            config.gas_limit,
+            &config,
             context.executor.clone(),
             log.clone(),
         ));
@@ -414,7 +413,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             .runtime_context(context.service_context("block".into()))
             .graffiti(config.graffiti)
             .graffiti_file(config.graffiti_file.clone())
-            .private_tx_proposals(config.builder_proposals)
             .build()?;
 
         let attestation_service = AttestationServiceBuilder::new()

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -363,6 +363,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             doppelganger_service.clone(),
             slot_clock.clone(),
             config.fee_recipient,
+            config.gas_limit,
             context.executor.clone(),
             log.clone(),
         ));
@@ -413,7 +414,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             .runtime_context(context.service_context("block".into()))
             .graffiti(config.graffiti)
             .graffiti_file(config.graffiti_file.clone())
-            .private_tx_proposals(config.private_tx_proposals)
+            .private_tx_proposals(config.builder_proposals)
             .build()?;
 
         let attestation_service = AttestationServiceBuilder::new()
@@ -487,7 +488,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
         self.preparation_service
             .clone()
             .start_update_service(
-                self.config.private_tx_proposals,
+                self.config.builder_proposals,
                 &self.context.eth2_config.spec,
             )
             .map_err(|e| format!("Unable to start preparation service: {}", e))?;

--- a/validator_client/src/preparation_service.rs
+++ b/validator_client/src/preparation_service.rs
@@ -221,7 +221,7 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
         let validator_registration_fut = async move {
             loop {
                 // Poll the endpoint immediately to ensure fee recipients are received.
-                if let Err(e) = self.register_validators(&spec).await {
+                if let Err(e) = self.register_validators().await {
                     error!(log,"Error during validator registration";"error" => ?e);
                 }
 
@@ -264,33 +264,48 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
     }
 
     fn collect_preparation_data(&self, spec: &ChainSpec) -> Vec<ProposerPreparationData> {
-        self.collect_data(spec, |_, validator_index, fee_recipient, _| {
-            ProposerPreparationData {
-                validator_index,
-                fee_recipient,
-            }
-        })
-    }
-
-    fn collect_validator_registration_keys(
-        &self,
-        spec: &ChainSpec,
-    ) -> Vec<ValidatorRegistrationKey> {
-        self.collect_data(spec, |pubkey, _, fee_recipient, gas_limit| {
-            ValidatorRegistrationKey {
-                fee_recipient,
-                gas_limit,
-                pubkey,
-            }
-        })
-    }
-
-    fn collect_data<G, U>(&self, spec: &ChainSpec, map_fn: G) -> Vec<U>
-    where
-        G: Fn(PublicKeyBytes, u64, Address, u64) -> U,
-    {
         let log = self.context.log();
+        self.collect_proposal_data(|pubkey, proposal_data| {
+            if let Some(fee_recipient) = proposal_data.fee_recipient {
+                Some(ProposerPreparationData {
+                    // Ignore fee recipients for keys without indices, they are inactive.
+                    validator_index: proposal_data.validator_index?,
+                    fee_recipient,
+                })
+            } else {
+                if spec.bellatrix_fork_epoch.is_some() {
+                    error!(
+                        log,
+                        "Validator is missing fee recipient";
+                        "msg" => "update validator_definitions.yml",
+                        "pubkey" => ?pubkey
+                    );
+                }
+                None
+            }
+        })
+    }
 
+    fn collect_validator_registration_keys(&self) -> Vec<ValidatorRegistrationKey> {
+        self.collect_proposal_data(|pubkey, proposal_data| {
+            // We don't log for missing fee recipients here because this will be logged more
+            // frequently in `collect_preparation_data`.
+            proposal_data.fee_recipient.and_then(|fee_recipient| {
+                proposal_data
+                    .builder_proposals
+                    .then(|| ValidatorRegistrationKey {
+                        fee_recipient,
+                        gas_limit: proposal_data.gas_limit,
+                        pubkey,
+                    })
+            })
+        })
+    }
+
+    fn collect_proposal_data<G, U>(&self, map_fn: G) -> Vec<U>
+    where
+        G: Fn(PublicKeyBytes, ProposalData) -> Option<U>,
+    {
         let all_pubkeys: Vec<_> = self
             .validator_store
             .voting_pubkeys(DoppelgangerStatus::ignored);
@@ -298,24 +313,8 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
         all_pubkeys
             .into_iter()
             .filter_map(|pubkey| {
-                // Ignore fee recipients for keys without indices, they are inactive.
-                let validator_index = self.validator_store.validator_index(&pubkey)?;
-                let fee_recipient = self.validator_store.get_fee_recipient(&pubkey);
-                let gas_limit = self.validator_store.get_gas_limit(&pubkey);
-
-                if let Some(fee_recipient) = fee_recipient {
-                    Some(map_fn(pubkey, validator_index, fee_recipient, gas_limit))
-                } else {
-                    if spec.bellatrix_fork_epoch.is_some() {
-                        error!(
-                            log,
-                            "Validator is missing fee recipient";
-                            "msg" => "update validator_definitions.yml",
-                            "pubkey" => ?pubkey
-                        );
-                    }
-                    None
-                }
+                let proposal_data = self.validator_store.proposal_data(&pubkey)?;
+                map_fn(pubkey, proposal_data)
             })
             .collect()
     }
@@ -353,8 +352,8 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
     }
 
     /// Register validators with builders, used in the blinded block proposal flow.
-    async fn register_validators(&self, spec: &ChainSpec) -> Result<(), String> {
-        let registration_keys = self.collect_validator_registration_keys(spec);
+    async fn register_validators(&self) -> Result<(), String> {
+        let registration_keys = self.collect_validator_registration_keys();
 
         let mut changed_keys = vec![];
 
@@ -468,4 +467,11 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
         }
         Ok(())
     }
+}
+
+pub struct ProposalData {
+    pub(crate) validator_index: Option<u64>,
+    pub(crate) fee_recipient: Option<Address>,
+    pub(crate) gas_limit: u64,
+    pub(crate) builder_proposals: bool,
 }


### PR DESCRIPTION
## Issue Addressed

#3295
#3357

## Proposed Changes

Follows a similar pattern of management to `suggested_fee_recipient`. Persistence to validator definitions file. A CLI flag that acts as a fallback for any unspecified values in the definitions file. Additionally if nothing is specified, we default `gas_limit` to `30_000_000` because this is the current execution layer default, and we will default `builder_proposals` to `false`.

Blocked on #3134