### PR TITLE
[Merged by Bors] - Add Goerli `--network` flag as duplicate of Prater: Option A

### DIFF
--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -241,7 +241,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         mainnet,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "mainnet",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
@@ -251,7 +251,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         prater,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "prater",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
@@ -261,7 +261,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         goerli,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         //
         // The Goerli network is effectively an alias to Prater.
@@ -273,7 +273,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         gnosis,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "gnosis",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
@@ -283,7 +283,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         kiln,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "kiln",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
@@ -293,7 +293,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         ropsten,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "ropsten",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
@@ -303,7 +303,7 @@ define_hardcoded_nets!(
     (
         // Network name (must be unique among all networks).
         sepolia,
-        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // The name of the directory in the `eth2_network_config/built_in_network_configs`
         // directory where the configuration files are located for this network.
         "sepolia",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -69,7 +69,6 @@ impl Eth2Config {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Eth2NetArchiveAndDirectory<'a> {
     pub name: &'a str,
-    pub unique_id: &'a str,
     pub config_dir: &'a str,
     pub genesis_is_known: bool,
 }
@@ -118,7 +117,6 @@ macro_rules! define_archive {
 
                 pub const ETH2_NET_DIR: Eth2NetArchiveAndDirectory = Eth2NetArchiveAndDirectory {
                     name: stringify!($name_ident),
-                    unique_id: stringify!($name_ident),
                     config_dir: $config_dir,
                     genesis_is_known: $genesis_is_known,
                 };

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -108,15 +108,15 @@ pub struct HardcodedNet {
 /// It also defines a `include_<title>_file!` macro which provides a wrapper around
 /// `std::include_bytes`, allowing the inclusion of bytes from the specific testnet directory.
 macro_rules! define_archive {
-    ($name_ident: ident, $name_str: tt, $genesis_is_known: ident) => {
+    ($name_ident: ident, $genesis_is_known: ident) => {
         paste! {
             #[macro_use]
             pub mod $name_ident {
                 use super::*;
 
                 pub const ETH2_NET_DIR: Eth2NetArchiveAndDirectory = Eth2NetArchiveAndDirectory {
-                    name: $name_str,
-                    unique_id: $name_str,
+                    name: stringify!($name_ident),
+                    unique_id: stringify!($name_ident),
                     genesis_is_known: $genesis_is_known,
                 };
 
@@ -130,7 +130,7 @@ macro_rules! define_archive {
                             "/",
                             $this_crate::predefined_networks_dir!(),
                             "/",
-                            $name_str,
+                            stringify!($name_ident),
                             "/",
                             $filename
                         ))
@@ -164,13 +164,13 @@ macro_rules! define_net {
 /// - `HARDCODED_NET_NAMES`: a list of the *names* of the networks defined by this macro.
 #[macro_export]
 macro_rules! define_nets {
-    ($this_crate: ident, $($name_ident: ident, $name_str: tt,)+) => {
+    ($this_crate: ident, $($name_ident: ident,)+) => {
         $this_crate::paste! {
             $(
             const [<$name_ident:upper>]: $this_crate::HardcodedNet = $this_crate::define_net!($this_crate, $name_ident, [<include_ $name_ident _file>]);
             )+
             const HARDCODED_NETS: &[$this_crate::HardcodedNet] = &[$([<$name_ident:upper>],)+];
-            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$($name_str,)+];
+            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$(stringify!($name_ident),)+];
         }
     };
 }
@@ -197,9 +197,9 @@ macro_rules! define_nets {
 /// `build.rs` which will unzip the genesis states. Then, that `eth2_network_configs` crate can
 /// perform the final step of using `std::include_bytes` to bake the files (bytes) into the binary.
 macro_rules! define_hardcoded_nets {
-    ($(($name_ident: ident, $name_str: tt, $genesis_is_known: ident)),+) => {
+    ($(($name_ident: ident, $genesis_is_known: ident)),+) => {
         $(
-        define_archive!($name_ident, $name_str, $genesis_is_known);
+        define_archive!($name_ident, $genesis_is_known);
         )+
 
         pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name_ident::ETH2_NET_DIR,)+];
@@ -213,7 +213,7 @@ macro_rules! define_hardcoded_nets {
         #[macro_export]
         macro_rules! instantiate_hardcoded_nets {
             ($this_crate: ident) => {
-                $this_crate::define_nets!($this_crate, $($name_ident, $name_str,)+);
+                $this_crate::define_nets!($this_crate, $($name_ident,)+);
             }
         }
     };
@@ -234,10 +234,46 @@ macro_rules! define_hardcoded_nets {
 //
 // The directory containing the testnet files should match the human-friendly name (element 1).
 define_hardcoded_nets!(
-    (mainnet, "mainnet", GENESIS_STATE_IS_KNOWN),
-    (prater, "prater", GENESIS_STATE_IS_KNOWN),
-    (gnosis, "gnosis", GENESIS_STATE_IS_KNOWN),
-    (kiln, "kiln", GENESIS_STATE_IS_KNOWN),
-    (ropsten, "ropsten", GENESIS_STATE_IS_KNOWN),
-    (sepolia, "sepolia", GENESIS_STATE_IS_KNOWN)
+    (
+        // Testnet name as an `ident`.
+        mainnet,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Testnet name as an `ident`.
+        prater,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Testnet name as an `ident`.
+        gnosis,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Testnet name as an `ident`.
+        kiln,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Testnet name as an `ident`.
+        ropsten,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Testnet name as an `ident`.
+        sepolia,
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    )
 );

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -70,6 +70,7 @@ impl Eth2Config {
 pub struct Eth2NetArchiveAndDirectory<'a> {
     pub name: &'a str,
     pub unique_id: &'a str,
+    pub config_dir: &'a str,
     pub genesis_is_known: bool,
 }
 
@@ -81,7 +82,7 @@ impl<'a> Eth2NetArchiveAndDirectory<'a> {
             .parse::<PathBuf>()
             .expect("should parse manifest dir as path")
             .join(PREDEFINED_NETWORKS_DIR)
-            .join(self.unique_id)
+            .join(self.config_dir)
     }
 
     pub fn genesis_state_archive(&self) -> PathBuf {
@@ -96,6 +97,7 @@ const GENESIS_STATE_IS_KNOWN: bool = true;
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct HardcodedNet {
     pub name: &'static str,
+    pub config_dir: &'static str,
     pub genesis_is_known: bool,
     pub config: &'static [u8],
     pub deploy_block: &'static [u8],
@@ -108,7 +110,7 @@ pub struct HardcodedNet {
 /// It also defines a `include_<title>_file!` macro which provides a wrapper around
 /// `std::include_bytes`, allowing the inclusion of bytes from the specific testnet directory.
 macro_rules! define_archive {
-    ($name_ident: ident, $genesis_is_known: ident) => {
+    ($name_ident: ident, $config_dir: tt, $genesis_is_known: ident) => {
         paste! {
             #[macro_use]
             pub mod $name_ident {
@@ -117,6 +119,7 @@ macro_rules! define_archive {
                 pub const ETH2_NET_DIR: Eth2NetArchiveAndDirectory = Eth2NetArchiveAndDirectory {
                     name: stringify!($name_ident),
                     unique_id: stringify!($name_ident),
+                    config_dir: $config_dir,
                     genesis_is_known: $genesis_is_known,
                 };
 
@@ -130,7 +133,7 @@ macro_rules! define_archive {
                             "/",
                             $this_crate::predefined_networks_dir!(),
                             "/",
-                            stringify!($name_ident),
+                            $config_dir,
                             "/",
                             $filename
                         ))
@@ -149,6 +152,7 @@ macro_rules! define_net {
 
         $this_crate::HardcodedNet {
             name: ETH2_NET_DIR.name,
+            config_dir: ETH2_NET_DIR.config_dir,
             genesis_is_known: ETH2_NET_DIR.genesis_is_known,
             config: $this_crate::$include_file!($this_crate, "../", "config.yaml"),
             deploy_block: $this_crate::$include_file!($this_crate, "../", "deploy_block.txt"),
@@ -197,9 +201,9 @@ macro_rules! define_nets {
 /// `build.rs` which will unzip the genesis states. Then, that `eth2_network_configs` crate can
 /// perform the final step of using `std::include_bytes` to bake the files (bytes) into the binary.
 macro_rules! define_hardcoded_nets {
-    ($(($name_ident: ident, $genesis_is_known: ident)),+) => {
+    ($(($name_ident: ident, $config_dir: tt, $genesis_is_known: ident)),+) => {
         $(
-        define_archive!($name_ident, $genesis_is_known);
+        define_archive!($name_ident, $config_dir, $genesis_is_known);
         )+
 
         pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name_ident::ETH2_NET_DIR,)+];
@@ -235,43 +239,73 @@ macro_rules! define_hardcoded_nets {
 // The directory containing the testnet files should match the human-friendly name (element 1).
 define_hardcoded_nets!(
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
         mainnet,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "mainnet",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN
     ),
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
         prater,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "prater",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN
     ),
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
+        goerli,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        //
+        // The Goerli network is effectively an alias to Prater.
+        "prater",
+        // Set to `true` if the genesis state can be found in the `built_in_network_configs`
+        // directory.
+        GENESIS_STATE_IS_KNOWN
+    ),
+    (
+        // Network name (must be unique among all networks).
         gnosis,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "gnosis",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN
     ),
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
         kiln,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "kiln",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN
     ),
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
         ropsten,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "ropsten",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN
     ),
     (
-        // Testnet name as an `ident`.
+        // Network name (must be unique among all networks).
         sepolia,
+        // The name of the directory in the `eth2_network_configs/build_in_network_configs`
+        // directory where the configuration files are located for this network.
+        "sepolia",
         // Set to `true` if the genesis state can be found in the `built_in_network_configs`
         // directory.
         GENESIS_STATE_IS_KNOWN

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -275,7 +275,7 @@ mod tests {
                 "{:?}",
                 net.name
             );
-            assert_eq!(config.config.config_name, Some(net.name.to_string()));
+            assert_eq!(config.config.config_name, Some(net.config_dir.to_string()));
         }
     }
 

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -257,6 +257,13 @@ mod tests {
     }
 
     #[test]
+    fn prater_and_goerli_are_equal() {
+        let goerli = Eth2NetworkConfig::from_hardcoded_net(&GOERLI).unwrap();
+        let prater = Eth2NetworkConfig::from_hardcoded_net(&PRATER).unwrap();
+        assert_eq!(goerli, prater);
+    }
+
+    #[test]
     fn hard_coded_nets_work() {
         for net in HARDCODED_NETS {
             let config = Eth2NetworkConfig::from_hardcoded_net(net)


### PR DESCRIPTION
## Issue Addressed

- Resolves #3338

## Proposed Changes

This PR adds a new `--network goerli` flag that reuses the [Prater network configs](https://github.com/sigp/lighthouse/tree/stable/common/eth2_network_config/built_in_network_configs/prater).

As you'll see in #3338, there are several approaches to the problem of the Goerli/Prater alias. This approach achieves:

1. No duplication of the genesis state between Goerli and Prater.
    - Upside: the genesis state for Prater is ~17mb, duplication would increase the size of the binary by that much.
2. When the user supplies `--network goerli`, they will get a datadir in `~/.lighthouse/goerli`.
    - Upside: our docs stay correct when they declare a datadir is located at `~/.lighthouse/{network}`
    - Downside: switching from `--network prater` to `--network goerli` will require some manual migration. 
3. When using `--network goerli`, the [`config/spec`](https://ethereum.github.io/beacon-APIs/#/Config/getSpec) endpoint will return a [`CONFIG_NAME`](https://github.com/ethereum/consensus-specs/blob/02a2b71d64fcf5023a8bd890dabce774a6e9802e/configs/mainnet.yaml#L11) of "prater".
    - Upside: VC running `--network prater` will still think it's on the same network as one using `--network goerli`.
    - Downside: potentially confusing.
    
#3348 achieves the same goal as this PR with a different approach and set of trade-offs.

## Additional Info

### Notes for reviewers:

In https://github.com/sigp/lighthouse/commit/e4896c268217e501ab581ce857d526572b235b91 you'll see that I remove the `$name_str` by just using `stringify!($name_ident)` instead. This is a simplification that should have have been there in the first place.

Then, in https://github.com/sigp/lighthouse/commit/90b5e22fca366c1db741c6d8f02902d9e375279f I reclaim that second parameter with a new purpose; to specify the directory from which to load configs.
