### PR TITLE
Add Goerli `--network` flag as duplicate of Prater: Option B

### DIFF
--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -180,16 +180,16 @@ macro_rules! define_net {
 /// Calls `define_net` on a list of networks, and then defines two more lists:
 ///
 /// - `HARDCODED_NETS`: a list of all the networks defined by this macro.
-/// - `HARDCODED_NET_NAMES`: a list of the *names* of the networks defined by this macro.
+/// - `HARDCODED_NET_ALIASES`: a list of the names and aliases of the networks defined by this macro.
 #[macro_export]
 macro_rules! define_nets {
-    ($this_crate: ident, $($name_ident: ident, $name_str: tt,)+) => {
+    ($this_crate: ident, $($name_ident: ident, $name_str: tt $(, $aliases: tt)*)+) => {
         $this_crate::paste! {
             $(
             const [<$name_ident:upper>]: $this_crate::HardcodedNet = $this_crate::define_net!($this_crate, $name_ident, [<include_ $name_ident _file>]);
             )+
             const HARDCODED_NETS: &[$this_crate::HardcodedNet] = &[$([<$name_ident:upper>],)+];
-            pub const HARDCODED_NET_NAMES: &[&'static str] = &[$($name_str,)+];
+            pub const HARDCODED_NET_ALIASES: &[&'static str] = &[$($name_str, $($aliases,)*)+];
         }
     };
 }
@@ -218,7 +218,7 @@ macro_rules! define_nets {
 macro_rules! define_hardcoded_nets {
     ($(($name_ident: ident, $genesis_is_known: ident, $name_str: tt $(, $aliases: tt)*)),+) => {
         $(
-        define_archive!($name_ident, $name_str, $genesis_is_known);
+        define_archive!($name_ident, $name_str, $genesis_is_known $(, $aliases)*);
         )+
 
         pub const ETH2_NET_DIRS: &[Eth2NetArchiveAndDirectory<'static>] = &[$($name_ident::ETH2_NET_DIR,)+];
@@ -228,11 +228,11 @@ macro_rules! define_hardcoded_nets {
         ///
         /// - A `HardcodedNet` for each network.
         /// - `HARDCODED_NETS`: a list of all the above `HardcodedNet`.
-        /// - `HARDCODED_NET_NAMES`: a list of all the names of the above `HardcodedNet` (as `&str`).
+        /// - `HARDCODED_NET_ALIASES`: a list of all the names and aliases of the above `HardcodedNet` (as `&str`).
         #[macro_export]
         macro_rules! instantiate_hardcoded_nets {
             ($this_crate: ident) => {
-                $this_crate::define_nets!($this_crate, $($name_ident, $name_str,)+);
+                $this_crate::define_nets!($this_crate, $($name_ident, $name_str $(, $aliases)*)+);
             }
         }
     };

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -27,7 +27,7 @@ pub const BASE_CONFIG_FILE: &str = "config.yaml";
 //
 // - Each of the `HardcodedNet` values (e.g., `MAINNET`, `PRATER`, etc).
 // - `HARDCODED_NETS: &[HardcodedNet]`
-// - `HARDCODED_NET_NAMES: &[&'static str]`
+// - `HARDCODED_NET_ALIASES: &[&'static str]`
 instantiate_hardcoded_nets!(eth2_config);
 
 pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
@@ -225,6 +225,7 @@ impl Eth2NetworkConfig {
 mod tests {
     use super::*;
     use ssz::Encode;
+    use std::iter;
     use tempfile::Builder as TempBuilder;
     use types::{Config, Eth1Data, GnosisEthSpec, Hash256, MainnetEthSpec, GNOSIS};
 
@@ -232,15 +233,21 @@ mod tests {
 
     #[test]
     fn default_network_exists() {
-        assert!(HARDCODED_NET_NAMES.contains(&DEFAULT_HARDCODED_NETWORK));
+        assert!(HARDCODED_NET_ALIASES.contains(&DEFAULT_HARDCODED_NETWORK));
     }
 
     #[test]
     fn hardcoded_testnet_names() {
-        assert_eq!(HARDCODED_NET_NAMES.len(), HARDCODED_NETS.len());
-        for (name, net) in HARDCODED_NET_NAMES.iter().zip(HARDCODED_NETS.iter()) {
-            assert_eq!(name, &net.name);
-        }
+        let expected_count: usize = HARDCODED_NETS
+            .iter()
+            .map(|net| {
+                iter::once(net.name)
+                    .chain(net.aliases.iter().map(|s| *s))
+                    .inspect(|name| assert!(HARDCODED_NET_ALIASES.contains(name)))
+                    .count()
+            })
+            .sum();
+        assert_eq!(HARDCODED_NET_ALIASES.len(), expected_count);
     }
 
     #[test]

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -242,7 +242,7 @@ mod tests {
             .iter()
             .map(|net| {
                 iter::once(net.name)
-                    .chain(net.aliases.iter().map(|s| *s))
+                    .chain(net.aliases.iter().copied())
                     .inspect(|name| assert!(HARDCODED_NET_ALIASES.contains(name)))
                     .count()
             })

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -51,7 +51,7 @@ impl Eth2NetworkConfig {
     pub fn constant(name: &str) -> Result<Option<Self>, String> {
         HARDCODED_NETS
             .iter()
-            .find(|net| net.name == name)
+            .find(|net| net.goes_by(name))
             .map(Self::from_hardcoded_net)
             .transpose()
     }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -9,7 +9,7 @@ use directory::{parse_path_or_default, DEFAULT_BEACON_NODE_DIR, DEFAULT_VALIDATO
 use env_logger::{Builder, Env};
 use environment::{EnvironmentBuilder, LoggerConfig};
 use eth2_hashing::have_sha_extensions;
-use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK, HARDCODED_NET_NAMES};
+use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK, HARDCODED_NET_ALIASES};
 use lighthouse_version::VERSION;
 use malloc_utils::configure_memory_allocator;
 use slog::{crit, info, warn};
@@ -178,7 +178,7 @@ fn main() {
                 .long("network")
                 .value_name("network")
                 .help("Name of the Eth2 chain Lighthouse will sync and follow.")
-                .possible_values(HARDCODED_NET_NAMES)
+                .possible_values(HARDCODED_NET_ALIASES)
                 .conflicts_with("testnet-dir")
                 .takes_value(true)
                 .global(true)


### PR DESCRIPTION
## Issue Addressed

- Resolves #3338

## Proposed Changes

Adds a new `--network goerli` flag which is a simple alias to `--network prater`.

As you'll see in #3338 there are multiple ways to approach the problem of the Goerli/Prater alias. This approach achieves:

1. No duplication of the genesis state between Goerli and Prater.
    - Upside: the genesis state for Prater is ~17mb, duplication would increase the size of the binary by that much.
2. When the user supplies `--network goerli`, they will get a datadir in `~/.lighthouse/prater`.
    - Upside: switching from `--network prater` to `--network goerli` requires no manual file migration.
    - Downside: our docs are kinda wrong when they say a datadir is located at `~/.lighthouse/{network}`
        - Upside: A future migration could fix this, whilst a future migration is infeasible in #3346
3. When using `--network goerli`, the [`config/spec`](https://ethereum.github.io/beacon-APIs/#/Config/getSpec) endpoint will return a [`CONFIG_NAME`](https://github.com/ethereum/consensus-specs/blob/02a2b71d64fcf5023a8bd890dabce774a6e9802e/configs/mainnet.yaml#L11) of "prater".
    - Upside: VC running `--network prater` will still think it's on the same network as one using `--network goerli`.
    - Downside: potentially confusing.

#3346 achieves the same goal as this PR with a different approach and set of trade-offs.

## Additional Info

NA
