### PR TITLE
[Merged by Bors] - Fix Gossip Penalties During Optimistic Sync Window

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -335,15 +335,30 @@ pub enum ExecutionPayloadError {
         terminal_block_hash: ExecutionBlockHash,
         payload_parent_hash: ExecutionBlockHash,
     },
-    /// The execution node failed to provide a parent block to a known block. This indicates an
-    /// issue with the execution node.
+    /// The execution node is syncing but we fail the conditions for optimistic sync
     ///
     /// ## Peer scoring
     ///
     /// The peer is not necessarily invalid.
-    PoWParentMissing(ExecutionBlockHash),
-    /// The execution node is syncing but we fail the conditions for optimistic sync
     UnverifiedNonOptimisticCandidate,
+}
+
+impl ExecutionPayloadError {
+    pub fn penalize_peer(&self) -> bool {
+        // This match statement should never have a default case so that we are
+        // always forced to consider here whether or not to penalize a peer when
+        // we add a new error condition.
+        match self {
+            ExecutionPayloadError::NoExecutionConnection => false,
+            ExecutionPayloadError::RequestFailed(_) => false,
+            ExecutionPayloadError::RejectedByExecutionEngine { .. } => true,
+            ExecutionPayloadError::InvalidPayloadTimestamp { .. } => true,
+            ExecutionPayloadError::InvalidTerminalPoWBlock { .. } => true,
+            ExecutionPayloadError::InvalidActivationEpoch { .. } => true,
+            ExecutionPayloadError::InvalidTerminalBlockHash { .. } => true,
+            ExecutionPayloadError::UnverifiedNonOptimisticCandidate => false,
+        }
+    }
 }
 
 impl From<execution_layer::Error> for ExecutionPayloadError {


### PR DESCRIPTION
## Issue Addressed
* #3344 

## Proposed Changes

There are a number of cases during block processing where we might get an `ExecutionPayloadError` but we shouldn't penalize peers. We were forgetting to enumerate all of the non-penalizing errors in every single match statement where we are making that decision. I created a function to make it explicit when we should and should not penalize peers and I used that function in all places where this logic is needed. This way we won't make the same mistake if we add another variant of `ExecutionPayloadError` in the future. 
