### PR TITLE
Pin `debug-tests-ubuntu` to Rust  1.62.0

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -109,7 +109,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Get latest version of stable Rust
-      run: rustup update stable
+      run: rustup update 1.62.0
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run tests in debug


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

CI is consistently failing on `debug-tests-ubuntu` due to a linking error:

```
2022-07-20T06:42:01.2147113Z    Compiling lighthouse v2.3.2-rc.0 (/home/runner/work/lighthouse/lighthouse/lighthouse)
2022-07-20T06:48:08.5686415Z error: linking with `cc` failed: exit status: 1
2022-07-20T06:48:08.5697264Z   |
2022-07-20T06:48:08.5982922Z   = note: "cc" "-m64"  <OMMITTED>  "-Wl,--gc-sections" "-pie" "-Wl,-zrelro,-znow" "-nodefaultlibs"
2022-07-20T06:48:08.6112649Z   = note: collect2: error: ld returned 1 exit status
2022-07-20T06:48:08.6118123Z           
2022-07-20T06:48:08.6121130Z 
2022-07-20T06:48:08.8197676Z error: could not compile `lighthouse` due to previous error
2022-07-20T06:48:11.5242083Z make: *** [Makefile:85: test-debug] Error 101
2022-07-20T06:48:11.5595218Z ##[error]Process completed with exit code 2.
2022-07-20T06:48:11.6308193Z Cleaning up orphan processes
```

As pointed out by @michaelsproul, Rust just released a new patch version: https://blog.rust-lang.org/2022/07/19/Rust-1.62.1.html

That patch version smells like the suspect. Whilst it would be great to figure out the fundamental reason, we need to get a release out. This is temporary measure. If it works, let's create an issue to revert this PR before merging it.

## Additional Info

NA
