### PR TITLE
Remove EL redundancy, bump VC warning to error

### DIFF
--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -327,21 +327,17 @@ where
         self
     }
 
-    pub fn execution_layer(mut self, urls: &[&str]) -> Self {
+    pub fn execution_layer(mut self, urls: &str) -> Self {
         assert!(
             self.execution_layer.is_none(),
             "execution layer already defined"
         );
 
-        let urls: Vec<SensitiveUrl> = urls
-            .iter()
-            .map(|s| SensitiveUrl::parse(*s))
-            .collect::<Result<_, _>>()
-            .unwrap();
+        let urls = Some(SensitiveUrl::parse(urls).unwrap());
 
         let config = execution_layer::Config {
             execution_endpoints: urls,
-            secret_files: vec![],
+            secret_files: None,
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -327,17 +327,17 @@ where
         self
     }
 
-    pub fn execution_layer(mut self, urls: &str) -> Self {
+    pub fn execution_layer(mut self, url: &str) -> Self {
         assert!(
             self.execution_layer.is_none(),
             "execution layer already defined"
         );
 
-        let urls = Some(SensitiveUrl::parse(urls).unwrap());
+        let url = Some(SensitiveUrl::parse(url).unwrap());
 
         let config = execution_layer::Config {
-            execution_endpoints: urls,
-            secret_files: None,
+            execution_endpoint: url,
+            secret_file: None,
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -117,11 +117,11 @@ struct Inner<E: EthSpec> {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Endpoint urls for EL nodes that are running the engine api.
-    pub execution_endpoints: Option<SensitiveUrl>,
+    pub execution_endpoint: Option<SensitiveUrl>,
     /// Endpoint urls for services providing the builder api.
     pub builder_url: Option<SensitiveUrl>,
     /// JWT secrets for the above endpoints running the engine api.
-    pub secret_files: Option<PathBuf>,
+    pub secret_file: Option<PathBuf>,
     /// The default fee recipient to use on the beacon node if none if provided from
     /// the validator client during block preparation.
     pub suggested_fee_recipient: Option<Address>,
@@ -144,19 +144,19 @@ impl<T: EthSpec> ExecutionLayer<T> {
     /// Instantiate `Self` with an Execution engine specified in `Config`, using JSON-RPC via HTTP.
     pub fn from_config(config: Config, executor: TaskExecutor, log: Logger) -> Result<Self, Error> {
         let Config {
-            execution_endpoints: urls,
+            execution_endpoint: url,
             builder_url,
-            secret_files,
+            secret_file,
             suggested_fee_recipient,
             jwt_id,
             jwt_version,
             default_datadir,
         } = config;
 
-        let execution_url = urls.into_iter().next().ok_or(Error::NoEngine)?;
+        let execution_url = url.into_iter().next().ok_or(Error::NoEngine)?;
 
         // Use the default jwt secret path if not provided via cli.
-        let secret_file = secret_files
+        let secret_file = secret_file
             .into_iter()
             .next()
             .unwrap_or_else(|| default_datadir.join(DEFAULT_JWT_FILE));

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -117,11 +117,11 @@ struct Inner<E: EthSpec> {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Endpoint urls for EL nodes that are running the engine api.
-    pub execution_endpoints: Vec<SensitiveUrl>,
+    pub execution_endpoints: Option<SensitiveUrl>,
     /// Endpoint urls for services providing the builder api.
     pub builder_url: Option<SensitiveUrl>,
     /// JWT secrets for the above endpoints running the engine api.
-    pub secret_files: Vec<PathBuf>,
+    pub secret_files: Option<PathBuf>,
     /// The default fee recipient to use on the beacon node if none if provided from
     /// the validator client during block preparation.
     pub suggested_fee_recipient: Option<Address>,
@@ -153,9 +153,6 @@ impl<T: EthSpec> ExecutionLayer<T> {
             default_datadir,
         } = config;
 
-        if urls.len() > 1 {
-            warn!(log, "Only the first execution engine url will be used");
-        }
         let execution_url = urls.into_iter().next().ok_or(Error::NoEngine)?;
 
         // Use the default jwt secret path if not provided via cli.

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -61,9 +61,9 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         std::fs::write(&path, hex::encode(DEFAULT_JWT_SECRET)).unwrap();
 
         let config = Config {
-            execution_endpoints: Some(url),
+            execution_endpoint: Some(url),
             builder_url,
-            secret_files: Some(path),
+            secret_file: Some(path),
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -61,9 +61,9 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         std::fs::write(&path, hex::encode(DEFAULT_JWT_SECRET)).unwrap();
 
         let config = Config {
-            execution_endpoints: vec![url],
+            execution_endpoints: Some(url),
             builder_url,
-            secret_files: vec![path],
+            secret_files: Some(path),
             suggested_fee_recipient: Some(Address::repeat_byte(42)),
             ..Default::default()
         };

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -295,8 +295,8 @@ pub fn get_config<E: EthSpec>(
         }
 
         // Set config values from parse values.
-        el_config.secret_files = Some(secret_file.clone());
-        el_config.execution_endpoints = Some(execution_endpoint.clone());
+        el_config.secret_file = Some(secret_file.clone());
+        el_config.execution_endpoint = Some(execution_endpoint.clone());
         el_config.suggested_fee_recipient =
             clap_utils::parse_optional(cli_args, "suggested-fee-recipient")?;
         el_config.jwt_id = clap_utils::parse_optional(cli_args, "execution-jwt-id")?;

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -295,8 +295,8 @@ pub fn get_config<E: EthSpec>(
         }
 
         // Set config values from parse values.
-        el_config.secret_files = vec![secret_file.clone()];
-        el_config.execution_endpoints = vec![execution_endpoint.clone()];
+        el_config.secret_files = Some(secret_file.clone());
+        el_config.execution_endpoints = Some(execution_endpoint.clone());
         el_config.suggested_fee_recipient =
             clap_utils::parse_optional(cli_args, "suggested-fee-recipient")?;
         el_config.jwt_id = clap_utils::parse_optional(cli_args, "execution-jwt-id")?;

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -287,9 +287,9 @@ fn run_merge_execution_endpoints_flag_test(flag: &str) {
         .run_with_zero_port()
         .with_config(|config| {
             let config = config.execution_layer.as_ref().unwrap();
-            assert_eq!(config.execution_endpoints.len(), 1);
+            assert_eq!(config.execution_endpoint.len(), 1);
             assert_eq!(
-                config.execution_endpoints[0],
+                config.execution_endpoint[0],
                 SensitiveUrl::parse(&urls[0]).unwrap()
             );
             // Only the first secret file should be used.
@@ -322,7 +322,7 @@ fn run_execution_endpoints_overrides_eth1_endpoints_test(eth1_flag: &str, execut
         .run_with_zero_port()
         .with_config(|config| {
             assert_eq!(
-                config.execution_layer.as_ref().unwrap().execution_endpoints,
+                config.execution_layer.as_ref().unwrap().execution_endpoint,
                 vec![SensitiveUrl::parse(execution_endpoint).unwrap()]
             );
 

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -113,11 +113,11 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         let ee_a = {
             let execution_engine = ExecutionEngine::new(generic_engine.clone());
-            let urls = Some(execution_engine.http_auth_url());
+            let url = Some(execution_engine.http_auth_url());
 
             let config = execution_layer::Config {
-                execution_endpoints: urls,
-                secret_files: None,
+                execution_endpoint: url,
+                secret_file: None,
                 suggested_fee_recipient: Some(Address::repeat_byte(42)),
                 default_datadir: execution_engine.datadir(),
                 ..Default::default()
@@ -132,11 +132,11 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         let ee_b = {
             let execution_engine = ExecutionEngine::new(generic_engine);
-            let urls = Some(execution_engine.http_auth_url());
+            let url = Some(execution_engine.http_auth_url());
 
             let config = execution_layer::Config {
-                execution_endpoints: urls,
-                secret_files: None,
+                execution_endpoint: url,
+                secret_file: None,
                 suggested_fee_recipient: fee_recipient,
                 default_datadir: execution_engine.datadir(),
                 ..Default::default()

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -113,11 +113,11 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         let ee_a = {
             let execution_engine = ExecutionEngine::new(generic_engine.clone());
-            let urls = vec![execution_engine.http_auth_url()];
+            let urls = Some(execution_engine.http_auth_url());
 
             let config = execution_layer::Config {
                 execution_endpoints: urls,
-                secret_files: vec![],
+                secret_files: None,
                 suggested_fee_recipient: Some(Address::repeat_byte(42)),
                 default_datadir: execution_engine.datadir(),
                 ..Default::default()
@@ -132,11 +132,11 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         let ee_b = {
             let execution_engine = ExecutionEngine::new(generic_engine);
-            let urls = vec![execution_engine.http_auth_url()];
+            let urls = Some(execution_engine.http_auth_url());
 
             let config = execution_layer::Config {
                 execution_endpoints: urls,
-                secret_files: vec![],
+                secret_files: None,
                 suggested_fee_recipient: fee_recipient,
                 default_datadir: execution_engine.datadir(),
                 ..Default::default()

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -152,11 +152,11 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
 
         if post_merge_sim {
             let el_config = execution_layer::Config {
-                execution_endpoints: vec![SensitiveUrl::parse(&format!(
+                execution_endpoints: Some(SensitiveUrl::parse(&format!(
                     "http://localhost:{}",
                     EXECUTION_PORT
                 ))
-                .unwrap()],
+                .unwrap()),
                 ..Default::default()
             };
 

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -152,11 +152,9 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
 
         if post_merge_sim {
             let el_config = execution_layer::Config {
-                execution_endpoint: Some(SensitiveUrl::parse(&format!(
-                    "http://localhost:{}",
-                    EXECUTION_PORT
-                ))
-                .unwrap()),
+                execution_endpoint: Some(
+                    SensitiveUrl::parse(&format!("http://localhost:{}", EXECUTION_PORT)).unwrap(),
+                ),
                 ..Default::default()
             };
 

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -152,7 +152,7 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
 
         if post_merge_sim {
             let el_config = execution_layer::Config {
-                execution_endpoints: Some(SensitiveUrl::parse(&format!(
+                execution_endpoint: Some(SensitiveUrl::parse(&format!(
                     "http://localhost:{}",
                     EXECUTION_PORT
                 ))

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -79,8 +79,8 @@ impl<E: EthSpec> LocalNetwork<E> {
                 mock_execution_config,
             );
             el_config.default_datadir = execution_node.datadir.path().to_path_buf();
-            el_config.secret_files = Some(execution_node.datadir.path().join("jwt.hex"));
-            el_config.execution_endpoints =
+            el_config.secret_file = Some(execution_node.datadir.path().join("jwt.hex"));
+            el_config.execution_endpoint =
                 Some(SensitiveUrl::parse(&execution_node.server.url()).unwrap());
             vec![execution_node]
         } else {
@@ -153,8 +153,8 @@ impl<E: EthSpec> LocalNetwork<E> {
                 config,
             );
             el_config.default_datadir = execution_node.datadir.path().to_path_buf();
-            el_config.secret_files = Some(execution_node.datadir.path().join("jwt.hex"));
-            el_config.execution_endpoints =
+            el_config.secret_file = Some(execution_node.datadir.path().join("jwt.hex"));
+            el_config.execution_endpoint =
                 Some(SensitiveUrl::parse(&execution_node.server.url()).unwrap());
             self.execution_nodes.write().push(execution_node);
         }

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -79,9 +79,9 @@ impl<E: EthSpec> LocalNetwork<E> {
                 mock_execution_config,
             );
             el_config.default_datadir = execution_node.datadir.path().to_path_buf();
-            el_config.secret_files = vec![execution_node.datadir.path().join("jwt.hex")];
+            el_config.secret_files = Some(execution_node.datadir.path().join("jwt.hex"));
             el_config.execution_endpoints =
-                vec![SensitiveUrl::parse(&execution_node.server.url()).unwrap()];
+                Some(SensitiveUrl::parse(&execution_node.server.url()).unwrap());
             vec![execution_node]
         } else {
             vec![]
@@ -153,9 +153,9 @@ impl<E: EthSpec> LocalNetwork<E> {
                 config,
             );
             el_config.default_datadir = execution_node.datadir.path().to_path_buf();
-            el_config.secret_files = vec![execution_node.datadir.path().join("jwt.hex")];
+            el_config.secret_files = Some(execution_node.datadir.path().join("jwt.hex"));
             el_config.execution_endpoints =
-                vec![SensitiveUrl::parse(&execution_node.server.url()).unwrap()];
+                Some(SensitiveUrl::parse(&execution_node.server.url()).unwrap());
             self.execution_nodes.write().push(execution_node);
         }
 

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -559,7 +559,7 @@ async fn init_from_beacon_node<E: EthSpec>(
             );
             break;
         } else {
-            warn!(
+            error!(
                 context.log(),
                 "Unable to connect to a beacon node";
                 "retry in" => format!("{} seconds", RETRY_DELAY.as_secs()),


### PR DESCRIPTION
## Issue Addressed

Resolves #3307
Resolves #3127

## Proposed Changes

- remove execution layer redundancy
- change the warning to an error when "Unable to connect to a beacon node"
