### PR TITLE
[Merged by Bors] - Allow setting web3signer version through environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ perf.data*
 /bin
 genesis.ssz
 /clippy.toml
+
+# IntelliJ
+/*.iml

--- a/testing/web3signer_tests/build.rs
+++ b/testing/web3signer_tests/build.rs
@@ -29,6 +29,8 @@ pub async fn download_binary(dest_dir: PathBuf) {
 
     let version = if let Some(version) = FIXED_VERSION_STRING {
         version.to_string()
+    } else if let Ok(env_version) = env::var("LIGHTHOUSE_WEB3SIGNER_VERSION") {
+        env_version
     } else {
         // Get the latest release of the web3 signer repo.
         let latest_response: Value = client


### PR DESCRIPTION
## Issue Addressed

#3369 

## Proposed Changes

The goal is to make it possible to build Lighthouse without network access,
so builds can be reproducible.

This parallels the existing functionality in `common/deposit_contract/build.rs`,
which allows specifying a filename through the environment to avoid downloading
it. In this case, by specifying the version and making it available on the
filesystem, the existing logic will avoid a network download.