### PR TITLE
[Merged by Bors] - Remove equivocating validators from fork choice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,7 @@ version = "0.4.1"
 dependencies = [
  "eth2_ssz_derive",
  "ethereum-types 0.12.1",
+ "itertools",
  "smallvec",
 ]
 

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -8,6 +8,7 @@ use crate::{metrics, BeaconSnapshot};
 use derivative::Derivative;
 use fork_choice::ForkChoiceStore;
 use ssz_derive::{Decode, Encode};
+use std::collections::BTreeSet;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use store::{Error as StoreError, HotColdDB, ItemStore};
@@ -158,6 +159,7 @@ pub struct BeaconForkChoiceStore<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<
     unrealized_justified_checkpoint: Checkpoint,
     unrealized_finalized_checkpoint: Checkpoint,
     proposer_boost_root: Hash256,
+    equivocating_indices: BTreeSet<u64>,
     _phantom: PhantomData<E>,
 }
 
@@ -206,6 +208,7 @@ where
             unrealized_justified_checkpoint: justified_checkpoint,
             unrealized_finalized_checkpoint: finalized_checkpoint,
             proposer_boost_root: Hash256::zero(),
+            equivocating_indices: BTreeSet::new(),
             _phantom: PhantomData,
         }
     }
@@ -223,6 +226,7 @@ where
             unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
             unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
             proposer_boost_root: self.proposer_boost_root,
+            equivocating_indices: self.equivocating_indices.clone(),
         }
     }
 
@@ -242,6 +246,7 @@ where
             unrealized_justified_checkpoint: persisted.unrealized_justified_checkpoint,
             unrealized_finalized_checkpoint: persisted.unrealized_finalized_checkpoint,
             proposer_boost_root: persisted.proposer_boost_root,
+            equivocating_indices: persisted.equivocating_indices,
             _phantom: PhantomData,
         })
     }
@@ -350,30 +355,40 @@ where
     fn set_proposer_boost_root(&mut self, proposer_boost_root: Hash256) {
         self.proposer_boost_root = proposer_boost_root;
     }
+
+    fn equivocating_indices(&self) -> &BTreeSet<u64> {
+        &self.equivocating_indices
+    }
+
+    fn extend_equivocating_indices(&mut self, indices: Vec<u64>) {
+        self.equivocating_indices.extend(indices);
+    }
 }
 
 /// A container which allows persisting the `BeaconForkChoiceStore` to the on-disk database.
 #[superstruct(
-    variants(V1, V7, V8, V10),
+    variants(V1, V7, V8, V10, V11),
     variant_attributes(derive(Encode, Decode)),
     no_enum
 )]
 pub struct PersistedForkChoiceStore {
     #[superstruct(only(V1, V7))]
     pub balances_cache: BalancesCacheV1,
-    #[superstruct(only(V8, V10))]
+    #[superstruct(only(V8, V10, V11))]
     pub balances_cache: BalancesCacheV8,
     pub time: Slot,
     pub finalized_checkpoint: Checkpoint,
     pub justified_checkpoint: Checkpoint,
     pub justified_balances: Vec<u64>,
     pub best_justified_checkpoint: Checkpoint,
-    #[superstruct(only(V10))]
+    #[superstruct(only(V10, V11))]
     pub unrealized_justified_checkpoint: Checkpoint,
-    #[superstruct(only(V10))]
+    #[superstruct(only(V10, V11))]
     pub unrealized_finalized_checkpoint: Checkpoint,
-    #[superstruct(only(V7, V8, V10))]
+    #[superstruct(only(V7, V8, V10, V11))]
     pub proposer_boost_root: Hash256,
+    #[superstruct(only(V11))]
+    pub equivocating_indices: BTreeSet<u64>,
 }
 
-pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV10;
+pub type PersistedForkChoiceStore = PersistedForkChoiceStoreV11;

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -360,7 +360,7 @@ where
         &self.equivocating_indices
     }
 
-    fn extend_equivocating_indices(&mut self, indices: Vec<u64>) {
+    fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>) {
         self.equivocating_indices.extend(indices);
     }
 }

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -1,6 +1,6 @@
 use crate::beacon_fork_choice_store::{
-    PersistedForkChoiceStoreV1, PersistedForkChoiceStoreV10, PersistedForkChoiceStoreV7,
-    PersistedForkChoiceStoreV8,
+    PersistedForkChoiceStoreV1, PersistedForkChoiceStoreV10, PersistedForkChoiceStoreV11,
+    PersistedForkChoiceStoreV7, PersistedForkChoiceStoreV8,
 };
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
@@ -8,10 +8,10 @@ use store::{DBColumn, Error, StoreItem};
 use superstruct::superstruct;
 
 // If adding a new version you should update this type alias and fix the breakages.
-pub type PersistedForkChoice = PersistedForkChoiceV10;
+pub type PersistedForkChoice = PersistedForkChoiceV11;
 
 #[superstruct(
-    variants(V1, V7, V8, V10),
+    variants(V1, V7, V8, V10, V11),
     variant_attributes(derive(Encode, Decode)),
     no_enum
 )]
@@ -25,6 +25,8 @@ pub struct PersistedForkChoice {
     pub fork_choice_store: PersistedForkChoiceStoreV8,
     #[superstruct(only(V10))]
     pub fork_choice_store: PersistedForkChoiceStoreV10,
+    #[superstruct(only(V11))]
+    pub fork_choice_store: PersistedForkChoiceStoreV11,
 }
 
 macro_rules! impl_store_item {
@@ -49,3 +51,4 @@ impl_store_item!(PersistedForkChoiceV1);
 impl_store_item!(PersistedForkChoiceV7);
 impl_store_item!(PersistedForkChoiceV8);
 impl_store_item!(PersistedForkChoiceV10);
+impl_store_item!(PersistedForkChoiceV11);

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v11.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v11.rs
@@ -1,0 +1,77 @@
+use crate::beacon_fork_choice_store::{PersistedForkChoiceStoreV10, PersistedForkChoiceStoreV11};
+use crate::persisted_fork_choice::{PersistedForkChoiceV10, PersistedForkChoiceV11};
+use slog::{warn, Logger};
+use std::collections::BTreeSet;
+
+/// Add the equivocating indices field.
+pub fn update_fork_choice(fork_choice_v10: PersistedForkChoiceV10) -> PersistedForkChoiceV11 {
+    let PersistedForkChoiceStoreV10 {
+        balances_cache,
+        time,
+        finalized_checkpoint,
+        justified_checkpoint,
+        justified_balances,
+        best_justified_checkpoint,
+        unrealized_justified_checkpoint,
+        unrealized_finalized_checkpoint,
+        proposer_boost_root,
+    } = fork_choice_v10.fork_choice_store;
+
+    PersistedForkChoiceV11 {
+        fork_choice: fork_choice_v10.fork_choice,
+        fork_choice_store: PersistedForkChoiceStoreV11 {
+            balances_cache,
+            time,
+            finalized_checkpoint,
+            justified_checkpoint,
+            justified_balances,
+            best_justified_checkpoint,
+            unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint,
+            proposer_boost_root,
+            equivocating_indices: BTreeSet::new(),
+        },
+    }
+}
+
+pub fn downgrade_fork_choice(
+    fork_choice_v11: PersistedForkChoiceV11,
+    log: Logger,
+) -> PersistedForkChoiceV10 {
+    let PersistedForkChoiceStoreV11 {
+        balances_cache,
+        time,
+        finalized_checkpoint,
+        justified_checkpoint,
+        justified_balances,
+        best_justified_checkpoint,
+        unrealized_justified_checkpoint,
+        unrealized_finalized_checkpoint,
+        proposer_boost_root,
+        equivocating_indices,
+    } = fork_choice_v11.fork_choice_store;
+
+    if !equivocating_indices.is_empty() {
+        warn!(
+            log,
+            "Deleting slashed validators from fork choice store";
+            "count" => equivocating_indices.len(),
+            "message" => "this may make your node more susceptible to following the wrong chain",
+        );
+    }
+
+    PersistedForkChoiceV10 {
+        fork_choice: fork_choice_v11.fork_choice,
+        fork_choice_store: PersistedForkChoiceStoreV10 {
+            balances_cache,
+            time,
+            finalized_checkpoint,
+            justified_checkpoint,
+            justified_balances,
+            best_justified_checkpoint,
+            unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint,
+            proposer_boost_root,
+        },
+    }
+}

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Checkpoint, Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(10);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(11);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -82,5 +82,5 @@ pub trait ForkChoiceStore<T: EthSpec>: Sized {
     fn equivocating_indices(&self) -> &BTreeSet<u64>;
 
     /// Adds to the set of equivocating indices.
-    fn extend_equivocating_indices(&mut self, indices: Vec<u64>);
+    fn extend_equivocating_indices(&mut self, indices: impl IntoIterator<Item = u64>);
 }

--- a/consensus/fork_choice/src/fork_choice_store.rs
+++ b/consensus/fork_choice/src/fork_choice_store.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use types::{BeaconBlockRef, BeaconState, Checkpoint, EthSpec, ExecPayload, Hash256, Slot};
 
 /// Approximates the `Store` in "Ethereum 2.0 Phase 0 -- Beacon Chain Fork Choice":
@@ -76,4 +77,10 @@ pub trait ForkChoiceStore<T: EthSpec>: Sized {
 
     /// Sets the proposer boost root.
     fn set_proposer_boost_root(&mut self, proposer_boost_root: Hash256);
+
+    /// Gets the equivocating indices.
+    fn equivocating_indices(&self) -> &BTreeSet<u64>;
+
+    /// Adds to the set of equivocating indices.
+    fn extend_equivocating_indices(&mut self, indices: Vec<u64>);
 }

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -6,6 +6,7 @@ mod votes;
 use crate::proto_array_fork_choice::{Block, ExecutionStatus, ProtoArrayForkChoice};
 use crate::InvalidationOperation;
 use serde_derive::{Deserialize, Serialize};
+use std::collections::BTreeSet;
 use types::{
     AttestationShufflingId, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
     MainnetEthSpec, Slot,
@@ -88,6 +89,7 @@ impl ForkChoiceTestDefinition {
             ExecutionStatus::Optimistic(ExecutionBlockHash::zero()),
         )
         .expect("should create fork choice struct");
+        let equivocating_indices = BTreeSet::new();
 
         for (op_index, op) in self.operations.into_iter().enumerate() {
             match op.clone() {
@@ -103,6 +105,7 @@ impl ForkChoiceTestDefinition {
                             finalized_checkpoint,
                             &justified_state_balances,
                             Hash256::zero(),
+                            &equivocating_indices,
                             Slot::new(0),
                             &spec,
                         )
@@ -130,6 +133,7 @@ impl ForkChoiceTestDefinition {
                             finalized_checkpoint,
                             &justified_state_balances,
                             proposer_boost_root,
+                            &equivocating_indices,
                             Slot::new(0),
                             &spec,
                         )
@@ -154,6 +158,7 @@ impl ForkChoiceTestDefinition {
                         finalized_checkpoint,
                         &justified_state_balances,
                         Hash256::zero(),
+                        &equivocating_indices,
                         Slot::new(0),
                         &spec,
                     );

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -14,7 +14,8 @@ eth2_ssz_derive = "0.3.0"
 
 [dependencies]
 ethereum-types = "0.12.1"
-smallvec = "1.6.1"
+smallvec = { version = "1.6.1", features = ["const_generics"] }
+itertools = "0.10.3"
 
 [features]
 arbitrary = ["ethereum-types/arbitrary"]

--- a/consensus/ssz/src/decode.rs
+++ b/consensus/ssz/src/decode.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 type SmallVec8<T> = SmallVec<[T; 8]>;
 
 pub mod impls;
+pub mod try_from_iter;
 
 /// Returned when SSZ decoding fails.
 #[derive(Debug, PartialEq, Clone)]

--- a/consensus/ssz/src/decode/try_from_iter.rs
+++ b/consensus/ssz/src/decode/try_from_iter.rs
@@ -1,0 +1,96 @@
+use smallvec::SmallVec;
+use std::collections::{BTreeMap, BTreeSet};
+use std::convert::Infallible;
+use std::fmt::Debug;
+
+/// Partial variant of `std::iter::FromIterator`.
+///
+/// This trait is implemented for types which can be constructed from an iterator of decoded SSZ
+/// values, but which may refuse values once a length limit is reached.
+pub trait TryFromIter<T>: Sized {
+    type Error: Debug;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>;
+}
+
+// It would be nice to be able to do a blanket impl, e.g.
+//
+// `impl TryFromIter<T> for C where C: FromIterator<T>`
+//
+// However this runs into trait coherence issues due to the type parameter `T` on `TryFromIter`.
+//
+// E.g. If we added an impl downstream for `List<T, N>` then another crate downstream of that
+// could legally add an impl of `FromIterator<Local> for List<Local, N>` which would create
+// two conflicting implementations for `List<Local, N>`. Hence the `List<T, N>` impl is disallowed
+// by the compiler in the presence of the blanket impl. That's obviously annoying, so we opt to
+// abandon the blanket impl in favour of impls for selected types.
+impl<T> TryFromIter<T> for Vec<T> {
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Ok(Self::from_iter(iter))
+    }
+}
+
+impl<T, const N: usize> TryFromIter<T> for SmallVec<[T; N]> {
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Ok(Self::from_iter(iter))
+    }
+}
+
+impl<K, V> TryFromIter<(K, V)> for BTreeMap<K, V>
+where
+    K: Ord,
+{
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = (K, V)>,
+    {
+        Ok(Self::from_iter(iter))
+    }
+}
+
+impl<T> TryFromIter<T> for BTreeSet<T>
+where
+    T: Ord,
+{
+    type Error = Infallible;
+
+    fn try_from_iter<I>(iter: I) -> Result<Self, Self::Error>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        Ok(Self::from_iter(iter))
+    }
+}
+
+/// Partial variant of `collect`.
+pub trait TryCollect: Iterator {
+    fn try_collect<C>(self) -> Result<C, C::Error>
+    where
+        C: TryFromIter<Self::Item>;
+}
+
+impl<I> TryCollect for I
+where
+    I: Iterator,
+{
+    fn try_collect<C>(self) -> Result<C, C::Error>
+    where
+        C: TryFromIter<Self::Item>,
+    {
+        C::try_from_iter(self)
+    }
+}

--- a/consensus/ssz/src/lib.rs
+++ b/consensus/ssz/src/lib.rs
@@ -40,8 +40,8 @@ pub mod legacy;
 mod union_selector;
 
 pub use decode::{
-    impls::decode_list_of_variable_length_items, read_offset, split_union_bytes, Decode,
-    DecodeError, SszDecoder, SszDecoderBuilder,
+    impls::decode_list_of_variable_length_items, read_offset, split_union_bytes,
+    try_from_iter::TryFromIter, Decode, DecodeError, SszDecoder, SszDecoderBuilder,
 };
 pub use encode::{encode_length, Encode, SszEncoder};
 pub use union_selector::UnionSelector;

--- a/consensus/ssz/tests/tests.rs
+++ b/consensus/ssz/tests/tests.rs
@@ -4,6 +4,8 @@ use ssz_derive::{Decode, Encode};
 
 mod round_trip {
     use super::*;
+    use std::collections::BTreeMap;
+    use std::iter::FromIterator;
 
     fn round_trip<T: Encode + Decode + std::fmt::Debug + PartialEq>(items: Vec<T>) {
         for item in items {
@@ -320,6 +322,52 @@ mod round_trip {
         ];
 
         round_trip(vec);
+    }
+
+    #[test]
+    fn btree_map_fixed() {
+        let data = vec![
+            BTreeMap::new(),
+            BTreeMap::from_iter(vec![(0u8, 0u16), (1, 2), (2, 4), (4, 6)]),
+        ];
+        round_trip(data);
+    }
+
+    #[test]
+    fn btree_map_variable_value() {
+        let data = vec![
+            BTreeMap::new(),
+            BTreeMap::from_iter(vec![
+                (
+                    0u64,
+                    ThreeVariableLen {
+                        a: 1,
+                        b: vec![3, 5, 7],
+                        c: vec![],
+                        d: vec![0, 0],
+                    },
+                ),
+                (
+                    1,
+                    ThreeVariableLen {
+                        a: 99,
+                        b: vec![1],
+                        c: vec![2, 3, 4, 5, 6, 7, 8, 9, 10],
+                        d: vec![4, 5, 6, 7, 8],
+                    },
+                ),
+                (
+                    2,
+                    ThreeVariableLen {
+                        a: 0,
+                        b: vec![],
+                        c: vec![],
+                        d: vec![],
+                    },
+                ),
+            ]),
+        ];
+        round_trip(data);
     }
 }
 

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -255,7 +255,8 @@ where
                 })
                 .map(Into::into)
         } else {
-            ssz::decode_list_of_variable_length_items(bytes, Some(max_len)).map(|vec| vec.into())
+            ssz::decode_list_of_variable_length_items(bytes, Some(max_len))
+                .map(|vec: Vec<_>| vec.into())
         }
     }
 }

--- a/consensus/state_processing/src/verify_operation.rs
+++ b/consensus/state_processing/src/verify_operation.rs
@@ -12,7 +12,7 @@ use types::{
 /// Wrapper around an operation type that acts as proof that its signature has been checked.
 ///
 /// The inner field is private, meaning instances of this type can only be constructed
-/// by calling `validate` or using `new_unsafe` (which should only be used in tests).
+/// by calling `validate`.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SigVerifiedOp<T>(T);
 
@@ -23,10 +23,6 @@ impl<T> SigVerifiedOp<T> {
 
     pub fn as_inner(&self) -> &T {
         &self.0
-    }
-
-    pub fn new_unsafe(val: T) -> Self {
-        SigVerifiedOp(val)
     }
 }
 

--- a/consensus/state_processing/src/verify_operation.rs
+++ b/consensus/state_processing/src/verify_operation.rs
@@ -12,7 +12,7 @@ use types::{
 /// Wrapper around an operation type that acts as proof that its signature has been checked.
 ///
 /// The inner field is private, meaning instances of this type can only be constructed
-/// by calling `validate`.
+/// by calling `validate` or using `new_unsafe` (which should only be used in tests).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SigVerifiedOp<T>(T);
 
@@ -23,6 +23,10 @@ impl<T> SigVerifiedOp<T> {
 
     pub fn as_inner(&self) -> &T {
         &self.0
+    }
+
+    pub fn new_unsafe(val: T) -> Self {
+        SigVerifiedOp(val)
     }
 }
 

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.1.10
+TESTS_TAG := v1.2.0-rc.1
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -33,6 +33,8 @@ excluded_paths = [
     "tests/.*/.*/ssz_static/LightClientSnapshot",
     # Merkle-proof tests for light clients
     "tests/.*/.*/merkle/single_proof",
+    # Capella tests are disabled for now.
+    "tests/.*/capella",
     # One of the EF researchers likes to pack the tarballs on a Mac
     ".*\.DS_Store.*"
 ]

--- a/testing/ef_tests/src/cases/epoch_processing.rs
+++ b/testing/ef_tests/src/cases/epoch_processing.rs
@@ -276,7 +276,8 @@ impl<E: EthSpec, T: EpochTransition<E>> Case for EpochProcessing<E, T> {
                     && T::name() != "inactivity_updates"
                     && T::name() != "participation_flag_updates"
             }
-            ForkName::Altair | ForkName::Merge => true, // TODO: revisit when tests are out
+            // No phase0 tests for Altair and later.
+            ForkName::Altair | ForkName::Merge => T::name() != "participation_record_updates",
         }
     }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -75,12 +75,7 @@ pub struct ForkChoiceTest<E: EthSpec> {
     pub anchor_state: BeaconState<E>,
     pub anchor_block: BeaconBlock<E>,
     #[allow(clippy::type_complexity)]
-    pub steps: Vec<Step<SignedBeaconBlock<E>, Attestation<E>, PowBlock, AttesterSlashing<E>>>,
-}
-
-/// Spec to be used for fork choice tests.
-pub fn fork_choice_spec<E: EthSpec>(fork_name: ForkName) -> ChainSpec {
-    testing_spec::<E>(fork_name)
+    pub steps: Vec<Step<SignedBeaconBlock<E>, Attestation<E>, AttesterSlashing<E>, PowBlock>>,
 }
 
 impl<E: EthSpec> LoadCase for ForkChoiceTest<E> {

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -52,7 +52,7 @@ pub trait Handler {
                 .filter(|e| e.file_type().map(|ty| ty.is_dir()).unwrap_or(false))
         };
         let test_cases = fs::read_dir(&handler_path)
-            .expect("handler dir exists")
+            .unwrap_or_else(|e| panic!("handler dir {} exists: {:?}", handler_path.display(), e))
             .filter_map(as_directory)
             .flat_map(|suite| fs::read_dir(suite.path()).expect("suite dir exists"))
             .filter_map(as_directory)

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -378,7 +378,8 @@ fn epoch_processing_participation_record_updates() {
 #[test]
 fn epoch_processing_sync_committee_updates() {
     EpochProcessingHandler::<MinimalEthSpec, SyncCommitteeUpdates>::default().run();
-    EpochProcessingHandler::<MainnetEthSpec, SyncCommitteeUpdates>::default().run();
+    // FIXME(sproul): these mainnet tests have gone missing
+    // EpochProcessingHandler::<MainnetEthSpec, SyncCommitteeUpdates>::default().run();
 }
 
 #[test]

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -377,9 +377,9 @@ fn epoch_processing_participation_record_updates() {
 
 #[test]
 fn epoch_processing_sync_committee_updates() {
+    // There are presently no mainnet tests, see:
+    // https://github.com/ethereum/consensus-spec-tests/issues/29
     EpochProcessingHandler::<MinimalEthSpec, SyncCommitteeUpdates>::default().run();
-    // FIXME(sproul): these mainnet tests have gone missing
-    // EpochProcessingHandler::<MainnetEthSpec, SyncCommitteeUpdates>::default().run();
 }
 
 #[test]


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/3241
Closes https://github.com/sigp/lighthouse/issues/3242

## Proposed Changes

* [x] Implement logic to remove equivocating validators from fork choice per https://github.com/ethereum/consensus-specs/pull/2845
* [x] Update tests to v1.2.0-rc.1. The new test which exercises `equivocating_indices` is passing.
* [x] Pull in some SSZ abstractions from the `tree-states` branch that make implementing Vec-compatible encoding for types like `BTreeSet` and `BTreeMap`.
* [x] Implement schema upgrades and downgrades for the database (new schema version is V11).
* [x] Apply attester slashings from blocks to fork choice

## Additional Info

* This PR doesn't need the `BTreeMap` impl, but `tree-states` does, and I don't think there's any harm in keeping it. But I could also be convinced to drop it.

Blocked on #3322.
