### PR TITLE
[Merged by Bors] - Add `is_optimistic` to `eth/v1/node/syncing` response

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1852,8 +1852,13 @@ pub fn serve<T: BeaconChainTypes>(
                     // Taking advantage of saturating subtraction on slot.
                     let sync_distance = current_slot - head_slot;
 
+                    let is_optimistic = chain
+                        .is_optimistic_head()
+                        .map_err(warp_utils::reject::beacon_chain_error)?;
+
                     let syncing_data = api_types::SyncingData {
                         is_syncing: network_globals.sync_state.read().is_syncing(),
+                        is_optimistic,
                         head_slot,
                         sync_distance,
                     };

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1281,6 +1281,7 @@ impl ApiTester {
 
         let expected = SyncingData {
             is_syncing: false,
+            is_optimistic: false,
             head_slot,
             sync_distance,
         };

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -552,6 +552,7 @@ pub struct VersionData {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncingData {
     pub is_syncing: bool,
+    pub is_optimistic: bool,
     pub head_slot: Slot,
     pub sync_distance: Slot,
 }


### PR DESCRIPTION
## Issue Addressed

As specified in the [Beacon Chain API specs](https://github.com/ethereum/beacon-APIs/blob/master/apis/node/syncing.yaml#L32-L35) we should return `is_optimistic` as part of the response to a query for the `eth/v1/node/syncing` endpoint.

## Proposed Changes

Compute the optimistic status of the head and add it to the `SyncingData` response.
