### PR TITLE
[Merged by Bors] - Allow syncing or accepted in integration test

### DIFF
--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -488,7 +488,11 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .notify_new_payload(&second_payload)
             .await
             .unwrap();
-        assert_eq!(status, PayloadStatus::Accepted);
+        // TODO: we should remove the `Accepted` status here once Geth fixes it
+        assert!(matches!(
+            status,
+            PayloadStatus::Syncing | PayloadStatus::Accepted
+        ));
 
         /*
          * Execution Engine B:


### PR DESCRIPTION
## Issue Addressed

Unblock CI for this failure: https://github.com/sigp/lighthouse/runs/7529551988

The root cause is a disagreement between the test and Nethermind over whether the appropriate status for a payload with an unknown parent is SYNCING or ACCEPTED. According to the spec, SYNCING is correct so we should update the test to expect this correct behaviour. However Geth still returns `ACCEPTED`, so for now we allow either.
