### PR TITLE
[Merged by Bors] - Downgrade Geth to v1.10.20 in EE integration tests

### DIFF
--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -7,7 +7,10 @@ use std::{env, fs::File};
 use tempfile::TempDir;
 use unused_port::unused_tcp_port;
 
-const GETH_BRANCH: &str = "master";
+// TODO: this should be set back to `master` once the following issue is resolved:
+//
+// - https://github.com/ethereum/go-ethereum/issues/25427
+const GETH_BRANCH: &str = "v1.10.20";
 const GETH_REPO_URL: &str = "https://github.com/ethereum/go-ethereum";
 
 pub fn build_result(repo_dir: &Path) -> Output {

--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -7,10 +7,7 @@ use std::{env, fs::File};
 use tempfile::TempDir;
 use unused_port::unused_tcp_port;
 
-// TODO: this should be set back to `master` once the following issue is resolved:
-//
-// - https://github.com/ethereum/go-ethereum/issues/25427
-const GETH_BRANCH: &str = "v1.10.20";
+// const GETH_BRANCH: &str = "master";
 const GETH_REPO_URL: &str = "https://github.com/ethereum/go-ethereum";
 
 pub fn build_result(repo_dir: &Path) -> Output {
@@ -29,8 +26,13 @@ pub fn build(execution_clients_dir: &Path) {
         build_utils::clone_repo(execution_clients_dir, GETH_REPO_URL).unwrap();
     }
 
+    // TODO: this should be set back to the latest release once the following issue is resolved:
+    //
+    // - https://github.com/ethereum/go-ethereum/issues/25427
+    //
     // Get the latest tag on the branch
-    let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
+    // let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
+    let last_release = "v1.10.20";
     build_utils::checkout(&repo_dir, dbg!(&last_release)).unwrap();
 
     // Build geth

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -359,7 +359,10 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .notify_new_payload(&valid_payload)
             .await
             .unwrap();
-        assert_eq!(status, PayloadStatus::Valid);
+        assert!(matches!(
+            status,
+            PayloadStatus::Valid | PayloadStatus::Accepted
+        ));
         check_payload_reconstruction(&self.ee_a, &valid_payload).await;
 
         /*

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -359,10 +359,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .notify_new_payload(&valid_payload)
             .await
             .unwrap();
-        assert!(matches!(
-            status,
-            PayloadStatus::Valid | PayloadStatus::Accepted
-        ));
+        assert_eq!(status, PayloadStatus::Valid);
         check_payload_reconstruction(&self.ee_a, &valid_payload).await;
 
         /*


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

The execution integration tests have started failing since Geth updated to v1.10.21. More details here: https://github.com/ethereum/go-ethereum/issues/25427#issuecomment-1197552755

This PR pins our version at v1.10.20.

## Additional Info

NA
