### PR TITLE
[Merged by Bors] - Fix penalties in sync methods

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -7,10 +7,10 @@ use crate::beacon_processor::DuplicateCache;
 use crate::metrics;
 use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
+use beacon_chain::CountUnrealized;
 use beacon_chain::{
     BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,
 };
-use beacon_chain::{CountUnrealized, ExecutionPayloadError};
 use lighthouse_network::PeerAction;
 use slog::{debug, error, info, warn};
 use std::sync::Arc;
@@ -485,24 +485,22 @@ impl<T: BeaconChainTypes> Worker<T> {
                     mode: FailureMode::ConsensusLayer,
                 })
             }
-            BlockError::ExecutionPayloadError(e) => match &e {
-                ExecutionPayloadError::NoExecutionConnection { .. }
-                | ExecutionPayloadError::RequestFailed { .. } => {
+            ref err @ BlockError::ExecutionPayloadError(ref epe) => {
+                if !epe.penalize_peer() {
                     // These errors indicate an issue with the EL and not the `ChainSegment`.
                     // Pause the syncing while the EL recovers
                     debug!(self.log,
                         "Execution layer verification failed";
                         "outcome" => "pausing sync",
-                        "err" => ?e
+                        "err" => ?err
                     );
                     Err(ChainSegmentFailed {
-                        message: format!("Execution layer offline. Reason: {:?}", e),
+                        message: format!("Execution layer offline. Reason: {:?}", err),
                         // Do not penalize peers for internal errors.
                         peer_action: None,
                         mode: FailureMode::ExecutionLayer { pause_sync: true },
                     })
-                }
-                err => {
+                } else {
                     debug!(self.log,
                         "Invalid execution payload";
                         "error" => ?err
@@ -516,7 +514,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                         mode: FailureMode::ExecutionLayer { pause_sync: false },
                     })
                 }
-            },
+            }
             other => {
                 debug!(
                     self.log, "Invalid block received";


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Uses the `penalize_peer` function added in #3350 in sync methods as well. The existing code in sync methods missed the `ExecutionPayloadError::UnverifiedNonOptimisticCandidate` case.
