### PR TITLE
[Merged by Bors] - `crypto/bls`: make `blst` dependency optional

### DIFF
--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -17,12 +17,12 @@ eth2_hashing = "0.3.0"
 ethereum-types = "0.12.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
-blst = "0.3.3"
+blst = { version = "0.3.3", optional = true }
 
 [features]
 default = ["supranational"]
 fake_crypto = []
 milagro = ["milagro_bls"]
-supranational = []
+supranational = ["blst"]
 supranational-portable = ["supranational", "blst/portable"]
 supranational-force-adx = ["supranational", "blst/force-adx"]

--- a/crypto/bls/src/impls/mod.rs
+++ b/crypto/bls/src/impls/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "supranational")]
 pub mod blst;
 pub mod fake_crypto;
 #[cfg(feature = "milagro")]

--- a/crypto/bls/src/lib.rs
+++ b/crypto/bls/src/lib.rs
@@ -41,6 +41,7 @@ pub use generic_signature::{INFINITY_SIGNATURE, SIGNATURE_BYTES_LEN};
 pub use get_withdrawal_credentials::get_withdrawal_credentials;
 pub use zeroize_hash::ZeroizeHash;
 
+#[cfg(feature = "supranational")]
 use blst::BLST_ERROR as BlstError;
 #[cfg(feature = "milagro")]
 use milagro_bls::AmclError;
@@ -53,6 +54,7 @@ pub enum Error {
     #[cfg(feature = "milagro")]
     MilagroError(AmclError),
     /// An error was raised from the Supranational BLST BLS library.
+    #[cfg(feature = "supranational")]
     BlstError(BlstError),
     /// The provided bytes were an incorrect length.
     InvalidByteLength { got: usize, expected: usize },
@@ -71,6 +73,7 @@ impl From<AmclError> for Error {
     }
 }
 
+#[cfg(feature = "supranational")]
 impl From<BlstError> for Error {
     fn from(e: BlstError) -> Error {
         Error::BlstError(e)
@@ -130,6 +133,7 @@ macro_rules! define_mod {
 
 #[cfg(feature = "milagro")]
 define_mod!(milagro_implementations, crate::impls::milagro::types);
+#[cfg(feature = "supranational")]
 define_mod!(blst_implementations, crate::impls::blst::types);
 #[cfg(feature = "fake_crypto")]
 define_mod!(


### PR DESCRIPTION
## Issue Addressed

#3386 

## Proposed Changes

* make `blst` crate `optional`
* include `blst` dependency into `supranational` feature
* hide `blst`-related code with `supranational` feature