### PR TITLE
[Merged by Bors] - Include validator indices in attestation logs

### DIFF
--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -429,7 +429,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
                 log,
                 "Successfully published attestations";
                 "count" => attestations.len(),
-                "validator_indices" => format!("{:?}", validator_indices),
+                "validator_indices" => ?validator_indices,
                 "head_block" => ?attestation_data.beacon_block_root,
                 "committee_index" => attestation_data.index,
                 "slot" => attestation_data.slot.as_u64(),


### PR DESCRIPTION
## Issue Addressed

Fixes #2967

## Proposed Changes

Collect validator indices alongside attestations when creating signed
attestations (and aggregates) for inclusion in the logs.

## Additional Info

This is my first time looking at Lighthouse source code and using Rust, so newbie feedback appreciated!