### PR TITLE
[Merged by Bors] - Use latest Geth release in EE integration tests

### DIFF
--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -100,6 +100,11 @@ impl GenericExecutionEngine for GethEngine {
             .arg("--allow-insecure-unlock")
             .arg("--authrpc.jwtsecret")
             .arg(jwt_secret_path.as_path().to_str().unwrap())
+            // This flag is required to help Geth perform reliably when feeding it blocks
+            // one-by-one. For more information, see:
+            //
+            // https://github.com/sigp/lighthouse/pull/3382#issuecomment-1197680345
+            .arg("--syncmode=full")
             .stdout(build_utils::build_stdio())
             .stderr(build_utils::build_stdio())
             .spawn()

--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -7,7 +7,7 @@ use std::{env, fs::File};
 use tempfile::TempDir;
 use unused_port::unused_tcp_port;
 
-// const GETH_BRANCH: &str = "master";
+const GETH_BRANCH: &str = "master";
 const GETH_REPO_URL: &str = "https://github.com/ethereum/go-ethereum";
 
 pub fn build_result(repo_dir: &Path) -> Output {
@@ -26,13 +26,8 @@ pub fn build(execution_clients_dir: &Path) {
         build_utils::clone_repo(execution_clients_dir, GETH_REPO_URL).unwrap();
     }
 
-    // TODO: this should be set back to the latest release once the following issue is resolved:
-    //
-    // - https://github.com/ethereum/go-ethereum/issues/25427
-    //
     // Get the latest tag on the branch
-    // let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
-    let last_release = "v1.10.20";
+    let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
     build_utils::checkout(&repo_dir, dbg!(&last_release)).unwrap();
 
     // Build geth


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR reverts #3382 and adds the `--syncmode=full` as described here: https://github.com/sigp/lighthouse/pull/3382#issuecomment-1197680345

## Additional Info

- Blocked on #3392
