### PR TITLE
[Merged by Bors] - Make fork choice prune again

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -719,6 +719,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         drop(old_cached_head);
 
         // If the finalized checkpoint changed, perform some updates.
+        //
+        // The `after_finalization` function will take a write-lock on `fork_choice`, therefore it
+        // is a dead-lock risk to hold any other lock on fork choice at this point.
         if new_view.finalized_checkpoint != old_view.finalized_checkpoint {
             if let Err(e) =
                 self.after_finalization(&new_cached_head, new_view, finalized_proto_block)
@@ -878,6 +881,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Perform updates to caches and other components after the finalized checkpoint has been
     /// changed.
+    ///
+    /// This function will take a write-lock on `canonical_head.fork_choice`, therefore it would be
+    /// unwise to hold any lock on fork choice while calling this function.
     fn after_finalization(
         self: &Arc<Self>,
         new_cached_head: &CachedHead<T::EthSpec>,
@@ -965,6 +971,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             new_view.finalized_checkpoint,
             self.head_tracker.clone(),
         )?;
+
+        // Take a write-lock on the canonical head and signal for it to prune.
+        self.canonical_head.fork_choice_write_lock.prune()?;
 
         Ok(())
     }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -973,7 +973,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         )?;
 
         // Take a write-lock on the canonical head and signal for it to prune.
-        self.canonical_head.fork_choice_write_lock.prune()?;
+        self.canonical_head.fork_choice_write_lock().prune()?;
 
         Ok(())
     }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

There was a regression in #3244 (released in v2.4.0) which stopped pruning fork choice (see [here](https://github.com/sigp/lighthouse/pull/3244#discussion_r935187485)).

This would form a very slow memory leak, using ~100mb per month. The release has been out for ~11 days, so users should not be seeing a dangerous increase in memory, *yet*.

Credits to @michaelsproul for noticing this :tada: 

## Additional Info

NA
