### PR TITLE
[Merged by Bors] - Restore backwards compatibility when using older BNs

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1704,7 +1704,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let syncing_data = api_types::SyncingData {
                         is_syncing: network_globals.sync_state.read().is_syncing(),
-                        is_optimistic,
+                        is_optimistic: Some(is_optimistic),
                         head_slot,
                         sync_distance,
                     };

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1300,7 +1300,7 @@ impl ApiTester {
 
         let expected = SyncingData {
             is_syncing: false,
-            is_optimistic: false,
+            is_optimistic: Some(false),
             head_slot,
             sync_distance,
         };

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -552,7 +552,7 @@ pub struct VersionData {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncingData {
     pub is_syncing: bool,
-    pub is_optimistic: bool,
+    pub is_optimistic: Option<bool>,
     pub head_slot: Slot,
     pub sync_distance: Slot,
 }


### PR DESCRIPTION
## Issue Addressed

https://github.com/status-im/nimbus-eth2/issues/3930

## Proposed Changes

We can trivially support beacon nodes which do not provide the `is_optimistic` field by wrapping the field in an `Option`.
