### PR TITLE
[Merged by Bors] - Downgrade log for 204 from builder

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -605,7 +605,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             Ok(local)
                         }
                         (Ok(None), Ok(local)) => {
-                            warn!(
+                            info!(
                                 self.log(),
                                 "No payload provided by connected builder. \
                                 Attempting to propose through local execution engine"


### PR DESCRIPTION
## Issue Addressed

A 204 from the connected builder just indicates there's no payload available from the builder, not that there's an issue. So I don't actually think this should be a warn. During the merge transition when we are pre-finalization a 204 will actually be expected. And maybe even longer if the relay chooses to delay providing payloads for a longer period post-merge.