### PR TITLE
Fix EL sync status

### DIFF
--- a/beacon_node/beacon_chain/src/merge_readiness.rs
+++ b/beacon_node/beacon_chain/src/merge_readiness.rs
@@ -157,7 +157,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 };
             }
 
-            if !el.is_synced_for_notifier().await {
+            if !el.is_synced().await {
                 // The EL is not synced.
                 return MergeReadiness::NotSynced;
             }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -399,29 +399,6 @@ impl<T: EthSpec> ExecutionLayer<T> {
         self.engine().is_synced().await
     }
 
-    /// Execution nodes return a "SYNCED" response when they do not have any peers.
-    ///
-    /// This function is a wrapper over `Self::is_synced` that makes an additional
-    /// check for the execution layer sync status. Checks if the latest block has
-    /// a `block_number != 0`.
-    /// Returns the `Self::is_synced` response if unable to get latest block.
-    pub async fn is_synced_for_notifier(&self) -> bool {
-        let synced = self.is_synced().await;
-        if synced {
-            if let Ok(Some(block)) = self
-                .engine()
-                .api
-                .get_block_by_number(BlockByNumberQuery::Tag(LATEST_TAG))
-                .await
-            {
-                if block.block_number == 0 {
-                    return false;
-                }
-            }
-        }
-        synced
-    }
-
     /// Updates the proposer preparation data provided by validators
     pub async fn update_proposer_preparation(
         &self,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Correctly estimate the sync status of the EL. EL's return "synced" response to `eth_syncing` json rpc requests even when they aren't synced in some cases like:
- EL has no peers to estimate it's synced status
- EL is reverse syncing beacon headers (this is for geth)

Here, we add an additional check to see if the latest EL block's timestamp is within some distance of the current time. 

