### PR TITLE
[Merged by Bors] - Handle processing results of non faulty batches

### DIFF
--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -76,9 +76,7 @@ mod work_reprocessing_queue;
 mod worker;
 
 use crate::beacon_processor::work_reprocessing_queue::QueuedGossipBlock;
-pub use worker::{
-    ChainSegmentProcessId, FailureMode, GossipAggregatePackage, GossipAttestationPackage,
-};
+pub use worker::{ChainSegmentProcessId, GossipAggregatePackage, GossipAttestationPackage};
 
 /// The maximum size of the channel for work events to the `BeaconProcessor`.
 ///

--- a/beacon_node/network/src/beacon_processor/worker/mod.rs
+++ b/beacon_node/network/src/beacon_processor/worker/mod.rs
@@ -10,7 +10,7 @@ mod rpc_methods;
 mod sync_methods;
 
 pub use gossip_methods::{GossipAggregatePackage, GossipAttestationPackage};
-pub use sync_methods::{ChainSegmentProcessId, FailureMode};
+pub use sync_methods::ChainSegmentProcessId;
 
 pub(crate) const FUTURE_SLOT_TOLERANCE: u64 = 1;
 

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -12,7 +12,7 @@ use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent as BeaconWorkEven
 use crate::sync::manager::{BatchProcessResult, Id};
 use crate::sync::network_context::SyncNetworkContext;
 use crate::sync::range_sync::{
-    BatchConfig, BatchId, BatchInfo, BatchProcessingResult, BatchState, BatchOperationOutcome,
+    BatchConfig, BatchId, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState,
 };
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::types::{BackFillState, NetworkGlobals};

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use store::{Hash256, SignedBeaconBlock};
 use tokio::sync::mpsc;
 
-use crate::beacon_processor::{ChainSegmentProcessId, FailureMode, WorkEvent};
+use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent};
 use crate::metrics;
 
 use self::{
@@ -610,34 +610,25 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 chain_hash
             );
             #[cfg(not(debug_assertions))]
-            return crit!(self.log, "Chain process response for a parent lookup request that was not found"; "chain_hash" => %chain_hash);
+            return debug!(self.log, "Chain process response for a parent lookup request that was not found"; "chain_hash" => %chain_hash);
         };
 
         debug!(self.log, "Parent chain processed"; "chain_hash" => %chain_hash, "result" => ?result);
         match result {
-            BatchProcessResult::Success(_) => {
+            BatchProcessResult::Success { .. } => {
                 // nothing to do.
             }
-            BatchProcessResult::Failed {
+            BatchProcessResult::FaultyFailure {
                 imported_blocks: _,
-                peer_action,
-                mode,
+                penalty,
             } => {
-                if let FailureMode::ExecutionLayer { pause_sync: _ } = mode {
-                    debug!(
-                        self.log,
-                        "Chain segment processing failed. Execution layer is offline";
-                        "chain_hash" => %chain_hash,
-                        "error" => ?mode
-                    );
-                } else {
-                    self.failed_chains.insert(parent_lookup.chain_hash());
-                    if let Some(peer_action) = peer_action {
-                        for &peer_id in parent_lookup.used_peers() {
-                            cx.report_peer(peer_id, peer_action, "parent_chain_failure")
-                        }
-                    }
+                self.failed_chains.insert(parent_lookup.chain_hash());
+                for &peer_id in parent_lookup.used_peers() {
+                    cx.report_peer(peer_id, penalty, "parent_chain_failure")
                 }
+            }
+            BatchProcessResult::NonFaultyFailure => {
+                // We might request this chain again if there is need but otherwise, don't try again
             }
         }
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -284,7 +284,10 @@ fn test_parent_lookup_happy_path() {
     // Processing succeeds, now the rest of the chain should be sent for processing.
     bl.parent_block_processed(chain_hash, BlockError::BlockIsAlreadyKnown.into(), &mut cx);
     rig.expect_parent_chain_process();
-    bl.parent_chain_processed(chain_hash, BatchProcessResult::Success(true), &mut cx);
+    let process_result = BatchProcessResult::Success {
+        was_non_empty: true,
+    };
+    bl.parent_chain_processed(chain_hash, process_result, &mut cx);
     assert_eq!(bl.parent_queue.len(), 0);
 }
 
@@ -318,7 +321,10 @@ fn test_parent_lookup_wrong_response() {
     // Processing succeeds, now the rest of the chain should be sent for processing.
     bl.parent_block_processed(chain_hash, Ok(()).into(), &mut cx);
     rig.expect_parent_chain_process();
-    bl.parent_chain_processed(chain_hash, BatchProcessResult::Success(true), &mut cx);
+    let process_result = BatchProcessResult::Success {
+        was_non_empty: true,
+    };
+    bl.parent_chain_processed(chain_hash, process_result, &mut cx);
     assert_eq!(bl.parent_queue.len(), 0);
 }
 
@@ -347,7 +353,10 @@ fn test_parent_lookup_empty_response() {
     // Processing succeeds, now the rest of the chain should be sent for processing.
     bl.parent_block_processed(chain_hash, Ok(()).into(), &mut cx);
     rig.expect_parent_chain_process();
-    bl.parent_chain_processed(chain_hash, BatchProcessResult::Success(true), &mut cx);
+    let process_result = BatchProcessResult::Success {
+        was_non_empty: true,
+    };
+    bl.parent_chain_processed(chain_hash, process_result, &mut cx);
     assert_eq!(bl.parent_queue.len(), 0);
 }
 
@@ -375,7 +384,10 @@ fn test_parent_lookup_rpc_failure() {
     // Processing succeeds, now the rest of the chain should be sent for processing.
     bl.parent_block_processed(chain_hash, Ok(()).into(), &mut cx);
     rig.expect_parent_chain_process();
-    bl.parent_chain_processed(chain_hash, BatchProcessResult::Success(true), &mut cx);
+    let process_result = BatchProcessResult::Success {
+        was_non_empty: true,
+    };
+    bl.parent_chain_processed(chain_hash, process_result, &mut cx);
     assert_eq!(bl.parent_queue.len(), 0);
 }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -38,7 +38,7 @@ use super::block_lookups::BlockLookups;
 use super::network_context::SyncNetworkContext;
 use super::peer_sync_info::{remote_sync_type, PeerSyncType};
 use super::range_sync::{RangeSync, RangeSyncType, EPOCHS_PER_BATCH};
-use crate::beacon_processor::{ChainSegmentProcessId, FailureMode, WorkEvent as BeaconWorkEvent};
+use crate::beacon_processor::{ChainSegmentProcessId, WorkEvent as BeaconWorkEvent};
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError};
@@ -139,13 +139,15 @@ pub enum BlockProcessResult<T: EthSpec> {
 #[derive(Debug)]
 pub enum BatchProcessResult {
     /// The batch was completed successfully. It carries whether the sent batch contained blocks.
-    Success(bool),
-    /// The batch processing failed. It carries whether the processing imported any block.
-    Failed {
-        imported_blocks: bool,
-        peer_action: Option<PeerAction>,
-        mode: FailureMode,
+    Success {
+        was_non_empty: bool,
     },
+    /// The batch processing failed. It carries whether the processing imported any block.
+    FaultyFailure {
+        imported_blocks: bool,
+        penalty: PeerAction,
+    },
+    NonFaultyFailure,
 }
 
 /// The primary object for handling and driving all the current syncing logic. It maintains the

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -9,4 +9,4 @@ mod peer_sync_info;
 mod range_sync;
 
 pub use manager::{BatchProcessResult, SyncMessage};
-pub use range_sync::ChainId;
+pub use range_sync::{ChainId, BatchOperationOutcome};

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -9,4 +9,4 @@ mod peer_sync_info;
 mod range_sync;
 
 pub use manager::{BatchProcessResult, SyncMessage};
-pub use range_sync::{ChainId, BatchOperationOutcome};
+pub use range_sync::{BatchOperationOutcome, ChainId};

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -179,7 +179,7 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
         )
     }
 
-    /// Verifies if an incomming block belongs to this batch.
+    /// Verifies if an incoming block belongs to this batch.
     pub fn is_expecting_block(&self, peer_id: &PeerId, request_id: &Id) -> bool {
         if let BatchState::Downloading(expected_peer, _, expected_id) = &self.state {
             return peer_id == expected_peer && expected_id == request_id;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -38,7 +38,7 @@ pub type ProcessingResult = Result<KeepChain, RemoveChain>;
 pub enum RemoveChain {
     EmptyPeerPool,
     ChainCompleted,
-    /// A chain has failed. This bool signales whether the chain should be blacklisted.
+    /// A chain has failed. This boolean signals whether the chain should be blacklisted.
     ChainFailed(bool),
     WrongBatchState(String),
     WrongChainState(String),

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -529,10 +529,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 imported_blocks,
                 penalty,
             } => {
-                // The peer is considered objectively faulty.
-                debug!(self.log, "Batch processing failed"; "imported_blocks" => imported_blocks, "peer_penalty" => ?penalty,
-                    "batch_epoch" => batch_id, "peer" => %peer, "client" => %network.client_type(&peer));
-
                 // Penalize the peer appropiately.
                 network.report_peer(peer, *penalty, "faulty_batch");
 

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -8,7 +8,7 @@ mod chain_collection;
 mod range;
 mod sync_type;
 
-pub use batch::{BatchConfig, BatchInfo, BatchProcessingResult, BatchState, BatchOperationOutcome};
+pub use batch::{BatchConfig, BatchInfo, BatchOperationOutcome, BatchProcessingResult, BatchState};
 pub use chain::{BatchId, ChainId, EPOCHS_PER_BATCH};
 pub use range::RangeSync;
 pub use sync_type::RangeSyncType;

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -8,7 +8,7 @@ mod chain_collection;
 mod range;
 mod sync_type;
 
-pub use batch::{BatchConfig, BatchInfo, BatchProcessingResult, BatchState};
+pub use batch::{BatchConfig, BatchInfo, BatchProcessingResult, BatchState, OpOutcome};
 pub use chain::{BatchId, ChainId, EPOCHS_PER_BATCH};
 pub use range::RangeSync;
 pub use sync_type::RangeSyncType;

--- a/beacon_node/network/src/sync/range_sync/mod.rs
+++ b/beacon_node/network/src/sync/range_sync/mod.rs
@@ -8,7 +8,7 @@ mod chain_collection;
 mod range;
 mod sync_type;
 
-pub use batch::{BatchConfig, BatchInfo, BatchProcessingResult, BatchState, OpOutcome};
+pub use batch::{BatchConfig, BatchInfo, BatchProcessingResult, BatchState, BatchOperationOutcome};
 pub use chain::{BatchId, ChainId, EPOCHS_PER_BATCH};
 pub use range::RangeSync;
 pub use sync_type::RangeSyncType;

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -356,8 +356,8 @@ where
             debug!(self.log, "Chain removed"; "sync_type" => ?sync_type, &chain, "reason" => ?remove_reason, "op" => op);
         }
 
-        if let RemoveChain::ChainFailed(_) = remove_reason {
-            if RangeSyncType::Finalized == sync_type {
+        if let RemoveChain::ChainFailed(should_blacklist) = remove_reason {
+            if RangeSyncType::Finalized == sync_type && should_blacklist {
                 warn!(self.log, "Chain failed! Syncing to its head won't be retried for at least the next {} seconds", FAILED_CHAINS_EXPIRY_SECONDS; &chain);
                 self.failed_chains.insert(chain.target_head_root);
             }

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -356,8 +356,8 @@ where
             debug!(self.log, "Chain removed"; "sync_type" => ?sync_type, &chain, "reason" => ?remove_reason, "op" => op);
         }
 
-        if let RemoveChain::ChainFailed(should_blacklist) = remove_reason {
-            if RangeSyncType::Finalized == sync_type && should_blacklist {
+        if let RemoveChain::ChainFailed { blacklist, .. } = remove_reason {
+            if RangeSyncType::Finalized == sync_type && blacklist {
                 warn!(self.log, "Chain failed! Syncing to its head won't be retried for at least the next {} seconds", FAILED_CHAINS_EXPIRY_SECONDS; &chain);
                 self.failed_chains.insert(chain.target_head_root);
             }


### PR DESCRIPTION
## Issue Addressed
Solves #3390 

So after checking some logs @pawanjay176 got, we conclude that this happened because we blacklisted a chain after trying it "too much". Now here, in all occurrences it seems that "too much" means we got too many download failures. This happened very slowly, exactly because the batch is allowed to stay alive for very long times after not counting penalties when the ee is offline. The error here then was not that the batch failed because of offline ee errors, but that we blacklisted a chain because of download errors, which we can't pin on the chain but on the peer. This PR fixes that.

## Proposed Changes

Adds a missing piece of logic so that if a chain fails for errors that can't be attributed to an objectively bad behavior from the peer, it is not blacklisted. The issue at hand occurred when new peers arrived claiming a head that had wrongfully blacklisted, even if the original peers participating in the chain were not penalized.

Another notable change is that we need to consider a batch invalid if it processed correctly but its next non empty batch fails processing. Now since a batch can fail processing in non empty ways, there is no need to mark as invalid previous batches.

Improves some logging as well.

## Additional Info

We should do this regardless of pausing sync on ee offline/unsynced state. This is because I think it's almost impossible to ensure a processing result will reach in a predictable order with a synced notification from the ee. Doing this handles what I think are inevitable data races when we actually pause sync

This also fixes a return that reports which batch failed and caused us some confusion checking the logs
