### PR TITLE
Implement pessimistic sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "slasher",
  "slog",
  "store",
+ "strum",
  "task_executor",
  "types",
  "unused_port",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -41,3 +41,4 @@ monitoring_api = { path = "../common/monitoring_api" }
 sensitive_url = { path = "../common/sensitive_url" }
 http_api = { path = "http_api" }
 unused_port = { path = "../common/unused_port" }
+strum = "0.24.1"

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -835,6 +835,7 @@ where
             "head_state" => format!("{}", head.beacon_state_root()),
             "head_block" => format!("{}", head.beacon_block_root),
             "head_slot" => format!("{}", head.beacon_block.slot()),
+            "optimistic_sync" => %beacon_chain.config.optimistic_sync,
         );
 
         // Check for states to reconstruct (in the background).

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -1,4 +1,5 @@
 use serde_derive::{Deserialize, Serialize};
+use strum::{Display, EnumString, EnumVariantNames};
 use types::Checkpoint;
 
 pub const DEFAULT_FORK_CHOICE_BEFORE_PROPOSAL_TIMEOUT: u64 = 250;
@@ -35,6 +36,19 @@ pub struct ChainConfig {
     /// Whether any chain health checks should be considered when deciding whether to use the builder API.
     pub builder_fallback_disable_checks: bool,
     pub count_unrealized: bool,
+    /// Optimistic sync configuration.
+    ///
+    /// This controls whether or not to import blocks while the execution node is syncing.
+    pub optimistic_sync: OptimisticSyncConfig,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Display, EnumString, EnumVariantNames,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum OptimisticSyncConfig {
+    On,
+    Off,
 }
 
 impl Default for ChainConfig {
@@ -52,6 +66,7 @@ impl Default for ChainConfig {
             builder_fallback_epochs_since_finalization: 3,
             builder_fallback_disable_checks: false,
             count_unrealized: true,
+            optimistic_sync: OptimisticSyncConfig::On,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::beacon_chain::{
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON, MAXIMUM_GOSSIP_CLOCK_DISPARITY,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;
-pub use self::chain_config::ChainConfig;
+pub use self::chain_config::{ChainConfig, OptimisticSyncConfig};
 pub use self::errors::{BeaconChainError, BlockProductionError};
 pub use self::historical_blocks::HistoricalBlockError;
 pub use attestation_verification::Error as AttestationError;

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::{App, Arg};
+use strum::VariantNames;
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
     App::new("beacon_node")
@@ -756,5 +757,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        vote tracking method.")
                 .takes_value(true)
                 .default_value("true")
+        )
+        .arg(
+            Arg::with_name("optimistic-sync")
+                .long("optimistic-sync")
+                .help("Control the optimistic import of blocks while the execution node is syncing")
+                .takes_value(true)
+                .possible_values(beacon_chain::OptimisticSyncConfig::VARIANTS)
+                .default_value("on")
         )
 }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -633,6 +633,8 @@ pub fn get_config<E: EthSpec>(
     client_config.chain.count_unrealized =
         clap_utils::parse_required(cli_args, "count-unrealized")?;
 
+    client_config.chain.optimistic_sync = clap_utils::parse_required(cli_args, "optimistic-sync")?;
+
     /*
      * Builder fallback configs.
      */

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -164,6 +164,31 @@ fn count_unrealized_true() {
 }
 
 #[test]
+fn optimistic_sync_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.chain.optimistic_sync,
+                beacon_node::beacon_chain::OptimisticSyncConfig::On
+            )
+        });
+}
+
+#[test]
+fn optimistic_sync_off() {
+    CommandLineTest::new()
+        .flag("optimistic-sync", Some("off"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.chain.optimistic_sync,
+                beacon_node::beacon_chain::OptimisticSyncConfig::Off
+            )
+        });
+}
+
+#[test]
 fn freezer_dir_flag() {
     let dir = TempDir::new().expect("Unable to create temporary directory");
     CommandLineTest::new()


### PR DESCRIPTION
## Proposed Changes

The name is a joke, but this PR adds a flag `--optimistic-sync={on,off}` which enables opting out of optimistic sync.

This is a defensive option :shield: for users who prefer a conservative approach to block validation. It _should not_ be used during initial sync, but may be used once the execution node has synced.

## Additional Info

Some execution clients may not work without optimistic sync. @paulhauner mentions that Erigon is unlikely to work because it will return SYNCING on `newPayload` while waiting for the `forkchoiceUpdated` message.
