### PR TITLE
[Merged by Bors] - lighthouse_version: Fix version string regex

### DIFF
--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -37,8 +37,9 @@ mod test {
 
     #[test]
     fn version_formatting() {
-        let re = Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?-[[:xdigit:]]{7}\+?$")
-            .unwrap();
+        let re =
+            Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?(-[[:xdigit:]]{7})?\+?$")
+                .unwrap();
         assert!(
             re.is_match(VERSION),
             "version doesn't match regex: {}",


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

If the build tree is not a git repository, the unit test will fail. This PR fixes the issue.

## Additional Info

N/A