### PR TITLE
[Merged by Bors] - Fix lints for Rust 1.63

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ lint:
 	cargo clippy --workspace --tests -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D warnings \
+		-A clippy::derive_partial_eq_without_eq \
 		-A clippy::from-over-into \
 		-A clippy::upper-case-acronyms \
 		-A clippy::vec-init-then-push

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -90,10 +90,10 @@ impl BlockId {
                         .map_err(warp_utils::reject::beacon_chain_error)?;
                     Ok((*root, execution_optimistic))
                 } else {
-                    return Err(warp_utils::reject::custom_not_found(format!(
+                    Err(warp_utils::reject::custom_not_found(format!(
                         "beacon block with root {}",
                         root
-                    )));
+                    )))
                 }
             }
         }

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -212,7 +212,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
             (Err(BeaconStateError::SlotOutOfBounds), Err(BeaconStateError::SlotOutOfBounds)) => {
                 // Read a `BeaconState` from the store that has access to prior historical roots.
                 if let Some(beacon_state) =
-                    next_historical_root_backtrack_state(&*self.store, &self.beacon_state)
+                    next_historical_root_backtrack_state(self.store, &self.beacon_state)
                         .handle_unavailable()?
                 {
                     self.beacon_state = Cow::Owned(beacon_state);

--- a/common/deposit_contract/build.rs
+++ b/common/deposit_contract/build.rs
@@ -54,12 +54,10 @@ fn read_contract_file_from_url(url: Url) -> Result<Value, String> {
                     .map_err(|e| format!("Respsonse is not a valid json {:?}", e))?;
                 Ok(contract)
             }
-            Err(e) => {
-                return Err(format!(
-                    "No abi file found. Failed to download from github: {:?}",
-                    e
-                ))
-            }
+            Err(e) => Err(format!(
+                "No abi file found. Failed to download from github: {:?}",
+                e
+            )),
         }
     }
 }

--- a/common/sensitive_url/src/lib.rs
+++ b/common/sensitive_url/src/lib.rs
@@ -46,7 +46,7 @@ impl Serialize for SensitiveUrl {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.full.to_string())
+        serializer.serialize_str(self.full.as_ref())
     }
 }
 

--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -353,7 +353,7 @@ mod test {
         let vec = vec![0, 2, 4, 6];
         let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
 
-        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
         assert_eq!(fixed.get(4), None);
     }

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -335,7 +335,7 @@ mod test {
         let vec = vec![0, 2, 4, 6];
         let fixed: VariableList<u64, U4> = VariableList::from(vec);
 
-        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
         assert_eq!(fixed.get(4), None);
     }

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -15,6 +15,7 @@ struct ExitTest {
     validator_index: u64,
     exit_epoch: Epoch,
     state_epoch: Epoch,
+    #[allow(clippy::type_complexity)]
     state_modifier: Box<dyn FnOnce(&mut BeaconState<E>)>,
     #[allow(clippy::type_complexity)]
     block_modifier:


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Fix clippy lints for latest rust version 1.63. I have allowed the [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) lint as satisfying this lint would result in more code that we might not want and I feel it's not required. 

Happy to fix this lint across lighthouse if required though.