### PR TITLE
Fixed `make lint` errors in `unstable`

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -62,7 +62,7 @@ pub fn get_effective_balances<T: EthSpec>(state: &BeaconState<T>) -> Vec<u64> {
 
 #[superstruct(
     variants(V1, V8),
-    variant_attributes(derive(PartialEq, Clone, Debug, Encode, Decode)),
+    variant_attributes(derive(Clone, Debug, Eq, PartialEq, Encode, Decode)),
     no_enum
 )]
 pub(crate) struct CacheItem {
@@ -76,7 +76,7 @@ pub(crate) type CacheItem = CacheItemV8;
 
 #[superstruct(
     variants(V1, V8),
-    variant_attributes(derive(PartialEq, Clone, Default, Debug, Encode, Decode)),
+    variant_attributes(derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)),
     no_enum
 )]
 pub struct BalancesCache {

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -28,7 +28,7 @@ use types::*;
 pub type PreparePayloadResult<Payload> = Result<Payload, BlockProductionError>;
 pub type PreparePayloadHandle<Payload> = JoinHandle<Option<PreparePayloadResult<Payload>>>;
 
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub enum AllowOptimisticImport {
     Yes,
     No,

--- a/beacon_node/beacon_chain/src/head_tracker.rs
+++ b/beacon_node/beacon_chain/src/head_tracker.rs
@@ -3,7 +3,7 @@ use ssz_derive::{Decode, Encode};
 use std::collections::HashMap;
 use types::{Hash256, Slot};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     MismatchingLengths { roots_len: usize, slots_len: usize },
 }

--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -22,7 +22,7 @@ const SLOTS_RETAINED: usize = 3;
 const MAX_ATTESTATIONS_PER_SLOT: usize = 16_384;
 
 /// Returned upon successfully inserting an item into the pool.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum InsertOutcome {
     /// The item had not been seen before and was added to the pool.
     NewItemInserted { committee_index: usize },
@@ -34,7 +34,7 @@ pub enum InsertOutcome {
     SignatureAggregated { committee_index: usize },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// The given `data.slot` was too low to be stored. No changes were made.
     SlotTooLow {

--- a/beacon_node/beacon_chain/src/observed_aggregates.rs
+++ b/beacon_node/beacon_chain/src/observed_aggregates.rs
@@ -69,7 +69,7 @@ impl<T: EthSpec> Consts for SyncCommitteeContribution<T> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ObserveOutcome {
     /// This item was already known.
     AlreadyKnown,
@@ -77,7 +77,7 @@ pub enum ObserveOutcome {
     New,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     SlotTooLow {
         slot: Slot,

--- a/beacon_node/beacon_chain/src/observed_attesters.rs
+++ b/beacon_node/beacon_chain/src/observed_attesters.rs
@@ -44,7 +44,7 @@ pub type ObservedAggregators<E> = AutoPruningEpochContainer<EpochHashSet, E>;
 pub type ObservedSyncAggregators<E> =
     AutoPruningSlotContainer<SlotSubcommitteeIndex, SyncAggregatorSlotHashSet, E>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     EpochTooLow {
         epoch: Epoch,

--- a/beacon_node/beacon_chain/src/observed_block_producers.rs
+++ b/beacon_node/beacon_chain/src/observed_block_producers.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use types::{BeaconBlockRef, Epoch, EthSpec, Slot, Unsigned};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// The slot of the provided block is prior to finalization and should not have been provided
     /// to this function. This is an internal error.

--- a/beacon_node/beacon_chain/src/otb_verification_service.rs
+++ b/beacon_node/beacon_chain/src/otb_verification_service.rs
@@ -18,7 +18,7 @@ use tree_hash::TreeHash;
 use types::{BeaconBlockRef, EthSpec, Hash256, Slot};
 use DBColumn::OptimisticTransitionBlock as OTBColumn;
 
-#[derive(Clone, Debug, Decode, Encode, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode)]
 pub struct OptimisticTransitionBlock {
     root: Hash256,
     slot: Slot,

--- a/beacon_node/beacon_chain/src/schema_change/types.rs
+++ b/beacon_node/beacon_chain/src/schema_change/types.rs
@@ -13,7 +13,7 @@ four_byte_option_impl!(four_byte_option_checkpoint, Checkpoint);
 
 #[superstruct(
     variants(V1, V6, V7, V10),
-    variant_attributes(derive(Clone, PartialEq, Debug, Encode, Decode)),
+    variant_attributes(derive(Clone, Debug, Eq, PartialEq, Encode, Decode)),
     no_enum
 )]
 pub struct ProtoNode {

--- a/beacon_node/eth1/src/block_cache.rs
+++ b/beacon_node/eth1/src/block_cache.rs
@@ -3,7 +3,7 @@ use std::ops::RangeInclusive;
 
 pub use eth2::lighthouse::Eth1Block;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The timestamp of each block equal to or later than the block prior to it.
     InconsistentTimestamp { parent: u64, child: u64 },
@@ -18,7 +18,7 @@ pub enum Error {
 
 /// Stores block and deposit contract information and provides queries based upon the block
 /// timestamp.
-#[derive(Debug, PartialEq, Clone, Default, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)]
 pub struct BlockCache {
     blocks: Vec<Eth1Block>,
 }

--- a/beacon_node/eth1/src/deposit_cache.rs
+++ b/beacon_node/eth1/src/deposit_cache.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use tree_hash::TreeHash;
 use types::{Deposit, Hash256, DEPOSIT_TREE_DEPTH};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// A deposit log was added when a prior deposit was not already in the cache.
     ///
@@ -31,7 +31,7 @@ pub enum Error {
     Internal(String),
 }
 
-#[derive(Encode, Decode, Clone)]
+#[derive(Clone, Encode, Decode)]
 pub struct SszDepositCache {
     logs: Vec<DepositLog>,
     leaves: Vec<Hash256>,
@@ -102,7 +102,7 @@ impl Default for DepositCache {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DepositCacheInsertOutcome {
     Inserted,
     Duplicate,

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -50,7 +50,7 @@ const CATCHUP_MIN_FOLLOW_DISTANCE: u64 = 64;
 /// distance would imply, we store `CACHE_FACTOR` more blocks in our cache.
 const CACHE_FACTOR: u64 = 2;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum EndpointError {
     RequestFailed(String),
     WrongNetworkId,
@@ -304,7 +304,7 @@ async fn relevant_new_block_numbers_from_endpoint(
     service.relevant_new_block_numbers(remote_highest_block, None, head_type)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SingleEndpointError {
     /// Endpoint is currently not functional.
     EndpointError(EndpointError),
@@ -345,21 +345,21 @@ pub enum Error {
 }
 
 /// The success message for an Eth1Data cache update.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlockCacheUpdateOutcome {
     pub blocks_imported: usize,
     pub head_block_number: Option<u64>,
 }
 
 /// The success message for an Eth1 deposit cache update.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DepositCacheUpdateOutcome {
     pub logs_imported: usize,
 }
 
 /// Supports either one authenticated jwt JSON-RPC endpoint **or**
 /// multiple non-authenticated endpoints with fallback.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Eth1Endpoint {
     Auth {
         endpoint: SensitiveUrl,
@@ -386,7 +386,7 @@ impl Eth1Endpoint {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Config {
     /// An Eth1 node (e.g., Geth) running a HTTP JSON-RPC endpoint.
     pub endpoints: Eth1Endpoint,

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -71,7 +71,7 @@ impl From<builder_client::Error> for Error {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PayloadStatusV1Status {
     Valid,
     Invalid,
@@ -80,14 +80,14 @@ pub enum PayloadStatusV1Status {
     InvalidBlockHash,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PayloadStatusV1 {
     pub status: PayloadStatusV1Status,
     pub latest_valid_hash: Option<ExecutionBlockHash>,
     pub validation_error: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum BlockByNumberQuery<'a> {
     Tag(&'a str),
@@ -96,7 +96,7 @@ pub enum BlockByNumberQuery<'a> {
 /// Representation of an exection block with enough detail to determine the terminal PoW block.
 ///
 /// See `get_pow_block_hash_at_total_difficulty`.
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ExecutionBlock {
     #[serde(rename = "hash")]
@@ -138,27 +138,27 @@ pub struct ExecutionBlockWithTransactions<T: EthSpec> {
     pub transactions: Vec<Transaction>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PayloadAttributes {
     pub timestamp: u64,
     pub prev_randao: Hash256,
     pub suggested_fee_recipient: Address,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ForkchoiceUpdatedResponse {
     pub payload_status: PayloadStatusV1,
     pub payload_id: Option<PayloadId>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ProposeBlindedBlockResponseStatus {
     Valid,
     Invalid,
     Syncing,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposeBlindedBlockResponse {
     pub status: ProposeBlindedBlockResponseStatus,
     pub latest_valid_hash: Option<Hash256>,

--- a/beacon_node/execution_layer/src/engine_api/auth.rs
+++ b/beacon_node/execution_layer/src/engine_api/auth.rs
@@ -146,7 +146,7 @@ impl Auth {
 }
 
 /// Claims struct as defined in https://github.com/ethereum/execution-apis/blob/main/src/engine/authentication.md#jwt-claims
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Claims {
     /// issued-at claim. Represented as seconds passed since UNIX_EPOCH.
     iat: u64,

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -67,7 +67,7 @@ pub mod deposit_log {
     const INDEX_LEN: usize = 8;
 
     /// A reduced set of fields from an Eth1 contract log.
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct Log {
         pub block_number: u64,
         pub data: Vec<u8>,
@@ -191,14 +191,14 @@ pub mod deposit_methods {
     pub const DEPOSIT_ROOT_BYTES: usize = 32;
 
     /// Represents an eth1 chain/network id.
-    #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
     pub enum Eth1Id {
         Goerli,
         Mainnet,
         Custom(u64),
     }
 
-    #[derive(Debug, PartialEq, Clone)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct Block {
         pub hash: Hash256,
         pub timestamp: u64,

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -2,7 +2,7 @@ use super::*;
 use serde::{Deserialize, Serialize};
 use types::{EthSpec, ExecutionBlockHash, FixedVector, Transaction, Unsigned, VariableList};
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonRequestBody<'a> {
     pub jsonrpc: &'a str,
@@ -11,13 +11,13 @@ pub struct JsonRequestBody<'a> {
     pub id: serde_json::Value,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct JsonError {
     pub code: i64,
     pub message: String,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonResponseBody {
     pub jsonrpc: String,
@@ -28,7 +28,7 @@ pub struct JsonResponseBody {
     pub id: serde_json::Value,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct TransparentJsonPayloadId(#[serde(with = "eth2_serde_utils::bytes_8_hex")] pub PayloadId);
 
@@ -48,14 +48,14 @@ impl From<TransparentJsonPayloadId> for PayloadId {
 pub type JsonPayloadIdRequest = TransparentJsonPayloadId;
 
 /// On the response, expect without the object wrapper (non-transparent).
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPayloadIdResponse {
     #[serde(with = "eth2_serde_utils::bytes_8_hex")]
     pub payload_id: PayloadId,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "T: EthSpec", rename_all = "camelCase")]
 pub struct JsonExecutionPayloadHeaderV1<T: EthSpec> {
     pub parent_hash: ExecutionBlockHash,
@@ -226,7 +226,7 @@ impl<T: EthSpec> From<JsonExecutionPayloadV1<T>> for ExecutionPayload<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPayloadAttributesV1 {
     #[serde(with = "eth2_serde_utils::u64_hex_be")]
@@ -269,7 +269,7 @@ impl From<JsonPayloadAttributesV1> for PayloadAttributes {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonForkChoiceStateV1 {
     pub head_block_hash: ExecutionBlockHash,
@@ -311,7 +311,7 @@ impl From<JsonForkChoiceStateV1> for ForkChoiceState {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum JsonPayloadStatusV1Status {
     Valid,
@@ -321,7 +321,7 @@ pub enum JsonPayloadStatusV1Status {
     InvalidBlockHash,
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonPayloadStatusV1 {
     pub status: JsonPayloadStatusV1Status,
@@ -386,7 +386,7 @@ impl From<JsonPayloadStatusV1> for PayloadStatusV1 {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonForkchoiceUpdatedV1Response {
     pub payload_status: JsonPayloadStatusV1,
@@ -422,7 +422,7 @@ impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedV1Response {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransitionConfigurationV1 {
     #[serde(with = "eth2_serde_utils::u256_hex_be")]

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -18,7 +18,7 @@ use types::{Address, ExecutionBlockHash, Hash256};
 const PAYLOAD_ID_LRU_CACHE_SIZE: usize = 512;
 
 /// Stores the remembered state of a engine.
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum EngineState {
     Synced,
     Offline,
@@ -26,7 +26,7 @@ enum EngineState {
     AuthFailed,
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct ForkChoiceState {
     pub head_block_hash: ExecutionBlockHash,
     pub safe_block_hash: ExecutionBlockHash,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -86,19 +86,19 @@ impl From<ApiError> for Error {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct ProposerPreparationDataEntry {
     update_epoch: Epoch,
     preparation_data: ProposerPreparationData,
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(Eq, Hash, PartialEq)]
 pub struct ProposerKey {
     slot: Slot,
     head_block_root: Hash256,
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Proposer {
     validator_index: u64,
     payload_attributes: PayloadAttributes,
@@ -138,7 +138,7 @@ struct Inner<E: EthSpec> {
     log: Logger,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Config {
     /// Endpoint urls for EL nodes that are running the engine api.
     pub execution_endpoints: Vec<SensitiveUrl>,

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -6,7 +6,7 @@ use types::ExecutionBlockHash;
 /// Provides a simpler, easier to parse version of `PayloadStatusV1` for upstream users.
 ///
 /// It primarily ensures that the `latest_valid_hash` is always present when relevant.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PayloadStatus {
     Valid,
     Invalid {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -95,7 +95,7 @@ impl<T: EthSpec> Block<T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, TreeHash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, TreeHash)]
 #[serde(rename_all = "camelCase")]
 pub struct PoWBlock {
     pub block_number: u64,

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -394,7 +394,7 @@ struct MissingIdField;
 
 impl warp::reject::Reject for MissingIdField {}
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StaticNewPayloadResponse {
     status: PayloadStatusV1,
     should_import: bool,
@@ -422,7 +422,7 @@ pub struct Context<T: EthSpec> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub listen_addr: Ipv4Addr,
     pub listen_port: u16,

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -90,10 +90,10 @@ impl BlockId {
                         .map_err(warp_utils::reject::beacon_chain_error)?;
                     Ok((*root, execution_optimistic))
                 } else {
-                    return Err(warp_utils::reject::custom_not_found(format!(
+                    Err(warp_utils::reject::custom_not_found(format!(
                         "beacon block with root {}",
                         root
-                    )));
+                    )))
                 }
             }
         }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -79,7 +79,7 @@ type HttpServer = (SocketAddr, Pin<Box<dyn Future<Output = ()> + Send>>);
 pub type ExecutionOptimistic = bool;
 
 /// Configuration used when serving the HTTP server over TLS.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TlsConfig {
     pub cert: PathBuf,
     pub key: PathBuf,
@@ -98,7 +98,7 @@ pub struct Context<T: BeaconChainTypes> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,
@@ -2083,7 +2083,7 @@ pub fn serve<T: BeaconChainTypes>(
                     .to_ref()
                     .fork_name(&chain.spec)
                     .map_err(inconsistent_fork_rejection)?;
-                // Pose as a V2 endpoint so we return the fork `version`. 
+                // Pose as a V2 endpoint so we return the fork `version`.
                 fork_versioned_response(V2, fork_name, block)
                     .map(|response| warp::reply::json(&response))
             },

--- a/beacon_node/http_metrics/src/lib.rs
+++ b/beacon_node/http_metrics/src/lib.rs
@@ -45,7 +45,7 @@ pub struct Context<T: BeaconChainTypes> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,

--- a/beacon_node/lighthouse_network/src/behaviour/mod.rs
+++ b/beacon_node/lighthouse_network/src/behaviour/mod.rs
@@ -1321,7 +1321,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> NetworkBehaviourEventProcess<PeerManagerEv
 // NOTE: This is an application-level wrapper over the lower network level requests that can be
 //       sent. The main difference is the absence of the Ping, Metadata and Goodbye protocols, which don't
 //       leave the Behaviour. For all protocols managed by RPC see `RPCRequest`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Request {
     /// A Status message.
     Status(StatusMessage),

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -76,7 +76,7 @@ pub enum DiscoveryEvent {
     SocketUpdated(SocketAddr),
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 struct SubnetQuery {
     subnet: Subnet,
     min_ttl: Option<Instant>,
@@ -109,7 +109,7 @@ impl std::fmt::Debug for SubnetQuery {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum QueryType {
     /// We are searching for subnet peers.
     Subnet(Vec<SubnetQuery>),

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/client.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/client.rs
@@ -21,7 +21,7 @@ pub struct Client {
     pub agent_string: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Serialize, PartialEq, AsRefStr, IntoStaticStr, EnumIter)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, AsRefStr, IntoStaticStr, EnumIter)]
 pub enum ClientKind {
     /// A lighthouse node (the best kind).
     Lighthouse,

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -99,7 +99,7 @@ impl std::fmt::Display for PeerAction {
 }
 
 /// The expected state of the peer given the peer's score.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ScoreState {
     /// We are content with the peers performance. We permit connections and messages.
     Healthy,

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -58,7 +58,7 @@ impl ToString for ErrorType {
 /* Requests */
 
 /// The STATUS request/response handshake message.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
 pub struct StatusMessage {
     /// The fork version of the chain we are broadcasting.
     pub fork_digest: [u8; 4],
@@ -77,7 +77,7 @@ pub struct StatusMessage {
 }
 
 /// The PING request/response message.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+#[derive(Encode, Decode, Clone, Debug, Eq, PartialEq)]
 pub struct Ping {
     /// The metadata sequence number.
     pub data: u64,
@@ -109,7 +109,7 @@ pub struct MetaData<T: EthSpec> {
 /// Note: any unknown `u64::into(n)` will resolve to `Goodbye::Unknown` for any unknown `n`,
 /// however `GoodbyeReason::Unknown.into()` will go into `0_u64`. Therefore de-serializing then
 /// re-serializing may not return the same bytes.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum GoodbyeReason {
     /// This node has shutdown.
     ClientShutdown = 1,
@@ -195,7 +195,7 @@ impl ssz::Decode for GoodbyeReason {
 }
 
 /// Request a number of beacon block roots from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
 pub struct BlocksByRangeRequest {
     /// The starting slot to request blocks.
     pub start_slot: u64,
@@ -205,7 +205,7 @@ pub struct BlocksByRangeRequest {
 }
 
 /// Request a number of beacon block roots from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode)]
 pub struct OldBlocksByRangeRequest {
     /// The starting slot to request blocks.
     pub start_slot: u64,
@@ -222,7 +222,7 @@ pub struct OldBlocksByRangeRequest {
 }
 
 /// Request a number of beacon block bodies from a peer.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlocksByRootRequest {
     /// The list of beacon block bodies being requested.
     pub block_roots: VariableList<Hash256, MaxRequestBlocks>,
@@ -274,7 +274,7 @@ pub enum RPCCodedResponse<T: EthSpec> {
 }
 
 /// The code assigned to an erroneous `RPCResponse`.
-#[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RPCResponseErrorCode {
     RateLimited,

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -25,14 +25,14 @@ use types::{EthSpec, ForkContext};
 // Combines all the RPC requests into a single enum to implement `UpgradeInfo` and
 // `OutboundUpgrade`
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct OutboundRequestContainer<TSpec: EthSpec> {
     pub req: OutboundRequest<TSpec>,
     pub fork_context: Arc<ForkContext>,
     pub max_rpc_size: usize,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OutboundRequest<TSpec: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -232,7 +232,7 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
 }
 
 /// Represents the ssz length bounds for RPC messages.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct RpcLimits {
     pub min: usize,
     pub max: usize,
@@ -411,7 +411,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum InboundRequest<TSpec: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),
@@ -511,7 +511,7 @@ impl<TSpec: EthSpec> InboundRequest<TSpec> {
 }
 
 /// Error in RPC Encoding/Decoding.
-#[derive(Debug, Clone, PartialEq, IntoStaticStr)]
+#[derive(Clone, Debug, Eq, PartialEq, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RPCError {
     /// Error when decoding the raw buffer from ssz.

--- a/beacon_node/lighthouse_network/src/types/sync_state.rs
+++ b/beacon_node/lighthouse_network/src/types/sync_state.rs
@@ -26,7 +26,7 @@ pub enum SyncState {
     Stalled,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 /// The state of the backfill sync.
 pub enum BackFillState {
     /// The sync is partially completed and currently paused.

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use types::{Epoch, Hash256, SignedBeaconBlock};
 
 /// Id associated to a batch processing request, either a sync batch or a parent lookup.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ChainSegmentProcessId {
     /// Processing Id of a range syncing batch.
     RangeBatchId(ChainId, Epoch, CountUnrealized),

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -428,7 +428,7 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
 /// Represents a peer's attempt and providing the result for this batch.
 ///
 /// Invalid attempts will downscore a peer.
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Attempt {
     /// The peer that made the attempt.
     pub peer_id: PeerId,

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -106,7 +106,7 @@ pub struct SyncingChain<T: BeaconChainTypes> {
     log: slog::Logger,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChainSyncingState {
     /// The chain is not being synced.
     Stopped,

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -48,7 +48,7 @@ pub struct OperationPool<T: EthSpec + Default> {
     _phantom: PhantomData<T>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum OpPoolError {
     GetAttestationsTotalBalanceError(BeaconStateError),
     GetBlockRootError(BeaconStateError),

--- a/beacon_node/store/src/chunked_vector.rs
+++ b/beacon_node/store/src/chunked_vector.rs
@@ -645,7 +645,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum ChunkError {
     ZeroLengthVector,
     InvalidSize {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1552,7 +1552,7 @@ pub fn migrate_database<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>(
 }
 
 /// Struct for storing the split slot and state root in the database.
-#[derive(Debug, Clone, Copy, PartialEq, Default, Encode, Decode, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Encode, Decode, Deserialize, Serialize)]
 pub struct Split {
     pub(crate) slot: Slot,
     pub(crate) state_root: Hash256,

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -212,7 +212,7 @@ impl<'a, T: EthSpec, Hot: ItemStore<T>, Cold: ItemStore<T>> RootsIterator<'a, T,
             (Err(BeaconStateError::SlotOutOfBounds), Err(BeaconStateError::SlotOutOfBounds)) => {
                 // Read a `BeaconState` from the store that has access to prior historical roots.
                 if let Some(beacon_state) =
-                    next_historical_root_backtrack_state(&*self.store, &self.beacon_state)
+                    next_historical_root_backtrack_state(self.store, &self.beacon_state)
                         .handle_unavailable()?
                 {
                     self.beacon_state = Cow::Owned(beacon_state);

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -224,7 +224,7 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
 impl<E: EthSpec> ItemStore<E> for LevelDB<E> {}
 
 /// Used for keying leveldb.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct BytesKey {
     key: Vec<u8>,
 }

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -164,7 +164,7 @@ pub enum StoreOp<'a, E: EthSpec> {
 }
 
 /// A unique column identifier.
-#[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr, EnumString)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntoStaticStr, EnumString)]
 pub enum DBColumn {
     /// For data related to the database itself.
     #[strum(serialize = "bma")]
@@ -255,7 +255,7 @@ mod tests {
     use ssz_derive::{Decode, Encode};
     use tempfile::tempdir;
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct StorableThing {
         a: u64,
         b: u64,

--- a/common/account_utils/src/lib.rs
+++ b/common/account_utils/src/lib.rs
@@ -191,7 +191,7 @@ pub fn mnemonic_from_phrase(phrase: &str) -> Result<Mnemonic, String> {
 /// Provides a new-type wrapper around `String` that is zeroized on `Drop`.
 ///
 /// Useful for ensuring that password memory is zeroed-out on drop.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
 #[serde(transparent)]
 pub struct ZeroizeString(String);

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -69,7 +69,7 @@ pub struct Web3SignerDefinition {
 }
 
 /// Defines how the validator client should attempt to sign messages for this validator.
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum SigningDefinition {
     /// A validator that is defined by an EIP-2335 keystore on the local filesystem.
@@ -98,7 +98,7 @@ impl SigningDefinition {
 ///
 /// Presently there is only a single variant, however we expect more variants to arise (e.g.,
 /// remote signing).
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorDefinition {
     pub enabled: bool,
     pub voting_public_key: PublicKey,

--- a/common/compare_fields/src/lib.rs
+++ b/common/compare_fields/src/lib.rs
@@ -88,7 +88,7 @@
 //! ```
 use std::fmt::Debug;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Comparison {
     Child(FieldComparison),
     Parent {
@@ -147,7 +147,7 @@ impl Comparison {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct FieldComparison {
     pub field_name: String,
     pub equal: bool,

--- a/common/deposit_contract/build.rs
+++ b/common/deposit_contract/build.rs
@@ -54,12 +54,10 @@ fn read_contract_file_from_url(url: Url) -> Result<Value, String> {
                     .map_err(|e| format!("Respsonse is not a valid json {:?}", e))?;
                 Ok(contract)
             }
-            Err(e) => {
-                Err(format!(
-                    "No abi file found. Failed to download from github: {:?}",
-                    e
-                ))
-            }
+            Err(e) => Err(format!(
+                "No abi file found. Failed to download from github: {:?}",
+                e
+            )),
         }
     }
 }

--- a/common/deposit_contract/build.rs
+++ b/common/deposit_contract/build.rs
@@ -55,7 +55,7 @@ fn read_contract_file_from_url(url: Url) -> Result<Value, String> {
                 Ok(contract)
             }
             Err(e) => {
-                return Err(format!(
+                Err(format!(
                     "No abi file found. Failed to download from github: {:?}",
                     e
                 ))

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -32,7 +32,7 @@ four_byte_option_impl!(four_byte_option_hash256, Hash256);
 
 /// Information returned by `peers` and `connected_peers`.
 // TODO: this should be deserializable..
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 #[serde(bound = "T: EthSpec")]
 pub struct Peer<T: EthSpec> {
     /// The Peer's ID
@@ -44,7 +44,7 @@ pub struct Peer<T: EthSpec> {
 /// The results of validators voting during an epoch.
 ///
 /// Provides information about the current and previous epochs.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GlobalValidatorInclusionData {
     /// The total effective balance of all active validators during the _current_ epoch.
     pub current_epoch_active_gwei: u64,
@@ -61,7 +61,7 @@ pub struct GlobalValidatorInclusionData {
     pub previous_epoch_head_attesting_gwei: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorInclusionData {
     /// True if the validator has been slashed, ever.
     pub is_slashed: bool,
@@ -224,7 +224,7 @@ impl SystemHealth {
 }
 
 /// Process specific health
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProcessHealth {
     /// The pid of this process.
     pub pid: u32,
@@ -310,7 +310,7 @@ pub struct DepositLog {
 }
 
 /// A block of the eth1 chain.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct Eth1Block {
     pub hash: Hash256,
     pub timestamp: u64,

--- a/common/eth2/src/lighthouse/attestation_performance.rs
+++ b/common/eth2/src/lighthouse/attestation_performance.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use types::Epoch;
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttestationPerformanceStatistics {
     pub active: bool,
     pub head: bool,
@@ -12,7 +12,7 @@ pub struct AttestationPerformanceStatistics {
     pub delay: Option<u64>,
 }
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttestationPerformance {
     pub index: u64,
     pub epochs: HashMap<u64, AttestationPerformanceStatistics>,
@@ -32,7 +32,7 @@ impl AttestationPerformance {
 }
 
 /// Query parameters for the `/lighthouse/analysis/attestation_performance` endpoint.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttestationPerformanceQuery {
     pub start_epoch: Epoch,
     pub end_epoch: Epoch,

--- a/common/eth2/src/lighthouse/block_packing_efficiency.rs
+++ b/common/eth2/src/lighthouse/block_packing_efficiency.rs
@@ -5,19 +5,19 @@ type CommitteePosition = usize;
 type Committee = u64;
 type ValidatorIndex = u64;
 
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct UniqueAttestation {
     pub slot: Slot,
     pub committee_index: Committee,
     pub committee_position: CommitteePosition,
 }
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProposerInfo {
     pub validator_index: ValidatorIndex,
     pub graffiti: String,
 }
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockPackingEfficiency {
     pub slot: Slot,
     pub block_hash: Hash256,
@@ -27,7 +27,7 @@ pub struct BlockPackingEfficiency {
     pub prior_skip_slots: u64,
 }
 
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockPackingEfficiencyQuery {
     pub start_epoch: Epoch,
     pub end_epoch: Epoch,

--- a/common/eth2/src/lighthouse/block_rewards.rs
+++ b/common/eth2/src/lighthouse/block_rewards.rs
@@ -8,7 +8,7 @@ use types::{AttestationData, Hash256, Slot};
 ///
 /// Presently this only counts attestation rewards, but in future should be expanded
 /// to include information on slashings and sync committee aggregates too.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockReward {
     /// Sum of all reward components.
     pub total: u64,
@@ -22,7 +22,7 @@ pub struct BlockReward {
     pub sync_committee_rewards: u64,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockRewardMeta {
     pub slot: Slot,
     pub parent_slot: Slot,
@@ -30,7 +30,7 @@ pub struct BlockRewardMeta {
     pub graffiti: String,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttestationRewards {
     /// Total block reward from attestations included.
     pub total: u64,
@@ -48,7 +48,7 @@ pub struct AttestationRewards {
 }
 
 /// Query parameters for the `/lighthouse/block_rewards` endpoint.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockRewardsQuery {
     /// Lower slot limit for block rewards returned (inclusive).
     pub start_slot: Slot,

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -28,7 +28,7 @@ pub struct ValidatorClientHttpClient {
     authorization_header: AuthorizationHeader,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AuthorizationHeader {
     /// Do not send any Authorization header.
     Omit,

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -4,23 +4,23 @@ use serde::{Deserialize, Serialize};
 use slashing_protection::interchange::Interchange;
 use types::{Address, PublicKeyBytes};
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct GetFeeRecipientResponse {
     pub pubkey: PublicKeyBytes,
     pub ethaddress: Address,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct AuthResponse {
     pub token_path: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ListKeystoresResponse {
     pub data: Vec<SingleKeystoreResponse>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SingleKeystoreResponse {
     pub validating_pubkey: PublicKeyBytes,
     pub derivation_path: Option<String>,
@@ -36,7 +36,7 @@ pub struct ImportKeystoresRequest {
     pub slashing_protection: Option<InterchangeJsonStr>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct KeystoreJsonStr(#[serde(with = "eth2_serde_utils::json_str")] pub Keystore);
 
@@ -47,7 +47,7 @@ impl std::ops::Deref for KeystoreJsonStr {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(transparent)]
 pub struct InterchangeJsonStr(#[serde(with = "eth2_serde_utils::json_str")] pub Interchange);
 
@@ -56,7 +56,7 @@ pub struct ImportKeystoresResponse {
     pub data: Vec<Status<ImportKeystoreStatus>>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Status<T> {
     pub status: T,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -79,7 +79,7 @@ impl<T> Status<T> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ImportKeystoreStatus {
     Imported,
@@ -100,7 +100,7 @@ pub struct DeleteKeystoresResponse {
     pub slashing_protection: Interchange,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeleteKeystoreStatus {
     Deleted,
@@ -109,31 +109,31 @@ pub enum DeleteKeystoreStatus {
     Error,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ListRemotekeysResponse {
     pub data: Vec<SingleListRemotekeysResponse>,
 }
 
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SingleListRemotekeysResponse {
     pub pubkey: PublicKeyBytes,
     pub url: String,
     pub readonly: bool,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ImportRemotekeysRequest {
     pub remote_keys: Vec<SingleImportRemotekeysRequest>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SingleImportRemotekeysRequest {
     pub pubkey: PublicKeyBytes,
     pub url: String,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ImportRemotekeyStatus {
     Imported,
@@ -152,7 +152,7 @@ pub struct DeleteRemotekeysRequest {
     pub pubkeys: Vec<PublicKeyBytes>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeleteRemotekeyStatus {
     Deleted,

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -9,14 +9,14 @@ pub use crate::lighthouse_vc::std_types::*;
 pub use crate::types::{GenericResponse, VersionData};
 pub use types::*;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorData {
     pub enabled: bool,
     pub description: String,
     pub voting_pubkey: PublicKeyBytes,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorRequest {
     pub enable: bool,
     pub description: String,
@@ -36,7 +36,7 @@ pub struct ValidatorRequest {
     pub deposit_gwei: u64,
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CreateValidatorsMnemonicRequest {
     pub mnemonic: ZeroizeString,
     #[serde(with = "eth2_serde_utils::quoted_u32")]
@@ -44,7 +44,7 @@ pub struct CreateValidatorsMnemonicRequest {
     pub validators: Vec<ValidatorRequest>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CreatedValidator {
     pub enabled: bool,
     pub description: String,
@@ -66,13 +66,13 @@ pub struct CreatedValidator {
     pub deposit_gwei: u64,
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PostValidatorsResponseData {
     pub mnemonic: ZeroizeString,
     pub validators: Vec<CreatedValidator>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorPatchRequest {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -85,7 +85,7 @@ pub struct ValidatorPatchRequest {
     pub builder_proposals: Option<bool>,
 }
 
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KeystoreValidatorsPostRequest {
     pub password: ZeroizeString,
     pub enable: bool,
@@ -104,7 +104,7 @@ pub struct KeystoreValidatorsPostRequest {
     pub builder_proposals: Option<bool>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Web3SignerValidatorRequest {
     pub enable: bool,
     pub description: String,
@@ -134,7 +134,7 @@ pub struct Web3SignerValidatorRequest {
     pub client_identity_password: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct UpdateFeeRecipientRequest {
     pub ethaddress: Address,
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -16,7 +16,7 @@ pub use types::*;
 use crate::lighthouse::BlockReward;
 
 /// An API error serializable to JSON.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Error {
     Indexed(IndexedErrorMessage),
@@ -24,7 +24,7 @@ pub enum Error {
 }
 
 /// An API error serializable to JSON.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ErrorMessage {
     pub code: u16,
     pub message: String,
@@ -33,7 +33,7 @@ pub struct ErrorMessage {
 }
 
 /// An indexed API error serializable to JSON.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct IndexedErrorMessage {
     pub code: u16,
     pub message: String,
@@ -41,7 +41,7 @@ pub struct IndexedErrorMessage {
 }
 
 /// A single failure in an index of API errors, serializable to JSON.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Failure {
     pub index: u64,
     pub message: String,
@@ -57,7 +57,7 @@ impl Failure {
 }
 
 /// The version of a single API endpoint, e.g. the `v1` in `/eth/v1/beacon/blocks`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct EndpointVersion(pub u64);
 
 impl FromStr for EndpointVersion {
@@ -80,7 +80,7 @@ impl std::fmt::Display for EndpointVersion {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GenesisData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub genesis_time: u64,
@@ -89,7 +89,7 @@ pub struct GenesisData {
     pub genesis_fork_version: [u8; 4],
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BlockId {
     Head,
     Genesis,
@@ -137,7 +137,7 @@ impl fmt::Display for BlockId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StateId {
     Head,
     Genesis,
@@ -251,7 +251,7 @@ pub struct ForkVersionedResponse<T> {
     pub data: T,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct RootData {
     pub root: Hash256,
 }
@@ -262,14 +262,14 @@ impl From<Hash256> for RootData {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct FinalityCheckpointsData {
     pub previous_justified: Checkpoint,
     pub current_justified: Checkpoint,
     pub finalized: Checkpoint,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ValidatorId {
     PublicKey(PublicKeyBytes),
     Index(u64),
@@ -300,7 +300,7 @@ impl fmt::Display for ValidatorId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub index: u64,
@@ -310,7 +310,7 @@ pub struct ValidatorData {
     pub validator: Validator,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorBalanceData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub index: u64,
@@ -326,7 +326,7 @@ pub struct ValidatorBalanceData {
 // this proposal:
 //
 // https://hackmd.io/bQxMDRt1RbS1TLno8K4NPg?view
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ValidatorStatus {
     PendingInitialized,
@@ -470,7 +470,7 @@ pub struct ValidatorsQuery {
     pub status: Option<Vec<ValidatorStatus>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CommitteeData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub index: u64,
@@ -479,14 +479,14 @@ pub struct CommitteeData {
     pub validators: Vec<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncCommitteeByValidatorIndices {
     #[serde(with = "eth2_serde_utils::quoted_u64_vec")]
     pub validators: Vec<u64>,
     pub validator_aggregates: Vec<SyncSubcommittee>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SyncSubcommittee {
     #[serde(with = "eth2_serde_utils::quoted_u64_vec")]
@@ -499,27 +499,27 @@ pub struct HeadersQuery {
     pub parent_root: Option<Hash256>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockHeaderAndSignature {
     pub message: BeaconBlockHeader,
     pub signature: SignatureBytes,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct BlockHeaderData {
     pub root: Hash256,
     pub canonical: bool,
     pub header: BlockHeaderAndSignature,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DepositContractData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub chain_id: u64,
     pub address: Address,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ChainHeadData {
     pub slot: Slot,
     pub root: Hash256,
@@ -527,7 +527,7 @@ pub struct ChainHeadData {
     pub execution_optimistic: Option<bool>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct IdentityData {
     pub peer_id: String,
     pub enr: Enr,
@@ -536,7 +536,7 @@ pub struct IdentityData {
     pub metadata: MetaData,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MetaData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub seq_number: u64,
@@ -544,12 +544,12 @@ pub struct MetaData {
     pub syncnets: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VersionData {
     pub version: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncingData {
     pub is_syncing: bool,
     pub is_optimistic: Option<bool>,
@@ -634,7 +634,7 @@ pub struct ValidatorIndexDataRef<'a>(
     #[serde(serialize_with = "eth2_serde_utils::quoted_u64_vec::serialize")] pub &'a [u64],
 );
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttesterData {
     pub pubkey: PublicKeyBytes,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -650,7 +650,7 @@ pub struct AttesterData {
     pub slot: Slot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProposerData {
     pub pubkey: PublicKeyBytes,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -682,7 +682,7 @@ pub struct ValidatorAggregateAttestationQuery {
     pub slot: Slot,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BeaconCommitteeSubscription {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub validator_index: u64,
@@ -703,7 +703,7 @@ pub struct PeersQuery {
     pub direction: Option<Vec<PeerDirection>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerData {
     pub peer_id: String,
     pub enr: Option<String>,
@@ -712,18 +712,18 @@ pub struct PeerData {
     pub direction: PeerDirection,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeersData {
     pub data: Vec<PeerData>,
     pub meta: PeersMetaData,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeersMetaData {
     pub count: u64,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PeerState {
     Connected,
@@ -770,7 +770,7 @@ impl fmt::Display for PeerState {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum PeerDirection {
     Inbound,
@@ -807,7 +807,7 @@ impl fmt::Display for PeerDirection {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PeerCount {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub connected: u64,
@@ -821,14 +821,14 @@ pub struct PeerCount {
 
 // --------- Server Sent Event Types -----------
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SseBlock {
     pub slot: Slot,
     pub block: Hash256,
     pub execution_optimistic: bool,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SseFinalizedCheckpoint {
     pub block: Hash256,
     pub state: Hash256,
@@ -836,7 +836,7 @@ pub struct SseFinalizedCheckpoint {
     pub execution_optimistic: bool,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SseHead {
     pub slot: Slot,
     pub block: Hash256,
@@ -847,7 +847,7 @@ pub struct SseHead {
     pub execution_optimistic: bool,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SseChainReorg {
     pub slot: Slot,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -860,7 +860,7 @@ pub struct SseChainReorg {
     pub execution_optimistic: bool,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SseLateHead {
     pub slot: Slot,
     pub block: Hash256,
@@ -973,7 +973,7 @@ pub struct EventQuery {
     pub topics: Vec<EventTopic>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EventTopic {
     Head,
@@ -1025,7 +1025,7 @@ impl fmt::Display for EventTopic {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Accept {
     Json,
     Ssz,
@@ -1084,7 +1084,7 @@ pub struct LivenessRequestData {
     pub indices: Vec<u64>,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LivenessResponseData {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub index: u64,

--- a/common/eth2_config/src/lib.rs
+++ b/common/eth2_config/src/lib.rs
@@ -66,7 +66,7 @@ impl Eth2Config {
 ///
 /// Used by the `eth2_network_config` crate to initialize the network directories during build and
 /// access them at runtime.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Eth2NetArchiveAndDirectory<'a> {
     pub name: &'a str,
     pub config_dir: &'a str,
@@ -93,7 +93,7 @@ impl<'a> Eth2NetArchiveAndDirectory<'a> {
 /// deposit ceremony has concluded and the final genesis `BeaconState` is known.
 const GENESIS_STATE_IS_KNOWN: bool = true;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct HardcodedNet {
     pub name: &'static str,
     pub config_dir: &'static str,

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 /// Specifies an Eth2 network.
 ///
 /// See the crate-level documentation for more details.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Eth2NetworkConfig {
     /// Note: instead of the block where the contract is deployed, it is acceptable to set this
     /// value to be the block number where the first deposit occurs.

--- a/common/fallback/src/lib.rs
+++ b/common/fallback/src/lib.rs
@@ -7,7 +7,7 @@ pub struct Fallback<T> {
     pub servers: Vec<T>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum FallbackError<E> {
     AllErrored(Vec<E>),
 }

--- a/common/monitoring_api/src/types.rs
+++ b/common/monitoring_api/src/types.rs
@@ -7,7 +7,7 @@ pub const VERSION: u64 = 1;
 pub const CLIENT_NAME: &str = "lighthouse";
 
 /// An API error serializable to JSON.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ErrorMessage {
     pub code: u16,
     pub message: String,
@@ -15,7 +15,7 @@ pub struct ErrorMessage {
     pub stacktraces: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MonitoringMetrics {
     #[serde(flatten)]
     pub metadata: Metadata,
@@ -23,7 +23,7 @@ pub struct MonitoringMetrics {
     pub process_metrics: Process,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProcessType {
     BeaconNode,
@@ -31,7 +31,7 @@ pub enum ProcessType {
     System,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Metadata {
     version: u64,
     timestamp: u128,
@@ -51,7 +51,7 @@ impl Metadata {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Process {
     Beacon(BeaconProcessMetrics),
@@ -60,7 +60,7 @@ pub enum Process {
 }
 
 /// Common metrics for all processes.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProcessMetrics {
     cpu_process_seconds_total: u64,
     memory_process_bytes: u64,
@@ -83,7 +83,7 @@ impl From<ProcessHealth> for ProcessMetrics {
 }
 
 /// Metrics related to the system.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SystemMetrics {
     cpu_cores: u64,
     cpu_threads: u64,
@@ -146,7 +146,7 @@ impl From<SystemHealth> for SystemMetrics {
 }
 
 /// All beacon process metrics.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BeaconProcessMetrics {
     #[serde(flatten)]
     pub common: ProcessMetrics,
@@ -155,7 +155,7 @@ pub struct BeaconProcessMetrics {
 }
 
 /// All validator process metrics
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorProcessMetrics {
     #[serde(flatten)]
     pub common: ProcessMetrics,

--- a/common/sensitive_url/src/lib.rs
+++ b/common/sensitive_url/src/lib.rs
@@ -17,7 +17,7 @@ impl fmt::Display for SensitiveError {
 }
 
 // Wrapper around Url which provides a custom `Display` implementation to protect user secrets.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct SensitiveUrl {
     pub full: Url,
     pub redacted: String,
@@ -46,7 +46,7 @@ impl Serialize for SensitiveUrl {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.full.to_string())
+        serializer.serialize_str(self.full.as_ref())
     }
 }
 

--- a/common/task_executor/src/lib.rs
+++ b/common/task_executor/src/lib.rs
@@ -10,7 +10,7 @@ use tokio::runtime::{Handle, Runtime};
 pub use tokio::task::JoinHandle;
 
 /// Provides a reason when Lighthouse is shut down.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ShutdownReason {
     /// The node shut down successfully.
     Success(&'static str),

--- a/consensus/cached_tree_hash/src/cache.rs
+++ b/consensus/cached_tree_hash/src/cache.rs
@@ -10,7 +10,7 @@ type CacheArena = cache_arena::CacheArena<Hash256>;
 type CacheArenaAllocation = cache_arena::CacheArenaAllocation<Hash256>;
 
 /// Sparse Merkle tree suitable for tree hashing vectors and lists.
-#[derive(Debug, PartialEq, Clone, Default, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)]
 pub struct TreeHashCache {
     pub initialized: bool,
     /// Depth is such that the tree has a capacity for 2^depth leaves

--- a/consensus/cached_tree_hash/src/cache_arena.rs
+++ b/consensus/cached_tree_hash/src/cache_arena.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering;
 use std::marker::PhantomData;
 use std::ops::Range;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     UnknownAllocId(usize),
     OffsetOverflow,
@@ -199,7 +199,7 @@ impl<T: Encode + Decode> CacheArena<T> {
 /// For all functions that accept a `CacheArena<T>` parameter, that arena should always be the one
 /// that created `Self`. I.e., do not mix-and-match allocations and arenas unless you _really_ know
 /// what you're doing (or want to have a bad time).
-#[derive(Debug, PartialEq, Clone, Default, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)]
 pub struct CacheArenaAllocation<T> {
     alloc_id: usize,
     #[ssz(skip_serializing, skip_deserializing)]

--- a/consensus/cached_tree_hash/src/cache_arena.rs
+++ b/consensus/cached_tree_hash/src/cache_arena.rs
@@ -20,7 +20,7 @@ pub enum Error {
 ///
 /// Because all of the allocations are stored in one big `Vec`, resizing any of the allocations
 /// will mean all items to the right of that allocation will be moved.
-#[derive(Debug, PartialEq, Clone, Default, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)]
 pub struct CacheArena<T: Encode + Decode> {
     /// The backing array, storing cached values.
     backing: Vec<T>,

--- a/consensus/cached_tree_hash/src/lib.rs
+++ b/consensus/cached_tree_hash/src/lib.rs
@@ -12,7 +12,7 @@ pub use crate::cache::TreeHashCache;
 pub use crate::impls::int_log;
 use ethereum_types::H256 as Hash256;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Attempting to provide more than 2^depth leaves to a Merkle tree is disallowed.
     TooManyLeaves,

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -137,7 +137,7 @@ impl<T> From<String> for Error<T> {
 /// Indicates whether the unrealized justification of a block should be calculated and tracked.
 /// If a block has been finalized, this can be set to false. This is useful when syncing finalized
 /// portions of the chain. Otherwise this should always be set to true.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CountUnrealized {
     True,
     False,
@@ -197,7 +197,7 @@ impl UpdateJustifiedCheckpointSlots {
 /// Indicates if a block has been verified by an execution payload.
 ///
 /// There is no variant for "invalid", since such a block should never be added to fork choice.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PayloadVerificationStatus {
     /// An EL has declared the execution payload to be valid.
     Verified,
@@ -244,7 +244,7 @@ fn compute_start_slot_at_epoch<E: EthSpec>(epoch: Epoch) -> Slot {
 
 /// Used for queuing attestations from the current slot. Only contains the minimum necessary
 /// information about the attestation.
-#[derive(Clone, PartialEq, Encode, Decode)]
+#[derive(Clone, Eq, PartialEq, Encode, Decode)]
 pub struct QueuedAttestation {
     slot: Slot,
     attesting_indices: Vec<u64>,
@@ -298,7 +298,7 @@ pub struct ForkchoiceUpdateParameters {
     pub finalized_hash: Option<ExecutionBlockHash>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ForkChoiceView {
     pub head_block_root: Hash256,
     pub justified_checkpoint: Checkpoint,

--- a/consensus/merkle_proof/src/lib.rs
+++ b/consensus/merkle_proof/src/lib.rs
@@ -100,9 +100,7 @@ impl MerkleTree {
                     (Leaf(_), Leaf(_)) => return Err(MerkleTreeError::MerkleTreeFull),
                     // There is a right node so insert in right node
                     (Node(_, _, _), Node(_, _, _)) => {
-                        if let Err(e) = right.push_leaf(elem, depth - 1) {
-                            return Err(e);
-                        }
+                        right.push_leaf(elem, depth - 1)?;
                     }
                     // Both branches are zero, insert in left one
                     (Zero(_), Zero(_)) => {

--- a/consensus/merkle_proof/src/lib.rs
+++ b/consensus/merkle_proof/src/lib.rs
@@ -29,7 +29,7 @@ pub enum MerkleTree {
     Zero(usize),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum MerkleTreeError {
     // Trying to push in a leaf
     LeafReached,

--- a/consensus/proto_array/src/error.rs
+++ b/consensus/proto_array/src/error.rs
@@ -1,6 +1,6 @@
 use types::{Checkpoint, Epoch, ExecutionBlockHash, Hash256, Slot};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     FinalizedNodeUnknown(Hash256),
     JustifiedNodeUnknown(Hash256),
@@ -50,7 +50,7 @@ pub enum Error {
     },
 }
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvalidBestNodeInfo {
     pub current_slot: Slot,
     pub start_root: Hash256,

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -66,7 +66,7 @@ impl InvalidationOperation {
     }
 }
 
-#[derive(Clone, PartialEq, Debug, Encode, Decode, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Encode, Decode, Serialize, Deserialize)]
 pub struct ProtoNode {
     /// The `slot` is not necessary for `ProtoArray`, it just exists so external components can
     /// easily query the block slot. This is useful for upstream fork choice logic.
@@ -103,7 +103,7 @@ pub struct ProtoNode {
     pub unrealized_finalized_checkpoint: Option<Checkpoint>,
 }
 
-#[derive(PartialEq, Debug, Encode, Decode, Serialize, Deserialize, Copy, Clone)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Encode, Decode, Serialize, Deserialize)]
 pub struct ProposerBoost {
     pub root: Hash256,
     pub score: u64,
@@ -118,7 +118,7 @@ impl Default for ProposerBoost {
     }
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProtoArray {
     /// Do not attempt to prune the tree unless it has at least this many nodes. Small prunes
     /// simply waste time.

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -14,7 +14,7 @@ use types::{
 
 pub const DEFAULT_PRUNE_THRESHOLD: usize = 256;
 
-#[derive(Default, PartialEq, Clone, Encode, Decode)]
+#[derive(Clone, Default, Eq, PartialEq, Encode, Decode)]
 pub struct VoteTracker {
     current_root: Hash256,
     next_root: Hash256,
@@ -22,7 +22,7 @@ pub struct VoteTracker {
 }
 
 /// Represents the verification status of an execution payload.
-#[derive(Clone, Copy, Debug, PartialEq, Encode, Decode, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Encode, Decode, Serialize, Deserialize)]
 #[ssz(enum_behaviour = "union")]
 pub enum ExecutionStatus {
     /// An EL has determined that the payload is valid.
@@ -124,7 +124,7 @@ impl ExecutionStatus {
 /// A block that is to be applied to the fork choice.
 ///
 /// A simplified version of `types::BeaconBlock`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Block {
     pub slot: Slot,
     pub root: Hash256,

--- a/consensus/serde_utils/src/quoted_int.rs
+++ b/consensus/serde_utils/src/quoted_int.rs
@@ -196,7 +196,7 @@ pub mod quoted_u256 {
 mod test {
     use super::*;
 
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct WrappedU256(#[serde(with = "quoted_u256")] U256);
 

--- a/consensus/serde_utils/src/u256_hex_be.rs
+++ b/consensus/serde_utils/src/u256_hex_be.rs
@@ -59,7 +59,7 @@ mod test {
     use serde::{Deserialize, Serialize};
     use serde_json;
 
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct Wrapper {
         #[serde(with = "super")]

--- a/consensus/serde_utils/src/u64_hex_be.rs
+++ b/consensus/serde_utils/src/u64_hex_be.rs
@@ -81,7 +81,7 @@ mod test {
     use serde::{Deserialize, Serialize};
     use serde_json;
 
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
     #[serde(transparent)]
     struct Wrapper {
         #[serde(with = "super")]

--- a/consensus/ssz/src/decode.rs
+++ b/consensus/ssz/src/decode.rs
@@ -8,7 +8,7 @@ pub mod impls;
 pub mod try_from_iter;
 
 /// Returned when SSZ decoding fails.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum DecodeError {
     /// The bytes supplied were too short to be decoded into the specified type.
     InvalidByteLength { len: usize, expected: usize },

--- a/consensus/ssz/src/legacy.rs
+++ b/consensus/ssz/src/legacy.rs
@@ -168,7 +168,7 @@ mod test {
         }
     }
 
-    #[derive(Debug, PartialEq, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct TwoVariableLenOptions {
         a: u16,
         #[ssz(with = "impl_u16")]

--- a/consensus/ssz/tests/tests.rs
+++ b/consensus/ssz/tests/tests.rs
@@ -77,7 +77,7 @@ mod round_trip {
         round_trip(items);
     }
 
-    #[derive(Debug, PartialEq, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct FixedLen {
         a: u16,
         b: u64,
@@ -137,7 +137,7 @@ mod round_trip {
         round_trip(items);
     }
 
-    #[derive(Debug, PartialEq, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct VariableLen {
         a: u16,
         b: Vec<u16>,
@@ -259,7 +259,7 @@ mod round_trip {
         round_trip(items);
     }
 
-    #[derive(Debug, PartialEq, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct ThreeVariableLen {
         a: u16,
         b: Vec<u16>,
@@ -385,14 +385,14 @@ mod derive_macro {
         assert_eq!(T::from_ssz_bytes(bytes).unwrap(), *item);
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     #[ssz(enum_behaviour = "union")]
     enum TwoFixedUnion {
         U8(u8),
         U16(u16),
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct TwoFixedUnionStruct {
         a: TwoFixedUnion,
     }
@@ -409,38 +409,38 @@ mod derive_macro {
         assert_encode_decode(&TwoFixedUnionStruct { a: sixteen }, &[4, 0, 0, 0, 1, 1, 0]);
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct VariableA {
         a: u8,
         b: Vec<u8>,
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct VariableB {
         a: Vec<u8>,
         b: u8,
     }
 
-    #[derive(PartialEq, Debug, Encode)]
+    #[derive(Debug, Eq, PartialEq, Encode)]
     #[ssz(enum_behaviour = "transparent")]
     enum TwoVariableTrans {
         A(VariableA),
         B(VariableB),
     }
 
-    #[derive(PartialEq, Debug, Encode)]
+    #[derive(Debug, Eq, PartialEq, Encode)]
     struct TwoVariableTransStruct {
         a: TwoVariableTrans,
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     #[ssz(enum_behaviour = "union")]
     enum TwoVariableUnion {
         A(VariableA),
         B(VariableB),
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     struct TwoVariableUnionStruct {
         a: TwoVariableUnion,
     }
@@ -493,7 +493,7 @@ mod derive_macro {
         );
     }
 
-    #[derive(PartialEq, Debug, Encode, Decode)]
+    #[derive(Debug, Eq, PartialEq, Encode, Decode)]
     #[ssz(enum_behaviour = "union")]
     enum TwoVecUnion {
         A(Vec<u8>),

--- a/consensus/ssz_types/src/bitfield.rs
+++ b/consensus/ssz_types/src/bitfield.rs
@@ -22,7 +22,7 @@ pub trait BitfieldBehaviour: Clone {}
 /// A marker struct used to declare SSZ `Variable` behaviour on a `Bitfield`.
 ///
 /// See the [`Bitfield`](struct.Bitfield.html) docs for usage.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Variable<N> {
     _phantom: PhantomData<N>,
 }
@@ -30,7 +30,7 @@ pub struct Variable<N> {
 /// A marker struct used to declare SSZ `Fixed` behaviour on a `Bitfield`.
 ///
 /// See the [`Bitfield`](struct.Bitfield.html) docs for usage.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub struct Fixed<N> {
     _phantom: PhantomData<N>,
 }

--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -326,7 +326,7 @@ mod test {
 
         assert_eq!(fixed[0], 1);
         assert_eq!(&fixed[0..1], &vec[0..1]);
-        assert_eq!((&fixed[..]).len(), 8192);
+        assert_eq!((fixed[..]).len(), 8192);
 
         fixed[1] = 3;
         assert_eq!(fixed[1], 3);

--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -353,7 +353,7 @@ mod test {
         let vec = vec![0, 2, 4, 6];
         let fixed: FixedVector<u64, U4> = FixedVector::from(vec);
 
-        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
         assert_eq!(fixed.get(4), None);
     }

--- a/consensus/ssz_types/src/lib.rs
+++ b/consensus/ssz_types/src/lib.rs
@@ -54,7 +54,7 @@ pub mod length {
 }
 
 /// Returned when an item encounters an error.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     OutOfBounds {
         i: usize,

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -335,7 +335,7 @@ mod test {
         let vec = vec![0, 2, 4, 6];
         let fixed: VariableList<u64, U4> = VariableList::from(vec);
 
-        assert_eq!(fixed.get(0), Some(&0));
+        assert_eq!(fixed.first(), Some(&0));
         assert_eq!(fixed.get(3), Some(&6));
         assert_eq!(fixed.get(4), None);
     }

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -308,7 +308,7 @@ mod test {
 
         assert_eq!(fixed[0], 1);
         assert_eq!(&fixed[0..1], &vec[0..1]);
-        assert_eq!((&fixed[..]).len(), 2);
+        assert_eq!((fixed[..]).len(), 2);
 
         fixed[1] = 3;
         assert_eq!(fixed[1], 3);

--- a/consensus/state_processing/src/block_replayer.rs
+++ b/consensus/state_processing/src/block_replayer.rs
@@ -60,7 +60,7 @@ impl From<BlockProcessingError> for BlockReplayError {
 }
 
 /// Defines how state roots should be computed during block replay.
-#[derive(PartialEq)]
+#[derive(Eq, PartialEq)]
 pub enum StateRootStrategy {
     /// Perform all transitions faithfully to the specification.
     Accurate,

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -40,7 +40,7 @@ use arbitrary::Arbitrary;
 
 /// The strategy to be used when validating the block's signatures.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum BlockSignatureStrategy {
     /// Do not validate any signature. Use with caution.
     NoVerification,
@@ -54,7 +54,7 @@ pub enum BlockSignatureStrategy {
 
 /// The strategy to be used when validating the block's signatures.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(PartialEq, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum VerifySignatures {
     /// Validate all signatures encountered.
     True,
@@ -70,7 +70,7 @@ impl VerifySignatures {
 
 /// Control verification of the latest block header.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(PartialEq, Clone, Copy)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum VerifyBlockRoot {
     True,
     False,

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -199,7 +199,7 @@ impl<T> From<ArithError> for BlockOperationError<T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum HeaderInvalid {
     ProposalSignatureInvalid,
     StateSlotMismatch,
@@ -218,7 +218,7 @@ pub enum HeaderInvalid {
     ProposerSlashed(usize),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposerSlashingInvalid {
     /// The proposer index is not a known validator.
     ProposerUnknown(u64),
@@ -240,7 +240,7 @@ pub enum ProposerSlashingInvalid {
     BadProposal2Signature,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AttesterSlashingInvalid {
     /// The attestations were not in conflict.
     NotSlashable,
@@ -255,7 +255,7 @@ pub enum AttesterSlashingInvalid {
 }
 
 /// Describes why an object is invalid.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AttestationInvalid {
     /// Commmittee index exceeds number of committees in that slot.
     BadCommitteeIndex,
@@ -315,7 +315,7 @@ impl From<BlockOperationError<IndexedAttestationInvalid>>
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum IndexedAttestationInvalid {
     /// The number of indices is 0.
     IndicesEmpty,
@@ -332,7 +332,7 @@ pub enum IndexedAttestationInvalid {
     SignatureSetError(SignatureSetError),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DepositInvalid {
     /// The signature (proof-of-possession) does not match the given pubkey.
     BadSignature,
@@ -343,7 +343,7 @@ pub enum DepositInvalid {
     BadMerkleProof,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ExitInvalid {
     /// The specified validator is not active.
     NotActive(u64),
@@ -367,7 +367,7 @@ pub enum ExitInvalid {
     SignatureSetError(SignatureSetError),
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SyncAggregateInvalid {
     /// One or more of the aggregate public keys is invalid.
     PubkeyInvalid,

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -17,7 +17,7 @@ use types::{
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// Signature verification failed. The block is invalid.
     SignatureInvalid(DecodeError),

--- a/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/participation_cache.rs
@@ -20,7 +20,7 @@ use types::{
     BeaconState, BeaconStateError, ChainSpec, Epoch, EthSpec, ParticipationFlags, RelativeEpoch,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     InvalidFlagIndex(usize),
     InvalidValidatorIndex(usize),
@@ -29,7 +29,7 @@ pub enum Error {
 /// A balance which will never be below the specified `minimum`.
 ///
 /// This is an effort to ensure the `EFFECTIVE_BALANCE_INCREMENT` minimum is always respected.
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 struct Balance {
     raw: u64,
     minimum: u64,
@@ -53,7 +53,7 @@ impl Balance {
 }
 
 /// Caches the participation values for one epoch (either the previous or current).
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 struct SingleEpochParticipationCache {
     /// Maps an active validator index to their participation flags.
     ///
@@ -173,7 +173,7 @@ impl SingleEpochParticipationCache {
 }
 
 /// Maintains a cache to be used during `altair::process_epoch`.
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct ParticipationCache {
     current_epoch: Epoch,
     /// Caches information about active validators pertaining to `self.current_epoch`.

--- a/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
@@ -17,7 +17,7 @@ macro_rules! set_self_if_other_is_true {
 
 /// The information required to reward a block producer for including an attestation in a block.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct InclusionInfo {
     /// The distance between the attestation slot and the slot that attestation was included in a
     /// block.
@@ -49,7 +49,7 @@ impl InclusionInfo {
 
 /// Information required to reward some validator during the current and previous epoch.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct ValidatorStatus {
     /// True if the validator has been slashed, ever.
     pub is_slashed: bool,
@@ -114,7 +114,7 @@ impl ValidatorStatus {
 /// The total effective balances for different sets of validators during the previous and current
 /// epochs.
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
 pub struct TotalBalances {
     /// The effective balance increment from the spec.

--- a/consensus/state_processing/src/per_epoch_processing/errors.rs
+++ b/consensus/state_processing/src/per_epoch_processing/errors.rs
@@ -1,7 +1,7 @@
 use crate::per_epoch_processing::altair::participation_cache::Error as ParticipationCacheError;
 use types::{BeaconStateError, InconsistentFork};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum EpochProcessingError {
     UnableToDetermineProducer,
     NoBlockRoots,
@@ -57,7 +57,7 @@ impl From<ParticipationCacheError> for EpochProcessingError {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum InclusionError {
     /// The validator did not participate in an attestation in this period.
     NoAttestationsForValidator,

--- a/consensus/state_processing/src/per_slot_processing.rs
+++ b/consensus/state_processing/src/per_slot_processing.rs
@@ -3,7 +3,7 @@ use crate::{per_epoch_processing::EpochProcessingSummary, *};
 use safe_arith::{ArithError, SafeArith};
 use types::*;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     BeaconStateError(BeaconStateError),
     EpochProcessingError(EpochProcessingError),

--- a/consensus/state_processing/src/state_advance.rs
+++ b/consensus/state_processing/src/state_advance.rs
@@ -7,7 +7,7 @@
 use crate::*;
 use types::{BeaconState, ChainSpec, EthSpec, Hash256, Slot};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     BadTargetSlot { target_slot: Slot, state_slot: Slot },
     PerSlotProcessing(per_slot_processing::Error),

--- a/consensus/tree_hash/src/lib.rs
+++ b/consensus/tree_hash/src/lib.rs
@@ -98,7 +98,7 @@ fn get_zero_hash(height: usize) -> &'static [u8] {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum TreeHashType {
     Basic,
     Vector,

--- a/consensus/tree_hash/src/merkle_hasher.rs
+++ b/consensus/tree_hash/src/merkle_hasher.rs
@@ -5,7 +5,7 @@ use std::mem;
 
 type SmallVec8<T> = SmallVec<[T; 8]>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The maximum number of leaves defined by the initialization `depth` has been exceed.
     MaximumLeavesExceeded { max_leaves: usize },

--- a/consensus/types/src/application_domain.rs
+++ b/consensus/types/src/application_domain.rs
@@ -2,7 +2,7 @@
 /// Little endian hex: 0x00000001, Binary: 1000000000000000000000000
 pub const APPLICATION_DOMAIN_BUILDER: u32 = 16777216;
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ApplicationDomain {
     Builder,
 }

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -13,7 +13,7 @@ use super::{
     Signature, SignedRoot,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
     AlreadySigned(usize),

--- a/consensus/types/src/attestation_duty.rs
+++ b/consensus/types/src/attestation_duty.rs
@@ -2,7 +2,7 @@ use crate::*;
 use serde_derive::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AttestationDuty {
     /// The slot during which the attester must attest.
     pub slot: Slot,

--- a/consensus/types/src/beacon_committee.rs
+++ b/consensus/types/src/beacon_committee.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct BeaconCommittee<'a> {
     pub slot: Slot,
     pub index: CommitteeIndex,
@@ -18,7 +18,7 @@ impl<'a> BeaconCommittee<'a> {
 }
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct OwnedBeaconCommittee {
     pub slot: Slot,
     pub index: CommitteeIndex,

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -42,7 +42,7 @@ mod tree_hash_cache;
 pub const CACHED_EPOCHS: usize = 3;
 const MAX_RANDOM_BYTE: u64 = (1 << 8) - 1;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// A state for a different hard-fork was required -- a severe logic error.
     IncorrectStateVariant,
@@ -127,7 +127,7 @@ pub enum Error {
 }
 
 /// Control whether an epoch-indexed field can be indexed at the next epoch or not.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum AllowNextEpoch {
     True,
     False,

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -19,7 +19,7 @@ four_byte_option_impl!(four_byte_option_non_zero_usize, NonZeroUsize);
 
 /// Computes and stores the shuffling for an epoch. Provides various getters to allow callers to
 /// read the committees for the given epoch.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct CommitteeCache {
     #[ssz(with = "four_byte_option_epoch")]
     initialized_epoch: Option<Epoch>,
@@ -346,7 +346,7 @@ impl arbitrary::Arbitrary<'_> for CommitteeCache {
 /// This is a shim struct to ensure that we can encode a `Vec<Option<NonZeroUsize>>` an SSZ union
 /// with a four-byte selector. The SSZ specification changed from four bytes to one byte during 2021
 /// and we use this shim to avoid breaking the Lighthouse database.
-#[derive(Debug, Default, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 struct NonZeroUsizeOption(Option<NonZeroUsize>);
 

--- a/consensus/types/src/beacon_state/exit_cache.rs
+++ b/consensus/types/src/beacon_state/exit_cache.rs
@@ -4,7 +4,7 @@ use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Map from exit epoch to the number of validators with that exit epoch.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ExitCache {
     initialized: bool,
     exit_epoch_counts: HashMap<Epoch, u64>,

--- a/consensus/types/src/beacon_state/pubkey_cache.rs
+++ b/consensus/types/src/beacon_state/pubkey_cache.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 type ValidatorIndex = usize;
 
-#[derive(Debug, PartialEq, Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PubkeyCache {
     /// Maintain the number of keys added to the map. It is not sufficient to just use the HashMap
     /// len, as it does not increase when duplicate keys are added. Duplicate keys are used during

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -31,7 +31,7 @@ const NODES_PER_VALIDATOR: usize = 15;
 /// Do not set to 0.
 const VALIDATORS_PER_ARENA: usize = 4_096;
 
-#[derive(Debug, PartialEq, Clone, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Eq, Encode, Decode)]
 pub struct Eth1DataVotesTreeHashCache<T: EthSpec> {
     arena: CacheArena,
     tree_hash_cache: TreeHashCache,
@@ -455,7 +455,7 @@ impl<V, I: Iterator<Item = V>> ExactSizeIterator for ForcedExactSizeIterator<I> 
 
 /// Provides a cache for each of the `Validator` objects in `state.validators` and computes the
 /// roots of these using Rayon parallelization.
-#[derive(Debug, PartialEq, Clone, Default, Encode, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode)]
 pub struct ParallelValidatorTreeHash {
     /// Each arena and its associated sub-trees.
     arenas: Vec<(CacheArena, Vec<TreeHashCache>)>,
@@ -554,12 +554,12 @@ impl ParallelValidatorTreeHash {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OptionalTreeHashCache {
     inner: Option<OptionalTreeHashCacheInner>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OptionalTreeHashCacheInner {
     arena: CacheArena,
     tree_hash_cache: TreeHashCache,

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use tree_hash_derive::TreeHash;
 
 #[serde_as]
-#[derive(PartialEq, Debug, Serialize, Deserialize, TreeHash, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TreeHash)]
 #[serde(bound = "E: EthSpec, Payload: ExecPayload<E>")]
 pub struct BuilderBid<E: EthSpec, Payload: ExecPayload<E>> {
     #[serde_as(as = "BlindedPayloadAsHeader<E>")]
@@ -24,7 +24,7 @@ pub struct BuilderBid<E: EthSpec, Payload: ExecPayload<E>> {
 impl<E: EthSpec, Payload: ExecPayload<E>> SignedRoot for BuilderBid<E, Payload> {}
 
 /// Validator registration, for use in interacting with servers implementing the builder API.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "E: EthSpec, Payload: ExecPayload<E>")]
 pub struct SignedBuilderBid<E: EthSpec, Payload: ExecPayload<E>> {
     pub message: BuilderBid<E, Payload>,

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use tree_hash::TreeHash;
 
 /// Each of the BLS signature domains.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Domain {
     BeaconProposer,
     BeaconAttester,
@@ -28,7 +28,7 @@ pub enum Domain {
 ///
 /// Contains a mixture of "preset" and "config" values w.r.t to the EF definitions.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ChainSpec {
     /*
      * Config name
@@ -807,7 +807,7 @@ impl Default for ChainSpec {
 /// Fields relevant to hard forks after Altair should be optional so that we can continue
 /// to parse Altair configs. This default approach turns out to be much simpler than trying to
 /// make `Config` a superstruct because of the hassle of deserializing an untagged enum.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct Config {
     #[serde(default)]

--- a/consensus/types/src/config_and_preset.rs
+++ b/consensus/types/src/config_and_preset.rs
@@ -12,9 +12,9 @@ use superstruct::superstruct;
 /// Mostly useful for the API.
 #[superstruct(
     variants(Altair, Bellatrix),
-    variant_attributes(derive(Serialize, Deserialize, Debug, PartialEq, Clone))
+    variant_attributes(derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize))
 )]
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub struct ConfigAndPreset {
     #[serde(flatten)]

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -11,7 +11,9 @@ use tree_hash_derive::TreeHash;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+)]
 pub struct DepositMessage {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -11,7 +11,7 @@ use tree_hash_derive::TreeHash;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct DepositMessage {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/enr_fork_id.rs
+++ b/consensus/types/src/enr_fork_id.rs
@@ -12,7 +12,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.11
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct EnrForkId {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/enr_fork_id.rs
+++ b/consensus/types/src/enr_fork_id.rs
@@ -12,7 +12,17 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.11
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct EnrForkId {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -16,7 +16,7 @@ const MINIMAL: &str = "minimal";
 pub const GNOSIS: &str = "gnosis";
 
 /// Used to identify one of the `EthSpec` instances defined here.
-#[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum EthSpecId {
     Mainnet,

--- a/consensus/types/src/fork.rs
+++ b/consensus/types/src/fork.rs
@@ -14,6 +14,7 @@ use tree_hash_derive::TreeHash;
     Debug,
     Clone,
     Copy,
+    Eq,
     PartialEq,
     Default,
     Serialize,

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -11,7 +11,17 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct ForkData {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -11,7 +11,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct ForkData {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/free_attestation.rs
+++ b/consensus/types/src/free_attestation.rs
@@ -5,7 +5,7 @@ use super::{AttestationData, Signature};
 use serde_derive::Serialize;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct FreeAttestation {
     pub data: AttestationData,
     pub signature: Signature,

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -12,7 +12,7 @@ use tree_hash::TreeHash;
 pub const GRAFFITI_BYTES_LEN: usize = 32;
 
 /// The 32-byte `graffiti` field on a beacon block.
-#[derive(Default, Debug, PartialEq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct Graffiti(#[serde(with = "serde_graffiti")] pub [u8; GRAFFITI_BYTES_LEN]);
@@ -43,7 +43,7 @@ impl Into<[u8; GRAFFITI_BYTES_LEN]> for Graffiti {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Default)]
 #[serde(transparent)]
 pub struct GraffitiString(String);
 

--- a/consensus/types/src/participation_flags.rs
+++ b/consensus/types/src/participation_flags.rs
@@ -5,7 +5,7 @@ use ssz::{Decode, DecodeError, Encode};
 use test_random_derive::TestRandom;
 use tree_hash::{TreeHash, TreeHashType};
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize, TestRandom)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Deserialize, Serialize, TestRandom)]
 #[serde(transparent)]
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct ParticipationFlags {

--- a/consensus/types/src/preset.rs
+++ b/consensus/types/src/preset.rs
@@ -9,7 +9,7 @@ use serde_derive::{Deserialize, Serialize};
 /// one of these structs.
 ///
 /// https://github.com/ethereum/eth2.0-specs/blob/dev/presets/mainnet/phase0.yaml
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct BasePreset {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -120,7 +120,7 @@ impl BasePreset {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct AltairPreset {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
@@ -150,7 +150,7 @@ impl AltairPreset {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "UPPERCASE")]
 pub struct BellatrixPreset {
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/proposer_preparation_data.rs
+++ b/consensus/types/src/proposer_preparation_data.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// A proposer preparation, created when a validator prepares the beacon node for potential proposers
 /// by supplying information required when proposing blocks for the given validators.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProposerPreparationData {
     /// The validators index.
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/relative_epoch.rs
+++ b/consensus/types/src/relative_epoch.rs
@@ -1,7 +1,7 @@
 use crate::*;
 use safe_arith::{ArithError, SafeArith};
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Error {
     EpochTooLow { base: Epoch, other: Epoch },
     EpochTooHigh { base: Epoch, other: Epoch },
@@ -22,7 +22,7 @@ use arbitrary::Arbitrary;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RelativeEpoch {
     /// The prior epoch.
     Previous,

--- a/consensus/types/src/selection_proof.rs
+++ b/consensus/types/src/selection_proof.rs
@@ -8,7 +8,7 @@ use std::cmp;
 use std::convert::TryInto;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SelectionProof(Signature);
 
 impl SelectionProof {

--- a/consensus/types/src/signed_voluntary_exit.rs
+++ b/consensus/types/src/signed_voluntary_exit.rs
@@ -11,7 +11,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct SignedVoluntaryExit {
     pub message: VoluntaryExit,

--- a/consensus/types/src/signing_data.rs
+++ b/consensus/types/src/signing_data.rs
@@ -8,7 +8,7 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct SigningData {
     pub object_root: Hash256,
     pub domain: Hash256,

--- a/consensus/types/src/signing_data.rs
+++ b/consensus/types/src/signing_data.rs
@@ -8,7 +8,9 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+)]
 pub struct SigningData {
     pub object_root: Hash256,
     pub domain: Hash256,

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -8,7 +8,7 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
     ArithError(ArithError),

--- a/consensus/types/src/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_aggregator_selection_data.rs
@@ -8,7 +8,7 @@ use tree_hash_derive::TreeHash;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, Hash, Encode, Decode, TreeHash, TestRandom,
+    Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct SyncAggregatorSelectionData {
     pub slot: Slot,

--- a/consensus/types/src/sync_committee.rs
+++ b/consensus/types/src/sync_committee.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     ArithError(ArithError),
     InvalidSubcommitteeRange {

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -7,7 +7,7 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
     AlreadySigned(usize),
@@ -76,7 +76,7 @@ impl<T: EthSpec> SyncCommitteeContribution<T> {
 impl SignedRoot for Hash256 {}
 
 /// This is not in the spec, but useful for determining uniqueness of sync committee contributions
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct SyncContributionData {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -76,7 +76,9 @@ impl<T: EthSpec> SyncCommitteeContribution<T> {
 impl SignedRoot for Hash256 {}
 
 /// This is not in the spec, but useful for determining uniqueness of sync committee contributions
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+)]
 pub struct SyncContributionData {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_message.rs
+++ b/consensus/types/src/sync_committee_message.rs
@@ -9,7 +9,7 @@ use tree_hash_derive::TreeHash;
 
 /// The data upon which a `SyncCommitteeContribution` is based.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
 pub struct SyncCommitteeMessage {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_message.rs
+++ b/consensus/types/src/sync_committee_message.rs
@@ -9,7 +9,9 @@ use tree_hash_derive::TreeHash;
 
 /// The data upon which a `SyncCommitteeContribution` is based.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+)]
 pub struct SyncCommitteeMessage {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_subscription.rs
+++ b/consensus/types/src/sync_committee_subscription.rs
@@ -4,7 +4,7 @@ use ssz_derive::{Decode, Encode};
 
 /// A sync committee subscription created when a validator subscribes to sync committee subnets to perform
 /// sync committee duties.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct SyncCommitteeSubscription {
     /// The validators index.
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/sync_duty.rs
+++ b/consensus/types/src/sync_duty.rs
@@ -4,7 +4,7 @@ use safe_arith::ArithError;
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncDuty {
     pub pubkey: PublicKeyBytes,
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/sync_selection_proof.rs
+++ b/consensus/types/src/sync_selection_proof.rs
@@ -13,7 +13,7 @@ use std::cmp;
 use std::convert::TryInto;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SyncSelectionProof(Signature);
 
 impl SyncSelectionProof {

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
 pub struct Validator {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -10,7 +10,9 @@ use tree_hash_derive::TreeHash;
 ///
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash,
+)]
 pub struct Validator {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/validator_registration_data.rs
+++ b/consensus/types/src/validator_registration_data.rs
@@ -4,13 +4,13 @@ use ssz_derive::{Decode, Encode};
 use tree_hash_derive::TreeHash;
 
 /// Validator registration, for use in interacting with servers implementing the builder API.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SignedValidatorRegistrationData {
     pub message: ValidatorRegistrationData,
     pub signature: Signature,
 }
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode, TreeHash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash)]
 pub struct ValidatorRegistrationData {
     pub fee_recipient: Address,
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/validator_subscription.rs
+++ b/consensus/types/src/validator_subscription.rs
@@ -4,7 +4,7 @@ use ssz_derive::{Decode, Encode};
 
 /// A validator subscription, created when a validator subscribes to a slot to perform optional aggregation
 /// duties.
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Encode, Decode)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Encode, Decode)]
 pub struct ValidatorSubscription {
     /// The validators index.
     pub validator_index: u64,

--- a/consensus/types/src/voluntary_exit.rs
+++ b/consensus/types/src/voluntary_exit.rs
@@ -13,7 +13,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct VoluntaryExit {
     /// Earliest epoch when voluntary exit can be processed.

--- a/crypto/bls/src/generic_aggregate_signature.rs
+++ b/crypto/bls/src/generic_aggregate_signature.rs
@@ -56,7 +56,7 @@ pub trait TAggregateSignature<Pub, AggPub, Sig>: Sized + Clone {
 ///
 /// Provides generic functionality whilst deferring all serious cryptographic operations to the
 /// generics.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct GenericAggregateSignature<Pub, AggPub, Sig, AggSig> {
     /// The underlying point which performs *actual* cryptographic operations.
     point: Option<AggSig>,

--- a/crypto/bls/src/lib.rs
+++ b/crypto/bls/src/lib.rs
@@ -48,7 +48,7 @@ use milagro_bls::AmclError;
 
 pub type Hash256 = ethereum_types::H256;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// An error was raised from the Milagro BLS library.
     #[cfg(feature = "milagro")]

--- a/crypto/eth2_key_derivation/src/derived_key.rs
+++ b/crypto/eth2_key_derivation/src/derived_key.rs
@@ -35,7 +35,7 @@ pub const MOD_R_L: usize = 48;
 #[zeroize(drop)]
 pub struct DerivedKey(ZeroizeHash);
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     EmptySeed,
 }

--- a/crypto/eth2_key_derivation/src/plain_text.rs
+++ b/crypto/eth2_key_derivation/src/plain_text.rs
@@ -1,7 +1,7 @@
 use zeroize::Zeroize;
 
 /// Provides wrapper around `Vec<u8>` that implements `Zeroize`.
-#[derive(Zeroize, Clone, PartialEq)]
+#[derive(Zeroize, Clone, Eq, PartialEq)]
 #[zeroize(drop)]
 pub struct PlainText(Vec<u8>);
 

--- a/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 use std::convert::TryFrom;
 
 /// Used for ensuring that serde only decodes valid checksum functions.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum ChecksumFunction {
     Sha256,
@@ -35,7 +35,7 @@ impl TryFrom<String> for ChecksumFunction {
 }
 
 /// Used for ensuring serde only decodes an empty map.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "Value", into = "Value")]
 pub struct EmptyMap;
 
@@ -57,7 +57,7 @@ impl TryFrom<Value> for EmptyMap {
 }
 
 /// Checksum module for `Keystore`.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChecksumModule {
     pub function: ChecksumFunction,
@@ -65,7 +65,7 @@ pub struct ChecksumModule {
     pub message: HexBytes,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Sha256Checksum(String);
 
 impl Sha256Checksum {

--- a/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// Used for ensuring that serde only decodes valid cipher functions.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum CipherFunction {
     Aes128Ctr,
@@ -34,7 +34,7 @@ impl TryFrom<String> for CipherFunction {
 }
 
 /// Cipher module representation.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CipherModule {
     pub function: CipherFunction,
@@ -43,13 +43,13 @@ pub struct CipherModule {
 }
 
 /// Parameters for AES128 with ctr mode.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Aes128Ctr {
     pub iv: HexBytes,
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Cipher {
     Aes128Ctr(Aes128Ctr),

--- a/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
+++ b/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
 /// To allow serde to encode/decode byte arrays from HEX ASCII strings.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct HexBytes(Vec<u8>);
 

--- a/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
@@ -11,7 +11,7 @@ use sha2::Sha256;
 use std::convert::TryFrom;
 
 /// KDF module representation.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct KdfModule {
     pub function: KdfFunction,
@@ -20,7 +20,7 @@ pub struct KdfModule {
 }
 
 /// Used for ensuring serde only decodes an empty string.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub struct EmptyString;
 
@@ -41,7 +41,7 @@ impl TryFrom<String> for EmptyString {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Kdf {
     Scrypt(Scrypt),
@@ -58,7 +58,7 @@ impl Kdf {
 }
 
 /// PRF for use in `pbkdf2`.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Prf {
     #[serde(rename = "hmac-sha256")]
     #[default]
@@ -75,7 +75,7 @@ impl Prf {
 }
 
 /// Parameters for `pbkdf2` key derivation.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Pbkdf2 {
     pub c: u32,
@@ -85,7 +85,7 @@ pub struct Pbkdf2 {
 }
 
 /// Used for ensuring that serde only decodes valid KDF functions.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum KdfFunction {
     Scrypt,
@@ -114,7 +114,7 @@ impl TryFrom<String> for KdfFunction {
 }
 
 /// Parameters for `scrypt` key derivation.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Scrypt {
     pub dklen: u32,

--- a/crypto/eth2_keystore/src/json_keystore/mod.rs
+++ b/crypto/eth2_keystore/src/json_keystore/mod.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use serde_repr::*;
 
 /// JSON representation of [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335) keystore.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonKeystore {
     pub crypto: Crypto,
@@ -35,7 +35,7 @@ pub struct JsonKeystore {
 }
 
 /// Version for `JsonKeystore`.
-#[derive(Debug, Clone, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum Version {
     V4 = 4,
@@ -48,7 +48,7 @@ impl Version {
 }
 
 /// Crypto module for keystore.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Crypto {
     pub kdf: KdfModule,

--- a/crypto/eth2_keystore/src/keystore.rs
+++ b/crypto/eth2_keystore/src/keystore.rs
@@ -64,7 +64,7 @@ pub const DEFAULT_PBKDF2_C: u32 = 262_144;
 /// Provides a new-type wrapper around `String` that is zeroized on `Drop`.
 ///
 /// Useful for ensuring that password memory is zeroed-out on drop.
-#[derive(Clone, PartialEq, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
 #[serde(transparent)]
 struct ZeroizeString(String);
@@ -100,7 +100,7 @@ impl FromIterator<char> for ZeroizeString {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     InvalidSecretKeyLen { len: usize, expected: usize },
     InvalidPassword,
@@ -187,7 +187,7 @@ impl<'a> KeystoreBuilder<'a> {
 /// Provides a BLS keystore as defined in [EIP-2335](https://eips.ethereum.org/EIPS/eip-2335).
 ///
 /// Use `KeystoreBuilder` to create a new keystore.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Keystore {
     json: JsonKeystore,

--- a/crypto/eth2_wallet/src/json_wallet/mod.rs
+++ b/crypto/eth2_wallet/src/json_wallet/mod.rs
@@ -8,7 +8,7 @@ pub use eth2_keystore::json_keystore::{
 };
 pub use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonWallet {
     pub crypto: Crypto,
@@ -21,7 +21,7 @@ pub struct JsonWallet {
 }
 
 /// Version for `JsonWallet`.
-#[derive(Debug, Clone, PartialEq, Serialize_repr, Deserialize_repr)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum Version {
     V1 = 1,
@@ -34,7 +34,7 @@ impl Version {
 }
 
 /// Used for ensuring that serde only decodes valid checksum functions.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(try_from = "String", into = "String")]
 pub enum TypeField {
     Hd,

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 pub use uuid::Uuid;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     KeystoreError(KeystoreError),
     PathExhausted,
@@ -119,7 +119,7 @@ impl<'a> WalletBuilder<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Wallet {
     json: JsonWallet,

--- a/slasher/src/lib.rs
+++ b/slasher/src/lib.rs
@@ -28,7 +28,7 @@ use types::{AttesterSlashing, EthSpec, IndexedAttestation, ProposerSlashing};
 pub type Environment = mdbx::Environment<mdbx::NoWriteMap>;
 pub type RwTransaction<'env> = mdbx::Transaction<'env, mdbx::RW, mdbx::NoWriteMap>;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AttesterSlashingStatus<E: EthSpec> {
     NotSlashable,
     /// A weird outcome that can occur when we go to lookup an attestation by its target
@@ -40,7 +40,7 @@ pub enum AttesterSlashingStatus<E: EthSpec> {
     SurroundedByExisting(Box<IndexedAttestation<E>>),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ProposerSlashingStatus {
     NotSlashable,
     DoubleVote(Box<ProposerSlashing>),

--- a/testing/ef_tests/src/case_result.rs
+++ b/testing/ef_tests/src/case_result.rs
@@ -6,7 +6,7 @@ use types::BeaconState;
 
 pub const MAX_VALUE_STRING_LEN: usize = 500;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CaseResult {
     pub case_index: usize,
     pub desc: String,

--- a/testing/ef_tests/src/cases/common.rs
+++ b/testing/ef_tests/src/cases/common.rs
@@ -22,7 +22,7 @@ impl<T: BlsCase> LoadCase for T {
 /// Macro to wrap U128 and U256 so they deserialize correctly.
 macro_rules! uint_wrapper {
     ($wrapper_name:ident, $wrapped_type:ty) => {
-        #[derive(Debug, Clone, Copy, Default, PartialEq, Decode, Encode, Deserialize)]
+        #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Decode, Encode, Deserialize)]
         #[serde(try_from = "String")]
         pub struct $wrapper_name {
             pub x: $wrapped_type,

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -20,7 +20,7 @@ use types::{
     ExecutionBlockHash, ForkName, Hash256, IndexedAttestation, SignedBeaconBlock, Slot, Uint256,
 };
 
-#[derive(Default, Debug, PartialEq, Clone, Deserialize, Decode)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Deserialize, Decode)]
 #[serde(deny_unknown_fields)]
 pub struct PowBlock {
     pub block_hash: ExecutionBlockHash,
@@ -28,14 +28,14 @@ pub struct PowBlock {
     pub total_difficulty: Uint256,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Head {
     slot: Slot,
     root: Hash256,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Checks {
     head: Option<Head>,
@@ -50,7 +50,7 @@ pub struct Checks {
     proposer_boost_root: Option<Hash256>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(untagged, deny_unknown_fields)]
 pub enum Step<B, A, AS, P> {
     Tick { tick: u64 },
@@ -62,7 +62,7 @@ pub enum Step<B, A, AS, P> {
     Checks { checks: Box<Checks> },
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Meta {
     #[serde(rename(deserialize = "description"))]

--- a/testing/ef_tests/src/cases/rewards.rs
+++ b/testing/ef_tests/src/cases/rewards.rs
@@ -19,7 +19,7 @@ use types::{
     BeaconState, EthSpec, ForkName,
 };
 
-#[derive(Debug, Clone, PartialEq, Decode, Encode, CompareFields)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode, CompareFields)]
 pub struct Deltas {
     #[compare_fields(as_slice)]
     rewards: Vec<u64>,
@@ -31,7 +31,7 @@ pub struct Deltas {
 // for encoding the union selector.
 four_byte_option_impl!(four_byte_option_deltas, Deltas);
 
-#[derive(Debug, Clone, PartialEq, Decode, Encode, CompareFields)]
+#[derive(Clone, Debug, Eq, PartialEq, Decode, Encode, CompareFields)]
 pub struct AllDeltas {
     source_deltas: Deltas,
     target_deltas: Deltas,
@@ -41,12 +41,12 @@ pub struct AllDeltas {
     inactivity_penalty_deltas: Deltas,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct Metadata {
     pub description: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct RewardsTest<E: EthSpec> {
     pub path: PathBuf,
     pub metadata: Metadata,

--- a/testing/ef_tests/src/cases/ssz_generic.rs
+++ b/testing/ef_tests/src/cases/ssz_generic.rs
@@ -12,14 +12,14 @@ use tree_hash_derive::TreeHash;
 use types::typenum::*;
 use types::{BitList, BitVector, FixedVector, ForkName, VariableList};
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct Metadata {
     root: String,
     #[serde(rename(deserialize = "signing_root"))]
     _signing_root: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SszGeneric {
     path: PathBuf,
     handler_name: String,
@@ -232,32 +232,32 @@ fn ssz_generic_test<T: SszStaticType + ssz::Decode>(path: &Path) -> Result<(), E
 }
 
 // Containers for SSZ generic tests
-#[derive(Debug, Clone, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct SingleFieldTestStruct {
     A: u8,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct SmallTestStruct {
     A: u16,
     B: u16,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct FixedTestStruct {
     A: u8,
     B: u64,
     C: u32,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct VarTestStruct {
     A: u16,
     B: VariableList<u16, U1024>,
     C: u8,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct ComplexTestStruct {
     A: u16,
     B: VariableList<u16, U128>,
@@ -269,7 +269,7 @@ struct ComplexTestStruct {
     G: FixedVector<VarTestStruct, U2>,
 }
 
-#[derive(Debug, Clone, PartialEq, Decode, Encode, TreeHash, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Decode, Encode, TreeHash, Deserialize)]
 struct BitsStruct {
     A: BitList<U5>,
     B: BitVector<U2>,

--- a/testing/ef_tests/src/error.rs
+++ b/testing/ef_tests/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// The value in the test didn't match our value.
     NotEqual(String),

--- a/validator_client/slashing_protection/src/interchange.rs
+++ b/validator_client/slashing_protection/src/interchange.rs
@@ -5,7 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::io;
 use types::{Epoch, Hash256, PublicKeyBytes, Slot};
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterchangeMetadata {
@@ -14,7 +14,7 @@ pub struct InterchangeMetadata {
     pub genesis_validators_root: Hash256,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct InterchangeData {
@@ -23,7 +23,7 @@ pub struct InterchangeData {
     pub signed_attestations: Vec<SignedAttestation>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SignedBlock {
@@ -33,7 +33,7 @@ pub struct SignedBlock {
     pub signing_root: Option<Hash256>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct SignedAttestation {
@@ -45,7 +45,7 @@ pub struct SignedAttestation {
     pub signing_root: Option<Hash256>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Interchange {
     pub metadata: InterchangeMetadata,

--- a/validator_client/slashing_protection/src/lib.rs
+++ b/validator_client/slashing_protection/src/lib.rs
@@ -41,7 +41,7 @@ pub enum NotSafe {
 }
 
 /// The attestation or block is safe to sign, and will not cause the signer to be slashed.
-#[derive(PartialEq, Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Safe {
     /// Casting the exact same data (block or attestation) twice is never slashable.
     SameData,

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -64,7 +64,7 @@ pub fn start_fallback_updater_service<T: SlotClock + 'static, E: EthSpec>(
 }
 
 /// Indicates if a beacon node must be synced before some action is performed on it.
-#[derive(PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum RequireSynced {
     Yes,
     No,

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -45,7 +45,7 @@ use types::{Epoch, EthSpec, PublicKeyBytes, Slot};
 
 /// A wrapper around `PublicKeyBytes` which encodes information about the status of a validator
 /// pubkey with regards to doppelganger protection.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum DoppelgangerStatus {
     /// Doppelganger protection has approved this for signing.
     ///
@@ -115,7 +115,7 @@ struct LivenessResponses {
 pub const DEFAULT_REMAINING_DETECTION_EPOCHS: u64 = 1;
 
 /// Store the per-validator status of doppelganger checking.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DoppelgangerState {
     /// The next epoch for which the validator should be checked for liveness.
     ///

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -69,7 +69,7 @@ pub struct Context<T: SlotClock, E: EthSpec> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,

--- a/validator_client/src/http_metrics/mod.rs
+++ b/validator_client/src/http_metrics/mod.rs
@@ -50,7 +50,7 @@ pub struct Context<T: EthSpec> {
 }
 
 /// Configuration for the HTTP server.
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Config {
     pub enabled: bool,
     pub listen_addr: IpAddr,

--- a/validator_client/src/key_cache.rs
+++ b/validator_client/src/key_cache.rs
@@ -21,7 +21,7 @@ pub const CACHE_FILENAME: &str = "validator_key_cache.json";
 /// The file name for the temporary `KeyCache`.
 pub const TEMP_CACHE_FILENAME: &str = ".validator_key_cache.json.tmp";
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum State {
     NotDecrypted,
     DecryptedAndSaved,

--- a/validator_client/src/signing_method.rs
+++ b/validator_client/src/signing_method.rs
@@ -19,7 +19,7 @@ pub use web3signer::Web3SignerObject;
 
 mod web3signer;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     InconsistentDomains {
         message_type_domain: Domain,

--- a/validator_client/src/signing_method/web3signer.rs
+++ b/validator_client/src/signing_method/web3signer.rs
@@ -4,7 +4,7 @@ use super::Error;
 use serde::{Deserialize, Serialize};
 use types::*;
 
-#[derive(Debug, PartialEq, Copy, Clone, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum MessageType {
     AggregationSlot,
@@ -20,7 +20,7 @@ pub enum MessageType {
     ValidatorRegistration,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ForkName {
     Phase0,
@@ -28,7 +28,7 @@ pub enum ForkName {
     Bellatrix,
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct ForkInfo {
     pub fork: Fork,
     pub genesis_validators_root: Hash256,
@@ -127,7 +127,7 @@ pub struct SigningRequest<'a, T: EthSpec, Payload: ExecPayload<T>> {
     pub object: Web3SignerObject<'a, T, Payload>,
 }
 
-#[derive(Debug, PartialEq, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Deserialize)]
 pub struct SigningResponse {
     pub signature: Signature,
 }


### PR DESCRIPTION
## Issue Addressed

We can't merge anything into `unstable` until these lint issues are fixed.