### PR TITLE
[Merged by Bors] - Increase merge-readiness lookhead

### DIFF
--- a/beacon_node/beacon_chain/src/merge_readiness.rs
+++ b/beacon_node/beacon_chain/src/merge_readiness.rs
@@ -9,7 +9,7 @@ use types::*;
 
 /// The time before the Bellatrix fork when we will start issuing warnings about preparation.
 const SECONDS_IN_A_WEEK: u64 = 604800;
-pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK;
+pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK * 3;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct MergeConfig {

--- a/beacon_node/beacon_chain/src/merge_readiness.rs
+++ b/beacon_node/beacon_chain/src/merge_readiness.rs
@@ -9,7 +9,7 @@ use types::*;
 
 /// The time before the Bellatrix fork when we will start issuing warnings about preparation.
 const SECONDS_IN_A_WEEK: u64 = 604800;
-pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK * 5 / 2;
+pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK * 2;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct MergeConfig {

--- a/beacon_node/beacon_chain/src/merge_readiness.rs
+++ b/beacon_node/beacon_chain/src/merge_readiness.rs
@@ -9,7 +9,7 @@ use types::*;
 
 /// The time before the Bellatrix fork when we will start issuing warnings about preparation.
 const SECONDS_IN_A_WEEK: u64 = 604800;
-pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK * 3;
+pub const MERGE_READINESS_PREPARATION_SECONDS: u64 = SECONDS_IN_A_WEEK * 5 / 2;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct MergeConfig {

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -387,6 +387,7 @@ async fn merge_readiness_logging<T: BeaconChainTypes>(
                 log,
                 "Not ready for merge";
                 "info" => %readiness,
+                "hint" => "try updating Lighthouse and/or the execution layer",
             )
         }
         readiness @ MergeReadiness::NotSynced => warn!(


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Start issuing merge-readiness logs 2 weeks before the Bellatrix fork epoch. Additionally, if the Bellatrix epoch is specified and the use has configured an EL, always log merge readiness logs, this should benefit pro-active users.

### Lookahead Reasoning

- Bellatrix fork is:
    - epoch 144896
    - slot 4636672
    - Unix timestamp: `1606824023 + (4636672 * 12) = 1662464087`
    - GMT: Tue Sep 06 2022 11:34:47 GMT+0000
- Warning start time is:
    - Unix timestamp: `1662464087 - 604800 * 2 = 1661254487`
    - GMT: Tue Aug 23 2022 11:34:47 GMT+0000

The [current expectation](https://discord.com/channels/595666850260713488/745077610685661265/1007445305198911569) is that EL and CL clients will releases out by Aug 22nd at the latest, then an EF announcement will go out on the 23rd. If all goes well, LH will start alerting users about merge-readiness just after the announcement.

## Additional Info

NA