### PR TITLE
[Merged by Bors] - Optimistic sync: remove justified block check

### DIFF
--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -1332,15 +1332,6 @@ where
             return Ok(true);
         }
 
-        // If the justified block has execution enabled, then optimistically import any block.
-        if self
-            .get_justified_block()?
-            .execution_status
-            .is_execution_enabled()
-        {
-            return Ok(true);
-        }
-
         // If the parent block has execution enabled, always import the block.
         //
         // See:


### PR DESCRIPTION
## Issue Addressed

Implements spec change https://github.com/ethereum/consensus-specs/pull/2881

## Proposed Changes

Remove the justified block check from `is_optimistic_candidate_block`.