### PR TITLE
[Merged by Bors] - Unblock CI by updating git submodules directly in execution integration tests

### DIFF
--- a/testing/execution_engine_integration/src/build_utils.rs
+++ b/testing/execution_engine_integration/src/build_utils.rs
@@ -20,7 +20,6 @@ pub fn clone_repo(repo_dir: &Path, repo_url: &str) -> Result<(), String> {
         Command::new("git")
             .arg("clone")
             .arg(repo_url)
-            .arg("--recursive")
             .current_dir(repo_dir)
             .output()
             .map_err(|_| format!("failed to clone repo at {repo_url}"))?,
@@ -38,6 +37,21 @@ pub fn checkout(repo_dir: &Path, revision_or_branch: &str) -> Result<(), String>
             .map_err(|_| {
                 format!(
                     "failed to checkout branch or revision at {repo_dir:?}/{revision_or_branch}",
+                )
+            })?,
+        |_| {},
+    )?;
+    output_to_result(
+        Command::new("git")
+            .arg("submodule")
+            .arg("update")
+            .arg("--init")
+            .arg("--recursive")
+            .current_dir(repo_dir)
+            .output()
+            .map_err(|_| {
+                format!(
+                    "failed to update submodules on branch or revision at {repo_dir:?}/{revision_or_branch}",
                 )
             })?,
         |_| {},


### PR DESCRIPTION
## Issue Addressed

Recent changes to the Nethermind codebase removed the `rocksdb` git submodule in favour of a `nuget` package.
This appears to have broken our ability to build the latest release of Nethermind inside our integration tests.

## Proposed Changes

~Temporarily pin the version used for the Nethermind integration tests to `master`. This ensures we use the packaged version of `rocksdb`. This is only necessary until a new release of Nethermind is available.~

Use `git submodule update --init --recursive` to ensure the required submodules are pulled before building.