### PR TITLE
[Merged by Bors] - Bump EF tests to `v1.2.0 rc.3`

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.2.0-rc.2
+TESTS_TAG := v1.2.0-rc.3
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -45,6 +45,8 @@ excluded_paths = [
     "tests/.*/capella",
     # One of the EF researchers likes to pack the tarballs on a Mac
     ".*\.DS_Store.*"
+    # More Mac weirdness.
+    "tests/mainnet/bellatrix/operations/deposit/pyspec_tests/deposit_with_previous_fork_version__valid_ineffective/._meta.yaml"
 ]
 
 def normalize_path(path):

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -44,7 +44,7 @@ excluded_paths = [
     # Capella tests are disabled for now.
     "tests/.*/capella",
     # One of the EF researchers likes to pack the tarballs on a Mac
-    ".*\.DS_Store.*"
+    ".*\.DS_Store.*",
     # More Mac weirdness.
     "tests/mainnet/bellatrix/operations/deposit/pyspec_tests/deposit_with_previous_fork_version__valid_ineffective/._meta.yaml"
 ]


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Bumps test vectors and ignores another weird MacOS file.

## Additional Info

NA
