### PR TITLE
[Merged by Bors] - Run per-slot fork choice at a further distance from the head

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -131,7 +131,11 @@ const PREPARE_PROPOSER_HISTORIC_EPOCHS: u64 = 4;
 /// run the per-slot tasks (primarily fork choice).
 ///
 /// This prevents unnecessary work during sync.
-const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 128;
+///
+/// The value is set to 256 since this would be just over one slot (12.8s) when syncing at
+/// 20 slots/second. Having a single fork-choice run interrupt syncing would have very little
+/// impact whilst having 8 epochs without a block is a comfortable grace period.
+const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 256;
 
 /// Reported to the user when the justified block has an invalid execution payload.
 pub const INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON: &str =

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -131,7 +131,7 @@ const PREPARE_PROPOSER_HISTORIC_EPOCHS: u64 = 4;
 /// run the per-slot tasks (primarily fork choice).
 ///
 /// This prevents unnecessary work during sync.
-const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 64;
+const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 128;
 
 /// Reported to the user when the justified block has an invalid execution payload.
 pub const INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON: &str =

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -131,7 +131,7 @@ const PREPARE_PROPOSER_HISTORIC_EPOCHS: u64 = 4;
 /// run the per-slot tasks (primarily fork choice).
 ///
 /// This prevents unnecessary work during sync.
-const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 4;
+const MAX_PER_SLOT_FORK_CHOICE_DISTANCE: u64 = 64;
 
 /// Reported to the user when the justified block has an invalid execution payload.
 pub const INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON: &str =

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -38,7 +38,7 @@ use types::{AttestationShufflingId, EthSpec, Hash256, RelativeEpoch, Slot};
 const MAX_ADVANCE_DISTANCE: u64 = 4;
 
 /// Similarly for fork choice: avoid the fork choice lookahead during sync.
-const MAX_FORK_CHOICE_DISTANCE: u64 = 64;
+const MAX_FORK_CHOICE_DISTANCE: u64 = 128;
 
 #[derive(Debug)]
 enum Error {

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -38,7 +38,11 @@ use types::{AttestationShufflingId, EthSpec, Hash256, RelativeEpoch, Slot};
 const MAX_ADVANCE_DISTANCE: u64 = 4;
 
 /// Similarly for fork choice: avoid the fork choice lookahead during sync.
-const MAX_FORK_CHOICE_DISTANCE: u64 = 128;
+///
+/// The value is set to 256 since this would be just over one slot (12.8s) when syncing at
+/// 20 slots/second. Having a single fork-choice run interrupt syncing would have very little
+/// impact whilst having 8 epochs without a block is a comfortable grace period.
+const MAX_FORK_CHOICE_DISTANCE: u64 = 256;
 
 #[derive(Debug)]
 enum Error {

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -38,7 +38,7 @@ use types::{AttestationShufflingId, EthSpec, Hash256, RelativeEpoch, Slot};
 const MAX_ADVANCE_DISTANCE: u64 = 4;
 
 /// Similarly for fork choice: avoid the fork choice lookahead during sync.
-const MAX_FORK_CHOICE_DISTANCE: u64 = 4;
+const MAX_FORK_CHOICE_DISTANCE: u64 = 64;
 
 #[derive(Debug)]
 enum Error {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Run fork choice when the head is 256 slots from the wall-clock slot, rather than 4.

The reason we don't *always* run FC is so that it doesn't slow us down during sync. As the comments state, setting the value to 256 means that we'd only have one interrupting fork-choice call if we were syncing at 20 slots/sec.

## Additional Info

NA