### PR TITLE
[Merged by Bors] - Enable `block_lookup_failed` EF test

### DIFF
--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -156,13 +156,6 @@ impl<E: EthSpec> Case for ForkChoiceTest<E> {
     fn result(&self, _case_index: usize, fork_name: ForkName) -> Result<(), Error> {
         let tester = Tester::new(self, testing_spec::<E>(fork_name))?;
 
-        // TODO(merge): re-enable this test before production.
-        // This test is skipped until we can do retrospective confirmations of the terminal
-        // block after an optimistic sync.
-        if self.description == "block_lookup_failed" {
-            return Err(Error::SkippedKnownFailure);
-        };
-
         for step in &self.steps {
             match step {
                 Step::Tick { tick } => tester.set_tick(*tick),


### PR DESCRIPTION
## Issue Addressed

Resolves #3448

## Proposed Changes

Removes a known failure that wasn't actually a known failure. The tests declare this block invalid and we refuse to import it due to `ExecutionPayloadError(UnverifiedNonOptimisticCandidate)`.

This is correct since there is only one "eth1" block included in this test and two are required to trigger the merge (pre- and post-TTD blocks). It is slot 1 (tick = 12s) when this block is imported so the import must be prevented by `SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY`.

I'm not sure where I got the idea in #3448 that this test needed retrospective checking, that seems like a false assumption in hindsight.

## Additional Info

- Blocked on #3464 
