### PR TITLE
[Merged by Bors] - Return `readonly: false` for local keystores

### DIFF
--- a/validator_client/src/http_api/keystores.rs
+++ b/validator_client/src/http_api/keystores.rs
@@ -40,7 +40,7 @@ pub fn list<T: SlotClock + 'static, E: EthSpec>(
                     SigningMethod::LocalKeystore {
                         ref voting_keystore,
                         ..
-                    } => (voting_keystore.path(), None),
+                    } => (voting_keystore.path(), Some(false)),
                     SigningMethod::Web3Signer { .. } => (None, Some(true)),
                 });
 

--- a/validator_client/src/http_api/tests/keystores.rs
+++ b/validator_client/src/http_api/tests/keystores.rs
@@ -399,7 +399,7 @@ fn get_web3_signer_keystores() {
             .map(|local_keystore| SingleKeystoreResponse {
                 validating_pubkey: keystore_pubkey(local_keystore),
                 derivation_path: local_keystore.path(),
-                readonly: None,
+                readonly: Some(false),
             })
             .chain(remote_vals.iter().map(|remote_val| SingleKeystoreResponse {
                 validating_pubkey: remote_val.voting_public_key.compress(),
@@ -1775,7 +1775,7 @@ fn import_same_local_and_remote_keys() {
             .map(|local_keystore| SingleKeystoreResponse {
                 validating_pubkey: keystore_pubkey(local_keystore),
                 derivation_path: local_keystore.path(),
-                readonly: None,
+                readonly: Some(false),
             })
             .collect::<Vec<_>>();
         for response in expected_responses {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Indicate that local keystores are `readonly: Some(false)` rather than `None` via the `/eth/v1/keystores` method on the VC API.

I'll mark this as backwards-incompat so we remember to mention it in the release notes. There aren't any type-level incompatibilities here, just a change in how Lighthouse responds to responses.

## Additional Info

- Blocked on #3464 
