### PR TITLE
Move dialing to the Peer manager

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -12,6 +12,7 @@ use peerdb::{client::ClientKind, BanOperation, BanResult, ScoreUpdateResult};
 use rand::seq::SliceRandom;
 use slog::{debug, error, trace, warn};
 use smallvec::SmallVec;
+use std::collections::VecDeque;
 use std::{
     sync::Arc,
     time::{Duration, Instant},
@@ -71,6 +72,8 @@ pub struct PeerManager<TSpec: EthSpec> {
     status_peers: HashSetDelay<PeerId>,
     /// The target number of peers we would like to connect to.
     target_peers: usize,
+    /// Peers queued to be dialed.
+    peers_to_dial: VecDeque<(PeerId, Option<Enr>)>,
     /// A collection of sync committee subnets that we need to stay subscribed to.
     /// Sync committee subnets are longer term (256 epochs). Hence, we need to re-run
     /// discovery queries for subnet peers if we disconnect from existing sync
@@ -135,6 +138,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         Ok(PeerManager {
             network_globals,
             events: SmallVec::new(),
+            peers_to_dial: Default::default(),
             inbound_ping_peers: HashSetDelay::new(Duration::from_secs(ping_interval_inbound)),
             outbound_ping_peers: HashSetDelay::new(Duration::from_secs(ping_interval_outbound)),
             status_peers: HashSetDelay::new(Duration::from_secs(status_interval)),
@@ -360,8 +364,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     /* Notifications from the Swarm */
 
     // A peer is being dialed.
-    pub fn inject_dialing(&mut self, peer_id: &PeerId, enr: Option<Enr>) {
-        self.inject_peer_connection(peer_id, ConnectingType::Dialing, enr);
+    pub fn dial_peer(&mut self, peer_id: &PeerId, enr: Option<Enr>) {
+        self.peers_to_dial.push_back((*peer_id, enr));
     }
 
     /// Reports if a peer is banned or not.


### PR DESCRIPTION
## Issue Addressed

libp2p's latest release forces a quite big refactor on our lighthouse network crate mainly because of the deprecation of the `NetworkBehaviourEventProcess`. While doing this, I'll need to remove `InternalBehaviourMessage`. This PR removes one of the variants: `DialPeer` moving dialing from the main `Behaviour` to the `PeerManager`.

## Proposed Changes
This change should maintain essentially the same over-all behaviour:
Before we would tell the peer manager to set a peer as dialing and queue an internal behaviour event to emit the Dial `NBAction`. The way the derive macro for `NetworkBehaviour` works is by polling each sub-behaviour in the order they are defined and then calling the custom poll function. Since the peer manager is the last behaviour, having the dial at the beginning of the custom poll function and at the end of the poll for the peer manager should be equivalent. 

## Additional Info

na