### PR TITLE
[Merged by Bors] - Fix attestation performance API `InvalidValidatorIndex` error

### DIFF
--- a/beacon_node/http_api/src/attestation_performance.rs
+++ b/beacon_node/http_api/src/attestation_performance.rs
@@ -163,17 +163,11 @@ pub fn get_attestation_performance<T: BeaconChainTypes>(
 
                 let is_active = summary.is_active_unslashed_in_previous_epoch(index);
 
-                let received_source_reward = summary
-                    .is_previous_epoch_source_attester(index)
-                    .unwrap_or(false);
+                let received_source_reward = summary.is_previous_epoch_source_attester(index)?;
 
-                let received_head_reward = summary
-                    .is_previous_epoch_head_attester(index)
-                    .unwrap_or(false);
+                let received_head_reward = summary.is_previous_epoch_head_attester(index)?;
 
-                let received_target_reward = summary
-                    .is_previous_epoch_target_attester(index)
-                    .unwrap_or(false);
+                let received_target_reward = summary.is_previous_epoch_target_attester(index)?;
 
                 let inclusion_delay = summary
                     .previous_epoch_inclusion_info(index)

--- a/beacon_node/http_api/src/attestation_performance.rs
+++ b/beacon_node/http_api/src/attestation_performance.rs
@@ -83,6 +83,10 @@ pub fn get_attestation_performance<T: BeaconChainTypes>(
     }
 
     // Either use the global validator set, or the specified index.
+    //
+    // Does no further validation of the indices, so in the event an index has not yet been
+    // activated or does not yet exist (according to the head state), it will return all fields as
+    // `false`.
     let index_range = if target.to_lowercase() == "global" {
         chain
             .with_head(|head| Ok((0..head.beacon_state.validators().len() as u64).collect()))
@@ -159,11 +163,17 @@ pub fn get_attestation_performance<T: BeaconChainTypes>(
 
                 let is_active = summary.is_active_unslashed_in_previous_epoch(index);
 
-                let received_source_reward = summary.is_previous_epoch_source_attester(index)?;
+                let received_source_reward = summary
+                    .is_previous_epoch_source_attester(index)
+                    .unwrap_or(false);
 
-                let received_head_reward = summary.is_previous_epoch_head_attester(index)?;
+                let received_head_reward = summary
+                    .is_previous_epoch_head_attester(index)
+                    .unwrap_or(false);
 
-                let received_target_reward = summary.is_previous_epoch_target_attester(index)?;
+                let received_target_reward = summary
+                    .is_previous_epoch_target_attester(index)
+                    .unwrap_or(false);
 
                 let inclusion_delay = summary
                     .previous_epoch_inclusion_info(index)

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -129,7 +129,12 @@ impl<T: EthSpec> EpochProcessingSummary<T> {
             EpochProcessingSummary::Altair {
                 participation_cache,
                 ..
-            } => participation_cache.is_current_epoch_timely_target_attester(val_index),
+            } => participation_cache
+                .is_current_epoch_timely_target_attester(val_index)
+                .or_else(|e| match e {
+                    ParticipationCacheError::InvalidValidatorIndex(_) => Ok(false),
+                    e => Err(e),
+                }),
         }
     }
 
@@ -222,7 +227,12 @@ impl<T: EthSpec> EpochProcessingSummary<T> {
             EpochProcessingSummary::Altair {
                 participation_cache,
                 ..
-            } => participation_cache.is_previous_epoch_timely_target_attester(val_index),
+            } => participation_cache
+                .is_previous_epoch_timely_target_attester(val_index)
+                .or_else(|e| match e {
+                    ParticipationCacheError::InvalidValidatorIndex(_) => Ok(false),
+                    e => Err(e),
+                }),
         }
     }
 
@@ -248,7 +258,12 @@ impl<T: EthSpec> EpochProcessingSummary<T> {
             EpochProcessingSummary::Altair {
                 participation_cache,
                 ..
-            } => participation_cache.is_previous_epoch_timely_head_attester(val_index),
+            } => participation_cache
+                .is_previous_epoch_timely_head_attester(val_index)
+                .or_else(|e| match e {
+                    ParticipationCacheError::InvalidValidatorIndex(_) => Ok(false),
+                    e => Err(e),
+                }),
         }
     }
 
@@ -274,7 +289,12 @@ impl<T: EthSpec> EpochProcessingSummary<T> {
             EpochProcessingSummary::Altair {
                 participation_cache,
                 ..
-            } => participation_cache.is_previous_epoch_timely_source_attester(val_index),
+            } => participation_cache
+                .is_previous_epoch_timely_source_attester(val_index)
+                .or_else(|e| match e {
+                    ParticipationCacheError::InvalidValidatorIndex(_) => Ok(false),
+                    e => Err(e),
+                }),
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

When requesting an index which is not active during `start_epoch`, Lighthouse returns: 
```
curl "http://localhost:5052/lighthouse/analysis/attestation_performance/999999999?start_epoch=100000&end_epoch=100000"
```
```json
{
  "code": 500,
  "message": "INTERNAL_SERVER_ERROR: ParticipationCache(InvalidValidatorIndex(999999999))",
  "stacktraces": []
}
```

This error occurs even when the index in question becomes active before `end_epoch` which is undesirable as it can prevent larger queries from completing.

## Proposed Changes

In the event the index is out-of-bounds (has not yet been activated), simply return all fields as `false`:

```
-> curl "http://localhost:5052/lighthouse/analysis/attestation_performance/999999999?start_epoch=100000&end_epoch=100000"
```
```json
[
  {
    "index": 999999999,
    "epochs": {
      "100000": {
        "active": false,
        "head": false,
        "target": false,
        "source": false
      }
    }
  }
]
```

By doing this, we cover the case where a validator becomes active sometime between `start_epoch` and `end_epoch`.

## Additional Info

Note that this error only occurs for epochs after the Altair hard fork.
