### PR TITLE
Add freezer DB debugging tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,7 @@ dependencies = [
  "clap",
  "clap_utils",
  "environment",
+ "hex",
  "logging",
  "slog",
  "sloggers",

--- a/beacon_node/beacon_chain/src/otb_verification_service.rs
+++ b/beacon_node/beacon_chain/src/otb_verification_service.rs
@@ -119,10 +119,13 @@ pub fn start_otb_verification_service<T: BeaconChainTypes>(
 pub fn load_optimistic_transition_blocks<T: BeaconChainTypes>(
     chain: &BeaconChain<T>,
 ) -> Result<Vec<OptimisticTransitionBlock>, StoreError> {
-    process_results(chain.store.hot_db.iter_column(OTBColumn), |iter| {
-        iter.map(|(_, bytes)| OptimisticTransitionBlock::from_store_bytes(&bytes))
-            .collect()
-    })?
+    process_results(
+        chain.store.hot_db.iter_column::<Hash256>(OTBColumn),
+        |iter| {
+            iter.map(|(_, bytes)| OptimisticTransitionBlock::from_store_bytes(&bytes))
+                .collect()
+        },
+    )?
 }
 
 #[derive(Debug)]

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -45,6 +45,7 @@ pub enum Error {
     ResyncRequiredForExecutionPayloadSeparation,
     SlotClockUnavailableForMigration,
     V9MigrationFailure(Hash256),
+    InvalidKey,
 }
 
 pub trait HandleUnavailable<T> {

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::hot_cold_store::HotColdDBError;
 use crate::metrics;
-use db_key::Key;
 use leveldb::compaction::Compaction;
 use leveldb::database::batch::{Batch, Writebatch};
 use leveldb::database::kv::KV;
@@ -177,9 +176,9 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
     }
 
     /// Iterate through all keys and values in a particular column.
-    fn iter_column(&self, column: DBColumn) -> ColumnIter {
+    fn iter_column<K: Key>(&self, column: DBColumn) -> ColumnIter<K> {
         let start_key =
-            BytesKey::from_vec(get_key_for_col(column.into(), Hash256::zero().as_bytes()));
+            BytesKey::from_vec(get_key_for_col(column.into(), &vec![0; column.key_size()]));
 
         let iter = self.db.iter(self.read_options());
         iter.seek(&start_key);
@@ -187,13 +186,12 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
         Box::new(
             iter.take_while(move |(key, _)| key.matches_column(column))
                 .map(move |(bytes_key, value)| {
-                    let key =
-                        bytes_key
-                            .remove_column(column)
-                            .ok_or(HotColdDBError::IterationError {
-                                unexpected_key: bytes_key,
-                            })?;
-                    Ok((key, value))
+                    let key = bytes_key.remove_column_variable(column).ok_or_else(|| {
+                        HotColdDBError::IterationError {
+                            unexpected_key: bytes_key.clone(),
+                        }
+                    })?;
+                    Ok((K::from_bytes(key)?, value))
                 }),
         )
     }
@@ -224,12 +222,12 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
 impl<E: EthSpec> ItemStore<E> for LevelDB<E> {}
 
 /// Used for keying leveldb.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct BytesKey {
     key: Vec<u8>,
 }
 
-impl Key for BytesKey {
+impl db_key::Key for BytesKey {
     fn from_u8(key: &[u8]) -> Self {
         Self { key: key.to_vec() }
     }
@@ -245,12 +243,20 @@ impl BytesKey {
         self.key.starts_with(column.as_bytes())
     }
 
-    /// Remove the column from a key, returning its `Hash256` portion.
+    /// Remove the column from a 32 byte key, yielding the `Hash256` key.
     pub fn remove_column(&self, column: DBColumn) -> Option<Hash256> {
+        let key = self.remove_column_variable(column)?;
+        (column.key_size() == 32).then(|| Hash256::from_slice(key))
+    }
+
+    /// Remove the column from a key.
+    ///
+    /// Will return `None` if the value doesn't match the column or has the wrong length.
+    pub fn remove_column_variable(&self, column: DBColumn) -> Option<&[u8]> {
         if self.matches_column(column) {
             let subkey = &self.key[column.as_bytes().len()..];
-            if subkey.len() == 32 {
-                return Some(Hash256::from_slice(subkey));
+            if subkey.len() == column.key_size() {
+                return Some(subkey);
             }
         }
         None

--- a/database_manager/Cargo.toml
+++ b/database_manager/Cargo.toml
@@ -16,3 +16,4 @@ tempfile = "3.1.0"
 types = { path = "../consensus/types" }
 slog = "2.5.2"
 strum = { version = "0.24.0", features = ["derive"] }
+hex = "0.4.2"

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -57,6 +57,24 @@ pub fn inspect_cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("sizes")
                 .possible_values(InspectTarget::VARIANTS),
         )
+        .arg(
+            Arg::with_name("skip")
+                .long("skip")
+                .value_name("N")
+                .help("Skip over the first N keys"),
+        )
+        .arg(
+            Arg::with_name("limit")
+                .long("limit")
+                .value_name("N")
+                .help("Output at most N keys"),
+        )
+        .arg(
+            Arg::with_name("freezer")
+                .long("freezer")
+                .help("Inspect the freezer DB rather than the hot DB")
+                .takes_value(false),
+        )
 }
 
 pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
@@ -142,24 +160,40 @@ pub fn display_db_version<E: EthSpec>(
     Ok(())
 }
 
-#[derive(Debug, EnumString, EnumVariantNames)]
+#[derive(Debug, PartialEq, Eq, EnumString, EnumVariantNames)]
 pub enum InspectTarget {
     #[strum(serialize = "sizes")]
     ValueSizes,
     #[strum(serialize = "total")]
     ValueTotal,
+    #[strum(serialize = "values")]
+    ValueBytes,
+    #[strum(serialize = "gaps")]
+    Gaps,
 }
 
 pub struct InspectConfig {
     column: DBColumn,
     target: InspectTarget,
+    skip: Option<usize>,
+    limit: Option<usize>,
+    freezer: bool,
 }
 
 fn parse_inspect_config(cli_args: &ArgMatches) -> Result<InspectConfig, String> {
     let column = clap_utils::parse_required(cli_args, "column")?;
     let target = clap_utils::parse_required(cli_args, "output")?;
+    let skip = clap_utils::parse_optional(cli_args, "skip")?;
+    let limit = clap_utils::parse_optional(cli_args, "limit")?;
+    let freezer = cli_args.is_present("freezer");
 
-    Ok(InspectConfig { column, target })
+    Ok(InspectConfig {
+        column,
+        target,
+        skip,
+        limit,
+        freezer,
+    })
 }
 
 pub fn inspect_db<E: EthSpec>(
@@ -182,26 +216,63 @@ pub fn inspect_db<E: EthSpec>(
     )?;
 
     let mut total = 0;
+    let mut num_keys = 0;
 
-    for res in db.hot_db.iter_column(inspect_config.column) {
+    let sub_db = if inspect_config.freezer {
+        &db.cold_db
+    } else {
+        &db.hot_db
+    };
+
+    let skip = inspect_config.skip.unwrap_or(0);
+    let limit = inspect_config.limit.unwrap_or(usize::MAX);
+
+    let mut prev_key = 0;
+    let mut found_gaps = false;
+
+    for res in sub_db
+        .iter_column::<Vec<u8>>(inspect_config.column)
+        .skip(skip)
+        .take(limit)
+    {
         let (key, value) = res?;
 
         match inspect_config.target {
             InspectTarget::ValueSizes => {
-                println!("{:?}: {} bytes", key, value.len());
-                total += value.len();
+                println!("{}: {} bytes", hex::encode(&key), value.len());
             }
-            InspectTarget::ValueTotal => {
-                total += value.len();
+            InspectTarget::ValueBytes => {
+                println!("{}: {}", hex::encode(&key), hex::encode(&value));
             }
+            InspectTarget::Gaps => {
+                // Convert last 8 bytes of key to u64.
+                let numeric_key = u64::from_be_bytes(
+                    key[key.len() - 8..]
+                        .try_into()
+                        .expect("key is at least 8 bytes"),
+                );
+
+                if numeric_key > prev_key + 1 {
+                    println!(
+                        "gap between keys {} and {} (offset: {})",
+                        prev_key, numeric_key, num_keys,
+                    );
+                    found_gaps = true;
+                }
+                prev_key = numeric_key;
+            }
+            InspectTarget::ValueTotal => (),
         }
+        total += value.len();
+        num_keys += 1;
     }
 
-    match inspect_config.target {
-        InspectTarget::ValueSizes | InspectTarget::ValueTotal => {
-            println!("Total: {} bytes", total);
-        }
+    if inspect_config.target == InspectTarget::Gaps && !found_gaps {
+        println!("No gaps found!");
     }
+
+    println!("Num keys: {}", num_keys);
+    println!("Total: {} bytes", total);
 
     Ok(())
 }


### PR DESCRIPTION
## Issue Addressed

Related to:

- https://github.com/sigp/lighthouse/issues/3011
- https://github.com/sigp/lighthouse/issues/3455
- https://github.com/sigp/lighthouse/issues/3433

## Proposed Changes

This PR adds some extra capabilities to `lighthouse db inspect` for examining freezer databases.

The main one that's useful for detecting corruption is the `--output gaps` option which can be used to search for gaps in the linear arrays of block roots, state roots, etc:

```
./lighthouse db inspect --datadir /mnt/lighthouse/lighthouse/ --freezer --column bbr --output gaps
Aug 26 07:27:34.751 INFO Running database manager for mainnet network
Aug 26 07:27:39.232 INFO Hot-Cold DB initialized                 split_state: 0xd415ec08990df5be242cf0e2c7f32ee8b7419edb1c214c33eb71eaa1eaad99e7, split_slot: 4556160
No gaps found!
Num keys: 35586
Total: 145756192 bytes
```

The 4 columns of interest are:

- `bbr`: block roots. Should be gap-free whenever historic block sync has completed. Should contain 1 gap otherwise.
- `bsr`: state roots. Should be gap-free whenever _state reconstruction_ has completed. Should contain 1 gap otherwise.
- `bhr`: historic roots. Same gap-status as state roots.
- `brm`: randao mixes. Same gap-status as state roots.

On my node with historic states all of these 4 columns are gap-free as they should be, indicating that my database (probably) isn't corrupt. Next week or in a follow-up PR I'll add some tools for verifying the actual _data_ stored.
