### PR TITLE
[Merged by Bors] - Add  timeout for --checkpoint-sync-url

### DIFF
--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -112,9 +112,8 @@ pub struct Timeouts {
     pub proposer_duties: Duration,
     pub sync_committee_contribution: Duration,
     pub sync_duties: Duration,
-
     pub get_beacon_blocks_ssz: Duration,
-    pub get_debug_beacon_states: Duration
+    pub get_debug_beacon_states: Duration,
 }
 
 impl Timeouts {
@@ -127,9 +126,8 @@ impl Timeouts {
             proposer_duties: timeout,
             sync_committee_contribution: timeout,
             sync_duties: timeout,
-
             get_beacon_blocks_ssz: timeout,
-            get_debug_beacon_states: timeout
+            get_debug_beacon_states: timeout,
         }
     }
 }
@@ -245,7 +243,7 @@ impl BeaconNodeHttpClient {
         &self,
         url: U,
         accept_header: Accept,
-        timeout: Duration
+        timeout: Duration,
     ) -> Result<Option<Vec<u8>>, Error> {
         let opt_response = self
             .get_response(url, |b| b.accept(accept_header).timeout(timeout))

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -112,6 +112,9 @@ pub struct Timeouts {
     pub proposer_duties: Duration,
     pub sync_committee_contribution: Duration,
     pub sync_duties: Duration,
+
+    pub get_beacon_blocks_ssz: Duration,
+    pub get_debug_beacon_states: Duration
 }
 
 impl Timeouts {
@@ -124,6 +127,9 @@ impl Timeouts {
             proposer_duties: timeout,
             sync_committee_contribution: timeout,
             sync_duties: timeout,
+
+            get_beacon_blocks_ssz: timeout,
+            get_debug_beacon_states: timeout
         }
     }
 }
@@ -239,9 +245,10 @@ impl BeaconNodeHttpClient {
         &self,
         url: U,
         accept_header: Accept,
+        timeout: Duration
     ) -> Result<Option<Vec<u8>>, Error> {
         let opt_response = self
-            .get_response(url, |b| b.accept(accept_header))
+            .get_response(url, |b| b.accept(accept_header).timeout(timeout))
             .await
             .optional()?;
         match opt_response {
@@ -701,7 +708,7 @@ impl BeaconNodeHttpClient {
     ) -> Result<Option<SignedBeaconBlock<T>>, Error> {
         let path = self.get_beacon_blocks_path(block_id)?;
 
-        self.get_bytes_opt_accept_header(path, Accept::Ssz)
+        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_beacon_blocks_ssz)
             .await?
             .map(|bytes| SignedBeaconBlock::from_ssz_bytes(&bytes, spec).map_err(Error::InvalidSsz))
             .transpose()
@@ -1167,7 +1174,7 @@ impl BeaconNodeHttpClient {
     ) -> Result<Option<BeaconState<T>>, Error> {
         let path = self.get_debug_beacon_states_path(state_id)?;
 
-        self.get_bytes_opt_accept_header(path, Accept::Ssz)
+        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_debug_beacon_states)
             .await?
             .map(|bytes| BeaconState::from_ssz_bytes(&bytes, spec).map_err(Error::InvalidSsz))
             .transpose()

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -74,6 +74,8 @@ const HTTP_PROPOSAL_TIMEOUT_QUOTIENT: u32 = 2;
 const HTTP_PROPOSER_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 
 const DOPPELGANGER_SERVICE_NAME: &str = "doppelganger";
 
@@ -284,6 +286,10 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                         sync_committee_contribution: slot_duration
                             / HTTP_SYNC_COMMITTEE_CONTRIBUTION_TIMEOUT_QUOTIENT,
                         sync_duties: slot_duration / HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT,
+                        get_beacon_blocks_ssz: slot_duration
+                            / HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT,
+                        get_debug_beacon_states: slot_duration
+                            / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
                     }
                 } else {
                     Timeouts::set_all(slot_duration)


### PR DESCRIPTION
## Issue Addressed

[Have --checkpoint-sync-url timeout](https://github.com/sigp/lighthouse/issues/3478)

## Proposed Changes

I added a parameter for `get_bytes_opt_accept_header<U: IntoUrl>` which accept a timeout duration, and modified the body of `get_beacon_blocks_ssz` and `get_debug_beacon_states_ssz` to pass corresponding timeout durations.  
