### PR TITLE
[Merged by Bors] - Docker builds in GitHub actions

### DIFF
--- a/.github/workflows/docker-antithesis.yml
+++ b/.github/workflows/docker-antithesis.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
     build-docker:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         steps:
             - uses: actions/checkout@v2
             - name: Update Rust

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -2,7 +2,7 @@
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
 FROM rust:1.62.1-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG PORTABLE
 ENV PORTABLE $PORTABLE


### PR DESCRIPTION
## Issue Addressed

I think the antithesis is failing due to an OOM which may be resolved by updating the ubuntu image it runs on. The lcli build looks like it's failing because the image lacks the `libclang` dependency

