### PR TITLE
[Merged by Bors] - Publish subscriptions to all beacon nodes

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -442,3 +442,19 @@ fn monitoring_endpoint() {
             assert_eq!(api_conf.update_period_secs, Some(30));
         });
 }
+#[test]
+fn disable_run_on_all_default() {
+    CommandLineTest::new().run().with_config(|config| {
+        assert!(!config.disable_run_on_all);
+    });
+}
+
+#[test]
+fn disable_run_on_all() {
+    CommandLineTest::new()
+        .flag("disable-run-on-all", None)
+        .run()
+        .with_config(|config| {
+            assert!(config.disable_run_on_all);
+        });
+}

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -491,7 +491,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
         Err(Errors(errors))
     }
 
-    /// Run `func` against all candidates in `self`, collecting the result of func against each
+    /// Run `func` against all candidates in `self`, collecting the result of `func` against each
     /// candidate.
     ///
     /// First this function will try all nodes with a suitable status. If no candidates are suitable

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -109,8 +109,8 @@ pub struct Errors<E>(pub Vec<(String, Error<E>)>);
 
 impl<E: Debug> fmt::Display for Errors<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.0.len() > 1 {
-            write!(f, "Some endpoints failed")?;
+        if !self.0.is_empty() {
+            write!(f, "Some endpoints failed, num_failed: {}", self.0.len())?;
         }
         for (i, (id, error)) in self.0.iter().enumerate() {
             let comma = if i + 1 < self.0.len() { "," } else { "" };

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -616,7 +616,6 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
             }
         }
 
-        // There were no candidates already ready and we were unable to make any of them ready.
         Results(results)
     }
 }

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -601,7 +601,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
 
         let errors: Vec<_> = results.into_iter().filter_map(|res| res.err()).collect();
 
-        if errors.len() > 0 {
+        if !errors.is_empty() {
             Err(Errors(errors))
         } else {
             Ok(())

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -296,15 +296,22 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
 pub struct BeaconNodeFallback<T, E> {
     candidates: Vec<CandidateBeaconNode<E>>,
     slot_clock: Option<T>,
+    disable_run_on_all: bool,
     spec: ChainSpec,
     log: Logger,
 }
 
 impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
-    pub fn new(candidates: Vec<CandidateBeaconNode<E>>, spec: ChainSpec, log: Logger) -> Self {
+    pub fn new(
+        candidates: Vec<CandidateBeaconNode<E>>,
+        disable_run_on_all: bool,
+        spec: ChainSpec,
+        log: Logger,
+    ) -> Self {
         Self {
             candidates,
             slot_clock: None,
+            disable_run_on_all,
             spec,
             log,
         }
@@ -615,13 +622,12 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
         require_synced: RequireSynced,
         offline_on_failure: OfflineOnFailure,
         func: F,
-        disable_run_on_all: bool,
     ) -> Result<(), Errors<Err>>
     where
         F: Fn(&'a BeaconNodeHttpClient) -> R,
         R: Future<Output = Result<(), Err>>,
     {
-        if disable_run_on_all {
+        if self.disable_run_on_all {
             self.first_success(require_synced, offline_on_failure, func)
                 .await?;
             Ok(())

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -1,4 +1,4 @@
-use crate::beacon_node_fallback::{AllErrored, Error as FallbackError};
+use crate::beacon_node_fallback::{Error as FallbackError, Errors};
 use crate::{
     beacon_node_fallback::{BeaconNodeFallback, RequireSynced},
     graffiti_file::GraffitiFile,
@@ -20,8 +20,8 @@ pub enum BlockError {
     Irrecoverable(String),
 }
 
-impl From<AllErrored<BlockError>> for BlockError {
-    fn from(e: AllErrored<BlockError>) -> Self {
+impl From<Errors<BlockError>> for BlockError {
+    fn from(e: Errors<BlockError>) -> Self {
         if e.0.iter().any(|(_, error)| {
             matches!(
                 error,

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -27,7 +27,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("disable-publish-subsriptions-all")
+            Arg::with_name("disable-publish-subscriptions-all")
                 .long("disable-publish-subsriptions-all")
                 .value_name("DISABLE_PUBLISH_ALL")
                 .help("By default, Lighthouse publishes attestation and sync committee subscriptions \

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -26,6 +26,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 )
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("disable-publish-subsriptions-all")
+                .long("disable-publish-subsriptions-all")
+                .value_name("DISABLE_PUBLISH_ALL")
+                .help("By default, Lighthouse publishes attestation and sync committee subscriptions \
+                       to all beacon nodes provided in the `--beacon-nodes flag`. This option changes \
+                       that behaviour such that the subscriptions only go out to the first available \
+                       and synced beacon node")
+                .takes_value(false)
+        )
         // This argument is deprecated, use `--beacon-nodes` instead.
         .arg(
             Arg::with_name("server")

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -28,7 +28,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("disable-publish-subscriptions-all")
-                .long("disable-publish-subsriptions-all")
+                .long("disable-publish-subscriptions-all")
                 .value_name("DISABLE_PUBLISH_ALL")
                 .help("By default, Lighthouse publishes attestation and sync committee subscriptions \
                        to all beacon nodes provided in the `--beacon-nodes flag`. This option changes \

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -27,13 +27,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("disable-publish-subscriptions-all")
-                .long("disable-publish-subscriptions-all")
-                .value_name("DISABLE_PUBLISH_ALL")
-                .help("By default, Lighthouse publishes attestation and sync committee subscriptions \
-                       to all beacon nodes provided in the `--beacon-nodes flag`. This option changes \
-                       that behaviour such that the subscriptions only go out to the first available \
-                       and synced beacon node")
+            Arg::with_name("disable-run-on-all")
+                .long("disable-run-on-all")
+                .value_name("DISABLE_RUN_ON_ALL")
+                .help("By default, Lighthouse publishes attestation, sync committee subscriptions \
+                       and proposer preparation messages to all beacon nodes provided in the \
+                       `--beacon-nodes flag`. This option changes that behaviour such that these \
+                       api calls only go out to the first available and synced beacon node")
                 .takes_value(false)
         )
         // This argument is deprecated, use `--beacon-nodes` instead.

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -61,8 +61,8 @@ pub struct Config {
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to a beacon node over SSL/TLS.
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
-    /// Disables publishing beacon and sync committee subscriptions to all beacon nodes.
-    pub disable_publish_subscriptions_all: bool,
+    /// Disables publishing http api requests to all beacon nodes for select api calls.
+    pub disable_run_on_all: bool,
 }
 
 impl Default for Config {
@@ -98,7 +98,7 @@ impl Default for Config {
             builder_proposals: false,
             builder_registration_timestamp_override: None,
             gas_limit: None,
-            disable_publish_subscriptions_all: false,
+            disable_run_on_all: false,
         }
     }
 }
@@ -180,8 +180,7 @@ impl Config {
         }
 
         config.allow_unsynced_beacon_node = cli_args.is_present("allow-unsynced");
-        config.disable_publish_subscriptions_all =
-            cli_args.is_present("disable-publish-subscriptions-all");
+        config.disable_run_on_all = cli_args.is_present("disable-publish-subscriptions-all");
         config.disable_auto_discover = cli_args.is_present("disable-auto-discover");
         config.init_slashing_protection = cli_args.is_present("init-slashing-protection");
         config.use_long_timeouts = cli_args.is_present("use-long-timeouts");

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -181,7 +181,7 @@ impl Config {
 
         config.allow_unsynced_beacon_node = cli_args.is_present("allow-unsynced");
         config.disable_publish_subscriptions_all =
-            cli_args.is_present("disable-publish-subsriptions-all");
+            cli_args.is_present("disable-publish-subscriptions-all");
         config.disable_auto_discover = cli_args.is_present("disable-auto-discover");
         config.init_slashing_protection = cli_args.is_present("init-slashing-protection");
         config.use_long_timeouts = cli_args.is_present("use-long-timeouts");

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -61,6 +61,8 @@ pub struct Config {
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to a beacon node over SSL/TLS.
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
+    /// Disables publishing beacon and sync committee subscriptions to all beacon nodes.
+    pub disable_publish_subscriptions_all: bool,
 }
 
 impl Default for Config {
@@ -96,6 +98,7 @@ impl Default for Config {
             builder_proposals: false,
             builder_registration_timestamp_override: None,
             gas_limit: None,
+            disable_publish_subscriptions_all: false,
         }
     }
 }
@@ -177,6 +180,8 @@ impl Config {
         }
 
         config.allow_unsynced_beacon_node = cli_args.is_present("allow-unsynced");
+        config.disable_publish_subscriptions_all =
+            cli_args.is_present("disable-publish-subsriptions-all");
         config.disable_auto_discover = cli_args.is_present("disable-auto-discover");
         config.init_slashing_protection = cli_args.is_present("init-slashing-protection");
         config.use_long_timeouts = cli_args.is_present("use-long-timeouts");

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -180,7 +180,7 @@ impl Config {
         }
 
         config.allow_unsynced_beacon_node = cli_args.is_present("allow-unsynced");
-        config.disable_run_on_all = cli_args.is_present("disable-publish-subscriptions-all");
+        config.disable_run_on_all = cli_args.is_present("disable-run-on-all");
         config.disable_auto_discover = cli_args.is_present("disable-auto-discover");
         config.init_slashing_protection = cli_args.is_present("init-slashing-protection");
         config.use_long_timeouts = cli_args.is_present("use-long-timeouts");

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -122,7 +122,6 @@ pub struct DutiesService<T, E: EthSpec> {
     /// aren't synced, but we keep it around for an emergency.
     pub require_synced: RequireSynced,
     pub context: RuntimeContext<E>,
-    pub disable_run_on_all: bool,
     pub spec: ChainSpec,
 }
 
@@ -588,7 +587,6 @@ async fn poll_beacon_attesters<T: SlotClock + 'static, E: EthSpec>(
                         .post_validator_beacon_committee_subscriptions(subscriptions_ref)
                         .await
                 },
-                duties_service.disable_run_on_all,
             )
             .await
         {

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -122,7 +122,7 @@ pub struct DutiesService<T, E: EthSpec> {
     /// aren't synced, but we keep it around for an emergency.
     pub require_synced: RequireSynced,
     pub context: RuntimeContext<E>,
-    pub disable_publish_subscriptions_all: bool,
+    pub disable_run_on_all: bool,
     pub spec: ChainSpec,
 }
 
@@ -574,7 +574,7 @@ async fn poll_beacon_attesters<T: SlotClock + 'static, E: EthSpec>(
     // If there are any subscriptions, push them out to beacon nodes
     if !subscriptions.is_empty() {
         let subscriptions_ref = &subscriptions;
-        if let Err(e) = if duties_service.disable_publish_subscriptions_all {
+        if let Err(e) = if duties_service.disable_run_on_all {
             duties_service
                 .beacon_nodes
                 .first_success(

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -327,8 +327,12 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
         // Initialize the number of connected, avaliable beacon nodes to 0.
         set_gauge(&http_metrics::metrics::AVAILABLE_BEACON_NODES_COUNT, 0);
 
-        let mut beacon_nodes: BeaconNodeFallback<_, T> =
-            BeaconNodeFallback::new(candidates, context.eth2_config.spec.clone(), log.clone());
+        let mut beacon_nodes: BeaconNodeFallback<_, T> = BeaconNodeFallback::new(
+            candidates,
+            config.disable_run_on_all,
+            context.eth2_config.spec.clone(),
+            log.clone(),
+        );
 
         // Perform some potentially long-running initialization tasks.
         let (genesis_time, genesis_validators_root) = tokio::select! {
@@ -404,7 +408,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                 RequireSynced::No
             },
             spec: context.eth2_config.spec.clone(),
-            disable_run_on_all: config.disable_run_on_all,
             context: duties_context,
         });
 
@@ -437,7 +440,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             .beacon_nodes(beacon_nodes.clone())
             .runtime_context(context.service_context("preparation".into()))
             .builder_registration_timestamp_override(config.builder_registration_timestamp_override)
-            .disable_run_on_all(config.disable_run_on_all)
             .build()?;
 
         let sync_committee_service = SyncCommitteeService::new(

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -404,7 +404,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                 RequireSynced::No
             },
             spec: context.eth2_config.spec.clone(),
-            disable_publish_subscriptions_all: config.disable_publish_subscriptions_all,
+            disable_run_on_all: config.disable_run_on_all,
             context: duties_context,
         });
 
@@ -437,6 +437,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             .beacon_nodes(beacon_nodes.clone())
             .runtime_context(context.service_context("preparation".into()))
             .builder_registration_timestamp_override(config.builder_registration_timestamp_override)
+            .disable_run_on_all(config.disable_run_on_all)
             .build()?;
 
         let sync_committee_service = SyncCommitteeService::new(

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -404,6 +404,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                 RequireSynced::No
             },
             spec: context.eth2_config.spec.clone(),
+            disable_publish_subscriptions_all: config.disable_publish_subscriptions_all,
             context: duties_context,
         });
 

--- a/validator_client/src/preparation_service.rs
+++ b/validator_client/src/preparation_service.rs
@@ -33,7 +33,6 @@ pub struct PreparationServiceBuilder<T: SlotClock + 'static, E: EthSpec> {
     beacon_nodes: Option<Arc<BeaconNodeFallback<T, E>>>,
     context: Option<RuntimeContext<E>>,
     builder_registration_timestamp_override: Option<u64>,
-    disable_run_on_all: Option<bool>,
 }
 
 impl<T: SlotClock + 'static, E: EthSpec> PreparationServiceBuilder<T, E> {
@@ -44,7 +43,6 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationServiceBuilder<T, E> {
             beacon_nodes: None,
             context: None,
             builder_registration_timestamp_override: None,
-            disable_run_on_all: None,
         }
     }
 
@@ -65,11 +63,6 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationServiceBuilder<T, E> {
 
     pub fn runtime_context(mut self, context: RuntimeContext<E>) -> Self {
         self.context = Some(context);
-        self
-    }
-
-    pub fn disable_run_on_all(mut self, disable_run_on_all: bool) -> Self {
-        self.disable_run_on_all = Some(disable_run_on_all);
         self
     }
 
@@ -96,7 +89,6 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationServiceBuilder<T, E> {
                 context: self
                     .context
                     .ok_or("Cannot build PreparationService without runtime_context")?,
-                disable_run_on_all: self.disable_run_on_all.unwrap_or(false),
                 builder_registration_timestamp_override: self
                     .builder_registration_timestamp_override,
                 validator_registration_cache: RwLock::new(HashMap::new()),
@@ -115,7 +107,6 @@ pub struct Inner<T, E: EthSpec> {
     // Used to track unpublished validator registration changes.
     validator_registration_cache:
         RwLock<HashMap<ValidatorRegistrationKey, SignedValidatorRegistrationData>>,
-    disable_run_on_all: bool,
 }
 
 #[derive(Hash, Eq, PartialEq, Debug, Clone)]
@@ -348,7 +339,6 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                         .post_validator_prepare_beacon_proposer(preparation_entries)
                         .await
                 },
-                self.inner.disable_run_on_all,
             )
             .await
         {

--- a/validator_client/src/sync_committee_service.rs
+++ b/validator_client/src/sync_committee_service.rs
@@ -566,7 +566,7 @@ impl<T: SlotClock + 'static, E: EthSpec> SyncCommitteeService<T, E> {
             );
         }
 
-        if let Err(e) = if self.duties_service.disable_publish_subscriptions_all {
+        if let Err(e) = if self.duties_service.disable_run_on_all {
             self.beacon_nodes
                 .first_success(
                     RequireSynced::No,

--- a/validator_client/src/sync_committee_service.rs
+++ b/validator_client/src/sync_committee_service.rs
@@ -576,7 +576,6 @@ impl<T: SlotClock + 'static, E: EthSpec> SyncCommitteeService<T, E> {
                         .post_validator_sync_committee_subscriptions(subscriptions_slice)
                         .await
                 },
-                self.duties_service.disable_run_on_all,
             )
             .await
         {


### PR DESCRIPTION
## Issue Addressed

Resolves #3516 

## Proposed Changes

Adds a beacon fallback function for running a beacon node http query on all available fallbacks instead of returning on a first successful result. Uses the new `run_on_all` method for attestation and sync committee subscriptions. 

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
