### PR TITLE
[Merged by Bors] - Configurable monitoring endpoint frequency

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -325,8 +325,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("monitoring-endpoint-frequency")
                 .value_name("SECONDS")
                 .help("Defines how many seconds to wait between each message sent to \
-                       the monitoring-endpoint.")
-                .default_value(Box::leak(monitoring_api::DEFAULT_UPDATE_DURATION.to_string().into_boxed_str()))
+                       the monitoring-endpoint. Default: 60s")
                 .requires("monitoring-endpoint")
                 .takes_value(true),
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -320,6 +320,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 and never provide an untrusted URL.")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("monitoring-endpoint-frequency")
+                .long("monitoring-endpoint-frequency")
+                .value_name("SECONDS")
+                .help("Defines how many seconds to wait between each message sent to \
+                       the monitoring-endpoint.")
+                .default_value(Box::leak(monitoring_api::DEFAULT_UPDATE_DURATION.to_string().into_boxed_str()))
+                .requires("monitoring-endpoint")
+                .takes_value(true),
+        )
 
         /*
          * Standard staking flags

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -321,8 +321,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("monitoring-endpoint-frequency")
-                .long("monitoring-endpoint-frequency")
+            Arg::with_name("monitoring-endpoint-period")
+                .long("monitoring-endpoint-period")
                 .value_name("SECONDS")
                 .help("Defines how many seconds to wait between each message sent to \
                        the monitoring-endpoint. Default: 60s")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -178,9 +178,13 @@ pub fn get_config<E: EthSpec>(
      * Explorer metrics
      */
     if let Some(monitoring_endpoint) = cli_args.value_of("monitoring-endpoint") {
+        let update_frequency_secs =
+            clap_utils::parse_optional(cli_args, "monitoring-endpoint-frequency")?;
+
         client_config.monitoring_api = Some(monitoring_api::Config {
             db_path: None,
             freezer_db_path: None,
+            update_frequency_secs,
             monitoring_endpoint: monitoring_endpoint.to_string(),
         });
     }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -178,13 +178,13 @@ pub fn get_config<E: EthSpec>(
      * Explorer metrics
      */
     if let Some(monitoring_endpoint) = cli_args.value_of("monitoring-endpoint") {
-        let update_frequency_secs =
-            clap_utils::parse_optional(cli_args, "monitoring-endpoint-frequency")?;
+        let update_period_secs =
+            clap_utils::parse_optional(cli_args, "monitoring-endpoint-period")?;
 
         client_config.monitoring_api = Some(monitoring_api::Config {
             db_path: None,
             freezer_db_path: None,
-            update_frequency_secs,
+            update_period_secs,
             monitoring_endpoint: monitoring_endpoint.to_string(),
         });
     }

--- a/book/src/advanced_metrics.md
+++ b/book/src/advanced_metrics.md
@@ -69,6 +69,9 @@ The specification for the monitoring endpoint can be found here:
 
 - <https://github.com/gobitfly/eth2-client-metrics>
 
+_Note: the similarly named [Validator Monitor](./validator-monitoring.md) feature is entirely
+independent of remote metric monitoring_.
+
 ### Update Period
 
 You can adjust the frequency at which Lighthouse sends metrics to the remote server using the

--- a/book/src/advanced_metrics.md
+++ b/book/src/advanced_metrics.md
@@ -48,3 +48,36 @@ Check to ensure that the metrics are available on the default port:
 ```bash
 curl localhost:5064/metrics
 ```
+
+## Remote Monitoring
+
+Lighthouse has the ability to send a subset of metrics to a remote server for collection. Presently
+the main server offering remote monitoring is beaconcha.in. Instructions for setting this up
+can be found in beaconcha.in's docs:
+
+- <https://kb.beaconcha.in/beaconcha.in-explorer/mobile-app-less-than-greater-than-beacon-node>
+
+The Lighthouse flag for setting the monitoring URL is `--monitoring-endpoint`.
+
+When sending metrics to a remote server you should be conscious of security:
+
+- Only use a monitoring service that you trust: you are sending detailed information about
+  your validators and beacon node to this service which could be used to track you.
+- Always use an HTTPS URL to prevent the traffic being intercepted in transit.
+
+The specification for the monitoring endpoint can be found here:
+
+- <https://github.com/gobitfly/eth2-client-metrics>
+
+### Update Period
+
+You can adjust the frequency at which Lighthouse sends metrics to the remote server using the
+`--monitoring-endpoint-period` flag. It takes an integer value in seconds, defaulting to 60
+seconds.
+
+```
+lighthouse bn --monitoring-endpoint-period 60 --monitoring-endpoint "https://url"
+```
+
+Increasing the monitoring period between can be useful if you are running into rate limits when
+posting large amounts of data for multiple nodes.

--- a/book/src/validator-monitoring.md
+++ b/book/src/validator-monitoring.md
@@ -4,6 +4,9 @@ Lighthouse allows for fine-grained monitoring of specific validators using the "
 Generally users will want to use this function to track their own validators, however, it can be
 used for any validator, regardless of who controls it.
 
+_Note: If you are looking for remote metric monitoring, please see the docs on
+[Prometheus Metrics](./advanced_metrics.md)_.
+
 ## Monitoring is in the Beacon Node
 
 Lighthouse performs validator monitoring in the Beacon Node (BN) instead of the Validator Client

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -16,7 +16,7 @@ use types::*;
 pub use types::ProcessType;
 
 /// Duration after which we collect and send metrics to remote endpoint.
-pub const UPDATE_DURATION: u64 = 60;
+pub const DEFAULT_UPDATE_DURATION: u64 = 120;
 /// Timeout for HTTP requests.
 pub const TIMEOUT_DURATION: u64 = 5;
 
@@ -55,6 +55,8 @@ pub struct Config {
     /// Path for the cold database required for fetching beacon db size metrics.
     /// Note: not relevant for validator and system metrics.
     pub freezer_db_path: Option<PathBuf>,
+    /// User-defined update frequency in seconds.
+    pub update_frequency_secs: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -64,6 +66,7 @@ pub struct MonitoringHttpClient {
     db_path: Option<PathBuf>,
     /// Path to the freezer database.
     freezer_db_path: Option<PathBuf>,
+    update_frequency: Duration,
     monitoring_endpoint: SensitiveUrl,
     log: slog::Logger,
 }
@@ -74,6 +77,11 @@ impl MonitoringHttpClient {
             client: reqwest::Client::new(),
             db_path: config.db_path.clone(),
             freezer_db_path: config.freezer_db_path.clone(),
+            update_frequency: Duration::from_secs(
+                config
+                    .update_frequency_secs
+                    .unwrap_or(DEFAULT_UPDATE_DURATION),
+            ),
             monitoring_endpoint: SensitiveUrl::parse(&config.monitoring_endpoint)
                 .map_err(|e| format!("Invalid monitoring endpoint: {:?}", e))?,
             log,
@@ -100,10 +108,15 @@ impl MonitoringHttpClient {
         let mut interval = interval_at(
             // Have some initial delay for the metrics to get initialized
             Instant::now() + Duration::from_secs(25),
-            Duration::from_secs(UPDATE_DURATION),
+            self.update_frequency,
         );
 
-        info!(self.log, "Starting monitoring api"; "endpoint" => %self.monitoring_endpoint);
+        info!(
+            self.log,
+            "Starting monitoring API";
+            "endpoint" => %self.monitoring_endpoint,
+            "update_frequency" => format!("{}s", self.update_frequency.as_secs()),
+        );
 
         let update_future = async move {
             loop {

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -55,8 +55,8 @@ pub struct Config {
     /// Path for the cold database required for fetching beacon db size metrics.
     /// Note: not relevant for validator and system metrics.
     pub freezer_db_path: Option<PathBuf>,
-    /// User-defined update frequency in seconds.
-    pub update_frequency_secs: Option<u64>,
+    /// User-defined update period in seconds.
+    pub update_period_secs: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -66,7 +66,7 @@ pub struct MonitoringHttpClient {
     db_path: Option<PathBuf>,
     /// Path to the freezer database.
     freezer_db_path: Option<PathBuf>,
-    update_frequency: Duration,
+    update_period: Duration,
     monitoring_endpoint: SensitiveUrl,
     log: slog::Logger,
 }
@@ -77,10 +77,8 @@ impl MonitoringHttpClient {
             client: reqwest::Client::new(),
             db_path: config.db_path.clone(),
             freezer_db_path: config.freezer_db_path.clone(),
-            update_frequency: Duration::from_secs(
-                config
-                    .update_frequency_secs
-                    .unwrap_or(DEFAULT_UPDATE_DURATION),
+            update_period: Duration::from_secs(
+                config.update_period_secs.unwrap_or(DEFAULT_UPDATE_DURATION),
             ),
             monitoring_endpoint: SensitiveUrl::parse(&config.monitoring_endpoint)
                 .map_err(|e| format!("Invalid monitoring endpoint: {:?}", e))?,
@@ -108,14 +106,14 @@ impl MonitoringHttpClient {
         let mut interval = interval_at(
             // Have some initial delay for the metrics to get initialized
             Instant::now() + Duration::from_secs(25),
-            self.update_frequency,
+            self.update_period,
         );
 
         info!(
             self.log,
             "Starting monitoring API";
             "endpoint" => %self.monitoring_endpoint,
-            "update_frequency" => format!("{}s", self.update_frequency.as_secs()),
+            "update_period" => format!("{}s", self.update_period.as_secs()),
         );
 
         let update_future = async move {

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -16,7 +16,7 @@ use types::*;
 pub use types::ProcessType;
 
 /// Duration after which we collect and send metrics to remote endpoint.
-pub const DEFAULT_UPDATE_DURATION: u64 = 120;
+pub const DEFAULT_UPDATE_DURATION: u64 = 60;
 /// Timeout for HTTP requests.
 pub const TIMEOUT_DURATION: u64 = 5;
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1373,11 +1373,11 @@ fn ensure_panic_on_failed_launch() {
 fn monitoring_endpoint() {
     CommandLineTest::new()
         .flag("monitoring-endpoint", Some("http://example:8000"))
-        .flag("monitoring-endpoint-frequency", Some("30"))
+        .flag("monitoring-endpoint-period", Some("30"))
         .run_with_zero_port()
         .with_config(|config| {
             let api_conf = config.monitoring_api.as_ref().unwrap();
             assert_eq!(api_conf.monitoring_endpoint.as_str(), "http://example:8000");
-            assert_eq!(api_conf.update_frequency_secs, Some(30));
+            assert_eq!(api_conf.update_period_secs, Some(30));
         });
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1345,7 +1345,7 @@ fn slasher_backend_override_to_default() {
 }
 
 #[test]
-pub fn malloc_tuning_flag() {
+fn malloc_tuning_flag() {
     CommandLineTest::new()
         .flag("disable-malloc-tuning", None)
         .run_with_zero_port()
@@ -1366,5 +1366,18 @@ fn ensure_panic_on_failed_launch() {
                 .as_ref()
                 .expect("Unable to parse Slasher config");
             assert_eq!(slasher_config.chunk_size, 10);
+        });
+}
+
+#[test]
+fn monitoring_endpoint() {
+    CommandLineTest::new()
+        .flag("monitoring-endpoint", Some("http://example:8000"))
+        .flag("monitoring-endpoint-frequency", Some("30"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            let api_conf = config.monitoring_api.as_ref().unwrap();
+            assert_eq!(api_conf.monitoring_endpoint.as_str(), "http://example:8000");
+            assert_eq!(api_conf.update_frequency_secs, Some(30));
         });
 }

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -448,11 +448,11 @@ fn no_strict_fee_recipient_flag() {
 fn monitoring_endpoint() {
     CommandLineTest::new()
         .flag("monitoring-endpoint", Some("http://example:8000"))
-        .flag("monitoring-endpoint-frequency", Some("30"))
+        .flag("monitoring-endpoint-period", Some("30"))
         .run()
         .with_config(|config| {
             let api_conf = config.monitoring_api.as_ref().unwrap();
             assert_eq!(api_conf.monitoring_endpoint.as_str(), "http://example:8000");
-            assert_eq!(api_conf.update_frequency_secs, Some(30));
+            assert_eq!(api_conf.update_period_secs, Some(30));
         });
 }

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -443,3 +443,16 @@ fn no_strict_fee_recipient_flag() {
         .run()
         .with_config(|config| assert!(!config.strict_fee_recipient));
 }
+
+#[test]
+fn monitoring_endpoint() {
+    CommandLineTest::new()
+        .flag("monitoring-endpoint", Some("http://example:8000"))
+        .flag("monitoring-endpoint-frequency", Some("30"))
+        .run()
+        .with_config(|config| {
+            let api_conf = config.monitoring_api.as_ref().unwrap();
+            assert_eq!(api_conf.monitoring_endpoint.as_str(), "http://example:8000");
+            assert_eq!(api_conf.update_frequency_secs, Some(30));
+        });
+}

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -237,6 +237,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("monitoring-endpoint-frequency")
+                .long("monitoring-endpoint-frequency")
+                .value_name("SECONDS")
+                .help("Defines how many seconds to wait between each message sent to \
+                       the monitoring-endpoint.")
+                .default_value(Box::leak(monitoring_api::DEFAULT_UPDATE_DURATION.to_string().into_boxed_str()))
+                .requires("monitoring-endpoint")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("enable-doppelganger-protection")
                 .long("enable-doppelganger-protection")
                 .value_name("ENABLE_DOPPELGANGER_PROTECTION")

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -237,12 +237,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("monitoring-endpoint-frequency")
-                .long("monitoring-endpoint-frequency")
+            Arg::with_name("monitoring-endpoint-period")
+                .long("monitoring-endpoint-period")
                 .value_name("SECONDS")
                 .help("Defines how many seconds to wait between each message sent to \
-                       the monitoring-endpoint.")
-                .default_value(Box::leak(monitoring_api::DEFAULT_UPDATE_DURATION.to_string().into_boxed_str()))
+                       the monitoring-endpoint. Default: 60s")
                 .requires("monitoring-endpoint")
                 .takes_value(true),
         )

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -296,12 +296,12 @@ impl Config {
          * Explorer metrics
          */
         if let Some(monitoring_endpoint) = cli_args.value_of("monitoring-endpoint") {
-            let update_frequency_secs =
-                clap_utils::parse_optional(cli_args, "monitoring-endpoint-frequency")?;
+            let update_period_secs =
+                clap_utils::parse_optional(cli_args, "monitoring-endpoint-period")?;
             config.monitoring_api = Some(monitoring_api::Config {
                 db_path: None,
                 freezer_db_path: None,
-                update_frequency_secs,
+                update_period_secs,
                 monitoring_endpoint: monitoring_endpoint.to_string(),
             });
         }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -296,9 +296,12 @@ impl Config {
          * Explorer metrics
          */
         if let Some(monitoring_endpoint) = cli_args.value_of("monitoring-endpoint") {
+            let update_frequency_secs =
+                clap_utils::parse_optional(cli_args, "monitoring-endpoint-frequency")?;
             config.monitoring_api = Some(monitoring_api::Config {
                 db_path: None,
                 freezer_db_path: None,
+                update_frequency_secs,
                 monitoring_endpoint: monitoring_endpoint.to_string(),
             });
         }


### PR DESCRIPTION
## Issue Addressed

Closes #3514

## Proposed Changes

- Change default monitoring endpoint frequency to 120 seconds to fit with 30k requests/month limit.
- Allow configuration of the monitoring endpoint frequency using `--monitoring-endpoint-frequency N` where `N` is a value in seconds.
