### PR TITLE
[Merged by Bors] - Add flag 'log-color' preserving color of log redirected to file. 

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -747,6 +747,7 @@ fn run<T: EthSpec>(
             debug_level: "trace",
             logfile_debug_level: "trace",
             log_format: None,
+            log_color: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -141,11 +141,12 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
             }
         } else {
             let stdout_decorator_builder = slog_term::TermDecorator::new();
-            let stdout_decorator = if config.log_color { 
+            let stdout_decorator = if config.log_color {
                 stdout_decorator_builder.force_color()
-            } else { 
-                stdout_decorator_builder 
-            }.build();
+            } else {
+                stdout_decorator_builder
+            }
+            .build();
             let stdout_decorator =
                 logging::AlignedTermDecorator::new(stdout_decorator, logging::MAX_MESSAGE_WIDTH);
             let stdout_drain = slog_term::FullFormat::new(stdout_decorator).build().fuse();

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -47,6 +47,7 @@ pub struct LoggerConfig<'a> {
     pub debug_level: &'a str,
     pub logfile_debug_level: &'a str,
     pub log_format: Option<&'a str>,
+    pub log_color: bool,
     pub max_log_size: u64,
     pub max_log_number: usize,
     pub compression: bool,
@@ -139,7 +140,12 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
                 _ => return Err("Logging format provided is not supported".to_string()),
             }
         } else {
-            let stdout_decorator = slog_term::TermDecorator::new().build();
+            let stdout_decorator_builder = slog_term::TermDecorator::new();
+            let stdout_decorator = if config.log_color { 
+                stdout_decorator_builder.force_color()
+            } else { 
+                stdout_decorator_builder 
+            }.build();
             let stdout_decorator =
                 logging::AlignedTermDecorator::new(stdout_decorator, logging::MAX_MESSAGE_WIDTH);
             let stdout_drain = slog_term::FullFormat::new(stdout_decorator).build().fuse();

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -433,7 +433,7 @@ fn run<E: EthSpec>(
         debug_level,
         logfile_debug_level,
         log_format,
-        log_color: log_color,
+        log_color,
         max_log_size: logfile_max_size * 1_024 * 1_024,
         max_log_number: logfile_max_number,
         compression: logfile_compress,

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -141,6 +141,7 @@ fn main() {
         .arg(
             Arg::with_name("log-color")
                 .long("log-color")
+                .alias("log-colour")
                 .help("Force outputting colors when emitting logs to the terminal.")
                 .global(true),
         )

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -139,6 +139,12 @@ fn main() {
                 .global(true),
         )
         .arg(
+            Arg::with_name("log-color")
+                .long("log-color")
+                .help("Force outputting colors when emitting logs to the terminal.")
+                .global(true),
+        )
+        .arg(
             Arg::with_name("debug-level")
                 .long("debug-level")
                 .value_name("LEVEL")
@@ -372,6 +378,8 @@ fn run<E: EthSpec>(
 
     let log_format = matches.value_of("log-format");
 
+    let log_color = matches.is_present("log-color");
+
     let logfile_debug_level = matches
         .value_of("logfile-debug-level")
         .ok_or("Expected --logfile-debug-level flag")?;
@@ -424,6 +432,7 @@ fn run<E: EthSpec>(
         debug_level,
         logfile_debug_level,
         log_format,
+        log_color: log_color,
         max_log_size: logfile_max_size * 1_024 * 1_024,
         max_log_number: logfile_max_number,
         compression: logfile_compress,

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -65,6 +65,7 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             debug_level: log_level,
             logfile_debug_level: "debug",
             log_format,
+            log_color: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/testing/simulator/src/no_eth1_sim.rs
+++ b/testing/simulator/src/no_eth1_sim.rs
@@ -50,6 +50,7 @@ pub fn run_no_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             debug_level: log_level,
             logfile_debug_level: "debug",
             log_format,
+            log_color: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/testing/simulator/src/sync_sim.rs
+++ b/testing/simulator/src/sync_sim.rs
@@ -51,6 +51,7 @@ fn syncing_sim(
             debug_level: log_level,
             logfile_debug_level: "debug",
             log_format,
+            log_color: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,


### PR DESCRIPTION
Add flag 'log-color' which preserves colors of log when stdout is redirected to a file.

This is my first lighthouse PR, please let me know if I'm not following contribution guidelines, I welcome meta-feeback (feedback on git commit messages, git branch naming, and the contents of the description of this PR.)

## Issue Addressed

Solves https://github.com/sigp/lighthouse/issues/3527

## Proposed Changes

Adding a flag which enables log color preserving when stdout is redirected to a file.

### Usage
Below I demonstrate current behaviour (without using the new flag) and the new behaviur (when using new flag).

In the screenshot below, I have to panes, one on top running `lighthouse` which redirects to file `~/Desktop/test.log` and one pane in the bottom which runs `tail -f ~/Desktop/test.log`.

#### Current behaviour
```sh
lighthouse --network prater vc |& tee -a ~/Desktop/test.log
```

**Result is no colors**

<img width="1624" alt="current" src="https://user-images.githubusercontent.com/864410/188258226-bfcf8271-4c9e-474c-848e-ac92a60df25c.png">


#### New behaviour
```sh
lighthouse --network prater vc --log-color |& tee -a ~/Desktop/test.log
```

**Result is colors** 🔴🟢🔵🟡

<img width="1624" alt="new" src="https://user-images.githubusercontent.com/864410/188258223-7d9ecf09-92c8-4cba-8f24-bd4d88fc0353.png">

## Additional Info

I chose American spelling of "color" instead of Brittish "colour' since that was aligned with `slog`'s API - method`force_color()`, let me know if you prefer spelling "colour" instead. I also chose to let it be an arg not taking any argument, just like `logfile-compress` flag, rather than having to write `--log-color true`.