### PR TITLE
Update cross to install protoc

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-3.9"]
+dockerfile = './scripts/cross/x86_64-unknown-linux-gnu.dockerfile'
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-3.9"]
+dockerfile = './scripts/cross/aarch64-unknown-linux-gnu.dockerfile'

--- a/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/aarch64-unknown-linux-gnu.dockerfile
@@ -1,0 +1,14 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update -y && apt-get upgrade -y
+
+RUN apt-get install -y unzip && \
+    PB_REL="https://github.com/protocolbuffers/protobuf/releases" && \
+    curl -L $PB_REL/download/v3.15.8/protoc-3.15.8-linux-aarch_64.zip -o protoc.zip && \
+    unzip protoc.zip -d /usr && \
+    chmod +x /usr/bin/protoc
+
+RUN apt-get install -y cmake clang-3.9
+
+ENV PROTOC=/usr/bin/protoc

--- a/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
+++ b/scripts/cross/x86_64-unknown-linux-gnu.dockerfile
@@ -1,0 +1,14 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN apt-get update -y && apt-get upgrade -y
+
+RUN apt-get install -y unzip && \
+    PB_REL="https://github.com/protocolbuffers/protobuf/releases" && \
+    curl -L $PB_REL/download/v3.15.8/protoc-3.15.8-linux-x86_64.zip -o protoc.zip && \
+    unzip protoc.zip -d /usr && \
+    chmod +x /usr/bin/protoc
+
+RUN apt-get install -y cmake clang-3.9
+
+ENV PROTOC=/usr/bin/protoc


### PR DESCRIPTION
## Issue Addressed
updates cross routines to deal with installing protoc

## Proposed Changes
use custom dockerfiles for this

## Additional Info

If you have a better location for the scripts or another alternative, happy to hear them.
I ended up with dockerfiles to deal with the `PROTOC` env variable, since it can't be set from the pre build scripts and would otherwise need to be passed from the calling shell. This way, we can keep using cross as always

**NOTE** that this is against the `libp2p-v0.47.0-upgrade` branch where I've been doing incremental PRs for the upgrade