### PR TITLE
[Merged by Bors] - Fix ganache test endpoint for ipv6 machines

### DIFF
--- a/testing/eth1_test_rig/src/ganache.rs
+++ b/testing/eth1_test_rig/src/ganache.rs
@@ -166,7 +166,7 @@ impl GanacheInstance {
 }
 
 fn endpoint(port: u16) -> String {
-    format!("http://localhost:{}", port)
+    format!("http://127.0.0.1:{}", port)
 }
 
 impl Drop for GanacheInstance {


### PR DESCRIPTION
## Issue Addressed

#3562

## Proposed Changes

Change the fork endpoint from `localhost` to `127.0.0.1` to match the ganache default listening host.
This way it doesn't try (and fail) to connect to `::1` on IPV6 machines.

## Additional Info

First PR
