### PR TITLE
[Merged by Bors] - Pass EL JWT secret key via cli flag

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -440,7 +440,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        JSON-RPC connection. Uses the same endpoint to populate the \
                        deposit cache.")
                 .takes_value(true)
-                .requires("execution-jwt")
         )
         .arg(
             Arg::with_name("execution-jwt")
@@ -448,6 +447,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("EXECUTION-JWT")
                 .alias("jwt-secrets")
                 .help("File path which contains the hex-encoded JWT secret for the \
+                       execution endpoint provided in the --execution-endpoint flag.")
+                .requires("execution-endpoint")
+                .takes_value(true)
+        )
+        .arg(
+            Arg::with_name("execution-jwt-secret-key")
+                .long("execution-jwt-secret-key")
+                .value_name("EXECUTION-JWT-SECRET-KEY")
+                .alias("jwt-secret-key")
+                .help("Hex-encoded JWT secret for the \
                        execution endpoint provided in the --execution-endpoint flag.")
                 .requires("execution-endpoint")
                 .takes_value(true)

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -459,6 +459,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Hex-encoded JWT secret for the \
                        execution endpoint provided in the --execution-endpoint flag.")
                 .requires("execution-endpoint")
+                .conflicts_with("execution-jwt")
                 .takes_value(true)
         )
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -313,7 +313,7 @@ pub fn get_config<E: EthSpec>(
                 .write_all(jwt_secret_key.as_bytes())
                 .expect("Error occured while writing to jwt_secret_key file!");
         } else {
-            panic!("Error! Please set either --execution-jwt file_path or --execution-jwt-secret-key directly via cli when using --execution-endpoint")
+            return Err("Error! Please set either --execution-jwt file_path or --execution-jwt-secret-key directly via cli when using --execution-endpoint".to_string());
         }
 
         // Parse and set the payload builder, if any.

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 use unused_port::{unused_tcp_port, unused_udp_port};
+use execution_layer::DEFAULT_JWT_FILE;
 
 /// Gets the fully-initialized global client.
 ///
@@ -291,12 +292,27 @@ pub fn get_config<E: EthSpec>(
         let execution_endpoint =
             parse_only_one_value(endpoints, SensitiveUrl::parse, "--execution-endpoint", log)?;
 
-        // Parse a single JWT secret, logging warnings if multiple are supplied.
-        //
-        // JWTs are required if `--execution-endpoint` is supplied.
-        let secret_files: String = clap_utils::parse_required(cli_args, "execution-jwt")?;
-        let secret_file =
-            parse_only_one_value(&secret_files, PathBuf::from_str, "--execution-jwt", log)?;
+        // JWTs are required if `--execution-endpoint` is supplied. They can be either passed via
+        // file_path or directly as string.
+
+        let secret_file: PathBuf;
+        // Parse a single JWT secret from a given file_path, logging warnings if multiple are supplied.
+        if let Some(secret_files) = cli_args.value_of("execution-jwt") {
+            secret_file = parse_only_one_value(secret_files, PathBuf::from_str, "--execution-jwt", log)?;
+
+        // Check if the JWT secret key is passed directly via cli flag and persist it to the default
+        // file location.
+        } else if let Some(jwt_secret_key) = cli_args.value_of("execution-jwt-secret-key") {
+            use std::fs::File;
+            use std::io::Write;
+            secret_file = client_config.data_dir.join(DEFAULT_JWT_FILE);
+            let mut jwt_secret_key_file = File::create(secret_file.clone())
+                .expect("Error while creating jwt_secret_key file!");
+            jwt_secret_key_file.write_all(jwt_secret_key.as_bytes())
+                .expect("Error occured while writing to jwt_secret_key file!");
+        } else {
+            panic!("Error! Please set either --execution-jwt file_path or --execution-jwt-secret-key directly via cli when using --execution-endpoint")
+        }
 
         // Parse and set the payload builder, if any.
         if let Some(endpoint) = cli_args.value_of("builder") {

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -3,6 +3,7 @@ use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
+use execution_layer::DEFAULT_JWT_FILE;
 use genesis::Eth1Endpoint;
 use http_api::TlsConfig;
 use lighthouse_network::{multiaddr::Protocol, Enr, Multiaddr, NetworkConfig, PeerIdSerialized};
@@ -18,7 +19,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes, GRAFFITI_BYTES_LEN};
 use unused_port::{unused_tcp_port, unused_udp_port};
-use execution_layer::DEFAULT_JWT_FILE;
 
 /// Gets the fully-initialized global client.
 ///
@@ -298,7 +298,8 @@ pub fn get_config<E: EthSpec>(
         let secret_file: PathBuf;
         // Parse a single JWT secret from a given file_path, logging warnings if multiple are supplied.
         if let Some(secret_files) = cli_args.value_of("execution-jwt") {
-            secret_file = parse_only_one_value(secret_files, PathBuf::from_str, "--execution-jwt", log)?;
+            secret_file =
+                parse_only_one_value(secret_files, PathBuf::from_str, "--execution-jwt", log)?;
 
         // Check if the JWT secret key is passed directly via cli flag and persist it to the default
         // file location.
@@ -308,7 +309,8 @@ pub fn get_config<E: EthSpec>(
             secret_file = client_config.data_dir.join(DEFAULT_JWT_FILE);
             let mut jwt_secret_key_file = File::create(secret_file.clone())
                 .expect("Error while creating jwt_secret_key file!");
-            jwt_secret_key_file.write_all(jwt_secret_key.as_bytes())
+            jwt_secret_key_file
+                .write_all(jwt_secret_key.as_bytes())
                 .expect("Error occured while writing to jwt_secret_key file!");
         } else {
             panic!("Error! Please set either --execution-jwt file_path or --execution-jwt-secret-key directly via cli when using --execution-endpoint")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -308,10 +308,15 @@ pub fn get_config<E: EthSpec>(
             use std::io::Write;
             secret_file = client_config.data_dir.join(DEFAULT_JWT_FILE);
             let mut jwt_secret_key_file = File::create(secret_file.clone())
-                .expect("Error while creating jwt_secret_key file!");
+                .map_err(|e| format!("Error while creating jwt_secret_key file: {:?}", e))?;
             jwt_secret_key_file
                 .write_all(jwt_secret_key.as_bytes())
-                .expect("Error occured while writing to jwt_secret_key file!");
+                .map_err(|e| {
+                    format!(
+                        "Error occured while writing to jwt_secret_key file: {:?}",
+                        e
+                    )
+                })?;
         } else {
             return Err("Error! Please set either --execution-jwt file_path or --execution-jwt-secret-key directly via cli when using --execution-endpoint".to_string());
         }

--- a/book/src/merge-migration.md
+++ b/book/src/merge-migration.md
@@ -43,20 +43,14 @@ present in post-merge blocks. Two new flags are used to configure this connectio
   `http://localhost:8551`.
 - `--execution-jwt <FILE>`: the path to the file containing the JWT secret shared by Lighthouse and the
   execution engine.
-- `--execution-jwt-secret-key <STRING>`: the hex-encoded JWT secret shared by Lighthouse and the
-  execution engine.
 
-If you set up an execution engine with `--execution-endpoint` then you *must* provide a JWT secret.
-This is a mandatory form of authentication that ensures that Lighthouse
+If you set up an execution engine with `--execution-endpoint` then you *must* provide a JWT secret
+using `--execution-jwt`. This is a mandatory form of authentication that ensures that Lighthouse
 has authority to control the execution engine.
 
-The first option is to specify the file path with the JWT secret using `--execution-jwt`.
-
-The second option is to pass the JWT secret directly with the cli flag `--execution-jwt-secret-key`.
-This option can also be used in combination with docker and environment variables by injecting the key
-as an env variable to the cli flags:
-
-`--execution-jwt-secret-key=$EXECUTION_JWT_SECRET_KEY`
+> Tip: the --execution-jwt-secret-key <STRING> flag can be used instead of --execution-jwt <FILE>.
+> This is useful, for example, for users who wish to inject the value into a Docker container without
+> needing to pass a jwt secret file.
 
 The execution engine connection must be **exclusive**, i.e. you must have one execution node
 per beacon node. The reason for this is that the beacon node _controls_ the execution node. Please

--- a/book/src/merge-migration.md
+++ b/book/src/merge-migration.md
@@ -43,10 +43,20 @@ present in post-merge blocks. Two new flags are used to configure this connectio
   `http://localhost:8551`.
 - `--execution-jwt <FILE>`: the path to the file containing the JWT secret shared by Lighthouse and the
   execution engine.
+- `--execution-jwt-secret-key <STRING>`: the hex-encoded JWT secret shared by Lighthouse and the
+  execution engine.
 
-If you set up an execution engine with `--execution-endpoint` then you *must* provide a JWT secret
-using `--execution-jwt`. This is a mandatory form of authentication that ensures that Lighthouse
+If you set up an execution engine with `--execution-endpoint` then you *must* provide a JWT secret.
+This is a mandatory form of authentication that ensures that Lighthouse
 has authority to control the execution engine.
+
+The first option is to specify the file path with the JWT secret using `--execution-jwt`.
+
+The second option is to pass the JWT secret directly with the cli flag `--execution-jwt-secret-key`.
+This option can also be used in combination with docker and environment variables by injecting the key
+as an env variable to the cli flags:
+
+`--execution-jwt-secret-key=$EXECUTION_JWT_SECRET_KEY`
 
 The execution engine connection must be **exclusive**, i.e. you must have one execution node
 per beacon node. The reason for this is that the beacon node _controls_ the execution node. Please

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -401,10 +401,7 @@ fn run_execution_jwt_secret_key_is_persisted() {
     let jwt_secret_key = "0x3cbc11b0d8fa16f3344eacfd6ff6430b9d30734450e8adcf5400f88d327dcb33";
     CommandLineTest::new()
         .flag("execution-endpoint", Some("http://localhost:8551/"))
-        .flag(
-            "execution-jwt-secret-key",
-            Some(jwt_secret_key),
-        )
+        .flag("execution-jwt-secret-key", Some(jwt_secret_key))
         .run_with_zero_port()
         .with_config(|config| {
             let config = config.execution_layer.as_ref().unwrap();

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -4,7 +4,7 @@ use crate::exec::{CommandLineTestExec, CompletedTest};
 use eth1::Eth1Endpoint;
 use lighthouse_network::PeerId;
 use std::fs::File;
-use std::io::Write;
+use std::io::{Read, Write};
 use std::net::IpAddr;
 use std::path::PathBuf;
 use std::process::Command;
@@ -394,6 +394,30 @@ fn run_merge_execution_endpoints_flag_test(flag: &str) {
             );
             // Only the first secret file should be used.
             assert_eq!(config.secret_files, vec![jwts[0].clone()]);
+        });
+}
+#[test]
+fn run_execution_jwt_secret_key_is_persisted() {
+    let jwt_secret_key = "0x3cbc11b0d8fa16f3344eacfd6ff6430b9d30734450e8adcf5400f88d327dcb33";
+    CommandLineTest::new()
+        .flag("execution-endpoint", Some("http://localhost:8551/"))
+        .flag(
+            "execution-jwt-secret-key",
+            Some(jwt_secret_key),
+        )
+        .run_with_zero_port()
+        .with_config(|config| {
+            let config = config.execution_layer.as_ref().unwrap();
+            assert_eq!(
+                config.execution_endpoints[0].full.to_string(),
+                "http://localhost:8551/"
+            );
+            let mut file_jwt_secret_key = String::new();
+            File::open(config.secret_files[0].clone())
+                .expect("could not open jwt_secret_key file")
+                .read_to_string(&mut file_jwt_secret_key)
+                .expect("could not read from file");
+            assert_eq!(file_jwt_secret_key, jwt_secret_key);
         });
 }
 #[test]


### PR DESCRIPTION
## Proposed Changes

In this change I've added a new beacon_node cli flag `--execution-jwt-secret-key` for passing the JWT secret directly as string.

Without this flag, it was non-trivial to pass a secrets file containing a JWT secret key without compromising its contents into some management repo or fiddling around with manual file mounts for cloud-based deployments.

When used in combination with environment variables, the secret can be injected into container-based systems like docker & friends quite easily.

It's both possible to either specify the file_path to the JWT secret or pass the JWT secret directly.

I've modified the docs and attached a test as well.

## Additional Info

The logic has been adapted a bit so that either one of `--execution-jwt` or `--execution-jwt-secret-key` must be set when specifying `--execution-endpoint` so that it's still compatible with the semantics before this change and there's at least one secret provided.
