### PR TITLE
[Merged by Bors] - Avoid duplicate committee cache loads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ version = "0.2.0"
 dependencies = [
  "bitvec 0.20.4",
  "bls",
+ "crossbeam-channel",
  "derivative",
  "environment",
  "eth1",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -63,6 +63,7 @@ superstruct = "0.5.0"
 hex = "0.4.2"
 exit-future = "0.2.0"
 unused_port = {path = "../../common/unused_port"}
+crossbeam-channel = "0.5.6"
 
 [[test]]
 name = "beacon_chain_tests"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4594,8 +4594,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             state.build_committee_cache(relative_epoch, &self.spec)?;
 
-            let committee_cache = state.committee_cache(relative_epoch)?;
-            let committee_cache = Arc::new(committee_cache.clone());
+            let committee_cache = state.take_committee_cache(relative_epoch)?;
+            let committee_cache = Arc::new(committee_cache);
             let shuffling_decision_block = shuffling_id.shuffling_decision_block;
 
             self.shuffling_cache

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4500,7 +4500,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             //
             // Creating the promise whilst we hold the `shuffling_cache` lock will prevent the same
             // promise from being created twice.
-            let sender = shuffling_cache.create_promise(shuffling_id.clone());
+            let sender = shuffling_cache.create_promise(shuffling_id.clone())?;
 
             // Drop the shuffling cache to avoid holding the lock for any longer than
             // required.

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -203,6 +203,7 @@ pub enum BeaconChainError {
     AttestationHeadNotInForkChoice(Hash256),
     MissingPersistedForkChoice,
     CommitteeCacheWait(crossbeam_channel::RecvError),
+    MaxCommitteePromises(usize),
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -202,6 +202,7 @@ pub enum BeaconChainError {
     },
     AttestationHeadNotInForkChoice(Hash256),
     MissingPersistedForkChoice,
+    CommitteeCacheWait(crossbeam_channel::RecvError),
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -254,6 +254,10 @@ lazy_static! {
         try_create_int_counter("beacon_shuffling_cache_hits_total", "Count of times shuffling cache fulfils request");
     pub static ref SHUFFLING_CACHE_MISSES: Result<IntCounter> =
         try_create_int_counter("beacon_shuffling_cache_misses_total", "Count of times shuffling cache fulfils request");
+    pub static ref SHUFFLING_CACHE_PROMISE_HITS: Result<IntCounter> =
+        try_create_int_counter("beacon_shuffling_cache_promise_hits_total", "Count of times shuffling cache returns a promise to future shuffling");
+    pub static ref SHUFFLING_CACHE_PROMISE_FAILS: Result<IntCounter> =
+        try_create_int_counter("beacon_shuffling_cache_promise_fails_total", "Count of times shuffling cache detects a failed promise");
 
     /*
      * Early attester cache

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -63,9 +63,9 @@ impl ShufflingCache {
     pub fn get(&mut self, key: &AttestationShufflingId) -> Option<CacheItem> {
         match self.cache.get(key) {
             // The cache contained the committee cache, return it.
-            Some(CacheItem::Committee(committee)) => {
+            item @ Some(CacheItem::Committee(_)) => {
                 metrics::inc_counter(&metrics::SHUFFLING_CACHE_HITS);
-                Some(committee.clone())
+                item.cloned()
             }
             // The cache contains a promise for the committee cache. Check to see if the promise has
             // already been resolved, without waiting for it.

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -1,5 +1,7 @@
-use crate::metrics;
+use crate::{metrics, BeaconChainError};
+use crossbeam_channel::{bounded, Receiver, Sender, TryRecvError};
 use lru::LruCache;
+use std::sync::Arc;
 use types::{beacon_state::CommitteeCache, AttestationShufflingId, Epoch, Hash256};
 
 /// The size of the LRU cache that stores committee caches for quicker verification.
@@ -9,12 +11,29 @@ use types::{beacon_state::CommitteeCache, AttestationShufflingId, Epoch, Hash256
 /// ignores a few extra bytes in the caches that should be insignificant compared to the indices).
 const CACHE_SIZE: usize = 16;
 
+#[derive(Clone)]
+pub enum CacheItem {
+    Ready(Arc<CommitteeCache>),
+    Promise(Receiver<Arc<CommitteeCache>>),
+}
+
+impl CacheItem {
+    pub fn wait(self) -> Result<Arc<CommitteeCache>, BeaconChainError> {
+        match self {
+            CacheItem::Ready(cache) => Ok(cache),
+            CacheItem::Promise(receiver) => receiver
+                .recv()
+                .map_err(BeaconChainError::CommitteeCacheWait),
+        }
+    }
+}
+
 /// Provides an LRU cache for `CommitteeCache`.
 ///
 /// It has been named `ShufflingCache` because `CommitteeCacheCache` is a bit weird and looks like
 /// a find/replace error.
 pub struct ShufflingCache {
-    cache: LruCache<AttestationShufflingId, CommitteeCache>,
+    cache: LruCache<AttestationShufflingId, CacheItem>,
 }
 
 impl ShufflingCache {
@@ -24,26 +43,73 @@ impl ShufflingCache {
         }
     }
 
-    pub fn get(&mut self, key: &AttestationShufflingId) -> Option<&CommitteeCache> {
-        let opt = self.cache.get(key);
-
-        if opt.is_some() {
-            metrics::inc_counter(&metrics::SHUFFLING_CACHE_HITS);
-        } else {
-            metrics::inc_counter(&metrics::SHUFFLING_CACHE_MISSES);
+    pub fn get(&mut self, key: &AttestationShufflingId) -> Option<CacheItem> {
+        match self.cache.get(key) {
+            // The cache contained the committee cache, return it.
+            item @ Some(CacheItem::Ready(_)) => {
+                metrics::inc_counter(&metrics::SHUFFLING_CACHE_HITS);
+                item.cloned()
+            }
+            // The cache contains a promise for the committee cache. Check to see if the promise has
+            // already been resolved, without waiting for it.
+            item @ Some(CacheItem::Promise(receiver)) => match receiver.try_recv() {
+                // The promise has already been resolved. Replace the entry in the cache with a
+                // `Ready` entry and then return the committee.
+                Ok(committee) => {
+                    metrics::inc_counter(&metrics::SHUFFLING_CACHE_HITS);
+                    let ready = CacheItem::Ready(committee);
+                    self.cache.put(key.clone(), ready.clone());
+                    Some(ready)
+                }
+                // The promise has not yet been resolved. Return the promise so the caller can await
+                // it.
+                Err(TryRecvError::Empty) => {
+                    metrics::inc_counter(&metrics::SHUFFLING_CACHE_HITS);
+                    item.cloned()
+                }
+                // The sender has been dropped without sending a committee. There was most likely
+                // and error computing the committee cache. Drop the key from the cache and return
+                // `None` so the caller can recompute the cache.
+                Err(TryRecvError::Disconnected) => {
+                    metrics::inc_counter(&metrics::SHUFFLING_CACHE_MISSES);
+                    self.cache.pop(key);
+                    None
+                }
+            },
+            // The cache does not have this committee and it's not already promised to be computed.
+            None => {
+                metrics::inc_counter(&metrics::SHUFFLING_CACHE_MISSES);
+                None
+            }
         }
-
-        opt
     }
 
     pub fn contains(&self, key: &AttestationShufflingId) -> bool {
         self.cache.contains(key)
     }
 
-    pub fn insert(&mut self, key: AttestationShufflingId, committee_cache: &CommitteeCache) {
-        if !self.cache.contains(&key) {
-            self.cache.put(key, committee_cache.clone());
+    pub fn insert_committee_cache(
+        &mut self,
+        key: AttestationShufflingId,
+        committee_cache: &CommitteeCache,
+    ) {
+        if self
+            .cache
+            .get(&key)
+            // Replace the committee if it's not present, or if it's a promise. An actual value is
+            // always better than a promise!
+            .map_or(true, |item| matches!(item, CacheItem::Promise(_)))
+        {
+            self.cache
+                .put(key, CacheItem::Ready(Arc::new(committee_cache.clone())));
         }
+    }
+
+    #[must_use]
+    pub fn create_promise(&mut self, key: AttestationShufflingId) -> Sender<Arc<CommitteeCache>> {
+        let (sender, receiver) = bounded(1);
+        self.cache.put(key, CacheItem::Promise(receiver));
+        sender
     }
 }
 

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -173,6 +173,8 @@ impl BlockShufflingIds {
     }
 }
 
+// Disable tests in debug since the beacon chain harness is slow unless in release.
+#[cfg(not(debug_assertions))]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -14,7 +14,13 @@ const CACHE_SIZE: usize = 16;
 /// The maximum number of concurrent committee cache "promises" that can be issued. In effect, this
 /// limits the number of concurrent states that can be loaded into memory for the committee cache.
 /// This prevents excessive memory usage at the cost of rejecting some attestations.
-const MAX_CONCURRENT_PROMISES: usize = 4;
+///
+/// We set this value to 2 since states can be quite large and have a significant impact on memory
+/// usage. A healthy network cannot have more than a few committee caches and those caches should
+/// always be inserted during block import. Unstable networks with a high degree of forking might
+/// see some attestations dropped due to this concurrency limit, however I propose that this is
+/// better than low-resource nodes going OOM.
+const MAX_CONCURRENT_PROMISES: usize = 2;
 
 #[derive(Clone)]
 pub enum CacheItem {

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -394,7 +394,7 @@ fn advance_head<T: BeaconChainTypes>(
             .shuffling_cache
             .try_write_for(ATTESTATION_CACHE_LOCK_TIMEOUT)
             .ok_or(BeaconChainError::AttestationCacheLockTimeout)?
-            .insert(shuffling_id.clone(), committee_cache);
+            .insert_committee_cache(shuffling_id.clone(), committee_cache);
 
         debug!(
             log,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

I have observed scenarios on Goerli where Lighthouse was receiving attestations which reference the same, un-cached shuffling on multiple threads at the same time. Lighthouse was then loading the same state from database and determining the shuffling on multiple threads at the same time. This is unnecessary load on the disk and RAM.

This PR modifies the shuffling cache so that each entry can be either:

- A committee
- A promise for a committee (i.e., a `crossbeam_channel::Receiver`)

Now, in the scenario where we have thread A and thread B simultaneously requesting the same un-cached shuffling, we will have the following:

1. Thread A will take the write-lock on the shuffling cache, find that there's no cached committee and then create a "promise" (a `crossbeam_channel::Sender`) for a committee before dropping the write-lock.
1. Thread B will then be allowed to take the write-lock for the shuffling cache and find the promise created by thread A. It will block the current thread waiting for thread A to fulfill that promise.
1. Thread A will load the state from disk, obtain the shuffling, send it down the channel, insert the entry into the cache and then continue to verify the attestation.
1. Thread B will then receive the shuffling from the receiver, be un-blocked and then continue to verify the attestation.

In the case where thread A fails to generate the shuffling and drops the sender, the next time that specific shuffling is requested we will detect that the channel is disconnected and return a `None` entry for that shuffling. This will cause the shuffling to be re-calculated.

## Additional Info

NA
