### PR TITLE
Reduce finalization migration frequency

### DIFF
--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -3,6 +3,7 @@ use crate::errors::BeaconChainError;
 use crate::head_tracker::{HeadTracker, SszHeadTracker};
 use crate::persisted_beacon_chain::{PersistedBeaconChain, DUMMY_CANONICAL_HEAD_BLOCK_ROOT};
 use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
 use slog::{debug, error, info, warn, Logger};
 use std::collections::{HashMap, HashSet};
 use std::mem;
@@ -25,20 +26,43 @@ const MIN_COMPACTION_PERIOD_SECONDS: u64 = 7200;
 /// Compact after a large finality gap, if we respect `MIN_COMPACTION_PERIOD_SECONDS`.
 const COMPACTION_FINALITY_DISTANCE: u64 = 1024;
 
+/// Default number of epochs to wait between finalization migrations.
+pub const DEFAULT_EPOCHS_PER_RUN: u64 = 4;
+
 /// The background migrator runs a thread to perform pruning and migrate state from the hot
 /// to the cold database.
 pub struct BackgroundMigrator<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
     db: Arc<HotColdDB<E, Hot, Cold>>,
     #[allow(clippy::type_complexity)]
     tx_thread: Option<Mutex<(mpsc::Sender<Notification>, thread::JoinHandle<()>)>>,
+    /// Record of when the last migration ran, for enforcing `epochs_per_run`.
+    prev_migration: Arc<Mutex<PrevMigration>>,
     /// Genesis block root, for persisting the `PersistedBeaconChain`.
     genesis_block_root: Hash256,
     log: Logger,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MigratorConfig {
     pub blocking: bool,
+    /// Run migrations at most once per `epochs_per_run`.
+    ///
+    /// If set to 0, then run every finalization.
+    pub epochs_per_run: u64,
+}
+
+impl Default for MigratorConfig {
+    fn default() -> Self {
+        Self {
+            blocking: false,
+            epochs_per_run: DEFAULT_EPOCHS_PER_RUN,
+        }
+    }
+}
+
+pub struct PrevMigration {
+    epoch: Option<Epoch>,
+    epochs_per_run: u64,
 }
 
 impl MigratorConfig {
@@ -95,6 +119,18 @@ pub struct FinalizationNotification {
     genesis_block_root: Hash256,
 }
 
+impl Notification {
+    pub fn epoch(&self) -> Option<Epoch> {
+        match self {
+            Notification::Finalization(FinalizationNotification {
+                finalized_checkpoint,
+                ..
+            }) => Some(finalized_checkpoint.epoch),
+            Notification::Reconstruction => None,
+        }
+    }
+}
+
 impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Hot, Cold> {
     /// Create a new `BackgroundMigrator` and spawn its thread if necessary.
     pub fn new(
@@ -103,14 +139,23 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         genesis_block_root: Hash256,
         log: Logger,
     ) -> Self {
+        let prev_migration = Arc::new(Mutex::new(PrevMigration {
+            epoch: None,
+            epochs_per_run: config.epochs_per_run,
+        }));
         let tx_thread = if config.blocking {
             None
         } else {
-            Some(Mutex::new(Self::spawn_thread(db.clone(), log.clone())))
+            Some(Mutex::new(Self::spawn_thread(
+                db.clone(),
+                prev_migration.clone(),
+                log.clone(),
+            )))
         };
         Self {
             db,
             tx_thread,
+            prev_migration,
             genesis_block_root,
             log,
         }
@@ -173,7 +218,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
 
             // Restart the background thread if it has crashed.
             if let Err(tx_err) = tx.send(notif) {
-                let (new_tx, new_thread) = Self::spawn_thread(self.db.clone(), self.log.clone());
+                let (new_tx, new_thread) = Self::spawn_thread(
+                    self.db.clone(),
+                    self.prev_migration.clone(),
+                    self.log.clone(),
+                );
 
                 *tx = new_tx;
                 let old_thread = mem::replace(thread, new_thread);
@@ -297,6 +346,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
     /// Return a channel handle for sending requests to the thread.
     fn spawn_thread(
         db: Arc<HotColdDB<E, Hot, Cold>>,
+        prev_migration: Arc<Mutex<PrevMigration>>,
         log: Logger,
     ) -> (mpsc::Sender<Notification>, thread::JoinHandle<()>) {
         let (tx, rx) = mpsc::channel();
@@ -321,6 +371,29 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
                                 }
                             }
                         });
+
+                // Do not run too frequently.
+                if let Some(epoch) = notif.epoch() {
+                    let mut prev_migration = prev_migration.lock();
+
+                    if let Some(prev_epoch) = prev_migration.epoch {
+                        if epoch < prev_epoch + prev_migration.epochs_per_run {
+                            debug!(
+                                log,
+                                "Database consolidation deferred";
+                                "last_finalized_epoch" => prev_epoch,
+                                "new_finalized_epoch" => epoch,
+                                "epochs_per_run" => prev_migration.epochs_per_run,
+                            );
+                            continue;
+                        }
+                    }
+
+                    // We intend to run at this epoch, update the in-memory record of the last epoch
+                    // at which we ran. This value isn't tracked on disk so we will always migrate
+                    // on the first finalization after startup.
+                    prev_migration.epoch = Some(epoch);
+                }
 
                 match notif {
                     Notification::Reconstruction => Self::run_reconstruction(db.clone(), &log),

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -170,6 +170,7 @@ where
             .task_executor(context.executor.clone())
             .custom_spec(spec.clone())
             .chain_config(chain_config)
+            .store_migrator_config(config.store_migrator.clone())
             .graffiti(graffiti)
             .event_handler(event_handler)
             .execution_layer(execution_layer)

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -1,3 +1,4 @@
+use beacon_chain::migrate::MigratorConfig;
 use directory::DEFAULT_ROOT_DIR;
 use network::NetworkConfig;
 use sensitive_url::SensitiveUrl;
@@ -64,6 +65,7 @@ pub struct Config {
     /// via the CLI at runtime, instead of from a configuration file saved to disk.
     pub genesis: ClientGenesis,
     pub store: store::StoreConfig,
+    pub store_migrator: MigratorConfig,
     pub network: network::NetworkConfig,
     pub chain: beacon_chain::ChainConfig,
     pub eth1: eth1::Config,
@@ -83,6 +85,7 @@ impl Default for Config {
             log_file: PathBuf::from(""),
             genesis: <_>::default(),
             store: <_>::default(),
+            store_migrator: <_>::default(),
             network: NetworkConfig::default(),
             chain: <_>::default(),
             dummy_eth1_backend: false,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -420,6 +420,16 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Specifies how many blocks the database should cache in memory [default: 5]")
                 .takes_value(true)
         )
+        .arg(
+            Arg::with_name("db-migration-period")
+                .long("db-migration-period")
+                .value_name("EPOCHS")
+                .help("Specifies the number of epochs to wait between applying each finalization \
+                       migration to the database. Applying migrations less frequently can lead to \
+                       less total disk writes.")
+                .default_value("4")
+                .takes_value(true)
+        )
         /*
          * Execution Layer Integration
          */

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -358,6 +358,11 @@ pub fn get_config<E: EthSpec>(
             .map_err(|_| "auto-compact-db takes a boolean".to_string())?;
     }
 
+    if let Some(epochs_per_migration) = clap_utils::parse_optional(cli_args, "db-migration-period")?
+    {
+        client_config.store_migrator.epochs_per_run = epochs_per_migration;
+    }
+
     /*
      * Zero-ports
      *

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1239,6 +1239,24 @@ fn no_reconstruct_historic_states_flag() {
         .run_with_zero_port()
         .with_config(|config| assert!(!config.chain.reconstruct_historic_states));
 }
+#[test]
+fn db_migration_period_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.store_migrator.epochs_per_run,
+                beacon_node::beacon_chain::migrate::DEFAULT_EPOCHS_PER_RUN
+            )
+        });
+}
+#[test]
+fn db_migration_period_override() {
+    CommandLineTest::new()
+        .flag("db-migration-period", Some("128"))
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.store_migrator.epochs_per_run, 128));
+}
 
 // Tests for Slasher flags.
 #[test]


### PR DESCRIPTION
## Proposed Changes

This is a low-hanging change I've been wanting to make for a while that might help reduce disk I/O a little bit.

It prevents the database finalization migration from running _every time_ finalization happens, and runs it every 4 finalized epochs instead (configurable).

The finalization migration does quite a bit of I/O which should be more efficient when batched into a single larger transaction:

- Reads the finalized state from disk
- Deletes non-canonical blocks and states
- Deletes finalized canonical states from the hot database
- Writes finalized block/state/randao roots to the freezer database
- Writes a finalized state to the freezer database (on a restore point boundary)

Impacts and considerations:

- We store more states in the hot DB. They are not particularly large on disk, around 60MB for the head state at time of writing (no tree hash cache). 4 states is therefore only around 250MB, and even 256 states could fit in a modest 16GB. Keeping in mind the blocks alone are ~100GB, this isn't a substantial increase.
- We forego purely-frozen forwards block iterators for the finalized-but-not-yet-migrated part of the chain. I think this is OK, as usually these slots will be in range of the 8192 lookback on the head state. We already clone the head state for these iterators on-demand here: https://github.com/sigp/lighthouse/blob/aa022f46855df2a1420a6a80a788c73dc2779aa7/beacon_node/beacon_chain/src/beacon_chain.rs#L561-L579
- Block and attestation processing are still able to efficiently determine whether blocks are pre or post finalization, as they mostly use fork choice for this, and a few other caches. See: [`check_block_against_finalized_slot`](https://github.com/sigp/lighthouse/blob/aa022f46855df2a1420a6a80a788c73dc2779aa7/beacon_node/beacon_chain/src/block_verification.rs#L1434-L1459) and [`verify_head_block_is_known`](https://github.com/sigp/lighthouse/blob/aa022f46855df2a1420a6a80a788c73dc2779aa7/beacon_node/beacon_chain/src/attestation_verification.rs#L980-L1022). The only time the split slot is relevant is in [`get_inconsistent_state_for_attestation_verification_only`](https://github.com/sigp/lighthouse/blob/2983235650811437b44199f9c94e517e948a1e9b/beacon_node/store/src/hot_cold_store.rs#L523-L542), which is only called if we deem the attestation's head block suitable via the fork choice check.
- If any undesired effects are discovered after release, they can be opted out of with `--db-migration-period 0` (or 1), which completely restores the current behaviour.

## Additional Info

I don't think this will solve the majority of our database woes, for that more drastic reform is needed, e.g.

- https://github.com/sigp/lighthouse/issues/3208
- https://github.com/sigp/lighthouse/issues/2844
- https://github.com/sigp/lighthouse/issues/3211

etc