### PR TITLE
[Merged by Bors] - Add disable-log-timestamp flag (#3101)

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -785,6 +785,7 @@ fn run<T: EthSpec>(
             logfile_debug_level: "trace",
             log_format: None,
             log_color: false,
+            disable_log_timestamp: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -17,6 +17,7 @@ use sloggers::{file::FileLoggerBuilder, types::Format, types::Severity, Build};
 use std::fs::create_dir_all;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::io::{Write, Result as IOResult};
 use task_executor::{ShutdownReason, TaskExecutor};
 use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 use types::{EthSpec, GnosisEthSpec, MainnetEthSpec, MinimalEthSpec};
@@ -48,6 +49,7 @@ pub struct LoggerConfig<'a> {
     pub logfile_debug_level: &'a str,
     pub log_format: Option<&'a str>,
     pub log_color: bool,
+    pub disable_log_timestamp: bool,
     pub max_log_size: u64,
     pub max_log_number: usize,
     pub compression: bool,
@@ -121,6 +123,8 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
         Ok(self)
     }
 
+    fn log_nothing(_: &mut dyn Write) -> IOResult<()> { Ok(()) }
+
     /// Initializes the logger using the specified configuration.
     /// The logger is "async" because it has a dedicated thread that accepts logs and then
     /// asynchronously flushes them to stdout/files/etc. This means the thread that raised the log
@@ -149,7 +153,11 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
             .build();
             let stdout_decorator =
                 logging::AlignedTermDecorator::new(stdout_decorator, logging::MAX_MESSAGE_WIDTH);
-            let stdout_drain = slog_term::FullFormat::new(stdout_decorator).build().fuse();
+            let stdout_drain = slog_term::FullFormat::new(stdout_decorator);
+            let stdout_drain = if config.disable_log_timestamp {
+                stdout_drain.use_custom_timestamp(Self::log_nothing)
+            } else { stdout_drain }
+            .build().fuse();
             slog_async::Async::new(stdout_drain)
                 .chan_size(LOG_CHANNEL_SIZE)
                 .build()

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -146,6 +146,12 @@ fn main() {
                 .global(true),
         )
         .arg(
+            Arg::with_name("disable-log-timestamp")
+            .long("disable-log-timestamp")
+            .help("If present, do not include timestamps in logging output.")
+            .global(true),
+        )
+        .arg(
             Arg::with_name("debug-level")
                 .long("debug-level")
                 .value_name("LEVEL")
@@ -381,6 +387,8 @@ fn run<E: EthSpec>(
 
     let log_color = matches.is_present("log-color");
 
+    let disable_log_timestamp = matches.is_present("disable-log-timestamp");
+
     let logfile_debug_level = matches
         .value_of("logfile-debug-level")
         .ok_or("Expected --logfile-debug-level flag")?;
@@ -434,6 +442,7 @@ fn run<E: EthSpec>(
         logfile_debug_level,
         log_format,
         log_color,
+        disable_log_timestamp,
         max_log_size: logfile_max_size * 1_024 * 1_024,
         max_log_number: logfile_max_number,
         compression: logfile_compress,

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -66,6 +66,7 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             logfile_debug_level: "debug",
             log_format,
             log_color: false,
+            disable_log_timestamp: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/testing/simulator/src/no_eth1_sim.rs
+++ b/testing/simulator/src/no_eth1_sim.rs
@@ -51,6 +51,7 @@ pub fn run_no_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             logfile_debug_level: "debug",
             log_format,
             log_color: false,
+            disable_log_timestamp: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,

--- a/testing/simulator/src/sync_sim.rs
+++ b/testing/simulator/src/sync_sim.rs
@@ -52,6 +52,7 @@ fn syncing_sim(
             logfile_debug_level: "debug",
             log_format,
             log_color: false,
+            disable_log_timestamp: false,
             max_log_size: 0,
             max_log_number: 0,
             compression: false,


### PR DESCRIPTION
## Issues Addressed

Closes https://github.com/sigp/lighthouse/issues/3101

## Proposed Changes

Add global flag to suppress timestamps in the terminal logger.