### PR TITLE
[Merged by Bors] - Avoid holding write-lock whilst waiting on shuffling cache promise

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4491,6 +4491,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         metrics::stop_timer(cache_wait_timer);
 
         if let Some(cache_item) = shuffling_cache.get(&shuffling_id) {
+            // The shuffling cache is no longer required, drop the write-lock to allow concurrent
+            // access.
+            drop(shuffling_cache);
+
             let committee_cache = cache_item.wait()?;
             map_fn(&committee_cache, shuffling_id.shuffling_decision_block)
         } else {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Fixes a bug which hogged the write-lock for the `shuffling_cache`.

## Additional Info

NA