### PR TITLE
[Merged by Bors] - Deduplicate block root computation

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2220,7 +2220,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 }
             }
 
-            match check_block_relevancy(&block, Some(block_root), self) {
+            match check_block_relevancy(&block, block_root, self) {
                 // If the block is relevant, add it to the filtered chain segment.
                 Ok(_) => filtered_chain_segment.push((block_root, block)),
                 // If the block is already known, simply ignore this block.
@@ -2344,7 +2344,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // Import the blocks into the chain.
             for signature_verified_block in signature_verified_blocks {
                 match self
-                    .process_block(signature_verified_block, count_unrealized)
+                    .process_block(
+                        signature_verified_block.block_root(),
+                        signature_verified_block,
+                        count_unrealized,
+                    )
                     .await
                 {
                     Ok(_) => imported_blocks += 1,
@@ -2429,6 +2433,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// verification.
     pub async fn process_block<B: IntoExecutionPendingBlock<T>>(
         self: &Arc<Self>,
+        block_root: Hash256,
         unverified_block: B,
         count_unrealized: CountUnrealized,
     ) -> Result<Hash256, BlockError<T::EthSpec>> {
@@ -2444,7 +2449,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // A small closure to group the verification and import errors.
         let chain = self.clone();
         let import_block = async move {
-            let execution_pending = unverified_block.into_execution_pending_block(&chain)?;
+            let execution_pending =
+                unverified_block.into_execution_pending_block(block_root, &chain)?;
             chain
                 .import_execution_pending_block(execution_pending, count_unrealized)
                 .await

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -529,7 +529,7 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     }
 
     let (first_root, first_block) = chain_segment.remove(0);
-    let (mut parent, first_block) = load_parent(first_block, chain)?;
+    let (mut parent, first_block) = load_parent(first_root, first_block, chain)?;
     let slot = first_block.slot();
     chain_segment.insert(0, (first_root, first_block));
 
@@ -781,7 +781,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         } else {
             // The proposer index was *not* cached and we must load the parent in order to determine
             // the proposer index.
-            let (mut parent, block) = load_parent(block, chain)?;
+            let (mut parent, block) = load_parent(block_root, block, chain)?;
 
             debug!(
                 chain.log,
@@ -907,7 +907,7 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
         // Check the anchor slot before loading the parent, to avoid spurious lookups.
         check_block_against_anchor_slot(block.message(), chain)?;
 
-        let (mut parent, block) = load_parent(block, chain)?;
+        let (mut parent, block) = load_parent(block_root, block, chain)?;
 
         // Reject any block that exceeds our limit on skipped slots.
         check_block_skip_slots(chain, parent.beacon_block.slot(), block.message())?;
@@ -955,7 +955,7 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
         let (mut parent, block) = if let Some(parent) = from.parent {
             (parent, from.block)
         } else {
-            load_parent(from.block, chain)?
+            load_parent(from.block_root, from.block, chain)?
         };
 
         let state = cheap_state_advance_to_obtain_committees(
@@ -1003,7 +1003,7 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
         let (parent, block) = if let Some(parent) = self.parent {
             (parent, self.block)
         } else {
-            load_parent(self.block, chain)
+            load_parent(self.block_root, self.block, chain)
                 .map_err(|e| BlockSlashInfo::SignatureValid(header.clone(), e))?
         };
 
@@ -1581,6 +1581,7 @@ fn verify_parent_block_is_known<T: BeaconChainTypes>(
 /// whilst attempting the operation.
 #[allow(clippy::type_complexity)]
 fn load_parent<T: BeaconChainTypes>(
+    block_root: Hash256,
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
     chain: &BeaconChain<T>,
 ) -> Result<
@@ -1614,7 +1615,7 @@ fn load_parent<T: BeaconChainTypes>(
         .block_times_cache
         .read()
         .get_block_delays(
-            block.canonical_root(),
+            block_root,
             chain
                 .slot_clock
                 .start_of(block.slot())

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -55,7 +55,9 @@ pub use self::errors::{BeaconChainError, BlockProductionError};
 pub use self::historical_blocks::HistoricalBlockError;
 pub use attestation_verification::Error as AttestationError;
 pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceStoreError};
-pub use block_verification::{BlockError, ExecutionPayloadError, GossipVerifiedBlock};
+pub use block_verification::{
+    get_block_root, BlockError, ExecutionPayloadError, GossipVerifiedBlock,
+};
 pub use canonical_head::{CachedHead, CanonicalHead, CanonicalHeadRwLock};
 pub use eth1_chain::{Eth1Chain, Eth1ChainBackend};
 pub use events::ServerSentEventHandler;

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1453,12 +1453,13 @@ where
     pub async fn process_block(
         &self,
         slot: Slot,
+        block_root: Hash256,
         block: SignedBeaconBlock<E>,
     ) -> Result<SignedBeaconBlockHash, BlockError<E>> {
         self.set_current_slot(slot);
         let block_hash: SignedBeaconBlockHash = self
             .chain
-            .process_block(Arc::new(block), CountUnrealized::True)
+            .process_block(block_root, Arc::new(block), CountUnrealized::True)
             .await?
             .into();
         self.chain.recompute_head_at_current_slot().await;
@@ -1467,11 +1468,12 @@ where
 
     pub async fn process_block_result(
         &self,
+        block_root: Hash256,
         block: SignedBeaconBlock<E>,
     ) -> Result<SignedBeaconBlockHash, BlockError<E>> {
         let block_hash: SignedBeaconBlockHash = self
             .chain
-            .process_block(Arc::new(block), CountUnrealized::True)
+            .process_block(block_root, Arc::new(block), CountUnrealized::True)
             .await?
             .into();
         self.chain.recompute_head_at_current_slot().await;
@@ -1536,7 +1538,9 @@ where
     ) -> Result<(SignedBeaconBlockHash, SignedBeaconBlock<E>, BeaconState<E>), BlockError<E>> {
         self.set_current_slot(slot);
         let (block, new_state) = self.make_block(state, slot).await;
-        let block_hash = self.process_block(slot, block.clone()).await?;
+        let block_hash = self
+            .process_block(slot, block.canonical_root(), block.clone())
+            .await?;
         Ok((block_hash, block, new_state))
     }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1468,12 +1468,15 @@ where
 
     pub async fn process_block_result(
         &self,
-        block_root: Hash256,
         block: SignedBeaconBlock<E>,
     ) -> Result<SignedBeaconBlockHash, BlockError<E>> {
         let block_hash: SignedBeaconBlockHash = self
             .chain
-            .process_block(block_root, Arc::new(block), CountUnrealized::True)
+            .process_block(
+                block.canonical_root(),
+                Arc::new(block),
+                CountUnrealized::True,
+            )
             .await?
             .into();
         self.chain.recompute_head_at_current_slot().await;

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -685,6 +685,7 @@ async fn run_skip_slot_test(skip_slots: u64) {
         harness_b
             .chain
             .process_block(
+                harness_a.chain.head_snapshot().beacon_block_root,
                 harness_a.chain.head_snapshot().beacon_block.clone(),
                 CountUnrealized::True
             )

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1393,12 +1393,13 @@ impl<T: EthSpec> ExecutionLayer<T> {
 
     pub async fn propose_blinded_beacon_block(
         &self,
+        block_root: Hash256,
         block: &SignedBeaconBlock<T, BlindedPayload<T>>,
     ) -> Result<ExecutionPayload<T>, Error> {
         debug!(
             self.log(),
             "Sending block to builder";
-            "root" => ?block.canonical_root(),
+            "root" => ?block_root,
         );
         if let Some(builder) = self.builder() {
             builder

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1046,7 +1046,7 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
              log: Logger| async move {
-                publish_blocks::publish_block(block, chain, &network_tx, log)
+                publish_blocks::publish_block(None, block, chain, &network_tx, log)
                     .await
                     .map(|()| warp::reply())
             },

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -67,7 +67,10 @@ pub async fn fork_choice_before_proposal() {
 
     let state_a = harness.get_current_state();
     let (block_b, state_b) = harness.make_block(state_a.clone(), slot_b).await;
-    let block_root_b = harness.process_block(slot_b, block_b).await.unwrap();
+    let block_root_b = harness
+        .process_block(slot_b, block_b.canonical_root(), block_b)
+        .await
+        .unwrap();
 
     // Create attestations to B but keep them in reserve until after C has been processed.
     let attestations_b = harness.make_attestations(
@@ -80,7 +83,7 @@ pub async fn fork_choice_before_proposal() {
 
     let (block_c, state_c) = harness.make_block(state_a, slot_c).await;
     let block_root_c = harness
-        .process_block(slot_c, block_c.clone())
+        .process_block(slot_c, block_c.canonical_root(), block_c.clone())
         .await
         .unwrap();
 

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -577,6 +577,7 @@ impl<T: BeaconChainTypes> std::convert::From<ReadyWork<T>> for WorkEvent<T> {
                 },
             },
             ReadyWork::RpcBlock(QueuedRpcBlock {
+                block_root: _,
                 block,
                 seen_timestamp,
                 process_type,

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -242,6 +242,7 @@ impl TestRig {
 
     pub fn enqueue_rpc_block(&self) {
         let event = WorkEvent::rpc_beacon_block(
+            self.next_block.canonical_root(),
             self.next_block.clone(),
             std::time::Duration::default(),
             BlockProcessType::ParentLookup {
@@ -253,6 +254,7 @@ impl TestRig {
 
     pub fn enqueue_single_lookup_rpc_block(&self) {
         let event = WorkEvent::rpc_beacon_block(
+            self.next_block.canonical_root(),
             self.next_block.clone(),
             std::time::Duration::default(),
             BlockProcessType::SingleBlock { id: 1 },

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -109,6 +109,7 @@ pub struct QueuedGossipBlock<T: BeaconChainTypes> {
 /// A block that arrived for processing when the same block was being imported over gossip.
 /// It is queued for later import.
 pub struct QueuedRpcBlock<T: EthSpec> {
+    pub block_root: Hash256,
     pub block: Arc<SignedBeaconBlock<T>>,
     pub process_type: BlockProcessType,
     pub seen_timestamp: Duration,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -776,7 +776,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     "Unknown parent for gossip block";
                     "root" => ?block_root
                 );
-                self.send_sync_message(SyncMessage::UnknownBlock(peer_id, block));
+                self.send_sync_message(SyncMessage::UnknownBlock(peer_id, block, block_root));
                 return None;
             }
             Err(e @ BlockError::BeaconChainError(_)) => {
@@ -969,7 +969,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     "Block with unknown parent attempted to be processed";
                     "peer_id" => %peer_id
                 );
-                self.send_sync_message(SyncMessage::UnknownBlock(peer_id, block));
+                self.send_sync_message(SyncMessage::UnknownBlock(peer_id, block, block_root));
             }
             Err(ref e @ BlockError::ExecutionPayloadError(ref epe)) if !epe.penalize_peer() => {
                 debug!(

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -934,7 +934,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
         match self
             .chain
-            .process_block(verified_block, CountUnrealized::True)
+            .process_block(block_root, verified_block, CountUnrealized::True)
             .await
         {
             Ok(block_root) => {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -713,16 +713,28 @@ impl<T: BeaconChainTypes> Worker<T> {
             block_delay,
         );
 
+        let verification_result = self
+            .chain
+            .clone()
+            .verify_block_for_gossip(block.clone())
+            .await;
+
+        let block_root = if let Ok(verified_block) = &verification_result {
+            verified_block.block_root
+        } else {
+            block.canonical_root()
+        };
+
         // Write the time the block was observed into delay cache.
         self.chain.block_times_cache.write().set_time_observed(
-            block.canonical_root(),
+            block_root,
             block.slot(),
             seen_duration,
             Some(peer_id.to_string()),
             Some(peer_client.to_string()),
         );
 
-        let verified_block = match self.chain.clone().verify_block_for_gossip(block).await {
+        let verified_block = match verification_result {
             Ok(verified_block) => {
                 if block_delay >= self.chain.slot_clock.unagg_attestation_production_delay() {
                     metrics::inc_counter(&metrics::BEACON_BLOCK_GOSSIP_ARRIVED_LATE_TOTAL);
@@ -762,7 +774,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 debug!(
                     self.log,
                     "Unknown parent for gossip block";
-                    "root" => ?block.canonical_root()
+                    "root" => ?block_root
                 );
                 self.send_sync_message(SyncMessage::UnknownBlock(peer_id, block));
                 return None;
@@ -918,6 +930,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         _seen_duration: Duration,
     ) {
         let block: Arc<_> = verified_block.block.clone();
+        let block_root = verified_block.block_root;
 
         match self
             .chain
@@ -970,7 +983,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     self.log,
                     "Invalid gossip beacon block";
                     "outcome" => ?other,
-                    "block root" => ?block.canonical_root(),
+                    "block root" => ?block_root,
                     "block slot" => block.slot()
                 );
                 self.gossip_penalize_peer(

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -56,14 +56,15 @@ impl<T: BeaconChainTypes> Worker<T> {
             return;
         }
         // Check if the block is already being imported through another source
-        let handle = match duplicate_cache.check_and_insert(block.canonical_root()) {
+        let block_root = block.canonical_root();
+        let handle = match duplicate_cache.check_and_insert(block_root) {
             Some(handle) => handle,
             None => {
                 debug!(
                     self.log,
                     "Gossip block is being processed";
                     "action" => "sending rpc block to reprocessing queue",
-                    "block_root" => %block.canonical_root(),
+                    "block_root" => %block_root,
                 );
                 // Send message to work reprocess queue to retry the block
                 let reprocess_msg = ReprocessQueueMessage::RpcBlock(QueuedRpcBlock {
@@ -74,7 +75,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 });
 
                 if reprocess_tx.try_send(reprocess_msg).is_err() {
-                    error!(self.log, "Failed to inform block import"; "source" => "rpc", "block_root" => %block.canonical_root())
+                    error!(self.log, "Failed to inform block import"; "source" => "rpc", "block_root" => %block_root)
                 };
                 return;
             }

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -68,6 +68,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 );
                 // Send message to work reprocess queue to retry the block
                 let reprocess_msg = ReprocessQueueMessage::RpcBlock(QueuedRpcBlock {
+                    block_root,
                     block: block.clone(),
                     process_type,
                     seen_timestamp,

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -83,7 +83,10 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
         };
         let slot = block.slot();
-        let result = self.chain.process_block(block, CountUnrealized::True).await;
+        let result = self
+            .chain
+            .process_block(block_root, block, CountUnrealized::True)
+            .await;
 
         metrics::inc_counter(&metrics::BEACON_PROCESSOR_RPC_BLOCK_IMPORTED_TOTAL);
 

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -38,8 +38,10 @@ struct ChainSegmentFailed {
 
 impl<T: BeaconChainTypes> Worker<T> {
     /// Attempt to process a block received from a direct RPC request.
+    #[allow(clippy::too_many_arguments)]
     pub async fn process_rpc_block(
         self,
+        block_root: Hash256,
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         seen_timestamp: Duration,
         process_type: BlockProcessType,
@@ -56,7 +58,6 @@ impl<T: BeaconChainTypes> Worker<T> {
             return;
         }
         // Check if the block is already being imported through another source
-        let block_root = block.canonical_root();
         let handle = match duplicate_cache.check_and_insert(block_root) {
             Some(handle) => handle,
             None => {

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -1,3 +1,4 @@
+use super::RootBlockTuple;
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::PeerId;
 use std::sync::Arc;
@@ -134,12 +135,15 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         &mut self,
         block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
         failed_chains: &mut lru_cache::LRUTimeCache<Hash256>,
-    ) -> Result<Option<Arc<SignedBeaconBlock<T::EthSpec>>>, VerifyError> {
-        let block = self.current_parent_request.verify_block(block)?;
+    ) -> Result<Option<RootBlockTuple<T::EthSpec>>, VerifyError> {
+        let root_and_block = self.current_parent_request.verify_block(block)?;
 
         // check if the parent of this block isn't in the failed cache. If it is, this chain should
         // be dropped and the peer downscored.
-        if let Some(parent_root) = block.as_ref().map(|block| block.parent_root()) {
+        if let Some(parent_root) = root_and_block
+            .as_ref()
+            .map(|(_, block)| block.parent_root())
+        {
             if failed_chains.contains(&parent_root) {
                 self.current_parent_request.register_failure_downloading();
                 self.current_parent_request_id = None;
@@ -147,7 +151,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             }
         }
 
-        Ok(block)
+        Ok(root_and_block)
     }
 
     pub fn get_processing_peer(&self, chain_hash: Hash256) -> Option<PeerId> {

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -58,11 +58,15 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             .any(|d_block| d_block.as_ref() == block)
     }
 
-    pub fn new(block: Arc<SignedBeaconBlock<T::EthSpec>>, peer_id: PeerId) -> Self {
+    pub fn new(
+        block_root: Hash256,
+        block: Arc<SignedBeaconBlock<T::EthSpec>>,
+        peer_id: PeerId,
+    ) -> Self {
         let current_parent_request = SingleBlockRequest::new(block.parent_root(), peer_id);
 
         Self {
-            chain_hash: block.canonical_root(),
+            chain_hash: block_root,
             downloaded_blocks: vec![block],
             current_parent_request,
             current_parent_request_id: None,

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use super::RootBlockTuple;
+use beacon_chain::get_block_root;
 use lighthouse_network::{rpc::BlocksByRootRequest, PeerId};
 use rand::seq::IteratorRandom;
 use ssz_types::VariableList;
@@ -113,7 +114,9 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
             }
             State::Downloading { peer_id } => match block {
                 Some(block) => {
-                    let block_root = block.canonical_root();
+                    // Compute the block root using this specific function so that we can get timing
+                    // metrics.
+                    let block_root = get_block_root(&block);
                     if block_root != self.hash {
                         // return an error and drop the block
                         // NOTE: we take this is as a download failure to prevent counting the

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use super::RootBlockTuple;
 use lighthouse_network::{rpc::BlocksByRootRequest, PeerId};
 use rand::seq::IteratorRandom;
 use ssz_types::VariableList;
@@ -104,7 +105,7 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
     pub fn verify_block<T: EthSpec>(
         &mut self,
         block: Option<Arc<SignedBeaconBlock<T>>>,
-    ) -> Result<Option<Arc<SignedBeaconBlock<T>>>, VerifyError> {
+    ) -> Result<Option<RootBlockTuple<T>>, VerifyError> {
         match self.state {
             State::AwaitingDownload => {
                 self.register_failure_downloading();
@@ -112,7 +113,8 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
             }
             State::Downloading { peer_id } => match block {
                 Some(block) => {
-                    if block.canonical_root() != self.hash {
+                    let block_root = block.canonical_root();
+                    if block_root != self.hash {
                         // return an error and drop the block
                         // NOTE: we take this is as a download failure to prevent counting the
                         // attempt as a chain failure, but simply a peer failure.
@@ -121,7 +123,7 @@ impl<const MAX_ATTEMPTS: u8> SingleBlockRequest<MAX_ATTEMPTS> {
                     } else {
                         // Return the block for processing.
                         self.state = State::Processing { peer_id };
-                        Ok(Some(block))
+                        Ok(Some((block_root, block)))
                     }
                 }
                 None => {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -94,7 +94,7 @@ pub enum SyncMessage<T: EthSpec> {
     },
 
     /// A block with an unknown parent has been received.
-    UnknownBlock(PeerId, Arc<SignedBeaconBlock<T>>),
+    UnknownBlock(PeerId, Arc<SignedBeaconBlock<T>>, Hash256),
 
     /// A peer has sent an object that references a block that is unknown. This triggers the
     /// manager to attempt to find the block matching the unknown hash.
@@ -503,7 +503,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             } => {
                 self.rpc_block_received(request_id, peer_id, beacon_block, seen_timestamp);
             }
-            SyncMessage::UnknownBlock(peer_id, block) => {
+            SyncMessage::UnknownBlock(peer_id, block, block_root) => {
                 // If we are not synced or within SLOT_IMPORT_TOLERANCE of the block, ignore
                 if !self.network_globals.sync_state.read().is_synced() {
                     let head_slot = self.chain.canonical_head.cached_head().head_slot();
@@ -523,7 +523,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     && self.network.is_execution_engine_online()
                 {
                     self.block_lookups
-                        .search_parent(block, peer_id, &mut self.network);
+                        .search_parent(block_root, block, peer_id, &mut self.network);
                 }
             }
             SyncMessage::UnknownBlockHash(peer_id, block_hash) => {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -331,11 +331,11 @@ impl<E: EthSpec> Tester<E> {
     pub fn process_block(&self, block: SignedBeaconBlock<E>, valid: bool) -> Result<(), Error> {
         let block_root = block.canonical_root();
         let block = Arc::new(block);
-        let result = self.block_on_dangerous(
-            self.harness
-                .chain
-                .process_block(block.clone(), CountUnrealized::False),
-        )?;
+        let result = self.block_on_dangerous(self.harness.chain.process_block(
+            block_root,
+            block.clone(),
+            CountUnrealized::False,
+        ))?;
         if result.is_ok() != valid {
             return Err(Error::DidntFail(format!(
                 "block with root {} was valid={} whilst test expects valid={}. result: {:?}",


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR removes duplicated block root computation.

Computing the `SignedBeaconBlock::canonical_root` has become more expensive since the merge as we need to compute the merke root of each transaction inside an `ExecutionPayload`.

Computing the root for [a mainnet block](https://beaconcha.in/slot/4704236) is taking ~10ms on my i7-8700K CPU @ 3.70GHz (no sha extensions). Given that our median seen-to-imported time for blocks is presently 300-400ms, removing a few duplicated block roots (~30ms) could represent an easy 10% improvement. When we consider that the seen-to-imported times include operations *after* the block has been placed in the early attester cache, we could expect the 30ms to be more significant WRT our seen-to-attestable times.

## Additional Info

NA
