### PR TITLE
[Merged by Bors] - Fix ee integration tests

### DIFF
--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -239,13 +239,16 @@ impl<E: GenericExecutionEngine> TestRig<E> {
 
         // Submit transactions before getting payload
         let txs = transactions::<MainnetEthSpec>(account1, account2);
+        let mut pending_txs = Vec::new();
         for tx in txs.clone().into_iter() {
-            self.ee_a
+            let pending_tx = self
+                .ee_a
                 .execution_engine
                 .provider
                 .send_transaction(tx, None)
                 .await
                 .unwrap();
+            pending_txs.push(pending_tx);
         }
 
         /*
@@ -328,8 +331,6 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .unwrap()
             .execution_payload;
 
-        assert_eq!(valid_payload.transactions.len(), txs.len());
-
         /*
          * Execution Engine A:
          *
@@ -393,6 +394,18 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
+        assert_eq!(valid_payload.transactions.len(), pending_txs.len());
+
+        // Verify that all submitted txs were successful
+        for pending_tx in pending_txs {
+            let tx_receipt = pending_tx.await.unwrap().unwrap();
+            assert_eq!(
+                tx_receipt.status,
+                Some(1.into()),
+                "Tx index {} has invalid status ",
+                tx_receipt.transaction_index
+            );
+        }
 
         /*
          * Execution Engine A:
@@ -580,6 +593,9 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
+
+        let a = futures::future::pending();
+        let _: () = a.await;
     }
 }
 

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -593,9 +593,6 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
-
-        let a = futures::future::pending();
-        let _: () = a.await;
     }
 }
 

--- a/testing/execution_engine_integration/src/transactions.rs
+++ b/testing/execution_engine_integration/src/transactions.rs
@@ -56,11 +56,16 @@ impl Transaction {
                 .value(1)
                 .with_access_list(AccessList::default())
                 .into(),
-            Self::DeployDepositContract(addr) => TransactionRequest::new()
-                .from(*addr)
-                .data(Bytes::from(BYTECODE.to_vec()))
-                .gas(CONTRACT_DEPLOY_GAS)
-                .into(),
+            Self::DeployDepositContract(addr) => {
+                let mut bytecode = String::from_utf8(BYTECODE.to_vec()).unwrap();
+                bytecode.retain(|c| c.is_ascii_hexdigit());
+                let bytecode = hex::decode(&bytecode[1..]).unwrap();
+                TransactionRequest::new()
+                    .from(*addr)
+                    .data(Bytes::from(bytecode))
+                    .gas(CONTRACT_DEPLOY_GAS)
+                    .into()
+            }
             Self::DepositDepositContract {
                 sender,
                 deposit_contract_address,

--- a/testing/execution_engine_integration/src/transactions.rs
+++ b/testing/execution_engine_integration/src/transactions.rs
@@ -1,7 +1,7 @@
 use deposit_contract::{encode_eth1_tx_data, BYTECODE, CONTRACT_DEPLOY_GAS, DEPOSIT_GAS};
 use ethers_core::types::{
     transaction::{eip2718::TypedTransaction, eip2930::AccessList},
-    Address, Bytes, Eip1559TransactionRequest, TransactionRequest,
+    Address, Bytes, Eip1559TransactionRequest, TransactionRequest, U256,
 };
 use types::{DepositData, EthSpec, Hash256, Keypair, Signature};
 
@@ -72,19 +72,20 @@ impl Transaction {
             } => {
                 let keypair = Keypair::random();
 
+                let amount: u64 = 32_000_000_000;
                 let mut deposit = DepositData {
                     pubkey: keypair.pk.into(),
                     withdrawal_credentials: Hash256::zero(),
-                    amount: 32_000_000_000,
+                    amount,
                     signature: Signature::empty().into(),
                 };
-
                 deposit.signature = deposit.create_signature(&keypair.sk, &E::default_spec());
                 TransactionRequest::new()
                     .from(*sender)
                     .to(*deposit_contract_address)
                     .data(Bytes::from(encode_eth1_tx_data(&deposit).unwrap()))
                     .gas(DEPOSIT_GAS)
+                    .value(U256::from(amount) * U256::exp10(9))
                     .into()
             }
         }


### PR DESCRIPTION
## Issue Addressed

Resolves #3573 

## Proposed Changes

Fix the bytecode for the deposit contract deployment transaction and value for deposit transaction in the execution engine integration tests. Also verify that all published transaction make it to the execution payload and have a valid status.

