### PR TITLE
Drop log level of failed committee promise

### DIFF
--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1752,6 +1752,15 @@ impl<T: BeaconChainTypes> Worker<T> {
                 debug!(self.log, "Attestation for finalized state"; "peer_id" => % peer_id);
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
             }
+            e @ AttnError::BeaconChainError(BeaconChainError::CommitteeCacheWait(_)) => {
+                debug!(
+                    self.log,
+                    "Rejected attestation";
+                    "error" => ?e,
+                    "peer_id" => %peer_id
+                );
+                self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
+            }
             e @ AttnError::BeaconChainError(BeaconChainError::MaxCommitteePromises(_)) => {
                 debug!(
                     self.log,


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Drop the log level when a committee promise fails.

I observed some logs like this:

```
Sep 20 06:56:17.001 INFO Synced                                  slot: 4736079, block: 0xaa8a…180d, epoch: 148002, finalized_epoch: 148000, finalized_root: 0x2775…47f2, exec_hash: 0x2ca5…ffde (verified), peers: 6, service: slot_notifier
Sep 20 06:56:23.237 ERRO Unable to validate attestation          error: CommitteeCacheWait(RecvError), peer_id: 16Uiu2HAm2Jnnj8868tb7hCta1rmkXUf5YjqUH1YPj35DCwNyeEzs, type: "aggregated", slot: Slot(4736047), beacon_block_root: 0x88d318534b1010e0ebd79aed60b6b6da1d70357d72b271c01adf55c2b46206c1
```

I believe they were due to an attestation being rejected due to `HotColdDBError::AttestationStateIsFinalized` or other error which is a `debug!` log in the `BeaconProcessor`. I think it's fairly simple to see that we only drop the promise sender when the state load fails with an error. That error will be propagated up by the attestation that created the promise, so it seems to be of marginal value to ensure that attestations depending on that promise also propagate the same error.

I attempted to change the promise channel to accept a `Result`, however the lack of `Clone` on `BeaconChainError` made this difficult.

## Additional Info

NA
