### PR TITLE
[Merged by Bors] - beacon_node: add --disable-deposit-contract-sync flag

### DIFF
--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -457,7 +457,9 @@ where
             ClientGenesis::FromStore => builder.resume_from_db().map(|v| (v, None))?,
         };
 
-        self.eth1_service = eth1_service_option;
+        if config.sync_eth1_chain {
+            self.eth1_service = eth1_service_option;
+        }
         self.beacon_chain_builder = Some(beacon_chain_builder);
         Ok(self)
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -853,9 +853,10 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false)
         )
         .arg(
-            Arg::with_name("disable-eth1-sync")
-                .long("disable-eth1-sync")
+            Arg::with_name("disable-deposit-contract-sync")
+                .long("disable-deposit-contract-sync")
                 .help("Explictly disables the eth1 service. \
+                      This overrides any previous option that depend on it. \
                       Useful if you intend to run a non-validating beacon node.")
                 .takes_value(false)
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -856,7 +856,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("disable-deposit-contract-sync")
                 .long("disable-deposit-contract-sync")
                 .help("Explictly disables syncing of deposit logs from the execution node. \
-                      This overrides any previous option that depend on it. \
+                      This overrides any previous option that depends on it. \
                       Useful if you intend to run a non-validating beacon node.")
                 .takes_value(false)
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -852,4 +852,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        failure caused by the execution layer.")
                 .takes_value(false)
         )
+        .arg(
+            Arg::with_name("disable-eth1-sync")
+                .long("disable-eth1-sync")
+                .help("Explictly disables the eth1 service. \
+                      Useful if you intend to run a non-validating beacon node.")
+                .takes_value(false)
+        )
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -855,7 +855,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("disable-deposit-contract-sync")
                 .long("disable-deposit-contract-sync")
-                .help("Explictly disables the eth1 service. \
+                .help("Explictly disables syncing of deposit logs from the execution node. \
                       This overrides any previous option that depend on it. \
                       Useful if you intend to run a non-validating beacon node.")
                 .takes_value(false)

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -668,7 +668,8 @@ pub fn get_config<E: EthSpec>(
         client_config.chain.enable_lock_timeouts = false;
     }
 
-    if cli_args.is_present("disable-eth1-sync") {
+    // Note: This overrides any previous flags that enable this option.
+    if cli_args.is_present("disable-deposit-contract-sync") {
         client_config.sync_eth1_chain = false;
     }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -668,6 +668,10 @@ pub fn get_config<E: EthSpec>(
         client_config.chain.enable_lock_timeouts = false;
     }
 
+    if cli_args.is_present("disable-eth1-sync") {
+        client_config.sync_eth1_chain = false;
+    }
+
     if let Some(timeout) =
         clap_utils::parse_optional(cli_args, "fork-choice-before-proposal-timeout")?
     {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1527,3 +1527,37 @@ fn enabled_disable_log_timestamp_flag() {
             assert!(config.logger_config.disable_log_timestamp);
         });
 }
+
+#[test]
+fn sync_eth1_chain_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.sync_eth1_chain, false));
+}
+
+#[test]
+fn sync_eth1_chain_execution_endpoints_flag() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
+    CommandLineTest::new()
+        .flag("execution-endpoints", Some("http://localhost:8551/"))
+        .flag(
+            "execution-jwt",
+            dir.path().join("jwt-file").as_os_str().to_str(),
+        )
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.sync_eth1_chain, true));
+}
+
+#[test]
+fn sync_eth1_chain_disable_deposit_contract_sync_flag() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
+    CommandLineTest::new()
+        .flag("disable-deposit-contract-sync", None)
+        .flag("execution-endpoints", Some("http://localhost:8551/"))
+        .flag(
+            "execution-jwt",
+            dir.path().join("jwt-file").as_os_str().to_str(),
+        )
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.sync_eth1_chain, false));
+}


### PR DESCRIPTION
Overrides any previous option that enables the eth1 service.
Useful for operating a `light` beacon node.