### PR TITLE
[Merged by Bors] - Consensus context with proposer index caching

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3498,7 +3498,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         let slot = state.slot();
-        let proposer_index = state.get_beacon_proposer_index(state.slot(), &self.spec)? as u64;
 
         let sync_aggregate = if matches!(&state, BeaconState::Base(_)) {
             None

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -80,7 +80,7 @@ use state_processing::{
     },
     per_slot_processing,
     state_advance::{complete_state_advance, partial_state_advance},
-    BlockSignatureStrategy, SigVerifiedOp, VerifyBlockRoot, VerifyOperation,
+    BlockSignatureStrategy, ConsensusContext, SigVerifiedOp, VerifyBlockRoot, VerifyOperation,
 };
 use std::cmp::Ordering;
 use std::collections::HashMap;
@@ -3645,12 +3645,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             ProduceBlockVerification::VerifyRandao => BlockSignatureStrategy::VerifyRandao,
             ProduceBlockVerification::NoVerification => BlockSignatureStrategy::NoVerification,
         };
+        let mut ctxt = ConsensusContext::new(block.slot()).set_proposer_index(proposer_index);
         per_block_processing(
             &mut state,
             &block,
-            None,
             signature_strategy,
             VerifyBlockRoot::True,
+            &mut ctxt,
             &self.spec,
         )?;
         drop(process_timer);

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3645,7 +3645,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             ProduceBlockVerification::VerifyRandao => BlockSignatureStrategy::VerifyRandao,
             ProduceBlockVerification::NoVerification => BlockSignatureStrategy::NoVerification,
         };
-        let mut ctxt = ConsensusContext::new(block.slot()).set_proposer_index(proposer_index);
+        // Use a context without block root or proposer index so that both are checked.
+        let mut ctxt = ConsensusContext::new(block.slot());
         per_block_processing(
             &mut state,
             &block,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -71,7 +71,8 @@ use state_processing::{
     block_signature_verifier::{BlockSignatureVerifier, Error as BlockSignatureVerifierError},
     per_block_processing, per_slot_processing,
     state_advance::partial_state_advance,
-    BlockProcessingError, BlockSignatureStrategy, SlotProcessingError, VerifyBlockRoot,
+    BlockProcessingError, BlockSignatureStrategy, ConsensusContext, SlotProcessingError,
+    VerifyBlockRoot,
 };
 use std::borrow::Cow;
 use std::fs;
@@ -560,10 +561,16 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
 
     let mut signature_verified_blocks = chain_segment
         .into_iter()
-        .map(|(block_root, block)| SignatureVerifiedBlock {
-            block,
-            block_root,
-            parent: None,
+        .map(|(block_root, block)| {
+            // FIXME(sproul): safe to include proposer index here?
+            let consensus_context =
+                ConsensusContext::new(block.slot()).set_current_block_root(block_root);
+            SignatureVerifiedBlock {
+                block,
+                block_root,
+                parent: None,
+                consensus_context,
+            }
         })
         .collect::<Vec<_>>();
 
@@ -582,6 +589,7 @@ pub struct GossipVerifiedBlock<T: BeaconChainTypes> {
     pub block: Arc<SignedBeaconBlock<T::EthSpec>>,
     pub block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
+    consensus_context: ConsensusContext<T::EthSpec>,
 }
 
 /// A wrapper around a `SignedBeaconBlock` that indicates that all signatures (except the deposit
@@ -590,6 +598,7 @@ pub struct SignatureVerifiedBlock<T: BeaconChainTypes> {
     block: Arc<SignedBeaconBlock<T::EthSpec>>,
     block_root: Hash256,
     parent: Option<PreProcessingSnapshot<T::EthSpec>>,
+    consensus_context: ConsensusContext<T::EthSpec>,
 }
 
 /// Used to await the result of executing payload with a remote EE.
@@ -863,10 +872,16 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         // Validate the block's execution_payload (if any).
         validate_execution_payload_for_gossip(&parent_block, block.message(), chain)?;
 
+        // Having checked the proposer index and the block root we can cache them.
+        let consensus_context = ConsensusContext::new(block.slot())
+            .set_current_block_root(block_root)
+            .set_proposer_index(block.message().proposer_index());
+
         Ok(Self {
             block,
             block_root,
             parent,
+            consensus_context,
         })
     }
 
@@ -930,6 +945,8 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
 
         if signature_verifier.verify().is_ok() {
             Ok(Self {
+                consensus_context: ConsensusContext::new(block.slot())
+                    .set_current_block_root(block_root),
                 block,
                 block_root,
                 parent: Some(parent),
@@ -979,6 +996,7 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
                 block,
                 block_root: from.block_root,
                 parent: Some(parent),
+                consensus_context: from.consensus_context,
             })
         } else {
             Err(BlockError::InvalidSignature)
@@ -1015,8 +1033,14 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
                 .map_err(|e| BlockSlashInfo::SignatureValid(header.clone(), e))?
         };
 
-        ExecutionPendingBlock::from_signature_verified_components(block, block_root, parent, chain)
-            .map_err(|e| BlockSlashInfo::SignatureValid(header, e))
+        ExecutionPendingBlock::from_signature_verified_components(
+            block,
+            block_root,
+            parent,
+            self.consensus_context,
+            chain,
+        )
+        .map_err(|e| BlockSlashInfo::SignatureValid(header, e))
     }
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec> {
@@ -1057,6 +1081,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         block_root: Hash256,
         parent: PreProcessingSnapshot<T::EthSpec>,
+        mut consensus_context: ConsensusContext<T::EthSpec>,
         chain: &Arc<BeaconChain<T>>,
     ) -> Result<Self, BlockError<T::EthSpec>> {
         if let Some(parent) = chain
@@ -1340,10 +1365,10 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         if let Err(err) = per_block_processing(
             &mut state,
             &block,
-            Some(block_root),
             // Signatures were verified earlier in this function.
             BlockSignatureStrategy::NoVerification,
             VerifyBlockRoot::True,
+            &mut consensus_context,
             &chain.spec,
         ) {
             match err {

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -11,7 +11,7 @@ use slasher::{Config as SlasherConfig, Slasher};
 use state_processing::{
     common::get_indexed_attestation,
     per_block_processing::{per_block_processing, BlockSignatureStrategy},
-    per_slot_processing, BlockProcessingError, VerifyBlockRoot,
+    per_slot_processing, BlockProcessingError, ConsensusContext, VerifyBlockRoot,
 };
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -1139,14 +1139,15 @@ async fn add_base_block_to_altair_chain() {
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
         let mut state = state;
+        let mut ctxt = ConsensusContext::new(base_block.slot());
         per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(
                 &mut state,
                 &base_block,
-                None,
                 BlockSignatureStrategy::NoVerification,
                 VerifyBlockRoot::True,
+                &mut ctxt,
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(
@@ -1271,14 +1272,15 @@ async fn add_altair_block_to_base_chain() {
     // Ensure that it would be impossible to apply this block to `per_block_processing`.
     {
         let mut state = state;
+        let mut ctxt = ConsensusContext::new(altair_block.slot());
         per_slot_processing(&mut state, None, &harness.chain.spec).unwrap();
         assert!(matches!(
             per_block_processing(
                 &mut state,
                 &altair_block,
-                None,
                 BlockSignatureStrategy::NoVerification,
                 VerifyBlockRoot::True,
+                &mut ctxt,
                 &harness.chain.spec,
             ),
             Err(BlockProcessingError::InconsistentBlockFork(

--- a/consensus/state_processing/src/block_replayer.rs
+++ b/consensus/state_processing/src/block_replayer.rs
@@ -1,6 +1,7 @@
 use crate::{
     per_block_processing, per_epoch_processing::EpochProcessingSummary, per_slot_processing,
-    BlockProcessingError, BlockSignatureStrategy, SlotProcessingError, VerifyBlockRoot,
+    BlockProcessingError, BlockSignatureStrategy, ConsensusContext, SlotProcessingError,
+    VerifyBlockRoot,
 };
 use std::marker::PhantomData;
 use types::{BeaconState, BlindedPayload, ChainSpec, EthSpec, Hash256, SignedBeaconBlock, Slot};
@@ -254,12 +255,13 @@ where
                     VerifyBlockRoot::False
                 }
             });
+            let mut ctxt = ConsensusContext::new(block.slot());
             per_block_processing(
                 &mut self.state,
                 block,
-                None,
                 self.block_sig_strategy,
                 verify_block_root,
+                &mut ctxt,
                 self.spec,
             )
             .map_err(BlockReplayError::from)?;

--- a/consensus/state_processing/src/block_replayer.rs
+++ b/consensus/state_processing/src/block_replayer.rs
@@ -255,7 +255,10 @@ where
                     VerifyBlockRoot::False
                 }
             });
-            let mut ctxt = ConsensusContext::new(block.slot());
+            // Proposer index was already checked when this block was originally processed, we
+            // can omit recomputing it during replay.
+            let mut ctxt = ConsensusContext::new(block.slot())
+                .set_proposer_index(block.message().proposer_index());
             per_block_processing(
                 &mut self.state,
                 block,

--- a/consensus/state_processing/src/common/slash_validator.rs
+++ b/consensus/state_processing/src/common/slash_validator.rs
@@ -1,9 +1,13 @@
-use crate::common::{decrease_balance, increase_balance, initiate_validator_exit};
+use crate::{
+    common::{decrease_balance, increase_balance, initiate_validator_exit},
+    per_block_processing::errors::BlockProcessingError,
+    ConsensusContext,
+};
 use safe_arith::SafeArith;
 use std::cmp;
 use types::{
     consts::altair::{PROPOSER_WEIGHT, WEIGHT_DENOMINATOR},
-    BeaconStateError as Error, *,
+    *,
 };
 
 /// Slash the validator with index `slashed_index`.
@@ -11,8 +15,9 @@ pub fn slash_validator<T: EthSpec>(
     state: &mut BeaconState<T>,
     slashed_index: usize,
     opt_whistleblower_index: Option<usize>,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
-) -> Result<(), Error> {
+) -> Result<(), BlockProcessingError> {
     let epoch = state.current_epoch();
 
     initiate_validator_exit(state, slashed_index, spec)?;
@@ -39,7 +44,7 @@ pub fn slash_validator<T: EthSpec>(
     )?;
 
     // Apply proposer and whistleblower rewards
-    let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)?;
+    let proposer_index = ctxt.get_proposer_index(state, spec)? as usize;
     let whistleblower_index = opt_whistleblower_index.unwrap_or(proposer_index);
     let whistleblower_reward =
         validator_effective_balance.safe_div(spec.whistleblower_reward_quotient)?;
@@ -52,7 +57,7 @@ pub fn slash_validator<T: EthSpec>(
 
     // Ensure the whistleblower index is in the validator registry.
     if state.validators().get(whistleblower_index).is_none() {
-        return Err(BeaconStateError::UnknownValidator(whistleblower_index));
+        return Err(BeaconStateError::UnknownValidator(whistleblower_index).into());
     }
 
     increase_balance(state, proposer_index, proposer_reward)?;

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -1,0 +1,92 @@
+use std::marker::PhantomData;
+use tree_hash::TreeHash;
+use types::{
+    BeaconState, BeaconStateError, ChainSpec, EthSpec, ExecPayload, Hash256, SignedBeaconBlock,
+    Slot,
+};
+
+#[derive(Debug)]
+pub struct ConsensusContext<T: EthSpec> {
+    /// Slot to act as an identifier/safeguard
+    slot: Slot,
+    /// Proposer index of the block at `slot`.
+    proposer_index: Option<u64>,
+    /// Block root of the block at `slot`.
+    current_block_root: Option<Hash256>,
+    _phantom: PhantomData<T>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum ContextError {
+    BeaconState(BeaconStateError),
+    SlotMismatch { slot: Slot, expected: Slot },
+}
+
+impl From<BeaconStateError> for ContextError {
+    fn from(e: BeaconStateError) -> Self {
+        Self::BeaconState(e)
+    }
+}
+
+impl<T: EthSpec> ConsensusContext<T> {
+    pub fn new(slot: Slot) -> Self {
+        Self {
+            slot,
+            proposer_index: None,
+            current_block_root: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    pub fn set_proposer_index(mut self, proposer_index: u64) -> Self {
+        self.proposer_index = Some(proposer_index);
+        self
+    }
+
+    pub fn get_proposer_index(
+        &mut self,
+        state: &BeaconState<T>,
+        spec: &ChainSpec,
+    ) -> Result<u64, ContextError> {
+        self.check_slot(state.slot())?;
+
+        if let Some(proposer_index) = self.proposer_index {
+            return Ok(proposer_index);
+        }
+
+        let proposer_index = state.get_beacon_proposer_index(self.slot, spec)? as u64;
+        self.proposer_index = Some(proposer_index);
+        Ok(proposer_index)
+    }
+
+    pub fn set_current_block_root(mut self, block_root: Hash256) -> Self {
+        self.current_block_root = Some(block_root);
+        self
+    }
+
+    pub fn get_current_block_root<Payload: ExecPayload<T>>(
+        &mut self,
+        block: &SignedBeaconBlock<T, Payload>,
+    ) -> Result<Hash256, ContextError> {
+        self.check_slot(block.slot())?;
+
+        if let Some(current_block_root) = self.current_block_root {
+            return Ok(current_block_root);
+        }
+
+        let current_block_root = block.message().tree_hash_root();
+        self.current_block_root = Some(current_block_root);
+        Ok(current_block_root)
+    }
+
+    fn check_slot(&self, slot: Slot) -> Result<(), ContextError> {
+        if slot == self.slot {
+            Ok(())
+        } else {
+            Err(ContextError::SlotMismatch {
+                slot,
+                expected: self.slot,
+            })
+        }
+    }
+}

--- a/consensus/state_processing/src/lib.rs
+++ b/consensus/state_processing/src/lib.rs
@@ -18,6 +18,7 @@ mod metrics;
 
 pub mod block_replayer;
 pub mod common;
+pub mod consensus_context;
 pub mod genesis;
 pub mod per_block_processing;
 pub mod per_epoch_processing;
@@ -27,6 +28,7 @@ pub mod upgrade;
 pub mod verify_operation;
 
 pub use block_replayer::{BlockReplayError, BlockReplayer, StateRootStrategy};
+pub use consensus_context::{ConsensusContext, ContextError};
 pub use genesis::{
     eth2_genesis_time, initialize_beacon_state_from_eth1, is_valid_genesis_state,
     process_activations,

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -112,6 +112,7 @@ pub fn per_block_processing<T: EthSpec, Payload: ExecPayload<T>>(
         BlockSignatureStrategy::VerifyBulk => {
             // Verify all signatures in the block at once.
             let block_root = Some(ctxt.get_current_block_root(signed_block)?);
+            let proposer_index = Some(ctxt.get_proposer_index(state, spec)?);
             block_verify!(
                 BlockSignatureVerifier::verify_entire_block(
                     state,
@@ -119,6 +120,7 @@ pub fn per_block_processing<T: EthSpec, Payload: ExecPayload<T>>(
                     |pk_bytes| pk_bytes.decompress().ok().map(Cow::Owned),
                     signed_block,
                     block_root,
+                    proposer_index,
                     spec
                 )
                 .is_ok(),
@@ -160,7 +162,7 @@ pub fn per_block_processing<T: EthSpec, Payload: ExecPayload<T>>(
         process_execution_payload(state, payload, spec)?;
     }
 
-    process_randao(state, block, verify_randao, spec)?;
+    process_randao(state, block, verify_randao, ctxt, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
     process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
 
@@ -243,12 +245,14 @@ pub fn verify_block_signature<T: EthSpec, Payload: ExecPayload<T>>(
     spec: &ChainSpec,
 ) -> Result<(), BlockOperationError<HeaderInvalid>> {
     let block_root = Some(ctxt.get_current_block_root(block)?);
+    let proposer_index = Some(ctxt.get_proposer_index(state, spec)?);
     verify!(
         block_proposal_signature_set(
             state,
             |i| get_pubkey_from_state(state, i),
             block,
             block_root,
+            proposer_index,
             spec
         )?
         .verify(),
@@ -264,12 +268,21 @@ pub fn process_randao<T: EthSpec, Payload: ExecPayload<T>>(
     state: &mut BeaconState<T>,
     block: BeaconBlockRef<'_, T, Payload>,
     verify_signatures: VerifySignatures,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     if verify_signatures.is_true() {
         // Verify RANDAO reveal signature.
+        let proposer_index = ctxt.get_proposer_index(state, spec)?;
         block_verify!(
-            randao_signature_set(state, |i| get_pubkey_from_state(state, i), block, spec)?.verify(),
+            randao_signature_set(
+                state,
+                |i| get_pubkey_from_state(state, i),
+                block,
+                Some(proposer_index),
+                spec
+            )?
+            .verify(),
             BlockProcessingError::RandaoSignatureInvalid
         );
     }

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -164,7 +164,7 @@ pub fn per_block_processing<T: EthSpec, Payload: ExecPayload<T>>(
 
     process_randao(state, block, verify_randao, ctxt, spec)?;
     process_eth1_data(state, block.body().eth1_data())?;
-    process_operations(state, block.body(), proposer_index, verify_signatures, spec)?;
+    process_operations(state, block.body(), verify_signatures, ctxt, spec)?;
 
     if let Ok(sync_aggregate) = block.body().sync_aggregate() {
         process_sync_aggregate(

--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -123,10 +123,11 @@ where
         decompressor: D,
         block: &'a SignedBeaconBlock<T, Payload>,
         block_root: Option<Hash256>,
+        verified_proposer_index: Option<u64>,
         spec: &'a ChainSpec,
     ) -> Result<()> {
         let mut verifier = Self::new(state, get_pubkey, decompressor, spec);
-        verifier.include_all_signatures(block, block_root)?;
+        verifier.include_all_signatures(block, block_root, verified_proposer_index)?;
         verifier.verify()
     }
 
@@ -135,9 +136,10 @@ where
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
         block_root: Option<Hash256>,
+        verified_proposer_index: Option<u64>,
     ) -> Result<()> {
-        self.include_block_proposal(block, block_root)?;
-        self.include_all_signatures_except_proposal(block)?;
+        self.include_block_proposal(block, block_root, verified_proposer_index)?;
+        self.include_all_signatures_except_proposal(block, verified_proposer_index)?;
 
         Ok(())
     }
@@ -147,8 +149,9 @@ where
     pub fn include_all_signatures_except_proposal<Payload: ExecPayload<T>>(
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
+        verified_proposer_index: Option<u64>,
     ) -> Result<()> {
-        self.include_randao_reveal(block)?;
+        self.include_randao_reveal(block, verified_proposer_index)?;
         self.include_proposer_slashings(block)?;
         self.include_attester_slashings(block)?;
         self.include_attestations(block)?;
@@ -164,12 +167,14 @@ where
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
         block_root: Option<Hash256>,
+        verified_proposer_index: Option<u64>,
     ) -> Result<()> {
         let set = block_proposal_signature_set(
             self.state,
             self.get_pubkey.clone(),
             block,
             block_root,
+            verified_proposer_index,
             self.spec,
         )?;
         self.sets.push(set);
@@ -180,11 +185,13 @@ where
     pub fn include_randao_reveal<Payload: ExecPayload<T>>(
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
+        verified_proposer_index: Option<u64>,
     ) -> Result<()> {
         let set = randao_signature_set(
             self.state,
             self.get_pubkey.clone(),
             block.message(),
+            verified_proposer_index,
             self.spec,
         )?;
         self.sets.push(set);

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -1,4 +1,5 @@
 use super::signature_sets::Error as SignatureSetError;
+use crate::ContextError;
 use merkle_proof::MerkleTreeError;
 use safe_arith::ArithError;
 use types::*;
@@ -70,6 +71,7 @@ pub enum BlockProcessingError {
         found: u64,
     },
     ExecutionInvalid,
+    ConsensusContext(ContextError),
 }
 
 impl From<BeaconStateError> for BlockProcessingError {
@@ -102,6 +104,12 @@ impl From<SyncAggregateInvalid> for BlockProcessingError {
     }
 }
 
+impl From<ContextError> for BlockProcessingError {
+    fn from(e: ContextError) -> Self {
+        BlockProcessingError::ConsensusContext(e)
+    }
+}
+
 impl From<BlockOperationError<HeaderInvalid>> for BlockProcessingError {
     fn from(e: BlockOperationError<HeaderInvalid>) -> BlockProcessingError {
         match e {
@@ -109,6 +117,7 @@ impl From<BlockOperationError<HeaderInvalid>> for BlockProcessingError {
             BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+            BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
         }
     }
@@ -136,6 +145,7 @@ macro_rules! impl_into_block_processing_error_with_index {
                         BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
                         BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
                         BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+                        BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
                         BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
                     }
                 }
@@ -167,6 +177,7 @@ pub enum BlockOperationError<T> {
     BeaconStateError(BeaconStateError),
     SignatureSetError(SignatureSetError),
     SszTypesError(ssz_types::Error),
+    ConsensusContext(ContextError),
     ArithError(ArithError),
 }
 
@@ -199,6 +210,12 @@ impl<T> From<ArithError> for BlockOperationError<T> {
     }
 }
 
+impl<T> From<ContextError> for BlockOperationError<T> {
+    fn from(e: ContextError) -> Self {
+        BlockOperationError::ConsensusContext(e)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum HeaderInvalid {
     ProposalSignatureInvalid,
@@ -208,14 +225,14 @@ pub enum HeaderInvalid {
         block_slot: Slot,
     },
     ProposerIndexMismatch {
-        block_proposer_index: usize,
-        state_proposer_index: usize,
+        block_proposer_index: u64,
+        state_proposer_index: u64,
     },
     ParentBlockRootMismatch {
         state: Hash256,
         block: Hash256,
     },
-    ProposerSlashed(usize),
+    ProposerSlashed(u64),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -310,6 +327,7 @@ impl From<BlockOperationError<IndexedAttestationInvalid>>
             BlockOperationError::BeaconStateError(e) => BlockOperationError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockOperationError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockOperationError::SszTypesError(e),
+            BlockOperationError::ConsensusContext(e) => BlockOperationError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockOperationError::ArithError(e),
         }
     }

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -12,23 +12,25 @@ use types::consts::altair::{PARTICIPATION_FLAG_WEIGHTS, PROPOSER_WEIGHT, WEIGHT_
 pub fn process_operations<'a, T: EthSpec, Payload: ExecPayload<T>>(
     state: &mut BeaconState<T>,
     block_body: BeaconBlockBodyRef<'a, T, Payload>,
-    proposer_index: u64,
     verify_signatures: VerifySignatures,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     process_proposer_slashings(
         state,
         block_body.proposer_slashings(),
         verify_signatures,
+        ctxt,
         spec,
     )?;
     process_attester_slashings(
         state,
         block_body.attester_slashings(),
         verify_signatures,
+        ctxt,
         spec,
     )?;
-    process_attestations(state, block_body, proposer_index, verify_signatures, spec)?;
+    process_attestations(state, block_body, verify_signatures, ctxt, spec)?;
     process_deposits(state, block_body.deposits(), spec)?;
     process_exits(state, block_body.voluntary_exits(), verify_signatures, spec)?;
     Ok(())
@@ -45,12 +47,13 @@ pub mod base {
         state: &mut BeaconState<T>,
         attestations: &[Attestation<T>],
         verify_signatures: VerifySignatures,
+        ctxt: &mut ConsensusContext<T>,
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
         // Ensure the previous epoch cache exists.
         state.build_committee_cache(RelativeEpoch::Previous, spec)?;
 
-        let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
+        let proposer_index = ctxt.get_proposer_index(state, spec)?;
 
         // Verify and apply each attestation.
         for (i, attestation) in attestations.iter().enumerate() {
@@ -87,10 +90,11 @@ pub mod altair {
     pub fn process_attestations<T: EthSpec>(
         state: &mut BeaconState<T>,
         attestations: &[Attestation<T>],
-        proposer_index: u64,
         verify_signatures: VerifySignatures,
+        ctxt: &mut ConsensusContext<T>,
         spec: &ChainSpec,
     ) -> Result<(), BlockProcessingError> {
+        let proposer_index = ctxt.get_proposer_index(state, spec)?;
         attestations
             .iter()
             .enumerate()
@@ -170,6 +174,7 @@ pub fn process_proposer_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     proposer_slashings: &[ProposerSlashing],
     verify_signatures: VerifySignatures,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     // Verify and apply proposer slashings in series.
@@ -186,6 +191,7 @@ pub fn process_proposer_slashings<T: EthSpec>(
                 state,
                 proposer_slashing.signed_header_1.message.proposer_index as usize,
                 None,
+                ctxt,
                 spec,
             )?;
 
@@ -201,6 +207,7 @@ pub fn process_attester_slashings<T: EthSpec>(
     state: &mut BeaconState<T>,
     attester_slashings: &[AttesterSlashing<T>],
     verify_signatures: VerifySignatures,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     for (i, attester_slashing) in attester_slashings.iter().enumerate() {
@@ -211,7 +218,7 @@ pub fn process_attester_slashings<T: EthSpec>(
             get_slashable_indices(state, attester_slashing).map_err(|e| e.into_with_index(i))?;
 
         for i in slashable_indices {
-            slash_validator(state, i as usize, None, spec)?;
+            slash_validator(state, i as usize, None, ctxt, spec)?;
         }
     }
 
@@ -222,20 +229,26 @@ pub fn process_attester_slashings<T: EthSpec>(
 pub fn process_attestations<'a, T: EthSpec, Payload: ExecPayload<T>>(
     state: &mut BeaconState<T>,
     block_body: BeaconBlockBodyRef<'a, T, Payload>,
-    proposer_index: u64,
     verify_signatures: VerifySignatures,
+    ctxt: &mut ConsensusContext<T>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     match block_body {
         BeaconBlockBodyRef::Base(_) => {
-            base::process_attestations(state, block_body.attestations(), verify_signatures, spec)?;
+            base::process_attestations(
+                state,
+                block_body.attestations(),
+                verify_signatures,
+                ctxt,
+                spec,
+            )?;
         }
         BeaconBlockBodyRef::Altair(_) | BeaconBlockBodyRef::Merge(_) => {
             altair::process_attestations(
                 state,
                 block_body.attestations(),
-                proposer_index,
                 verify_signatures,
+                ctxt,
                 spec,
             )?;
         }

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -76,6 +76,7 @@ pub fn block_proposal_signature_set<'a, T, F, Payload: ExecPayload<T>>(
     get_pubkey: F,
     signed_block: &'a SignedBeaconBlock<T, Payload>,
     block_root: Option<Hash256>,
+    verified_proposer_index: Option<u64>,
     spec: &'a ChainSpec,
 ) -> Result<SignatureSet<'a>>
 where
@@ -83,8 +84,12 @@ where
     F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
 {
     let block = signed_block.message();
-    let proposer_index = state.get_beacon_proposer_index(block.slot(), spec)? as u64;
 
+    let proposer_index = if let Some(proposer_index) = verified_proposer_index {
+        proposer_index
+    } else {
+        state.get_beacon_proposer_index(block.slot(), spec)? as u64
+    };
     if proposer_index != block.proposer_index() {
         return Err(Error::IncorrectBlockProposer {
             block: block.proposer_index(),
@@ -156,13 +161,18 @@ pub fn randao_signature_set<'a, T, F, Payload: ExecPayload<T>>(
     state: &'a BeaconState<T>,
     get_pubkey: F,
     block: BeaconBlockRef<'a, T, Payload>,
+    verified_proposer_index: Option<u64>,
     spec: &'a ChainSpec,
 ) -> Result<SignatureSet<'a>>
 where
     T: EthSpec,
     F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
 {
-    let proposer_index = state.get_beacon_proposer_index(block.slot(), spec)?;
+    let proposer_index = if let Some(proposer_index) = verified_proposer_index {
+        proposer_index
+    } else {
+        state.get_beacon_proposer_index(block.slot(), spec)? as u64
+    };
 
     let domain = spec.get_domain(
         block.slot().epoch(T::slots_per_epoch()),
@@ -178,7 +188,7 @@ where
 
     Ok(SignatureSet::single_pubkey(
         block.body().randao_reveal(),
-        get_pubkey(proposer_index).ok_or(Error::ValidatorUnknown(proposer_index as u64))?,
+        get_pubkey(proposer_index as usize).ok_or(Error::ValidatorUnknown(proposer_index))?,
         message,
     ))
 }

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -391,11 +391,12 @@ async fn invalid_attestation_no_committee_for_index() {
     head_block.to_mut().body_mut().attestations_mut()[0]
         .data
         .index += 1;
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -429,11 +430,12 @@ async fn invalid_attestation_wrong_justified_checkpoint() {
         .data
         .source = new_justified_checkpoint;
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -468,11 +470,12 @@ async fn invalid_attestation_bad_aggregation_bitfield_len() {
     head_block.to_mut().body_mut().attestations_mut()[0].aggregation_bits =
         Bitfield::with_capacity(spec.target_committee_size).unwrap();
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -500,11 +503,12 @@ async fn invalid_attestation_bad_signature() {
         .0;
     head_block.to_mut().body_mut().attestations_mut()[0].signature = AggregateSignature::empty();
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
     // Expecting BadSignature because we're signing with invalid secret_keys
@@ -538,11 +542,12 @@ async fn invalid_attestation_included_too_early() {
         .data
         .slot = new_attesation_slot;
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -580,11 +585,12 @@ async fn invalid_attestation_included_too_late() {
         .data
         .slot = new_attesation_slot;
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
     assert_eq!(
@@ -618,11 +624,12 @@ async fn invalid_attestation_target_epoch_slot_mismatch() {
         .target
         .epoch += Epoch::new(1);
 
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attestations(
         &mut state,
         head_block.body(),
-        head_block.proposer_index(),
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
     assert_eq!(
@@ -645,10 +652,12 @@ async fn valid_insert_attester_slashing() {
     let attester_slashing = harness.make_attester_slashing(vec![1, 2]);
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -665,10 +674,12 @@ async fn invalid_attester_slashing_not_slashable() {
     attester_slashing.attestation_1 = attester_slashing.attestation_2.clone();
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -691,10 +702,12 @@ async fn invalid_attester_slashing_1_invalid() {
     attester_slashing.attestation_1.attesting_indices = VariableList::from(vec![2, 1]);
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -720,10 +733,12 @@ async fn invalid_attester_slashing_2_invalid() {
     attester_slashing.attestation_2.attesting_indices = VariableList::from(vec![2, 1]);
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_attester_slashings(
         &mut state,
         &[attester_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -746,10 +761,12 @@ async fn valid_insert_proposer_slashing() {
     let harness = get_harness::<MainnetEthSpec>(EPOCH_OFFSET, VALIDATOR_COUNT).await;
     let proposer_slashing = harness.make_proposer_slashing(1);
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
     // Expecting Ok(_) because we inserted a valid proposer slashing
@@ -765,10 +782,12 @@ async fn invalid_proposer_slashing_proposals_identical() {
     proposer_slashing.signed_header_1.message = proposer_slashing.signed_header_2.message.clone();
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -792,10 +811,12 @@ async fn invalid_proposer_slashing_proposer_unknown() {
     proposer_slashing.signed_header_2.message.proposer_index = 3_141_592;
 
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -816,10 +837,12 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
 
     let proposer_slashing = harness.make_proposer_slashing(1);
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result_1 = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing.clone()],
         VerifySignatures::False,
+        &mut ctxt,
         &spec,
     );
     assert!(result_1.is_ok());
@@ -828,6 +851,7 @@ async fn invalid_proposer_slashing_duplicate_slashing() {
         &mut state,
         &[proposer_slashing],
         VerifySignatures::False,
+        &mut ctxt,
         &spec,
     );
     // Expecting ProposerNotSlashable because we've already slashed the validator
@@ -847,10 +871,12 @@ async fn invalid_bad_proposal_1_signature() {
     let mut proposer_slashing = harness.make_proposer_slashing(1);
     proposer_slashing.signed_header_1.signature = Signature::empty();
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -871,10 +897,12 @@ async fn invalid_bad_proposal_2_signature() {
     let mut proposer_slashing = harness.make_proposer_slashing(1);
     proposer_slashing.signed_header_2.signature = Signature::empty();
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::True,
+        &mut ctxt,
         &spec,
     );
 
@@ -896,10 +924,12 @@ async fn invalid_proposer_slashing_proposal_epoch_mismatch() {
     proposer_slashing.signed_header_1.message.slot = Slot::new(0);
     proposer_slashing.signed_header_2.message.slot = Slot::new(128);
     let mut state = harness.get_current_state();
+    let mut ctxt = ConsensusContext::new(state.slot());
     let result = process_operations::process_proposer_slashings(
         &mut state,
         &[proposer_slashing],
         VerifySignatures::False,
+        &mut ctxt,
         &spec,
     );
 

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -55,7 +55,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
-use types::{BeaconState, CloneConfig, EthSpec, Hash256};
+use types::{BeaconState, EthSpec, Hash256};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -121,7 +121,7 @@ pub fn run<T: EthSpec>(mut env: Environment<T>, matches: &ArgMatches) -> Result<
     };
 
     for i in 0..runs {
-        let mut state = state.clone_with(CloneConfig::committee_caches_only());
+        let mut state = state.clone_with(CloneConfig::all());
 
         let start = Instant::now();
 

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -55,7 +55,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
-use types::{BeaconState, EthSpec, Hash256};
+use types::{BeaconState, CloneConfig, EthSpec, Hash256};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -74,7 +74,7 @@ use eth2::{
 use ssz::Encode;
 use state_processing::{
     block_signature_verifier::BlockSignatureVerifier, per_block_processing, per_slot_processing,
-    BlockSignatureStrategy, VerifyBlockRoot,
+    BlockSignatureStrategy, ConsensusContext, VerifyBlockRoot,
 };
 use std::borrow::Cow;
 use std::fs::File;
@@ -367,12 +367,15 @@ fn do_transition<T: EthSpec>(
     }
 
     let t = Instant::now();
+    let mut ctxt = ConsensusContext::new(pre_state.slot())
+        .set_current_block_root(block_root)
+        .set_proposer_index(block.message().proposer_index());
     per_block_processing(
         &mut pre_state,
         &block,
-        None,
         BlockSignatureStrategy::NoVerification,
         VerifyBlockRoot::True,
+        &mut ctxt,
         spec,
     )
     .map_err(|e| format!("State transition failed: {:?}", e))?;

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -83,7 +83,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use store::HotColdDB;
-use types::{BeaconState, ChainSpec, CloneConfig, EthSpec, Hash256, SignedBeaconBlock};
+use types::{BeaconState, ChainSpec, EthSpec, Hash256, SignedBeaconBlock};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -360,6 +360,7 @@ fn do_transition<T: EthSpec>(
             decompressor,
             &block,
             Some(block_root),
+            None,
             spec,
         )
         .map_err(|e| format!("Invalid block signature: {:?}", e))?;

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -83,7 +83,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use store::HotColdDB;
-use types::{BeaconState, ChainSpec, EthSpec, Hash256, SignedBeaconBlock};
+use types::{BeaconState, ChainSpec, CloneConfig, EthSpec, Hash256, SignedBeaconBlock};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -360,7 +360,7 @@ fn do_transition<T: EthSpec>(
             decompressor,
             &block,
             Some(block_root),
-            None,
+            Some(block.message().proposer_index()),
             spec,
         )
         .map_err(|e| format!("Invalid block signature: {:?}", e))?;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -79,11 +79,16 @@ impl<E: EthSpec> Operation<E> for Attestation<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        let proposer_index = state.get_beacon_proposer_index(state.slot(), spec)? as u64;
+        let mut ctxt = ConsensusContext::new(state.slot());
+        let proposer_index = ctxt.get_proposer_index(state, spec)?;
         match state {
-            BeaconState::Base(_) => {
-                base::process_attestations(state, &[self.clone()], VerifySignatures::True, spec)
-            }
+            BeaconState::Base(_) => base::process_attestations(
+                state,
+                &[self.clone()],
+                VerifySignatures::True,
+                &mut ctxt,
+                spec,
+            ),
             BeaconState::Altair(_) | BeaconState::Merge(_) => altair::process_attestation(
                 state,
                 self,
@@ -111,7 +116,14 @@ impl<E: EthSpec> Operation<E> for AttesterSlashing<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_attester_slashings(state, &[self.clone()], VerifySignatures::True, spec)
+        let mut ctxt = ConsensusContext::new(state.slot());
+        process_attester_slashings(
+            state,
+            &[self.clone()],
+            VerifySignatures::True,
+            &mut ctxt,
+            spec,
+        )
     }
 }
 
@@ -145,7 +157,14 @@ impl<E: EthSpec> Operation<E> for ProposerSlashing {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
-        process_proposer_slashings(state, &[self.clone()], VerifySignatures::True, spec)
+        let mut ctxt = ConsensusContext::new(state.slot());
+        process_proposer_slashings(
+            state,
+            &[self.clone()],
+            VerifySignatures::True,
+            &mut ctxt,
+            spec,
+        )
     }
 }
 

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -5,14 +5,17 @@ use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yam
 use crate::testing_spec;
 use crate::type_name::TypeName;
 use serde_derive::Deserialize;
-use state_processing::per_block_processing::{
-    errors::BlockProcessingError,
-    process_block_header, process_execution_payload,
-    process_operations::{
-        altair, base, process_attester_slashings, process_deposits, process_exits,
-        process_proposer_slashings,
+use state_processing::{
+    per_block_processing::{
+        errors::BlockProcessingError,
+        process_block_header, process_execution_payload,
+        process_operations::{
+            altair, base, process_attester_slashings, process_deposits, process_exits,
+            process_proposer_slashings,
+        },
+        process_sync_aggregate, VerifyBlockRoot, VerifySignatures,
     },
-    process_sync_aggregate, VerifyBlockRoot, VerifySignatures,
+    ConsensusContext,
 };
 use std::fmt::Debug;
 use std::path::Path;
@@ -184,10 +187,12 @@ impl<E: EthSpec> Operation<E> for BeaconBlock<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
+        let mut ctxt = ConsensusContext::new(state.slot());
         process_block_header(
             state,
             self.to_ref().temporary_block_header(),
             VerifyBlockRoot::True,
+            &mut ctxt,
             spec,
         )?;
         Ok(())

--- a/testing/ef_tests/src/cases/transition.rs
+++ b/testing/ef_tests/src/cases/transition.rs
@@ -4,7 +4,7 @@ use crate::decode::{ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use serde_derive::Deserialize;
 use state_processing::{
     per_block_processing, state_advance::complete_state_advance, BlockSignatureStrategy,
-    VerifyBlockRoot,
+    ConsensusContext, VerifyBlockRoot,
 };
 use std::str::FromStr;
 use types::{BeaconState, Epoch, ForkName, SignedBeaconBlock};
@@ -91,12 +91,13 @@ impl<E: EthSpec> Case for TransitionTest<E> {
                     .map_err(|e| format!("Failed to advance: {:?}", e))?;
 
                 // Apply block.
+                let mut ctxt = ConsensusContext::new(state.slot());
                 per_block_processing(
                     &mut state,
                     block,
-                    None,
                     BlockSignatureStrategy::VerifyBulk,
                     VerifyBlockRoot::True,
+                    &mut ctxt,
                     spec,
                 )
                 .map_err(|e| format!("Block processing failed: {:?}", e))?;


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/2371

## Proposed Changes

Backport some changes from `tree-states` that remove duplicated calculations of the `proposer_index`.

With this change the proposer index should be calculated only once for each block, and then plumbed through to every place it is required.

## Additional Info

In future I hope to add more data to the consensus context that is cached on a per-epoch basis, like the effective balances of validators and the base rewards.

There are some other changes to remove indexing in tests that were also useful for `tree-states` (the `tree-states` types don't implement `Index`).
