### PR TITLE
[Merged by Bors] - Use #!/usr/bin/env everywhere for local testnets 

### DIFF
--- a/scripts/local_testnet/clean.sh
+++ b/scripts/local_testnet/clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Deletes all files associated with the local testnet.

--- a/scripts/local_testnet/dump_logs.sh
+++ b/scripts/local_testnet/dump_logs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Print all the logs output from local testnet
 


### PR DESCRIPTION
Full local testnet support for people that don't have `/bin/bash`