### PR TITLE
Removed Redundant JSON Structures

### DIFF
--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -12,9 +12,7 @@ use beacon_chain::{
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
 };
 use execution_layer::{
-    json_structures::{JsonForkChoiceStateV1, JsonPayloadAttributesV1},
-    test_utils::ExecutionBlockGenerator,
-    ExecutionLayer, ForkChoiceState, PayloadAttributes,
+    test_utils::ExecutionBlockGenerator, ExecutionLayer, ForkChoiceState, PayloadAttributes,
 };
 use fork_choice::{
     CountUnrealized, Error as ForkChoiceError, InvalidationOperation, PayloadVerificationStatus,
@@ -126,14 +124,14 @@ impl InvalidPayloadRig {
         let params = json.get("params").expect("no params");
 
         let fork_choice_state_json = params.get(0).expect("no payload param");
-        let fork_choice_state: JsonForkChoiceStateV1 =
+        let fork_choice_state: ForkChoiceState =
             serde_json::from_value(fork_choice_state_json.clone()).unwrap();
 
         let payload_param_json = params.get(1).expect("no payload param");
-        let attributes: JsonPayloadAttributesV1 =
+        let attributes: PayloadAttributes =
             serde_json::from_value(payload_param_json.clone()).unwrap();
 
-        (fork_choice_state.into(), attributes.into())
+        (fork_choice_state, attributes)
     }
 
     fn previous_payload_attributes(&self) -> PayloadAttributes {

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -1,7 +1,6 @@
 use crate::engines::ForkChoiceState;
 pub use ethers_core::types::Transaction;
 use http::deposit_methods::RpcError;
-pub use json_structures::TransitionConfigurationV1;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use strum::IntoStaticStr;
@@ -72,7 +71,8 @@ impl From<builder_client::Error> for Error {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, IntoStaticStr)]
+#[derive(Clone, Copy, Debug, PartialEq, IntoStaticStr, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[strum(serialize_all = "snake_case")]
 pub enum PayloadStatusV1Status {
     Valid,
@@ -82,7 +82,8 @@ pub enum PayloadStatusV1Status {
     InvalidBlockHash,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PayloadStatusV1 {
     pub status: PayloadStatusV1Status,
     pub latest_valid_hash: Option<ExecutionBlockHash>,
@@ -140,8 +141,10 @@ pub struct ExecutionBlockWithTransactions<T: EthSpec> {
     pub transactions: Vec<Transaction>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PayloadAttributes {
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub timestamp: u64,
     pub prev_randao: Hash256,
     pub suggested_fee_recipient: Address,
@@ -151,6 +154,16 @@ pub struct PayloadAttributes {
 pub struct ForkchoiceUpdatedResponse {
     pub payload_status: PayloadStatusV1,
     pub payload_id: Option<PayloadId>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransitionConfigurationV1 {
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
+    pub terminal_total_difficulty: Uint256,
+    pub terminal_block_hash: ExecutionBlockHash,
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
+    pub terminal_block_number: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -1,6 +1,5 @@
 use super::*;
 use serde::{Deserialize, Serialize};
-use types::{EthSpec, ExecutionBlockHash, FixedVector, Transaction, Unsigned, VariableList};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -55,408 +54,36 @@ pub struct JsonPayloadIdResponse {
     pub payload_id: PayloadId,
 }
 
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
-pub struct JsonExecutionPayloadHeaderV1<T: EthSpec> {
-    pub parent_hash: ExecutionBlockHash,
-    pub fee_recipient: Address,
-    pub state_root: Hash256,
-    pub receipts_root: Hash256,
-    #[serde(with = "serde_logs_bloom")]
-    pub logs_bloom: FixedVector<u8, T::BytesPerLogsBloom>,
-    pub prev_randao: Hash256,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub block_number: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_limit: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_used: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub timestamp: u64,
-    #[serde(with = "ssz_types::serde_utils::hex_var_list")]
-    pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(with = "eth2_serde_utils::u256_hex_be")]
-    pub base_fee_per_gas: Uint256,
-    pub block_hash: ExecutionBlockHash,
-    pub transactions_root: Hash256,
-}
-
-impl<T: EthSpec> From<JsonExecutionPayloadHeaderV1<T>> for ExecutionPayloadHeader<T> {
-    fn from(e: JsonExecutionPayloadHeaderV1<T>) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonExecutionPayloadHeaderV1 {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions_root,
-        } = e;
-
-        Self {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions_root,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
-#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
-pub struct JsonExecutionPayloadV1<T: EthSpec> {
-    pub parent_hash: ExecutionBlockHash,
-    pub fee_recipient: Address,
-    pub state_root: Hash256,
-    pub receipts_root: Hash256,
-    #[serde(with = "serde_logs_bloom")]
-    pub logs_bloom: FixedVector<u8, T::BytesPerLogsBloom>,
-    pub prev_randao: Hash256,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub block_number: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_limit: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_used: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub timestamp: u64,
-    #[serde(with = "ssz_types::serde_utils::hex_var_list")]
-    pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(with = "eth2_serde_utils::u256_hex_be")]
-    pub base_fee_per_gas: Uint256,
-    pub block_hash: ExecutionBlockHash,
-    #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]
-    pub transactions:
-        VariableList<Transaction<T::MaxBytesPerTransaction>, T::MaxTransactionsPerPayload>,
-}
-
-impl<T: EthSpec> From<ExecutionPayload<T>> for JsonExecutionPayloadV1<T> {
-    fn from(e: ExecutionPayload<T>) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let ExecutionPayload {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions,
-        } = e;
-
-        Self {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions,
-        }
-    }
-}
-
-impl<T: EthSpec> From<JsonExecutionPayloadV1<T>> for ExecutionPayload<T> {
-    fn from(e: JsonExecutionPayloadV1<T>) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonExecutionPayloadV1 {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions,
-        } = e;
-
-        Self {
-            parent_hash,
-            fee_recipient,
-            state_root,
-            receipts_root,
-            logs_bloom,
-            prev_randao,
-            block_number,
-            gas_limit,
-            gas_used,
-            timestamp,
-            extra_data,
-            base_fee_per_gas,
-            block_hash,
-            transactions,
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct JsonPayloadAttributesV1 {
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub timestamp: u64,
-    pub prev_randao: Hash256,
-    pub suggested_fee_recipient: Address,
-}
-
-impl From<PayloadAttributes> for JsonPayloadAttributesV1 {
-    fn from(p: PayloadAttributes) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let PayloadAttributes {
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
-        } = p;
-
-        Self {
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
-        }
-    }
-}
-
-impl From<JsonPayloadAttributesV1> for PayloadAttributes {
-    fn from(j: JsonPayloadAttributesV1) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonPayloadAttributesV1 {
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
-        } = j;
-
-        Self {
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JsonForkChoiceStateV1 {
-    pub head_block_hash: ExecutionBlockHash,
-    pub safe_block_hash: ExecutionBlockHash,
-    pub finalized_block_hash: ExecutionBlockHash,
-}
-
-impl From<ForkChoiceState> for JsonForkChoiceStateV1 {
-    fn from(f: ForkChoiceState) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let ForkChoiceState {
-            head_block_hash,
-            safe_block_hash,
-            finalized_block_hash,
-        } = f;
-
-        Self {
-            head_block_hash,
-            safe_block_hash,
-            finalized_block_hash,
-        }
-    }
-}
-
-impl From<JsonForkChoiceStateV1> for ForkChoiceState {
-    fn from(j: JsonForkChoiceStateV1) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonForkChoiceStateV1 {
-            head_block_hash,
-            safe_block_hash,
-            finalized_block_hash,
-        } = j;
-
-        Self {
-            head_block_hash,
-            safe_block_hash,
-            finalized_block_hash,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum JsonPayloadStatusV1Status {
-    Valid,
-    Invalid,
-    Syncing,
-    Accepted,
-    InvalidBlockHash,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JsonPayloadStatusV1 {
-    pub status: JsonPayloadStatusV1Status,
-    pub latest_valid_hash: Option<ExecutionBlockHash>,
-    pub validation_error: Option<String>,
-}
-
-impl From<PayloadStatusV1Status> for JsonPayloadStatusV1Status {
-    fn from(e: PayloadStatusV1Status) -> Self {
-        match e {
-            PayloadStatusV1Status::Valid => JsonPayloadStatusV1Status::Valid,
-            PayloadStatusV1Status::Invalid => JsonPayloadStatusV1Status::Invalid,
-            PayloadStatusV1Status::Syncing => JsonPayloadStatusV1Status::Syncing,
-            PayloadStatusV1Status::Accepted => JsonPayloadStatusV1Status::Accepted,
-            PayloadStatusV1Status::InvalidBlockHash => JsonPayloadStatusV1Status::InvalidBlockHash,
-        }
-    }
-}
-impl From<JsonPayloadStatusV1Status> for PayloadStatusV1Status {
-    fn from(j: JsonPayloadStatusV1Status) -> Self {
-        match j {
-            JsonPayloadStatusV1Status::Valid => PayloadStatusV1Status::Valid,
-            JsonPayloadStatusV1Status::Invalid => PayloadStatusV1Status::Invalid,
-            JsonPayloadStatusV1Status::Syncing => PayloadStatusV1Status::Syncing,
-            JsonPayloadStatusV1Status::Accepted => PayloadStatusV1Status::Accepted,
-            JsonPayloadStatusV1Status::InvalidBlockHash => PayloadStatusV1Status::InvalidBlockHash,
-        }
-    }
-}
-
-impl From<PayloadStatusV1> for JsonPayloadStatusV1 {
-    fn from(p: PayloadStatusV1) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let PayloadStatusV1 {
-            status,
-            latest_valid_hash,
-            validation_error,
-        } = p;
-
-        Self {
-            status: status.into(),
-            latest_valid_hash,
-            validation_error,
-        }
-    }
-}
-
-impl From<JsonPayloadStatusV1> for PayloadStatusV1 {
-    fn from(j: JsonPayloadStatusV1) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonPayloadStatusV1 {
-            status,
-            latest_valid_hash,
-            validation_error,
-        } = j;
-
-        Self {
-            status: status.into(),
-            latest_valid_hash,
-            validation_error,
-        }
-    }
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct JsonForkchoiceUpdatedV1Response {
-    pub payload_status: JsonPayloadStatusV1,
+pub struct JsonForkchoiceUpdatedResponse {
+    pub payload_status: PayloadStatusV1,
     pub payload_id: Option<TransparentJsonPayloadId>,
 }
 
-impl From<JsonForkchoiceUpdatedV1Response> for ForkchoiceUpdatedResponse {
-    fn from(j: JsonForkchoiceUpdatedV1Response) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonForkchoiceUpdatedV1Response {
+impl From<JsonForkchoiceUpdatedResponse> for ForkchoiceUpdatedResponse {
+    fn from(j: JsonForkchoiceUpdatedResponse) -> Self {
+        let JsonForkchoiceUpdatedResponse {
             payload_status: status,
             payload_id,
         } = j;
 
         Self {
-            payload_status: status.into(),
+            payload_status: status,
             payload_id: payload_id.map(Into::into),
         }
     }
 }
-impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedV1Response {
+impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedResponse {
     fn from(f: ForkchoiceUpdatedResponse) -> Self {
-        // Use this verbose deconstruction pattern to ensure no field is left unused.
         let ForkchoiceUpdatedResponse {
             payload_status: status,
             payload_id,
         } = f;
 
         Self {
-            payload_status: status.into(),
+            payload_status: status,
             payload_id: payload_id.map(Into::into),
         }
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransitionConfigurationV1 {
-    #[serde(with = "eth2_serde_utils::u256_hex_be")]
-    pub terminal_total_difficulty: Uint256,
-    pub terminal_block_hash: ExecutionBlockHash,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub terminal_block_number: u64,
-}
-
-/// Serializes the `logs_bloom` field of an `ExecutionPayload`.
-pub mod serde_logs_bloom {
-    use super::*;
-    use eth2_serde_utils::hex::PrefixedHexVisitor;
-    use serde::{Deserializer, Serializer};
-
-    pub fn serialize<S, U>(bytes: &FixedVector<u8, U>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        U: Unsigned,
-    {
-        let mut hex_string: String = "0x".to_string();
-        hex_string.push_str(&hex::encode(&bytes[..]));
-
-        serializer.serialize_str(&hex_string)
-    }
-
-    pub fn deserialize<'de, D, U>(deserializer: D) -> Result<FixedVector<u8, U>, D::Error>
-    where
-        D: Deserializer<'de>,
-        U: Unsigned,
-    {
-        let vec = deserializer.deserialize_string(PrefixedHexVisitor)?;
-
-        FixedVector::new(vec)
-            .map_err(|e| serde::de::Error::custom(format!("invalid logs bloom: {:?}", e)))
     }
 }

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -5,6 +5,7 @@ use crate::engine_api::{
 };
 use crate::HttpJsonRpc;
 use lru::LruCache;
+use serde::{Deserialize, Serialize};
 use slog::{debug, error, info, Logger};
 use std::future::Future;
 use std::sync::Arc;
@@ -87,7 +88,8 @@ impl State {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ForkChoiceState {
     pub head_block_hash: ExecutionBlockHash,
     pub safe_block_hash: ExecutionBlockHash,

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -1,10 +1,8 @@
 use crate::engines::ForkChoiceState;
 use crate::{
     engine_api::{
-        json_structures::{
-            JsonForkchoiceUpdatedV1Response, JsonPayloadStatusV1, JsonPayloadStatusV1Status,
-        },
-        ExecutionBlock, PayloadAttributes, PayloadId, PayloadStatusV1, PayloadStatusV1Status,
+        ExecutionBlock, ForkchoiceUpdatedResponse, PayloadAttributes, PayloadId, PayloadStatusV1,
+        PayloadStatusV1Status,
     },
     ExecutionBlockWithTransactions,
 };
@@ -327,7 +325,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
         &mut self,
         forkchoice_state: ForkChoiceState,
         payload_attributes: Option<PayloadAttributes>,
-    ) -> Result<JsonForkchoiceUpdatedV1Response, String> {
+    ) -> Result<ForkchoiceUpdatedResponse, String> {
         if let Some(payload) = self
             .pending_payloads
             .remove(&forkchoice_state.head_block_hash)
@@ -346,9 +344,9 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
                 .contains_key(&forkchoice_state.finalized_block_hash);
 
         if unknown_head_block_hash || unknown_safe_block_hash || unknown_finalized_block_hash {
-            return Ok(JsonForkchoiceUpdatedV1Response {
-                payload_status: JsonPayloadStatusV1 {
-                    status: JsonPayloadStatusV1Status::Syncing,
+            return Ok(ForkchoiceUpdatedResponse {
+                payload_status: PayloadStatusV1 {
+                    status: PayloadStatusV1Status::Syncing,
                     latest_valid_hash: None,
                     validation_error: None,
                 },
@@ -405,9 +403,9 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
             }
         };
 
-        Ok(JsonForkchoiceUpdatedV1Response {
-            payload_status: JsonPayloadStatusV1 {
-                status: JsonPayloadStatusV1Status::Valid,
+        Ok(ForkchoiceUpdatedResponse {
+            payload_status: PayloadStatusV1 {
+                status: PayloadStatusV1Status::Valid,
                 latest_valid_hash: Some(forkchoice_state.head_block_hash),
                 validation_error: None,
             },

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -90,18 +90,14 @@ pub async fn handle_rpc<T: EthSpec>(
                 };
 
             let dynamic_response = if should_import {
-                Some(
-                    ctx.execution_block_generator
-                        .write()
-                        .new_payload(request.into()),
-                )
+                Some(ctx.execution_block_generator.write().new_payload(request))
             } else {
                 None
             };
 
             let response = static_response.or(dynamic_response).unwrap();
 
-            Ok(serde_json::to_value(PayloadStatusV1::from(response)).unwrap())
+            Ok(serde_json::to_value(response).unwrap())
         }
         ENGINE_GET_PAYLOAD_V1 => {
             let request: JsonPayloadIdRequest = get_param(params, 0)?;
@@ -131,7 +127,7 @@ pub async fn handle_rpc<T: EthSpec>(
                     status.latest_valid_hash = Some(head_block_hash)
                 }
 
-                response.payload_status = status.into();
+                response.payload_status = status;
             }
 
             Ok(serde_json::to_value(JsonForkchoiceUpdatedResponse::from(response)).unwrap())

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -17,26 +17,26 @@ pub type Transactions<T> = VariableList<
     Default, Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Derivative,
 )]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
-#[serde(bound = "T: EthSpec")]
+#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
 pub struct ExecutionPayload<T: EthSpec> {
     pub parent_hash: ExecutionBlockHash,
     pub fee_recipient: Address,
     pub state_root: Hash256,
     pub receipts_root: Hash256,
-    #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
+    #[serde(with = "serde_logs_bloom")]
     pub logs_bloom: FixedVector<u8, T::BytesPerLogsBloom>,
     pub prev_randao: Hash256,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub block_number: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub gas_limit: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub gas_used: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(with = "eth2_serde_utils::quoted_u256")]
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: ExecutionBlockHash,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]
@@ -57,5 +57,34 @@ impl<T: EthSpec> ExecutionPayload<T> {
             + (T::max_extra_data_bytes() * <u8 as Encode>::ssz_fixed_len())
             // Max size of variable length `transactions` field
             + (T::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + T::max_bytes_per_transaction()))
+    }
+}
+
+/// Serializes the `logs_bloom` field of an `ExecutionPayload`.
+pub mod serde_logs_bloom {
+    use super::*;
+    use eth2_serde_utils::hex::PrefixedHexVisitor;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S, U>(bytes: &FixedVector<u8, U>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        U: Unsigned,
+    {
+        let mut hex_string: String = "0x".to_string();
+        hex_string.push_str(&hex::encode(&bytes[..]));
+
+        serializer.serialize_str(&hex_string)
+    }
+
+    pub fn deserialize<'de, D, U>(deserializer: D) -> Result<FixedVector<u8, U>, D::Error>
+    where
+        D: Deserializer<'de>,
+        U: Unsigned,
+    {
+        let vec = deserializer.deserialize_string(PrefixedHexVisitor)?;
+
+        FixedVector::new(vec)
+            .map_err(|e| serde::de::Error::custom(format!("invalid logs bloom: {:?}", e)))
     }
 }

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -1,5 +1,6 @@
 use crate::{test_utils::TestRandom, *};
 use derivative::Derivative;
+use execution_payload::serde_logs_bloom;
 use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
@@ -11,25 +12,26 @@ use tree_hash_derive::TreeHash;
     Default, Debug, Clone, Serialize, Deserialize, Derivative, Encode, Decode, TreeHash, TestRandom,
 )]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
+#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
 pub struct ExecutionPayloadHeader<T: EthSpec> {
     pub parent_hash: ExecutionBlockHash,
     pub fee_recipient: Address,
     pub state_root: Hash256,
     pub receipts_root: Hash256,
-    #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
+    #[serde(with = "serde_logs_bloom")]
     pub logs_bloom: FixedVector<u8, T::BytesPerLogsBloom>,
     pub prev_randao: Hash256,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub block_number: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub gas_limit: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub gas_used: u64,
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub timestamp: u64,
     #[serde(with = "ssz_types::serde_utils::hex_var_list")]
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(with = "eth2_serde_utils::quoted_u256")]
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub base_fee_per_gas: Uint256,
     pub block_hash: ExecutionBlockHash,
     pub transactions_root: Hash256,


### PR DESCRIPTION
When I originally wrote a lot of this `engine_api` code, I thought it would be best to create separate JSON structures for objects [defined in the engine api](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md). The `engine_api` objects are versioned (e.g. [`ExecutionPayloadV1`](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#executionpayloadv1)) but often correspond to spec objects (e.g. [`ExecutionPayload`](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#executionpayload)) so I thought having separate versioned JSON structures would be cleaner for future API changes.

However, the [proposed changes for `Capella`](https://github.com/ethereum/execution-apis/pull/195) have the `engine_api` object versions corresponding directly to the fork variants of the spec objects. So for now it is significantly cleaner and reduces a lot of duplicated code to just remove the separate `Json*` objects and use the underlying spec objects directly.

The only `Json*` object I didn't get rid of was:
```rust
#[derive(Debug, PartialEq, Serialize, Deserialize)]
#[serde(rename_all = "camelCase")]
pub struct JsonForkchoiceUpdatedResponse {
    pub payload_status: PayloadStatusV1,
    pub payload_id: Option<TransparentJsonPayloadId>,
}
```
because the `PayloadId` requires a custom serializer but concisely applying a custom serializer to `T` in an `Option<T>` has been an open issue in serde for 5 years
* https://github.com/serde-rs/serde/issues/723

and just having a separate object solves it nicely.