### PR TITLE
[Merged by Bors] - Register blocks in validator monitor

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -109,6 +109,11 @@ impl EpochSummary {
         }
     }
 
+    pub fn register_block(&mut self, delay: Duration) {
+        self.blocks += 1;
+        Self::update_if_lt(&mut self.block_min_delay, delay);
+    }
+
     pub fn register_unaggregated_attestation(&mut self, delay: Duration) {
         self.attestations += 1;
         Self::update_if_lt(&mut self.attestation_min_delay, delay);
@@ -625,13 +630,6 @@ impl<T: EthSpec> ValidatorMonitor<T> {
         Ok(())
     }
 
-    fn get_validator_id(&self, validator_index: u64) -> Option<&str> {
-        self.indices
-            .get(&validator_index)
-            .and_then(|pubkey| self.validators.get(pubkey))
-            .map(|validator| validator.id.as_str())
-    }
-
     fn get_validator(&self, validator_index: u64) -> Option<&MonitoredValidator> {
         self.indices
             .get(&validator_index)
@@ -697,7 +695,9 @@ impl<T: EthSpec> ValidatorMonitor<T> {
         block_root: Hash256,
         slot_clock: &S,
     ) {
-        if let Some(id) = self.get_validator_id(block.proposer_index()) {
+        let epoch = block.slot().epoch(T::slots_per_epoch());
+        if let Some(validator) = self.get_validator(block.proposer_index()) {
+            let id = &validator.id;
             let delay = get_block_delay_ms(seen_timestamp, block, slot_clock);
 
             metrics::inc_counter_vec(&metrics::VALIDATOR_MONITOR_BEACON_BLOCK_TOTAL, &[src, id]);
@@ -716,6 +716,10 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 "src" => src,
                 "validator" => %id,
             );
+
+            validator.with_epoch_summary(epoch, |summary| {
+                summary.register_aggregated_attestation(delay)
+            });
         }
     }
 

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1,4 +1,4 @@
-/! Provides detailed logging and metrics for a set of registered validators.
+//! Provides detailed logging and metrics for a set of registered validators.
 //!
 //! This component should not affect consensus.
 
@@ -717,9 +717,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 "validator" => %id,
             );
 
-            validator.with_epoch_summary(epoch, |summary| {
-                summary.register_block(delay)
-            });
+            validator.with_epoch_summary(epoch, |summary| summary.register_block(delay));
         }
     }
 

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -717,7 +717,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 "validator" => %id,
             );
 
-            validator.with_epoch_summary(epoch, |epoch_summary| epoch_summary.register_block(delay));
+            validator.with_epoch_summary(epoch, |summary| summary.register_block(delay));
         }
     }
 

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1,4 +1,4 @@
-//! Provides detailed logging and metrics for a set of registered validators.
+/! Provides detailed logging and metrics for a set of registered validators.
 //!
 //! This component should not affect consensus.
 
@@ -718,7 +718,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
             );
 
             validator.with_epoch_summary(epoch, |summary| {
-                summary.register_aggregated_attestation(delay)
+                summary.register_block(delay)
             });
         }
     }

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -717,7 +717,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 "validator" => %id,
             );
 
-            validator.with_epoch_summary(epoch, |summary| summary.register_block(delay));
+            validator.with_epoch_summary(epoch, |epoch_summary| epoch_summary.register_block(delay));
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

Closes #3460

## Proposed Changes

`blocks` and `block_min_delay` are never updated in the epoch summary

