### PR TITLE
[Merged by Bors] - bors: require slasher and syncing sim tests

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -20,7 +20,9 @@ status = [
     "doppelganger-protection-test",
     "execution-engine-integration-ubuntu",
     "cargo-vendor",
-    "check-msrv"
+    "check-msrv",
+    "slasher-tests",
+    "syncing-simulator-ubuntu"
 ]
 use_squash_merge = true
 timeout_sec = 10800

--- a/bors.toml
+++ b/bors.toml
@@ -22,7 +22,8 @@ status = [
     "cargo-vendor",
     "check-msrv",
     "slasher-tests",
-    "syncing-simulator-ubuntu"
+    "syncing-simulator-ubuntu",
+    "disallowed-from-async-lint"
 ]
 use_squash_merge = true
 timeout_sec = 10800


### PR DESCRIPTION
## Issue Addressed
I noticed that [this build](https://github.com/sigp/lighthouse/actions/runs/3269950873/jobs/5378036501) wasn't marked failed by Bors when the `syncing-simulator-ubuntu` job failed. This is because that job is absent from the `bors.toml` config.

## Proposed Changes

Add missing jobs to Bors config so that they are required:

- `syncing-simulator-ubuntu`
- `slasher-tests`
- `disallowed-from-async-lint`

The `disallowed-from-async-lint` was previously allowed to fail because it was considered beta, but I think it's stable enough now we may as well require it.
