### PR TITLE
Add engine_getPayloadV2

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -123,6 +123,14 @@ impl<T: EthSpec> From<JsonExecutionPayloadHeaderV1<T>> for ExecutionPayloadHeade
 
 #[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 #[serde(bound = "T: EthSpec", rename_all = "camelCase")]
+pub struct JsonExecutionPayloadV2<T: EthSpec> {
+    pub execution_payload_v1: JsonExecutionPayloadV1<T>,
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
+    pub block_value: Uint256,
+}
+
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
+#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
 pub struct JsonExecutionPayloadV1<T: EthSpec> {
     pub parent_hash: ExecutionBlockHash,
     pub fee_recipient: Address,


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/execution-apis/pull/314

## Proposed Changes

Add an `engine_getPayloadV2` method that returns the block value along with the payload. Compare the block value with the bid received from the builder and pick the local execution block if it's of equal or higher value.

## Additional Info

This PR assumes that the v2 method is available and queries the endpoint and falls back to the v1 method if the v2 method returns an error. Not certain how we should handle EL's not having the v2 method once it's rolled out in all ELs.
cc @realbigsean @paulhauner 