### PR TITLE
[Merged by Bors] - Ban and unban peers at the swarm level

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1342,10 +1342,12 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                 Some(NetworkEvent::PeerDisconnected(peer_id))
             }
             PeerManagerEvent::Banned(peer_id, associated_ips) => {
+                self.swarm.ban_peer_id(peer_id);
                 self.discovery_mut().ban_peer(&peer_id, associated_ips);
                 Some(NetworkEvent::PeerBanned(peer_id))
             }
             PeerManagerEvent::UnBanned(peer_id, associated_ips) => {
+                self.swarm.unban_peer_id(peer_id);
                 self.discovery_mut().unban_peer(&peer_id, associated_ips);
                 Some(NetworkEvent::PeerUnbanned(peer_id))
             }


### PR DESCRIPTION
## Issue Addressed

I missed this from https://github.com/sigp/lighthouse/pull/3491. peers were being banned at the behaviour level only. The identify errors are explained by this as well

## Proposed Changes

Add banning and unbanning 

## Additional Info

Befor,e having tests that catch this was hard because the swarm was outside the behaviour. We could now have tests that prevent something like this in the future
