### PR TITLE
Allow random `VariableList` lengths in `TestRandom` implementation

### DIFF
--- a/consensus/types/src/test_utils/test_random.rs
+++ b/consensus/types/src/test_utils/test_random.rs
@@ -108,7 +108,7 @@ where
         let mut output = vec![];
 
         if N::to_usize() != 0 {
-            for _ in 0..(usize::random_for_test(rng) % std::cmp::min(4, N::to_usize())) {
+            for _ in 0..(usize::random_for_test(rng) % N::to_usize()) {
                 output.push(<T>::random_for_test(rng));
             }
         }


### PR DESCRIPTION
## Issue Addressed

I stumbled upon this when creating random sized blobs today. The existing `TestRandom` implementation for `VariableList` caps the size at `usize::random_for_test(rng) % std::cmp::min(4, N::to_usize())` where N is max the length of the variable list. Since N is usually > 4, this means the max size of a randomly generated list is usually from 0 to 3. 

## Proposed Changes

I updated the max length to `usize::random_for_test(rng) % N::to_usize()` so the length can be anything from 0 to N - 1. I'm actually not sure what the intention of the original implementation was, so it's possible it was intentionally bounding the size, or that we always want the length divisible by four or something, but I'm not sure.
