### PR TITLE
Fix compilation error on eip4844 branch

### DIFF
--- a/consensus/state_processing/src/upgrade/eip4844.rs
+++ b/consensus/state_processing/src/upgrade/eip4844.rs
@@ -14,7 +14,7 @@ pub fn upgrade_to_eip4844<E: EthSpec>(
     let previous_fork_version = if cfg!(feature ="withdrawals") {
         pre.fork.current_version
     } else {
-        spec.bellatrix_fork_epoch
+        spec.bellatrix_fork_version
     };
 
     // Where possible, use something like `mem::take` to move fields from behind the &mut


### PR DESCRIPTION
## Issue Addressed

Fix incorrect return value causing compilation to fail.

Note: I also had to upgrade my local rustc to 1.65 to get rid of the [GAT](https://blog.rust-lang.org/2022/10/28/gats-stabilization.html) errors. @michaelsproul confirmed the plan is to upgrade Minimum Supported Rust Version (MSRV) to 1.65 soon.
