### PR TITLE
[Merged by Bors] - CI gardening maintenance

### DIFF
--- a/.github/workflows/docker-antithesis.yml
+++ b/.github/workflows/docker-antithesis.yml
@@ -17,7 +17,7 @@ jobs:
     build-docker:
         runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Update Rust
               run: rustup update stable
             - name: Dockerhub login

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
     # `unstable`, but for now we keep the two parts of the version separate for backwards
     # compatibility.
     extract-version:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         steps:
             - name: Extract version (if stable)
               if: github.event.ref == 'refs/heads/stable'
@@ -44,7 +44,7 @@ jobs:
             VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
     build-docker-single-arch:
         name: build-docker-${{ matrix.binary }}
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 binary: [aarch64,
@@ -61,7 +61,7 @@ jobs:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Update Rust
               run: rustup update stable
             - name: Dockerhub login
@@ -102,7 +102,7 @@ jobs:
                       --push
     build-docker-multiarch:
         name: build-docker-multiarch${{ matrix.modernity }}
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         needs: [build-docker-single-arch, extract-version]
         strategy:
             matrix:
@@ -123,13 +123,13 @@ jobs:
                       --amend ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX}${{ matrix.modernity }};
                   docker manifest push ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}${{ matrix.modernity }}
     build-docker-lcli:
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-22.04
         needs: [extract-version]
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Create docker network
         run: docker network create book

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-18.04
-          - macos-latest
+          - ubuntu-22.04
+          - macos-12
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -16,7 +16,7 @@ jobs:
           - macos-12
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - name: Get latest version of stable Rust
         run: rustup update stable
@@ -28,7 +28,7 @@ jobs:
         run: npm install ganache@latest --global
 
       # https://github.com/actions/cache/blob/main/examples.md#rust---cargo
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: cache-cargo
         with:
           path: |

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -30,7 +30,7 @@ jobs:
         env:
             TAG: ${{ needs.extract-tag.outputs.TAG }}
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Update Rust
               run: rustup update stable
             - name: Cargo login

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -19,7 +19,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Extract tag
-              run: echo "::set-output name=TAG::$(echo ${GITHUB_REF#refs/tags/})"
+              run: echo "TAG=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
               id: extract_tag
         outputs:
             TAG: ${{ steps.extract_tag.outputs.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Extract version
-              run: echo "::set-output name=VERSION::$(echo ${GITHUB_REF#refs/tags/})"
+              run: echo "VERSION=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
               id: extract_version
         outputs:
             VERSION: ${{ steps.extract_version.outputs.VERSION }}
@@ -216,7 +216,7 @@ jobs:
 
             - name: Generate Full Changelog
               id: changelog
-              run: echo "::set-output name=CHANGELOG::$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})"
+              run: echo "CHANGELOG=$(git log --pretty=format:"- %s" $(git describe --tags --abbrev=0 ${{ env.VERSION }}^)..${{ env.VERSION }})" >> $GITHUB_OUTPUT
 
             - name: Create Release Draft
               env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         needs: extract-version
         steps:
             - name: Checkout sources
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
             - name: Build toolchain
               uses: actions-rs/toolchain@v1
               with:
@@ -199,7 +199,7 @@ jobs:
         steps:
             # This is necessary for generating the changelog. It has to come before "Download Artifacts" or else it deletes the artifacts.
             - name: Checkout sources
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,6 +52,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run tests in release
@@ -94,6 +96,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run beacon_chain tests for all known forks
       run: make test-beacon-chain
   op-pool-tests:
@@ -106,6 +110,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run operation_pool tests for all known forks
       run: make test-op-pool
   slasher-tests:
@@ -128,6 +134,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run tests in debug
@@ -142,6 +150,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run state_transition_vectors in release.
       run: make run-state-transition-tests
   ef-tests-ubuntu:
@@ -154,6 +164,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run consensus-spec-tests with blst, milagro and fake_crypto
       run: make test-ef
   dockerfile-ubuntu:
@@ -178,6 +190,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run the beacon chain sim that starts from an eth1 contract
@@ -192,6 +206,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run the beacon chain sim and go through the merge transition
@@ -206,6 +222,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run the beacon chain sim without an eth1 connection
@@ -220,6 +238,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Run the syncing simulator
@@ -234,6 +254,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install ganache
       run: sudo npm install -g ganache
     - name: Install lighthouse and lcli
@@ -264,6 +286,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run exec engine integration tests in release
       run: make test-exec-engine
   check-benchmarks:
@@ -276,6 +300,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Typecheck benchmark code without running it
       run: make check-benches
   check-consensus:
@@ -298,6 +324,8 @@ jobs:
       run: rustup update stable
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Lint code for quality and style with Clippy
       run: make lint
     - name: Certify Cargo.lock freshness
@@ -319,6 +347,8 @@ jobs:
         cargo build --release --bin cargo-clippy --bin clippy-driver -Zunstable-options --out-dir $(rustc --print=sysroot)/bin
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run Clippy with the disallowed-from-async lint
       run: make nightly-lint
   check-msrv:
@@ -331,6 +361,8 @@ jobs:
       run: rustup override set ${{ needs.extract-msrv.outputs.MSRV }}
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run cargo check
       run: cargo check --workspace
   arbitrary-check:
@@ -373,6 +405,8 @@ jobs:
     # https://github.com/est31/cargo-udeps/issues/135
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo-udeps
       run: cargo install cargo-udeps --locked --force --version 0.1.30
     - name: Create Cargo config dir

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -24,7 +24,7 @@ jobs:
   extract-msrv:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Extract Minimum Supported Rust Version (MSRV)
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
@@ -37,7 +37,7 @@ jobs:
     name: cargo-fmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Check formatting with cargo fmt
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -63,7 +63,7 @@ jobs:
     runs-on: windows-2019
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Use Node.js
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Run slasher tests for all supported backends
@@ -129,7 +129,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Build the root Dockerfile
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -217,7 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -233,7 +233,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -249,7 +249,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
         go-version: '1.17'
@@ -295,7 +295,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -309,7 +309,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Typecheck consensus code in strict mode
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc
@@ -336,7 +336,7 @@ jobs:
     needs: cargo-fmt
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Install SigP Clippy fork
       run: |
         cd ..
@@ -356,7 +356,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [cargo-fmt, extract-msrv]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Install Rust @ MSRV (${{ needs.extract-msrv.outputs.MSRV }})
       run: rustup override set ${{ needs.extract-msrv.outputs.MSRV }}
     - name: Install Protoc
@@ -370,7 +370,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Validate state_processing feature arbitrary-fuzz
@@ -380,7 +380,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
@@ -390,7 +390,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
       run:  CARGO_HOME=$(readlink -f $HOME) make vendor
   cargo-udeps:
@@ -398,7 +398,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: cargo-fmt
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Install Rust (${{ env.PINNED_NIGHTLY }})
       run: rustup toolchain install $PINNED_NIGHTLY
     # NOTE: cargo-udeps version is pinned until this issue is resolved:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -276,10 +276,10 @@ jobs:
     needs: cargo-fmt
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.17'
-    - uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v3
       with:
         dotnet-version: '6.0.201'
     - name: Get latest version of stable Rust

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,7 +29,7 @@ jobs:
       run: |
         metadata=$(cargo metadata --no-deps --format-version 1)
         msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "lighthouse")) | .[0].rust_version')
-        echo "::set-output name=MSRV::$msrv"
+        echo "MSRV=$msrv" >> $GITHUB_OUTPUT
       id: extract_msrv
     outputs:
       MSRV: ${{ steps.extract_msrv.outputs.MSRV }}


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/3656

## Proposed Changes

* Replace `set-output` by `$GITHUB_OUTPUT` usage
* Avoid rate-limits when installing `protoc` by making authenticated requests (continuation of https://github.com/sigp/lighthouse/pull/3621)
* Upgrade all Ubuntu 18.04 usage to 22.04 (18.04 is end of life)
* Upgrade macOS-latest to explicit macOS-12 to silence warning
* Use `actions/checkout@v3` and `actions/cache@v3` to avoid deprecated NodeJS v12

## Additional Info

Can't silence the NodeJS warnings entirely due to https://github.com/sigp/lighthouse/issues/3705. Can fix that in future.
