### PR TITLE
[Merged by Bors] - compile with beta compiler on CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -384,3 +384,14 @@ jobs:
     env:
       # Allow warnings on Nightly
       RUSTFLAGS: ""
+  compile-with-beta-compiler:
+    name: compile-with-beta-compiler
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang protobuf-compiler
+    - name: Use Rust beta
+      run: rustup override set beta
+    - name: Run make
+      run: make

--- a/bors.toml
+++ b/bors.toml
@@ -23,7 +23,7 @@ status = [
     "check-msrv",
     "slasher-tests",
     "syncing-simulator-ubuntu",
-    "disallowed-from-async-lint"
+    "disallowed-from-async-lint",
     "compile-with-beta-compiler"
 ]
 use_squash_merge = true

--- a/bors.toml
+++ b/bors.toml
@@ -24,6 +24,7 @@ status = [
     "slasher-tests",
     "syncing-simulator-ubuntu",
     "disallowed-from-async-lint"
+    "compile-with-beta-compiler"
 ]
 use_squash_merge = true
 timeout_sec = 10800


### PR DESCRIPTION
## Issue Addressed

Closes #3709 

## Proposed Changes

Add the job `compile-with-beta-compiler` to `test-suite`. This job has the following steps:

1. Use `actions/checkout@v3`. (Needed to run make in a later step.)
2. Install the dependencies listed in [build from source guide](https://lighthouse-book.sigmaprime.io/installation-source.html).
3. Change the compiler to the current beta version with `rustup override`.
4. Run `make`.