### PR TITLE
Light client rpc 

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -47,8 +47,6 @@ pub struct ChainConfig {
     pub count_unrealized_full: CountUnrealizedFull,
     /// Optionally set timeout for calls to checkpoint sync endpoint.
     pub checkpoint_sync_url_timeout: u64,
-    /// Whether to enable the light client server protocol.
-    pub enable_light_client_server: bool,
 }
 
 impl Default for ChainConfig {
@@ -70,7 +68,6 @@ impl Default for ChainConfig {
             paranoid_block_proposal: false,
             count_unrealized_full: CountUnrealizedFull::default(),
             checkpoint_sync_url_timeout: 60,
-            enable_light_client_server: false,
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -130,6 +130,9 @@ pub struct Config {
 
     /// Whether metrics are enabled.
     pub metrics_enabled: bool,
+
+    /// Whether light client protocols should be enabled.
+    pub enable_light_client_server: bool,
 }
 
 impl Default for Config {
@@ -207,6 +210,7 @@ impl Default for Config {
             shutdown_after_sync: false,
             topics: Vec::new(),
             metrics_enabled: false,
+            enable_light_client_server: false,
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -501,6 +501,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     Protocol::Ping => PeerAction::MidToleranceError,
                     Protocol::BlocksByRange => PeerAction::MidToleranceError,
                     Protocol::BlocksByRoot => PeerAction::MidToleranceError,
+                    Protocol::LightClientBootstrap => PeerAction::LowToleranceError,
                     Protocol::Goodbye => PeerAction::LowToleranceError,
                     Protocol::MetaData => PeerAction::LowToleranceError,
                     Protocol::Status => PeerAction::LowToleranceError,
@@ -517,6 +518,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     Protocol::BlocksByRange => return,
                     Protocol::BlocksByRoot => return,
                     Protocol::Goodbye => return,
+                    Protocol::LightClientBootstrap => return,
                     Protocol::MetaData => PeerAction::LowToleranceError,
                     Protocol::Status => PeerAction::LowToleranceError,
                 }
@@ -531,6 +533,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     Protocol::Ping => PeerAction::LowToleranceError,
                     Protocol::BlocksByRange => PeerAction::MidToleranceError,
                     Protocol::BlocksByRoot => PeerAction::MidToleranceError,
+                    Protocol::LightClientBootstrap => return,
                     Protocol::Goodbye => return,
                     Protocol::MetaData => return,
                     Protocol::Status => return,

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -9,15 +9,15 @@ use snap::read::FrameDecoder;
 use snap::write::FrameEncoder;
 use ssz::{Decode, Encode};
 use ssz_types::VariableList;
-use std::{io::Cursor};
+use std::io::Cursor;
 use std::io::ErrorKind;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use tokio_util::codec::{Decoder, Encoder};
 use types::{
-    EthSpec, ForkContext, ForkName, SignedBeaconBlock, SignedBeaconBlockAltair,
-    SignedBeaconBlockBase, SignedBeaconBlockMerge, Hash256, light_client_bootstrap::LightClientBootstrap,
+    light_client_bootstrap::LightClientBootstrap, EthSpec, ForkContext, ForkName, Hash256,
+    SignedBeaconBlock, SignedBeaconBlockAltair, SignedBeaconBlockBase, SignedBeaconBlockMerge,
 };
 use unsigned_varint::codec::Uvi;
 
@@ -474,9 +474,11 @@ fn handle_v1_request<T: EthSpec>(
         Protocol::Ping => Ok(Some(InboundRequest::Ping(Ping {
             data: u64::from_ssz_bytes(decoded_buffer)?,
         }))),
-        Protocol::LightClientBootstrap => Ok(Some(InboundRequest::LightClientBootstrap(LightClientBootstrapRequest{
-            root: Hash256::from_ssz_bytes(decoded_buffer)?,
-        }))),
+        Protocol::LightClientBootstrap => Ok(Some(InboundRequest::LightClientBootstrap(
+            LightClientBootstrapRequest {
+                root: Hash256::from_ssz_bytes(decoded_buffer)?,
+            },
+        ))),
         // MetaData requests return early from InboundUpgrade and do not reach the decoder.
         // Handle this case just for completeness.
         Protocol::MetaData => {
@@ -549,8 +551,8 @@ fn handle_v1_response<T: EthSpec>(
             MetaDataV1::from_ssz_bytes(decoded_buffer)?,
         )))),
         Protocol::LightClientBootstrap => Ok(Some(RPCResponse::LightClientBootstrap(
-            LightClientBootstrap::from_ssz_bytes(decoded_buffer)?
-        )))
+            LightClientBootstrap::from_ssz_bytes(decoded_buffer)?,
+        ))),
     }
 }
 

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -9,7 +9,7 @@ use snap::read::FrameDecoder;
 use snap::write::FrameEncoder;
 use ssz::{Decode, Encode};
 use ssz_types::VariableList;
-use std::io::Cursor;
+use std::{io::Cursor};
 use std::io::ErrorKind;
 use std::io::{Read, Write};
 use std::marker::PhantomData;
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tokio_util::codec::{Decoder, Encoder};
 use types::{
     EthSpec, ForkContext, ForkName, SignedBeaconBlock, SignedBeaconBlockAltair,
-    SignedBeaconBlockBase, SignedBeaconBlockMerge,
+    SignedBeaconBlockBase, SignedBeaconBlockMerge, Hash256, light_client_bootstrap::LightClientBootstrap,
 };
 use unsigned_varint::codec::Uvi;
 
@@ -70,6 +70,7 @@ impl<TSpec: EthSpec> Encoder<RPCCodedResponse<TSpec>> for SSZSnappyInboundCodec<
                 RPCResponse::Status(res) => res.as_ssz_bytes(),
                 RPCResponse::BlocksByRange(res) => res.as_ssz_bytes(),
                 RPCResponse::BlocksByRoot(res) => res.as_ssz_bytes(),
+                RPCResponse::LightClientBootstrap(res) => res.as_ssz_bytes(),
                 RPCResponse::Pong(res) => res.data.as_ssz_bytes(),
                 RPCResponse::MetaData(res) =>
                 // Encode the correct version of the MetaData response based on the negotiated version.
@@ -230,6 +231,7 @@ impl<TSpec: EthSpec> Encoder<OutboundRequest<TSpec>> for SSZSnappyOutboundCodec<
             OutboundRequest::BlocksByRoot(req) => req.block_roots.as_ssz_bytes(),
             OutboundRequest::Ping(req) => req.as_ssz_bytes(),
             OutboundRequest::MetaData(_) => return Ok(()), // no metadata to encode
+            OutboundRequest::LightClientBootstrap(req) => req.as_ssz_bytes(),
         };
         // SSZ encoded bytes should be within `max_packet_size`
         if bytes.len() > self.max_packet_size {
@@ -472,7 +474,9 @@ fn handle_v1_request<T: EthSpec>(
         Protocol::Ping => Ok(Some(InboundRequest::Ping(Ping {
             data: u64::from_ssz_bytes(decoded_buffer)?,
         }))),
-
+        Protocol::LightClientBootstrap => Ok(Some(InboundRequest::LightClientBootstrap(LightClientBootstrapRequest{
+            root: Hash256::from_ssz_bytes(decoded_buffer)?,
+        }))),
         // MetaData requests return early from InboundUpgrade and do not reach the decoder.
         // Handle this case just for completeness.
         Protocol::MetaData => {
@@ -544,6 +548,9 @@ fn handle_v1_response<T: EthSpec>(
         Protocol::MetaData => Ok(Some(RPCResponse::MetaData(MetaData::V1(
             MetaDataV1::from_ssz_bytes(decoded_buffer)?,
         )))),
+        Protocol::LightClientBootstrap => Ok(Some(RPCResponse::LightClientBootstrap(
+            LightClientBootstrap::from_ssz_bytes(decoded_buffer)?
+        )))
     }
 }
 
@@ -866,6 +873,9 @@ mod tests {
                 }
                 OutboundRequest::MetaData(metadata) => {
                     assert_eq!(decoded, InboundRequest::MetaData(metadata))
+                }
+                OutboundRequest::LightClientBootstrap(bootstrap) => {
+                    assert_eq!(decoded, InboundRequest::LightClientBootstrap(bootstrap))
                 }
             }
         }

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
-use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot};
+use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot, light_client_bootstrap::LightClientBootstrap};
 
 /// Maximum number of blocks in a single request.
 pub type MaxRequestBlocks = U1024;
@@ -243,6 +243,9 @@ pub enum RPCResponse<T: EthSpec> {
     /// A response to a get BLOCKS_BY_ROOT request.
     BlocksByRoot(Arc<SignedBeaconBlock<T>>),
 
+    /// A response to a get LIGHTCLIENT_BOOTSTRAP request.
+    LightClientBootstrap(LightClientBootstrap<T>),
+
     /// A PONG response to a PING request.
     Pong(Ping),
 
@@ -271,6 +274,12 @@ pub enum RPCCodedResponse<T: EthSpec> {
 
     /// Received a stream termination indicating which response is being terminated.
     StreamTermination(ResponseTermination),
+}
+
+/// Request a light_client_bootstrap for lightclients peers.
+#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+pub struct LightClientBootstrapRequest {
+    pub root: Hash256,
 }
 
 /// The code assigned to an erroneous `RPCResponse`.
@@ -321,6 +330,7 @@ impl<T: EthSpec> RPCCodedResponse<T> {
                 RPCResponse::BlocksByRoot(_) => true,
                 RPCResponse::Pong(_) => false,
                 RPCResponse::MetaData(_) => false,
+                RPCResponse::LightClientBootstrap(_) => false,
             },
             RPCCodedResponse::Error(_, _) => true,
             // Stream terminations are part of responses that have chunks
@@ -355,6 +365,7 @@ impl<T: EthSpec> RPCResponse<T> {
             RPCResponse::BlocksByRoot(_) => Protocol::BlocksByRoot,
             RPCResponse::Pong(_) => Protocol::Ping,
             RPCResponse::MetaData(_) => Protocol::MetaData,
+            RPCResponse::LightClientBootstrap(_) => Protocol::LightClientBootstrap,
         }
     }
 }
@@ -390,6 +401,8 @@ impl<T: EthSpec> std::fmt::Display for RPCResponse<T> {
             }
             RPCResponse::Pong(ping) => write!(f, "Pong: {}", ping.data),
             RPCResponse::MetaData(metadata) => write!(f, "Metadata: {}", metadata.seq_number()),
+            RPCResponse::LightClientBootstrap(bootstrap) => 
+                write!(f, "LigthClientBootstrap Slot: {}", bootstrap.header.slot)
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -12,7 +12,9 @@ use std::ops::Deref;
 use std::sync::Arc;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
-use types::{Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot, light_client_bootstrap::LightClientBootstrap};
+use types::{
+    light_client_bootstrap::LightClientBootstrap, Epoch, EthSpec, Hash256, SignedBeaconBlock, Slot,
+};
 
 /// Maximum number of blocks in a single request.
 pub type MaxRequestBlocks = U1024;
@@ -401,8 +403,9 @@ impl<T: EthSpec> std::fmt::Display for RPCResponse<T> {
             }
             RPCResponse::Pong(ping) => write!(f, "Pong: {}", ping.data),
             RPCResponse::MetaData(metadata) => write!(f, "Metadata: {}", metadata.seq_number()),
-            RPCResponse::LightClientBootstrap(bootstrap) => 
+            RPCResponse::LightClientBootstrap(bootstrap) => {
                 write!(f, "LigthClientBootstrap Slot: {}", bootstrap.header.slot)
+            }
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -404,7 +404,7 @@ impl<T: EthSpec> std::fmt::Display for RPCResponse<T> {
             RPCResponse::Pong(ping) => write!(f, "Pong: {}", ping.data),
             RPCResponse::MetaData(metadata) => write!(f, "Metadata: {}", metadata.seq_number()),
             RPCResponse::LightClientBootstrap(bootstrap) => {
-                write!(f, "LigthClientBootstrap Slot: {}", bootstrap.header.slot)
+                write!(f, "LightClientBootstrap Slot: {}", bootstrap.header.slot)
             }
         }
     }

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -108,12 +108,17 @@ pub struct RPC<Id: ReqId, TSpec: EthSpec> {
     /// Queue of events to be processed.
     events: Vec<NetworkBehaviourAction<RPCMessage<Id, TSpec>, RPCHandler<Id, TSpec>>>,
     fork_context: Arc<ForkContext>,
+    enable_light_client_server: bool,
     /// Slog logger for RPC behaviour.
     log: slog::Logger,
 }
 
 impl<Id: ReqId, TSpec: EthSpec> RPC<Id, TSpec> {
-    pub fn new(fork_context: Arc<ForkContext>, log: slog::Logger) -> Self {
+    pub fn new(
+        fork_context: Arc<ForkContext>,
+        enable_light_client_server: bool,
+        log: slog::Logger,
+    ) -> Self {
         let log = log.new(o!("service" => "libp2p_rpc"));
         let limiter = RPCRateLimiterBuilder::new()
             .n_every(Protocol::MetaData, 2, Duration::from_secs(5))
@@ -133,6 +138,7 @@ impl<Id: ReqId, TSpec: EthSpec> RPC<Id, TSpec> {
             limiter,
             events: Vec::new(),
             fork_context,
+            enable_light_client_server,
             log,
         }
     }
@@ -189,6 +195,7 @@ where
                 RPCProtocol {
                     fork_context: self.fork_context.clone(),
                     max_rpc_size: max_rpc_size(&self.fork_context),
+                    enable_light_client_server: self.enable_light_client_server,
                     phantom: PhantomData,
                 },
                 (),

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -26,9 +26,8 @@ pub(crate) use protocol::{InboundRequest, RPCProtocol};
 
 pub use handler::SubstreamId;
 pub use methods::{
-    BlocksByRangeRequest, BlocksByRootRequest, GoodbyeReason, MaxRequestBlocks,
-    RPCResponseErrorCode, ResponseTermination, StatusMessage, MAX_REQUEST_BLOCKS,
-    LightClientBootstrapRequest,
+    BlocksByRangeRequest, BlocksByRootRequest, GoodbyeReason, LightClientBootstrapRequest,
+    MaxRequestBlocks, RPCResponseErrorCode, ResponseTermination, StatusMessage, MAX_REQUEST_BLOCKS,
 };
 pub(crate) use outbound::OutboundRequest;
 pub use protocol::{max_rpc_size, Protocol, RPCError};

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -28,6 +28,7 @@ pub use handler::SubstreamId;
 pub use methods::{
     BlocksByRangeRequest, BlocksByRootRequest, GoodbyeReason, MaxRequestBlocks,
     RPCResponseErrorCode, ResponseTermination, StatusMessage, MAX_REQUEST_BLOCKS,
+    LightClientBootstrapRequest,
 };
 pub(crate) use outbound::OutboundRequest;
 pub use protocol::{max_rpc_size, Protocol, RPCError};
@@ -120,6 +121,7 @@ impl<Id: ReqId, TSpec: EthSpec> RPC<Id, TSpec> {
             .n_every(Protocol::Ping, 2, Duration::from_secs(10))
             .n_every(Protocol::Status, 5, Duration::from_secs(15))
             .one_every(Protocol::Goodbye, Duration::from_secs(10))
+            .one_every(Protocol::LightClientBootstrap, Duration::from_secs(10))
             .n_every(
                 Protocol::BlocksByRange,
                 methods::MAX_REQUEST_BLOCKS,

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -49,14 +49,7 @@ impl<TSpec: EthSpec> UpgradeInfo for OutboundRequestContainer<TSpec> {
 
     // add further protocols as we support more encodings/versions
     fn protocol_info(&self) -> Self::InfoIter {
-        self.req.supported_protocols()
-    }
-}
-
-/// Implements the encoding per supported protocol for `RPCRequest`.
-impl<TSpec: EthSpec> OutboundRequest<TSpec> {
-    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
-        match self {
+        match self.req {
             // add more protocols when versions/encodings are supported
             OutboundRequest::Status(_) => vec![ProtocolId::new(
                 Protocol::Status,
@@ -85,14 +78,16 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
                 ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
                 ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
             ],
-            OutboundRequest::LightClientBootstrap(_) => vec![ProtocolId::new(
-                Protocol::LightClientBootstrap,
-                Version::V1,
-                Encoding::SSZSnappy,
-            )],
+            // Note: This match arm is technically unreachable as we only respond to light client requests
+            // that we generate from the beacon state.
+            // We do not make light client rpc requests from the beacon node
+            OutboundRequest::LightClientBootstrap(_) => vec![],
         }
     }
+}
 
+/// Implements the encoding per supported protocol for `RPCRequest`.
+impl<TSpec: EthSpec> OutboundRequest<TSpec> {
     /* These functions are used in the handler for stream management */
 
     /// Number of responses expected for this request.

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -1,3 +1,4 @@
+use std::fs::write;
 use std::marker::PhantomData;
 
 use super::methods::*;
@@ -38,6 +39,7 @@ pub enum OutboundRequest<TSpec: EthSpec> {
     Goodbye(GoodbyeReason),
     BlocksByRange(OldBlocksByRangeRequest),
     BlocksByRoot(BlocksByRootRequest),
+    LightClientBootstrap(LightClientBootstrapRequest),
     Ping(Ping),
     MetaData(PhantomData<TSpec>),
 }
@@ -84,6 +86,9 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
                 ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
                 ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
             ],
+            OutboundRequest::LightClientBootstrap(_) => vec![
+                ProtocolId::new(Protocol::LightClientBootstrap, Version::V1, Encoding::SSZSnappy)
+            ]
         }
     }
 
@@ -98,6 +103,7 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
             OutboundRequest::BlocksByRoot(req) => req.block_roots.len() as u64,
             OutboundRequest::Ping(_) => 1,
             OutboundRequest::MetaData(_) => 1,
+            OutboundRequest::LightClientBootstrap(_) => 1,
         }
     }
 
@@ -110,6 +116,7 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
             OutboundRequest::BlocksByRoot(_) => Protocol::BlocksByRoot,
             OutboundRequest::Ping(_) => Protocol::Ping,
             OutboundRequest::MetaData(_) => Protocol::MetaData,
+            OutboundRequest::LightClientBootstrap(_) => Protocol::LightClientBootstrap,
         }
     }
 
@@ -121,6 +128,7 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
             // variants that have `multiple_responses()` can have values.
             OutboundRequest::BlocksByRange(_) => ResponseTermination::BlocksByRange,
             OutboundRequest::BlocksByRoot(_) => ResponseTermination::BlocksByRoot,
+            OutboundRequest::LightClientBootstrap(_) => unreachable!(),
             OutboundRequest::Status(_) => unreachable!(),
             OutboundRequest::Goodbye(_) => unreachable!(),
             OutboundRequest::Ping(_) => unreachable!(),
@@ -178,6 +186,7 @@ impl<TSpec: EthSpec> std::fmt::Display for OutboundRequest<TSpec> {
             OutboundRequest::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
             OutboundRequest::Ping(ping) => write!(f, "Ping: {}", ping.data),
             OutboundRequest::MetaData(_) => write!(f, "MetaData request"),
+            OutboundRequest::LightClientBootstrap(bootstrap) => write!(f, "Lightclient Bootstrap: {}", bootstrap.root),
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -49,7 +49,14 @@ impl<TSpec: EthSpec> UpgradeInfo for OutboundRequestContainer<TSpec> {
 
     // add further protocols as we support more encodings/versions
     fn protocol_info(&self) -> Self::InfoIter {
-        match self.req {
+        self.req.supported_protocols()
+    }
+}
+
+/// Implements the encoding per supported protocol for `RPCRequest`.
+impl<TSpec: EthSpec> OutboundRequest<TSpec> {
+    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
+        match self {
             // add more protocols when versions/encodings are supported
             OutboundRequest::Status(_) => vec![ProtocolId::new(
                 Protocol::Status,
@@ -84,10 +91,6 @@ impl<TSpec: EthSpec> UpgradeInfo for OutboundRequestContainer<TSpec> {
             OutboundRequest::LightClientBootstrap(_) => vec![],
         }
     }
-}
-
-/// Implements the encoding per supported protocol for `RPCRequest`.
-impl<TSpec: EthSpec> OutboundRequest<TSpec> {
     /* These functions are used in the handler for stream management */
 
     /// Number of responses expected for this request.

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -1,4 +1,3 @@
-use std::fs::write;
 use std::marker::PhantomData;
 
 use super::methods::*;

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -85,9 +85,11 @@ impl<TSpec: EthSpec> OutboundRequest<TSpec> {
                 ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
                 ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
             ],
-            OutboundRequest::LightClientBootstrap(_) => vec![
-                ProtocolId::new(Protocol::LightClientBootstrap, Version::V1, Encoding::SSZSnappy)
-            ]
+            OutboundRequest::LightClientBootstrap(_) => vec![ProtocolId::new(
+                Protocol::LightClientBootstrap,
+                Version::V1,
+                Encoding::SSZSnappy,
+            )],
         }
     }
 
@@ -185,7 +187,9 @@ impl<TSpec: EthSpec> std::fmt::Display for OutboundRequest<TSpec> {
             OutboundRequest::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
             OutboundRequest::Ping(ping) => write!(f, "Ping: {}", ping.data),
             OutboundRequest::MetaData(_) => write!(f, "MetaData request"),
-            OutboundRequest::LightClientBootstrap(bootstrap) => write!(f, "Lightclient Bootstrap: {}", bootstrap.root),
+            OutboundRequest::LightClientBootstrap(bootstrap) => {
+                write!(f, "Lightclient Bootstrap: {}", bootstrap.root)
+            }
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -433,58 +433,8 @@ pub enum InboundRequest<TSpec: EthSpec> {
     MetaData(PhantomData<TSpec>),
 }
 
-impl<TSpec: EthSpec> UpgradeInfo for InboundRequest<TSpec> {
-    type Info = ProtocolId;
-    type InfoIter = Vec<Self::Info>;
-
-    // add further protocols as we support more encodings/versions
-    fn protocol_info(&self) -> Self::InfoIter {
-        self.supported_protocols()
-    }
-}
-
 /// Implements the encoding per supported protocol for `RPCRequest`.
 impl<TSpec: EthSpec> InboundRequest<TSpec> {
-    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
-        match self {
-            // add more protocols when versions/encodings are supported
-            InboundRequest::Status(_) => vec![ProtocolId::new(
-                Protocol::Status,
-                Version::V1,
-                Encoding::SSZSnappy,
-            )],
-            InboundRequest::Goodbye(_) => vec![ProtocolId::new(
-                Protocol::Goodbye,
-                Version::V1,
-                Encoding::SSZSnappy,
-            )],
-            InboundRequest::BlocksByRange(_) => vec![
-                // V2 has higher preference when negotiating a stream
-                ProtocolId::new(Protocol::BlocksByRange, Version::V2, Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy),
-            ],
-            InboundRequest::BlocksByRoot(_) => vec![
-                // V2 has higher preference when negotiating a stream
-                ProtocolId::new(Protocol::BlocksByRoot, Version::V2, Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::BlocksByRoot, Version::V1, Encoding::SSZSnappy),
-            ],
-            InboundRequest::Ping(_) => vec![ProtocolId::new(
-                Protocol::Ping,
-                Version::V1,
-                Encoding::SSZSnappy,
-            )],
-            InboundRequest::MetaData(_) => vec![
-                ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
-                ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
-            ],
-            InboundRequest::LightClientBootstrap(_) => vec![ProtocolId::new(
-                Protocol::LightClientBootstrap,
-                Version::V1,
-                Encoding::SSZSnappy,
-            )],
-        }
-    }
-
     /* These functions are used in the handler for stream management */
 
     /// Number of responses expected for this request.

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -210,6 +210,7 @@ impl std::fmt::Display for Version {
 pub struct RPCProtocol<TSpec: EthSpec> {
     pub fork_context: Arc<ForkContext>,
     pub max_rpc_size: usize,
+    pub enable_light_client_server: bool,
     pub phantom: PhantomData<TSpec>,
 }
 
@@ -219,7 +220,7 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
 
     /// The list of supported RPC protocols for Lighthouse.
     fn protocol_info(&self) -> Self::InfoIter {
-        vec![
+        let mut supported_protocols = vec![
             ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZSnappy),
             // V2 variants have higher preference then V1
@@ -230,7 +231,15 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
             ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
-        ]
+        ];
+        if self.enable_light_client_server {
+            supported_protocols.push(ProtocolId::new(
+                Protocol::LightClientBootstrap,
+                Version::V1,
+                Encoding::SSZSnappy,
+            ));
+        }
+        supported_protocols
     }
 }
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -154,7 +154,7 @@ pub enum Protocol {
     /// The `MetaData` protocol name.
     MetaData,
     /// The `LightClientBootstrap` protocol name.
-    LightClientBootstrap
+    LightClientBootstrap,
 }
 
 /// RPC Versions
@@ -319,8 +319,8 @@ impl ProtocolId {
                 <MetaDataV1<T> as Encode>::ssz_fixed_len(),
                 <MetaDataV2<T> as Encode>::ssz_fixed_len(),
             ),
-            Protocol::LightClientBootstrap => RpcLimits::new( 
-                <LightClientBootstrapRequest as Encode>::ssz_fixed_len(), 
+            Protocol::LightClientBootstrap => RpcLimits::new(
+                <LightClientBootstrapRequest as Encode>::ssz_fixed_len(),
                 <LightClientBootstrapRequest as Encode>::ssz_fixed_len(),
             ),
         }
@@ -477,9 +477,11 @@ impl<TSpec: EthSpec> InboundRequest<TSpec> {
                 ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
                 ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
             ],
-            InboundRequest::LightClientBootstrap(_) => vec![
-                ProtocolId::new(Protocol::LightClientBootstrap, Version::V1, Encoding::SSZSnappy),
-            ],
+            InboundRequest::LightClientBootstrap(_) => vec![ProtocolId::new(
+                Protocol::LightClientBootstrap,
+                Version::V1,
+                Encoding::SSZSnappy,
+            )],
         }
     }
 
@@ -627,7 +629,9 @@ impl<TSpec: EthSpec> std::fmt::Display for InboundRequest<TSpec> {
             InboundRequest::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
             InboundRequest::Ping(ping) => write!(f, "Ping: {}", ping.data),
             InboundRequest::MetaData(_) => write!(f, "MetaData request"),
-            InboundRequest::LightClientBootstrap(bootstrap) => write!(f, "LightClientBootstrap: {}", bootstrap.root),
+            InboundRequest::LightClientBootstrap(bootstrap) => {
+                write!(f, "LightClientBootstrap: {}", bootstrap.root)
+            }
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -73,6 +73,8 @@ pub struct RPCRateLimiter {
     bbrange_rl: Limiter<PeerId>,
     /// BlocksByRoot rate limiter.
     bbroots_rl: Limiter<PeerId>,
+    /// LightClientBootstrap rate limiter.
+    lcbootstrap_rl: Limiter<PeerId>,
 }
 
 /// Error type for non conformant requests
@@ -98,6 +100,8 @@ pub struct RPCRateLimiterBuilder {
     bbrange_quota: Option<Quota>,
     /// Quota for the BlocksByRoot protocol.
     bbroots_quota: Option<Quota>,
+    /// Quota for the LightClientBootstrap protocol.
+    lcbootstrap_quota: Option<Quota>,
 }
 
 impl RPCRateLimiterBuilder {
@@ -116,6 +120,7 @@ impl RPCRateLimiterBuilder {
             Protocol::Goodbye => self.goodbye_quota = q,
             Protocol::BlocksByRange => self.bbrange_quota = q,
             Protocol::BlocksByRoot => self.bbroots_quota = q,
+            Protocol::LightClientBootstrap => self.lcbootstrap_quota = q,
         }
         self
     }
@@ -155,6 +160,9 @@ impl RPCRateLimiterBuilder {
         let bbrange_quota = self
             .bbrange_quota
             .ok_or("BlocksByRange quota not specified")?;
+        let lcbootstrap_quote = self
+            .lcbootstrap_quota
+            .ok_or("LightClientBootstrap quota not specified")?;
 
         // create the rate limiters
         let ping_rl = Limiter::from_quota(ping_quota)?;
@@ -163,6 +171,7 @@ impl RPCRateLimiterBuilder {
         let goodbye_rl = Limiter::from_quota(goodbye_quota)?;
         let bbroots_rl = Limiter::from_quota(bbroots_quota)?;
         let bbrange_rl = Limiter::from_quota(bbrange_quota)?;
+        let lcbootstrap_rl = Limiter::from_quota(lcbootstrap_quote)?;
 
         // check for peers to prune every 30 seconds, starting in 30 seconds
         let prune_every = tokio::time::Duration::from_secs(30);
@@ -176,6 +185,7 @@ impl RPCRateLimiterBuilder {
             goodbye_rl,
             bbroots_rl,
             bbrange_rl,
+            lcbootstrap_rl,
             init_time: Instant::now(),
         })
     }
@@ -199,6 +209,7 @@ impl RPCRateLimiter {
             Protocol::Goodbye => &mut self.goodbye_rl,
             Protocol::BlocksByRange => &mut self.bbrange_rl,
             Protocol::BlocksByRoot => &mut self.bbroots_rl,
+            Protocol::LightClientBootstrap => &mut self.lcbootstrap_rl,
         };
         check(limiter)
     }

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use libp2p::core::connection::ConnectionId;
-use types::{EthSpec, SignedBeaconBlock};
+use types::{EthSpec, SignedBeaconBlock, light_client_bootstrap::LightClientBootstrap};
 
 use crate::rpc::{
     methods::{
         BlocksByRangeRequest, BlocksByRootRequest, OldBlocksByRangeRequest, RPCCodedResponse,
-        RPCResponse, ResponseTermination, StatusMessage,
+        RPCResponse, ResponseTermination, StatusMessage, LightClientBootstrapRequest,
     },
     OutboundRequest, SubstreamId,
 };
@@ -34,6 +34,8 @@ pub enum Request {
     BlocksByRange(BlocksByRangeRequest),
     /// A request blocks root request.
     BlocksByRoot(BlocksByRootRequest),
+    // light client bootstrap request
+    LightClientBootstrap(LightClientBootstrapRequest),
 }
 
 impl<TSpec: EthSpec> std::convert::From<Request> for OutboundRequest<TSpec> {
@@ -46,7 +48,8 @@ impl<TSpec: EthSpec> std::convert::From<Request> for OutboundRequest<TSpec> {
                     count,
                     step: 1,
                 })
-            }
+            },
+            Request::LightClientBootstrap(b) => OutboundRequest::LightClientBootstrap(b),
             Request::Status(s) => OutboundRequest::Status(s),
         }
     }
@@ -66,6 +69,8 @@ pub enum Response<TSpec: EthSpec> {
     BlocksByRange(Option<Arc<SignedBeaconBlock<TSpec>>>),
     /// A response to a get BLOCKS_BY_ROOT request.
     BlocksByRoot(Option<Arc<SignedBeaconBlock<TSpec>>>),
+    /// A response to a LightClientUpdate request.
+    LightClientBootstrap(LightClientBootstrap<TSpec>),
 }
 
 impl<TSpec: EthSpec> std::convert::From<Response<TSpec>> for RPCCodedResponse<TSpec> {
@@ -80,6 +85,7 @@ impl<TSpec: EthSpec> std::convert::From<Response<TSpec>> for RPCCodedResponse<TS
                 None => RPCCodedResponse::StreamTermination(ResponseTermination::BlocksByRange),
             },
             Response::Status(s) => RPCCodedResponse::Success(RPCResponse::Status(s)),
+            Response::LightClientBootstrap(b) => RPCCodedResponse::Success(RPCResponse::LightClientBootstrap(b)),
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use libp2p::core::connection::ConnectionId;
-use types::{EthSpec, SignedBeaconBlock, light_client_bootstrap::LightClientBootstrap};
+use types::{light_client_bootstrap::LightClientBootstrap, EthSpec, SignedBeaconBlock};
 
 use crate::rpc::{
     methods::{
-        BlocksByRangeRequest, BlocksByRootRequest, OldBlocksByRangeRequest, RPCCodedResponse,
-        RPCResponse, ResponseTermination, StatusMessage, LightClientBootstrapRequest,
+        BlocksByRangeRequest, BlocksByRootRequest, LightClientBootstrapRequest,
+        OldBlocksByRangeRequest, RPCCodedResponse, RPCResponse, ResponseTermination, StatusMessage,
     },
     OutboundRequest, SubstreamId,
 };
@@ -48,7 +48,7 @@ impl<TSpec: EthSpec> std::convert::From<Request> for OutboundRequest<TSpec> {
                     count,
                     step: 1,
                 })
-            },
+            }
             Request::LightClientBootstrap(b) => OutboundRequest::LightClientBootstrap(b),
             Request::Status(s) => OutboundRequest::Status(s),
         }
@@ -85,7 +85,9 @@ impl<TSpec: EthSpec> std::convert::From<Response<TSpec>> for RPCCodedResponse<TS
                 None => RPCCodedResponse::StreamTermination(ResponseTermination::BlocksByRange),
             },
             Response::Status(s) => RPCCodedResponse::Success(RPCResponse::Status(s)),
-            Response::LightClientBootstrap(b) => RPCCodedResponse::Success(RPCResponse::LightClientBootstrap(b)),
+            Response::LightClientBootstrap(b) => {
+                RPCCodedResponse::Success(RPCResponse::LightClientBootstrap(b))
+            }
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1250,9 +1250,14 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                         );
                         Some(event)
                     }
-                    InboundRequest::LightClientBootstrap(_) => {
-                        unreachable!()
-                    }
+                    InboundRequest::LightClientBootstrap(req) => {
+                        let event = self.build_request(
+                            peer_request_id,
+                            peer_id,
+                            Request::LightClientBootstrap(req),
+                        );
+                        Some(event)
+                    },
                 }
             }
             Ok(RPCReceived::Response(id, resp)) => {
@@ -1280,6 +1285,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     RPCResponse::BlocksByRoot(resp) => {
                         self.build_response(id, peer_id, Response::BlocksByRoot(Some(resp)))
                     }
+                    // Should never be reached
                     RPCResponse::LightClientBootstrap(bootstrap) => {
                         self.build_response(id, peer_id, Response::LightClientBootstrap(bootstrap))
                     }

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -259,7 +259,11 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             (gossipsub, update_gossipsub_scores)
         };
 
-        let eth2_rpc = RPC::new(ctx.fork_context.clone(), log.clone());
+        let eth2_rpc = RPC::new(
+            ctx.fork_context.clone(),
+            config.enable_light_client_server,
+            log.clone(),
+        );
 
         let discovery = {
             // Build and start the discovery sub-behaviour
@@ -1257,7 +1261,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                             Request::LightClientBootstrap(req),
                         );
                         Some(event)
-                    },
+                    }
                 }
             }
             Ok(RPCReceived::Response(id, resp)) => {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -978,6 +978,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             Request::Status(_) => {
                 metrics::inc_counter_vec(&metrics::TOTAL_RPC_REQUESTS, &["status"])
             }
+            Request::LightClientBootstrap(_) => {
+                metrics::inc_counter_vec(&metrics::TOTAL_RPC_REQUESTS, &["light_client_bootstrap"])
+            }
             Request::BlocksByRange { .. } => {
                 metrics::inc_counter_vec(&metrics::TOTAL_RPC_REQUESTS, &["blocks_by_range"])
             }
@@ -1247,6 +1250,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                         );
                         Some(event)
                     }
+                    InboundRequest::LightClientBootstrap(_) => {
+                        unreachable!()
+                    }
                 }
             }
             Ok(RPCReceived::Response(id, resp)) => {
@@ -1273,6 +1279,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     }
                     RPCResponse::BlocksByRoot(resp) => {
                         self.build_response(id, peer_id, Response::BlocksByRoot(Some(resp)))
+                    }
+                    RPCResponse::LightClientBootstrap(bootstrap) => {
+                        self.build_response(id, peer_id, Response::LightClientBootstrap(bootstrap))
                     }
                 }
             }

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1631,12 +1631,7 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 request_id,
                 request,
             } => task_spawner.spawn_blocking(move || {
-                worker.handle_light_client_bootstrap(
-                    sub_executor,
-                    peer_id,
-                    request_id,
-                    request,
-                )
+                worker.handle_light_client_bootstrap(sub_executor, peer_id, request_id, request)
             }),
             Work::UnknownBlockAttestation {
                 message_id,

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1630,10 +1630,9 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 peer_id,
                 request_id,
                 request,
-            } => task_spawner.spawn_blocking_with_manual_send_idle(move |send_idle_on_drop| {
+            } => task_spawner.spawn_blocking(move || {
                 worker.handle_light_client_bootstrap(
                     sub_executor,
-                    send_idle_on_drop,
                     peer_id,
                     request_id,
                     request,

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -208,7 +208,6 @@ impl<T: BeaconChainTypes> Worker<T> {
         pub fn handle_light_client_bootstrap(
             self,
             executor: TaskExecutor,
-            send_on_drop: SendOnDrop,
             peer_id: PeerId,
             request_id: PeerRequestId,
             request: LightClientBootstrapRequest,

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -217,8 +217,9 @@ impl<T: BeaconChainTypes> Worker<T> {
             async move {
                 let state_root = request.root;
                 let mut beacon_state = match self.chain.get_state(&state_root, None) {
-                    Ok(beacon_state) => {
-                        if beacon_state == None {
+                    Ok(beacon_state) => match beacon_state {
+                        Some(state) => state,
+                        None => {
                             self.send_error_response(
                                 peer_id,
                                 RPCResponseErrorCode::ResourceUnavailable,
@@ -227,8 +228,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                             );
                             return;
                         }
-                        beacon_state.unwrap()
-                    }
+                    },
                     Err(_) => {
                         self.send_error_response(
                             peer_id,

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -11,7 +11,7 @@ use slog::{debug, error};
 use slot_clock::SlotClock;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
-use types::{Epoch, EthSpec, Hash256, Slot, light_client_bootstrap::LightClientBootstrap};
+use types::{light_client_bootstrap::LightClientBootstrap, Epoch, EthSpec, Hash256, Slot};
 
 use super::Worker;
 
@@ -204,44 +204,21 @@ impl<T: BeaconChainTypes> Worker<T> {
         )
     }
 
-        /// Handle a `BlocksByRoot` request from the peer.
-        pub fn handle_light_client_bootstrap(
-            self,
-            executor: TaskExecutor,
-            peer_id: PeerId,
-            request_id: PeerRequestId,
-            request: LightClientBootstrapRequest,
-        ) {
-            // Fetching blocks is async because it may have to hit the execution layer for payloads.
-            executor.spawn(
-                async move {
-                    let state_root = request.root;
-                    let mut beacon_state = match self.chain.get_state(&state_root, None) {
-                        Ok(beacon_state) => {
-                            if beacon_state == None {
-                                self.send_error_response(
-                                    peer_id,
-                                    RPCResponseErrorCode::ResourceUnavailable,
-                                    "Bootstrap not avaiable".into(),
-                                    request_id,
-                                );
-                                return; 
-                            }
-                            beacon_state.unwrap()
-                        }
-                        Err(_) => {
-                            self.send_error_response(
-                                peer_id,
-                                RPCResponseErrorCode::ResourceUnavailable,
-                                "Bootstrap not avaiable".into(),
-                                request_id,
-                            );
-                            return;
-                        } 
-                    };
-                    let bootstrap = match LightClientBootstrap::from_beacon_state(&mut beacon_state) {
-                        Ok(bootstrap) => bootstrap,
-                        Err(_) => {
+    /// Handle a `BlocksByRoot` request from the peer.
+    pub fn handle_light_client_bootstrap(
+        self,
+        executor: TaskExecutor,
+        peer_id: PeerId,
+        request_id: PeerRequestId,
+        request: LightClientBootstrapRequest,
+    ) {
+        // Fetching blocks is async because it may have to hit the execution layer for payloads.
+        executor.spawn(
+            async move {
+                let state_root = request.root;
+                let mut beacon_state = match self.chain.get_state(&state_root, None) {
+                    Ok(beacon_state) => {
+                        if beacon_state == None {
                             self.send_error_response(
                                 peer_id,
                                 RPCResponseErrorCode::ResourceUnavailable,
@@ -250,13 +227,40 @@ impl<T: BeaconChainTypes> Worker<T> {
                             );
                             return;
                         }
-                    };
-                    self.send_response(peer_id, Response::LightClientBootstrap(bootstrap), request_id)
-                },
-                "load_lightclient_bootstrap",
-            )
-        }
-    
+                        beacon_state.unwrap()
+                    }
+                    Err(_) => {
+                        self.send_error_response(
+                            peer_id,
+                            RPCResponseErrorCode::ResourceUnavailable,
+                            "Bootstrap not avaiable".into(),
+                            request_id,
+                        );
+                        return;
+                    }
+                };
+                let bootstrap = match LightClientBootstrap::from_beacon_state(&mut beacon_state) {
+                    Ok(bootstrap) => bootstrap,
+                    Err(_) => {
+                        self.send_error_response(
+                            peer_id,
+                            RPCResponseErrorCode::ResourceUnavailable,
+                            "Bootstrap not avaiable".into(),
+                            request_id,
+                        );
+                        return;
+                    }
+                };
+                self.send_response(
+                    peer_id,
+                    Response::LightClientBootstrap(bootstrap),
+                    request_id,
+                )
+            },
+            "load_lightclient_bootstrap",
+        )
+    }
+
     /// Handle a `BlocksByRange` request from the peer.
     pub fn handle_blocks_by_range_request(
         self,

--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -168,6 +168,9 @@ impl<T: BeaconChainTypes> Router<T> {
             Request::BlocksByRoot(request) => self
                 .processor
                 .on_blocks_by_root_request(peer_id, id, request),
+            Request::LightClientBootstrap(request) => self
+                .processor
+                .on_lightclient_bootstrap(peer_id, id, request)
         }
     }
 
@@ -192,6 +195,7 @@ impl<T: BeaconChainTypes> Router<T> {
                 self.processor
                     .on_blocks_by_root_response(peer_id, request_id, beacon_block);
             }
+            Response::LightClientBootstrap(_) => unreachable!()
         }
     }
 

--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -170,7 +170,7 @@ impl<T: BeaconChainTypes> Router<T> {
                 .on_blocks_by_root_request(peer_id, id, request),
             Request::LightClientBootstrap(request) => self
                 .processor
-                .on_lightclient_bootstrap(peer_id, id, request)
+                .on_lightclient_bootstrap(peer_id, id, request),
         }
     }
 
@@ -195,7 +195,7 @@ impl<T: BeaconChainTypes> Router<T> {
                 self.processor
                     .on_blocks_by_root_response(peer_id, request_id, beacon_block);
             }
-            Response::LightClientBootstrap(_) => unreachable!()
+            Response::LightClientBootstrap(_) => unreachable!(),
         }
     }
 

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -160,6 +160,18 @@ impl<T: BeaconChainTypes> Processor<T> {
         ))
     }
 
+    /// Handle a `LightClientBootstrap` request from the peer.
+    pub fn on_lightclient_bootstrap(
+        &mut self,
+        peer_id: PeerId,
+        request_id: PeerRequestId,
+        request: LightClientBootstrapRequest,
+    ) {
+        self.send_beacon_processor_work(BeaconWorkEvent::lightclient_bootstrap_request(
+            peer_id, request_id, request,
+        ))
+    }
+
     /// Handle a `BlocksByRange` request from the peer.
     pub fn on_blocks_by_range_request(
         &mut self,

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -705,9 +705,6 @@ pub fn get_config<E: EthSpec>(
     client_config.chain.builder_fallback_disable_checks =
         cli_args.is_present("builder-fallback-disable-checks");
 
-    // Light client server config.
-    client_config.chain.enable_light_client_server = cli_args.is_present("light-client-server");
-
     Ok(client_config)
 }
 
@@ -918,6 +915,9 @@ pub fn set_network_config(
     if cli_args.is_present("enable-private-discovery") {
         config.discv5_config.table_filter = |_| true;
     }
+
+    // Light client server config.
+    config.enable_light_client_server = cli_args.is_present("light-client-server");
 
     Ok(())
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1585,7 +1585,7 @@ fn sync_eth1_chain_disable_deposit_contract_sync_flag() {
 fn light_client_server_default() {
     CommandLineTest::new()
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.chain.enable_light_client_server, false));
+        .with_config(|config| assert_eq!(config.network.enable_light_client_server, false));
 }
 
 #[test]

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1593,5 +1593,5 @@ fn light_client_server_enabled() {
     CommandLineTest::new()
         .flag("light-client-server", None)
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.chain.enable_light_client_server, true));
+        .with_config(|config| assert_eq!(config.network.enable_light_client_server, true));
 }


### PR DESCRIPTION
## Issue Addressed

Continuation to https://github.com/sigp/lighthouse/pull/3711
Can be cherry picked into the above PR or can be merged after

## Proposed Changes

1. Removes the `UpgradeInfo` trait on `InboundRequest`. This is likely a relic of an older libp2p version which we do not need anymore. Currently, we have `OutboundRequestContainer` implementing `OutboundUpgrade` and `RPCProtocol` implementing `InboundUpgrade` to advertise the RPC protocols we support.
2. Make the light client related protocol support advertising dependent on the config parameter.
3. Move the `enable_light_client_server` to network config instead of beacon config. @michaelsproul , sorry but I hadn't thought it out completely when you mentioned where to put the config :sweat_smile:  
I feel putting it in the network config will be better because we can disable support for the protocols when we advertise it to our peers. Doing that will ensure that we don't receive any light client related network messages (rpc or gossip) into the beacon processor.

## Additional info

@divagant-martian I removed the light client protocol support for `OutboundRequest` based on your comment here https://github.com/sigp/lighthouse/pull/3711#discussion_r1020903613

As I understand it, we do not need to advertise protocol support when creating outbound streams because we will not be making light client requests from the beacon node (server), so it's effectively an unreachable statement.