### PR TITLE
[Merged by Bors] - Add CLI flag for gui requirements

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -875,4 +875,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        [experimental]")
                 .takes_value(false)
         )
+        .arg(
+            Arg::with_name("gui")
+                .long("gui")
+                .hidden(true)
+                .help("Enable the graphical user interface and all its requirements. \
+                      This is equivalent to --http and --validator-monitor-auto.")
+                .takes_value(false)
+        )
 }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -708,6 +708,12 @@ pub fn get_config<E: EthSpec>(
     client_config.chain.builder_fallback_disable_checks =
         cli_args.is_present("builder-fallback-disable-checks");
 
+    // Graphical user interface config.
+    if cli_args.is_present("gui") {
+        client_config.http_api.enabled = true;
+        client_config.validator_monitor_auto = true;
+    }
+
     Ok(client_config)
 }
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1614,3 +1614,14 @@ fn light_client_server_enabled() {
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.network.enable_light_client_server, true));
 }
+
+#[test]
+fn gui_flag() {
+    CommandLineTest::new()
+        .flag("gui", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.http_api.enabled);
+            assert!(config.validator_monitor_auto);
+        });
+}


### PR DESCRIPTION
## Issue Addressed

#3723

## Proposed Changes

Adds a new CLI flag `--gui` which enables all the various flags required for the gui to function properly.
Currently enables the `--http` and `--validator-monitor-auto` flags.