### PR TITLE
[Merged by Bors] - Optimize finalized chain sync by skipping newPayload messages

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -636,8 +636,9 @@ pub trait IntoExecutionPendingBlock<T: BeaconChainTypes>: Sized {
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<ExecutionPendingBlock<T>, BlockError<T::EthSpec>> {
-        self.into_execution_pending_block_slashable(block_root, chain)
+        self.into_execution_pending_block_slashable(block_root, chain, is_syncing_finalized)
             .map(|execution_pending| {
                 // Supply valid block to slasher.
                 if let Some(slasher) = chain.slasher.as_ref() {
@@ -653,6 +654,7 @@ pub trait IntoExecutionPendingBlock<T: BeaconChainTypes>: Sized {
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>>;
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec>;
@@ -899,10 +901,15 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for GossipVerifiedBlock<T
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         let execution_pending =
             SignatureVerifiedBlock::from_gossip_verified_block_check_slashable(self, chain)?;
-        execution_pending.into_execution_pending_block_slashable(block_root, chain)
+        execution_pending.into_execution_pending_block_slashable(
+            block_root,
+            chain,
+            is_syncing_finalized,
+        )
     }
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec> {
@@ -1032,6 +1039,7 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         let header = self.block.signed_block_header();
         let (parent, block) = if let Some(parent) = self.parent {
@@ -1047,6 +1055,7 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
             parent,
             self.consensus_context,
             chain,
+            is_syncing_finalized,
         )
         .map_err(|e| BlockSlashInfo::SignatureValid(header, e))
     }
@@ -1063,13 +1072,14 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for Arc<SignedBeaconBlock
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         // Perform an early check to prevent wasting time on irrelevant blocks.
         let block_root = check_block_relevancy(&self, block_root, chain)
             .map_err(|e| BlockSlashInfo::SignatureNotChecked(self.signed_block_header(), e))?;
 
         SignatureVerifiedBlock::check_slashable(self, block_root, chain)?
-            .into_execution_pending_block_slashable(block_root, chain)
+            .into_execution_pending_block_slashable(block_root, chain, is_syncing_finalized)
     }
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec> {
@@ -1091,6 +1101,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         parent: PreProcessingSnapshot<T::EthSpec>,
         mut consensus_context: ConsensusContext<T::EthSpec>,
         chain: &Arc<BeaconChain<T>>,
+        is_syncing_finalized: bool,
     ) -> Result<Self, BlockError<T::EthSpec>> {
         if let Some(parent) = chain
             .canonical_head
@@ -1237,7 +1248,8 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
 
         // Define a future that will verify the execution payload with an execution engine (but
         // don't execute it yet).
-        let payload_notifier = PayloadNotifier::new(chain.clone(), block.clone(), &state)?;
+        let payload_notifier =
+            PayloadNotifier::new(chain.clone(), block.clone(), &state, is_syncing_finalized)?;
         let is_valid_merge_transition_block =
             is_merge_transition_block(&state, block.message().body());
         let payload_verification_future = async move {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -45,7 +45,7 @@
 use crate::eth1_finalization_cache::Eth1FinalizationData;
 use crate::execution_payload::{
     is_optimistic_candidate_block, validate_execution_payload_for_gossip, validate_merge_block,
-    AllowOptimisticImport, PayloadNotifier,
+    AllowOptimisticImport, NotifyExecutionLayer, PayloadNotifier,
 };
 use crate::snapshot_cache::PreProcessingSnapshot;
 use crate::validator_monitor::HISTORIC_EPOCHS as VALIDATOR_MONITOR_HISTORIC_EPOCHS;
@@ -636,9 +636,9 @@ pub trait IntoExecutionPendingBlock<T: BeaconChainTypes>: Sized {
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<ExecutionPendingBlock<T>, BlockError<T::EthSpec>> {
-        self.into_execution_pending_block_slashable(block_root, chain, is_syncing_finalized)
+        self.into_execution_pending_block_slashable(block_root, chain, notify_execution_layer)
             .map(|execution_pending| {
                 // Supply valid block to slasher.
                 if let Some(slasher) = chain.slasher.as_ref() {
@@ -654,7 +654,7 @@ pub trait IntoExecutionPendingBlock<T: BeaconChainTypes>: Sized {
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>>;
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec>;
@@ -901,14 +901,14 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for GossipVerifiedBlock<T
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         let execution_pending =
             SignatureVerifiedBlock::from_gossip_verified_block_check_slashable(self, chain)?;
         execution_pending.into_execution_pending_block_slashable(
             block_root,
             chain,
-            is_syncing_finalized,
+            notify_execution_layer,
         )
     }
 
@@ -1039,7 +1039,7 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         let header = self.block.signed_block_header();
         let (parent, block) = if let Some(parent) = self.parent {
@@ -1055,7 +1055,7 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBloc
             parent,
             self.consensus_context,
             chain,
-            is_syncing_finalized,
+            notify_execution_layer,
         )
         .map_err(|e| BlockSlashInfo::SignatureValid(header, e))
     }
@@ -1072,14 +1072,14 @@ impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for Arc<SignedBeaconBlock
         self,
         block_root: Hash256,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<ExecutionPendingBlock<T>, BlockSlashInfo<BlockError<T::EthSpec>>> {
         // Perform an early check to prevent wasting time on irrelevant blocks.
         let block_root = check_block_relevancy(&self, block_root, chain)
             .map_err(|e| BlockSlashInfo::SignatureNotChecked(self.signed_block_header(), e))?;
 
         SignatureVerifiedBlock::check_slashable(self, block_root, chain)?
-            .into_execution_pending_block_slashable(block_root, chain, is_syncing_finalized)
+            .into_execution_pending_block_slashable(block_root, chain, notify_execution_layer)
     }
 
     fn block(&self) -> &SignedBeaconBlock<T::EthSpec> {
@@ -1101,7 +1101,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         parent: PreProcessingSnapshot<T::EthSpec>,
         mut consensus_context: ConsensusContext<T::EthSpec>,
         chain: &Arc<BeaconChain<T>>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<Self, BlockError<T::EthSpec>> {
         if let Some(parent) = chain
             .canonical_head
@@ -1249,7 +1249,7 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         // Define a future that will verify the execution payload with an execution engine (but
         // don't execute it yet).
         let payload_notifier =
-            PayloadNotifier::new(chain.clone(), block.clone(), &state, is_syncing_finalized)?;
+            PayloadNotifier::new(chain.clone(), block.clone(), &state, notify_execution_layer)?;
         let is_valid_merge_transition_block =
             is_merge_transition_block(&state, block.message().body());
         let payload_verification_future = async move {

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -35,6 +35,16 @@ pub enum AllowOptimisticImport {
     No,
 }
 
+/// Signal whether the execution payloads of new blocks should be
+/// immediately verified with the EL or imported optimistically without
+/// any EL communication.
+#[derive(Default, Clone, Copy)]
+pub enum NotifyExecutionLayer {
+    #[default]
+    Yes,
+    No,
+}
+
 /// Used to await the result of executing payload with a remote EE.
 pub struct PayloadNotifier<T: BeaconChainTypes> {
     pub chain: Arc<BeaconChain<T>>,
@@ -47,28 +57,28 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
         chain: Arc<BeaconChain<T>>,
         block: Arc<SignedBeaconBlock<T::EthSpec>>,
         state: &BeaconState<T::EthSpec>,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<Self, BlockError<T::EthSpec>> {
-        let mut payload_verification_status = if is_execution_enabled(state, block.message().body())
-        {
-            // Perform the initial stages of payload verification.
-            //
-            // We will duplicate these checks again during `per_block_processing`, however these checks
-            // are cheap and doing them here ensures we protect the execution engine from junk.
-            partially_verify_execution_payload(
-                state,
-                block.message().execution_payload()?,
-                &chain.spec,
-            )
-            .map_err(BlockError::PerBlockProcessingError)?;
-            None
-        } else {
-            Some(PayloadVerificationStatus::Irrelevant)
+        let payload_verification_status = match notify_execution_layer {
+            NotifyExecutionLayer::No => Some(PayloadVerificationStatus::Optimistic),
+            NotifyExecutionLayer::Yes => {
+                if is_execution_enabled(state, block.message().body()) {
+                    // Perform the initial stages of payload verification.
+                    //
+                    // We will duplicate these checks again during `per_block_processing`, however these checks
+                    // are cheap and doing them here ensures we protect the execution engine from junk.
+                    partially_verify_execution_payload(
+                        state,
+                        block.message().execution_payload()?,
+                        &chain.spec,
+                    )
+                    .map_err(BlockError::PerBlockProcessingError)?;
+                    None
+                } else {
+                    Some(PayloadVerificationStatus::Irrelevant)
+                }
+            }
         };
-
-        if is_syncing_finalized {
-            payload_verification_status = Some(PayloadVerificationStatus::Optimistic);
-        }
 
         Ok(Self {
             chain,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -63,6 +63,7 @@ pub use canonical_head::{CachedHead, CanonicalHead, CanonicalHeadRwLock};
 pub use eth1_chain::{Eth1Chain, Eth1ChainBackend};
 pub use events::ServerSentEventHandler;
 pub use execution_layer::EngineState;
+pub use execution_payload::NotifyExecutionLayer;
 pub use fork_choice::{ExecutionStatus, ForkchoiceUpdateParameters};
 pub use metrics::scrape_for_metrics;
 pub use parking_lot;

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1460,7 +1460,7 @@ where
         self.set_current_slot(slot);
         let block_hash: SignedBeaconBlockHash = self
             .chain
-            .process_block(block_root, Arc::new(block), CountUnrealized::True)
+            .process_block(block_root, Arc::new(block), CountUnrealized::True, false)
             .await?
             .into();
         self.chain.recompute_head_at_current_slot().await;
@@ -1477,6 +1477,7 @@ where
                 block.canonical_root(),
                 Arc::new(block),
                 CountUnrealized::True,
+                false,
             )
             .await?
             .into();

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2,7 +2,7 @@ pub use crate::persisted_beacon_chain::PersistedBeaconChain;
 pub use crate::{
     beacon_chain::{BEACON_CHAIN_DB_KEY, ETH1_CACHE_DB_KEY, FORK_CHOICE_DB_KEY, OP_POOL_DB_KEY},
     migrate::MigratorConfig,
-    BeaconChainError, ProduceBlockVerification,
+    BeaconChainError, NotifyExecutionLayer, ProduceBlockVerification,
 };
 use crate::{
     builder::{BeaconChainBuilder, Witness},
@@ -1460,7 +1460,12 @@ where
         self.set_current_slot(slot);
         let block_hash: SignedBeaconBlockHash = self
             .chain
-            .process_block(block_root, Arc::new(block), CountUnrealized::True, false)
+            .process_block(
+                block_root,
+                Arc::new(block),
+                CountUnrealized::True,
+                NotifyExecutionLayer::Yes,
+            )
             .await?
             .into();
         self.chain.recompute_head_at_current_slot().await;
@@ -1477,7 +1482,7 @@ where
                 block.canonical_root(),
                 Arc::new(block),
                 CountUnrealized::True,
-                false,
+                NotifyExecutionLayer::Yes,
             )
             .await?
             .into();

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -147,14 +147,14 @@ async fn chain_segment_full_segment() {
     // Sneak in a little check to ensure we can process empty chain segments.
     harness
         .chain
-        .process_chain_segment(vec![], CountUnrealized::True)
+        .process_chain_segment(vec![], CountUnrealized::True, false)
         .await
         .into_block_error()
         .expect("should import empty chain segment");
 
     harness
         .chain
-        .process_chain_segment(blocks.clone(), CountUnrealized::True)
+        .process_chain_segment(blocks.clone(), CountUnrealized::True, false)
         .await
         .into_block_error()
         .expect("should import chain segment");
@@ -183,7 +183,7 @@ async fn chain_segment_varying_chunk_size() {
         for chunk in blocks.chunks(*chunk_size) {
             harness
                 .chain
-                .process_chain_segment(chunk.to_vec(), CountUnrealized::True)
+                .process_chain_segment(chunk.to_vec(), CountUnrealized::True, false)
                 .await
                 .into_block_error()
                 .unwrap_or_else(|_| panic!("should import chain segment of len {}", chunk_size));
@@ -219,7 +219,7 @@ async fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True)
+                .process_chain_segment(blocks, CountUnrealized::True, false)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
@@ -239,7 +239,7 @@ async fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True)
+                .process_chain_segment(blocks, CountUnrealized::True, false)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
@@ -270,7 +270,7 @@ async fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True)
+                .process_chain_segment(blocks, CountUnrealized::True, false)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
@@ -291,7 +291,7 @@ async fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True)
+                .process_chain_segment(blocks, CountUnrealized::True, false)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
@@ -317,7 +317,7 @@ async fn assert_invalid_signature(
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True)
+                .process_chain_segment(blocks, CountUnrealized::True, false)
                 .await
                 .into_block_error(),
             Err(BlockError::InvalidSignature)
@@ -339,7 +339,7 @@ async fn assert_invalid_signature(
     // imported prior to this test.
     let _ = harness
         .chain
-        .process_chain_segment(ancestor_blocks, CountUnrealized::True)
+        .process_chain_segment(ancestor_blocks, CountUnrealized::True, false)
         .await;
     harness.chain.recompute_head_at_current_slot().await;
 
@@ -349,6 +349,7 @@ async fn assert_invalid_signature(
             snapshots[block_index].beacon_block.canonical_root(),
             snapshots[block_index].beacon_block.clone(),
             CountUnrealized::True,
+            false,
         )
         .await;
     assert!(
@@ -400,7 +401,7 @@ async fn invalid_signature_gossip_block() {
             .collect();
         harness
             .chain
-            .process_chain_segment(ancestor_blocks, CountUnrealized::True)
+            .process_chain_segment(ancestor_blocks, CountUnrealized::True, false)
             .await
             .into_block_error()
             .expect("should import all blocks prior to the one being tested");
@@ -412,7 +413,8 @@ async fn invalid_signature_gossip_block() {
                     .process_block(
                         signed_block.canonical_root(),
                         Arc::new(signed_block),
-                        CountUnrealized::True
+                        CountUnrealized::True,
+                        false,
                     )
                     .await,
                 Err(BlockError::InvalidSignature)
@@ -446,7 +448,7 @@ async fn invalid_signature_block_proposal() {
             matches!(
                 harness
                     .chain
-                    .process_chain_segment(blocks, CountUnrealized::True)
+                    .process_chain_segment(blocks, CountUnrealized::True, false)
                     .await
                     .into_block_error(),
                 Err(BlockError::InvalidSignature)
@@ -644,7 +646,7 @@ async fn invalid_signature_deposit() {
             !matches!(
                 harness
                     .chain
-                    .process_chain_segment(blocks, CountUnrealized::True)
+                    .process_chain_segment(blocks, CountUnrealized::True, false)
                     .await
                     .into_block_error(),
                 Err(BlockError::InvalidSignature)
@@ -725,6 +727,7 @@ async fn block_gossip_verification() {
                 gossip_verified.block_root,
                 gossip_verified,
                 CountUnrealized::True,
+                false,
             )
             .await
             .expect("should import valid gossip verified block");
@@ -996,6 +999,7 @@ async fn verify_block_for_gossip_slashing_detection() {
             verified_block.block_root,
             verified_block,
             CountUnrealized::True,
+            false,
         )
         .await
         .unwrap();
@@ -1035,6 +1039,7 @@ async fn verify_block_for_gossip_doppelganger_detection() {
             verified_block.block_root,
             verified_block,
             CountUnrealized::True,
+            false,
         )
         .await
         .unwrap();
@@ -1180,7 +1185,8 @@ async fn add_base_block_to_altair_chain() {
             .process_block(
                 base_block.canonical_root(),
                 Arc::new(base_block.clone()),
-                CountUnrealized::True
+                CountUnrealized::True,
+                false,
             )
             .await
             .err()
@@ -1195,7 +1201,7 @@ async fn add_base_block_to_altair_chain() {
     assert!(matches!(
         harness
             .chain
-            .process_chain_segment(vec![Arc::new(base_block)], CountUnrealized::True)
+            .process_chain_segment(vec![Arc::new(base_block)], CountUnrealized::True, false)
             .await,
         ChainSegmentResult::Failed {
             imported_blocks: 0,
@@ -1313,7 +1319,8 @@ async fn add_altair_block_to_base_chain() {
             .process_block(
                 altair_block.canonical_root(),
                 Arc::new(altair_block.clone()),
-                CountUnrealized::True
+                CountUnrealized::True,
+                false,
             )
             .await
             .err()
@@ -1328,7 +1335,7 @@ async fn add_altair_block_to_base_chain() {
     assert!(matches!(
         harness
             .chain
-            .process_chain_segment(vec![Arc::new(altair_block)], CountUnrealized::True)
+            .process_chain_segment(vec![Arc::new(altair_block)], CountUnrealized::True, false)
             .await,
         ChainSegmentResult::Failed {
             imported_blocks: 0,

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -147,14 +147,18 @@ async fn chain_segment_full_segment() {
     // Sneak in a little check to ensure we can process empty chain segments.
     harness
         .chain
-        .process_chain_segment(vec![], CountUnrealized::True, false)
+        .process_chain_segment(vec![], CountUnrealized::True, NotifyExecutionLayer::Yes)
         .await
         .into_block_error()
         .expect("should import empty chain segment");
 
     harness
         .chain
-        .process_chain_segment(blocks.clone(), CountUnrealized::True, false)
+        .process_chain_segment(
+            blocks.clone(),
+            CountUnrealized::True,
+            NotifyExecutionLayer::Yes,
+        )
         .await
         .into_block_error()
         .expect("should import chain segment");
@@ -183,7 +187,11 @@ async fn chain_segment_varying_chunk_size() {
         for chunk in blocks.chunks(*chunk_size) {
             harness
                 .chain
-                .process_chain_segment(chunk.to_vec(), CountUnrealized::True, false)
+                .process_chain_segment(
+                    chunk.to_vec(),
+                    CountUnrealized::True,
+                    NotifyExecutionLayer::Yes,
+                )
                 .await
                 .into_block_error()
                 .unwrap_or_else(|_| panic!("should import chain segment of len {}", chunk_size));
@@ -219,7 +227,7 @@ async fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True, false)
+                .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
@@ -239,7 +247,7 @@ async fn chain_segment_non_linear_parent_roots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True, false)
+                .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearParentRoots)
@@ -270,7 +278,7 @@ async fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True, false)
+                .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
@@ -291,7 +299,7 @@ async fn chain_segment_non_linear_slots() {
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True, false)
+                .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                 .await
                 .into_block_error(),
             Err(BlockError::NonLinearSlots)
@@ -317,7 +325,7 @@ async fn assert_invalid_signature(
         matches!(
             harness
                 .chain
-                .process_chain_segment(blocks, CountUnrealized::True, false)
+                .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                 .await
                 .into_block_error(),
             Err(BlockError::InvalidSignature)
@@ -339,7 +347,11 @@ async fn assert_invalid_signature(
     // imported prior to this test.
     let _ = harness
         .chain
-        .process_chain_segment(ancestor_blocks, CountUnrealized::True, false)
+        .process_chain_segment(
+            ancestor_blocks,
+            CountUnrealized::True,
+            NotifyExecutionLayer::Yes,
+        )
         .await;
     harness.chain.recompute_head_at_current_slot().await;
 
@@ -349,7 +361,7 @@ async fn assert_invalid_signature(
             snapshots[block_index].beacon_block.canonical_root(),
             snapshots[block_index].beacon_block.clone(),
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await;
     assert!(
@@ -414,7 +426,7 @@ async fn invalid_signature_gossip_block() {
                         signed_block.canonical_root(),
                         Arc::new(signed_block),
                         CountUnrealized::True,
-                        false,
+                        NotifyExecutionLayer::Yes,
                     )
                     .await,
                 Err(BlockError::InvalidSignature)
@@ -448,7 +460,7 @@ async fn invalid_signature_block_proposal() {
             matches!(
                 harness
                     .chain
-                    .process_chain_segment(blocks, CountUnrealized::True, false)
+                    .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                     .await
                     .into_block_error(),
                 Err(BlockError::InvalidSignature)
@@ -646,7 +658,7 @@ async fn invalid_signature_deposit() {
             !matches!(
                 harness
                     .chain
-                    .process_chain_segment(blocks, CountUnrealized::True, false)
+                    .process_chain_segment(blocks, CountUnrealized::True, NotifyExecutionLayer::Yes)
                     .await
                     .into_block_error(),
                 Err(BlockError::InvalidSignature)
@@ -727,7 +739,7 @@ async fn block_gossip_verification() {
                 gossip_verified.block_root,
                 gossip_verified,
                 CountUnrealized::True,
-                false,
+                NotifyExecutionLayer::Yes,
             )
             .await
             .expect("should import valid gossip verified block");
@@ -999,7 +1011,7 @@ async fn verify_block_for_gossip_slashing_detection() {
             verified_block.block_root,
             verified_block,
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await
         .unwrap();
@@ -1039,7 +1051,7 @@ async fn verify_block_for_gossip_doppelganger_detection() {
             verified_block.block_root,
             verified_block,
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await
         .unwrap();
@@ -1186,7 +1198,7 @@ async fn add_base_block_to_altair_chain() {
                 base_block.canonical_root(),
                 Arc::new(base_block.clone()),
                 CountUnrealized::True,
-                false,
+                NotifyExecutionLayer::Yes,
             )
             .await
             .err()
@@ -1201,7 +1213,11 @@ async fn add_base_block_to_altair_chain() {
     assert!(matches!(
         harness
             .chain
-            .process_chain_segment(vec![Arc::new(base_block)], CountUnrealized::True, false)
+            .process_chain_segment(
+                vec![Arc::new(base_block)],
+                CountUnrealized::True,
+                NotifyExecutionLayer::Yes
+            )
             .await,
         ChainSegmentResult::Failed {
             imported_blocks: 0,
@@ -1320,7 +1336,7 @@ async fn add_altair_block_to_base_chain() {
                 altair_block.canonical_root(),
                 Arc::new(altair_block.clone()),
                 CountUnrealized::True,
-                false,
+                NotifyExecutionLayer::Yes,
             )
             .await
             .err()
@@ -1335,7 +1351,11 @@ async fn add_altair_block_to_base_chain() {
     assert!(matches!(
         harness
             .chain
-            .process_chain_segment(vec![Arc::new(altair_block)], CountUnrealized::True, false)
+            .process_chain_segment(
+                vec![Arc::new(altair_block)],
+                CountUnrealized::True,
+                NotifyExecutionLayer::Yes
+            )
             .await,
         ChainSegmentResult::Failed {
             imported_blocks: 0,

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -413,7 +413,11 @@ async fn invalid_signature_gossip_block() {
             .collect();
         harness
             .chain
-            .process_chain_segment(ancestor_blocks, CountUnrealized::True, false)
+            .process_chain_segment(
+                ancestor_blocks,
+                CountUnrealized::True,
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .into_block_error()
             .expect("should import all blocks prior to the one being tested");
@@ -1216,7 +1220,7 @@ async fn add_base_block_to_altair_chain() {
             .process_chain_segment(
                 vec![Arc::new(base_block)],
                 CountUnrealized::True,
-                NotifyExecutionLayer::Yes
+                NotifyExecutionLayer::Yes,
             )
             .await,
         ChainSegmentResult::Failed {

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -3,7 +3,7 @@
 use beacon_chain::test_utils::{
     AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
 };
-use beacon_chain::{BeaconSnapshot, BlockError, ChainSegmentResult};
+use beacon_chain::{BeaconSnapshot, BlockError, ChainSegmentResult, NotifyExecutionLayer};
 use fork_choice::CountUnrealized;
 use lazy_static::lazy_static;
 use logging::test_logger;

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -7,10 +7,9 @@ use beacon_chain::otb_verification_service::{
 use beacon_chain::{
     canonical_head::{CachedHead, CanonicalHead},
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
-    BeaconChainError, BlockError, ExecutionPayloadError, StateSkipConfig, WhenSlotSkipped,
-    INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON,
+    BeaconChainError, BlockError, ExecutionPayloadError, NotifyExecutionLayer, StateSkipConfig,
+    WhenSlotSkipped, INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON,
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
-    NotifyExecutionLayer,
 };
 use execution_layer::{
     json_structures::{JsonForkChoiceStateV1, JsonPayloadAttributesV1},

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -10,6 +10,7 @@ use beacon_chain::{
     BeaconChainError, BlockError, ExecutionPayloadError, StateSkipConfig, WhenSlotSkipped,
     INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON,
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
+    NotifyExecutionLayer,
 };
 use execution_layer::{
     json_structures::{JsonForkChoiceStateV1, JsonPayloadAttributesV1},

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -281,7 +281,12 @@ impl InvalidPayloadRig {
                 }
                 let root = self
                     .harness
-                    .process_block(slot, block.canonical_root(), block.clone())
+                    .process_block(
+                        slot,
+                        block.canonical_root(),
+                        block.clone(),
+                        NotifyExecutionLayer::Yes,
+                    )
                     .await
                     .unwrap();
 
@@ -322,7 +327,12 @@ impl InvalidPayloadRig {
 
                 match self
                     .harness
-                    .process_block(slot, block.canonical_root(), block)
+                    .process_block(
+                        slot,
+                        block.canonical_root(),
+                        block,
+                        NotifyExecutionLayer::Yes,
+                    )
                     .await
                 {
                     Err(error) if evaluate_error(&error) => (),
@@ -693,7 +703,7 @@ async fn invalidates_all_descendants() {
             fork_block.canonical_root(),
             Arc::new(fork_block),
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await
         .unwrap();
@@ -790,7 +800,7 @@ async fn switches_heads() {
             fork_block.canonical_root(),
             Arc::new(fork_block),
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await
         .unwrap();
@@ -1037,7 +1047,7 @@ async fn invalid_parent() {
 
     // Ensure the block built atop an invalid payload is invalid for import.
     assert!(matches!(
-        rig.harness.chain.process_block(block.canonical_root(), block.clone(), CountUnrealized::True, false).await,
+        rig.harness.chain.process_block(block.canonical_root(), block.clone(), CountUnrealized::True, NotifyExecutionLayer::Yes).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
         if invalid_root == parent_root
     ));
@@ -1319,7 +1329,12 @@ async fn build_optimistic_chain(
     for block in blocks {
         rig.harness
             .chain
-            .process_block(block.canonical_root(), block, CountUnrealized::True, false)
+            .process_block(
+                block.canonical_root(),
+                block,
+                CountUnrealized::True,
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .unwrap();
     }
@@ -1881,7 +1896,7 @@ async fn recover_from_invalid_head_by_importing_blocks() {
             fork_block.canonical_root(),
             fork_block.clone(),
             CountUnrealized::True,
-            false,
+            NotifyExecutionLayer::Yes,
         )
         .await
         .unwrap();

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -281,12 +281,7 @@ impl InvalidPayloadRig {
                 }
                 let root = self
                     .harness
-                    .process_block(
-                        slot,
-                        block.canonical_root(),
-                        block.clone(),
-                        NotifyExecutionLayer::Yes,
-                    )
+                    .process_block(slot, block.canonical_root(), block.clone())
                     .await
                     .unwrap();
 

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -693,6 +693,7 @@ async fn invalidates_all_descendants() {
             fork_block.canonical_root(),
             Arc::new(fork_block),
             CountUnrealized::True,
+            false,
         )
         .await
         .unwrap();
@@ -789,6 +790,7 @@ async fn switches_heads() {
             fork_block.canonical_root(),
             Arc::new(fork_block),
             CountUnrealized::True,
+            false,
         )
         .await
         .unwrap();
@@ -1035,7 +1037,7 @@ async fn invalid_parent() {
 
     // Ensure the block built atop an invalid payload is invalid for import.
     assert!(matches!(
-        rig.harness.chain.process_block(block.canonical_root(), block.clone(), CountUnrealized::True).await,
+        rig.harness.chain.process_block(block.canonical_root(), block.clone(), CountUnrealized::True, false).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
         if invalid_root == parent_root
     ));
@@ -1317,7 +1319,7 @@ async fn build_optimistic_chain(
     for block in blocks {
         rig.harness
             .chain
-            .process_block(block.canonical_root(), block, CountUnrealized::True)
+            .process_block(block.canonical_root(), block, CountUnrealized::True, false)
             .await
             .unwrap();
     }
@@ -1879,6 +1881,7 @@ async fn recover_from_invalid_head_by_importing_blocks() {
             fork_block.canonical_root(),
             fork_block.clone(),
             CountUnrealized::True,
+            false,
         )
         .await
         .unwrap();

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -322,12 +322,7 @@ impl InvalidPayloadRig {
 
                 match self
                     .harness
-                    .process_block(
-                        slot,
-                        block.canonical_root(),
-                        block,
-                        NotifyExecutionLayer::Yes,
-                    )
+                    .process_block(slot, block.canonical_root(), block)
                     .await
                 {
                     Err(error) if evaluate_error(&error) => (),

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2148,7 +2148,7 @@ async fn weak_subjectivity_sync() {
                 full_block.canonical_root(),
                 Arc::new(full_block),
                 CountUnrealized::True,
-                false
+                false,
             )
             .await
             .unwrap();

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -8,7 +8,7 @@ use beacon_chain::test_utils::{
 use beacon_chain::{
     historical_blocks::HistoricalBlockError, migrate::MigratorConfig, BeaconChain,
     BeaconChainError, BeaconChainTypes, BeaconSnapshot, ChainConfig, ServerSentEventHandler,
-    WhenSlotSkipped,
+    WhenSlotSkipped, NotifyExecutionLayer,
 };
 use fork_choice::CountUnrealized;
 use lazy_static::lazy_static;

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -7,8 +7,8 @@ use beacon_chain::test_utils::{
 };
 use beacon_chain::{
     historical_blocks::HistoricalBlockError, migrate::MigratorConfig, BeaconChain,
-    BeaconChainError, BeaconChainTypes, BeaconSnapshot, ChainConfig, ServerSentEventHandler,
-    WhenSlotSkipped, NotifyExecutionLayer,
+    BeaconChainError, BeaconChainTypes, BeaconSnapshot, ChainConfig, NotifyExecutionLayer,
+    ServerSentEventHandler, WhenSlotSkipped,
 };
 use fork_choice::CountUnrealized;
 use lazy_static::lazy_static;

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2148,7 +2148,7 @@ async fn weak_subjectivity_sync() {
                 full_block.canonical_root(),
                 Arc::new(full_block),
                 CountUnrealized::True,
-                false,
+                NotifyExecutionLayer::Yes,
             )
             .await
             .unwrap();
@@ -2407,11 +2407,21 @@ async fn revert_minority_fork_on_resume() {
         let (block, new_state) = harness1.make_block(state, slot).await;
 
         harness1
-            .process_block(slot, block.canonical_root(), block.clone())
+            .process_block(
+                slot,
+                block.canonical_root(),
+                block.clone(),
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .unwrap();
         harness2
-            .process_block(slot, block.canonical_root(), block.clone())
+            .process_block(
+                slot,
+                block.canonical_root(),
+                block.clone(),
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .unwrap();
 
@@ -2447,7 +2457,12 @@ async fn revert_minority_fork_on_resume() {
         // Minority chain block (no attesters).
         let (block1, new_state1) = harness1.make_block(state1, slot).await;
         harness1
-            .process_block(slot, block1.canonical_root(), block1)
+            .process_block(
+                slot,
+                block1.canonical_root(),
+                block1,
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .unwrap();
         state1 = new_state1;
@@ -2455,7 +2470,12 @@ async fn revert_minority_fork_on_resume() {
         // Majority chain block (all attesters).
         let (block2, new_state2) = harness2.make_block(state2, slot).await;
         harness2
-            .process_block(slot, block2.canonical_root(), block2.clone())
+            .process_block(
+                slot,
+                block2.canonical_root(),
+                block2.clone(),
+                NotifyExecutionLayer::Yes,
+            )
             .await
             .unwrap();
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2407,21 +2407,11 @@ async fn revert_minority_fork_on_resume() {
         let (block, new_state) = harness1.make_block(state, slot).await;
 
         harness1
-            .process_block(
-                slot,
-                block.canonical_root(),
-                block.clone(),
-                NotifyExecutionLayer::Yes,
-            )
+            .process_block(slot, block.canonical_root(), block.clone())
             .await
             .unwrap();
         harness2
-            .process_block(
-                slot,
-                block.canonical_root(),
-                block.clone(),
-                NotifyExecutionLayer::Yes,
-            )
+            .process_block(slot, block.canonical_root(), block.clone())
             .await
             .unwrap();
 
@@ -2457,12 +2447,7 @@ async fn revert_minority_fork_on_resume() {
         // Minority chain block (no attesters).
         let (block1, new_state1) = harness1.make_block(state1, slot).await;
         harness1
-            .process_block(
-                slot,
-                block1.canonical_root(),
-                block1,
-                NotifyExecutionLayer::Yes,
-            )
+            .process_block(slot, block1.canonical_root(), block1)
             .await
             .unwrap();
         state1 = new_state1;
@@ -2470,12 +2455,7 @@ async fn revert_minority_fork_on_resume() {
         // Majority chain block (all attesters).
         let (block2, new_state2) = harness2.make_block(state2, slot).await;
         harness2
-            .process_block(
-                slot,
-                block2.canonical_root(),
-                block2.clone(),
-                NotifyExecutionLayer::Yes,
-            )
+            .process_block(slot, block2.canonical_root(), block2.clone())
             .await
             .unwrap();
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2148,6 +2148,7 @@ async fn weak_subjectivity_sync() {
                 full_block.canonical_root(),
                 Arc::new(full_block),
                 CountUnrealized::True,
+                false
             )
             .await
             .unwrap();

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
         OP_POOL_DB_KEY,
     },
-    BeaconChain, StateSkipConfig, WhenSlotSkipped, NotifyExecutionLayer,
+    BeaconChain, NotifyExecutionLayer, StateSkipConfig, WhenSlotSkipped,
 };
 use fork_choice::CountUnrealized;
 use lazy_static::lazy_static;

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -688,7 +688,7 @@ async fn run_skip_slot_test(skip_slots: u64) {
                 harness_a.chain.head_snapshot().beacon_block_root,
                 harness_a.chain.head_snapshot().beacon_block.clone(),
                 CountUnrealized::True,
-                false
+                NotifyExecutionLayer::Yes,
             )
             .await
             .unwrap(),

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -6,7 +6,7 @@ use beacon_chain::{
         AttestationStrategy, BeaconChainHarness, BlockStrategy, EphemeralHarnessType,
         OP_POOL_DB_KEY,
     },
-    BeaconChain, StateSkipConfig, WhenSlotSkipped,
+    BeaconChain, StateSkipConfig, WhenSlotSkipped, NotifyExecutionLayer,
 };
 use fork_choice::CountUnrealized;
 use lazy_static::lazy_static;

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -687,7 +687,8 @@ async fn run_skip_slot_test(skip_slots: u64) {
             .process_block(
                 harness_a.chain.head_snapshot().beacon_block_root,
                 harness_a.chain.head_snapshot().beacon_block.clone(),
-                CountUnrealized::True
+                CountUnrealized::True,
+                false
             )
             .await
             .unwrap(),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -318,7 +318,6 @@ pub fn serve<T: BeaconChainTypes>(
 
     // Create a `warp` filter that provides access to the network globals.
     let inner_network_globals = ctx.network_globals.clone();
-
     let network_globals = warp::any()
         .map(move || inner_network_globals.clone())
         .and_then(|network_globals| async move {
@@ -1116,10 +1115,10 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .and_then(
-            move |block: Arc<SignedBeaconBlock<T::EthSpec>>,
-                  chain: Arc<BeaconChain<T>>,
-                  network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
-                  log: Logger| async move {
+            |block: Arc<SignedBeaconBlock<T::EthSpec>>,
+             chain: Arc<BeaconChain<T>>,
+             network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
+             log: Logger| async move {
                 publish_blocks::publish_block(None, block, chain, &network_tx, log)
                     .await
                     .map(|()| warp::reply())
@@ -1140,10 +1139,10 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .and_then(
-            move |block: SignedBeaconBlock<T::EthSpec, BlindedPayload<_>>,
-                  chain: Arc<BeaconChain<T>>,
-                  network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
-                  log: Logger| async move {
+            |block: SignedBeaconBlock<T::EthSpec, BlindedPayload<_>>,
+             chain: Arc<BeaconChain<T>>,
+             network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
+             log: Logger| async move {
                 publish_blocks::publish_blinded_block(block, chain, &network_tx, log)
                     .await
                     .map(|()| warp::reply())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -318,11 +318,6 @@ pub fn serve<T: BeaconChainTypes>(
 
     // Create a `warp` filter that provides access to the network globals.
     let inner_network_globals = ctx.network_globals.clone();
-    let is_syncing_finalized = if let Some(network_globals) = &ctx.network_globals {
-        network_globals.sync_state.read().is_syncing_finalized()
-    } else {
-        false
-    };
 
     let network_globals = warp::any()
         .map(move || inner_network_globals.clone())
@@ -1125,16 +1120,9 @@ pub fn serve<T: BeaconChainTypes>(
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   log: Logger| async move {
-                publish_blocks::publish_block(
-                    None,
-                    block,
-                    chain,
-                    &network_tx,
-                    log,
-                    is_syncing_finalized,
-                )
-                .await
-                .map(|()| warp::reply())
+                publish_blocks::publish_block(None, block, chain, &network_tx, log)
+                    .await
+                    .map(|()| warp::reply())
             },
         );
 
@@ -1156,15 +1144,9 @@ pub fn serve<T: BeaconChainTypes>(
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   log: Logger| async move {
-                publish_blocks::publish_blinded_block(
-                    block,
-                    chain,
-                    &network_tx,
-                    log,
-                    is_syncing_finalized,
-                )
-                .await
-                .map(|()| warp::reply())
+                publish_blocks::publish_blinded_block(block, chain, &network_tx, log)
+                    .await
+                    .map(|()| warp::reply())
             },
         );
 

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -21,6 +21,7 @@ pub async fn publish_block<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     network_tx: &UnboundedSender<NetworkMessage<T::EthSpec>>,
     log: Logger,
+    is_syncing_finalized: bool,
 ) -> Result<(), Rejection> {
     let seen_timestamp = timestamp_now();
 
@@ -35,7 +36,12 @@ pub async fn publish_block<T: BeaconChainTypes>(
     let block_root = block_root.unwrap_or_else(|| block.canonical_root());
 
     match chain
-        .process_block(block_root, block.clone(), CountUnrealized::True)
+        .process_block(
+            block_root,
+            block.clone(),
+            CountUnrealized::True,
+            is_syncing_finalized,
+        )
         .await
     {
         Ok(root) => {
@@ -129,6 +135,7 @@ pub async fn publish_blinded_block<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     network_tx: &UnboundedSender<NetworkMessage<T::EthSpec>>,
     log: Logger,
+    is_syncing_finalized: bool,
 ) -> Result<(), Rejection> {
     let block_root = block.canonical_root();
     let full_block = reconstruct_block(chain.clone(), block_root, block, log.clone()).await?;
@@ -138,6 +145,7 @@ pub async fn publish_blinded_block<T: BeaconChainTypes>(
         chain,
         network_tx,
         log,
+        is_syncing_finalized,
     )
     .await
 }

--- a/beacon_node/lighthouse_network/src/types/sync_state.rs
+++ b/beacon_node/lighthouse_network/src/types/sync_state.rs
@@ -74,6 +74,17 @@ impl SyncState {
         }
     }
 
+    pub fn is_syncing_finalized(&self) -> bool {
+        match self {
+            SyncState::SyncingFinalized { .. } => true,
+            SyncState::SyncingHead { .. } => false,
+            SyncState::SyncTransition => false,
+            SyncState::BackFillSyncing { .. } => false,
+            SyncState::Synced => false,
+            SyncState::Stalled => false,
+        }
+    }
+
     /// Returns true if the node is synced.
     ///
     /// NOTE: We consider the node synced if it is fetching old historical blocks.

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -7,7 +7,7 @@ use beacon_chain::{
     sync_committee_verification::{self, Error as SyncCommitteeError},
     validator_monitor::get_block_delay_ms,
     BeaconChainError, BeaconChainTypes, BlockError, CountUnrealized, ForkChoiceError,
-    GossipVerifiedBlock,
+    GossipVerifiedBlock, NotifyExecutionLayer,
 };
 use lighthouse_network::{Client, MessageAcceptance, MessageId, PeerAction, PeerId, ReportSource};
 use slog::{crit, debug, error, info, trace, warn};
@@ -659,7 +659,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         duplicate_cache: DuplicateCache,
         seen_duration: Duration,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) {
         if let Some(gossip_verified_block) = self
             .process_gossip_unverified_block(
@@ -679,7 +679,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     gossip_verified_block,
                     reprocess_tx,
                     seen_duration,
-                    is_syncing_finalized,
+                    notify_execution_layer,
                 )
                 .await;
                 // Drop the handle to remove the entry from the cache
@@ -930,7 +930,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         // This value is not used presently, but it might come in handy for debugging.
         _seen_duration: Duration,
-        is_syncing_finalized: bool,
+        notify_execution_layer: NotifyExecutionLayer,
     ) {
         let block: Arc<_> = verified_block.block.clone();
         let block_root = verified_block.block_root;
@@ -941,7 +941,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 block_root,
                 verified_block,
                 CountUnrealized::True,
-                is_syncing_finalized,
+                notify_execution_layer,
             )
             .await
         {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -659,7 +659,6 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         duplicate_cache: DuplicateCache,
         seen_duration: Duration,
-        notify_execution_layer: NotifyExecutionLayer,
     ) {
         if let Some(gossip_verified_block) = self
             .process_gossip_unverified_block(
@@ -679,7 +678,6 @@ impl<T: BeaconChainTypes> Worker<T> {
                     gossip_verified_block,
                     reprocess_tx,
                     seen_duration,
-                    notify_execution_layer,
                 )
                 .await;
                 // Drop the handle to remove the entry from the cache
@@ -930,7 +928,6 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         // This value is not used presently, but it might come in handy for debugging.
         _seen_duration: Duration,
-        notify_execution_layer: NotifyExecutionLayer,
     ) {
         let block: Arc<_> = verified_block.block.clone();
         let block_root = verified_block.block_root;
@@ -941,7 +938,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 block_root,
                 verified_block,
                 CountUnrealized::True,
-                notify_execution_layer,
+                NotifyExecutionLayer::Yes,
             )
             .await
         {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -659,6 +659,7 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         duplicate_cache: DuplicateCache,
         seen_duration: Duration,
+        is_syncing_finalized: bool,
     ) {
         if let Some(gossip_verified_block) = self
             .process_gossip_unverified_block(
@@ -678,6 +679,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     gossip_verified_block,
                     reprocess_tx,
                     seen_duration,
+                    is_syncing_finalized,
                 )
                 .await;
                 // Drop the handle to remove the entry from the cache
@@ -928,13 +930,19 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         // This value is not used presently, but it might come in handy for debugging.
         _seen_duration: Duration,
+        is_syncing_finalized: bool,
     ) {
         let block: Arc<_> = verified_block.block.clone();
         let block_root = verified_block.block_root;
 
         match self
             .chain
-            .process_block(block_root, verified_block, CountUnrealized::True)
+            .process_block(
+                block_root,
+                verified_block,
+                CountUnrealized::True,
+                is_syncing_finalized,
+            )
             .await
         {
             Ok(block_root) => {

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -49,7 +49,6 @@ impl<T: BeaconChainTypes> Worker<T> {
         reprocess_tx: mpsc::Sender<ReprocessQueueMessage<T>>,
         duplicate_cache: DuplicateCache,
         should_process: bool,
-        notify_execution_layer: NotifyExecutionLayer,
     ) {
         if !should_process {
             // Sync handles these results
@@ -91,7 +90,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 block_root,
                 block,
                 CountUnrealized::True,
-                notify_execution_layer,
+                NotifyExecutionLayer::Yes,
             )
             .await;
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -7,7 +7,7 @@ use beacon_chain::{
         obtain_indexed_attestation_and_committees_per_slot, VerifiedAttestation,
     },
     test_utils::{BeaconChainHarness, EphemeralHarnessType},
-    BeaconChainTypes, CachedHead, CountUnrealized,
+    BeaconChainTypes, CachedHead, CountUnrealized, NotifyExecutionLayer,
 };
 use execution_layer::{json_structures::JsonPayloadStatusV1Status, PayloadStatusV1};
 use serde::Deserialize;
@@ -388,7 +388,7 @@ impl<E: EthSpec> Tester<E> {
             block_root,
             block.clone(),
             CountUnrealized::False,
-            false,
+            NotifyExecutionLayer::Yes,
         ))?;
         if result.is_ok() != valid {
             return Err(Error::DidntFail(format!(

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -388,6 +388,7 @@ impl<E: EthSpec> Tester<E> {
             block_root,
             block.clone(),
             CountUnrealized::False,
+            false,
         ))?;
         if result.is_ok() != valid {
             return Err(Error::DidntFail(format!(


### PR DESCRIPTION
## Issue Addressed

#3704 

## Proposed Changes
Adds is_syncing_finalized: bool parameter for block verification functions. Sets the payload_verification_status to Optimistic if is_syncing_finalized is true. Uses SyncState in NetworkGlobals in BeaconProcessor to retrieve the syncing status.

## Additional Info
I could implement FinalizedSignatureVerifiedBlock if you think it would be nicer.
