### PR TITLE
Massive Update to Engine API

### DIFF
--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -153,7 +153,7 @@ pub enum BeaconChainError {
     },
     AddPayloadLogicError,
     ExecutionForkChoiceUpdateFailed(execution_layer::Error),
-    PrepareProposerBlockingFailed(execution_layer::Error),
+    PrepareProposerFailed(BlockProcessingError),
     ExecutionForkChoiceUpdateInvalid {
         status: PayloadStatus,
     },

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -17,6 +17,8 @@ use fork_choice::{InvalidationOperation, PayloadVerificationStatus};
 use proto_array::{Block as ProtoBlock, ExecutionStatus};
 use slog::debug;
 use slot_clock::SlotClock;
+#[cfg(feature = "withdrawals")]
+use state_processing::per_block_processing::get_expected_withdrawals;
 use state_processing::per_block_processing::{
     compute_timestamp_at_slot, is_execution_enabled, is_merge_transition_complete,
     partially_verify_execution_payload,
@@ -362,6 +364,15 @@ pub fn get_execution_payload<
     let random = *state.get_randao_mix(current_epoch)?;
     let latest_execution_payload_header_block_hash =
         state.latest_execution_payload_header()?.block_hash();
+    #[cfg(feature = "withdrawals")]
+    let withdrawals = match state {
+        &BeaconState::Capella(_) | &BeaconState::Eip4844(_) => {
+            Some(get_expected_withdrawals(state, spec)?.into())
+        }
+        &BeaconState::Merge(_) => None,
+        // These should happen but they're here to make the pattern irrefutable
+        &BeaconState::Base(_) | &BeaconState::Altair(_) => None,
+    };
 
     // Spawn a task to obtain the execution payload from the EL via a series of async calls. The
     // `join_handle` can be used to await the result of the function.
@@ -378,6 +389,8 @@ pub fn get_execution_payload<
                     proposer_index,
                     latest_execution_payload_header_block_hash,
                     builder_params,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals,
                 )
                 .await
             },
@@ -411,6 +424,7 @@ pub async fn prepare_execution_payload<T, Payload>(
     proposer_index: u64,
     latest_execution_payload_header_block_hash: ExecutionBlockHash,
     builder_params: BuilderParams,
+    #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
 ) -> Result<BlockProposalContents<T::EthSpec, Payload>, BlockProductionError>
 where
     T: BeaconChainTypes,
@@ -480,6 +494,9 @@ where
             proposer_index,
             forkchoice_update_params,
             builder_params,
+            fork,
+            #[cfg(feature = "withdrawals")]
+            withdrawals,
             &chain.spec,
         )
         .await

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -370,7 +370,7 @@ pub fn get_execution_payload<
             Some(get_expected_withdrawals(state, spec)?.into())
         }
         &BeaconState::Merge(_) => None,
-        // These should happen but they're here to make the pattern irrefutable
+        // These shouldn't happen but they're here to make the pattern irrefutable
         &BeaconState::Base(_) | &BeaconState::Altair(_) => None,
     };
 

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -12,9 +12,9 @@ use beacon_chain::{
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
 };
 use execution_layer::{
-    json_structures::{JsonForkChoiceStateV1, JsonPayloadAttributesV1},
+    json_structures::{JsonForkchoiceStateV1, JsonPayloadAttributesV1},
     test_utils::ExecutionBlockGenerator,
-    ExecutionLayer, ForkChoiceState, PayloadAttributes,
+    ExecutionLayer, ForkchoiceState, PayloadAttributes,
 };
 use fork_choice::{
     CountUnrealized, Error as ForkChoiceError, InvalidationOperation, PayloadVerificationStatus,
@@ -117,7 +117,7 @@ impl InvalidPayloadRig {
         &self.harness.chain.canonical_head
     }
 
-    fn previous_forkchoice_update_params(&self) -> (ForkChoiceState, PayloadAttributes) {
+    fn previous_forkchoice_update_params(&self) -> (ForkchoiceState, PayloadAttributes) {
         let mock_execution_layer = self.harness.mock_execution_layer.as_ref().unwrap();
         let json = mock_execution_layer
             .server
@@ -126,7 +126,7 @@ impl InvalidPayloadRig {
         let params = json.get("params").expect("no params");
 
         let fork_choice_state_json = params.get(0).expect("no payload param");
-        let fork_choice_state: JsonForkChoiceStateV1 =
+        let fork_choice_state: JsonForkchoiceStateV1 =
             serde_json::from_value(fork_choice_state_json.clone()).unwrap();
 
         let payload_param_json = params.get(1).expect("no payload param");

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-withdrawals = ["state_processing/withdrawals", "types/withdrawals"]
-withdrawals-processing = ["state_processing/withdrawals-processing"]
+withdrawals = ["state_processing/withdrawals", "types/withdrawals", "eth2/withdrawals"]
+withdrawals-processing = ["state_processing/withdrawals-processing", "eth2/withdrawals-processing"]
 
 [dependencies]
 types = { path = "../../consensus/types"}

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -309,9 +309,6 @@ pub struct ProposeBlindedBlockResponse {
 // but I'm writing this as it has been described
 #[derive(Clone, Copy)]
 pub struct SupportedApis {
-    // I wonder if it would be better to use a bitmask here..
-    // It would be 8x more space efficient but I do remember
-    // Mac saying something about the performance being bad..
     pub new_payload_v1: bool,
     pub new_payload_v2: bool,
     pub forkchoice_updated_v1: bool,

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -1,4 +1,4 @@
-use crate::engines::ForkChoiceState;
+use crate::engines::ForkchoiceState;
 pub use ethers_core::types::Transaction;
 use ethers_core::utils::rlp::{Decodable, Rlp};
 use http::deposit_methods::RpcError;
@@ -7,10 +7,11 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use strum::IntoStaticStr;
 use superstruct::superstruct;
+#[cfg(feature = "withdrawals")]
 use types::Withdrawal;
 pub use types::{
     Address, EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadHeader, FixedVector,
-    Hash256, Uint256, VariableList,
+    ForkName, Hash256, Uint256, VariableList,
 };
 
 pub mod auth;
@@ -44,6 +45,9 @@ pub enum Error {
     DeserializeWithdrawals(ssz_types::Error),
     BuilderApi(builder_client::Error),
     IncorrectStateVariant,
+    RequiredMethodUnsupported(&'static str),
+    UnsupportedForkVariant(String),
+    BadConversion(String),
 }
 
 impl From<reqwest::Error> for Error {
@@ -255,7 +259,29 @@ pub struct PayloadAttributes {
     pub suggested_fee_recipient: Address,
     #[cfg(feature = "withdrawals")]
     #[superstruct(only(V2))]
-    pub withdrawals: Vec<Withdrawal>,
+    pub withdrawals: Option<Vec<Withdrawal>>,
+}
+
+impl PayloadAttributes {
+    pub fn downgrade_to_v1(self) -> Result<Self, Error> {
+        match self {
+            PayloadAttributes::V1(_) => Ok(self),
+            PayloadAttributes::V2(v2) => {
+                #[cfg(features = "withdrawals")]
+                if v2.withdrawals.is_some() {
+                    return Err(Error::BadConversion(
+                        "Downgrading from PayloadAttributesV2 with non-null withdrawaals"
+                            .to_string(),
+                    ));
+                }
+                Ok(PayloadAttributes::V1(PayloadAttributesV1 {
+                    timestamp: v2.timestamp,
+                    prev_randao: v2.prev_randao,
+                    suggested_fee_recipient: v2.suggested_fee_recipient,
+                }))
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -276,4 +302,21 @@ pub struct ProposeBlindedBlockResponse {
     pub status: ProposeBlindedBlockResponseStatus,
     pub latest_valid_hash: Option<Hash256>,
     pub validation_error: Option<String>,
+}
+
+// This name is work in progress, it could
+// change when this method is actually proposed
+// but I'm writing this as it has been described
+#[derive(Clone, Copy)]
+pub struct SupportedApis {
+    // I wonder if it would be better to use a bitmask here..
+    // It would be 8x more space efficient but I do remember
+    // Mac saying something about the performance being bad..
+    pub new_payload_v1: bool,
+    pub new_payload_v2: bool,
+    pub forkchoice_updated_v1: bool,
+    pub forkchoice_updated_v2: bool,
+    pub get_payload_v1: bool,
+    pub get_payload_v2: bool,
+    pub exchange_transition_configuration_v1: bool,
 }

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -327,7 +327,7 @@ impl<T: EthSpec> TryFrom<ExecutionPayload<T>> for JsonExecutionPayloadV2<T> {
                 transactions: capella.transactions,
                 #[cfg(feature = "withdrawals")]
                 withdrawals: Some(
-                    Into::<Vec<_>>::into(capella.withdrawals)
+                    Vec::from(capella.withdrawals)
                         .into_iter()
                         .map(Into::into)
                         .collect::<Vec<_>>()

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -243,7 +243,7 @@ impl<T: EthSpec> JsonExecutionPayload<T> {
                     withdrawals: v3
                         .withdrawals
                         .map(|v| {
-                            Into::<Vec<_>>::into(v)
+                            Vec::from(v)
                                 .into_iter()
                                 .map(Into::into)
                                 .collect::<Vec<_>>()

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -3,11 +3,12 @@ use serde::{Deserialize, Serialize};
 use strum::EnumString;
 use superstruct::superstruct;
 use types::{
-    Blob, EthSpec, ExecutionBlockHash, ExecutionPayloadEip4844, ExecutionPayloadHeaderEip4844,
-    FixedVector, KzgCommitment, Transaction, Unsigned, VariableList,
+    Blob, EthSpec, ExecutionBlockHash, FixedVector, KzgCommitment, Transaction, Unsigned,
+    VariableList, Withdrawal,
 };
-use types::{ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadMerge};
-use types::{ExecutionPayloadHeader, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderMerge};
+use types::{
+    ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadEip4844, ExecutionPayloadMerge,
+};
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -62,169 +63,6 @@ pub struct JsonPayloadIdResponse {
     pub payload_id: PayloadId,
 }
 
-// (V1,V2,V3) -> (Merge,Capella,EIP4844)
-#[superstruct(
-    variants(V1, V2, V3),
-    variant_attributes(
-        derive(Debug, PartialEq, Default, Serialize, Deserialize,),
-        serde(bound = "T: EthSpec", rename_all = "camelCase"),
-    ),
-    cast_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
-    partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant")
-)]
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(bound = "T: EthSpec", rename_all = "camelCase", untagged)]
-pub struct JsonExecutionPayloadHeader<T: EthSpec> {
-    pub parent_hash: ExecutionBlockHash,
-    pub fee_recipient: Address,
-    pub state_root: Hash256,
-    pub receipts_root: Hash256,
-    #[serde(with = "serde_logs_bloom")]
-    pub logs_bloom: FixedVector<u8, T::BytesPerLogsBloom>,
-    pub prev_randao: Hash256,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub block_number: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_limit: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub gas_used: u64,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub timestamp: u64,
-    #[serde(with = "ssz_types::serde_utils::hex_var_list")]
-    pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
-    #[serde(with = "eth2_serde_utils::u256_hex_be")]
-    pub base_fee_per_gas: Uint256,
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    #[superstruct(only(V3))]
-    pub excess_blobs: u64,
-    pub block_hash: ExecutionBlockHash,
-    pub transactions_root: Hash256,
-    #[cfg(feature = "withdrawals")]
-    #[superstruct(only(V2, V3))]
-    pub withdrawals_root: Hash256,
-}
-
-impl<T: EthSpec> From<JsonExecutionPayloadHeader<T>> for ExecutionPayloadHeader<T> {
-    fn from(json_header: JsonExecutionPayloadHeader<T>) -> Self {
-        match json_header {
-            JsonExecutionPayloadHeader::V1(v1) => Self::Merge(ExecutionPayloadHeaderMerge {
-                parent_hash: v1.parent_hash,
-                fee_recipient: v1.fee_recipient,
-                state_root: v1.state_root,
-                receipts_root: v1.receipts_root,
-                logs_bloom: v1.logs_bloom,
-                prev_randao: v1.prev_randao,
-                block_number: v1.block_number,
-                gas_limit: v1.gas_limit,
-                gas_used: v1.gas_used,
-                timestamp: v1.timestamp,
-                extra_data: v1.extra_data,
-                base_fee_per_gas: v1.base_fee_per_gas,
-                block_hash: v1.block_hash,
-                transactions_root: v1.transactions_root,
-            }),
-            JsonExecutionPayloadHeader::V2(v2) => Self::Capella(ExecutionPayloadHeaderCapella {
-                parent_hash: v2.parent_hash,
-                fee_recipient: v2.fee_recipient,
-                state_root: v2.state_root,
-                receipts_root: v2.receipts_root,
-                logs_bloom: v2.logs_bloom,
-                prev_randao: v2.prev_randao,
-                block_number: v2.block_number,
-                gas_limit: v2.gas_limit,
-                gas_used: v2.gas_used,
-                timestamp: v2.timestamp,
-                extra_data: v2.extra_data,
-                base_fee_per_gas: v2.base_fee_per_gas,
-                block_hash: v2.block_hash,
-                transactions_root: v2.transactions_root,
-                #[cfg(feature = "withdrawals")]
-                withdrawals_root: v2.withdrawals_root,
-            }),
-            JsonExecutionPayloadHeader::V3(v3) => Self::Eip4844(ExecutionPayloadHeaderEip4844 {
-                parent_hash: v3.parent_hash,
-                fee_recipient: v3.fee_recipient,
-                state_root: v3.state_root,
-                receipts_root: v3.receipts_root,
-                logs_bloom: v3.logs_bloom,
-                prev_randao: v3.prev_randao,
-                block_number: v3.block_number,
-                gas_limit: v3.gas_limit,
-                gas_used: v3.gas_used,
-                timestamp: v3.timestamp,
-                extra_data: v3.extra_data,
-                base_fee_per_gas: v3.base_fee_per_gas,
-                excess_blobs: v3.excess_blobs,
-                block_hash: v3.block_hash,
-                transactions_root: v3.transactions_root,
-                #[cfg(feature = "withdrawals")]
-                withdrawals_root: v3.withdrawals_root,
-            }),
-        }
-    }
-}
-
-impl<T: EthSpec> From<ExecutionPayloadHeader<T>> for JsonExecutionPayloadHeader<T> {
-    fn from(header: ExecutionPayloadHeader<T>) -> Self {
-        match header {
-            ExecutionPayloadHeader::Merge(merge) => Self::V1(JsonExecutionPayloadHeaderV1 {
-                parent_hash: merge.parent_hash,
-                fee_recipient: merge.fee_recipient,
-                state_root: merge.state_root,
-                receipts_root: merge.receipts_root,
-                logs_bloom: merge.logs_bloom,
-                prev_randao: merge.prev_randao,
-                block_number: merge.block_number,
-                gas_limit: merge.gas_limit,
-                gas_used: merge.gas_used,
-                timestamp: merge.timestamp,
-                extra_data: merge.extra_data,
-                base_fee_per_gas: merge.base_fee_per_gas,
-                block_hash: merge.block_hash,
-                transactions_root: merge.transactions_root,
-            }),
-            ExecutionPayloadHeader::Capella(capella) => Self::V2(JsonExecutionPayloadHeaderV2 {
-                parent_hash: capella.parent_hash,
-                fee_recipient: capella.fee_recipient,
-                state_root: capella.state_root,
-                receipts_root: capella.receipts_root,
-                logs_bloom: capella.logs_bloom,
-                prev_randao: capella.prev_randao,
-                block_number: capella.block_number,
-                gas_limit: capella.gas_limit,
-                gas_used: capella.gas_used,
-                timestamp: capella.timestamp,
-                extra_data: capella.extra_data,
-                base_fee_per_gas: capella.base_fee_per_gas,
-                block_hash: capella.block_hash,
-                transactions_root: capella.transactions_root,
-                #[cfg(feature = "withdrawals")]
-                withdrawals_root: capella.withdrawals_root,
-            }),
-            ExecutionPayloadHeader::Eip4844(eip4844) => Self::V3(JsonExecutionPayloadHeaderV3 {
-                parent_hash: eip4844.parent_hash,
-                fee_recipient: eip4844.fee_recipient,
-                state_root: eip4844.state_root,
-                receipts_root: eip4844.receipts_root,
-                logs_bloom: eip4844.logs_bloom,
-                prev_randao: eip4844.prev_randao,
-                block_number: eip4844.block_number,
-                gas_limit: eip4844.gas_limit,
-                gas_used: eip4844.gas_used,
-                timestamp: eip4844.timestamp,
-                extra_data: eip4844.extra_data,
-                base_fee_per_gas: eip4844.base_fee_per_gas,
-                excess_blobs: eip4844.excess_blobs,
-                block_hash: eip4844.block_hash,
-                transactions_root: eip4844.transactions_root,
-                #[cfg(feature = "withdrawals")]
-                withdrawals_root: eip4844.withdrawals_root,
-            }),
-        }
-    }
-}
-
-// (V1,V2, V2) -> (Merge,Capella,EIP4844)
 #[superstruct(
     variants(V1, V2, V3),
     variant_attributes(
@@ -257,81 +95,173 @@ pub struct JsonExecutionPayload<T: EthSpec> {
     #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub base_fee_per_gas: Uint256,
     #[superstruct(only(V3))]
+    // FIXME: can't easily make this an option because of custom deserialization..
     #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub excess_blobs: u64,
     pub block_hash: ExecutionBlockHash,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]
     pub transactions:
         VariableList<Transaction<T::MaxBytesPerTransaction>, T::MaxTransactionsPerPayload>,
-    #[cfg(feature = "withdrawals")]
     #[superstruct(only(V2, V3))]
-    pub withdrawals: VariableList<Withdrawal, T::MaxWithdrawalsPerPayload>,
+    pub withdrawals: Option<VariableList<JsonWithdrawal, T::MaxWithdrawalsPerPayload>>,
 }
 
-impl<T: EthSpec> From<JsonExecutionPayload<T>> for ExecutionPayload<T> {
-    fn from(json_payload: JsonExecutionPayload<T>) -> Self {
-        match json_payload {
-            JsonExecutionPayload::V1(v1) => Self::Merge(ExecutionPayloadMerge {
-                parent_hash: v1.parent_hash,
-                fee_recipient: v1.fee_recipient,
-                state_root: v1.state_root,
-                receipts_root: v1.receipts_root,
-                logs_bloom: v1.logs_bloom,
-                prev_randao: v1.prev_randao,
-                block_number: v1.block_number,
-                gas_limit: v1.gas_limit,
-                gas_used: v1.gas_used,
-                timestamp: v1.timestamp,
-                extra_data: v1.extra_data,
-                base_fee_per_gas: v1.base_fee_per_gas,
-                block_hash: v1.block_hash,
-                transactions: v1.transactions,
-            }),
-            JsonExecutionPayload::V2(v2) => Self::Capella(ExecutionPayloadCapella {
-                parent_hash: v2.parent_hash,
-                fee_recipient: v2.fee_recipient,
-                state_root: v2.state_root,
-                receipts_root: v2.receipts_root,
-                logs_bloom: v2.logs_bloom,
-                prev_randao: v2.prev_randao,
-                block_number: v2.block_number,
-                gas_limit: v2.gas_limit,
-                gas_used: v2.gas_used,
-                timestamp: v2.timestamp,
-                extra_data: v2.extra_data,
-                base_fee_per_gas: v2.base_fee_per_gas,
-                block_hash: v2.block_hash,
-                transactions: v2.transactions,
-                #[cfg(feature = "withdrawals")]
-                withdrawals: v2.withdrawals,
-            }),
-            JsonExecutionPayload::V3(v3) => Self::Eip4844(ExecutionPayloadEip4844 {
-                parent_hash: v3.parent_hash,
-                fee_recipient: v3.fee_recipient,
-                state_root: v3.state_root,
-                receipts_root: v3.receipts_root,
-                logs_bloom: v3.logs_bloom,
-                prev_randao: v3.prev_randao,
-                block_number: v3.block_number,
-                gas_limit: v3.gas_limit,
-                gas_used: v3.gas_used,
-                timestamp: v3.timestamp,
-                extra_data: v3.extra_data,
-                base_fee_per_gas: v3.base_fee_per_gas,
-                excess_blobs: v3.excess_blobs,
-                block_hash: v3.block_hash,
-                transactions: v3.transactions,
-                #[cfg(feature = "withdrawals")]
-                withdrawals: v3.withdrawals,
-            }),
+impl<T: EthSpec> JsonExecutionPayload<T> {
+    pub fn try_into_execution_payload(
+        self,
+        fork_name: ForkName,
+    ) -> Result<ExecutionPayload<T>, Error> {
+        match self {
+            JsonExecutionPayload::V1(v1) => match fork_name {
+                ForkName::Merge => Ok(ExecutionPayload::Merge(ExecutionPayloadMerge {
+                    parent_hash: v1.parent_hash,
+                    fee_recipient: v1.fee_recipient,
+                    state_root: v1.state_root,
+                    receipts_root: v1.receipts_root,
+                    logs_bloom: v1.logs_bloom,
+                    prev_randao: v1.prev_randao,
+                    block_number: v1.block_number,
+                    gas_limit: v1.gas_limit,
+                    gas_used: v1.gas_used,
+                    timestamp: v1.timestamp,
+                    extra_data: v1.extra_data,
+                    base_fee_per_gas: v1.base_fee_per_gas,
+                    block_hash: v1.block_hash,
+                    transactions: v1.transactions,
+                })),
+                _ => Err(Error::UnsupportedForkVariant(format!("Unsupported conversion from JsonExecutionPayloadV1 for {}", fork_name))),
+            }
+            JsonExecutionPayload::V2(v2) => match fork_name {
+                ForkName::Merge => Ok(ExecutionPayload::Merge(ExecutionPayloadMerge {
+                    parent_hash: v2.parent_hash,
+                    fee_recipient: v2.fee_recipient,
+                    state_root: v2.state_root,
+                    receipts_root: v2.receipts_root,
+                    logs_bloom: v2.logs_bloom,
+                    prev_randao: v2.prev_randao,
+                    block_number: v2.block_number,
+                    gas_limit: v2.gas_limit,
+                    gas_used: v2.gas_used,
+                    timestamp: v2.timestamp,
+                    extra_data: v2.extra_data,
+                    base_fee_per_gas: v2.base_fee_per_gas,
+                    block_hash: v2.block_hash,
+                    transactions: v2.transactions,
+                })),
+                ForkName::Capella => Ok(ExecutionPayload::Capella(ExecutionPayloadCapella {
+                    parent_hash: v2.parent_hash,
+                    fee_recipient: v2.fee_recipient,
+                    state_root: v2.state_root,
+                    receipts_root: v2.receipts_root,
+                    logs_bloom: v2.logs_bloom,
+                    prev_randao: v2.prev_randao,
+                    block_number: v2.block_number,
+                    gas_limit: v2.gas_limit,
+                    gas_used: v2.gas_used,
+                    timestamp: v2.timestamp,
+                    extra_data: v2.extra_data,
+                    base_fee_per_gas: v2.base_fee_per_gas,
+                    block_hash: v2.block_hash,
+                    transactions: v2.transactions,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals: v2
+                        .withdrawals
+                        .map(|v| {
+                            Into::<Vec<_>>::into(v)
+                                .into_iter()
+                                .map(Into::into)
+                                .collect::<Vec<_>>()
+                                .into()
+                        })
+                        .ok_or(Error::BadConversion("Null withdrawal field converting JsonExecutionPayloadV2 -> ExecutionPayloadCapella".to_string()))?
+                })),
+                ForkName::Eip4844 => Err(Error::UnsupportedForkVariant("JsonExecutionPayloadV2 -> ExecutionPayloadEip4844 not implemented yet as it might never be".to_string())),
+                _ => Err(Error::UnsupportedForkVariant(format!("Unsupported conversion from JsonExecutionPayloadV2 for {}", fork_name))),
+            }
+            JsonExecutionPayload::V3(v3) => match fork_name {
+                ForkName::Merge => Ok(ExecutionPayload::Merge(ExecutionPayloadMerge {
+                    parent_hash: v3.parent_hash,
+                    fee_recipient: v3.fee_recipient,
+                    state_root: v3.state_root,
+                    receipts_root: v3.receipts_root,
+                    logs_bloom: v3.logs_bloom,
+                    prev_randao: v3.prev_randao,
+                    block_number: v3.block_number,
+                    gas_limit: v3.gas_limit,
+                    gas_used: v3.gas_used,
+                    timestamp: v3.timestamp,
+                    extra_data: v3.extra_data,
+                    base_fee_per_gas: v3.base_fee_per_gas,
+                    block_hash: v3.block_hash,
+                    transactions: v3.transactions,
+                })),
+                ForkName::Capella => Ok(ExecutionPayload::Capella(ExecutionPayloadCapella {
+                    parent_hash: v3.parent_hash,
+                    fee_recipient: v3.fee_recipient,
+                    state_root: v3.state_root,
+                    receipts_root: v3.receipts_root,
+                    logs_bloom: v3.logs_bloom,
+                    prev_randao: v3.prev_randao,
+                    block_number: v3.block_number,
+                    gas_limit: v3.gas_limit,
+                    gas_used: v3.gas_used,
+                    timestamp: v3.timestamp,
+                    extra_data: v3.extra_data,
+                    base_fee_per_gas: v3.base_fee_per_gas,
+                    block_hash: v3.block_hash,
+                    transactions: v3.transactions,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals: v3
+                        .withdrawals
+                        .map(|v| {
+                            Into::<Vec<_>>::into(v)
+                                .into_iter()
+                                .map(Into::into)
+                                .collect::<Vec<_>>()
+                                .into()
+                        })
+                        .ok_or(Error::BadConversion("Null withdrawal field converting JsonExecutionPayloadV3 -> ExecutionPayloadCapella".to_string()))?
+                })),
+                ForkName::Eip4844 => Ok(ExecutionPayload::Eip4844(ExecutionPayloadEip4844 {
+                    parent_hash: v3.parent_hash,
+                    fee_recipient: v3.fee_recipient,
+                    state_root: v3.state_root,
+                    receipts_root: v3.receipts_root,
+                    logs_bloom: v3.logs_bloom,
+                    prev_randao: v3.prev_randao,
+                    block_number: v3.block_number,
+                    gas_limit: v3.gas_limit,
+                    gas_used: v3.gas_used,
+                    timestamp: v3.timestamp,
+                    extra_data: v3.extra_data,
+                    base_fee_per_gas: v3.base_fee_per_gas,
+                    // FIXME: excess_blobs probably will be an option whenever the engine API is finalized
+                    excess_blobs: v3.excess_blobs,
+                    block_hash: v3.block_hash,
+                    transactions: v3.transactions,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals: v3
+                        .withdrawals
+                        .map(|v| {
+                            Into::<Vec<_>>::into(v)
+                                .into_iter()
+                                .map(Into::into)
+                                .collect::<Vec<_>>()
+                                .into()
+                        })
+                        .ok_or(Error::BadConversion("Null withdrawal field converting JsonExecutionPayloadV3 -> ExecutionPayloadEip4844".to_string()))?,
+                })),
+                _ => Err(Error::UnsupportedForkVariant(format!("Unsupported conversion from JsonExecutionPayloadV2 for {}", fork_name))),
+            }
         }
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayload<T>> for JsonExecutionPayload<T> {
-    fn from(payload: ExecutionPayload<T>) -> Self {
+impl<T: EthSpec> TryFrom<ExecutionPayload<T>> for JsonExecutionPayloadV1<T> {
+    type Error = Error;
+    fn try_from(payload: ExecutionPayload<T>) -> Result<Self, Error> {
         match payload {
-            ExecutionPayload::Merge(merge) => Self::V1(JsonExecutionPayloadV1 {
+            ExecutionPayload::Merge(merge) => Ok(JsonExecutionPayloadV1 {
                 parent_hash: merge.parent_hash,
                 fee_recipient: merge.fee_recipient,
                 state_root: merge.state_root,
@@ -347,7 +277,40 @@ impl<T: EthSpec> From<ExecutionPayload<T>> for JsonExecutionPayload<T> {
                 block_hash: merge.block_hash,
                 transactions: merge.transactions,
             }),
-            ExecutionPayload::Capella(capella) => Self::V2(JsonExecutionPayloadV2 {
+            ExecutionPayload::Capella(_) => Err(Error::UnsupportedForkVariant(format!(
+                "Unsupported conversion to JsonExecutionPayloadV1 for {}",
+                ForkName::Capella
+            ))),
+            ExecutionPayload::Eip4844(_) => Err(Error::UnsupportedForkVariant(format!(
+                "Unsupported conversion to JsonExecutionPayloadV1 for {}",
+                ForkName::Eip4844
+            ))),
+        }
+    }
+}
+
+impl<T: EthSpec> TryFrom<ExecutionPayload<T>> for JsonExecutionPayloadV2<T> {
+    type Error = Error;
+    fn try_from(payload: ExecutionPayload<T>) -> Result<Self, Error> {
+        match payload {
+            ExecutionPayload::Merge(merge) => Ok(JsonExecutionPayloadV2 {
+                parent_hash: merge.parent_hash,
+                fee_recipient: merge.fee_recipient,
+                state_root: merge.state_root,
+                receipts_root: merge.receipts_root,
+                logs_bloom: merge.logs_bloom,
+                prev_randao: merge.prev_randao,
+                block_number: merge.block_number,
+                gas_limit: merge.gas_limit,
+                gas_used: merge.gas_used,
+                timestamp: merge.timestamp,
+                extra_data: merge.extra_data,
+                base_fee_per_gas: merge.base_fee_per_gas,
+                block_hash: merge.block_hash,
+                transactions: merge.transactions,
+                withdrawals: None,
+            }),
+            ExecutionPayload::Capella(capella) => Ok(JsonExecutionPayloadV2 {
                 parent_hash: capella.parent_hash,
                 fee_recipient: capella.fee_recipient,
                 state_root: capella.state_root,
@@ -363,27 +326,20 @@ impl<T: EthSpec> From<ExecutionPayload<T>> for JsonExecutionPayload<T> {
                 block_hash: capella.block_hash,
                 transactions: capella.transactions,
                 #[cfg(feature = "withdrawals")]
-                withdrawals: capella.withdrawals,
+                withdrawals: Some(
+                    Into::<Vec<_>>::into(capella.withdrawals)
+                        .into_iter()
+                        .map(Into::into)
+                        .collect::<Vec<_>>()
+                        .into(),
+                ),
+                #[cfg(not(feature = "withdrawals"))]
+                withdrawals: None,
             }),
-            ExecutionPayload::Eip4844(eip4844) => Self::V3(JsonExecutionPayloadV3 {
-                parent_hash: eip4844.parent_hash,
-                fee_recipient: eip4844.fee_recipient,
-                state_root: eip4844.state_root,
-                receipts_root: eip4844.receipts_root,
-                logs_bloom: eip4844.logs_bloom,
-                prev_randao: eip4844.prev_randao,
-                block_number: eip4844.block_number,
-                gas_limit: eip4844.gas_limit,
-                gas_used: eip4844.gas_used,
-                timestamp: eip4844.timestamp,
-                extra_data: eip4844.extra_data,
-                base_fee_per_gas: eip4844.base_fee_per_gas,
-                excess_blobs: eip4844.excess_blobs,
-                block_hash: eip4844.block_hash,
-                transactions: eip4844.transactions,
-                #[cfg(feature = "withdrawals")]
-                withdrawals: eip4844.withdrawals,
-            }),
+            ExecutionPayload::Eip4844(_) => Err(Error::UnsupportedForkVariant(format!(
+                "Unsupported conversion to JsonExecutionPayloadV1 for {}",
+                ForkName::Eip4844
+            ))),
         }
     }
 }
@@ -424,12 +380,15 @@ impl From<JsonWithdrawal> for Withdrawal {
 
 #[superstruct(
     variants(V1, V2),
-    variant_attributes(derive(Clone, Debug, PartialEq, Serialize, Deserialize),),
+    variant_attributes(
+        derive(Clone, Debug, PartialEq, Serialize, Deserialize),
+        serde(rename_all = "camelCase")
+    ),
     cast_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant")
 )]
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", untagged)]
+#[serde(untagged)]
 pub struct JsonPayloadAttributes {
     #[serde(with = "eth2_serde_utils::u64_hex_be")]
     pub timestamp: u64,
@@ -437,7 +396,7 @@ pub struct JsonPayloadAttributes {
     pub suggested_fee_recipient: Address,
     #[cfg(feature = "withdrawals")]
     #[superstruct(only(V2))]
-    pub withdrawals: Vec<JsonWithdrawal>,
+    pub withdrawals: Option<Vec<JsonWithdrawal>>,
 }
 
 impl From<PayloadAttributes> for JsonPayloadAttributes {
@@ -453,7 +412,9 @@ impl From<PayloadAttributes> for JsonPayloadAttributes {
                 prev_randao: pa.prev_randao,
                 suggested_fee_recipient: pa.suggested_fee_recipient,
                 #[cfg(feature = "withdrawals")]
-                withdrawals: pa.withdrawals.into_iter().map(Into::into).collect(),
+                withdrawals: pa
+                    .withdrawals
+                    .map(|w| w.into_iter().map(Into::into).collect()),
             }),
         }
     }
@@ -472,7 +433,9 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
                 prev_randao: jpa.prev_randao,
                 suggested_fee_recipient: jpa.suggested_fee_recipient,
                 #[cfg(feature = "withdrawals")]
-                withdrawals: jpa.withdrawals.into_iter().map(Into::into).collect(),
+                withdrawals: jpa
+                    .withdrawals
+                    .map(|jw| jw.into_iter().map(Into::into).collect()),
             }),
         }
     }
@@ -488,16 +451,16 @@ pub struct JsonBlobBundles<T: EthSpec> {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct JsonForkChoiceStateV1 {
+pub struct JsonForkchoiceStateV1 {
     pub head_block_hash: ExecutionBlockHash,
     pub safe_block_hash: ExecutionBlockHash,
     pub finalized_block_hash: ExecutionBlockHash,
 }
 
-impl From<ForkChoiceState> for JsonForkChoiceStateV1 {
-    fn from(f: ForkChoiceState) -> Self {
+impl From<ForkchoiceState> for JsonForkchoiceStateV1 {
+    fn from(f: ForkchoiceState) -> Self {
         // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let ForkChoiceState {
+        let ForkchoiceState {
             head_block_hash,
             safe_block_hash,
             finalized_block_hash,
@@ -511,10 +474,10 @@ impl From<ForkChoiceState> for JsonForkChoiceStateV1 {
     }
 }
 
-impl From<JsonForkChoiceStateV1> for ForkChoiceState {
-    fn from(j: JsonForkChoiceStateV1) -> Self {
+impl From<JsonForkchoiceStateV1> for ForkchoiceState {
+    fn from(j: JsonForkchoiceStateV1) -> Self {
         // Use this verbose deconstruction pattern to ensure no field is left unused.
-        let JsonForkChoiceStateV1 {
+        let JsonForkchoiceStateV1 {
             head_block_hash,
             safe_block_hash,
             finalized_block_hash,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -12,7 +12,7 @@ use engine_api::Error as ApiError;
 pub use engine_api::*;
 pub use engine_api::{http, http::deposit_methods, http::HttpJsonRpc};
 use engines::{Engine, EngineError};
-pub use engines::{EngineState, ForkChoiceState};
+pub use engines::{EngineState, ForkchoiceState};
 use fork_choice::ForkchoiceUpdateParameters;
 use lru::LruCache;
 use payload_status::process_payload_status;
@@ -33,6 +33,8 @@ use tokio::{
     time::sleep,
 };
 use tokio_stream::wrappers::WatchStream;
+#[cfg(feature = "withdrawals")]
+use types::Withdrawal;
 use types::{AbstractExecPayload, Blob, ExecPayload, ExecutionPayloadEip4844, KzgCommitment};
 use types::{
     BlindedPayload, BlockType, ChainSpec, Epoch, ExecutionBlockHash, ForkName,
@@ -613,6 +615,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
         proposer_index: u64,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         builder_params: BuilderParams,
+        current_fork: ForkName,
+        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         spec: &ChainSpec,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         let suggested_fee_recipient = self.get_suggested_fee_recipient(proposer_index).await;
@@ -630,6 +634,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     suggested_fee_recipient,
                     forkchoice_update_params,
                     builder_params,
+                    current_fork,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals,
                     spec,
                 )
                 .await
@@ -645,6 +652,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     prev_randao,
                     suggested_fee_recipient,
                     forkchoice_update_params,
+                    current_fork,
+                    #[cfg(feature = "withdrawals")]
+                    withdrawals,
                 )
                 .await
             }
@@ -660,6 +670,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
         suggested_fee_recipient: Address,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         builder_params: BuilderParams,
+        current_fork: ForkName,
+        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         spec: &ChainSpec,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         if let Some(builder) = self.builder() {
@@ -683,6 +695,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             prev_randao,
                             suggested_fee_recipient,
                             forkchoice_update_params,
+                            current_fork,
+                            #[cfg(feature = "withdrawals")]
+                            withdrawals,
                         )
                     );
 
@@ -812,6 +827,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
             prev_randao,
             suggested_fee_recipient,
             forkchoice_update_params,
+            current_fork,
+            #[cfg(feature = "withdrawals")]
+            withdrawals,
         )
         .await
     }
@@ -824,6 +842,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
         prev_randao: Hash256,
         suggested_fee_recipient: Address,
         forkchoice_update_params: ForkchoiceUpdateParameters,
+        current_fork: ForkName,
+        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         self.get_full_payload_with(
             parent_hash,
@@ -831,6 +851,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
             prev_randao,
             suggested_fee_recipient,
             forkchoice_update_params,
+            current_fork,
+            #[cfg(feature = "withdrawals")]
+            withdrawals,
             noop,
         )
         .await
@@ -844,6 +867,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
         prev_randao: Hash256,
         suggested_fee_recipient: Address,
         forkchoice_update_params: ForkchoiceUpdateParameters,
+        current_fork: ForkName,
+        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         self.get_full_payload_with(
             parent_hash,
@@ -851,6 +876,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
             prev_randao,
             suggested_fee_recipient,
             forkchoice_update_params,
+            current_fork,
+            #[cfg(feature = "withdrawals")]
+            withdrawals,
             Self::cache_payload,
         )
         .await
@@ -863,10 +891,14 @@ impl<T: EthSpec> ExecutionLayer<T> {
         prev_randao: Hash256,
         suggested_fee_recipient: Address,
         forkchoice_update_params: ForkchoiceUpdateParameters,
+        current_fork: ForkName,
+        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         f: fn(&ExecutionLayer<T>, &ExecutionPayload<T>) -> Option<ExecutionPayload<T>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
+        #[cfg(feature = "withdrawals")]
+        let withdrawals_ref = &withdrawals;
         self.engine()
-            .request(|engine| async move {
+            .request(move |engine| async move {
                 let payload_id = if let Some(id) = engine
                     .get_payload_id(parent_hash, timestamp, prev_randao, suggested_fee_recipient)
                     .await
@@ -884,7 +916,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                         &metrics::EXECUTION_LAYER_PRE_PREPARED_PAYLOAD_ID,
                         &[metrics::MISS],
                     );
-                    let fork_choice_state = ForkChoiceState {
+                    let fork_choice_state = ForkchoiceState {
                         head_block_hash: parent_hash,
                         safe_block_hash: forkchoice_update_params
                             .justified_hash
@@ -893,12 +925,14 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             .finalized_hash
                             .unwrap_or_else(ExecutionBlockHash::zero),
                     };
-                    // FIXME: This will have to properly handle forks. To do that,
-                    //        withdrawals will need to be passed into this function
-                    let payload_attributes = PayloadAttributes::V1(PayloadAttributesV1 {
+                    // This must always be the latest PayloadAttributes
+                    // FIXME: How to non-capella EIP4844 testnets handle this?
+                    let payload_attributes = PayloadAttributes::V2(PayloadAttributesV2 {
                         timestamp,
                         prev_randao,
                         suggested_fee_recipient,
+                        #[cfg(feature = "withdrawals")]
+                        withdrawals: withdrawals_ref.clone(),
                     });
 
                     let response = engine
@@ -925,7 +959,11 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 };
 
                 let blob_fut = async {
-                    //FIXME(sean) do a fork check here and return None otherwise
+                    //FIXME(sean)   do a fork check here and return None otherwise
+                    //              ^
+                    //              well now we have the fork in this function so
+                    //              it should be easier to do that now
+                    //               - Mark
                     debug!(
                         self.log(),
                         "Issuing engine_getBlobsBundle";
@@ -945,9 +983,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
                         "timestamp" => timestamp,
                         "parent_hash" => ?parent_hash,
                     );
-                    engine.api.get_payload_v1::<T>(payload_id).await
+                    engine.api.get_payload::<T>(current_fork, payload_id).await
                 };
-
                 let (blob, payload) = tokio::join!(blob_fut, payload_fut);
                 let payload = payload.map(|full_payload| {
                     if full_payload.fee_recipient() != suggested_fee_recipient {
@@ -1020,7 +1057,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
 
         let result = self
             .engine()
-            .request(|engine| engine.api.new_payload_v1(execution_payload.clone()))
+            .request(|engine| engine.api.new_payload(execution_payload.clone()))
             .await;
 
         if let Ok(status) = &result {
@@ -1150,7 +1187,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             }
         }
 
-        let forkchoice_state = ForkChoiceState {
+        let forkchoice_state = ForkchoiceState {
             head_block_hash,
             safe_block_hash: justified_block_hash,
             finalized_block_hash,

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -26,7 +26,8 @@ use task_executor::TaskExecutor;
 use tempfile::NamedTempFile;
 use tree_hash::TreeHash;
 use types::{
-    Address, BeaconState, BlindedPayload, ChainSpec, EthSpec, ExecPayload, Hash256, Slot, Uint256,
+    Address, BeaconState, BlindedPayload, ChainSpec, EthSpec, ExecPayload, ForkName, Hash256, Slot,
+    Uint256,
 };
 
 #[derive(Clone)]
@@ -313,6 +314,10 @@ impl<E: EthSpec> mev_build_rs::BlindedBlockProvider for MockBuilder<E> {
                 *prev_randao,
                 fee_recipient,
                 forkchoice_update_params,
+                // TODO: do we need to write a test for this if this is Capella fork?
+                ForkName::Merge,
+                #[cfg(feature = "withdrawals")]
+                None,
             )
             .await
             .map_err(convert_err)?

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -114,7 +114,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
                         suggested_fee_recipient: Address::repeat_byte(42),
                         // FIXME: think about adding withdrawals here..
                         #[cfg(feature = "withdrawals")]
-                        withdrawals: vec![],
+                        withdrawals: Some(vec![]),
                     })
                 }
             },
@@ -159,6 +159,10 @@ impl<T: EthSpec> MockExecutionLayer<T> {
                 validator_index,
                 forkchoice_update_params,
                 builder_params,
+                // FIXME: do we need to consider other forks somehow? What about withdrawals?
+                ForkName::Merge,
+                #[cfg(feature = "withdrawals")]
+                Some(vec![]),
                 &self.spec,
             )
             .await
@@ -191,6 +195,10 @@ impl<T: EthSpec> MockExecutionLayer<T> {
                 validator_index,
                 forkchoice_update_params,
                 builder_params,
+                // FIXME: do we need to consider other forks somehow? What about withdrawals?
+                ForkName::Merge,
+                #[cfg(feature = "withdrawals")]
+                Some(vec![]),
                 &self.spec,
             )
             .await

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -35,3 +35,5 @@ procinfo = { version = "0.4.2", optional = true }
 [features]
 default = ["lighthouse"]
 lighthouse = ["proto_array", "psutil", "procinfo", "store", "slashing_protection"]
+withdrawals = ["store/withdrawals"]
+withdrawals-processing = ["store/withdrawals-processing"]

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -462,7 +462,7 @@ pub fn compute_timestamp_at_slot<T: EthSpec>(
 }
 
 /// FIXME: add link to this function once the spec is stable
-#[cfg(all(feature = "withdrawals", feature = "withdrawals-processing"))]
+#[cfg(feature = "withdrawals")]
 pub fn get_expected_withdrawals<T: EthSpec>(
     state: &BeaconState<T>,
     spec: &ChainSpec,
@@ -471,6 +471,10 @@ pub fn get_expected_withdrawals<T: EthSpec>(
     let mut withdrawal_index = state.next_withdrawal_index()?;
     let mut validator_index = state.next_withdrawal_validator_index()?;
     let mut withdrawals = vec![];
+
+    if cfg!(not(feature = "withdrawals-processing")) {
+        return Ok(withdrawals.into());
+    }
 
     for _ in 0..state.validators().len() {
         let validator = state.get_validator(validator_index as usize)?;

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -4,15 +4,19 @@ use crate::case_result::compare_beacon_state_results_without_caches;
 use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use crate::testing_spec;
 use serde_derive::Deserialize;
+#[cfg(all(feature = "withdrawals", feature = "withdrawals-processing"))]
+use state_processing::per_block_processing::process_operations::{
+    process_bls_to_execution_changes, process_bls_to_execution_changes,
+};
 use state_processing::{
     per_block_processing::{
         errors::BlockProcessingError,
         process_block_header, process_execution_payload,
         process_operations::{
-            altair, base, process_attester_slashings, process_bls_to_execution_changes,
-            process_deposits, process_exits, process_proposer_slashings,
+            altair, base, process_attester_slashings, process_deposits, process_exits,
+            process_proposer_slashings,
         },
-        process_sync_aggregate, process_withdrawals, VerifyBlockRoot, VerifySignatures,
+        process_sync_aggregate, VerifyBlockRoot, VerifySignatures,
     },
     ConsensusContext,
 };
@@ -340,6 +344,7 @@ impl<E: EthSpec> Operation<E> for BlindedPayload<E> {
     }
 }
 
+#[cfg(all(feature = "withdrawals", feature = "withdrawals-processing"))]
 impl<E: EthSpec> Operation<E> for WithdrawalsPayload<E> {
     fn handler_name() -> String {
         "withdrawals".into()
@@ -372,6 +377,7 @@ impl<E: EthSpec> Operation<E> for WithdrawalsPayload<E> {
     }
 }
 
+#[cfg(all(feature = "withdrawals", feature = "withdrawals-processing"))]
 impl<E: EthSpec> Operation<E> for SignedBlsToExecutionChange {
     fn handler_name() -> String {
         "bls_to_execution_change".into()

--- a/testing/execution_engine_integration/Cargo.toml
+++ b/testing/execution_engine_integration/Cargo.toml
@@ -21,3 +21,7 @@ deposit_contract = { path = "../../common/deposit_contract" }
 reqwest = { version = "0.11.0", features = ["json"] }
 hex = "0.4.2"
 fork_choice = { path = "../../consensus/fork_choice" }
+
+[features]
+default = []
+withdrawals = []

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -16,8 +16,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use task_executor::TaskExecutor;
 use tokio::time::sleep;
 use types::{
-    Address, ChainSpec, EthSpec, ExecutionBlockHash, ExecutionPayload, FullPayload, Hash256,
-    MainnetEthSpec, PublicKeyBytes, Slot, Uint256,
+    Address, ChainSpec, EthSpec, ExecutionBlockHash, ExecutionPayload, ForkName, FullPayload,
+    Hash256, MainnetEthSpec, PublicKeyBytes, Slot, Uint256,
 };
 const EXECUTION_ENGINE_START_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -326,6 +326,10 @@ impl<E: GenericExecutionEngine> TestRig<E> {
                 proposer_index,
                 forkchoice_update_params,
                 builder_params,
+                // FIXME: think about how to test other forks
+                ForkName::Merge,
+                #[cfg(feature = "withdrawals")]
+                None,
                 &self.spec,
             )
             .await
@@ -450,6 +454,10 @@ impl<E: GenericExecutionEngine> TestRig<E> {
                 proposer_index,
                 forkchoice_update_params,
                 builder_params,
+                // FIXME: think about how to test other forks
+                ForkName::Merge,
+                #[cfg(feature = "withdrawals")]
+                None,
                 &self.spec,
             )
             .await


### PR DESCRIPTION
This should properly call the `V2` engine API methods. There's a lot of stubbing out functionality for when a new API function is released that communicates the endpoints that the execution engine supports. I need to do a refactor of some of the methods and the proposer's cache to just accept/store a `PayloadAttributes` instead of the components of `PayloadAttributes`. Working on that now.