### PR TITLE
[Merged by Bors] - v3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -3185,7 +3185,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "3.2.1"
+version = "3.3.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2021"
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "3.2.1"
+version = "3.3.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v3.2.1-",
-    fallback = "Lighthouse/v3.2.1"
+    prefix = "Lighthouse/v3.3.0-",
+    fallback = "Lighthouse/v3.3.0"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "3.2.1"
+version = "3.3.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "3.2.1"
+version = "3.3.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -8,7 +8,10 @@ use std::process::{Child, Command, Output};
 use tempfile::TempDir;
 use unused_port::unused_tcp_port;
 
-const NETHERMIND_BRANCH: &str = "master";
+/// We've pinned the Nethermind version since our method of using the `master` branch to
+/// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
+/// We should fix this so we always pull the latest version of Nethermind.
+const NETHERMIND_BRANCH: &str = "release/1.14.6";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -18,7 +18,7 @@ use types::{
     Address, ChainSpec, EthSpec, ExecutionBlockHash, ExecutionPayload, FullPayload, Hash256,
     MainnetEthSpec, PublicKeyBytes, Slot, Uint256,
 };
-const EXECUTION_ENGINE_START_TIMEOUT: Duration = Duration::from_secs(20);
+const EXECUTION_ENGINE_START_TIMEOUT: Duration = Duration::from_secs(30);
 
 struct ExecutionPair<E, T: EthSpec> {
     /// The Lighthouse `ExecutionLayer` struct, connected to the `execution_engine` via HTTP.


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Bump versions
- Pin the `nethermind` version since our method of getting the latest tags on `master` is giving us an old version (`1.14.1`).
- Increase timeout for execution engine startup.

## Additional Info

- [x] ~Awaiting further testing~