### PR TITLE
Fix BlocksByRoot response types

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -629,12 +629,12 @@ fn handle_v2_response<T: EthSpec>(
                         decoded_buffer,
                     )?),
                 )))),
-                ForkName::Capella => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
+                ForkName::Capella => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
                     SignedBeaconBlock::Capella(SignedBeaconBlockCapella::from_ssz_bytes(
                         decoded_buffer,
                     )?),
                 )))),
-                ForkName::Eip4844 => Ok(Some(RPCResponse::BlocksByRange(Arc::new(
+                ForkName::Eip4844 => Ok(Some(RPCResponse::BlocksByRoot(Arc::new(
                     SignedBeaconBlock::Eip4844(SignedBeaconBlockEip4844::from_ssz_bytes(
                         decoded_buffer,
                     )?),


### PR DESCRIPTION
## Proposed Changes

Fix a copy-pasta bug whereby a `BlocksByRange` response was being sent in response to `BlocksByRoot` requests for Capella and 4844.

I've confirmed that this resolves the panics I was getting on my Capella testnet branch (https://github.com/sigp/lighthouse/pull/3742).

Credit to @divagant-martian for spotting the issue and identifying the fix
