### PR TITLE
Rename excess blobs and update 4844 json RPC serialization/deserialization

### DIFF
--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -154,8 +154,8 @@ pub struct ExecutionBlockWithTransactions<T: EthSpec> {
     pub extra_data: VariableList<u8, T::MaxExtraDataBytes>,
     pub base_fee_per_gas: Uint256,
     #[superstruct(only(Eip4844))]
-    #[serde(with = "eth2_serde_utils::u64_hex_be")]
-    pub excess_blobs: u64,
+    #[serde(with = "eth2_serde_utils::u256_hex_be")]
+    pub excess_data_gas: Uint256,
     #[serde(rename = "hash")]
     pub block_hash: ExecutionBlockHash,
     pub transactions: Vec<Transaction>,
@@ -227,7 +227,7 @@ impl<T: EthSpec> From<ExecutionPayload<T>> for ExecutionBlockWithTransactions<T>
                     timestamp: block.timestamp,
                     extra_data: block.extra_data,
                     base_fee_per_gas: block.base_fee_per_gas,
-                    excess_blobs: block.excess_blobs,
+                    excess_data_gas: block.excess_data_gas,
                     block_hash: block.block_hash,
                     transactions: block
                         .transactions

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -857,7 +857,6 @@ impl HttpJsonRpc {
     ) -> Result<PayloadStatusV1, Error> {
         let supported_apis = self.get_cached_supported_apis().await?;
         if supported_apis.new_payload_v2 {
-            // FIXME: I haven't thought at all about how to handle 4844..
             self.new_payload_v2(execution_payload).await
         } else if supported_apis.new_payload_v1 {
             self.new_payload_v1(execution_payload).await
@@ -875,7 +874,6 @@ impl HttpJsonRpc {
     ) -> Result<ExecutionPayload<T>, Error> {
         let supported_apis = self.get_cached_supported_apis().await?;
         if supported_apis.get_payload_v2 {
-            // FIXME: I haven't thought at all about how to handle 4844..
             self.get_payload_v2(fork_name, payload_id).await
         } else if supported_apis.new_payload_v1 {
             self.get_payload_v1(fork_name, payload_id).await
@@ -893,7 +891,6 @@ impl HttpJsonRpc {
     ) -> Result<ForkchoiceUpdatedResponse, Error> {
         let supported_apis = self.get_cached_supported_apis().await?;
         if supported_apis.forkchoice_updated_v2 {
-            // FIXME: I haven't thought at all about how to handle 4844..
             self.forkchoice_updated_v2(forkchoice_state, payload_attributes)
                 .await
         } else if supported_apis.forkchoice_updated_v1 {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1577,7 +1577,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     timestamp: eip4844_block.timestamp,
                     extra_data: eip4844_block.extra_data,
                     base_fee_per_gas: eip4844_block.base_fee_per_gas,
-                    excess_blobs: eip4844_block.excess_blobs,
+                    excess_data_gas: eip4844_block.excess_data_gas,
                     block_hash: eip4844_block.block_hash,
                     transactions,
                     #[cfg(feature = "withdrawals")]

--- a/consensus/serde_utils/src/lib.rs
+++ b/consensus/serde_utils/src/lib.rs
@@ -7,6 +7,7 @@ pub mod json_str;
 pub mod list_of_bytes_lists;
 pub mod quoted_u64_vec;
 pub mod u256_hex_be;
+pub mod u256_hex_be_opt;
 pub mod u32_hex;
 pub mod u64_hex_be;
 pub mod u8_hex;

--- a/consensus/serde_utils/src/u256_hex_be_opt.rs
+++ b/consensus/serde_utils/src/u256_hex_be_opt.rs
@@ -1,0 +1,169 @@
+use ethereum_types::U256;
+
+use serde::de::Visitor;
+use serde::{de, Deserializer, Serialize, Serializer};
+use std::fmt;
+use std::str::FromStr;
+
+pub fn serialize<S>(num: &Option<U256>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    num.serialize(serializer)
+}
+
+pub struct U256Visitor;
+
+impl<'de> Visitor<'de> for U256Visitor {
+    type Value = String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a well formatted hex string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        if !value.starts_with("0x") {
+            return Err(de::Error::custom("must start with 0x"));
+        }
+        let stripped = &value[2..];
+        if stripped.is_empty() {
+            Err(de::Error::custom(format!(
+                "quantity cannot be {:?}",
+                stripped
+            )))
+        } else if stripped == "0" {
+            Ok(value.to_string())
+        } else if stripped.starts_with('0') {
+            Err(de::Error::custom("cannot have leading zero"))
+        } else {
+            Ok(value.to_string())
+        }
+    }
+}
+
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let decoded = deserializer.deserialize_string(U256Visitor)?;
+
+    Some(
+        U256::from_str(&decoded)
+            .map_err(|e| de::Error::custom(format!("Invalid U256 string: {}", e))),
+    )
+    .transpose()
+}
+
+#[cfg(test)]
+mod test {
+    use ethereum_types::U256;
+    use serde::{Deserialize, Serialize};
+    use serde_json;
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct Wrapper {
+        #[serde(with = "super")]
+        val: Option<U256>,
+    }
+
+    #[test]
+    fn encoding() {
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(0.into())
+            })
+            .unwrap(),
+            "\"0x0\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(1.into())
+            })
+            .unwrap(),
+            "\"0x1\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(256.into())
+            })
+            .unwrap(),
+            "\"0x100\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(65.into())
+            })
+            .unwrap(),
+            "\"0x41\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(1024.into())
+            })
+            .unwrap(),
+            "\"0x400\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(U256::max_value() - 1)
+            })
+            .unwrap(),
+            "\"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe\""
+        );
+        assert_eq!(
+            &serde_json::to_string(&Wrapper {
+                val: Some(U256::max_value())
+            })
+            .unwrap(),
+            "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+        );
+    }
+
+    #[test]
+    fn decoding() {
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x0\"").unwrap(),
+            Wrapper {
+                val: Some(0.into())
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x41\"").unwrap(),
+            Wrapper {
+                val: Some(65.into())
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>("\"0x400\"").unwrap(),
+            Wrapper {
+                val: Some(1024.into())
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>(
+                "\"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe\""
+            )
+            .unwrap(),
+            Wrapper {
+                val: Some(U256::max_value() - 1)
+            },
+        );
+        assert_eq!(
+            serde_json::from_str::<Wrapper>(
+                "\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\""
+            )
+            .unwrap(),
+            Wrapper {
+                val: Some(U256::max_value())
+            },
+        );
+        serde_json::from_str::<Wrapper>("\"0x\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"0x0400\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"400\"").unwrap_err();
+        serde_json::from_str::<Wrapper>("\"ff\"").unwrap_err();
+    }
+}

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -74,9 +74,9 @@ pub struct ExecutionPayload<T: EthSpec> {
     #[superstruct(getter(copy))]
     pub base_fee_per_gas: Uint256,
     #[superstruct(only(Eip4844))]
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::quoted_u256")]
     #[superstruct(getter(copy))]
-    pub excess_blobs: u64,
+    pub excess_data_gas: Uint256,
     #[superstruct(getter(copy))]
     pub block_hash: ExecutionBlockHash,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -68,9 +68,9 @@ pub struct ExecutionPayloadHeader<T: EthSpec> {
     #[superstruct(getter(copy))]
     pub base_fee_per_gas: Uint256,
     #[superstruct(only(Eip4844))]
-    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    #[serde(with = "eth2_serde_utils::quoted_u256")]
     #[superstruct(getter(copy))]
-    pub excess_blobs: u64,
+    pub excess_data_gas: Uint256,
     #[superstruct(getter(copy))]
     pub block_hash: ExecutionBlockHash,
     #[superstruct(getter(copy))]
@@ -150,7 +150,7 @@ impl<T: EthSpec> ExecutionPayloadHeaderCapella<T> {
             extra_data: self.extra_data.clone(),
             base_fee_per_gas: self.base_fee_per_gas,
             // TODO: verify if this is correct
-            excess_blobs: 0,
+            excess_data_gas: Uint256::zero(),
             block_hash: self.block_hash,
             transactions_root: self.transactions_root,
             #[cfg(feature = "withdrawals")]
@@ -216,7 +216,7 @@ impl<T: EthSpec> From<ExecutionPayloadEip4844<T>> for ExecutionPayloadHeaderEip4
             timestamp: payload.timestamp,
             extra_data: payload.extra_data,
             base_fee_per_gas: payload.base_fee_per_gas,
-            excess_blobs: payload.excess_blobs,
+            excess_data_gas: payload.excess_data_gas,
             block_hash: payload.block_hash,
             transactions_root: payload.transactions.tree_hash_root(),
             #[cfg(feature = "withdrawals")]


### PR DESCRIPTION
## Issue Addressed

- Rename `excess_blobs` to `excess_data_gas` and change the type from a `u64` to a `Uint256`
- use the V2 endpoint with optional fields, similar to how withdrawals vs merge payloads are handled

https://github.com/ethereum/execution-apis/pull/322/files

I couldn't figure out a way around adding a new custom `serde_derive` for `Option<256>` 