### PR TITLE
[Merged by Bors] - Add CLI flag to opt in to world-readable log files

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -789,6 +789,7 @@ fn run<T: EthSpec>(
             max_log_size: 0,
             max_log_number: 0,
             compression: false,
+            is_restricted: true,
         })
         .map_err(|e| format!("should start logger: {:?}", e))?
         .build()

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -55,6 +55,7 @@ pub struct LoggerConfig {
     pub max_log_size: u64,
     pub max_log_number: usize,
     pub compression: bool,
+    pub is_restricted: bool,
 }
 impl Default for LoggerConfig {
     fn default() -> Self {
@@ -68,6 +69,7 @@ impl Default for LoggerConfig {
             max_log_size: 200,
             max_log_number: 5,
             compression: false,
+            is_restricted: true,
         }
     }
 }
@@ -257,7 +259,7 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
             .rotate_size(config.max_log_size)
             .rotate_keep(config.max_log_number)
             .rotate_compress(config.compression)
-            .restrict_permissions(true)
+            .restrict_permissions(config.is_restricted)
             .build()
             .map_err(|e| format!("Unable to build file logger: {}", e))?;
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -130,6 +130,15 @@ fn main() {
                 .global(true),
         )
         .arg(
+            Arg::with_name("logfile-no-restricted-perms")
+                .long("logfile-no-restricted-perms")
+                .help(
+                    "If present, log files will be generated as world-readable meaning they can be read by \
+                    any user on the machine. Note that logs can often contain sensitive information \
+                    about your validator and so this flag should be used with caution.")
+                .global(true),
+        )
+        .arg(
             Arg::with_name("log-format")
                 .long("log-format")
                 .value_name("FORMAT")
@@ -407,6 +416,8 @@ fn run<E: EthSpec>(
 
     let logfile_compress = matches.is_present("logfile-compress");
 
+    let logfile_restricted = !matches.is_present("logfile-no-restricted-perms");
+
     // Construct the path to the log file.
     let mut log_path: Option<PathBuf> = clap_utils::parse_optional(matches, "logfile")?;
     if log_path.is_none() {
@@ -446,6 +457,7 @@ fn run<E: EthSpec>(
         max_log_size: logfile_max_size * 1_024 * 1_024,
         max_log_number: logfile_max_number,
         compression: logfile_compress,
+        is_restricted: logfile_restricted,
     };
 
     let builder = environment_builder.initialize_logger(logger_config.clone())?;

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1558,7 +1558,7 @@ fn logfile_restricted_perms_default() {
 }
 #[test]
 fn logfile_no_restricted_perms_flag() {
-        CommandLineTest::new()
+    CommandLineTest::new()
         .flag("logfile-no-restricted-perms", None)
         .run_with_zero_port()
         .with_config(|config| {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1548,6 +1548,23 @@ fn enabled_disable_log_timestamp_flag() {
             assert!(config.logger_config.disable_log_timestamp);
         });
 }
+#[test]
+fn logfile_restricted_perms_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.logger_config.is_restricted);
+        });
+}
+#[test]
+fn logfile_no_restricted_perms_flag() {
+        CommandLineTest::new()
+        .flag("logfile-no-restricted-perms", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.logger_config.is_restricted == false);
+        });
+}
 
 #[test]
 fn sync_eth1_chain_default() {

--- a/testing/simulator/src/eth1_sim.rs
+++ b/testing/simulator/src/eth1_sim.rs
@@ -67,6 +67,7 @@ pub fn run_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             max_log_size: 0,
             max_log_number: 0,
             compression: false,
+            is_restricted: true,
         })?
         .multi_threaded_tokio_runtime()?
         .build()?;

--- a/testing/simulator/src/no_eth1_sim.rs
+++ b/testing/simulator/src/no_eth1_sim.rs
@@ -52,6 +52,7 @@ pub fn run_no_eth1_sim(matches: &ArgMatches) -> Result<(), String> {
             max_log_size: 0,
             max_log_number: 0,
             compression: false,
+            is_restricted: true,
         })?
         .multi_threaded_tokio_runtime()?
         .build()?;

--- a/testing/simulator/src/sync_sim.rs
+++ b/testing/simulator/src/sync_sim.rs
@@ -56,6 +56,7 @@ fn syncing_sim(
             max_log_size: 0,
             max_log_number: 0,
             compression: false,
+            is_restricted: true,
         })?
         .multi_threaded_tokio_runtime()?
         .build()?;


### PR DESCRIPTION
## Issue Addressed

#3732

## Proposed Changes

Add a CLI flag to allow users to opt out of the restrictive permissions of the log files.

## Additional Info

This is not recommended for most users. The log files can contain sensitive information such as validator indices, public keys and API tokens (see #2438). However some users using a multi-user setup may find this helpful if they understand the risks involved.
