### PR TITLE
Two Capella bugfixes

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -310,7 +310,7 @@ pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
             }
         };
 
-        if is_merge_transition_complete || !execution_payload.is_default() {
+        if is_merge_transition_complete || !execution_payload.is_default_with_empty_roots() {
             let expected_timestamp = chain
                 .slot_clock
                 .start_of(block.slot())

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -402,7 +402,7 @@ where
             |()| ExecutionStatus::irrelevant(),
             |message| {
                 let execution_payload = &message.body.execution_payload;
-                if execution_payload == &<_>::default() {
+                if execution_payload.is_default_with_zero_roots() {
                     // A default payload does not have execution enabled.
                     ExecutionStatus::irrelevant()
                 } else {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -402,7 +402,7 @@ where
             |()| ExecutionStatus::irrelevant(),
             |message| {
                 let execution_payload = &message.body.execution_payload;
-                if execution_payload.is_default_with_zero_roots() {
+                if execution_payload == &<_>::default() {
                     // A default payload does not have execution enabled.
                     ExecutionStatus::irrelevant()
                 } else {

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -428,9 +428,11 @@ pub fn process_execution_payload<'payload, T: EthSpec, Payload: AbstractExecPayl
 /// repeaetedly write code to treat these errors as false.
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
 pub fn is_merge_transition_complete<T: EthSpec>(state: &BeaconState<T>) -> bool {
+    // We must check defaultness against the payload header with 0x0 roots, as that's what's meant
+    // by `ExecutionPayloadHeader()` in the spec.
     state
         .latest_execution_payload_header()
-        .map(|header| !header.is_default())
+        .map(|header| !header.is_default_with_zero_roots())
         .unwrap_or(false)
 }
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#is_merge_transition_block
@@ -438,8 +440,12 @@ pub fn is_merge_transition_block<T: EthSpec, Payload: AbstractExecPayload<T>>(
     state: &BeaconState<T>,
     body: BeaconBlockBodyRef<T, Payload>,
 ) -> bool {
+    // For execution payloads in blocks (which may be headers) we must check defaultness against
+    // the payload with `transactions_root` equal to the tree hash of the empty list.
     body.execution_payload()
-        .map(|payload| !is_merge_transition_complete(state) && !payload.is_default())
+        .map(|payload| {
+            !is_merge_transition_complete(state) && !payload.is_default_with_empty_roots()
+        })
         .unwrap_or(false)
 }
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#is_execution_enabled

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -103,9 +103,9 @@ impl<T: EthSpec> ExecutionPayloadHeader<T> {
 }
 
 impl<'a, T: EthSpec> ExecutionPayloadHeaderRef<'a, T> {
-    pub fn is_default(self) -> bool {
+    pub fn is_default_with_zero_roots(self) -> bool {
         map_execution_payload_header_ref!(&'a _, self, |inner, cons| {
-            let _ = cons(inner);
+            cons(inner);
             *inner == Default::default()
         })
     }


### PR DESCRIPTION
## Proposed Changes

- Fix `is_default` implementation for `Payload` types by splitting it into `is_default_with_zero_roots` and `is_default_with_empty_roots`. This allows us to capture the difference between `is_merge_transition_complete` (zero roots) and `is_merge_transition_block` (empty roots).

- Fix the preparation of payload attributes for Capella. We need the advanced state so that the balances are up to date on epoch boundaries. Slot advance is cheap otherwise, but we should add a cache in future to save repeating the epoch transition.
