### PR TITLE
[Merged by Bors] - Ipv6 bootnodes

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -14,6 +14,7 @@ use std::cmp::max;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::fs;
+use std::net::Ipv6Addr;
 use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -837,9 +838,11 @@ pub fn set_network_config(
     }
 
     if cli_args.is_present("enr-match") {
-        // set the enr address to localhost if the address is 0.0.0.0
-        if config.listen_address == "0.0.0.0".parse::<IpAddr>().expect("valid ip addr") {
-            config.enr_address = Some("127.0.0.1".parse::<IpAddr>().expect("valid ip addr"));
+        // set the enr address to localhost if the address is unspecified
+        if config.listen_address == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
+            config.enr_address = Some(IpAddr::V4(Ipv4Addr::LOCALHOST));
+        } else if config.listen_address == IpAddr::V6(Ipv6Addr::UNSPECIFIED) {
+            config.enr_address = Some(IpAddr::V6(Ipv6Addr::LOCALHOST));
         } else {
             config.enr_address = Some(config.listen_address);
         }

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -1,10 +1,11 @@
 use beacon_node::{get_data_dir, set_network_config};
 use clap::ArgMatches;
 use eth2_network_config::Eth2NetworkConfig;
+use lighthouse_network::discv5::enr::EnrBuilder;
 use lighthouse_network::discv5::IpMode;
 use lighthouse_network::discv5::{enr::CombinedKey, Discv5Config, Enr};
 use lighthouse_network::{
-    discovery::{create_enr_builder_from_config, load_enr_from_disk, use_or_load_enr},
+    discovery::{load_enr_from_disk, use_or_load_enr},
     load_private_key, CombinedKeyExt, NetworkConfig,
 };
 use serde_derive::{Deserialize, Serialize};
@@ -53,10 +54,6 @@ impl<T: EthSpec> BootNodeConfig<T> {
         };
 
         let mut network_config = NetworkConfig::default();
-        // create ipv6 sockets and enable ipv4 mapped addresses.
-        network_config.discv5_config.ip_mode = IpMode::Ip6 {
-            enable_mapped_addresses: true,
-        };
 
         let logger = slog_scope::logger();
 
@@ -75,6 +72,15 @@ impl<T: EthSpec> BootNodeConfig<T> {
         // the address to listen on
         let listen_socket =
             SocketAddr::new(network_config.listen_address, network_config.discovery_port);
+        if listen_socket.is_ipv6() {
+            // create ipv6 sockets and enable ipv4 mapped addresses.
+            network_config.discv5_config.ip_mode = IpMode::Ip6 {
+                enable_mapped_addresses: true,
+            };
+        } else {
+            // Set explicitely as ipv4 otherwise
+            network_config.discv5_config.ip_mode = IpMode::Ip4;
+        }
 
         let private_key = load_private_key(&network_config, &logger);
         let local_key = CombinedKey::from_libp2p(&private_key)?;
@@ -109,13 +115,26 @@ impl<T: EthSpec> BootNodeConfig<T> {
             // Build the local ENR
 
             let mut local_enr = {
-                let mut builder = create_enr_builder_from_config(&network_config, false);
-                // Include the ipv6 ports too.
-                // NOTE: we do this explicitely to be able to upgrade the bootnodes to ipv6 without
-                // upgrading the beacon node yet.
-                if let Some(udp_port) = network_config.enr_udp_port {
-                    builder.udp6(udp_port);
-                }
+                let mut builder = EnrBuilder::new("v4");
+                // Set the enr address if specified. Set also the port.
+                // NOTE: if the port is specified but the the address is not, the port won't be
+                // set since it can't be known if it's an ipv6 or ipv4 udp port.
+                if let Some(enr_address) = network_config.enr_address {
+                    match enr_address {
+                        std::net::IpAddr::V4(ipv4_addr) => {
+                            builder.ip4(ipv4_addr);
+                            if let Some(port) = network_config.enr_udp_port {
+                                builder.udp4(port);
+                            }
+                        }
+                        std::net::IpAddr::V6(ipv6_addr) => {
+                            builder.ip6(ipv6_addr);
+                            if let Some(port) = network_config.enr_udp_port {
+                                builder.udp6(port);
+                            }
+                        }
+                    }
+                };
 
                 // If we know of the ENR field, add it to the initial construction
                 if let Some(enr_fork_bytes) = enr_fork {

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -78,7 +78,7 @@ impl<T: EthSpec> BootNodeConfig<T> {
                 enable_mapped_addresses: true,
             };
         } else {
-            // Set explicitely as ipv4 otherwise
+            // Set explicitly as ipv4 otherwise
             network_config.discv5_config.ip_mode = IpMode::Ip4;
         }
 
@@ -131,6 +131,9 @@ impl<T: EthSpec> BootNodeConfig<T> {
                             builder.ip6(ipv6_addr);
                             if let Some(port) = network_config.enr_udp_port {
                                 builder.udp6(port);
+                                // We are enabling mapped addresses in the boot node in this case,
+                                // so advertise an udp4 port as well.
+                                builder.udp4(port);
                             }
                         }
                     }

--- a/boot_node/src/server.rs
+++ b/boot_node/src/server.rs
@@ -9,53 +9,52 @@ use slog::info;
 use types::EthSpec;
 
 pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
+    let BootNodeConfig {
+        listen_socket,
+        boot_nodes,
+        local_enr,
+        local_key,
+        discv5_config,
+        ..
+    } = config;
     // Print out useful information about the generated ENR
 
-    let enr_socket = config
-        .local_enr
-        .udp4_socket()
-        .expect("Enr has a UDP socket");
-    let eth2_field = config
-        .local_enr
+    let enr_socket = local_enr.udp4_socket().expect("Enr has a UDP socket");
+    let eth2_field = local_enr
         .eth2()
         .map(|fork_id| hex::encode(fork_id.fork_digest))
         .unwrap_or_default();
 
-    info!(log, "Configuration parameters"; "listening_address" => format!("{}:{}", config.listen_socket.ip(), config.listen_socket.port()), "broadcast_address" => format!("{}:{}",enr_socket.ip(), enr_socket.port()), "eth2" => eth2_field);
+    info!(log, "Configuration parameters"; "listening_address" => %listen_socket, "broadcast_address" => %enr_socket, "eth2" => eth2_field);
 
-    info!(log, "Identity established"; "peer_id" => config.local_enr.peer_id().to_string(), "node_id" => config.local_enr.node_id().to_string());
+    info!(log, "Identity established"; "peer_id" => %local_enr.peer_id(), "node_id" => %local_enr.node_id());
 
     // build the contactable multiaddr list, adding the p2p protocol
-    info!(log, "Contact information"; "enr" => config.local_enr.to_base64());
-    info!(log, "Contact information"; "multiaddrs" => format!("{:?}", config.local_enr.multiaddr_p2p()));
+    info!(log, "Contact information"; "enr" => local_enr.to_base64());
+    info!(log, "Contact information"; "multiaddrs" => ?local_enr.multiaddr_p2p());
 
     // construct the discv5 server
-    let mut discv5 = Discv5::new(
-        config.local_enr.clone(),
-        config.local_key,
-        config.discv5_config,
-    )
-    .unwrap();
+    let mut discv5 = Discv5::new(local_enr.clone(), local_key, discv5_config).unwrap();
 
     // If there are any bootnodes add them to the routing table
-    for enr in config.boot_nodes {
+    for enr in boot_nodes {
         info!(
             log,
             "Adding bootnode";
             "address" => ?enr.udp4_socket(),
-            "peer_id" => enr.peer_id().to_string(),
-            "node_id" => enr.node_id().to_string()
+            "peer_id" => ?enr.peer_id(),
+            "node_id" => ?enr.node_id()
         );
-        if enr != config.local_enr {
+        if enr != local_enr {
             if let Err(e) = discv5.add_enr(enr) {
-                slog::warn!(log, "Failed adding ENR"; "error" => e.to_string());
+                slog::warn!(log, "Failed adding ENR"; "error" => ?e);
             }
         }
     }
 
     // start the server
-    if let Err(e) = discv5.start(config.listen_socket).await {
-        slog::crit!(log, "Could not start discv5 server"; "error" => e.to_string());
+    if let Err(e) = discv5.start(listen_socket).await {
+        slog::crit!(log, "Could not start discv5 server"; "error" => %e);
         return;
     }
 
@@ -72,7 +71,7 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
     let mut event_stream = match discv5.event_stream().await {
         Ok(stream) => stream,
         Err(e) => {
-            slog::crit!(log, "Failed to obtain event stream"; "error" => e.to_string());
+            slog::crit!(log, "Failed to obtain event stream"; "error" => %e);
             return;
         }
     };
@@ -83,7 +82,7 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
             _ = metric_interval.tick() => {
                 // display server metrics
                 let metrics = discv5.metrics();
-                info!(log, "Server metrics"; "connected_peers" => discv5.connected_peers(), "active_sessions" => metrics.active_sessions, "requests/s" => format!("{:.2}", metrics.unsolicited_requests_per_second));
+                info!(log, "Server metrics"; "connected_peers" => discv5.connected_peers(), "active_sessions" => metrics.active_sessions, "requests/s" => format_args!("{:.2}", metrics.unsolicited_requests_per_second));
             }
             Some(event) = event_stream.recv() => {
                 match event {
@@ -95,7 +94,7 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
                     Discv5Event::TalkRequest(_) => {}     // Ignore
                     Discv5Event::NodeInserted { .. } => {} // Ignore
                     Discv5Event::SocketUpdated(socket_addr) => {
-                        info!(log, "External socket address updated"; "socket_addr" => format!("{:?}", socket_addr));
+                        info!(log, "Advertised socket address updated"; "socket_addr" => %socket_addr);
                     }
                     Discv5Event::SessionEstablished{ .. } => {} // Ignore
                 }

--- a/boot_node/src/server.rs
+++ b/boot_node/src/server.rs
@@ -20,18 +20,20 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
 
     // Print out useful information about the generated ENR
 
-    let enr_v4_socket = local_enr.udp4_socket().expect("Enr has a ipv4 UDP socket");
-    let enr_v6_socket = local_enr.udp6_socket().expect("Enr has a ipv6 UDP socket");
+    let enr_v4_socket = local_enr.udp4_socket();
+    let enr_v6_socket = local_enr.udp6_socket();
     let eth2_field = local_enr
         .eth2()
         .map(|fork_id| hex::encode(fork_id.fork_digest))
         .unwrap_or_default();
 
+    let pretty_v4_socket = enr_v4_socket.as_ref().map(|addr| addr.to_string());
+    let pretty_v6_socket = enr_v6_socket.as_ref().map(|addr| addr.to_string());
     info!(
         log, "Configuration parameters";
         "listening_address" => %listen_socket,
-        "advertised_v4_address" => %enr_v4_socket,
-        "advertised_v6_address" => %enr_v6_socket,
+        "advertised_v4_address" => ?pretty_v4_socket,
+        "advertised_v6_address" => ?pretty_v6_socket,
         "eth2" => eth2_field
     );
 
@@ -49,7 +51,8 @@ pub async fn run<T: EthSpec>(config: BootNodeConfig<T>, log: slog::Logger) {
         info!(
             log,
             "Adding bootnode";
-            "address" => ?enr.udp4_socket(),
+            "ipv4_address" => ?enr.udp4_socket(),
+            "ipv6_address" => ?enr.udp6_socket(),
             "peer_id" => ?enr.peer_id(),
             "node_id" => ?enr.node_id()
         );


### PR DESCRIPTION
## Issue Addressed
our bootnodes as of now support only ipv4. this makes it so that they support ipv6

## Proposed Changes
- Adds code necessary to update the bootnodes to run on dual stack nodes and therefore contact and store ipv6 nodes.
- Adds some metrics about connectivity type of stored peers. It might have been nice to see some metrics over the sessions but that feels out of scope right now.

## Additional Info
- some code quality improvements sneaked in since the changes seemed small
- I think it depends on the OS, but enabling mapped addresses on an ipv6 node without dual stack support enabled could fail silently, making these nodes effectively ipv6 only. In the future I'll probably change this to use two sockets, which should fail loudly
