### PR TITLE
Store downloaded payloads if pruning disabled

### DIFF
--- a/beacon_node/beacon_chain/src/otb_verification_service.rs
+++ b/beacon_node/beacon_chain/src/otb_verification_service.rs
@@ -179,7 +179,7 @@ pub async fn validate_optimistic_transition_blocks<T: BeaconChainTypes>(
 
     // ensure finalized canonical otb are valid, otherwise kill client
     for otb in finalized_canonical_otbs {
-        match chain.get_block(otb.root()).await {
+        match chain.get_block(*otb.root()).await {
             Ok(Some(block)) => {
                 match validate_merge_block(chain, block.message(), AllowOptimisticImport::No).await
                 {
@@ -236,7 +236,7 @@ pub async fn validate_optimistic_transition_blocks<T: BeaconChainTypes>(
 
     // attempt to validate any non-finalized canonical otb blocks
     for otb in unfinalized_canonical_otbs {
-        match chain.get_block(otb.root()).await {
+        match chain.get_block(*otb.root()).await {
             Ok(Some(block)) => {
                 match validate_merge_block(chain, block.message(), AllowOptimisticImport::No).await
                 {

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -173,7 +173,7 @@ impl BlockId {
             CoreBlockId::Slot(slot) => {
                 let (root, execution_optimistic) = self.root(chain)?;
                 chain
-                    .get_block(&root)
+                    .get_block(root)
                     .await
                     .map_err(warp_utils::reject::beacon_chain_error)
                     .and_then(|block_opt| match block_opt {
@@ -195,7 +195,7 @@ impl BlockId {
             _ => {
                 let (root, execution_optimistic) = self.root(chain)?;
                 chain
-                    .get_block(&root)
+                    .get_block(root)
                     .await
                     .map_err(warp_utils::reject::beacon_chain_error)
                     .and_then(|block_opt| {

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -351,7 +351,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 let mut send_response = true;
 
                 for root in block_roots {
-                    match self.chain.get_block(&root).await {
+                    match self.chain.get_block(root).await {
                         Ok(Some(block)) => {
                             // Due to skip slots, blocks could be out of the range, we ensure they
                             // are in the range before sending

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -454,6 +454,18 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         self.get_item(block_root)
     }
 
+    /// Store the execution payload for a block to disk.
+    ///
+    /// This will commit immediately, usually you'll want to use a transaction.
+    pub fn put_execution_payload(
+        &self,
+        block_root: &Hash256,
+        execution_payload: &ExecutionPayload<E>,
+    ) -> Result<(), Error> {
+        let ops = vec![execution_payload.as_kv_store_op(*block_root)];
+        self.hot_db.do_atomically(ops)
+    }
+
     /// Check if the execution payload for a block exists on disk.
     pub fn execution_payload_exists(&self, block_root: &Hash256) -> Result<bool, Error> {
         self.get_item::<ExecutionPayload<E>>(block_root)


### PR DESCRIPTION
## Proposed Changes

Introduce another stop-gap for payload pruning while we wait for bulk payload APIs – store the downloaded payloads in the database to prevent redownloading. Credit to @paulhauner for the idea.

## Additional Info

Needs some more performance testing before it's ready for review.
