### PR TITLE
Refactored Execution Layer & Fixed Some Tests

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4191,6 +4191,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .await,
             #[cfg(feature = "withdrawals")]
             withdrawals,
+            #[cfg(not(feature = "withdrawals"))]
+            withdrawals: None,
         });
 
         debug!(

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -14,7 +14,7 @@ use beacon_chain::{
 use execution_layer::{
     json_structures::{JsonForkchoiceStateV1, JsonPayloadAttributes, JsonPayloadAttributesV1},
     test_utils::ExecutionBlockGenerator,
-    ExecutionLayer, ForkchoiceState, PayloadAttributes, PayloadAttributesV1,
+    ExecutionLayer, ForkchoiceState, PayloadAttributes,
 };
 use fork_choice::{
     CountUnrealized, Error as ForkChoiceError, InvalidationOperation, PayloadVerificationStatus,
@@ -985,20 +985,22 @@ async fn payload_preparation() {
         .await
         .unwrap();
 
-    let payload_attributes = PayloadAttributes::V1(PayloadAttributesV1 {
-        timestamp: rig
-            .harness
+    let payload_attributes = PayloadAttributes::new(
+        rig.harness
             .chain
             .slot_clock
             .start_of(next_slot)
             .unwrap()
             .as_secs(),
-        prev_randao: *head
+        *head
             .beacon_state
             .get_randao_mix(head.beacon_state.current_epoch())
             .unwrap(),
-        suggested_fee_recipient: fee_recipient,
-    });
+        fee_recipient,
+        None,
+    )
+    .downgrade_to_v1()
+    .unwrap();
     assert_eq!(rig.previous_payload_attributes(), payload_attributes);
 }
 

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -7,11 +7,9 @@ use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use strum::IntoStaticStr;
 use superstruct::superstruct;
-#[cfg(feature = "withdrawals")]
-use types::Withdrawal;
 pub use types::{
     Address, EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadHeader, FixedVector,
-    ForkName, Hash256, Uint256, VariableList,
+    ForkName, Hash256, Uint256, VariableList, Withdrawal,
 };
 
 pub mod auth;
@@ -257,7 +255,6 @@ pub struct PayloadAttributes {
     pub prev_randao: Hash256,
     #[superstruct(getter(copy))]
     pub suggested_fee_recipient: Address,
-    #[cfg(feature = "withdrawals")]
     #[superstruct(only(V2))]
     pub withdrawals: Option<Vec<Withdrawal>>,
 }

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -375,8 +375,9 @@ pub struct JsonPayloadAttributes {
     pub timestamp: u64,
     pub prev_randao: Hash256,
     pub suggested_fee_recipient: Address,
-    #[cfg(feature = "withdrawals")]
     #[superstruct(only(V2))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub withdrawals: Option<Vec<JsonWithdrawal>>,
 }
 
@@ -392,7 +393,6 @@ impl From<PayloadAttributes> for JsonPayloadAttributes {
                 timestamp: pa.timestamp,
                 prev_randao: pa.prev_randao,
                 suggested_fee_recipient: pa.suggested_fee_recipient,
-                #[cfg(feature = "withdrawals")]
                 withdrawals: pa
                     .withdrawals
                     .map(|w| w.into_iter().map(Into::into).collect()),
@@ -413,7 +413,6 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
                 timestamp: jpa.timestamp,
                 prev_randao: jpa.prev_randao,
                 suggested_fee_recipient: jpa.suggested_fee_recipient,
-                #[cfg(feature = "withdrawals")]
                 withdrawals: jpa
                     .withdrawals
                     .map(|jw| jw.into_iter().map(Into::into).collect()),

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -933,6 +933,8 @@ impl<T: EthSpec> ExecutionLayer<T> {
                         suggested_fee_recipient,
                         #[cfg(feature = "withdrawals")]
                         withdrawals: withdrawals_ref.clone(),
+                        #[cfg(not(feature = "withdrawals"))]
+                        withdrawals: None,
                     });
 
                     let response = engine

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -606,21 +606,15 @@ impl<T: EthSpec> ExecutionLayer<T> {
     ///
     /// The result will be returned from the first node that returns successfully. No more nodes
     /// will be contacted.
-    #[allow(clippy::too_many_arguments)]
     pub async fn get_payload<Payload: AbstractExecPayload<T>>(
         &self,
         parent_hash: ExecutionBlockHash,
-        timestamp: u64,
-        prev_randao: Hash256,
-        proposer_index: u64,
+        payload_attributes: &PayloadAttributes,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         builder_params: BuilderParams,
         current_fork: ForkName,
-        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         spec: &ChainSpec,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
-        let suggested_fee_recipient = self.get_suggested_fee_recipient(proposer_index).await;
-
         match Payload::block_type() {
             BlockType::Blinded => {
                 let _timer = metrics::start_timer_vec(
@@ -629,14 +623,10 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 );
                 self.get_blinded_payload(
                     parent_hash,
-                    timestamp,
-                    prev_randao,
-                    suggested_fee_recipient,
+                    payload_attributes,
                     forkchoice_update_params,
                     builder_params,
                     current_fork,
-                    #[cfg(feature = "withdrawals")]
-                    withdrawals,
                     spec,
                 )
                 .await
@@ -648,30 +638,22 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 );
                 self.get_full_payload(
                     parent_hash,
-                    timestamp,
-                    prev_randao,
-                    suggested_fee_recipient,
+                    payload_attributes,
                     forkchoice_update_params,
                     current_fork,
-                    #[cfg(feature = "withdrawals")]
-                    withdrawals,
                 )
                 .await
             }
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn get_blinded_payload<Payload: AbstractExecPayload<T>>(
         &self,
         parent_hash: ExecutionBlockHash,
-        timestamp: u64,
-        prev_randao: Hash256,
-        suggested_fee_recipient: Address,
+        payload_attributes: &PayloadAttributes,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         builder_params: BuilderParams,
         current_fork: ForkName,
-        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         spec: &ChainSpec,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         if let Some(builder) = self.builder() {
@@ -691,13 +673,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
                         builder.get_builder_header::<T, Payload>(slot, parent_hash, &pubkey),
                         self.get_full_payload_caching(
                             parent_hash,
-                            timestamp,
-                            prev_randao,
-                            suggested_fee_recipient,
+                            payload_attributes,
                             forkchoice_update_params,
                             current_fork,
-                            #[cfg(feature = "withdrawals")]
-                            withdrawals,
                         )
                     );
 
@@ -746,7 +724,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                                     falling back to local execution engine."
                                 );
                                 Ok(local)
-                            } else if header.prev_randao() != prev_randao {
+                            } else if header.prev_randao() != payload_attributes.prev_randao() {
                                 warn!(
                                     self.log(),
                                     "Invalid prev randao from connected builder, \
@@ -784,7 +762,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                                     bid from connected builder, falling back to local execution engine.");
                                 Ok(local)
                             } else {
-                                if header.fee_recipient() != suggested_fee_recipient {
+                                if header.fee_recipient() != payload_attributes.suggested_fee_recipient() {
                                     info!(
                                         self.log(),
                                         "Fee recipient from connected builder does \
@@ -823,13 +801,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
         }
         self.get_full_payload_caching(
             parent_hash,
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
+            payload_attributes,
             forkchoice_update_params,
             current_fork,
-            #[cfg(feature = "withdrawals")]
-            withdrawals,
         )
         .await
     }
@@ -838,22 +812,15 @@ impl<T: EthSpec> ExecutionLayer<T> {
     async fn get_full_payload<Payload: AbstractExecPayload<T>>(
         &self,
         parent_hash: ExecutionBlockHash,
-        timestamp: u64,
-        prev_randao: Hash256,
-        suggested_fee_recipient: Address,
+        payload_attributes: &PayloadAttributes,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         current_fork: ForkName,
-        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         self.get_full_payload_with(
             parent_hash,
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
+            payload_attributes,
             forkchoice_update_params,
             current_fork,
-            #[cfg(feature = "withdrawals")]
-            withdrawals,
             noop,
         )
         .await
@@ -863,22 +830,15 @@ impl<T: EthSpec> ExecutionLayer<T> {
     async fn get_full_payload_caching<Payload: AbstractExecPayload<T>>(
         &self,
         parent_hash: ExecutionBlockHash,
-        timestamp: u64,
-        prev_randao: Hash256,
-        suggested_fee_recipient: Address,
+        payload_attributes: &PayloadAttributes,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         current_fork: ForkName,
-        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
         self.get_full_payload_with(
             parent_hash,
-            timestamp,
-            prev_randao,
-            suggested_fee_recipient,
+            payload_attributes,
             forkchoice_update_params,
             current_fork,
-            #[cfg(feature = "withdrawals")]
-            withdrawals,
             Self::cache_payload,
         )
         .await
@@ -887,20 +847,15 @@ impl<T: EthSpec> ExecutionLayer<T> {
     async fn get_full_payload_with<Payload: AbstractExecPayload<T>>(
         &self,
         parent_hash: ExecutionBlockHash,
-        timestamp: u64,
-        prev_randao: Hash256,
-        suggested_fee_recipient: Address,
+        payload_attributes: &PayloadAttributes,
         forkchoice_update_params: ForkchoiceUpdateParameters,
         current_fork: ForkName,
-        #[cfg(feature = "withdrawals")] withdrawals: Option<Vec<Withdrawal>>,
         f: fn(&ExecutionLayer<T>, &ExecutionPayload<T>) -> Option<ExecutionPayload<T>>,
     ) -> Result<BlockProposalContents<T, Payload>, Error> {
-        #[cfg(feature = "withdrawals")]
-        let withdrawals_ref = &withdrawals;
         self.engine()
             .request(move |engine| async move {
                 let payload_id = if let Some(id) = engine
-                    .get_payload_id(parent_hash, timestamp, prev_randao, suggested_fee_recipient)
+                    .get_payload_id(&parent_hash, payload_attributes)
                     .await
                 {
                     // The payload id has been cached for this engine.
@@ -925,22 +880,11 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             .finalized_hash
                             .unwrap_or_else(ExecutionBlockHash::zero),
                     };
-                    // This must always be the latest PayloadAttributes
-                    // FIXME: How to non-capella EIP4844 testnets handle this?
-                    let payload_attributes = PayloadAttributes::V2(PayloadAttributesV2 {
-                        timestamp,
-                        prev_randao,
-                        suggested_fee_recipient,
-                        #[cfg(feature = "withdrawals")]
-                        withdrawals: withdrawals_ref.clone(),
-                        #[cfg(not(feature = "withdrawals"))]
-                        withdrawals: None,
-                    });
 
                     let response = engine
                         .notify_forkchoice_updated(
                             fork_choice_state,
-                            Some(payload_attributes),
+                            Some(payload_attributes.clone()),
                             self.log(),
                         )
                         .await?;
@@ -969,9 +913,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             debug!(
                                 self.log(),
                                 "Issuing engine_getBlobsBundle";
-                                "suggested_fee_recipient" => ?suggested_fee_recipient,
-                                "prev_randao" => ?prev_randao,
-                                "timestamp" => timestamp,
+                                "suggested_fee_recipient" => ?payload_attributes.suggested_fee_recipient(),
+                                "prev_randao" => ?payload_attributes.prev_randao(),
+                                "timestamp" => payload_attributes.timestamp(),
                                 "parent_hash" => ?parent_hash,
                             );
                             Some(engine.api.get_blobs_bundle_v1::<T>(payload_id).await)
@@ -982,16 +926,16 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     debug!(
                         self.log(),
                         "Issuing engine_getPayload";
-                        "suggested_fee_recipient" => ?suggested_fee_recipient,
-                        "prev_randao" => ?prev_randao,
-                        "timestamp" => timestamp,
+                        "suggested_fee_recipient" => ?payload_attributes.suggested_fee_recipient(),
+                        "prev_randao" => ?payload_attributes.prev_randao(),
+                        "timestamp" => payload_attributes.timestamp(),
                         "parent_hash" => ?parent_hash,
                     );
                     engine.api.get_payload::<T>(current_fork, payload_id).await
                 };
                 let (blob, payload) = tokio::join!(blob_fut, payload_fut);
                 let payload = payload.map(|full_payload| {
-                    if full_payload.fee_recipient() != suggested_fee_recipient {
+                    if full_payload.fee_recipient() != payload_attributes.suggested_fee_recipient() {
                         error!(
                             self.log(),
                             "Inconsistent fee recipient";
@@ -1001,7 +945,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             ensure that the value of suggested_fee_recipient is set correctly and \
                             that the Execution Engine is trusted.",
                             "fee_recipient" => ?full_payload.fee_recipient(),
-                            "suggested_fee_recipient" => ?suggested_fee_recipient,
+                            "suggested_fee_recipient" => ?payload_attributes.suggested_fee_recipient(),
                         );
                     }
                     if f(self, &full_payload).is_some() {

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -115,6 +115,8 @@ impl<T: EthSpec> MockExecutionLayer<T> {
                         // FIXME: think about adding withdrawals here..
                         #[cfg(feature = "withdrawals")]
                         withdrawals: Some(vec![]),
+                        #[cfg(not(feature = "withdrawals"))]
+                        withdrawals: None,
                     })
                 }
             },

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -148,8 +148,8 @@ impl<T: EthSpec> From<FullPayload<T>> for ExecutionPayload<T> {
 }
 
 impl<'a, T: EthSpec> From<FullPayloadRef<'a, T>> for ExecutionPayload<T> {
-    fn from(full_payload: FullPayloadRef<'a, T>) -> Self {
-        match full_payload {
+    fn from(full_payload_ref: FullPayloadRef<'a, T>) -> Self {
+        match full_payload_ref {
             FullPayloadRef::Merge(payload) => {
                 ExecutionPayload::Merge(payload.execution_payload.clone())
             }
@@ -158,6 +158,23 @@ impl<'a, T: EthSpec> From<FullPayloadRef<'a, T>> for ExecutionPayload<T> {
             }
             FullPayloadRef::Eip4844(payload) => {
                 ExecutionPayload::Eip4844(payload.execution_payload.clone())
+            }
+        }
+    }
+}
+
+// FIXME: can this be implemented as Deref or Clone somehow?
+impl<'a, T: EthSpec> From<FullPayloadRef<'a, T>> for FullPayload<T> {
+    fn from(full_payload_ref: FullPayloadRef<'a, T>) -> Self {
+        match full_payload_ref {
+            FullPayloadRef::Merge(payload_ref) => {
+                FullPayload::Merge(payload_ref.clone())
+            }
+            FullPayloadRef::Capella(payload_ref) => {
+                FullPayload::Capella(payload_ref.clone())
+            }
+            FullPayloadRef::Eip4844(payload_ref) => {
+                FullPayload::Eip4844(payload_ref.clone())
             }
         }
     }

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -167,15 +167,9 @@ impl<'a, T: EthSpec> From<FullPayloadRef<'a, T>> for ExecutionPayload<T> {
 impl<'a, T: EthSpec> From<FullPayloadRef<'a, T>> for FullPayload<T> {
     fn from(full_payload_ref: FullPayloadRef<'a, T>) -> Self {
         match full_payload_ref {
-            FullPayloadRef::Merge(payload_ref) => {
-                FullPayload::Merge(payload_ref.clone())
-            }
-            FullPayloadRef::Capella(payload_ref) => {
-                FullPayload::Capella(payload_ref.clone())
-            }
-            FullPayloadRef::Eip4844(payload_ref) => {
-                FullPayload::Eip4844(payload_ref.clone())
-            }
+            FullPayloadRef::Merge(payload_ref) => FullPayload::Merge(payload_ref.clone()),
+            FullPayloadRef::Capella(payload_ref) => FullPayload::Capella(payload_ref.clone()),
+            FullPayloadRef::Eip4844(payload_ref) => FullPayload::Eip4844(payload_ref.clone()),
         }
     }
 }

--- a/consensus/types/src/withdrawal.rs
+++ b/consensus/types/src/withdrawal.rs
@@ -10,7 +10,7 @@ use tree_hash_derive::TreeHash;
 /// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
 )]
 pub struct Withdrawal {
     #[serde(with = "eth2_serde_utils::quoted_u64")]


### PR DESCRIPTION
I've refactored the execution layer so that the functions just pass around a reference to a `PayloadAttributes` instead of passing around all the components of a `PayloadAttributes`. This is cleaner and it's much easier to deal with future versions of the engine API where there will be new `PayloadAttributesVN` objects.

I also fixed some tests that could use a review by @michaelsproul (you can narrow down that stuff by looking just at the [`Fixed some BeaconChain Tests`](https://github.com/sigp/lighthouse/commit/36170ec428a799bf8b1f97dbbcd2864d919022b4) commit).