### PR TITLE
[Merged by Bors] - Expose certain `validator_monitor` metrics to the HTTP API 

### DIFF
--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -22,7 +22,7 @@ pub mod fork_revert;
 mod head_tracker;
 pub mod historical_blocks;
 pub mod merge_readiness;
-mod metrics;
+pub mod metrics;
 pub mod migrate;
 mod naive_aggregation_pool;
 mod observed_aggregates;

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -629,6 +629,14 @@ impl<T: EthSpec> ValidatorMonitor<T> {
         self.validators.len()
     }
 
+    // Return the `id`'s of all monitored validators.
+    pub fn get_all_monitored_validators(&self) -> Vec<String> {
+        self.validators
+            .iter()
+            .map(|(_, val)| val.id.clone())
+            .collect()
+    }
+
     /// If `self.auto_register == true`, add the `validator_index` to `self.monitored_validators`.
     /// Otherwise, do nothing.
     pub fn auto_register_local_validator(&mut self, validator_index: u64) {

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2899,6 +2899,18 @@ pub fn serve<T: BeaconChainTypes>(
             })
         });
 
+    // POST lighthouse/ui/validator_metrics
+    let get_lighthouse_ui_validator_metrics = warp::path("lighthouse")
+        .and(warp::path("ui"))
+        .and(warp::path("validator_metrics"))
+        .and(warp::path::end())
+        .and(chain_filter.clone())
+        .and_then(|chain: Arc<BeaconChain<T>>| {
+            blocking_json_task(move || {
+                ui::get_validator_monitor_metrics(chain).map(api_types::GenericResponse::from)
+            })
+        });
+
     // GET lighthouse/syncing
     let get_lighthouse_syncing = warp::path("lighthouse")
         .and(warp::path("syncing"))
@@ -3349,6 +3361,8 @@ pub fn serve<T: BeaconChainTypes>(
                 .or(get_validator_sync_committee_contribution.boxed())
                 .or(get_lighthouse_health.boxed())
                 .or(get_lighthouse_ui_health.boxed())
+                .or(get_lighthouse_ui_validator_count.boxed())
+                .or(get_lighthouse_ui_validator_metrics.boxed())
                 .or(get_lighthouse_syncing.boxed())
                 .or(get_lighthouse_nat.boxed())
                 .or(get_lighthouse_peers.boxed())
@@ -3366,7 +3380,6 @@ pub fn serve<T: BeaconChainTypes>(
                 .or(get_lighthouse_attestation_performance.boxed())
                 .or(get_lighthouse_block_packing_efficiency.boxed())
                 .or(get_lighthouse_merge_readiness.boxed())
-                .or(get_lighthouse_ui_validator_count.boxed())
                 .or(get_events.boxed()),
         )
         .boxed()

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2900,16 +2900,20 @@ pub fn serve<T: BeaconChainTypes>(
         });
 
     // POST lighthouse/ui/validator_metrics
-    let get_lighthouse_ui_validator_metrics = warp::path("lighthouse")
+    let post_lighthouse_ui_validator_metrics = warp::path("lighthouse")
         .and(warp::path("ui"))
         .and(warp::path("validator_metrics"))
         .and(warp::path::end())
+        .and(warp::body::json())
         .and(chain_filter.clone())
-        .and_then(|chain: Arc<BeaconChain<T>>| {
-            blocking_json_task(move || {
-                ui::get_validator_monitor_metrics(chain).map(api_types::GenericResponse::from)
-            })
-        });
+        .and_then(
+            |request_data: ui::ValidatorMetricsRequestData, chain: Arc<BeaconChain<T>>| {
+                blocking_json_task(move || {
+                    ui::post_validator_monitor_metrics(request_data, chain)
+                        .map(api_types::GenericResponse::from)
+                })
+            },
+        );
 
     // GET lighthouse/syncing
     let get_lighthouse_syncing = warp::path("lighthouse")
@@ -3362,7 +3366,6 @@ pub fn serve<T: BeaconChainTypes>(
                 .or(get_lighthouse_health.boxed())
                 .or(get_lighthouse_ui_health.boxed())
                 .or(get_lighthouse_ui_validator_count.boxed())
-                .or(get_lighthouse_ui_validator_metrics.boxed())
                 .or(get_lighthouse_syncing.boxed())
                 .or(get_lighthouse_nat.boxed())
                 .or(get_lighthouse_peers.boxed())
@@ -3403,7 +3406,8 @@ pub fn serve<T: BeaconChainTypes>(
                 .or(post_lighthouse_liveness.boxed())
                 .or(post_lighthouse_database_reconstruct.boxed())
                 .or(post_lighthouse_database_historical_blocks.boxed())
-                .or(post_lighthouse_block_rewards.boxed()),
+                .or(post_lighthouse_block_rewards.boxed())
+                .or(post_lighthouse_ui_validator_metrics.boxed()),
         ))
         .recover(warp_utils::reject::handle_rejection)
         .with(slog_logging(log.clone()))

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -75,7 +75,13 @@ pub fn get_validator_count<T: BeaconChainTypes>(
 pub struct ValidatorMetrics {
     attestation_hits: u64,
     attestation_misses: u64,
-    head_hit_percentage: f64,
+    attestation_hit_percentage: f64,
+    attestation_head_hits: u64,
+    attestation_head_misses: u64,
+    attestation_head_hit_percentage: f64,
+    attestation_target_hits: u64,
+    attestation_target_misses: u64,
+    attestation_target_hit_percentage: f64,
 }
 
 #[derive(PartialEq, Serialize, Deserialize)]
@@ -93,30 +99,75 @@ pub fn get_validator_monitor_metrics<T: BeaconChainTypes>(
     let mut validators = HashMap::new();
 
     for id in ids {
-        let hits = metrics::get_int_counter(
+        let attestation_hits = metrics::get_int_counter(
             &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_ATTESTER_HIT,
             &[&id],
         )
         .map(|counter| counter.get())
         .unwrap_or(0);
-        let misses = metrics::get_int_counter(
+        let attestation_misses = metrics::get_int_counter(
             &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_ATTESTER_MISS,
             &[&id],
         )
         .map(|counter| counter.get())
         .unwrap_or(0);
-        let attestations = hits + misses;
-        let head_hit_percentage: f64 = if attestations == 0 {
+        let attestations = attestation_hits + attestation_misses;
+        let attestation_hit_percentage: f64 = if attestations == 0 {
             0.0
         } else {
-            (100 * hits / attestations) as f64
+            (100 * attestation_hits / attestations) as f64
+        };
+
+        let attestation_head_hits = metrics::get_int_counter(
+            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_HEAD_ATTESTER_HIT,
+            &[&id],
+        )
+        .map(|counter| counter.get())
+        .unwrap_or(0);
+        let attestation_head_misses = metrics::get_int_counter(
+            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_HEAD_ATTESTER_MISS,
+            &[&id],
+        )
+        .map(|counter| counter.get())
+        .unwrap_or(0);
+        let head_attestations = attestation_head_hits + attestation_head_misses;
+        let attestation_head_hit_percentage: f64 = if head_attestations == 0 {
+            0.0
+        } else {
+            (100 * attestation_head_hits / head_attestations) as f64
+        };
+
+        let attestation_target_hits = metrics::get_int_counter(
+            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_TARGET_ATTESTER_HIT,
+            &[&id],
+        )
+        .map(|counter| counter.get())
+        .unwrap_or(0);
+        let attestation_target_misses = metrics::get_int_counter(
+            &metrics::VALIDATOR_MONITOR_PREV_EPOCH_ON_CHAIN_TARGET_ATTESTER_MISS,
+            &[&id],
+        )
+        .map(|counter| counter.get())
+        .unwrap_or(0);
+        let target_attestations = attestation_target_hits + attestation_target_misses;
+        let attestation_target_hit_percentage: f64 = if target_attestations == 0 {
+            0.0
+        } else {
+            (100 * attestation_target_hits / target_attestations) as f64
         };
 
         let metrics = ValidatorMetrics {
-            attestation_hits: hits,
-            attestation_misses: misses,
-            head_hit_percentage,
+            attestation_hits,
+            attestation_misses,
+            attestation_hit_percentage,
+            attestation_head_hits,
+            attestation_head_misses,
+            attestation_head_hit_percentage,
+            attestation_target_hits,
+            attestation_target_misses,
+            attestation_target_hit_percentage,
         };
+
         validators.insert(id, metrics);
     }
 

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -123,9 +123,9 @@ curl -X GET "http://localhost:5052/lighthouse/ui/validator_count" -H "accept: ap
 
 ### `/lighthouse/ui/validator_metrics`
 Re-exposes certain metrics from the validator monitor to the HTTP API.
-Will only return metrics for the validators currently being monitored.
+Will only return metrics for the validators currently being monitored and are present in the POST data.
 ```bash
-curl -X GET "http://localhost:5052/lighthouse/ui/validator_metrics" -H "accept: application/json" | jq
+curl -X POST "http://localhost:5052/lighthouse/ui/validator_metrics" -d '{"indices": [12345]}' -H "Content-Type: application/json" | jq
 ```
 
 ```json

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -133,14 +133,15 @@ curl -X GET "http://localhost:5052/lighthouse/ui/validator_metrics" -H "accept: 
   "data": {
     "validators": {
       "12345": {
-        "attestation_hits": 50,
+        "attestation_hits": 10,
         "attestation_misses": 0,
-        "head_hit_percentage": 100
-      },
-      "678910": {
-        "attestation_hits": 25,
-        "attestation_misses": 25,
-        "head_hit_percentage": 50
+        "attestation_hit_percentage": 100,
+        "attestation_head_hits": 10,
+        "attestation_head_misses": 0,
+        "attestation_head_hit_percentage": 100,
+        "attestation_target_hits": 5,
+        "attestation_target_misses": 5,
+        "attestation_target_hit_percentage": 50 
       }
     }
   }

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -121,6 +121,32 @@ curl -X GET "http://localhost:5052/lighthouse/ui/validator_count" -H "accept: ap
 }
 ```
 
+### `/lighthouse/ui/validator_metrics`
+Re-exposes certain metrics from the validator monitor to the HTTP API.
+Will only return metrics for the validators currently being monitored.
+```bash
+curl -X GET "http://localhost:5052/lighthouse/ui/validator_metrics" -H "accept: application/json" | jq
+```
+
+```json
+{
+  "data": {
+    "validators": {
+      "12345": {
+        "attestation_hits": 50,
+        "attestation_misses": 0,
+        "head_hit_percentage": 100
+      },
+      "678910": {
+        "attestation_hits": 25,
+        "attestation_misses": 25,
+        "head_hit_percentage": 50
+      }
+    }
+  }
+}
+```
+
 ### `/lighthouse/syncing`
 
 ```bash


### PR DESCRIPTION
## Issue Addressed

#3724 

## Proposed Changes

Exposes certain `validator_monitor` as an endpoint on the HTTP API. Will only return metrics for validators which are actively being monitored.

### Usage

```bash
curl -X POST "http://localhost:5052/lighthouse/ui/validator_metrics" -d '{"indices": [12345]}' -H "Content-Type: application/json"
```

```json
{
  "data": {
    "validators": {
      "12345": {
        "attestation_hits": 10,
        "attestation_misses": 0,
        "attestation_hit_percentage": 100,
        "attestation_head_hits": 10,
        "attestation_head_misses": 0,
        "attestation_head_hit_percentage": 100,
        "attestation_target_hits": 5,
        "attestation_target_misses": 5,
        "attestation_target_hit_percentage": 50 
      }
    }
  }
}
```

## Additional Info

Based on #3756 which should be merged first.