### PR TITLE
[Merged by Bors] - docs: remove mention of phases in voluntary exits

### DIFF
--- a/book/src/voluntary-exit.md
+++ b/book/src/voluntary-exit.md
@@ -12,10 +12,10 @@ This number can be much higher depending on how many other validators are queued
 
 ## Withdrawal of exited funds
 
-Even though users can perform a voluntary exit in phase 0, they **cannot withdraw their exited funds at this point in time**.
+Even though users can currently perform a voluntary exit, they **cannot withdraw their exited funds at this point in time**.
 This implies that the staked funds are effectively **frozen** until withdrawals are enabled in future phases.
 
-To understand the phased rollout strategy for Ethereum upgrades, please visit <https://ethereum.org/en/upgrades/#roadmap>.
+To understand the rollout strategy for Ethereum upgrades, please visit <https://ethereum.org/en/upgrades>.
 
 
 

--- a/book/src/voluntary-exit.md
+++ b/book/src/voluntary-exit.md
@@ -13,7 +13,7 @@ This number can be much higher depending on how many other validators are queued
 ## Withdrawal of exited funds
 
 Even though users can currently perform a voluntary exit, they **cannot withdraw their exited funds at this point in time**.
-This implies that the staked funds are effectively **frozen** until withdrawals are enabled in a future hard fork.
+This implies that the staked funds are effectively **frozen** until withdrawals are enabled in a future hard fork (Capella).
 
 To understand the rollout strategy for Ethereum upgrades, please visit <https://ethereum.org/en/upgrades>.
 

--- a/book/src/voluntary-exit.md
+++ b/book/src/voluntary-exit.md
@@ -13,7 +13,7 @@ This number can be much higher depending on how many other validators are queued
 ## Withdrawal of exited funds
 
 Even though users can currently perform a voluntary exit, they **cannot withdraw their exited funds at this point in time**.
-This implies that the staked funds are effectively **frozen** until withdrawals are enabled in future phases.
+This implies that the staked funds are effectively **frozen** until withdrawals are enabled in a future hard fork.
 
 To understand the rollout strategy for Ethereum upgrades, please visit <https://ethereum.org/en/upgrades>.
 


### PR DESCRIPTION
The notion of "phases" doesn't exist anymore in the Ethereum roadmap. Also fix dead link to roadmap.