### PR TITLE
Fix dependency conflicts when used with git or path locations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,13 +93,6 @@ members = [
 [patch.crates-io]
 fixed-hash = { git = "https://github.com/paritytech/parity-common", rev="df638ab0885293d21d656dc300d39236b69ce57d" }
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
-eth2_ssz = { path = "consensus/ssz" }
-eth2_ssz_derive = { path = "consensus/ssz_derive" }
-eth2_ssz_types = { path = "consensus/ssz_types" }
-eth2_hashing = { path = "crypto/eth2_hashing" }
-tree_hash = { path = "consensus/tree_hash" }
-tree_hash_derive = { path = "consensus/tree_hash_derive" }
-eth2_serde_utils = { path = "consensus/serde_utils" }
 
 [profile.maxperf]
 inherits = "release"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -30,12 +30,12 @@ serde_derive = "1.0.116"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = { version = "2.1.1", features = ["json"] }
 slot_clock = { path = "../../common/slot_clock" }
-eth2_hashing = "0.3.0"
-eth2_ssz = "0.4.1"
-eth2_ssz_types = "0.2.2"
-eth2_ssz_derive = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_types = { version = "0.2.2", path = "../../consensus/ssz_types" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
 state_processing = { path = "../../consensus/state_processing" }
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 types = { path = "../../consensus/types" }
 tokio = "1.14.0"
 eth1 = { path = "../eth1" }

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -20,9 +20,9 @@ serde = { version = "1.0.116", features = ["derive"] }
 hex = "0.4.2"
 types = { path = "../../consensus/types"}
 merkle_proof = { path = "../../consensus/merkle_proof"}
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
-tree_hash = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 parking_lot = "0.12.0"
 slog = "2.5.2"
 superstruct = "0.5.0"

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -13,7 +13,7 @@ slog = "2.5.2"
 futures = "0.3.7"
 sensitive_url = { path = "../../common/sensitive_url" }
 reqwest = { version = "0.11.0", features = ["json","stream"] }
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../../consensus/serde_utils" }
 serde_json = "1.0.58"
 serde = { version = "1.0.116", features = ["derive"] }
 warp = { version = "0.3.2", features = ["tls"] }
@@ -22,13 +22,13 @@ environment = { path = "../../lighthouse/environment" }
 bytes = "1.1.0"
 task_executor = { path = "../../common/task_executor" }
 hex = "0.4.2"
-eth2_ssz = "0.4.1"
-eth2_ssz_types = "0.2.2"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_types = { version = "0.2.2", path = "../../consensus/ssz_types" }
 eth2 = { path = "../../common/eth2" }
 state_processing = { path = "../../consensus/state_processing" }
 lru = "0.7.1"
 exit-future = "0.2.0"
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 tree_hash_derive = { path = "../../consensus/tree_hash_derive"}
 parking_lot = "0.12.0"
 slot_clock = { path = "../../common/slot_clock" }

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -16,9 +16,9 @@ eth1 = { path = "../eth1"}
 rayon = "1.4.1"
 state_processing = { path = "../../consensus/state_processing" }
 merkle_proof = { path = "../../consensus/merkle_proof" }
-eth2_ssz = "0.4.1"
-eth2_hashing = "0.3.0"
-tree_hash = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 tokio = { version = "1.14.0", features = ["full"] }
 slog = "2.5.2"
 int_to_bytes = { path = "../../consensus/int_to_bytes" }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -24,7 +24,7 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 lazy_static = "1.4.0"
 warp_utils = { path = "../../common/warp_utils" }
 slot_clock = { path = "../../common/slot_clock" }
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
 bs58 = "0.4.0"
 futures = "0.3.8"
 execution_layer = {path = "../execution_layer"}
@@ -32,7 +32,7 @@ parking_lot = "0.12.0"
 safe_arith = {path = "../../consensus/safe_arith"}
 task_executor = { path = "../../common/task_executor" }
 lru = "0.7.7"
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 sysinfo = "0.26.5"
 system_health = { path = "../../common/system_health" }
 directory = { path = "../../common/directory" }

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 discv5 = { version = "0.1.0", features = ["libp2p"] }
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
-eth2_ssz_types = "0.2.2"
+eth2_ssz_types = { version = "0.2.2", path = "../../consensus/ssz_types" }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_derive = "1.0.116"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 lighthouse_version = { path = "../../common/lighthouse_version" }
 tokio = { version = "1.14.0", features = ["time", "macros"] }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -21,8 +21,8 @@ types = { path = "../../consensus/types" }
 slot_clock = { path = "../../common/slot_clock" }
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 hex = "0.4.2"
-eth2_ssz = "0.4.1"
-eth2_ssz_types = "0.2.2"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_types = { version = "0.2.2", path = "../../consensus/ssz_types" }
 futures = "0.3.7"
 error-chain = "0.12.4"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -12,8 +12,8 @@ lighthouse_metrics = { path = "../../common/lighthouse_metrics" }
 parking_lot = "0.12.0"
 types = { path = "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
 rayon = "1.5.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -13,8 +13,8 @@ db-key = "0.0.5"
 leveldb = { version = "0.8.6", default-features = false }
 parking_lot = "0.12.0"
 itertools = "0.10.0"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
 types = { path =  "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
 slog = "2.5.2"

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -10,7 +10,7 @@ clap = "2.33.3"
 clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 types = { path = "../consensus/types" }
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../consensus/ssz" }
 slog = "2.5.2"
 tokio = "1.14.0"
 log = "0.4.11"

--- a/common/clap_utils/Cargo.toml
+++ b/common/clap_utils/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2.33.3"
 hex = "0.4.2"
 dirs = "3.0.1"
 eth2_network_config = { path = "../eth2_network_config" }
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
 ethereum-types = "0.12.1"
 serde = "1.0.116"
 serde_json = "1.0.59"

--- a/common/deposit_contract/Cargo.toml
+++ b/common/deposit_contract/Cargo.toml
@@ -14,6 +14,6 @@ hex = "0.4.2"
 
 [dependencies]
 types = { path = "../../consensus/types"}
-eth2_ssz = "0.4.1"
-tree_hash = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 ethabi = "16.0.0"

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -13,15 +13,15 @@ types = { path = "../../consensus/types" }
 reqwest = { version = "0.11.0", features = ["json","stream"] }
 lighthouse_network = { path = "../../beacon_node/lighthouse_network" }
 proto_array = { path = "../../consensus/proto_array", optional = true }
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../../consensus/serde_utils" }
 eth2_keystore = { path = "../../crypto/eth2_keystore" }
 libsecp256k1 = "0.7.0"
 ring = "0.16.19"
 bytes = "1.0.1"
 account_utils = { path = "../../common/account_utils" }
 sensitive_url = { path = "../../common/sensitive_url" }
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
 futures-util = "0.3.8"
 futures = "0.3.8"
 store = { path = "../../beacon_node/store", optional = true }

--- a/common/eth2_interop_keypairs/Cargo.toml
+++ b/common/eth2_interop_keypairs/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 lazy_static = "1.4.0"
 num-bigint = "0.4.2"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 hex = "0.4.2"
 serde_yaml = "0.8.13"
 serde = "1.0.116"

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -16,6 +16,6 @@ tempfile = "3.1.0"
 [dependencies]
 serde_yaml = "0.8.13"
 types = { path = "../../consensus/types"}
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
 eth2_config = { path = "../eth2_config"}
 enr = { version = "0.6.2", features = ["ed25519", "k256"] }

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -16,7 +16,7 @@ filesystem = { path = "../filesystem" }
 types = { path = "../../consensus/types" }
 rand = "0.8.5"
 deposit_contract = { path = "../deposit_contract" }
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 hex = "0.4.2"
 derivative = "2.1.1"
 lockfile = { path = "../lockfile" }

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_ssz_types = "0.2.2"
-eth2_hashing = "0.3.0"
-eth2_ssz_derive = "0.3.0"
-eth2_ssz = "0.4.1"
-tree_hash = "0.4.1"
+eth2_ssz_types = { version = "0.2.2", path = "../ssz_types" }
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+tree_hash = { version = "0.4.1", path = "../tree_hash" }
 smallvec = "1.6.1"
 
 [dev-dependencies]

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 types = { path = "../types" }
 state_processing = { path = "../state_processing" }
 proto_array = { path = "../proto_array" }
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_trace"] }
 
 [dev-dependencies]

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 lazy_static = "1.4.0"
 safe_arith = { path = "../safe_arith" }
 

--- a/consensus/proto_array/Cargo.toml
+++ b/consensus/proto_array/Cargo.toml
@@ -10,8 +10,8 @@ path = "src/bin.rs"
 
 [dependencies]
 types = { path = "../types" }
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_yaml = "0.8.13"

--- a/consensus/ssz/Cargo.toml
+++ b/consensus/ssz/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "ssz"
 
 [dev-dependencies]
-eth2_ssz_derive = "0.3.0"
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
 
 [dependencies]
 ethereum-types = "0.12.1"

--- a/consensus/ssz_types/Cargo.toml
+++ b/consensus/ssz_types/Cargo.toml
@@ -10,11 +10,11 @@ license = "Apache-2.0"
 name = "ssz_types"
 
 [dependencies]
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../tree_hash" }
 serde = "1.0.116"
 serde_derive = "1.0.116"
-eth2_serde_utils = "0.1.1"
-eth2_ssz = "0.4.1"
+eth2_serde_utils = { version = "0.1.1", path = "../serde_utils" }
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
 typenum = "1.12.0"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 derivative = "2.1.1"
@@ -22,4 +22,4 @@ smallvec = "1.8.0"
 
 [dev-dependencies]
 serde_json = "1.0.58"
-tree_hash_derive = "0.4.0"
+tree_hash_derive = { version = "0.4.0", path = "../tree_hash_derive" }

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -13,15 +13,15 @@ tokio = { version = "1.14.0", features = ["rt-multi-thread"] }
 bls = { path = "../../crypto/bls" }
 integer-sqrt = "0.1.5"
 itertools = "0.10.0"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
-eth2_ssz_types = "0.2.2"
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
+eth2_ssz_types = { version = "0.2.2", path = "../ssz_types" }
 merkle_proof = { path = "../merkle_proof" }
 safe_arith = { path = "../safe_arith" }
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../tree_hash" }
 types = { path = "../types", default-features = false }
 rayon = "1.4.1"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 int_to_bytes = { path = "../int_to_bytes" }
 smallvec = "1.6.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -12,7 +12,7 @@ harness = false
 criterion = "0.3.3"
 
 [dependencies]
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 ethereum-types = "0.12.1"
 
 [features]

--- a/consensus/tree_hash/Cargo.toml
+++ b/consensus/tree_hash/Cargo.toml
@@ -8,15 +8,15 @@ description = "Efficient Merkle-hashing as used in Ethereum 2.0"
 
 [dev-dependencies]
 rand = "0.8.5"
-tree_hash_derive = "0.4.0"
+tree_hash_derive = { version = "0.4.0", path = "../tree_hash_derive" }
 types = { path = "../types" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
 
 [dependencies]
 ethereum-types = "0.12.1"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 smallvec = "1.6.1"
 
 [features]

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -15,7 +15,7 @@ compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
 ethereum-types = "0.12.1"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../../crypto/eth2_hashing" }
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }
 log = "0.4.11"
@@ -25,13 +25,13 @@ safe_arith = { path = "../safe_arith" }
 serde = {version = "1.0.116" , features = ["rc"] }
 serde_derive = "1.0.116"
 slog = "2.5.2"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
-eth2_ssz_types = "0.2.2"
+eth2_ssz = { version = "0.4.1", path = "../ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../ssz_derive" }
+eth2_ssz_types = { version = "0.2.2", path = "../ssz_types" }
 swap_or_not_shuffle = { path = "../swap_or_not_shuffle" }
 test_random_derive = { path = "../../common/test_random_derive" }
-tree_hash = "0.4.1"
-tree_hash_derive = "0.4.0"
+tree_hash = { version = "0.4.1", path = "../tree_hash" }
+tree_hash_derive = { version = "0.4.0", path = "../tree_hash_derive" }
 rand_xorshift = "0.3.0"
 cached_tree_hash = { path = "../cached_tree_hash" }
 serde_yaml = "0.8.13"
@@ -39,7 +39,7 @@ tempfile = "3.1.0"
 derivative = "2.1.1"
 rusqlite = { version = "0.25.3", features = ["bundled"], optional = true }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../serde_utils" }
 regex = "1.5.5"
 lazy_static = "1.4.0"
 parking_lot = "0.12.0"

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -5,15 +5,15 @@ authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 
 [dependencies]
-eth2_ssz = "0.4.1"
-tree_hash = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
 milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.2", optional = true }
 rand = "0.7.3"
 serde = "1.0.116"
 serde_derive = "1.0.116"
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../../consensus/serde_utils" }
 hex = "0.4.2"
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../eth2_hashing" }
 ethereum-types = "0.12.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -20,12 +20,12 @@ env_logger = "0.9.0"
 types = { path = "../consensus/types" }
 state_processing = { path = "../consensus/state_processing" }
 int_to_bytes = { path = "../consensus/int_to_bytes" }
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../consensus/ssz" }
 environment = { path = "../lighthouse/environment" }
 eth2_network_config = { path = "../common/eth2_network_config" }
 genesis = { path = "../beacon_node/genesis" }
 deposit_contract = { path = "../common/deposit_contract" }
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../consensus/tree_hash" }
 clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 validator_dir = { path = "../common/validator_dir", features = ["insecure_keys"] }

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -31,7 +31,7 @@ slog = { version = "2.5.2", features = ["max_level_trace"] }
 sloggers = { version = "2.1.1", features = ["json"] }
 types = { "path" = "../consensus/types" }
 bls = { path = "../crypto/bls" }
-eth2_hashing = "0.3.0"
+eth2_hashing = { version = "0.3.0", path = "../crypto/eth2_hashing" }
 clap = "2.33.3"
 env_logger = "0.9.0"
 environment = { path = "./environment" }

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -12,8 +12,8 @@ lmdb = ["lmdb-rkv", "lmdb-rkv-sys"]
 [dependencies]
 bincode = "1.3.1"
 byteorder = "1.3.4"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
+eth2_ssz = { version = "0.4.1", path = "../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../consensus/ssz_derive" }
 flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
@@ -26,8 +26,8 @@ serde = "1.0"
 serde_derive = "1.0"
 slog = "2.5.2"
 sloggers = { version = "2.1.1", features = ["json"] }
-tree_hash = "0.4.1"
-tree_hash_derive = "0.4.0"
+tree_hash = { version = "0.4.1", path = "../consensus/tree_hash" }
+tree_hash_derive = { version = "0.4.0", path = "../consensus/tree_hash_derive" }
 types = { path = "../consensus/types" }
 strum = { version = "0.24.1", features = ["derive"] }
 

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -22,10 +22,10 @@ serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_repr = "0.1.6"
 serde_yaml = "0.8.13"
-eth2_ssz = "0.4.1"
-eth2_ssz_derive = "0.3.0"
-tree_hash = "0.4.1"
-tree_hash_derive = "0.4.0"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
+eth2_ssz_derive = { version = "0.3.0", path = "../../consensus/ssz_derive" }
+tree_hash = { version = "0.4.1", path = "../../consensus/tree_hash" }
+tree_hash_derive = { version = "0.4.0", path = "../../consensus/tree_hash_derive" }
 cached_tree_hash = { path = "../../consensus/cached_tree_hash" }
 state_processing = { path = "../../consensus/state_processing" }
 swap_or_not_shuffle = { path = "../../consensus/swap_or_not_shuffle" }

--- a/testing/state_transition_vectors/Cargo.toml
+++ b/testing/state_transition_vectors/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [dependencies]
 state_processing = { path = "../../consensus/state_processing" }
 types = { path = "../../consensus/types" }
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", path = "../../consensus/ssz" }
 beacon_chain = { path = "../../beacon_node/beacon_chain" }
 lazy_static = "1.4.0"
 tokio = { version = "1.14.0", features = ["rt-multi-thread"] }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.14.0", features = ["time", "rt-multi-thread", "macros"] }
 logging = { path = "../common/logging" }
 
 [dependencies]
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", path = "../consensus/tree_hash" }
 clap = "2.33.3"
 slashing_protection = { path = "./slashing_protection" }
 slot_clock = { path = "../common/slot_clock" }
@@ -46,7 +46,7 @@ lighthouse_version = { path = "../common/lighthouse_version" }
 warp_utils = { path = "../common/warp_utils" }
 warp = "0.3.2"
 hyper = "0.14.4"
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../consensus/serde_utils" }
 libsecp256k1 = "0.7.0"
 ring = "0.16.19"
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -18,7 +18,7 @@ r2d2_sqlite = "0.18.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_json = "1.0.58"
-eth2_serde_utils = "0.1.1"
+eth2_serde_utils = { version = "0.1.1", path = "../../consensus/serde_utils" }
 filesystem = { path = "../../common/filesystem" }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
## Issue

When specifying crates that in `lighthouse` as dependencies with git or path locations, it always throws errors when builds.

Because the latest versions of some crates haven't published to `crates.io`.

An example:

- In `Cargo.toml`:

  ```toml
  eth2_ssz_types = { git = "https://github.com/sigp/lighthouse" }
  ```

- The error:

  ```
      Updating git repository `https://github.com/sigp/lighthouse`
      Updating crates.io index
  error: failed to select a version for the requirement `eth2_serde_utils = "^0.1.1"`
  candidate versions found which didn't match: 0.1.0
  location searched: crates.io index
  required by package `eth2_ssz_types v0.2.2 (https://github.com/sigp/lighthouse#bf533c8e)`
      ... which satisfies git dependency `eth2_ssz_types` of package `lighthouse-demo v0.1.0 (/tmp/lighthouse-demo)`
  ```

## Proposed Changes

Replace [the `patch` section] with [`multiple locations`] to specify dependencies.


[the `patch` section]: https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
[`multiple locations`]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations