### PR TITLE
Fix some capella nits

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2184,7 +2184,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
     }
 
-    /// Verify a signed BLS to exection change before allowing it to propagate on the gossip network.
+    /// Verify a signed BLS to execution change before allowing it to propagate on the gossip network.
     pub fn verify_bls_to_execution_change_for_gossip(
         &self,
         bls_to_execution_change: SignedBlsToExecutionChange,

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -305,7 +305,7 @@ pub enum AttesterSlashingInvalid {
 /// Describes why an object is invalid.
 #[derive(Debug, PartialEq, Clone)]
 pub enum AttestationInvalid {
-    /// Commmittee index exceeds number of committees in that slot.
+    /// Committee index exceeds number of committees in that slot.
     BadCommitteeIndex,
     /// Attestation included before the inclusion delay.
     IncludedTooEarly {
@@ -420,11 +420,11 @@ pub enum ExitInvalid {
 pub enum BlsExecutionChangeInvalid {
     /// The specified validator is not in the state's validator registry.
     ValidatorUnknown(u64),
-    /// Validator does not have BLS Withdrawal credentials before this change
+    /// Validator does not have BLS Withdrawal credentials before this change.
     NonBlsWithdrawalCredentials,
-    /// Provided BLS pubkey does not match withdrawal credentials
+    /// Provided BLS pubkey does not match withdrawal credentials.
     WithdrawalCredentialsMismatch,
-    /// The signature is invalid
+    /// The signature is invalid.
     BadSignature,
 }
 

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -293,7 +293,7 @@ pub fn process_exits<T: EthSpec>(
 
 /// Validates each `bls_to_execution_change` and updates the state
 ///
-/// Returns `Ok(())` if the validation and state updates completed successfully. Otherwise returs
+/// Returns `Ok(())` if the validation and state updates completed successfully. Otherwise returns
 /// an `Err` describing the invalid object or cause of failure.
 #[cfg(all(feature = "withdrawals", feature = "withdrawals-processing"))]
 pub fn process_bls_to_execution_changes<T: EthSpec>(

--- a/consensus/state_processing/src/upgrade/eip4844.rs
+++ b/consensus/state_processing/src/upgrade/eip4844.rs
@@ -67,7 +67,7 @@ pub fn upgrade_to_eip4844<E: EthSpec>(
         #[cfg(feature = "withdrawals")]
         next_withdrawal_index: pre.next_withdrawal_index,
         #[cfg(feature = "withdrawals")]
-        next_withdrawal_validator_index: 0,
+        next_withdrawal_validator_index: pre.next_withdrawal_validator_index,
         // Caches
         total_active_balance: pre.total_active_balance,
         committee_caches: mem::take(&mut pre.committee_caches),

--- a/consensus/types/src/bls_to_execution_change.rs
+++ b/consensus/types/src/bls_to_execution_change.rs
@@ -6,7 +6,6 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-/// A deposit to potentially become a beacon chain validator.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,

--- a/consensus/types/src/signed_bls_to_execution_change.rs
+++ b/consensus/types/src/signed_bls_to_execution_change.rs
@@ -6,7 +6,6 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-/// A deposit to potentially become a beacon chain validator.
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -67,7 +67,7 @@ impl Validator {
         && self.activation_epoch == spec.far_future_epoch
     }
 
-    /// Returns `true` if the validator has eth1 withdrawal credential
+    /// Returns `true` if the validator has eth1 withdrawal credential.
     pub fn has_eth1_withdrawal_credential(&self, spec: &ChainSpec) -> bool {
         self.withdrawal_credentials
             .as_bytes()
@@ -88,7 +88,7 @@ impl Validator {
             .flatten()
     }
 
-    /// Changes withdrawal credentials to  the provided eth1 execution address
+    /// Changes withdrawal credentials to  the provided eth1 execution address.
     ///
     /// WARNING: this function does NO VALIDATION - it just does it!
     pub fn change_withdrawal_credentials(&mut self, execution_address: &Address, spec: &ChainSpec) {
@@ -98,12 +98,12 @@ impl Validator {
         self.withdrawal_credentials = Hash256::from(bytes);
     }
 
-    /// Returns `true` if the validator is fully withdrawable at some epoch
+    /// Returns `true` if the validator is fully withdrawable at some epoch.
     pub fn is_fully_withdrawable_at(&self, balance: u64, epoch: Epoch, spec: &ChainSpec) -> bool {
         self.has_eth1_withdrawal_credential(spec) && self.withdrawable_epoch <= epoch && balance > 0
     }
 
-    /// Returns `true` if the validator is partially withdrawable
+    /// Returns `true` if the validator is partially withdrawable.
     pub fn is_partially_withdrawable_validator(&self, balance: u64, spec: &ChainSpec) -> bool {
         self.has_eth1_withdrawal_credential(spec)
             && self.effective_balance == spec.max_effective_balance

--- a/consensus/types/src/withdrawal.rs
+++ b/consensus/types/src/withdrawal.rs
@@ -5,9 +5,6 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-/// A deposit to potentially become a beacon chain validator.
-///
-/// Spec v0.12.1
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
     Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,


### PR DESCRIPTION
## Proposed Changes

Fixing a few minor nits I noticed during my initial review of your Capella implementation.

* Fix some typos in comments.
* Add punctuation to docstring comments.
* Remove misleading structure docstrings for:
  * `Withdrawal`
  * `BlsToExecutionChange`
  * `SignedBlsToExecutionChange`
* For the EIP-4844 upgrade, use `pre.next_withdrawal_validator_index` instead of 0.
  * According to the [fork logic](https://github.com/ethereum/consensus-specs/blob/dev/specs/eip4844/fork.md) this is what it's supposed to be.
  * ```python
    # Withdrawals
    next_withdrawal_index=pre.next_withdrawal_index,
    next_withdrawal_validator_index=pre.next_withdrawal_validator_index,
    ```

## Additional Info

I'm going to continue reviewing everything, but it's looking really great! 👍 