### PR TITLE
Use JsonPayload for payload reconstruction

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1622,8 +1622,14 @@ impl<T: EthSpec> ExecutionLayer<T> {
             }
             ExecutionBlockWithTransactions::Capella(capella_block) => {
                 #[cfg(feature = "withdrawals")]
-                let withdrawals = VariableList::new(capella_block.withdrawals.clone())
-                    .map_err(ApiError::DeserializeWithdrawals)?;
+                let withdrawals = VariableList::new(
+                    capella_block
+                        .withdrawals
+                        .into_iter()
+                        .map(|w| w.into())
+                        .collect(),
+                )
+                .map_err(ApiError::DeserializeWithdrawals)?;
 
                 ExecutionPayload::Capella(ExecutionPayloadCapella {
                     parent_hash: capella_block.parent_hash,
@@ -1646,8 +1652,14 @@ impl<T: EthSpec> ExecutionLayer<T> {
             }
             ExecutionBlockWithTransactions::Eip4844(eip4844_block) => {
                 #[cfg(feature = "withdrawals")]
-                let withdrawals = VariableList::new(eip4844_block.withdrawals.clone())
-                    .map_err(ApiError::DeserializeWithdrawals)?;
+                let withdrawals = VariableList::new(
+                    eip4844_block
+                        .withdrawals
+                        .into_iter()
+                        .map(|w| w.into())
+                        .collect(),
+                )
+                .map_err(ApiError::DeserializeWithdrawals)?;
 
                 ExecutionPayload::Eip4844(ExecutionPayloadEip4844 {
                     parent_hash: eip4844_block.parent_hash,

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -76,7 +76,7 @@ impl<T: EthSpec> Block<T> {
 
     pub fn as_execution_block_with_tx(&self) -> Option<ExecutionBlockWithTransactions<T>> {
         match self {
-            Block::PoS(payload) => Some(payload.clone().into()),
+            Block::PoS(payload) => Some(payload.clone().try_into().unwrap()),
             Block::PoW(_) => None,
         }
     }


### PR DESCRIPTION
## Issue Addressed

Closes #3787

## Proposed Changes

Building on #3796, fix payload reconstruction in the presence of withdrawals by using the `JsonPayload` type which implements EL-style decoding.

I also changed a fallible `From` implementation to `TryFrom` so that errors aren't silently discarded
