### PR TITLE
[Merged by Bors] - light client optimistic update reprocessing

### DIFF
--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -38,7 +38,7 @@ pub enum Error {
     /// Failed to construct a LightClientOptimisticUpdate from state.
     FailedConstructingUpdate,
     /// Unknown block with parent root.
-    UnknownBlockParentRoot(Hash256, Hash256),
+    UnknownBlockParentRoot(Hash256),
     /// Beacon chain error occured.
     BeaconChainError(BeaconChainError),
     LightClientUpdateError(LightClientUpdateError),
@@ -103,7 +103,6 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
 
         if canonical_root != head_block.message().parent_root() {
             return Err(Error::UnknownBlockParentRoot(
-                light_client_optimistic_update.attested_header.body_root,
                 canonical_root,
             ));
         }

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -94,17 +94,6 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
             None => Slot::new(0),
         };
 
-        // check if we can process the optimistic update immediately
-        // otherwise queue
-
-        let canonical_root = light_client_optimistic_update
-            .attested_header
-            .canonical_root();
-
-        if canonical_root != head_block.message().parent_root() {
-            return Err(Error::UnknownBlockParentRoot(canonical_root));
-        }
-
         // verify that no other optimistic_update with a lower or equal
         // optimistic_header.slot was already forwarded on the network
         if gossiped_optimistic_slot <= latest_seen_optimistic_update_slot {
@@ -120,6 +109,16 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
                 }
             }
             None => return Err(Error::SigSlotStartIsNone),
+        }
+
+        // check if we can process the optimistic update immediately
+        // otherwise queue
+        let canonical_root = light_client_optimistic_update
+            .attested_header
+            .canonical_root();
+
+        if canonical_root != head_block.message().parent_root() {
+            return Err(Error::UnknownBlockParentRoot(canonical_root));
         }
 
         let optimistic_update =

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -61,6 +61,7 @@ impl From<LightClientUpdateError> for Error {
 #[derivative(Clone(bound = "T: BeaconChainTypes"))]
 pub struct VerifiedLightClientOptimisticUpdate<T: BeaconChainTypes> {
     light_client_optimistic_update: LightClientOptimisticUpdate<T::EthSpec>,
+    pub parent_root: Hash256,
     seen_timestamp: Duration,
 }
 
@@ -136,6 +137,7 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
 
         Ok(Self {
             light_client_optimistic_update,
+            parent_root: canonical_root,
             seen_timestamp,
         })
     }

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -102,9 +102,7 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
             .canonical_root();
 
         if canonical_root != head_block.message().parent_root() {
-            return Err(Error::UnknownBlockParentRoot(
-                canonical_root,
-            ));
+            return Err(Error::UnknownBlockParentRoot(canonical_root));
         }
 
         // verify that no other optimistic_update with a lower or equal

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -705,6 +705,7 @@ impl<T: BeaconChainTypes> std::convert::From<ReadyWork<T>> for WorkEvent<T> {
                 message_id,
                 light_client_optimistic_update,
                 seen_timestamp,
+                ..
             }) => Self {
                 drop_during_sync: true,
                 work: Work::UnknownLightClientOptimisticUpdate {

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -67,7 +67,7 @@ use types::{
     SignedVoluntaryExit, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 use work_reprocessing_queue::{
-    spawn_reprocess_scheduler, QueuedAggregate, QueuedLCUpdate, QueuedRpcBlock, QueuedUnaggregate,
+    spawn_reprocess_scheduler, QueuedAggregate, QueuedLightClientUpdate, QueuedRpcBlock, QueuedUnaggregate,
     ReadyWork,
 };
 
@@ -700,14 +700,14 @@ impl<T: BeaconChainTypes> std::convert::From<ReadyWork<T>> for WorkEvent<T> {
                     seen_timestamp,
                 },
             },
-            ReadyWork::LCUpdate(QueuedLCUpdate {
+            ReadyWork::LightClientUpdate(QueuedLightClientUpdate {
                 peer_id,
                 message_id,
                 light_client_optimistic_update,
                 seen_timestamp,
             }) => Self {
                 drop_during_sync: true,
-                work: Work::UnknownLCOptimisticUpdate {
+                work: Work::UnknownLightClientOptimisticUpdate {
                     message_id,
                     peer_id,
                     light_client_optimistic_update,
@@ -753,7 +753,7 @@ pub enum Work<T: BeaconChainTypes> {
         aggregate: Box<SignedAggregateAndProof<T::EthSpec>>,
         seen_timestamp: Duration,
     },
-    UnknownLCOptimisticUpdate {
+    UnknownLightClientOptimisticUpdate {
         message_id: MessageId,
         peer_id: PeerId,
         light_client_optimistic_update: Box<LightClientOptimisticUpdate<T::EthSpec>>,
@@ -871,7 +871,7 @@ impl<T: BeaconChainTypes> Work<T> {
             Work::LightClientBootstrapRequest { .. } => LIGHT_CLIENT_BOOTSTRAP_REQUEST,
             Work::UnknownBlockAttestation { .. } => UNKNOWN_BLOCK_ATTESTATION,
             Work::UnknownBlockAggregate { .. } => UNKNOWN_BLOCK_AGGREGATE,
-            Work::UnknownLCOptimisticUpdate { .. } => UNKNOWN_LIGHT_CLIENT_UPDATE,
+            Work::UnknownLightClientOptimisticUpdate { .. } => UNKNOWN_LIGHT_CLIENT_UPDATE,
         }
     }
 }
@@ -1375,7 +1375,7 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                             Work::UnknownBlockAggregate { .. } => {
                                 unknown_block_aggregate_queue.push(work)
                             }
-                            Work::UnknownLCOptimisticUpdate { .. } => {
+                            Work::UnknownLightClientOptimisticUpdate { .. } => {
                                 unknown_light_client_update_queue.push(work, work_id, &self.log)
                             }
                         }
@@ -1820,7 +1820,7 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                     seen_timestamp,
                 )
             }),
-            Work::UnknownLCOptimisticUpdate {
+            Work::UnknownLightClientOptimisticUpdate {
                 message_id,
                 peer_id,
                 light_client_optimistic_update,

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1006,8 +1006,8 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
         // Using a FIFO queue for light client updates to maintain sequence order.
         let mut finality_update_queue = FifoQueue::new(MAX_GOSSIP_FINALITY_UPDATE_QUEUE_LEN);
         let mut optimistic_update_queue = FifoQueue::new(MAX_GOSSIP_OPTIMISTIC_UPDATE_QUEUE_LEN);
-        let mut unknown_light_client_update_queue = FifoQueue::new(MAX_GOSSIP_OPTIMISTIC_UPDATE_REPROCESS_QUEUE_LEN);
-            
+        let mut unknown_light_client_update_queue =
+            FifoQueue::new(MAX_GOSSIP_OPTIMISTIC_UPDATE_REPROCESS_QUEUE_LEN);
 
         // Using a FIFO queue since blocks need to be imported sequentially.
         let mut rpc_block_queue = FifoQueue::new(MAX_RPC_BLOCK_QUEUE_LEN);

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -67,8 +67,8 @@ use types::{
     SignedVoluntaryExit, SubnetId, SyncCommitteeMessage, SyncSubnetId,
 };
 use work_reprocessing_queue::{
-    spawn_reprocess_scheduler, QueuedAggregate, QueuedLightClientUpdate, QueuedRpcBlock, QueuedUnaggregate,
-    ReadyWork,
+    spawn_reprocess_scheduler, QueuedAggregate, QueuedLightClientUpdate, QueuedRpcBlock,
+    QueuedUnaggregate, ReadyWork,
 };
 
 use worker::{Toolbox, Worker};

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -48,7 +48,7 @@ const ADDITIONAL_QUEUED_BLOCK_DELAY: Duration = Duration::from_millis(5);
 pub const QUEUED_ATTESTATION_DELAY: Duration = Duration::from_secs(12);
 
 /// For how long to queue light client updates for re-processing.
-pub const QUEUED_LIGHT_CLIENT_UPDATE_DELAY: Duration = Duration::from_secs(12);
+pub const QUEUED_LIGHT_CLIENT_UPDATE_DELAY: Duration = Duration::from_secs(3);
 
 /// For how long to queue rpc blocks before sending them back for reprocessing.
 pub const QUEUED_RPC_BLOCK_DELAY: Duration = Duration::from_secs(3);

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -537,16 +537,18 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
                 self.awaiting_lc_updates_per_parent_root
                     .entry(
                         queued_light_client_optimistic_update
-                        .light_client_optimistic_update
-                        .attested_header
-                        .canonical_root()
+                            .light_client_optimistic_update
+                            .attested_header
+                            .canonical_root(),
                     )
                     .or_default()
                     .push(lc_id);
 
                 // Store the light client update and its info.
-                self.queued_lc_updates
-                    .insert(self.next_lc_update, (queued_light_client_optimistic_update, delay_key));
+                self.queued_lc_updates.insert(
+                    self.next_lc_update,
+                    (queued_light_client_optimistic_update, delay_key),
+                );
 
                 self.next_lc_update += 1;
             }
@@ -603,7 +605,7 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
                     .remove(&parent_root)
                 {
                     debug!(
-                        log, 
+                        log,
                         "unqueue lc optimistic updates";
                         "parent_root" => %parent_root,
                     );

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -274,7 +274,9 @@ impl<T: BeaconChainTypes> Stream for ReprocessQueue<T> {
 
         match self.lc_updates_delay_queue.poll_expired(cx) {
             Poll::Ready(Some(Ok(lc_id))) => {
-                return Poll::Ready(Some(InboundEvent::ReadyLightClientUpdate(lc_id.into_inner())));
+                return Poll::Ready(Some(InboundEvent::ReadyLightClientUpdate(
+                    lc_id.into_inner(),
+                )));
             }
             Poll::Ready(Some(Err(e))) => {
                 return Poll::Ready(Some(InboundEvent::DelayQueueError(e, "lc_updates_queue")));
@@ -527,7 +529,9 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
 
                 self.next_attestation += 1;
             }
-            InboundEvent::Msg(UnknownLightClientOptimisticUpdate(queued_light_client_optimistic_update)) => {
+            InboundEvent::Msg(UnknownLightClientOptimisticUpdate(
+                queued_light_client_optimistic_update,
+            )) => {
                 if self.lc_updates_delay_queue.len() >= MAXIMUM_QUEUED_LIGHT_CLIENT_UPDATES {
                     if self.lc_update_delay_debounce.elapsed() {
                         error!(

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -623,9 +623,10 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
                         log,
                         "Dequeuing light client optimistic updates";
                         "parent_root" => %parent_root,
+                        "count" => queued_lc_id.len(),
                     );
 
-                    for lc_id in queued_lc_id.iter() {
+                    for lc_id in queued_lc_id {
                         metrics::inc_counter(
                             &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_OPTIMISTIC_UPDATES,
                         );
@@ -645,7 +646,6 @@ impl<T: BeaconChainTypes> ReprocessQueue<T> {
                                 Ok(_) => trace!(
                                     log,
                                     "reprocessing light client update sent";
-                                    "count" => queued_lc_id.len(),
                                 ),
                                 Err(_) => error!(
                                     log,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -951,7 +951,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 if reprocess_tx
                     .try_send(ReprocessQueueMessage::BlockImported {
                         block_root,
-                        parent_root: block.parent_root(),
+                        parent_root: block.message().parent_root(),
                     })
                     .is_err()
                 {

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1401,7 +1401,9 @@ impl<T: BeaconChainTypes> Worker<T> {
             Err(e) => {
                 match e {
                     LightClientOptimisticUpdateError::UnknownBlockParentRoot(parent_root) => {
-                        metrics::register_optimistic_update_sent_for_reprocessing(&e);
+                        metrics::inc_counter(
+                            &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_SENT_OPTIMISTIC_UPDATES,
+                        );
                         debug!(
                             self.log,
                             "Optimistic update for unknown block";

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1388,6 +1388,13 @@ impl<T: BeaconChainTypes> Worker<T> {
             .verify_optimistic_update_for_gossip(light_client_optimistic_update, seen_timestamp)
         {
             Ok(_verified_light_client_optimistic_update) => {
+                debug!(
+                    self.log,
+                    "LC successful optimistic update";
+                    "peer" => %peer_id,
+                    "error" => ?e,
+                );
+
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);
             }
             Err(e) => {
@@ -1397,7 +1404,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                         block_root,
                         parent_root,
                     ) => {
-                        trace!(
+                        debug!(
                             self.log,
                             "Optimistic update for unknown block";
                             "peer_id" => %peer_id,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -28,7 +28,7 @@ use types::{
 
 use super::{
     super::work_reprocessing_queue::{
-        QueuedAggregate, QueuedGossipBlock, QueuedLCUpdate, QueuedUnaggregate,
+        QueuedAggregate, QueuedGossipBlock, QueuedLightClientUpdate, QueuedUnaggregate,
         ReprocessQueueMessage,
     },
     Worker,
@@ -1330,7 +1330,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     LightClientFinalityUpdateError::InvalidLightClientFinalityUpdate => {
                         debug!(
                             self.log,
-                            "LC invalid finality update";
+                            "Light client invalid finality update";
                             "peer" => %peer_id,
                             "error" => ?e,
                         );
@@ -1344,7 +1344,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     LightClientFinalityUpdateError::TooEarly => {
                         debug!(
                             self.log,
-                            "LC finality update too early";
+                            "Light client finality update too early";
                             "peer" => %peer_id,
                             "error" => ?e,
                         );
@@ -1357,7 +1357,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     }
                     LightClientFinalityUpdateError::FinalityUpdateAlreadySeen => debug!(
                         self.log,
-                        "LC finality update already seen";
+                        "Light client finality update already seen";
                         "peer" => %peer_id,
                         "error" => ?e,
                     ),
@@ -1366,7 +1366,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     | LightClientFinalityUpdateError::SigSlotStartIsNone
                     | LightClientFinalityUpdateError::FailedConstructingUpdate => debug!(
                         self.log,
-                        "LC error constructing finality update";
+                        "Light client error constructing finality update";
                         "peer" => %peer_id,
                         "error" => ?e,
                     ),
@@ -1391,7 +1391,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             Ok(verified_light_client_optimistic_update) => {
                 debug!(
                     self.log,
-                    "LC successful optimistic update";
+                    "Light client successful optimistic update";
                     "peer" => %peer_id,
                     "parent_root" => %verified_light_client_optimistic_update.parent_root,
                 );
@@ -1413,7 +1413,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                         if let Some(sender) = reprocess_tx {
                             let msg =
-                                ReprocessQueueMessage::UnknownLCOptimisticUpdate(QueuedLCUpdate {
+                                ReprocessQueueMessage::UnknownLightClientOptimisticUpdate(QueuedLightClientUpdate {
                                     peer_id,
                                     message_id,
                                     light_client_optimistic_update: Box::new(
@@ -1431,7 +1431,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                         } else {
                             debug!(
                                 self.log,
-                                "Not sending LC update because it had been reprocessed";
+                                "Not sendinglight clientupdate because it had been reprocessed";
                                 "peer_id" => %peer_id,
                                 "parent_root" => ?parent_root
                             );
@@ -1449,7 +1449,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                         debug!(
                             self.log,
-                            "LC invalid optimistic update";
+                            "Light client invalid optimistic update";
                             "peer" => %peer_id,
                             "error" => ?e,
                         );
@@ -1464,7 +1464,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                         metrics::register_optimistic_update_error(&e);
                         debug!(
                             self.log,
-                            "LC optimistic update too early";
+                            "Light client optimistic update too early";
                             "peer" => %peer_id,
                             "error" => ?e,
                         );
@@ -1480,7 +1480,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                         debug!(
                             self.log,
-                            "LC optimistic update already seen";
+                            "Light client optimistic update already seen";
                             "peer" => %peer_id,
                             "error" => ?e,
                         )
@@ -1493,7 +1493,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                         debug!(
                             self.log,
-                            "LC error constructing optimistic update";
+                            "Light client error constructing optimistic update";
                             "peer" => %peer_id,
                             "error" => ?e,
                         )

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1387,12 +1387,12 @@ impl<T: BeaconChainTypes> Worker<T> {
             .chain
             .verify_optimistic_update_for_gossip(light_client_optimistic_update, seen_timestamp)
         {
-            Ok(_verified_light_client_optimistic_update) => {
+            Ok(verified_light_client_optimistic_update) => {
                 debug!(
                     self.log,
                     "LC successful optimistic update";
                     "peer" => %peer_id,
-                    "error" => ?e,
+                    "parent_root" => %verified_light_client_optimistic_update.parent_root,
                 );
 
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Accept);

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1419,6 +1419,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                                     light_client_optimistic_update: Box::new(
                                         light_client_optimistic_update,
                                     ),
+                                    parent_root,
                                     seen_timestamp,
                                 },
                             );
@@ -1432,7 +1433,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                         } else {
                             debug!(
                                 self.log,
-                                "Not sendinglight clientupdate because it had been reprocessed";
+                                "Not sending light client update because it had been reprocessed";
                                 "peer_id" => %peer_id,
                                 "parent_root" => ?parent_root
                             );

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1475,7 +1475,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                             "light_client_gossip_error",
                         );
                     }
-                    LightClientOptimisticUpdateError::OptimisticUpdateAlreadySeen => {   
+                    LightClientOptimisticUpdateError::OptimisticUpdateAlreadySeen => {
                         metrics::register_optimistic_update_error(&e);
 
                         debug!(
@@ -1490,14 +1490,14 @@ impl<T: BeaconChainTypes> Worker<T> {
                     | LightClientOptimisticUpdateError::SigSlotStartIsNone
                     | LightClientOptimisticUpdateError::FailedConstructingUpdate => {
                         metrics::register_optimistic_update_error(&e);
-                        
+
                         debug!(
                             self.log,
                             "LC error constructing optimistic update";
                             "peer" => %peer_id,
                             "error" => ?e,
                         )
-                    },
+                    }
                 }
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
             }

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1412,15 +1412,16 @@ impl<T: BeaconChainTypes> Worker<T> {
                         );
 
                         if let Some(sender) = reprocess_tx {
-                            let msg =
-                                ReprocessQueueMessage::UnknownLightClientOptimisticUpdate(QueuedLightClientUpdate {
+                            let msg = ReprocessQueueMessage::UnknownLightClientOptimisticUpdate(
+                                QueuedLightClientUpdate {
                                     peer_id,
                                     message_id,
                                     light_client_optimistic_update: Box::new(
                                         light_client_optimistic_update,
                                     ),
                                     seen_timestamp,
-                                });
+                                },
+                            );
 
                             if sender.try_send(msg).is_err() {
                                 error!(

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -1408,7 +1408,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                             self.log,
                             "Optimistic update for unknown block";
                             "peer_id" => %peer_id,
-                            "parent_block" => ?parent_root
+                            "parent_root" => ?parent_root
                         );
                         if let Some(sender) = reprocess_tx {
                             let msg = ReprocessQueueMessage::BlockImported {

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -84,6 +84,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
         };
         let slot = block.slot();
+        let parent_root = block.parent_root();
         let result = self
             .chain
             .process_block(
@@ -101,7 +102,10 @@ impl<T: BeaconChainTypes> Worker<T> {
             info!(self.log, "New RPC block received"; "slot" => slot, "hash" => %hash);
 
             // Trigger processing for work referencing this block.
-            let reprocess_msg = ReprocessQueueMessage::BlockImported(hash);
+            let reprocess_msg = ReprocessQueueMessage::BlockImported {
+                block_root: hash,
+                parent_root,
+            };
             if reprocess_tx.try_send(reprocess_msg).is_err() {
                 error!(self.log, "Failed to inform block import"; "source" => "rpc", "block_root" => %hash)
             };

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -84,7 +84,7 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
         };
         let slot = block.slot();
-        let parent_root = block.parent_root();
+        let parent_root = block.message().parent_root();
         let result = self
             .chain
             .process_block(

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -362,6 +362,18 @@ lazy_static! {
         "Number of queued attestations where as matching block has been imported."
     );
 
+    /*
+     * Light client update reprocessing queue metrics.
+     */
+    pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_EXPIRED_OPTIMISTIC_UPDATES: Result<IntCounter> = try_create_int_counter(
+        "beacon_processor_reprocessing_queue_expired_optimistic_updates",
+        "Number of queued light client optimistic updates which have expired before a matching block has been found."
+    );
+    pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_OPTIMISTIC_UPDATES: Result<IntCounter> = try_create_int_counter(
+        "beacon_processor_reprocessing_queue_matched_optimistic_updates",
+        "Number of queued light client optimistic updates where as matching block has been imported."
+    );
+
 }
 
 pub fn update_bandwidth_metrics(bandwidth: Arc<BandwidthSinks>) {
@@ -379,6 +391,14 @@ pub fn register_finality_update_error(error: &LightClientFinalityUpdateError) {
 
 pub fn register_optimistic_update_error(error: &LightClientOptimisticUpdateError) {
     inc_counter_vec(&GOSSIP_OPTIMISTIC_UPDATE_ERRORS_PER_TYPE, &[error.as_ref()]);
+}
+
+pub fn register_optimistic_update_sent_for_reprocessing(error: &LightClientOptimisticUpdateError) {
+    match error {
+        LightClientOptimisticUpdateError::UnknownBlockParentRoot(_) =>
+            inc_counter_vec(&GOSSIP_OPTIMISTIC_UPDATE_ERRORS_PER_TYPE, &[error.as_ref()]),
+        _ => {},
+    }
 }
 
 pub fn register_attestation_error(error: &AttnError) {

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -373,7 +373,10 @@ lazy_static! {
         "beacon_processor_reprocessing_queue_matched_optimistic_updates",
         "Number of queued light client optimistic updates where as matching block has been imported."
     );
-
+    pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_SENT_OPTIMISTIC_UPDATES: Result<IntCounter> = try_create_int_counter(
+        "beacon_processor_reprocessing_queue_sent_optimistic_updates",
+        "Number of queued light client optimistic updates where as matching block has been imported."
+    );
 }
 
 pub fn update_bandwidth_metrics(bandwidth: Arc<BandwidthSinks>) {
@@ -391,14 +394,6 @@ pub fn register_finality_update_error(error: &LightClientFinalityUpdateError) {
 
 pub fn register_optimistic_update_error(error: &LightClientOptimisticUpdateError) {
     inc_counter_vec(&GOSSIP_OPTIMISTIC_UPDATE_ERRORS_PER_TYPE, &[error.as_ref()]);
-}
-
-pub fn register_optimistic_update_sent_for_reprocessing(error: &LightClientOptimisticUpdateError) {
-    match error {
-        LightClientOptimisticUpdateError::UnknownBlockParentRoot(_) =>
-            inc_counter_vec(&GOSSIP_OPTIMISTIC_UPDATE_ERRORS_PER_TYPE, &[error.as_ref()]),
-        _ => {},
-    }
 }
 
 pub fn register_attestation_error(error: &AttnError) {


### PR DESCRIPTION
## Issue Addressed
Currently there is a race between receiving blocks and receiving light client optimistic updates (in unstable), which results in processing errors. This is a continuation of PR #3693 and seeks to progress on issue #3651

## Proposed Changes

Add the parent_root to ReprocessQueueMessage::BlockImported so we can remove blocks from queue when a block arrives that has the same parent root. We use the parent root as opposed to the block_root because the LightClientOptimisticUpdate does not contain the block_root.

If light_client_optimistic_update.attested_header.canonical_root() != head_block.message().parent_root() then we queue the update. Otherwise we process immediately.
## Additional Info
michaelsproul came up with this idea.
The code was heavily based off of the attestation reprocessing.
I have not properly tested this to see if it works as intended.
