### PR TITLE
Switch el endpoints at capella fork

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4963,6 +4963,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         let forkchoice_updated_response = execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_hash,
                 justified_hash,
                 finalized_hash,

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use task_executor::TaskExecutor;
 use tokio::sync::{watch, Mutex, RwLock};
 use tokio_stream::wrappers::WatchStream;
-use types::ExecutionBlockHash;
+use types::{ExecutionBlockHash, ForkName};
 
 /// The number of payload IDs that will be stored for each `Engine`.
 ///
@@ -114,7 +114,7 @@ pub struct Engine {
     pub api: HttpJsonRpc,
     payload_id_cache: Mutex<LruCache<PayloadIdCacheKey, PayloadId>>,
     state: RwLock<State>,
-    latest_forkchoice_state: RwLock<Option<ForkchoiceState>>,
+    latest_forkchoice_state: RwLock<Option<(ForkchoiceState, ForkName)>>,
     executor: TaskExecutor,
     log: Logger,
 }
@@ -153,13 +153,14 @@ impl Engine {
 
     pub async fn notify_forkchoice_updated(
         &self,
+        fork_name: ForkName,
         forkchoice_state: ForkchoiceState,
         payload_attributes: Option<PayloadAttributes>,
         log: &Logger,
     ) -> Result<ForkchoiceUpdatedResponse, EngineApiError> {
         let response = self
             .api
-            .forkchoice_updated(forkchoice_state, payload_attributes.clone())
+            .forkchoice_updated(fork_name, forkchoice_state, payload_attributes.clone())
             .await?;
 
         if let Some(payload_id) = response.payload_id {
@@ -179,18 +180,18 @@ impl Engine {
         Ok(response)
     }
 
-    async fn get_latest_forkchoice_state(&self) -> Option<ForkchoiceState> {
+    async fn get_latest_forkchoice_state(&self) -> Option<(ForkchoiceState, ForkName)> {
         *self.latest_forkchoice_state.read().await
     }
 
-    pub async fn set_latest_forkchoice_state(&self, state: ForkchoiceState) {
-        *self.latest_forkchoice_state.write().await = Some(state);
+    pub async fn set_latest_forkchoice_state(&self, state: ForkchoiceState, fork_name: ForkName) {
+        *self.latest_forkchoice_state.write().await = Some((state, fork_name));
     }
 
     async fn send_latest_forkchoice_state(&self) {
         let latest_forkchoice_state = self.get_latest_forkchoice_state().await;
 
-        if let Some(forkchoice_state) = latest_forkchoice_state {
+        if let Some((forkchoice_state, fork_name)) = latest_forkchoice_state {
             if forkchoice_state.head_block_hash == ExecutionBlockHash::zero() {
                 debug!(
                     self.log,
@@ -208,7 +209,11 @@ impl Engine {
 
             // For simplicity, payload attributes are never included in this call. It may be
             // reasonable to include them in the future.
-            if let Err(e) = self.api.forkchoice_updated(forkchoice_state, None).await {
+            if let Err(e) = self
+                .api
+                .forkchoice_updated(fork_name, forkchoice_state, None)
+                .await
+            {
                 debug!(
                     self.log,
                     "Failed to issue latest head to engine";

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1018,6 +1018,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
 
                     let response = engine
                         .notify_forkchoice_updated(
+                            current_fork,
                             fork_choice_state,
                             Some(payload_attributes.clone()),
                             self.log(),
@@ -1228,6 +1229,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     /// - An error, if all nodes return an error.
     pub async fn notify_forkchoice_updated(
         &self,
+        spec: &ChainSpec,
         head_block_hash: ExecutionBlockHash,
         justified_block_hash: ExecutionBlockHash,
         finalized_block_hash: ExecutionBlockHash,
@@ -1278,8 +1280,10 @@ impl<T: EthSpec> ExecutionLayer<T> {
             finalized_block_hash,
         };
 
+        let fork_name = spec.fork_name_at_epoch(next_slot.epoch(T::slots_per_epoch()));
+
         self.engine()
-            .set_latest_forkchoice_state(forkchoice_state)
+            .set_latest_forkchoice_state(forkchoice_state, fork_name)
             .await;
 
         let payload_attributes_ref = &payload_attributes;
@@ -1288,6 +1292,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             .request(|engine| async move {
                 engine
                     .notify_forkchoice_updated(
+                        fork_name,
                         forkchoice_state,
                         payload_attributes_ref.clone(),
                         self.log(),

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -118,6 +118,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
 
         self.el
             .notify_forkchoice_updated(
+                &self.spec,
                 parent_hash,
                 ExecutionBlockHash::zero(),
                 ExecutionBlockHash::zero(),
@@ -207,6 +208,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         let head_block_root = Hash256::repeat_byte(13);
         self.el
             .notify_forkchoice_updated(
+                &self.spec,
                 block_hash,
                 ExecutionBlockHash::zero(),
                 ExecutionBlockHash::zero(),

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -290,6 +290,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_a
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 parent_hash,
                 justified_block_hash,
                 finalized_block_hash,
@@ -350,6 +351,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_a
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_block_hash,
                 justified_block_hash,
                 finalized_block_hash,
@@ -390,6 +392,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_a
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_block_hash,
                 justified_block_hash,
                 finalized_block_hash,
@@ -503,6 +506,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_a
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_block_hash,
                 justified_block_hash,
                 finalized_block_hash,
@@ -543,6 +547,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_b
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_block_hash,
                 justified_block_hash,
                 finalized_block_hash,
@@ -595,6 +600,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
             .ee_b
             .execution_layer
             .notify_forkchoice_updated(
+                &self.spec,
                 head_block_hash,
                 justified_block_hash,
                 finalized_block_hash,


### PR DESCRIPTION
## Issue Addressed

There seem to be issues with lighthouse compatibility with all EL's right now because we query EL V2 endpoints prior to Shapella. Although the spec seems to imply querying V2 endpoints pre capella is valid, it seems like we are the only client doing this currently.