### PR TITLE
Make engine_getPayloadV2 accept local block value

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -760,7 +760,7 @@ impl HttpJsonRpc {
     ) -> Result<ExecutionPayload<T>, Error> {
         let params = json!([JsonPayloadIdRequest::from(payload_id)]);
 
-        let payload_v2: JsonExecutionPayloadV2<T> = self
+        let response: JsonGetPayloadResponse<T> = self
             .rpc_request(
                 ENGINE_GET_PAYLOAD_V2,
                 params,
@@ -768,7 +768,7 @@ impl HttpJsonRpc {
             )
             .await?;
 
-        JsonExecutionPayload::V2(payload_v2).try_into_execution_payload(fork_name)
+        JsonExecutionPayload::V2(response.execution_payload).try_into_execution_payload(fork_name)
     }
 
     pub async fn get_blobs_bundle_v1<T: EthSpec>(

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -324,6 +324,15 @@ impl<T: EthSpec> TryFrom<ExecutionPayload<T>> for JsonExecutionPayloadV2<T> {
     }
 }
 
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
+pub struct JsonGetPayloadResponse<T: EthSpec> {
+    pub execution_payload: JsonExecutionPayloadV2<T>,
+    // uncomment this when geth fixes its serialization
+    //#[serde(with = "eth2_serde_utils::u256_hex_be")]
+    //pub block_value: Uint256,
+}
+
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct JsonWithdrawal {


### PR DESCRIPTION
## Issue Addressed

Make lighthouse compatible with:
 * https://github.com/ethereum/execution-apis/pull/314
 
## Additional Comments

Still much work to be done on this, but this PR will at least make lighthouse compatible with the new API