### PR TITLE
Add `BlobsByRange` and `BlobsByRoot` to supported protocols

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -253,6 +253,8 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
         let mut supported_protocols = vec![
             ProtocolId::new(Protocol::Status, Version::V1, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::Goodbye, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::BlobsByRange, Version::V1, Encoding::SSZSnappy),
+            ProtocolId::new(Protocol::BlobsByRoot, Version::V1, Encoding::SSZSnappy),
             // V2 variants have higher preference then V1
             ProtocolId::new(Protocol::BlocksByRange, Version::V2, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::BlocksByRange, Version::V1, Encoding::SSZSnappy),


### PR DESCRIPTION
## Issue Addressed

Issue raised by @Inphi here in the interop repo: https://github.com/Inphi/eip4844-interop/pull/77#issuecomment-1354330633

Looks like `blobs_sidecars_by_range` and `beacon_block_and_blobs_sidecar_by_root` are not advertised as supported protocols.

