### PR TITLE
Handle ResourceUnavailable errors and other rpc/sync fixes

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2948,6 +2948,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         ops.push(StoreOp::PutState(block.state_root(), &state));
 
         if let Some(blobs) = blobs {
+            //FIXME(sean) using this for debugging for now
+            info!(self.log, "Writing blobs to store"; "block_root" => ?block_root);
             ops.push(StoreOp::PutBlobs(block_root, blobs));
         };
         let txn_lock = self.store.hot_db.begin_rw_transaction();

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -87,6 +87,8 @@ pub enum BlobError {
     /// We were unable to process this sync committee message due to an internal error. It's unclear if the
     /// sync committee message is valid.
     BeaconChainError(BeaconChainError),
+    /// No blobs for the specified block where we would expect blobs.
+    MissingBlobs,
 }
 
 impl From<BeaconChainError> for BlobError {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -579,10 +579,8 @@ pub fn signature_verify_chain_segment<T: BeaconChainTypes>(
     let mut signature_verified_blocks = Vec::with_capacity(chain_segment.len());
 
     for (block_root, block) in &chain_segment {
-        let mut consensus_context = ConsensusContext::new(block.slot())
-            .set_current_block_root(*block_root)
-            //FIXME(sean) Consider removing this is we pass the blob wrapper everywhere
-            .set_blobs_sidecar(block.blobs_sidecar());
+        let mut consensus_context =
+            ConsensusContext::new(block.slot()).set_current_block_root(*block_root);
 
         signature_verifier.include_all_signatures(block.block(), &mut consensus_context)?;
 
@@ -936,8 +934,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             .set_current_block_root(block_root)
             .set_proposer_index(block.message().proposer_index())
             .set_blobs_sidecar_validated(true) // Validated in `validate_blob_for_gossip`
-            .set_blobs_verified_vs_txs(true) // Validated in `validate_blob_for_gossip`
-            .set_blobs_sidecar(block.blobs_sidecar()); // TODO: potentially remove
+            .set_blobs_verified_vs_txs(true);
 
         Ok(Self {
             block,
@@ -1009,9 +1006,8 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
 
         let mut signature_verifier = get_signature_verifier(&state, &pubkey_cache, &chain.spec);
 
-        let mut consensus_context = ConsensusContext::new(block.slot())
-            .set_current_block_root(block_root)
-            .set_blobs_sidecar(block.blobs_sidecar());
+        let mut consensus_context =
+            ConsensusContext::new(block.slot()).set_current_block_root(block_root);
 
         signature_verifier.include_all_signatures(block.block(), &mut consensus_context)?;
 
@@ -1564,48 +1560,50 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
          * Verify kzg proofs and kzg commitments against transactions if required
          */
         //FIXME(sean) should this be prior to applying attestions to fork choice above? done in parallel?
-        if let Some(ref sidecar) = consensus_context.blobs_sidecar() {
-            if let Some(data_availability_boundary) = chain.data_availability_boundary() {
-                if block_slot.epoch(T::EthSpec::slots_per_epoch()) > data_availability_boundary {
-                    let kzg = chain.kzg.as_ref().ok_or(BlockError::BlobValidation(
-                        BlobError::TrustedSetupNotInitialized,
-                    ))?;
-                    let transactions = block
-                        .message()
-                        .body()
-                        .execution_payload_eip4844()
-                        .map(|payload| payload.transactions())
-                        .map_err(|_| BlockError::BlobValidation(BlobError::TransactionsMissing))?
-                        .ok_or(BlockError::BlobValidation(BlobError::TransactionsMissing))?;
-                    let kzg_commitments =
-                        block.message().body().blob_kzg_commitments().map_err(|_| {
-                            BlockError::BlobValidation(BlobError::KzgCommitmentMissing)
-                        })?;
-                    if !consensus_context.blobs_sidecar_validated() {
-                        if !kzg_utils::validate_blobs_sidecar(
-                            &kzg,
-                            block.slot(),
-                            block_root,
-                            kzg_commitments,
-                            sidecar,
-                        )
-                        .map_err(|e| BlockError::BlobValidation(BlobError::KzgError(e)))?
-                        {
-                            return Err(BlockError::BlobValidation(BlobError::InvalidKzgProof));
-                        }
-                    }
-                    if !consensus_context.blobs_verified_vs_txs()
-                        && verify_kzg_commitments_against_transactions::<T::EthSpec>(
-                            transactions,
-                            kzg_commitments,
-                        )
-                        //FIXME(sean) we should maybe just map this error so we have more info about the mismatch
-                        .is_err()
+        if let Some(data_availability_boundary) = chain.data_availability_boundary() {
+            if block_slot.epoch(T::EthSpec::slots_per_epoch()) >= data_availability_boundary {
+                let sidecar = block
+                    .blobs()
+                    .ok_or(BlockError::BlobValidation(BlobError::MissingBlobs))?;
+                let kzg = chain.kzg.as_ref().ok_or(BlockError::BlobValidation(
+                    BlobError::TrustedSetupNotInitialized,
+                ))?;
+                let transactions = block
+                    .message()
+                    .body()
+                    .execution_payload_eip4844()
+                    .map(|payload| payload.transactions())
+                    .map_err(|_| BlockError::BlobValidation(BlobError::TransactionsMissing))?
+                    .ok_or(BlockError::BlobValidation(BlobError::TransactionsMissing))?;
+                let kzg_commitments = block
+                    .message()
+                    .body()
+                    .blob_kzg_commitments()
+                    .map_err(|_| BlockError::BlobValidation(BlobError::KzgCommitmentMissing))?;
+                if !consensus_context.blobs_sidecar_validated() {
+                    if !kzg_utils::validate_blobs_sidecar(
+                        &kzg,
+                        block.slot(),
+                        block_root,
+                        kzg_commitments,
+                        sidecar,
+                    )
+                    .map_err(|e| BlockError::BlobValidation(BlobError::KzgError(e)))?
                     {
-                        return Err(BlockError::BlobValidation(
-                            BlobError::TransactionCommitmentMismatch,
-                        ));
+                        return Err(BlockError::BlobValidation(BlobError::InvalidKzgProof));
                     }
+                }
+                if !consensus_context.blobs_verified_vs_txs()
+                    && verify_kzg_commitments_against_transactions::<T::EthSpec>(
+                        transactions,
+                        kzg_commitments,
+                    )
+                    //FIXME(sean) we should maybe just map this error so we have more info about the mismatch
+                    .is_err()
+                {
+                    return Err(BlockError::BlobValidation(
+                        BlobError::TransactionCommitmentMismatch,
+                    ));
                 }
             }
         }

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -32,7 +32,7 @@ pub async fn publish_block<T: BeaconChainTypes>(
     let block_root = block_root.unwrap_or_else(|| block.canonical_root());
 
     // Send the block, regardless of whether or not it is valid. The API
-    // specification is very clear that this isa the desired behaviour.
+    // specification is very clear that this is the desired behaviour.
     let wrapped_block = if matches!(block.as_ref(), &SignedBeaconBlock::Eip4844(_)) {
         if let Some(sidecar) = chain.blob_cache.pop(&block_root) {
             let block_and_blobs = SignedBeaconBlockAndBlobsSidecar {

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -473,6 +473,11 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             RPCError::ErrorResponse(code, _) => match code {
                 RPCResponseErrorCode::Unknown => PeerAction::HighToleranceError,
                 RPCResponseErrorCode::ResourceUnavailable => {
+                    // Don't ban on this because we want to retry with a block by root request.
+                    if matches!(protocol, Protocol::BlobsByRoot) {
+                        return;
+                    }
+
                     // NOTE: This error only makes sense for the `BlocksByRange` and `BlocksByRoot`
                     // protocols.
                     //

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -531,9 +531,6 @@ fn handle_v2_request<T: EthSpec>(
         Protocol::BlocksByRoot => Ok(Some(InboundRequest::BlocksByRoot(BlocksByRootRequest {
             block_roots: VariableList::from_ssz_bytes(decoded_buffer)?,
         }))),
-        Protocol::BlobsByRange => Ok(Some(InboundRequest::BlobsByRange(
-            BlobsByRangeRequest::from_ssz_bytes(decoded_buffer)?,
-        ))),
         // MetaData requests return early from InboundUpgrade and do not reach the decoder.
         // Handle this case just for completeness.
         Protocol::MetaData => {
@@ -826,8 +823,21 @@ mod tests {
         }
     }
 
+    fn blbrange_request() -> BlobsByRangeRequest {
+        BlobsByRangeRequest {
+            start_slot: 0,
+            count: 10,
+        }
+    }
+
     fn bbroot_request() -> BlocksByRootRequest {
         BlocksByRootRequest {
+            block_roots: VariableList::from(vec![Hash256::zero()]),
+        }
+    }
+
+    fn blbroot_request() -> BlobsByRootRequest {
+        BlobsByRootRequest {
             block_roots: VariableList::from(vec![Hash256::zero()]),
         }
     }
@@ -1454,6 +1464,8 @@ mod tests {
             OutboundRequest::Goodbye(GoodbyeReason::Fault),
             OutboundRequest::BlocksByRange(bbrange_request()),
             OutboundRequest::BlocksByRoot(bbroot_request()),
+            OutboundRequest::BlobsByRange(blbrange_request()),
+            OutboundRequest::BlobsByRoot(blbroot_request()),
             OutboundRequest::MetaData(PhantomData::<Spec>),
         ];
         for req in requests.iter() {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -75,6 +75,8 @@ pub enum NetworkEvent<AppReqId: ReqId, TSpec: EthSpec> {
         id: AppReqId,
         /// The peer to which this request was sent.
         peer_id: PeerId,
+        /// The error of the failed request.
+        error: RPCError,
     },
     RequestReceived {
         /// The peer that sent the request.
@@ -1177,9 +1179,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                             &error,
                             ConnectionDirection::Outgoing,
                         );
-                        // inform failures of requests comming outside the behaviour
+                        // inform failures of requests coming outside the behaviour
                         if let RequestId::Application(id) = id {
-                            Some(NetworkEvent::RPCFailed { peer_id, id })
+                            Some(NetworkEvent::RPCFailed { peer_id, id, error })
                         } else {
                             None
                         }

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -254,6 +254,14 @@ impl<T: BeaconChainTypes> Worker<T> {
                                 "peer" => %peer_id,
                                 "request_root" => ?root
                             );
+                            self.send_error_response(
+                                peer_id,
+                                RPCResponseErrorCode::ResourceUnavailable,
+                                "No blob for requested block".into(),
+                                request_id,
+                            );
+                            send_response = false;
+                            break;
                         }
                         Ok((None, Some(_))) => {
                             debug!(

--- a/beacon_node/network/src/router/mod.rs
+++ b/beacon_node/network/src/router/mod.rs
@@ -11,6 +11,7 @@ use crate::error;
 use crate::service::{NetworkMessage, RequestId};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use futures::prelude::*;
+use lighthouse_network::rpc::RPCError;
 use lighthouse_network::{
     MessageId, NetworkGlobals, PeerId, PeerRequestId, PubsubMessage, Request, Response,
 };
@@ -58,6 +59,7 @@ pub enum RouterMessage<T: EthSpec> {
     RPCFailed {
         peer_id: PeerId,
         request_id: RequestId,
+        error: RPCError,
     },
     /// A gossip message has been received. The fields are: message id, the peer that sent us this
     /// message, the message itself and a bool which indicates if the message should be processed
@@ -140,8 +142,9 @@ impl<T: BeaconChainTypes> Router<T> {
             RouterMessage::RPCFailed {
                 peer_id,
                 request_id,
+                error,
             } => {
-                self.processor.on_rpc_error(peer_id, request_id);
+                self.processor.on_rpc_error(peer_id, request_id, error);
             }
             RouterMessage::PubsubMessage(id, peer_id, gossip, should_process) => {
                 self.handle_gossip(id, peer_id, gossip, should_process);

--- a/beacon_node/network/src/router/processor.rs
+++ b/beacon_node/network/src/router/processor.rs
@@ -103,12 +103,13 @@ impl<T: BeaconChainTypes> Processor<T> {
 
     /// An error occurred during an RPC request. The state is maintained by the sync manager, so
     /// this function notifies the sync manager of the error.
-    pub fn on_rpc_error(&mut self, peer_id: PeerId, request_id: RequestId) {
+    pub fn on_rpc_error(&mut self, peer_id: PeerId, request_id: RequestId, error: RPCError) {
         // Check if the failed RPC belongs to sync
         if let RequestId::Sync(request_id) = request_id {
             self.send_to_sync(SyncMessage::RpcError {
                 peer_id,
                 request_id,
+                error,
             });
         }
     }

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -499,10 +499,11 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                     response,
                 });
             }
-            NetworkEvent::RPCFailed { id, peer_id } => {
+            NetworkEvent::RPCFailed { id, peer_id, error } => {
                 self.send_to_router(RouterMessage::RPCFailed {
                     peer_id,
                     request_id: id,
+                    error,
                 });
             }
             NetworkEvent::StatusPeer(peer_id) => {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -6,6 +6,7 @@ use super::range_sync::{BatchId, ChainId, ExpectedBatchTy};
 use crate::beacon_processor::WorkEvent;
 use crate::service::{NetworkMessage, RequestId};
 use crate::status::ToStatusMessage;
+use crate::sync::block_lookups::ForceBlockRequest;
 use beacon_chain::{BeaconChain, BeaconChainTypes, EngineState};
 use fnv::FnvHashMap;
 use lighthouse_network::rpc::methods::BlobsByRangeRequest;
@@ -50,7 +51,7 @@ impl<T: EthSpec> BlockBlobRequestInfo<T> {
     }
 
     pub fn pop_response(&mut self) -> Option<SignedBeaconBlockAndBlobsSidecar<T>> {
-        if !self.accumulated_blocks.is_empty() && !self.accumulated_blocks.is_empty() {
+        if !self.accumulated_blocks.is_empty() && !self.accumulated_sidecars.is_empty() {
             let beacon_block = self.accumulated_blocks.pop_front().expect("non empty");
             let blobs_sidecar = self.accumulated_sidecars.pop_front().expect("non empty");
             return Some(SignedBeaconBlockAndBlobsSidecar {
@@ -504,11 +505,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &mut self,
         peer_id: PeerId,
         request: BlocksByRootRequest,
+        force_block_request: ForceBlockRequest,
     ) -> Result<Id, &'static str> {
         let request = if self
             .chain
             .is_data_availability_check_required()
             .map_err(|_| "Unable to read slot clock")?
+            && matches!(force_block_request, ForceBlockRequest::False)
         {
             trace!(
                 self.log,

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -185,13 +185,4 @@ impl<T: EthSpec> ConsensusContext<T> {
     pub fn blobs_verified_vs_txs(&self) -> bool {
         self.blobs_verified_vs_txs
     }
-
-    pub fn set_blobs_sidecar(mut self, blobs_sidecar: Option<Arc<BlobsSidecar<T>>>) -> Self {
-        self.blobs_sidecar = blobs_sidecar;
-        self
-    }
-
-    pub fn blobs_sidecar(&self) -> Option<Arc<BlobsSidecar<T>>> {
-        self.blobs_sidecar.clone()
-    }
 }

--- a/consensus/types/src/signed_block_and_blobs.rs
+++ b/consensus/types/src/signed_block_and_blobs.rs
@@ -66,20 +66,21 @@ impl<T: EthSpec> BlockWrapper<T> {
             }
         }
     }
-    pub fn blobs_sidecar(&self) -> Option<Arc<BlobsSidecar<T>>> {
-        match self {
-            BlockWrapper::Block { block: _ } => None,
-            BlockWrapper::BlockAndBlob { block_sidecar_pair } => {
-                Some(block_sidecar_pair.blobs_sidecar.clone())
-            }
-        }
-    }
 
     pub fn blobs(&self) -> Option<&BlobsSidecar<T>> {
         match self {
             BlockWrapper::Block { .. } => None,
             BlockWrapper::BlockAndBlob { block_sidecar_pair } => {
                 Some(&block_sidecar_pair.blobs_sidecar)
+            }
+        }
+    }
+
+    pub fn blobs_cloned(&self) -> Option<Arc<BlobsSidecar<T>>> {
+        match self {
+            BlockWrapper::Block { block: _ } => None,
+            BlockWrapper::BlockAndBlob { block_sidecar_pair } => {
+                Some(block_sidecar_pair.blobs_sidecar.clone())
             }
         }
     }

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -120,7 +120,7 @@ EL_base_auth_http=5000
 (( $VC_COUNT < $BN_COUNT )) && SAS=-s || SAS=
 
 for (( el=1; el<=$BN_COUNT; el++ )); do
-    execute_command_add_PID geth_$el.log ./geth.sh $DATADIR/geth_datadir$el $((EL_base_network + $el)) $((EL_base_http + $el)) $((EL_base_auth_http + $el)) $genesis_file
+    execute_command_add_PID geth_$el.log ./geth.sh $DATADIR/geth_datadir$el $((EL_base_network + $el)) $((EL_base_http + $el)) $((EL_base_auth_http + $el + 10)) $genesis_file
 done
 
 sleeping 20
@@ -130,6 +130,8 @@ sed -i 's/"shanghaiTime".*$/"shanghaiTime": 0,/g' genesis.json
 sed -i 's/"shardingForkTime".*$/"shardingForkTime": 0,/g' genesis.json
 
 for (( bn=1; bn<=$BN_COUNT; bn++ )); do
+
+    execute_command_add_PID json_snoop_$bn.log json_rpc_snoop -p $((EL_base_auth_http + $bn)) -b 0.0.0.0 http://localhost:$((EL_base_auth_http + $bn + 10))
     secret=$DATADIR/geth_datadir$bn/geth/jwtsecret
     echo $secret
     execute_command_add_PID beacon_node_$bn.log ./beacon_node.sh $SAS -d $DEBUG_LEVEL $DATADIR/node_$bn $((BN_udp_tcp_base + $bn)) $((BN_http_port_base + $bn)) http://localhost:$((EL_base_auth_http + $bn)) $secret

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -120,7 +120,7 @@ EL_base_auth_http=5000
 (( $VC_COUNT < $BN_COUNT )) && SAS=-s || SAS=
 
 for (( el=1; el<=$BN_COUNT; el++ )); do
-    execute_command_add_PID geth_$el.log ./geth.sh $DATADIR/geth_datadir$el $((EL_base_network + $el)) $((EL_base_http + $el)) $((EL_base_auth_http + $el + 10)) $genesis_file
+    execute_command_add_PID geth_$el.log ./geth.sh $DATADIR/geth_datadir$el $((EL_base_network + $el)) $((EL_base_http + $el)) $((EL_base_auth_http + $el)) $genesis_file
 done
 
 sleeping 20
@@ -130,8 +130,6 @@ sed -i 's/"shanghaiTime".*$/"shanghaiTime": 0,/g' genesis.json
 sed -i 's/"shardingForkTime".*$/"shardingForkTime": 0,/g' genesis.json
 
 for (( bn=1; bn<=$BN_COUNT; bn++ )); do
-
-    execute_command_add_PID json_snoop_$bn.log json_rpc_snoop -p $((EL_base_auth_http + $bn)) -b 0.0.0.0 http://localhost:$((EL_base_auth_http + $bn + 10))
     secret=$DATADIR/geth_datadir$bn/geth/jwtsecret
     echo $secret
     execute_command_add_PID beacon_node_$bn.log ./beacon_node.sh $SAS -d $DEBUG_LEVEL $DATADIR/node_$bn $((BN_udp_tcp_base + $bn)) $((BN_http_port_base + $bn)) http://localhost:$((EL_base_auth_http + $bn)) $secret


### PR DESCRIPTION
## Issue Addressed

Various sync related changes

## Proposed Changes
the next list is @divagant-martian 's edit so it might be incomplete/ inaccurate:
- Removes the blobs from the `ConsensusContext` since those are now carried in the `BlockWrapper`.
- Adds a `MissingBlobs` error for blocks that need a blob in block verification, and changes needed to return this error
- Send `ResourceUnavailable` to peers when they requested a block and blob, but no blob was found.
- Remove incorrect handling of the non existent `BlobsByRange` `V2` request.
- Include encode then decode testing for Blob related requests.
- Do not ban peers that respond with a `ResourceUnavailable`  response to a `BlobsByRoot` request.
- Include the RPC error in the network message that informs a request has failed.
- Handle the propagated up rpc error to retry a `BlockByRoot` request instead of a `BlobByRoot` request for parent requests if the error is a `ResourceUnavailable` one.
- Fix bug in popping coupled blocks and blobs in the `NetworkContext`.
- Add temp logs.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
