### PR TITLE
Use bootnode binary variable in testnet scripts

### DIFF
--- a/scripts/local_testnet/el_bootnode.sh
+++ b/scripts/local_testnet/el_bootnode.sh
@@ -1,4 +1,4 @@
 priv_key="02fd74636e96a8ffac8e7b01b0de8dea94d6bcf4989513b38cf59eb32163ff91"
 
 
-/home/sean/CLionProjects/eip4844-interop/geth/go-ethereum/build/bin/bootnode --nodekeyhex $priv_key
+$BOOTNODE_BINARY --nodekeyhex $priv_key

--- a/scripts/local_testnet/el_bootnode.sh
+++ b/scripts/local_testnet/el_bootnode.sh
@@ -1,4 +1,5 @@
 priv_key="02fd74636e96a8ffac8e7b01b0de8dea94d6bcf4989513b38cf59eb32163ff91"
 
+source ./vars.env
 
 $BOOTNODE_BINARY --nodekeyhex $priv_key

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -1,4 +1,5 @@
 GETH_BINARY=geth
+BOOTNODE_BINARY=bootnode
 
 # Base directories for the validator keys and secrets
 DATADIR=~/.lighthouse/local-testnet


### PR DESCRIPTION
@realbigsean I had issues with geth syncing and realised EL bootnode wasn't starting because binary path wasn't updated on my machine. This PR extracts the `bootnode` binary path to `vars.env`