### PR TITLE
Handle peers sending no blob when the blob is empty in range responses

### DIFF
--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -5,11 +5,6 @@ use types::{
     SignedBeaconBlockAndBlobsSidecar,
 };
 
-struct ReceivedData<T: EthSpec> {
-    block: Option<Arc<SignedBeaconBlock<T>>>,
-    blob: Option<Arc<BlobsSidecar<T>>>,
-}
-
 #[derive(Debug, Default)]
 pub struct BlockBlobRequestInfo<T: EthSpec> {
     /// Blocks we have received awaiting for their corresponding sidecar.
@@ -17,84 +12,68 @@ pub struct BlockBlobRequestInfo<T: EthSpec> {
     /// Sidecars we have received awaiting for their corresponding block.
     accumulated_sidecars: VecDeque<Arc<BlobsSidecar<T>>>,
     /// Whether the individual RPC request for blocks is finished or not.
-    is_blocks_rpc_finished: bool,
+    is_blocks_stream_terminated: bool,
     /// Whether the individual RPC request for sidecars is finished or not.
-    is_sidecar_rpc_finished: bool,
+    is_sidecars_stream_terminated: bool,
 }
 
 impl<T: EthSpec> BlockBlobRequestInfo<T> {
     pub fn add_block_response(&mut self, maybe_block: Option<Arc<SignedBeaconBlock<T>>>) {
         match maybe_block {
             Some(block) => self.accumulated_blocks.push_back(block),
-            None => self.is_blocks_rpc_finished = true,
+            None => self.is_blocks_stream_terminated = true,
         }
     }
 
     pub fn add_sidecar_response(&mut self, maybe_sidecar: Option<Arc<BlobsSidecar<T>>>) {
         match maybe_sidecar {
             Some(sidecar) => self.accumulated_sidecars.push_back(sidecar),
-            None => self.is_sidecar_rpc_finished = true,
+            None => self.is_sidecars_stream_terminated = true,
         }
     }
 
     pub fn into_responses(self) -> Result<Vec<BlockWrapper<T>>, &'static str> {
         let BlockBlobRequestInfo {
             accumulated_blocks,
-            accumulated_sidecars,
+            mut accumulated_sidecars,
             ..
         } = self;
 
-        // Create the storage for our pairs.
-        let mut pairs = Vec::with_capacity(accumulated_blocks.len());
-
-        // ASSUMPTION: There can't be more more blobs than blocks. i.e. sending any block (empty
+        // ASSUMPTION: There can't be more more blobs than blocks. i.e. sending any blob (empty
         // included) for a skipped slot is not permitted.
-        for sidecar in accumulated_sidecars {
-            let blob_slot = sidecar.beacon_block_slot;
-            // First queue any blocks that might not have a blob.
-            while let Some(block) = {
-                // We identify those if their slot is less than the current blob's slot.
-                match accumulated_blocks.front() {
-                    Some(borrowed_block) if borrowed_block.slot() < blob_slot => {
-                        accumulated_blocks.pop_front()
-                    }
-                    Some(_) => None,
-                    None => {
-                        // We received a blob and ran out of blocks. This is a peer error
-                        return Err("Blob without more blobs to pair with returned by peer");
-                    }
+        let pairs = accumulated_blocks
+            .into_iter()
+            .map(|beacon_block| {
+                if accumulated_sidecars
+                    .front()
+                    .map(|sidecar| sidecar.beacon_block_slot == beacon_block.slot())
+                    .unwrap_or(false)
+                {
+                    let blobs_sidecar =
+                        accumulated_sidecars.pop_front().ok_or("missing sidecar")?;
+                    Ok(BlockWrapper::BlockAndBlob {
+                        block_sidecar_pair: SignedBeaconBlockAndBlobsSidecar {
+                            beacon_block,
+                            blobs_sidecar,
+                        },
+                    })
+                } else {
+                    Ok(BlockWrapper::Block {
+                        block: beacon_block,
+                    })
                 }
-            } {
-                pairs.push(BlockWrapper::Block { block })
-            }
+            })
+            .collect::<Result<Vec<_>, _>>();
 
-            // The next block must be present and must match the blob's slot
-            let next_block = accumulated_blocks
-                .pop_front()
-                .expect("If block stream ended, an error was previously returned");
-            if next_block.slot() != blob_slot {
-                // We verified that the slot of the block is not less than the slot of the blob (it
-                // would have been returned before). It's also not equal, so this block is ahead
-                // than the blob. This means the blob is not paired.
-                return Err("Blob without a matching block returned by peer");
-            }
-            pairs.push(BlockWrapper::BlockAndBlob {
-                block_sidecar_pair: SignedBeaconBlockAndBlobsSidecar {
-                    beacon_block: next_block,
-                    blobs_sidecar: sidecar,
-                },
-            });
+        // if accumulated sidecars is not empty, throw an error.
+        if !accumulated_sidecars.is_empty() {
+            return Err("Received more sidecars than blocks");
         }
 
-        // Every remaining block does not have a blob
-        for block in accumulated_blocks {
-            pairs.push(BlockWrapper::Block { block })
-        }
-
-        Ok(pairs)
+        pairs
     }
 
     pub fn is_finished(&self) -> bool {
-        self.is_blocks_rpc_finished && self.is_sidecar_rpc_finished
+        self.is_blocks_stream_terminated && self.is_sidecars_stream_terminated
     }
 }

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{hash_map::OccupiedEntry, VecDeque},
-    sync::Arc,
-};
+use std::{collections::VecDeque, sync::Arc};
 
 use types::{
     signed_block_and_blobs::BlockWrapper, BlobsSidecar, EthSpec, SignedBeaconBlock,
@@ -23,18 +20,6 @@ pub struct BlockBlobRequestInfo<T: EthSpec> {
     is_blocks_rpc_finished: bool,
     /// Whether the individual RPC request for sidecars is finished or not.
     is_sidecar_rpc_finished: bool,
-}
-
-pub struct BlockBlobRequestEntry<'a, K, T: EthSpec> {
-    entry: OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>,
-}
-
-impl<'a, K, T: EthSpec> From<OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>>
-    for BlockBlobRequestEntry<'a, K, T>
-{
-    fn from(entry: OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>) -> Self {
-        BlockBlobRequestEntry { entry }
-    }
 }
 
 impl<T: EthSpec> BlockBlobRequestInfo<T> {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,0 +1,115 @@
+use std::{
+    collections::{hash_map::OccupiedEntry, VecDeque},
+    sync::Arc,
+};
+
+use types::{
+    signed_block_and_blobs::BlockWrapper, BlobsSidecar, EthSpec, SignedBeaconBlock,
+    SignedBeaconBlockAndBlobsSidecar,
+};
+
+struct ReceivedData<T: EthSpec> {
+    block: Option<Arc<SignedBeaconBlock<T>>>,
+    blob: Option<Arc<BlobsSidecar<T>>>,
+}
+
+#[derive(Debug, Default)]
+pub struct BlockBlobRequestInfo<T: EthSpec> {
+    /// Blocks we have received awaiting for their corresponding sidecar.
+    accumulated_blocks: VecDeque<Arc<SignedBeaconBlock<T>>>,
+    /// Sidecars we have received awaiting for their corresponding block.
+    accumulated_sidecars: VecDeque<Arc<BlobsSidecar<T>>>,
+    /// Whether the individual RPC request for blocks is finished or not.
+    is_blocks_rpc_finished: bool,
+    /// Whether the individual RPC request for sidecars is finished or not.
+    is_sidecar_rpc_finished: bool,
+}
+
+pub struct BlockBlobRequestEntry<'a, K, T: EthSpec> {
+    entry: OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>,
+}
+
+impl<'a, K, T: EthSpec> From<OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>>
+    for BlockBlobRequestEntry<'a, K, T>
+{
+    fn from(entry: OccupiedEntry<'a, K, BlockBlobRequestInfo<T>>) -> Self {
+        BlockBlobRequestEntry { entry }
+    }
+}
+
+impl<T: EthSpec> BlockBlobRequestInfo<T> {
+    pub fn add_block_response(&mut self, maybe_block: Option<Arc<SignedBeaconBlock<T>>>) {
+        match maybe_block {
+            Some(block) => self.accumulated_blocks.push_back(block),
+            None => self.is_blocks_rpc_finished = true,
+        }
+    }
+
+    pub fn add_sidecar_response(&mut self, maybe_sidecar: Option<Arc<BlobsSidecar<T>>>) {
+        match maybe_sidecar {
+            Some(sidecar) => self.accumulated_sidecars.push_back(sidecar),
+            None => self.is_sidecar_rpc_finished = true,
+        }
+    }
+
+    pub fn into_responses(self) -> Result<Vec<BlockWrapper<T>>, &'static str> {
+        let BlockBlobRequestInfo {
+            accumulated_blocks,
+            accumulated_sidecars,
+            ..
+        } = self;
+
+        // Create the storage for our pairs.
+        let mut pairs = Vec::with_capacity(accumulated_blocks.len());
+
+        // ASSUMPTION: There can't be more more blobs than blocks. i.e. sending any block (empty
+        // included) for a skipped slot is not permitted.
+        for sidecar in accumulated_sidecars {
+            let blob_slot = sidecar.beacon_block_slot;
+            // First queue any blocks that might not have a blob.
+            while let Some(block) = {
+                // We identify those if their slot is less than the current blob's slot.
+                match accumulated_blocks.front() {
+                    Some(borrowed_block) if borrowed_block.slot() < blob_slot => {
+                        accumulated_blocks.pop_front()
+                    }
+                    Some(_) => None,
+                    None => {
+                        // We received a blob and ran out of blocks. This is a peer error
+                        return Err("Blob without more blobs to pair with returned by peer");
+                    }
+                }
+            } {
+                pairs.push(BlockWrapper::Block { block })
+            }
+
+            // The next block must be present and must match the blob's slot
+            let next_block = accumulated_blocks
+                .pop_front()
+                .expect("If block stream ended, an error was previously returned");
+            if next_block.slot() != blob_slot {
+                // We verified that the slot of the block is not less than the slot of the blob (it
+                // would have been returned before). It's also not equal, so this block is ahead
+                // than the blob. This means the blob is not paired.
+                return Err("Blob without a matching block returned by peer");
+            }
+            pairs.push(BlockWrapper::BlockAndBlob {
+                block_sidecar_pair: SignedBeaconBlockAndBlobsSidecar {
+                    beacon_block: next_block,
+                    blobs_sidecar: sidecar,
+                },
+            });
+        }
+
+        // Every remaining block does not have a blob
+        for block in accumulated_blocks {
+            pairs.push(BlockWrapper::Block { block })
+        }
+
+        Ok(pairs)
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.is_blocks_rpc_finished && self.is_sidecar_rpc_finished
+    }
+}

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -827,10 +827,10 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     }
                 }
                 Err(e) => {
-                    // inform backfill that the request needs to be treated as failed
+                    // inform range that the request needs to be treated as failed
                     // With time we will want to downgrade this log
                     warn!(
-                    self.log, "Blocks and blobs request for backfill received invalid data";
+                    self.log, "Blocks and blobs request for range received invalid data";
                     "peer_id" => %peer_id, "batch_id" => batch_id, "error" => e
                     );
                     // TODO: penalize the peer for being a bad boy

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -841,7 +841,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         }
     }
 
-    /// Handles receiving a response for a bacjfill sync request that should have both blocks and
+    /// Handles receiving a response for a Backfill sync request that should have both blocks and
     /// blobs.
     fn block_blob_backfill_response(
         &mut self,

--- a/beacon_node/network/src/sync/mod.rs
+++ b/beacon_node/network/src/sync/mod.rs
@@ -3,6 +3,7 @@
 //! Stores the various syncing methods for the beacon chain.
 mod backfill_sync;
 mod block_lookups;
+mod block_sidecar_coupling;
 pub mod manager;
 mod network_context;
 mod peer_sync_info;

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -304,7 +304,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     BlockOrBlob::Blob(maybe_sidecar) => info.add_sidecar_response(maybe_sidecar),
                 }
                 if info.is_finished() {
-                    // If the request is finished, unqueue everything
+                    // If the request is finished, dequeue everything
                     let (chain_id, batch_id, info) = entry.remove();
                     Some((chain_id, batch_id, info.into_responses()))
                 } else {
@@ -372,7 +372,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     BlockOrBlob::Blob(maybe_sidecar) => info.add_sidecar_response(maybe_sidecar),
                 }
                 if info.is_finished() {
-                    // If the request is finished, unqueue everything
+                    // If the request is finished, dequeue everything
                     let (batch_id, info) = entry.remove();
                     Some((batch_id, info.into_responses()))
                 } else {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -278,11 +278,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         is_stream_terminator: bool,
     ) -> Option<(ChainId, BatchId)> {
         if is_stream_terminator {
-            self.range_requests
-                .remove(&request_id)
-                .map(|(chain_id, batch_id)| (chain_id, batch_id))
+            self.range_requests.remove(&request_id)
         } else {
-            self.range_requests.get(&request_id).cloned()
+            self.range_requests.get(&request_id).copied()
         }
     }
 
@@ -354,7 +352,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 .remove(&request_id)
                 .map(|batch_id| batch_id)
         } else {
-            self.backfill_requests.get(&request_id).cloned()
+            self.backfill_requests.get(&request_id).copied()
         }
     }
 

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -686,13 +686,10 @@ mod tests {
         // add some peers
         let (peer1, local_info, head_info) = rig.head_peer();
         range.add_peer(&mut rig.cx, local_info, peer1, head_info);
-        let ((chain1, batch1, _), id1) = match rig.grab_request(&peer1).0 {
-            RequestId::Sync(crate::sync::manager::RequestId::RangeSync { id }) => (
-                rig.cx
-                    .range_sync_block_response(id, None, ExpectedBatchTy::OnlyBlock)
-                    .unwrap(),
-                id,
-            ),
+        let ((chain1, batch1), id1) = match rig.grab_request(&peer1).0 {
+            RequestId::Sync(crate::sync::manager::RequestId::RangeSync { id }) => {
+                (rig.cx.range_sync_response(id, true).unwrap(), id)
+            }
             other => panic!("unexpected request {:?}", other),
         };
 
@@ -708,13 +705,10 @@ mod tests {
         // while the ee is offline, more peers might arrive. Add a new finalized peer.
         let (peer2, local_info, finalized_info) = rig.finalized_peer();
         range.add_peer(&mut rig.cx, local_info, peer2, finalized_info);
-        let ((chain2, batch2, _), id2) = match rig.grab_request(&peer2).0 {
-            RequestId::Sync(crate::sync::manager::RequestId::RangeSync { id }) => (
-                rig.cx
-                    .range_sync_block_response(id, None, ExpectedBatchTy::OnlyBlock)
-                    .unwrap(),
-                id,
-            ),
+        let ((chain2, batch2), id2) = match rig.grab_request(&peer2).0 {
+            RequestId::Sync(crate::sync::manager::RequestId::RangeSync { id }) => {
+                (rig.cx.range_sync_response(id, true).unwrap(), id)
+            }
             other => panic!("unexpected request {:?}", other),
         };
 

--- a/consensus/types/src/blobs_sidecar.rs
+++ b/consensus/types/src/blobs_sidecar.rs
@@ -1,13 +1,17 @@
-use crate::{Blob, EthSpec, Hash256, SignedRoot, Slot};
+use crate::test_utils::TestRandom;
+use crate::{Blob, EthSpec, Hash256, SignedBeaconBlock, SignedRoot, Slot};
 use kzg::KzgProof;
 use serde_derive::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
+use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 #[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, PartialEq, Default)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, PartialEq, Default, TestRandom,
+)]
 #[serde(bound = "T: EthSpec")]
 pub struct BlobsSidecar<T: EthSpec> {
     pub beacon_block_root: Hash256,
@@ -23,6 +27,7 @@ impl<T: EthSpec> BlobsSidecar<T> {
     pub fn empty() -> Self {
         Self::default()
     }
+
     #[allow(clippy::integer_arithmetic)]
     pub fn max_size() -> usize {
         // Fixed part


### PR DESCRIPTION
## Issue Addressed
When a block has an empty Blob, a peer can skip the blob in the by range blob request, this changes how we handle blocks-blob pairing

## Proposed Changes

For now, I found it easier to wait for both streams to end and then unqueue everything. 
The logic is as follows:
- Check every blob (which must be order by slot), if there are any blocks with a slot less than that of the block it means the peer didn't send a blob so we dequeue them without a blob
- Since all blocks with slot less than the current blob have been dequeued, the next block must have the same slot as the blob. If it doesn't, the blob has no matching block and the peer is misbehaving. If it matches, dequeue them together.
- After all blobs have been dequeued, all remaining blocks are blocks without a matching blob and are dequeued that way.

## Additional Info
Not sure if it's actually better to try to dequeue one at a time, but it's notable that for multiple skipped slots, a single blob response or blob stream termination can dequeue several blocks. This means that even in that case dequeue is not just for one block at a time
