### PR TITLE
Remove sync validation no longer valid + Fix bakcfill batch sizes

### DIFF
--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -33,7 +33,7 @@ use types::{Epoch, EthSpec};
 /// we will negatively report peers with poor bandwidth. This can be set arbitrarily high, in which
 /// case the responder will fill the response up to the max request size, assuming they have the
 /// bandwidth to do so.
-pub const BACKFILL_EPOCHS_PER_BATCH: u64 = 2;
+pub const BACKFILL_EPOCHS_PER_BATCH: u64 = 1;
 
 /// The maximum number of batches to queue before requesting more.
 const BACKFILL_BATCH_BUFFER_SIZE: u8 = 20;

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::ops::Sub;
 use std::sync::Arc;
+use strum::Display;
 use types::signed_block_and_blobs::BlockWrapper;
 use types::{Epoch, EthSpec, SignedBeaconBlock, SignedBeaconBlockAndBlobsSidecar, Slot};
 
@@ -40,7 +41,8 @@ impl<T: EthSpec> BatchTy<T> {
 pub struct MixedBlockTyErr;
 
 /// Type of expected batch.
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone, Display)]
+#[strum(serialize_all = "snake_case")]
 pub enum ExpectedBatchTy {
     OnlyBlockBlobs,
     OnlyBlock,
@@ -247,7 +249,7 @@ impl<T: EthSpec, B: BatchConfig> BatchInfo<T, B> {
                 start_slot: self.start_slot.into(),
                 count: self.end_slot.sub(self.start_slot).into(),
             },
-            self.batch_type.clone(),
+            self.batch_type,
         )
     }
 
@@ -557,6 +559,7 @@ impl<T: EthSpec, B: BatchConfig> slog::KV for BatchInfo<T, B> {
         serializer.emit_usize("processed", self.failed_processing_attempts.len())?;
         serializer.emit_u8("processed_no_penalty", self.non_faulty_processing_attempts)?;
         serializer.emit_arguments("state", &format_args!("{:?}", self.state))?;
+        serializer.emit_arguments("batch_ty", &format_args!("{}", self.batch_type));
         slog::Result::Ok(())
     }
 }


### PR DESCRIPTION
## Issue Addressed

Miscelaneous changes to sync

## Proposed Changes
-After #3829 the assumption that a batch that requests both blocks anb blobs must have exclusively pairs of blocks and blobs is no longer true (we can have a single block because it's blob is empty/ has not blob) . Verification for this is removed.
- Add the batch type to the batch's KV to get some nice logging.
- Add compile time verification for number of epochs per batch.
- Make backfill batches request just one epoch.

## Additional Info

na