### PR TITLE
Fixed Some Tests

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1372,9 +1372,9 @@ impl ApiTester {
     pub async fn test_get_config_spec(self) -> Self {
         let result = self
             .client
-            .get_config_spec::<ConfigAndPresetBellatrix>()
+            .get_config_spec::<ConfigAndPresetCapella>()
             .await
-            .map(|res| ConfigAndPreset::Bellatrix(res.data))
+            .map(|res| ConfigAndPreset::Capella(res.data))
             .unwrap();
         let expected = ConfigAndPreset::from_chain_spec::<E>(&self.chain.spec, None);
 

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -212,9 +212,9 @@ impl ApiTester {
     pub async fn test_get_lighthouse_spec(self) -> Self {
         let result = self
             .client
-            .get_lighthouse_spec::<ConfigAndPresetBellatrix>()
+            .get_lighthouse_spec::<ConfigAndPresetCapella>()
             .await
-            .map(|res| ConfigAndPreset::Bellatrix(res.data))
+            .map(|res| ConfigAndPreset::Capella(res.data))
             .unwrap();
         let expected = ConfigAndPreset::from_chain_spec::<E>(&E::default_spec(), None);
 


### PR DESCRIPTION
Fixing some tests. The [definition of `from_chain_spec()`](https://github.com/sigp/lighthouse/blob/capella/consensus/types/src/config_and_preset.rs#L39) seems kinda broken.. returns `Capella` unless you set `ForkName` to something other than `Capella`.. idk what is supposed to happen with that. Not sure if that function is broken or these tests are broken. Could use @michaelsproul input.
