### PR TITLE
[Merged by Bors] - add logging for starting request  and receiving block

### DIFF
--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -333,6 +333,11 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
         let proposer_index = self.validator_store.validator_index(&validator_pubkey);
         let validator_pubkey_ref = &validator_pubkey;
 
+        info!(
+            log,
+            "Requesting unsigned block";
+            "slot" => slot.as_u64(),
+        );
         // Request block from first responsive beacon node.
         let block = self
             .beacon_nodes
@@ -345,6 +350,11 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                             let _get_timer = metrics::start_timer_vec(
                                 &metrics::BLOCK_SERVICE_TIMES,
                                 &[metrics::BEACON_BLOCK_HTTP_GET],
+                            );
+                            info!(
+                                log,
+                                "Received unsigned block";
+                                "slot" => slot.as_u64(),
                             );
                             beacon_node
                                 .get_validator_blocks::<E, Payload>(
@@ -365,6 +375,11 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                             let _get_timer = metrics::start_timer_vec(
                                 &metrics::BLOCK_SERVICE_TIMES,
                                 &[metrics::BLINDED_BEACON_BLOCK_HTTP_GET],
+                            );
+                            info!(
+                                log,
+                                "Received unsigned block";
+                                "slot" => slot.as_u64(),
                             );
                             beacon_node
                                 .get_validator_blinded_blocks::<E, Payload>(

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -411,7 +411,11 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
             .await
             .map_err(|e| BlockError::Recoverable(format!("Unable to sign block: {:?}", e)))?;
 
-        info!(log, "Publishing signed block");
+        info!(
+            log,
+            "Publishing signed block";
+            "slot" => slot.as_u64(),
+        );
         // Publish block with first available beacon node.
         self.beacon_nodes
             .first_success(

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -351,11 +351,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                                 &metrics::BLOCK_SERVICE_TIMES,
                                 &[metrics::BEACON_BLOCK_HTTP_GET],
                             );
-                            info!(
-                                log,
-                                "Received unsigned block";
-                                "slot" => slot.as_u64(),
-                            );
                             beacon_node
                                 .get_validator_blocks::<E, Payload>(
                                     slot,
@@ -376,11 +371,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                                 &metrics::BLOCK_SERVICE_TIMES,
                                 &[metrics::BLINDED_BEACON_BLOCK_HTTP_GET],
                             );
-                            info!(
-                                log,
-                                "Received unsigned block";
-                                "slot" => slot.as_u64(),
-                            );
                             beacon_node
                                 .get_validator_blinded_blocks::<E, Payload>(
                                     slot,
@@ -398,6 +388,11 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                         }
                     };
 
+                    info!(
+                        log,
+                        "Received unsigned block";
+                        "slot" => slot.as_u64(),
+                    );
                     if proposer_index != Some(block.proposer_index()) {
                         return Err(BlockError::Recoverable(
                             "Proposer index does not match block proposer. Beacon chain re-orged"
@@ -416,6 +411,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
             .await
             .map_err(|e| BlockError::Recoverable(format!("Unable to sign block: {:?}", e)))?;
 
+        info!(log, "Publishing signed block");
         // Publish block with first available beacon node.
         self.beacon_nodes
             .first_success(


### PR DESCRIPTION
## Issue Addressed

#3853 

## Proposed Changes

Added `INFO` level logs for requesting and receiving the unsigned block.

## Additional Info

Logging for successfully publishing the signed block is already there. And seemingly there is a log for when "We realize we are going to produce a block" in the `start_update_service`: `info!(log, "Block production service started");
`.  Is there anywhere else you'd like to see logging around this event?
