### PR TITLE
Bump MSRV to 1.65 for Capella

### DIFF
--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,7 +4,7 @@ version = "3.3.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false
-rust-version = "1.62"
+rust-version = "1.65"
 
 [features]
 default = ["slasher-mdbx"]


### PR DESCRIPTION
## Proposed Changes

We are using generic associated types in `capella` which requires Rust 1.65.0+. This bump should fix the `check-msrv` CI job.
