### PR TITLE
Allow leading skipped tuple fields

### DIFF
--- a/consensus/ssz_derive/tests/tests.rs
+++ b/consensus/ssz_derive/tests/tests.rs
@@ -213,3 +213,24 @@ fn transparent_struct_newtype_skipped_field() {
         &vec![42_u8].as_ssz_bytes(),
     );
 }
+
+#[derive(PartialEq, Debug, Encode, Decode)]
+#[ssz(struct_behaviour = "transparent")]
+struct TransparentStructNewTypeSkippedFieldReverse(
+    #[ssz(skip_serializing, skip_deserializing)] PhantomData<u64>,
+    Vec<u8>,
+);
+
+impl TransparentStructNewTypeSkippedFieldReverse {
+    fn new(inner: Vec<u8>) -> Self {
+        Self(PhantomData, inner)
+    }
+}
+
+#[test]
+fn transparent_struct_newtype_skipped_field_reverse() {
+    assert_encode_decode(
+        &TransparentStructNewTypeSkippedFieldReverse::new(vec![42_u8]),
+        &vec![42_u8].as_ssz_bytes(),
+    );
+}


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

This PR replaces #3644, since that PR has already been (mostly) merged into the `eip4844` branch. The only thing missing is a fix I [mentioned in the other PR](https://github.com/sigp/lighthouse/pull/3644#issuecomment-1313160567) about permitting skipped tuple fields *before* the non-skipped field (rather than just *after* the skipped field).

This PR will bring the `eip4844` branch in line with #3644.