### PR TITLE
Remove `withdrawals-processing` feature

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,7 +66,7 @@ jobs:
             DOCKER_CLI_EXPERIMENTAL: enabled
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-            CROSS_FEATURES: withdrawals-processing
+            CROSS_FEATURES: null
         steps:
             - uses: actions/checkout@v3
             - name: Update Rust

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CROSS_FEATURES ?= gnosis,slasher-lmdb,slasher-mdbx
 CROSS_PROFILE ?= release
 
 # List of features to use when running EF tests.
-EF_TEST_FEATURES ?= beacon_chain/withdrawals-processing
+EF_TEST_FEATURES ?=
 
 # Cargo profile for regular builds.
 PROFILE ?= release
@@ -89,12 +89,12 @@ build-release-tarballs:
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors.
 test-release:
-	cargo test --workspace --features withdrawals-processing --release --exclude ef_tests --exclude beacon_chain --exclude slasher
+	cargo test --workspace --release --exclude ef_tests --exclude beacon_chain --exclude slasher
 
 # Runs the full workspace tests in **debug**, without downloading any additional test
 # vectors.
 test-debug:
-	cargo test --workspace --features withdrawals-processing --exclude ef_tests --exclude beacon_chain
+	cargo test --workspace --exclude ef_tests --exclude beacon_chain
 
 # Runs cargo-fmt (linter).
 cargo-fmt:
@@ -120,7 +120,7 @@ run-ef-tests:
 test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 
 test-beacon-chain-%:
-	env FORK_NAME=$* cargo test --release --features fork_from_env,withdrawals-processing -p beacon_chain
+	env FORK_NAME=$* cargo test --release --features fork_from_env -p beacon_chain
 
 # Run the tests in the `operation_pool` crate for all known forks.
 test-op-pool: $(patsubst %,test-op-pool-%,$(FORKS))

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -13,11 +13,6 @@ node_test_rig = { path = "../testing/node_test_rig" }
 
 [features]
 write_ssz_files = ["beacon_chain/write_ssz_files"]  # Writes debugging .ssz files to /tmp during block processing.
-withdrawals-processing = [
-    "beacon_chain/withdrawals-processing",
-    "store/withdrawals-processing",
-    "execution_layer/withdrawals-processing",
-]
 
 [dependencies]
 eth2_config = { path = "../common/eth2_config" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -10,10 +10,6 @@ default = ["participation_metrics"]
 write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
 participation_metrics = []  # Exposes validator participation metrics to Prometheus.
 fork_from_env = [] # Initialise the harness chain spec from the FORK_NAME env variable
-withdrawals-processing = [
-    "state_processing/withdrawals-processing",
-    "execution_layer/withdrawals-processing",
-]
 
 [dev-dependencies]
 maplit = "1.0.2"

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -366,6 +366,7 @@ where
             .collect::<Result<_, _>>()
             .unwrap();
 
+        let spec = MainnetEthSpec::default_spec();
         let config = execution_layer::Config {
             execution_endpoints: urls,
             secret_files: vec![],
@@ -376,6 +377,7 @@ where
             config,
             self.runtime.task_executor.clone(),
             self.log.clone(),
+            &spec,
         )
         .unwrap();
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -420,7 +420,7 @@ where
             shanghai_time,
             eip4844_time,
             Some(JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap()),
-            spec.clone(),
+            spec,
             None,
         );
         self.execution_layer = Some(mock.el.clone());

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -416,13 +416,11 @@ where
         });
         let mock = MockExecutionLayer::new(
             self.runtime.task_executor.clone(),
-            spec.terminal_total_difficulty,
             DEFAULT_TERMINAL_BLOCK,
-            spec.terminal_block_hash,
-            spec.terminal_block_hash_activation_epoch,
             shanghai_time,
             eip4844_time,
             Some(JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap()),
+            spec.clone(),
             None,
         );
         self.execution_layer = Some(mock.el.clone());
@@ -444,13 +442,11 @@ where
         });
         let mock_el = MockExecutionLayer::new(
             self.runtime.task_executor.clone(),
-            spec.terminal_total_difficulty,
             DEFAULT_TERMINAL_BLOCK,
-            spec.terminal_block_hash,
-            spec.terminal_block_hash_activation_epoch,
             shanghai_time,
             eip4844_time,
             Some(JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap()),
+            spec.clone(),
             Some(builder_url.clone()),
         )
         .move_to_terminal_block();

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -154,6 +154,7 @@ where
                 config,
                 context.executor.clone(),
                 context.log().clone(),
+                &spec,
             )
             .map_err(|e| format!("unable to start execution layer endpoints: {:?}", e))?;
             Some(execution_layer)

--- a/beacon_node/eth1/src/inner.rs
+++ b/beacon_node/eth1/src/inner.rs
@@ -122,7 +122,7 @@ impl SszEth1Cache {
                 cache: self.deposit_cache.to_deposit_cache()?,
                 last_processed_block: self.last_processed_block,
             }),
-            endpoint: endpoint_from_config(&config)
+            endpoint: endpoint_from_config(&config, &spec)
                 .map_err(|e| format!("Failed to create endpoint: {:?}", e))?,
             to_finalize: RwLock::new(None),
             // Set the remote head_block zero when creating a new instance. We only care about

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -363,7 +363,7 @@ impl Default for Config {
     }
 }
 
-pub fn endpoint_from_config(config: &Config) -> Result<HttpJsonRpc, String> {
+pub fn endpoint_from_config(config: &Config, spec: &ChainSpec) -> Result<HttpJsonRpc, String> {
     match config.endpoint.clone() {
         Eth1Endpoint::Auth {
             endpoint,
@@ -377,7 +377,7 @@ pub fn endpoint_from_config(config: &Config) -> Result<HttpJsonRpc, String> {
                 .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
         }
         Eth1Endpoint::NoAuth(endpoint) => {
-            HttpJsonRpc::new(endpoint, Some(config.execution_timeout_multiplier))
+            HttpJsonRpc::new(endpoint, Some(config.execution_timeout_multiplier), &spec)
                 .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
         }
     }
@@ -404,7 +404,7 @@ impl Service {
                 deposit_cache: RwLock::new(DepositUpdater::new(
                     config.deposit_contract_deploy_block,
                 )),
-                endpoint: endpoint_from_config(&config)?,
+                endpoint: endpoint_from_config(&config, &spec)?,
                 to_finalize: RwLock::new(None),
                 remote_head_block: RwLock::new(None),
                 config: RwLock::new(config),
@@ -433,7 +433,7 @@ impl Service {
             inner: Arc::new(Inner {
                 block_cache: <_>::default(),
                 deposit_cache: RwLock::new(deposit_cache),
-                endpoint: endpoint_from_config(&config)
+                endpoint: endpoint_from_config(&config, &spec)
                     .map_err(Error::FailedToInitializeFromSnapshot)?,
                 to_finalize: RwLock::new(None),
                 remote_head_block: RwLock::new(None),

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -373,8 +373,13 @@ pub fn endpoint_from_config(config: &Config, spec: &ChainSpec) -> Result<HttpJso
         } => {
             let auth = Auth::new_with_path(jwt_path, jwt_id, jwt_version)
                 .map_err(|e| format!("Failed to initialize jwt auth: {:?}", e))?;
-            HttpJsonRpc::new_with_auth(endpoint, auth, Some(config.execution_timeout_multiplier))
-                .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
+            HttpJsonRpc::new_with_auth(
+                endpoint,
+                auth,
+                Some(config.execution_timeout_multiplier),
+                spec,
+            )
+            .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
         }
         Eth1Endpoint::NoAuth(endpoint) => {
             HttpJsonRpc::new(endpoint, Some(config.execution_timeout_multiplier), spec)

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -377,7 +377,7 @@ pub fn endpoint_from_config(config: &Config, spec: &ChainSpec) -> Result<HttpJso
                 .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
         }
         Eth1Endpoint::NoAuth(endpoint) => {
-            HttpJsonRpc::new(endpoint, Some(config.execution_timeout_multiplier), &spec)
+            HttpJsonRpc::new(endpoint, Some(config.execution_timeout_multiplier), spec)
                 .map_err(|e| format!("Failed to create eth1 json rpc client: {:?}", e))
         }
     }

--- a/beacon_node/eth1/tests/test.rs
+++ b/beacon_node/eth1/tests/test.rs
@@ -494,7 +494,8 @@ mod deposit_tree {
             let mut deposit_counts = vec![];
 
             let client =
-                HttpJsonRpc::new(SensitiveUrl::parse(&eth1.endpoint()).unwrap(), None).unwrap();
+                HttpJsonRpc::new(SensitiveUrl::parse(&eth1.endpoint()).unwrap(), None, spec)
+                    .unwrap();
 
             // Perform deposits to the smart contract, recording it's state along the way.
             for deposit in &deposits {
@@ -598,8 +599,12 @@ mod http {
                 .expect("should start eth1 environment");
             let deposit_contract = &eth1.deposit_contract;
             let web3 = eth1.web3();
-            let client =
-                HttpJsonRpc::new(SensitiveUrl::parse(&eth1.endpoint()).unwrap(), None).unwrap();
+            let client = HttpJsonRpc::new(
+                SensitiveUrl::parse(&eth1.endpoint()).unwrap(),
+                None,
+                &MainnetEthSpec::default_spec(),
+            )
+            .unwrap();
 
             let block_number = get_block_number(&web3).await;
             let logs = blocking_deposit_logs(&client, &eth1, 0..block_number).await;
@@ -697,6 +702,7 @@ mod fast {
             let web3 = eth1.web3();
 
             let now = get_block_number(&web3).await;
+            let spec = MainnetEthSpec::default_spec();
             let service = Service::new(
                 Config {
                     endpoint: Eth1Endpoint::NoAuth(
@@ -710,11 +716,12 @@ mod fast {
                     ..Config::default()
                 },
                 log,
-                MainnetEthSpec::default_spec(),
+                spec.clone(),
             )
             .unwrap();
             let client =
-                HttpJsonRpc::new(SensitiveUrl::parse(&eth1.endpoint()).unwrap(), None).unwrap();
+                HttpJsonRpc::new(SensitiveUrl::parse(&eth1.endpoint()).unwrap(), None, &spec)
+                    .unwrap();
             let n = 10;
             let deposits: Vec<_> = (0..n).map(|_| random_deposit_data()).collect();
             for deposit in &deposits {

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-[features]
-withdrawals-processing = ["state_processing/withdrawals-processing"]
 
 [dependencies]
 types = { path = "../../consensus/types"}

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -329,7 +329,7 @@ pub struct ProposeBlindedBlockResponse {
 // This name is work in progress, it could
 // change when this method is actually proposed
 // but I'm writing this as it has been described
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct SupportedApis {
     pub new_payload_v1: bool,
     pub new_payload_v2: bool,

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -974,6 +974,7 @@ mod test {
     impl Tester {
         pub fn new(with_auth: bool) -> Self {
             let server = MockServer::unit_testing();
+            let spec = MainnetEthSpec::default_spec();
 
             let rpc_url = SensitiveUrl::parse(&server.url()).unwrap();
             let echo_url = SensitiveUrl::parse(&format!("{}/echo", server.url())).unwrap();
@@ -989,8 +990,8 @@ mod test {
                 )
             } else {
                 (
-                    Arc::new(HttpJsonRpc::new(rpc_url, None).unwrap()),
-                    Arc::new(HttpJsonRpc::new(echo_url, None).unwrap()),
+                    Arc::new(HttpJsonRpc::new(rpc_url, None, &spec).unwrap()),
+                    Arc::new(HttpJsonRpc::new(echo_url, None, &spec).unwrap()),
                 )
             };
 

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use tokio::sync::RwLock;
 
 use std::time::Duration;
-use types::EthSpec;
+use types::{ChainSpec, EthSpec};
 
 pub use deposit_log::{DepositLog, Log};
 pub use reqwest::Client;
@@ -538,12 +538,27 @@ impl HttpJsonRpc {
     pub fn new(
         url: SensitiveUrl,
         execution_timeout_multiplier: Option<u32>,
+        spec: &ChainSpec,
     ) -> Result<Self, Error> {
+        // FIXME: remove this `cached_supported_apis` spec hack once the `engine_getCaps`
+        //        method is implemented in all execution clients:
+        //        https://github.com/ethereum/execution-apis/issues/321
+        let cached_supported_apis = RwLock::new(Some(SupportedApis {
+            new_payload_v1: true,
+            new_payload_v2: spec.capella_fork_epoch.is_some() || spec.eip4844_fork_epoch.is_some(),
+            forkchoice_updated_v1: true,
+            forkchoice_updated_v2: spec.capella_fork_epoch.is_some()
+                || spec.eip4844_fork_epoch.is_some(),
+            get_payload_v1: true,
+            get_payload_v2: spec.capella_fork_epoch.is_some() || spec.eip4844_fork_epoch.is_some(),
+            exchange_transition_configuration_v1: true,
+        }));
+
         Ok(Self {
             client: Client::builder().build()?,
             url,
             execution_timeout_multiplier: execution_timeout_multiplier.unwrap_or(1),
-            cached_supported_apis: Default::default(),
+            cached_supported_apis,
             auth: None,
         })
     }
@@ -848,21 +863,25 @@ impl HttpJsonRpc {
         Ok(response)
     }
 
-    // this is a stub as this method hasn't been defined yet
-    pub async fn supported_apis_v1(&self) -> Result<SupportedApis, Error> {
+    // TODO: This is currently a stub for the `engine_getCaps` method.
+    //       This stub is unused because we set cached_supported_apis
+    //       in the constructor based on the `spec`
+    //       Implement this once the execution clients support it
+    //       https://github.com/ethereum/execution-apis/issues/321
+    pub async fn get_caps(&self) -> Result<SupportedApis, Error> {
         Ok(SupportedApis {
             new_payload_v1: true,
-            new_payload_v2: cfg!(any(feature = "withdrawals-processing", test)),
+            new_payload_v2: true,
             forkchoice_updated_v1: true,
-            forkchoice_updated_v2: cfg!(any(feature = "withdrawals-processing", test)),
+            forkchoice_updated_v2: true,
             get_payload_v1: true,
-            get_payload_v2: cfg!(any(feature = "withdrawals-processing", test)),
+            get_payload_v2: true,
             exchange_transition_configuration_v1: true,
         })
     }
 
-    pub async fn set_cached_supported_apis(&self, supported_apis: SupportedApis) {
-        *self.cached_supported_apis.write().await = Some(supported_apis);
+    pub async fn set_cached_supported_apis(&self, supported_apis: Option<SupportedApis>) {
+        *self.cached_supported_apis.write().await = supported_apis;
     }
 
     pub async fn get_cached_supported_apis(&self) -> Result<SupportedApis, Error> {
@@ -870,8 +889,8 @@ impl HttpJsonRpc {
         if let Some(supported_apis) = cached_opt {
             Ok(supported_apis)
         } else {
-            let supported_apis = self.supported_apis_v1().await?;
-            self.set_cached_supported_apis(supported_apis).await;
+            let supported_apis = self.get_caps().await?;
+            self.set_cached_supported_apis(Some(supported_apis)).await;
             Ok(supported_apis)
         }
     }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -258,7 +258,12 @@ pub struct ExecutionLayer<T: EthSpec> {
 
 impl<T: EthSpec> ExecutionLayer<T> {
     /// Instantiate `Self` with an Execution engine specified in `Config`, using JSON-RPC via HTTP.
-    pub fn from_config(config: Config, executor: TaskExecutor, log: Logger) -> Result<Self, Error> {
+    pub fn from_config(
+        config: Config,
+        executor: TaskExecutor,
+        log: Logger,
+        spec: &ChainSpec,
+    ) -> Result<Self, Error> {
         let Config {
             execution_endpoints: urls,
             builder_url,
@@ -313,8 +318,9 @@ impl<T: EthSpec> ExecutionLayer<T> {
         let engine: Engine = {
             let auth = Auth::new(jwt_key, jwt_id, jwt_version);
             debug!(log, "Loaded execution endpoint"; "endpoint" => %execution_url, "jwt_path" => ?secret_file.as_path());
-            let api = HttpJsonRpc::new_with_auth(execution_url, auth, execution_timeout_multiplier)
-                .map_err(Error::ApiError)?;
+            let api =
+                HttpJsonRpc::new_with_auth(execution_url, auth, execution_timeout_multiplier, spec)
+                    .map_err(Error::ApiError)?;
             Engine::new(api, executor.clone(), &log)
         };
 

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -84,7 +84,8 @@ impl<E: EthSpec> TestingBuilder<E> {
         };
 
         let el =
-            ExecutionLayer::from_config(config, executor.clone(), executor.log().clone()).unwrap();
+            ExecutionLayer::from_config(config, executor.clone(), executor.log().clone(), &spec)
+                .unwrap();
 
         // This should probably be done for all fields, we only update ones we are testing with so far.
         let mut context = Context::for_mainnet();

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -9,7 +9,7 @@ use sensitive_url::SensitiveUrl;
 use task_executor::TaskExecutor;
 use tempfile::NamedTempFile;
 use tree_hash::TreeHash;
-use types::{Address, ChainSpec, Epoch, EthSpec, FullPayload, Hash256, Uint256};
+use types::{Address, ChainSpec, Epoch, EthSpec, FullPayload, Hash256, MainnetEthSpec};
 
 pub struct MockExecutionLayer<T: EthSpec> {
     pub server: MockServer<T>,
@@ -20,15 +20,17 @@ pub struct MockExecutionLayer<T: EthSpec> {
 
 impl<T: EthSpec> MockExecutionLayer<T> {
     pub fn default_params(executor: TaskExecutor) -> Self {
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.terminal_total_difficulty = DEFAULT_TERMINAL_DIFFICULTY.into();
+        spec.terminal_block_hash = ExecutionBlockHash::zero();
+        spec.terminal_block_hash_activation_epoch = Epoch::new(0);
         Self::new(
             executor,
-            DEFAULT_TERMINAL_DIFFICULTY.into(),
             DEFAULT_TERMINAL_BLOCK,
-            ExecutionBlockHash::zero(),
-            Epoch::new(0),
             None,
             None,
             Some(JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap()),
+            spec,
             None,
         )
     }
@@ -36,29 +38,22 @@ impl<T: EthSpec> MockExecutionLayer<T> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         executor: TaskExecutor,
-        terminal_total_difficulty: Uint256,
         terminal_block: u64,
-        terminal_block_hash: ExecutionBlockHash,
-        terminal_block_hash_activation_epoch: Epoch,
         shanghai_time: Option<u64>,
         eip4844_time: Option<u64>,
         jwt_key: Option<JwtKey>,
+        spec: ChainSpec,
         builder_url: Option<SensitiveUrl>,
     ) -> Self {
         let handle = executor.handle().unwrap();
-
-        let mut spec = T::default_spec();
-        spec.terminal_total_difficulty = terminal_total_difficulty;
-        spec.terminal_block_hash = terminal_block_hash;
-        spec.terminal_block_hash_activation_epoch = terminal_block_hash_activation_epoch;
 
         let jwt_key = jwt_key.unwrap_or_else(JwtKey::random);
         let server = MockServer::new(
             &handle,
             jwt_key,
-            terminal_total_difficulty,
+            spec.terminal_total_difficulty,
             terminal_block,
-            terminal_block_hash,
+            spec.terminal_block_hash,
             shanghai_time,
             eip4844_time,
         );

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -78,7 +78,8 @@ impl<T: EthSpec> MockExecutionLayer<T> {
             ..Default::default()
         };
         let el =
-            ExecutionLayer::from_config(config, executor.clone(), executor.log().clone()).unwrap();
+            ExecutionLayer::from_config(config, executor.clone(), executor.log().clone(), &spec)
+                .unwrap();
 
         Self {
             server,

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -26,6 +26,3 @@ lru = "0.7.1"
 sloggers = { version = "2.1.1", features = ["json"] }
 directory = { path = "../../common/directory" }
 strum = { version = "0.24.0", features = ["derive"] }
-
-[features]
-withdrawals-processing = ["state_processing/withdrawals-processing"]

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -43,4 +43,3 @@ arbitrary-fuzz = [
   "eth2_ssz_types/arbitrary",
   "tree_hash/arbitrary",
 ]
-withdrawals-processing = []

--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -474,10 +474,6 @@ pub fn get_expected_withdrawals<T: EthSpec>(
     let mut validator_index = state.next_withdrawal_validator_index()?;
     let mut withdrawals = vec![];
 
-    if cfg!(not(feature = "withdrawals-processing")) {
-        return Ok(withdrawals.into());
-    }
-
     let bound = std::cmp::min(
         state.validators().len() as u64,
         spec.max_validators_per_withdrawals_sweep,
@@ -525,9 +521,6 @@ pub fn process_withdrawals<'payload, T: EthSpec, Payload: AbstractExecPayload<T>
     payload: Payload::Ref<'payload>,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
-    if cfg!(not(feature = "withdrawals-processing")) {
-        return Ok(());
-    }
     match state {
         BeaconState::Merge(_) => Ok(()),
         BeaconState::Capella(_) | BeaconState::Eip4844(_) => {

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -300,9 +300,6 @@ pub fn process_bls_to_execution_changes<T: EthSpec>(
     verify_signatures: VerifySignatures,
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
-    if cfg!(not(feature = "withdrawals-processing")) {
-        return Ok(());
-    }
     for (i, signed_address_change) in bls_to_execution_changes.iter().enumerate() {
         verify_bls_to_execution_change(state, signed_address_change, verify_signatures, spec)
             .map_err(|e| e.into_with_index(i))?;

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -24,8 +24,6 @@ gnosis = []
 slasher-mdbx = ["slasher/mdbx"]
 # Support slasher LMDB backend.
 slasher-lmdb = ["slasher/lmdb"]
-# Support for withdrawals consensus processing logic.
-withdrawals-processing = ["beacon_node/withdrawals-processing"]
 
 [dependencies]
 beacon_node = { "path" = "../beacon_node" }

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -110,6 +110,8 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let (runtime_shutdown, exit) = exit_future::signal();
         let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
         let executor = TaskExecutor::new(Arc::downgrade(&runtime), exit, log.clone(), shutdown_tx);
+        let mut spec = MainnetEthSpec::default_spec();
+        spec.terminal_total_difficulty = Uint256::zero();
 
         let fee_recipient = None;
 
@@ -125,7 +127,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
                 ..Default::default()
             };
             let execution_layer =
-                ExecutionLayer::from_config(config, executor.clone(), log.clone()).unwrap();
+                ExecutionLayer::from_config(config, executor.clone(), log.clone(), &spec).unwrap();
             ExecutionPair {
                 execution_engine,
                 execution_layer,
@@ -144,15 +146,12 @@ impl<E: GenericExecutionEngine> TestRig<E> {
                 ..Default::default()
             };
             let execution_layer =
-                ExecutionLayer::from_config(config, executor, log.clone()).unwrap();
+                ExecutionLayer::from_config(config, executor, log.clone(), &spec).unwrap();
             ExecutionPair {
                 execution_engine,
                 execution_layer,
             }
         };
-
-        let mut spec = MainnetEthSpec::default_spec();
-        spec.terminal_total_difficulty = Uint256::zero();
 
         Self {
             runtime,


### PR DESCRIPTION
Disabling withdrawals for 4844 testing has been removed in the `v1.3.0-rc.0` spec so we can remove this feature. Now the `V2` engine_api methods will be enabled if the `spec` has `capella_fork_epoch` or `eip4844_fork_epoch` set.