### PR TITLE
Fix Arbitrary implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,9 +156,8 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
 name = "arbitrary"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d47fbf90d5149a107494b15a7dc8d69b351be2db3bb9691740e88ec17fd880"
+version = "1.2.2"
+source = "git+https://github.com/michaelsproul/arbitrary?rev=bf51d6276648c9259256ce68f2f9de9803b526d5#bf51d6276648c9259256ce68f2f9de9803b526d5"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -1231,8 +1230,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
+dependencies = [
+ "darling_core 0.14.2",
+ "darling_macro 0.14.2",
 ]
 
 [[package]]
@@ -1250,12 +1259,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
+dependencies = [
+ "darling_core 0.14.2",
  "quote",
  "syn",
 ]
@@ -1357,10 +1391,10 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903dff04948f22033ca30232ab8eca2c3fc4c913a8b6a34ee5199699814817f"
+version = "1.2.2"
+source = "git+https://github.com/michaelsproul/arbitrary?rev=bf51d6276648c9259256ce68f2f9de9803b526d5#bf51d6276648c9259256ce68f2f9de9803b526d5"
 dependencies = [
+ "darling 0.14.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -1856,7 +1890,7 @@ dependencies = [
 name = "eth2_ssz_derive"
 version = "0.3.1"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "eth2_ssz",
  "proc-macro2",
  "quote",
@@ -5791,7 +5825,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -6353,7 +6387,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a99807a055ff4ff5d249bb84c80d9eabb55ca3c452187daae43fd5b51ef695"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "itertools",
  "proc-macro2",
  "quote",
@@ -6367,7 +6401,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b9e5728aa1a87141cefd4e7509903fc01fa0dcb108022b1e841a67c5159fc5"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "itertools",
  "proc-macro2",
  "quote",
@@ -6991,7 +7025,7 @@ dependencies = [
 name = "tree_hash_derive"
 version = "0.4.0"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 [[package]]
 name = "arbitrary"
 version = "1.2.2"
-source = "git+https://github.com/michaelsproul/arbitrary?rev=bf51d6276648c9259256ce68f2f9de9803b526d5#bf51d6276648c9259256ce68f2f9de9803b526d5"
+source = "git+https://github.com/michaelsproul/arbitrary?rev=a572fd8743012a4f1ada5ee5968b1b3619c427ba#a572fd8743012a4f1ada5ee5968b1b3619c427ba"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "derive_arbitrary"
 version = "1.2.2"
-source = "git+https://github.com/michaelsproul/arbitrary?rev=bf51d6276648c9259256ce68f2f9de9803b526d5#bf51d6276648c9259256ce68f2f9de9803b526d5"
+source = "git+https://github.com/michaelsproul/arbitrary?rev=a572fd8743012a4f1ada5ee5968b1b3619c427ba#a572fd8743012a4f1ada5ee5968b1b3619c427ba"
 dependencies = [
  "darling 0.14.2",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ eth2_hashing = { path = "crypto/eth2_hashing" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
 eth2_serde_utils = { path = "consensus/serde_utils" }
+arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="bf51d6276648c9259256ce68f2f9de9803b526d5" }
 
 [profile.maxperf]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ eth2_hashing = { path = "crypto/eth2_hashing" }
 tree_hash = { path = "consensus/tree_hash" }
 tree_hash_derive = { path = "consensus/tree_hash_derive" }
 eth2_serde_utils = { path = "consensus/serde_utils" }
-arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="bf51d6276648c9259256ce68f2f9de9803b526d5" }
+arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="a572fd8743012a4f1ada5ee5968b1b3619c427ba" }
 
 [profile.maxperf]
 inherits = "release"

--- a/consensus/ssz_types/src/bitfield.rs
+++ b/consensus/ssz_types/src/bitfield.rs
@@ -660,7 +660,7 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Fixed<N>> {
         let size = N::to_usize();
         let mut vec = smallvec![0u8; size];
         u.fill_buffer(&mut vec)?;
-        Ok(Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)?)
+        Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 
@@ -672,7 +672,7 @@ impl<N: 'static + Unsigned> arbitrary::Arbitrary<'_> for Bitfield<Variable<N>> {
         let size = std::cmp::min(rand, max_size);
         let mut vec = smallvec![0u8; size];
         u.fill_buffer(&mut vec)?;
-        Ok(Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)?)
+        Self::from_bytes(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/consensus/ssz_types/src/fixed_vector.rs
+++ b/consensus/ssz_types/src/fixed_vector.rs
@@ -291,7 +291,7 @@ impl<'a, T: arbitrary::Arbitrary<'a>, N: 'static + Unsigned> arbitrary::Arbitrar
         for _ in 0..size {
             vec.push(<T>::arbitrary(u)?);
         }
-        Ok(Self::new(vec).map_err(|_| arbitrary::Error::IncorrectFormat)?)
+        Self::new(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -273,7 +273,7 @@ impl<'a, T: arbitrary::Arbitrary<'a>, N: 'static + Unsigned> arbitrary::Arbitrar
         for _ in 0..size {
             vec.push(<T>::arbitrary(u)?);
         }
-        Ok(Self::new(vec).map_err(|_| arbitrary::Error::IncorrectFormat)?)
+        Self::new(vec).map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -39,7 +39,9 @@ serde_yaml = "0.8.13"
 tempfile = "3.1.0"
 derivative = "2.1.1"
 rusqlite = { version = "0.25.3", features = ["bundled"], optional = true }
-arbitrary = { version = "1.0", features = ["derive"], optional = true }
+# The arbitrary dependency is enabled by default since Capella to avoid complexity introduced by
+# `AbstractExecPayload`
+arbitrary = { version = "1.0", features = ["derive"] }
 eth2_serde_utils = "0.1.1"
 regex = "1.5.5"
 lazy_static = "1.4.0"
@@ -64,7 +66,6 @@ default = ["sqlite", "legacy-arith"]
 legacy-arith = []
 sqlite = ["rusqlite"]
 arbitrary-fuzz = [
-  "arbitrary",
   "ethereum-types/arbitrary",
   "bls/arbitrary",
   "eth2_ssz/arbitrary",

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -11,11 +11,11 @@ harness = false
 [dependencies]
 serde-big-array = {version = "0.3.2", features = ["const-generics"]}
 merkle_proof = { path = "../../consensus/merkle_proof" }
-bls = { path = "../../crypto/bls" }
+bls = { path = "../../crypto/bls", features = ["arbitrary"] }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
-ethereum-types = "0.12.1"
+ethereum-types = { version = "0.12.1", features = ["arbitrary"] }
 eth2_hashing = "0.3.0"
 hex = "0.4.2"
 int_to_bytes = { path = "../int_to_bytes" }
@@ -26,12 +26,12 @@ safe_arith = { path = "../safe_arith" }
 serde = {version = "1.0.116" , features = ["rc"] }
 serde_derive = "1.0.116"
 slog = "2.5.2"
-eth2_ssz = "0.4.1"
+eth2_ssz = { version = "0.4.1", features = ["arbitrary"] }
 eth2_ssz_derive = "0.3.1"
-eth2_ssz_types = "0.2.2"
-swap_or_not_shuffle = { path = "../swap_or_not_shuffle" }
+eth2_ssz_types = { version = "0.2.2", features = ["arbitrary"] }
+swap_or_not_shuffle = { path = "../swap_or_not_shuffle", features = ["arbitrary"] }
 test_random_derive = { path = "../../common/test_random_derive" }
-tree_hash = "0.4.1"
+tree_hash = { version = "0.4.1", features = ["arbitrary"] }
 tree_hash_derive = "0.4.0"
 rand_xorshift = "0.3.0"
 cached_tree_hash = { path = "../cached_tree_hash" }
@@ -65,11 +65,6 @@ default = ["sqlite", "legacy-arith"]
 # Allow saturating arithmetic on slots and epochs. Enabled by default, but deprecated.
 legacy-arith = []
 sqlite = ["rusqlite"]
-arbitrary-fuzz = [
-  "ethereum-types/arbitrary",
-  "bls/arbitrary",
-  "eth2_ssz/arbitrary",
-  "eth2_ssz_types/arbitrary",
-  "swap_or_not_shuffle/arbitrary",
-  "tree_hash/arbitrary",
-]
+# The `arbitrary-fuzz` feature is a no-op provided for backwards compatibility.
+# For simplicity `Arbitrary` is now derived regardless of the feature's presence.
+arbitrary-fuzz = []

--- a/consensus/types/src/aggregate_and_proof.rs
+++ b/consensus/types/src/aggregate_and_proof.rs
@@ -11,9 +11,20 @@ use tree_hash_derive::TreeHash;
 /// A Validators aggregate attestation and selection proof.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    TreeHash,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct AggregateAndProof<T: EthSpec> {
     /// The index of the validator that created the attestation.
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -23,12 +23,21 @@ pub enum Error {
 /// Details an attestation that can be slashable.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Derivative,
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    Derivative,
 )]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct Attestation<T: EthSpec> {
     pub aggregation_bits: BitList<T::MaxValidatorsPerCommittee>,
     pub data: AttestationData,

--- a/consensus/types/src/attestation_data.rs
+++ b/consensus/types/src/attestation_data.rs
@@ -10,8 +10,8 @@ use tree_hash_derive::TreeHash;
 /// The data upon which an attestation is based.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
+    arbitrary::Arbitrary,
     Debug,
     Clone,
     PartialEq,

--- a/consensus/types/src/attestation_duty.rs
+++ b/consensus/types/src/attestation_duty.rs
@@ -1,8 +1,7 @@
 use crate::*;
 use serde_derive::{Deserialize, Serialize};
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Copy, Default, Serialize, Deserialize)]
+#[derive(arbitrary::Arbitrary, Debug, PartialEq, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct AttestationDuty {
     /// The slot during which the attester must attest.
     pub slot: Slot,

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -9,12 +9,21 @@ use tree_hash_derive::TreeHash;
 /// Two conflicting attestations.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Derivative, Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Derivative,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
 )]
 #[derivative(PartialEq, Eq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct AttesterSlashing<T: EthSpec> {
     pub attestation_1: IndexedAttestation<T>,
     pub attestation_2: IndexedAttestation<T>,

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -29,10 +29,14 @@ use tree_hash_derive::TreeHash;
             TreeHash,
             TestRandom,
             Derivative,
+            arbitrary::Arbitrary
         ),
-        derivative(PartialEq, Hash(bound = "T: EthSpec, Payload: ExecPayload<T>")),
-        serde(bound = "T: EthSpec, Payload: ExecPayload<T>", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary)),
+        derivative(PartialEq, Hash(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")),
+        serde(
+            bound = "T: EthSpec, Payload: AbstractExecPayload<T>",
+            deny_unknown_fields
+        ),
+        arbitrary(bound = "T: EthSpec, Payload: AbstractExecPayload<T>"),
     ),
     ref_attributes(
         derive(Debug, PartialEq, TreeHash),
@@ -41,11 +45,13 @@ use tree_hash_derive::TreeHash;
     map_ref_into(BeaconBlockBodyRef, BeaconBlock),
     map_ref_mut_into(BeaconBlockBodyRefMut)
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(untagged)]
-#[serde(bound = "T: EthSpec, Payload: ExecPayload<T>")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[serde(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")]
+#[arbitrary(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
 pub struct BeaconBlock<T: EthSpec, Payload: AbstractExecPayload<T> = FullPayload<T>> {

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -26,19 +26,23 @@ use tree_hash_derive::TreeHash;
             TreeHash,
             TestRandom,
             Derivative,
+            arbitrary::Arbitrary
         ),
-        derivative(PartialEq, Hash(bound = "T: EthSpec, Payload: ExecPayload<T>")),
-        serde(bound = "T: EthSpec, Payload: ExecPayload<T>", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))
+        derivative(PartialEq, Hash(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")),
+        serde(
+            bound = "T: EthSpec, Payload: AbstractExecPayload<T>",
+            deny_unknown_fields
+        ),
+        arbitrary(bound = "T: EthSpec, Payload: AbstractExecPayload<T>"),
     ),
     cast_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Derivative)]
+#[derive(Debug, Clone, Serialize, Deserialize, Derivative, arbitrary::Arbitrary)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(untagged)]
-#[serde(bound = "T: EthSpec, Payload: ExecPayload<T>")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[serde(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")]
+#[arbitrary(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")]
 pub struct BeaconBlockBody<T: EthSpec, Payload: AbstractExecPayload<T> = FullPayload<T>> {
     pub randao_reveal: Signature,
     pub eth1_data: Eth1Data,
@@ -71,6 +75,7 @@ pub struct BeaconBlockBody<T: EthSpec, Payload: AbstractExecPayload<T> = FullPay
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]
     #[serde(skip)]
+    #[arbitrary(default)]
     pub _phantom: PhantomData<Payload>,
 }
 

--- a/consensus/types/src/beacon_block_header.rs
+++ b/consensus/types/src/beacon_block_header.rs
@@ -10,9 +10,19 @@ use tree_hash_derive::TreeHash;
 /// A header of a `BeaconBlock`.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct BeaconBlockHeader {
     pub slot: Slot,

--- a/consensus/types/src/beacon_committee.rs
+++ b/consensus/types/src/beacon_committee.rs
@@ -17,8 +17,7 @@ impl<'a> BeaconCommittee<'a> {
     }
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Default, Clone, Debug, PartialEq)]
+#[derive(arbitrary::Arbitrary, Default, Clone, Debug, PartialEq)]
 pub struct OwnedBeaconCommittee {
     pub slot: Slot,
     pub index: CommitteeIndex,

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -145,8 +145,7 @@ impl AllowNextEpoch {
     }
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, Hash, Clone, Copy, arbitrary::Arbitrary)]
 pub struct BeaconStateHash(Hash256);
 
 impl fmt::Debug for BeaconStateHash {
@@ -188,18 +187,19 @@ impl From<BeaconStateHash> for Hash256 {
             TreeHash,
             TestRandom,
             CompareFields,
+            arbitrary::Arbitrary
         ),
         serde(bound = "T: EthSpec", deny_unknown_fields),
+        arbitrary(bound = "T: EthSpec"),
         derivative(Clone),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))
     ),
     cast_error(ty = "Error", expr = "Error::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "Error::IncorrectStateVariant")
 )]
-#[derive(Debug, PartialEq, Serialize, Deserialize, Encode, TreeHash)]
+#[derive(Debug, PartialEq, Serialize, Deserialize, Encode, TreeHash, arbitrary::Arbitrary)]
 #[serde(untagged)]
 #[serde(bound = "T: EthSpec")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
 pub struct BeaconState<T>

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -336,7 +336,6 @@ pub fn get_active_validator_indices(validators: &[Validator], epoch: Epoch) -> V
     active
 }
 
-#[cfg(feature = "arbitrary-fuzz")]
 impl arbitrary::Arbitrary<'_> for CommitteeCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())

--- a/consensus/types/src/beacon_state/exit_cache.rs
+++ b/consensus/types/src/beacon_state/exit_cache.rs
@@ -61,7 +61,6 @@ impl ExitCache {
     }
 }
 
-#[cfg(feature = "arbitrary-fuzz")]
 impl arbitrary::Arbitrary<'_> for ExitCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())

--- a/consensus/types/src/beacon_state/pubkey_cache.rs
+++ b/consensus/types/src/beacon_state/pubkey_cache.rs
@@ -42,7 +42,6 @@ impl PubkeyCache {
     }
 }
 
-#[cfg(feature = "arbitrary-fuzz")]
 impl arbitrary::Arbitrary<'_> for PubkeyCache {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())

--- a/consensus/types/src/beacon_state/tree_hash_cache.rs
+++ b/consensus/types/src/beacon_state/tree_hash_cache.rs
@@ -578,7 +578,6 @@ impl OptionalTreeHashCacheInner {
     }
 }
 
-#[cfg(feature = "arbitrary-fuzz")]
 impl<T: EthSpec> arbitrary::Arbitrary<'_> for BeaconTreeHashCache<T> {
     fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         Ok(Self::default())

--- a/consensus/types/src/blobs_sidecar.rs
+++ b/consensus/types/src/blobs_sidecar.rs
@@ -6,9 +6,20 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, PartialEq, Default)]
+#[derive(
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    PartialEq,
+    Default,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct BlobsSidecar<T: EthSpec> {
     pub beacon_block_root: Hash256,
     pub beacon_block_slot: Slot,

--- a/consensus/types/src/bls_to_execution_change.rs
+++ b/consensus/types/src/bls_to_execution_change.rs
@@ -6,9 +6,18 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct BlsToExecutionChange {
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -29,8 +29,7 @@ pub enum Domain {
 /// Lighthouse's internal configuration struct.
 ///
 /// Contains a mixture of "preset" and "config" values w.r.t to the EF definitions.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(arbitrary::Arbitrary, PartialEq, Debug, Clone)]
 pub struct ChainSpec {
     /*
      * Config name

--- a/consensus/types/src/checkpoint.rs
+++ b/consensus/types/src/checkpoint.rs
@@ -8,8 +8,8 @@ use tree_hash_derive::TreeHash;
 /// Casper FFG checkpoint, used in attestations.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
+    arbitrary::Arbitrary,
     Debug,
     Clone,
     Copy,

--- a/consensus/types/src/contribution_and_proof.rs
+++ b/consensus/types/src/contribution_and_proof.rs
@@ -9,9 +9,20 @@ use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 /// A Validators aggregate sync committee contribution and selection proof.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    TreeHash,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct ContributionAndProof<T: EthSpec> {
     /// The index of the validator that created the sync contribution.
     #[serde(with = "eth2_serde_utils::quoted_u64")]

--- a/consensus/types/src/deposit.rs
+++ b/consensus/types/src/deposit.rs
@@ -11,9 +11,18 @@ pub const DEPOSIT_TREE_DEPTH: usize = 32;
 /// A deposit to potentially become a beacon chain validator.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct Deposit {
     pub proof: FixedVector<Hash256, U33>,

--- a/consensus/types/src/deposit_data.rs
+++ b/consensus/types/src/deposit_data.rs
@@ -10,9 +10,18 @@ use tree_hash_derive::TreeHash;
 /// The data supplied by the user to the deposit contract.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct DepositData {
     pub pubkey: PublicKeyBytes,

--- a/consensus/types/src/deposit_message.rs
+++ b/consensus/types/src/deposit_message.rs
@@ -10,8 +10,18 @@ use tree_hash_derive::TreeHash;
 /// The data supplied by the user to the deposit contract.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+)]
 pub struct DepositMessage {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/enr_fork_id.rs
+++ b/consensus/types/src/enr_fork_id.rs
@@ -10,9 +10,18 @@ use tree_hash_derive::TreeHash;
 /// a nodes local ENR.
 ///
 /// Spec v0.11
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct EnrForkId {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/eth1_data.rs
+++ b/consensus/types/src/eth1_data.rs
@@ -9,8 +9,8 @@ use tree_hash_derive::TreeHash;
 /// Contains data obtained from the Eth1 chain.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
+    arbitrary::Arbitrary,
     Debug,
     PartialEq,
     Clone,

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -355,8 +355,7 @@ impl EthSpec for MinimalEthSpec {
 }
 
 /// Gnosis Beacon Chain specifications.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, arbitrary::Arbitrary)]
 pub struct GnosisEthSpec;
 
 impl EthSpec for GnosisEthSpec {

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -48,7 +48,9 @@ impl fmt::Display for EthSpecId {
     }
 }
 
-pub trait EthSpec: 'static + Default + Sync + Send + Clone + Debug + PartialEq + Eq {
+pub trait EthSpec:
+    'static + Default + Sync + Send + Clone + Debug + PartialEq + Eq + for<'a> arbitrary::Arbitrary<'a>
+{
     /*
      * Constants
      */
@@ -258,8 +260,7 @@ macro_rules! params_from_eth_spec {
 }
 
 /// Ethereum Foundation specifications.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, arbitrary::Arbitrary)]
 pub struct MainnetEthSpec;
 
 impl EthSpec for MainnetEthSpec {
@@ -305,8 +306,7 @@ impl EthSpec for MainnetEthSpec {
 }
 
 /// Ethereum Foundation minimal spec, as defined in the eth2.0-specs repo.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, arbitrary::Arbitrary)]
 pub struct MinimalEthSpec;
 
 impl EthSpec for MinimalEthSpec {

--- a/consensus/types/src/execution_block_hash.rs
+++ b/consensus/types/src/execution_block_hash.rs
@@ -6,8 +6,18 @@ use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError, Encode};
 use std::fmt;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Default, Clone, Copy, Serialize, Deserialize, Eq, PartialEq, Hash, Derivative)]
+#[derive(
+    arbitrary::Arbitrary,
+    Default,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Hash,
+    Derivative,
+)]
 #[derivative(Debug = "transparent")]
 #[serde(transparent)]
 pub struct ExecutionBlockHash(Hash256);

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -28,20 +28,23 @@ pub type Withdrawals<T> = VariableList<Withdrawal, <T as EthSpec>::MaxWithdrawal
             TreeHash,
             TestRandom,
             Derivative,
+            arbitrary::Arbitrary
         ),
         derivative(PartialEq, Hash(bound = "T: EthSpec")),
         serde(bound = "T: EthSpec", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))
+        arbitrary(bound = "T: EthSpec")
     ),
     cast_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant")
 )]
-#[derive(Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative)]
+#[derive(
+    Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec", untagged)]
+#[arbitrary(bound = "T: EthSpec")]
 #[ssz(enum_behaviour = "transparent")]
 #[tree_hash(enum_behaviour = "transparent")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExecutionPayload<T: EthSpec> {
     #[superstruct(getter(copy))]
     pub parent_hash: ExecutionBlockHash,

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -22,21 +22,24 @@ use BeaconStateError;
             TreeHash,
             TestRandom,
             Derivative,
+            arbitrary::Arbitrary
         ),
         derivative(PartialEq, Hash(bound = "T: EthSpec")),
         serde(bound = "T: EthSpec", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))
+        arbitrary(bound = "T: EthSpec")
     ),
     ref_attributes(derive(PartialEq, TreeHash), tree_hash(enum_behaviour = "transparent")),
     cast_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec", untagged)]
+#[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct ExecutionPayloadHeader<T: EthSpec> {
     #[superstruct(getter(copy))]
     pub parent_hash: ExecutionBlockHash,

--- a/consensus/types/src/fork.rs
+++ b/consensus/types/src/fork.rs
@@ -9,8 +9,8 @@ use tree_hash_derive::TreeHash;
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
+    arbitrary::Arbitrary,
     Debug,
     Clone,
     Copy,

--- a/consensus/types/src/fork_data.rs
+++ b/consensus/types/src/fork_data.rs
@@ -9,9 +9,18 @@ use tree_hash_derive::TreeHash;
 /// Specifies a fork of the `BeaconChain`, to prevent replay attacks.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Default, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct ForkData {
     #[serde(with = "eth2_serde_utils::bytes_4_hex")]

--- a/consensus/types/src/free_attestation.rs
+++ b/consensus/types/src/free_attestation.rs
@@ -4,8 +4,7 @@
 use super::{AttestationData, Signature};
 use serde_derive::Serialize;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(arbitrary::Arbitrary, Debug, Clone, PartialEq, Serialize)]
 pub struct FreeAttestation {
     pub data: AttestationData,
     pub signature: Signature,

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -14,7 +14,7 @@ pub const GRAFFITI_BYTES_LEN: usize = 32;
 /// The 32-byte `graffiti` field on a beacon block.
 #[derive(Default, Debug, PartialEq, Hash, Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[derive(arbitrary::Arbitrary)]
 pub struct Graffiti(#[serde(with = "serde_graffiti")] pub [u8; GRAFFITI_BYTES_LEN]);
 
 impl Graffiti {

--- a/consensus/types/src/historical_batch.rs
+++ b/consensus/types/src/historical_batch.rs
@@ -10,8 +10,19 @@ use tree_hash_derive::TreeHash;
 /// Historical block and state roots.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct HistoricalBatch<T: EthSpec> {
     pub block_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,
     pub state_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,

--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -12,12 +12,21 @@ use tree_hash_derive::TreeHash;
 /// To be included in an `AttesterSlashing`.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Derivative, Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    Derivative,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
 )]
 #[derivative(PartialEq, Eq)] // to satisfy Clippy's lint about `Hash`
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct IndexedAttestation<T: EthSpec> {
     /// Lists validator registry indices, not committee indices.
     #[serde(with = "quoted_variable_list_u64")]

--- a/consensus/types/src/kzg_commitment.rs
+++ b/consensus/types/src/kzg_commitment.rs
@@ -7,7 +7,9 @@ use std::fmt;
 use std::fmt::{Display, Formatter};
 use tree_hash::{PackedEncoding, TreeHash};
 
-#[derive(Derivative, Debug, Clone, Encode, Decode, Serialize, Deserialize)]
+#[derive(
+    Derivative, Debug, Clone, Encode, Decode, Serialize, Deserialize, arbitrary::Arbitrary,
+)]
 #[derivative(PartialEq, Eq, Hash)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct KzgCommitment(#[serde(with = "BigArray")] pub [u8; 48]);

--- a/consensus/types/src/kzg_proof.rs
+++ b/consensus/types/src/kzg_proof.rs
@@ -7,7 +7,18 @@ use tree_hash::{PackedEncoding, TreeHash};
 
 const KZG_PROOF_BYTES_LEN: usize = 48;
 
-#[derive(Debug, PartialEq, Hash, Clone, Copy, Encode, Decode, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    Serialize,
+    Deserialize,
+    arbitrary::Arbitrary,
+)]
 #[serde(transparent)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct KzgProof(#[serde(with = "BigArray")] pub [u8; KZG_PROOF_BYTES_LEN]);

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -8,9 +8,19 @@ use tree_hash::TreeHash;
 
 /// A LightClientBootstrap is the initializer we send over to lightclient nodes
 /// that are trying to generate their basic storage when booting up.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct LightClientBootstrap<T: EthSpec> {
     /// Requested beacon block header.
     pub header: BeaconBlockHeader,

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -10,9 +10,19 @@ use tree_hash::TreeHash;
 
 /// A LightClientFinalityUpdate is the update lightclient request or received by a gossip that
 /// signal a new finalized beacon block header for the light client sync protocol.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct LightClientFinalityUpdate<T: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
     pub attested_header: BeaconBlockHeader,

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -9,9 +9,19 @@ use tree_hash::TreeHash;
 
 /// A LightClientOptimisticUpdate is the update we send on each slot,
 /// it is based off the current unfinalized epoch is verified only against BLS signature.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct LightClientOptimisticUpdate<T: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
     pub attested_header: BeaconBlockHeader,

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -52,9 +52,19 @@ impl From<ArithError> for Error {
 /// A LightClientUpdate is the update we request solely to either complete the bootstraping process,
 /// or to sync up to the last committee period, we need to have one ready for each ALTAIR period
 /// we go over, note: there is no need to keep all of the updates from [ALTAIR_PERIOD, CURRENT_PERIOD].
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct LightClientUpdate<T: EthSpec> {
     /// The last `BeaconBlockHeader` from the last attested block by the sync committee.
     pub attested_header: BeaconBlockHeader,

--- a/consensus/types/src/participation_flags.rs
+++ b/consensus/types/src/participation_flags.rs
@@ -7,7 +7,7 @@ use tree_hash::{PackedEncoding, TreeHash, TreeHashType};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize, Serialize, TestRandom)]
 #[serde(transparent)]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[derive(arbitrary::Arbitrary)]
 pub struct ParticipationFlags {
     #[serde(with = "eth2_serde_utils::quoted_u8")]
     bits: u8,

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -80,7 +80,7 @@ pub trait AbstractExecPayload<T: EthSpec>:
     + TryFrom<ExecutionPayloadHeader<T>>
     + TryInto<Self::Merge>
     + TryInto<Self::Capella>
-    + TryInto<Self::Eip4844> // FIXME(sproul): delete + for<'a> arbitrary::Arbitrary<'a>
+    + TryInto<Self::Eip4844>
 {
     type Ref<'a>: ExecPayload<T>
         + Copy

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -48,7 +48,15 @@ pub trait ExecPayload<T: EthSpec>: Debug + Clone + PartialEq + Hash + TreeHash +
 
 /// `ExecPayload` functionality the requires ownership.
 pub trait OwnedExecPayload<T: EthSpec>:
-    ExecPayload<T> + Default + Serialize + DeserializeOwned + Encode + Decode + TestRandom + 'static
+    ExecPayload<T>
+    + Default
+    + Serialize
+    + DeserializeOwned
+    + Encode
+    + Decode
+    + TestRandom
+    + for<'a> arbitrary::Arbitrary<'a>
+    + 'static
 {
 }
 
@@ -60,6 +68,7 @@ impl<T: EthSpec, P> OwnedExecPayload<T> for P where
         + Encode
         + Decode
         + TestRandom
+        + for<'a> arbitrary::Arbitrary<'a>
         + 'static
 {
 }
@@ -71,7 +80,7 @@ pub trait AbstractExecPayload<T: EthSpec>:
     + TryFrom<ExecutionPayloadHeader<T>>
     + TryInto<Self::Merge>
     + TryInto<Self::Capella>
-    + TryInto<Self::Eip4844>
+    + TryInto<Self::Eip4844> // FIXME(sproul): delete + for<'a> arbitrary::Arbitrary<'a>
 {
     type Ref<'a>: ExecPayload<T>
         + Copy
@@ -108,10 +117,11 @@ pub trait AbstractExecPayload<T: EthSpec>:
             TestRandom,
             TreeHash,
             Derivative,
+            arbitrary::Arbitrary,
         ),
         derivative(PartialEq, Hash(bound = "T: EthSpec")),
         serde(bound = "T: EthSpec", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary)),
+        arbitrary(bound = "T: EthSpec"),
         ssz(struct_behaviour = "transparent"),
     ),
     ref_attributes(
@@ -123,9 +133,10 @@ pub trait AbstractExecPayload<T: EthSpec>:
     cast_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, TreeHash, Derivative)]
+#[derive(Debug, Clone, Serialize, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct FullPayload<T: EthSpec> {
     #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
@@ -418,10 +429,11 @@ impl<T: EthSpec> TryFrom<ExecutionPayloadHeader<T>> for FullPayload<T> {
             TestRandom,
             TreeHash,
             Derivative,
+            arbitrary::Arbitrary
         ),
         derivative(PartialEq, Hash(bound = "T: EthSpec")),
         serde(bound = "T: EthSpec", deny_unknown_fields),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary)),
+        arbitrary(bound = "T: EthSpec"),
         ssz(struct_behaviour = "transparent"),
     ),
     ref_attributes(
@@ -433,9 +445,10 @@ impl<T: EthSpec> TryFrom<ExecutionPayloadHeader<T>> for FullPayload<T> {
     cast_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
     partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant")
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, TreeHash, Derivative)]
+#[derive(Debug, Clone, Serialize, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct BlindedPayload<T: EthSpec> {
     #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]

--- a/consensus/types/src/pending_attestation.rs
+++ b/consensus/types/src/pending_attestation.rs
@@ -9,7 +9,19 @@ use tree_hash_derive::TreeHash;
 /// An attestation that has been included in the state but not yet fully processed.
 ///
 /// Spec v0.12.1
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct PendingAttestation<T: EthSpec> {
     pub aggregation_bits: BitList<T::MaxValidatorsPerCommittee>,
     pub data: AttestationData,
@@ -17,18 +29,6 @@ pub struct PendingAttestation<T: EthSpec> {
     pub inclusion_delay: u64,
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub proposer_index: u64,
-}
-
-#[cfg(feature = "arbitrary-fuzz")]
-impl<T: EthSpec> arbitrary::Arbitrary<'_> for PendingAttestation<T> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            aggregation_bits: <BitList<T::MaxValidatorsPerCommittee>>::arbitrary(u)?,
-            data: AttestationData::arbitrary(u)?,
-            inclusion_delay: u64::arbitrary(u)?,
-            proposer_index: u64::arbitrary(u)?,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/consensus/types/src/proposer_slashing.rs
+++ b/consensus/types/src/proposer_slashing.rs
@@ -9,9 +9,19 @@ use tree_hash_derive::TreeHash;
 /// Two conflicting proposals from the same proposer (validator).
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct ProposerSlashing {
     pub signed_header_1: SignedBeaconBlockHeader,

--- a/consensus/types/src/relative_epoch.rs
+++ b/consensus/types/src/relative_epoch.rs
@@ -14,15 +14,11 @@ impl From<ArithError> for Error {
     }
 }
 
-#[cfg(feature = "arbitrary-fuzz")]
-use arbitrary::Arbitrary;
-
 /// Defines the epochs relative to some epoch. Most useful when referring to the committees prior
 /// to and following some epoch.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, arbitrary::Arbitrary)]
 pub enum RelativeEpoch {
     /// The prior epoch.
     Previous,

--- a/consensus/types/src/selection_proof.rs
+++ b/consensus/types/src/selection_proof.rs
@@ -7,8 +7,7 @@ use ssz::Encode;
 use std::cmp;
 use std::convert::TryInto;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(arbitrary::Arbitrary, PartialEq, Debug, Clone)]
 pub struct SelectionProof(Signature);
 
 impl SelectionProof {

--- a/consensus/types/src/signed_aggregate_and_proof.rs
+++ b/consensus/types/src/signed_aggregate_and_proof.rs
@@ -12,9 +12,20 @@ use tree_hash_derive::TreeHash;
 /// gossipsub topic.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    TreeHash,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct SignedAggregateAndProof<T: EthSpec> {
     /// The `AggregateAndProof` that was signed.
     pub message: AggregateAndProof<T>,

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -8,8 +8,7 @@ use superstruct::superstruct;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Eq, Hash, Clone, Copy)]
+#[derive(arbitrary::Arbitrary, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct SignedBeaconBlockHash(Hash256);
 
 impl fmt::Debug for SignedBeaconBlockHash {
@@ -49,20 +48,23 @@ impl From<SignedBeaconBlockHash> for Hash256 {
             Decode,
             TreeHash,
             Derivative,
+            arbitrary::Arbitrary
         ),
         derivative(PartialEq, Hash(bound = "E: EthSpec")),
-        cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary)),
-        serde(bound = "E: EthSpec, Payload: ExecPayload<E>"),
+        serde(bound = "E: EthSpec, Payload: AbstractExecPayload<E>"),
+        arbitrary(bound = "E: EthSpec, Payload: AbstractExecPayload<E>"),
     ),
     map_into(BeaconBlock),
     map_ref_into(BeaconBlockRef),
     map_ref_mut_into(BeaconBlockRefMut)
 )]
-#[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
+#[derive(
+    Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative, arbitrary::Arbitrary,
+)]
 #[derivative(PartialEq, Hash(bound = "E: EthSpec"))]
 #[serde(untagged)]
-#[serde(bound = "E: EthSpec, Payload: ExecPayload<E>")]
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
+#[serde(bound = "E: EthSpec, Payload: AbstractExecPayload<E>")]
+#[arbitrary(bound = "E: EthSpec, Payload: AbstractExecPayload<E>")]
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
 pub struct SignedBeaconBlock<E: EthSpec, Payload: AbstractExecPayload<E> = FullPayload<E>> {

--- a/consensus/types/src/signed_beacon_block_header.rs
+++ b/consensus/types/src/signed_beacon_block_header.rs
@@ -10,9 +10,19 @@ use tree_hash_derive::TreeHash;
 /// A signed header of a `BeaconBlock`.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct SignedBeaconBlockHeader {
     pub message: BeaconBlockHeader,

--- a/consensus/types/src/signed_bls_to_execution_change.rs
+++ b/consensus/types/src/signed_bls_to_execution_change.rs
@@ -6,9 +6,18 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct SignedBlsToExecutionChange {
     pub message: BlsToExecutionChange,

--- a/consensus/types/src/signed_contribution_and_proof.rs
+++ b/consensus/types/src/signed_contribution_and_proof.rs
@@ -10,9 +10,20 @@ use tree_hash_derive::TreeHash;
 
 /// A Validators signed contribution proof to publish on the `sync_committee_contribution_and_proof`
 /// gossipsub topic.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    TreeHash,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct SignedContributionAndProof<T: EthSpec> {
     /// The `ContributionAndProof` that was signed.
     pub message: ContributionAndProof<T>,

--- a/consensus/types/src/signed_voluntary_exit.rs
+++ b/consensus/types/src/signed_voluntary_exit.rs
@@ -9,9 +9,18 @@ use tree_hash_derive::TreeHash;
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct SignedVoluntaryExit {
     pub message: VoluntaryExit,

--- a/consensus/types/src/signing_data.rs
+++ b/consensus/types/src/signing_data.rs
@@ -7,8 +7,18 @@ use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+)]
 pub struct SigningData {
     pub object_root: Hash256,
     pub domain: Hash256,

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -24,13 +24,35 @@ use std::iter::Iterator;
 #[cfg(feature = "legacy-arith")]
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, Sub, SubAssign};
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    arbitrary::Arbitrary,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+)]
 #[serde(transparent)]
 pub struct Slot(#[serde(with = "eth2_serde_utils::quoted_u64")] u64);
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(
+    arbitrary::Arbitrary,
+    Clone,
+    Copy,
+    Default,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+)]
 #[serde(transparent)]
 pub struct Epoch(#[serde(with = "eth2_serde_utils::quoted_u64")] u64);
 

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -18,8 +18,7 @@ lazy_static! {
     };
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(arbitrary::Arbitrary, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SubnetId(#[serde(with = "eth2_serde_utils::quoted_u64")] u64);
 

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -20,12 +20,21 @@ impl From<ArithError> for Error {
     }
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom, Derivative,
+    Debug,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    Derivative,
+    arbitrary::Arbitrary,
 )]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct SyncAggregate<T: EthSpec> {
     pub sync_committee_bits: BitVector<T::SyncCommitteeSize>,
     pub sync_committee_signature: AggregateSignature,

--- a/consensus/types/src/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_aggregator_selection_data.rs
@@ -6,9 +6,18 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Clone, Serialize, Deserialize, Hash, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    Hash,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct SyncAggregatorSelectionData {
     pub slot: Slot,

--- a/consensus/types/src/sync_committee.rs
+++ b/consensus/types/src/sync_committee.rs
@@ -25,9 +25,20 @@ impl From<ArithError> for Error {
     }
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Debug,
+    PartialEq,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct SyncCommittee<T: EthSpec> {
     pub pubkeys: FixedVector<PublicKeyBytes, T::SyncCommitteeSize>,
     pub aggregate_pubkey: PublicKeyBytes,

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -15,9 +15,20 @@ pub enum Error {
 }
 
 /// An aggregation of `SyncCommitteeMessage`s, used in creating a `SignedContributionAndProof`.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+    arbitrary::Arbitrary,
+)]
 #[serde(bound = "T: EthSpec")]
+#[arbitrary(bound = "T: EthSpec")]
 pub struct SyncCommitteeContribution<T: EthSpec> {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_committee_message.rs
+++ b/consensus/types/src/sync_committee_message.rs
@@ -8,8 +8,18 @@ use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
 /// The data upon which a `SyncCommitteeContribution` is based.
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom)]
+#[derive(
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
+)]
 pub struct SyncCommitteeMessage {
     pub slot: Slot,
     pub beacon_block_root: Hash256,

--- a/consensus/types/src/sync_selection_proof.rs
+++ b/consensus/types/src/sync_selection_proof.rs
@@ -12,8 +12,7 @@ use ssz_types::typenum::Unsigned;
 use std::cmp;
 use std::convert::TryInto;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(PartialEq, Debug, Clone)]
+#[derive(arbitrary::Arbitrary, PartialEq, Debug, Clone)]
 pub struct SyncSelectionProof(Signature);
 
 impl SyncSelectionProof {

--- a/consensus/types/src/sync_subnet_id.rs
+++ b/consensus/types/src/sync_subnet_id.rs
@@ -19,8 +19,7 @@ lazy_static! {
     };
 }
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(arbitrary::Arbitrary, Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SyncSubnetId(#[serde(with = "eth2_serde_utils::quoted_u64")] u64);
 

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -10,8 +10,18 @@ use tree_hash_derive::TreeHash;
 /// Information about a `BeaconChain` validator.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Encode, Decode, TestRandom, TreeHash)]
+#[derive(
+    arbitrary::Arbitrary,
+    Debug,
+    Clone,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TestRandom,
+    TreeHash,
+)]
 pub struct Validator {
     pub pubkey: PublicKeyBytes,
     pub withdrawal_credentials: Hash256,

--- a/consensus/types/src/voluntary_exit.rs
+++ b/consensus/types/src/voluntary_exit.rs
@@ -11,9 +11,18 @@ use tree_hash_derive::TreeHash;
 /// An exit voluntarily submitted a validator who wishes to withdraw.
 ///
 /// Spec v0.12.1
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct VoluntaryExit {
     /// Earliest epoch when voluntary exit can be processed.

--- a/consensus/types/src/withdrawal.rs
+++ b/consensus/types/src/withdrawal.rs
@@ -5,9 +5,19 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 #[derive(
-    Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, TestRandom,
+    arbitrary::Arbitrary,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    Encode,
+    Decode,
+    TreeHash,
+    TestRandom,
 )]
 pub struct Withdrawal {
     #[serde(with = "eth2_serde_utils::quoted_u64")]


### PR DESCRIPTION
## Issue Addressed

Make the CI job for `Arbitrary` pass again.

## Proposed Changes

Make `Arbitrary` non-optional for `consensus/types`. This saves having to define traits like `EthSpec` and `OwnedExecutionPayload` under a `cfg` (with & without a dependency on `Arbitrary`). The reason for the added complexity is the new `AbstractExecPayload` trait.

## Additional Info

The funky generics required some upstream changes in the `arbitrary` crate (https://github.com/rust-fuzz/arbitrary/pull/138) which we'll hopefully be able to get merged. For now there's a `[patch]` to apply them.
