### PR TITLE
Verify blockHash with withdrawals

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -91,9 +91,8 @@ impl Default for ChainConfig {
             count_unrealized_full: CountUnrealizedFull::default(),
             checkpoint_sync_url_timeout: 60,
             prepare_payload_lookahead: Duration::from_secs(4),
-            // TODO(capella): disabled until withdrawal verification is implemented
-            // See: https://github.com/sigp/lighthouse/issues/3870
-            optimistic_finalized_sync: false,
+            // This value isn't actually read except in tests.
+            optimistic_finalized_sync: true,
         }
     }
 }

--- a/consensus/types/src/execution_block_header.rs
+++ b/consensus/types/src/execution_block_header.rs
@@ -24,7 +24,9 @@ use metastruct::metastruct;
 ///
 /// Credit to Reth for the type definition.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[metastruct(mappings(map_execution_block_header_fields()))]
+#[metastruct(mappings(map_execution_block_header_fields_except_withdrawals(exclude(
+    withdrawals_root
+))))]
 pub struct ExecutionBlockHeader {
     pub parent_hash: Hash256,
     pub ommers_hash: Hash256,
@@ -42,6 +44,7 @@ pub struct ExecutionBlockHeader {
     pub mix_hash: Hash256,
     pub nonce: Hash64,
     pub base_fee_per_gas: Uint256,
+    pub withdrawals_root: Option<Hash256>,
 }
 
 impl ExecutionBlockHeader {
@@ -49,6 +52,7 @@ impl ExecutionBlockHeader {
         payload: ExecutionPayloadRef<E>,
         rlp_empty_list_root: Hash256,
         rlp_transactions_root: Hash256,
+        rlp_withdrawals_root: Option<Hash256>,
     ) -> Self {
         // Most of these field mappings are defined in EIP-3675 except for `mixHash`, which is
         // defined in EIP-4399.
@@ -69,6 +73,7 @@ impl ExecutionBlockHeader {
             mix_hash: payload.prev_randao(),
             nonce: Hash64::zero(),
             base_fee_per_gas: payload.base_fee_per_gas(),
+            withdrawals_root: rlp_withdrawals_root,
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/3870.

## Proposed Changes

This turned out to be quite straightforward. We just RLP serialize the withdrawals and hash them in a trie the same way we hash transactions.

This fixes the warnings about `Falling back to slow block hash verification` on Capella devnets. My previous attempt at disabling block hash verification hadn't worked because I forgot to update the CLI parsing code. I figured it was better to just fix the underlying cause.