### PR TITLE
Check data availability boundary in rpc request

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1063,12 +1063,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             Some(blobs) => Ok(Some(blobs)),
             None => {
                 // Check for the corresponding block to understand whether we *should* have blobs.
-                self
-                    .get_blinded_block(block_root)?
+                self.get_blinded_block(block_root)?
                     .map(|block| {
                         // If there are no KZG commitments in the block, we know the sidecar should
                         // be empty.
-                        let expected_kzg_commitments = block.message().body().blob_kzg_commitments()?;
+                        let expected_kzg_commitments =
+                            block.message().body().blob_kzg_commitments()?;
                         if expected_kzg_commitments.is_empty() {
                             Ok(Some(BlobsSidecar::empty_from_parts(
                                 *block_root,
@@ -1078,10 +1078,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             if let Some(boundary) = self.data_availability_boundary() {
                                 // We should have blobs for all blocks after the boundary.
                                 if boundary <= block.epoch() {
-                                    return Err(Error::DBInconsistent(format!(
-                                        "Expected kzg commitments but no blobs stored for block root {}",
-                                        block_root
-                                    )))
+                                    return Err(Error::BlobsUnavailable);
                                 }
                             }
                             Ok(None)

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1070,7 +1070,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         let expected_kzg_commitments =
                             match block.message().body().blob_kzg_commitments() {
                                 Ok(kzg_commitments) => kzg_commitments,
-                                Err(_) => return Err(Error::BlobsUnavailable),
+                                Err(_) => return Err(Error::NoKzgCommitmentsFieldOnBlock),
                             };
                         if expected_kzg_commitments.is_empty() {
                             Ok(Some(BlobsSidecar::empty_from_parts(
@@ -1079,12 +1079,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             )))
                         } else {
                             if let Some(boundary) = self.data_availability_boundary() {
-                                // We should have blobs for all blocks after the boundary.
+                                // We should have blobs for all blocks younger than the boundary.
                                 if boundary <= block.epoch() {
                                     return Err(Error::BlobsUnavailable);
                                 }
                             }
-                            Ok(None)
+                            Err(Error::BlobsOlderThanDataAvailabilityBoundary)
                         }
                     })
                     .transpose()

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1068,7 +1068,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         // If there are no KZG commitments in the block, we know the sidecar should
                         // be empty.
                         let expected_kzg_commitments =
-                            block.message().body().blob_kzg_commitments()?;
+                            match block.message().body().blob_kzg_commitments() {
+                                Ok(kzg_commitments) => kzg_commitments,
+                                Err(_) => return Err(Error::BlobsUnavailable),
+                            };
                         if expected_kzg_commitments.is_empty() {
                             Ok(Some(BlobsSidecar::empty_from_parts(
                                 *block_root,

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -209,6 +209,7 @@ pub enum BeaconChainError {
     BlsToExecutionChangeBadFork(ForkName),
     InconsistentFork(InconsistentFork),
     ProposerHeadForkChoiceError(fork_choice::Error<proto_array::Error>),
+    BlobsUnavailable,
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -55,6 +55,7 @@ pub enum BeaconChainError {
     BeaconStateError(BeaconStateError),
     DBInconsistent(String),
     DBError(store::Error),
+    BlobsDBError(store::Error),
     ForkChoiceError(ForkChoiceError),
     ForkChoiceStoreError(ForkChoiceStoreError),
     MissingBeaconBlock(Hash256),
@@ -211,7 +212,8 @@ pub enum BeaconChainError {
     ProposerHeadForkChoiceError(fork_choice::Error<proto_array::Error>),
     BlobsUnavailable,
     NoKzgCommitmentsFieldOnBlock,
-    BlobsOlderThanDataAvailabilityBoundary,
+    Eip4844ForkDisabled,
+    BlobsLookupForInexistentBlock,
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -210,6 +210,8 @@ pub enum BeaconChainError {
     InconsistentFork(InconsistentFork),
     ProposerHeadForkChoiceError(fork_choice::Error<proto_array::Error>),
     BlobsUnavailable,
+    NoKzgCommitmentsFieldOnBlock,
+    BlobsOlderThanDataAvailabilityBoundary,
 }
 
 easy_from_to!(SlotProcessingError, BeaconChainError);

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -184,7 +184,7 @@ impl BlockId {
                                     slot
                                 )));
                             }
-                            Ok((Arc::new(block), execution_optimistic))
+                            Ok((block, execution_optimistic))
                         }
                         None => Err(warp_utils::reject::custom_not_found(format!(
                             "beacon block with root {}",
@@ -200,7 +200,7 @@ impl BlockId {
                     .map_err(warp_utils::reject::beacon_chain_error)
                     .and_then(|block_opt| {
                         block_opt
-                            .map(|block| (Arc::new(block), execution_optimistic))
+                            .map(|block| (block, execution_optimistic))
                             .ok_or_else(|| {
                                 warp_utils::reject::custom_not_found(format!(
                                     "beacon block with root {}",

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -507,9 +507,23 @@ impl std::fmt::Display for OldBlocksByRangeRequest {
     }
 }
 
+impl std::fmt::Display for BlobsByRootRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Request: BlobsByRoot: Number of Requested Roots: {}",
+            self.block_roots.len()
+        )
+    }
+}
+
 impl std::fmt::Display for BlobsByRangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Start Slot: {}, Count: {}", self.start_slot, self.count)
+        write!(
+            f,
+            "Request: BlobsByRange: Start Slot: {}, Count: {}",
+            self.start_slot, self.count
+        )
     }
 }
 

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -258,14 +258,6 @@ impl<T: BeaconChainTypes> Worker<T> {
                                     "request_root" => ?root,
                                     "finalized_data_availability_boundary" => finalized_data_availability_boundary,
                                 );
-                                self.send_error_response(
-                                    peer_id,
-                                    RPCResponseErrorCode::ResourceUnavailable,
-                                    "Blobs unavailable".into(),
-                                    request_id,
-                                );
-                               send_response = false;
-                               break;
                             } else {
                                 debug!(
                                     self.log,
@@ -275,15 +267,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                                     "request_root" => ?root,
                                     "finalized_data_availability_boundary" => finalized_data_availability_boundary,
                                 );
-                                self.send_error_response(
-                                    peer_id,
-                                    RPCResponseErrorCode::ResourceUnavailable,
-                                    "Blobs unavailable".into(),
-                                    request_id,
-                                );
                             }
-                            send_response = false;
-                            break;
                         }
                         Ok((None, Some(_))) => {
                             debug!(
@@ -753,13 +737,6 @@ impl<T: BeaconChainTypes> Worker<T> {
                         "No blobs or block in the store for block root";
                         "block_root" => ?root
                     );
-                    self.send_error_response(
-                        peer_id,
-                        RPCResponseErrorCode::ResourceUnavailable,
-                        "Blobs unavailable".into(),
-                        request_id,
-                    );
-                    send_response = false;
                     break;
                 }
                 Err(BeaconChainError::BlobsUnavailable) => {

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -351,7 +351,7 @@ impl<T: BeaconChainTypes> Worker<T> {
 
                 // send stream termination
                 if send_response {
-                    self.send_response(peer_id, Response::BlocksByRoot(None), request_id);
+                    self.send_response(peer_id, Response::BlobsByRoot(None), request_id);
                 }
                 drop(send_on_drop);
             },

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -646,7 +646,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 self.send_error_response(
                     peer_id,
                     RPCResponseErrorCode::ResourceUnavailable,
-                    "Backfilling".into(),
+                    "Eip4844 fork is disabled".into(),
                     request_id,
                 );
                 return;

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -293,6 +293,21 @@ impl<T: BeaconChainTypes> Worker<T> {
                                 "request_root" => ?root
                             );
                         }
+                        Err(BeaconChainError::BlobsUnavailable) => {
+                            error!(
+                                self.log,
+                                "No blobs in the store for block root";
+                                "block_root" => ?root
+                            );
+                            self.send_error_response(
+                                peer_id,
+                                RPCResponseErrorCode::ResourceUnavailable,
+                                "Blobs unavailable".into(),
+                                request_id,
+                            );
+                            send_response = false;
+                            break;
+                        }
                         Err(BeaconChainError::BlockHashMissingFromExecutionLayer(_)) => {
                             debug!(
                                 self.log,
@@ -736,6 +751,21 @@ impl<T: BeaconChainTypes> Worker<T> {
                     error!(
                         self.log,
                         "No blobs or block in the store for block root";
+                        "block_root" => ?root
+                    );
+                    self.send_error_response(
+                        peer_id,
+                        RPCResponseErrorCode::ResourceUnavailable,
+                        "Blobs unavailable".into(),
+                        request_id,
+                    );
+                    send_response = false;
+                    break;
+                }
+                Err(BeaconChainError::BlobsUnavailable) => {
+                    error!(
+                        self.log,
+                        "No blobs in the store for block root";
                         "block_root" => ?root
                     );
                     self.send_error_response(

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -367,7 +367,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     self.send_error_response(
                         peer_id,
                         RPCResponseErrorCode::ResourceUnavailable,
-                        "Bootstrap not avaiable".into(),
+                        "Bootstrap not available".into(),
                         request_id,
                     );
                     return;
@@ -377,7 +377,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 self.send_error_response(
                     peer_id,
                     RPCResponseErrorCode::ResourceUnavailable,
-                    "Bootstrap not avaiable".into(),
+                    "Bootstrap not available".into(),
                     request_id,
                 );
                 return;
@@ -390,7 +390,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                     self.send_error_response(
                         peer_id,
                         RPCResponseErrorCode::ResourceUnavailable,
-                        "Bootstrap not avaiable".into(),
+                        "Bootstrap not available".into(),
                         request_id,
                     );
                     return;
@@ -400,7 +400,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 self.send_error_response(
                     peer_id,
                     RPCResponseErrorCode::ResourceUnavailable,
-                    "Bootstrap not avaiable".into(),
+                    "Bootstrap not available".into(),
                     request_id,
                 );
                 return;
@@ -412,7 +412,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                 self.send_error_response(
                     peer_id,
                     RPCResponseErrorCode::ResourceUnavailable,
-                    "Bootstrap not avaiable".into(),
+                    "Bootstrap not available".into(),
                     request_id,
                 );
                 return;

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -643,6 +643,12 @@ impl<T: BeaconChainTypes> Worker<T> {
             }
             None => {
                 debug!(self.log, "Eip4844 fork is disabled");
+                self.send_error_response(
+                    peer_id,
+                    RPCResponseErrorCode::ResourceUnavailable,
+                    "Backfilling".into(),
+                    request_id,
+                );
                 return;
             }
         };

--- a/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/rpc_methods.rs
@@ -247,7 +247,7 @@ impl<T: BeaconChainTypes> Worker<T> {
                             );
                         }
                         Ok((Some(block), None)) => {
-                            let data_availability_boundary_by_root = self.chain.data_availability_boundary_by_root_rpc_request();
+                            let data_availability_boundary_by_root = self.chain.finalized_data_availability_boundary();
                             let block_epoch = block.epoch();
 
                            if Some(block_epoch) >= data_availability_boundary_by_root {

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -195,7 +195,7 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedBeaconBlock<E, Payload> 
         }
 
         let domain = spec.get_domain(
-            self.slot().epoch(E::slots_per_epoch()),
+            self.epoch(),
             Domain::BeaconProposer,
             fork,
             genesis_validators_root,
@@ -225,6 +225,11 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedBeaconBlock<E, Payload> 
     /// Convenience accessor for the block's slot.
     pub fn slot(&self) -> Slot {
         self.message().slot()
+    }
+
+    /// Convenience accessor for the block's epoch.
+    pub fn epoch(&self) -> Epoch {
+        self.message().slot().epoch(E::slots_per_epoch())
     }
 
     /// Convenience accessor for the block's parent root.

--- a/consensus/types/src/signed_block_and_blobs.rs
+++ b/consensus/types/src/signed_block_and_blobs.rs
@@ -1,5 +1,7 @@
 use crate::signed_beacon_block::BlobReconstructionError;
-use crate::{BlobsSidecar, EthSpec, Hash256, SignedBeaconBlock, SignedBeaconBlockEip4844, Slot};
+use crate::{
+    BlobsSidecar, Epoch, EthSpec, Hash256, SignedBeaconBlock, SignedBeaconBlockEip4844, Slot,
+};
 use derivative::Derivative;
 use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError};
@@ -71,6 +73,14 @@ impl<T: EthSpec> BlockWrapper<T> {
             BlockWrapperInner::Block(block) => block.slot(),
             BlockWrapperInner::BlockAndBlob(block_sidecar_pair) => {
                 block_sidecar_pair.beacon_block.slot()
+            }
+        }
+    }
+    pub fn epoch(&self) -> Epoch {
+        match &self.0 {
+            BlockWrapperInner::Block(block) => block.epoch(),
+            BlockWrapperInner::BlockAndBlob(block_sidecar_pair) => {
+                block_sidecar_pair.beacon_block.epoch()
             }
         }
     }


### PR DESCRIPTION
## Issue Addressed

Addressing this closed PR https://github.com/ethereum/consensus-specs/pull/3211.

## Proposed Changes

Check data availability boundary differently for ByRange and ByRoot request and serve client error message with regard to data availability boundary.

## Additional Info

For blobs by root, should we do smthg here with the [`BeaconBlobOrphan` column](https://github.com/emhane/lighthouse/blob/ca80463be9fab745eb23d1131ff3ea91e30df16c/beacon_node/store/src/lib.rs#L183) eventually, like responding "data was available"? @michaelsproul 
As in the issues you mention here in the last two paragraphs https://github.com/sigp/lighthouse/pull/3852#pullrequestreview-1244785136