### PR TITLE
Update engine_api to Latest spec

### DIFF
--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -1007,9 +1007,7 @@ async fn payload_preparation() {
             .unwrap(),
         fee_recipient,
         None,
-    )
-    .downgrade_to_v1()
-    .unwrap();
+    );
     assert_eq!(rig.previous_payload_attributes(), payload_attributes);
 }
 

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -524,7 +524,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
                                     base_fee_per_gas: Uint256::one(),
                                     block_hash: ExecutionBlockHash::zero(),
                                     transactions: vec![].into(),
-                                    withdrawals: pa.withdrawals.as_ref().unwrap().clone().into(),
+                                    withdrawals: pa.withdrawals.clone().into(),
                                 })
                             }
                             ForkName::Eip4844 => {
@@ -545,7 +545,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
                                     excess_data_gas: Uint256::one(),
                                     block_hash: ExecutionBlockHash::zero(),
                                     transactions: vec![].into(),
-                                    withdrawals: pa.withdrawals.as_ref().unwrap().clone().into(),
+                                    withdrawals: pa.withdrawals.clone().into(),
                                 })
                             }
                             _ => unreachable!(),

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -79,9 +79,12 @@ pub async fn handle_rpc<T: EthSpec>(
                 ENGINE_NEW_PAYLOAD_V1 => {
                     JsonExecutionPayload::V1(get_param::<JsonExecutionPayloadV1<T>>(params, 0)?)
                 }
-                ENGINE_NEW_PAYLOAD_V2 => {
-                    JsonExecutionPayload::V2(get_param::<JsonExecutionPayloadV2<T>>(params, 0)?)
-                }
+                ENGINE_NEW_PAYLOAD_V2 => get_param::<JsonExecutionPayloadV2<T>>(params, 0)
+                    .map(|jep| JsonExecutionPayload::V2(jep))
+                    .or_else(|_| {
+                        get_param::<JsonExecutionPayloadV1<T>>(params, 0)
+                            .map(|jep| JsonExecutionPayload::V1(jep))
+                    })?,
                 // TODO(4844) add that here..
                 _ => unreachable!(),
             };
@@ -93,9 +96,9 @@ pub async fn handle_rpc<T: EthSpec>(
             // validate method called correctly according to shanghai fork time
             match fork {
                 ForkName::Merge => {
-                    if request.withdrawals().is_ok() && request.withdrawals().unwrap().is_some() {
+                    if matches!(request, JsonExecutionPayload::V2(_)) {
                         return Err(format!(
-                            "{} called with `withdrawals` before capella fork!",
+                            "{} called with `ExecutionPayloadV2` before capella fork!",
                             method
                         ));
                     }
@@ -104,12 +107,9 @@ pub async fn handle_rpc<T: EthSpec>(
                     if method == ENGINE_NEW_PAYLOAD_V1 {
                         return Err(format!("{} called after capella fork!", method));
                     }
-                    if request.withdrawals().is_err()
-                        || (request.withdrawals().is_ok()
-                            && request.withdrawals().unwrap().is_none())
-                    {
+                    if matches!(request, JsonExecutionPayload::V1(_)) {
                         return Err(format!(
-                            "{} called without `withdrawals` after capella fork!",
+                            "{} called with `ExecutionPayloadV1` after capella fork!",
                             method
                         ));
                     }
@@ -138,7 +138,7 @@ pub async fn handle_rpc<T: EthSpec>(
                 Some(
                     ctx.execution_block_generator
                         .write()
-                        .new_payload(request.try_into_execution_payload(fork).unwrap()),
+                        .new_payload(request.into()),
                 )
             } else {
                 None
@@ -171,14 +171,26 @@ pub async fn handle_rpc<T: EthSpec>(
             // TODO(4844) add 4844 error checking here
 
             match method {
-                ENGINE_GET_PAYLOAD_V1 => Ok(serde_json::to_value(
-                    JsonExecutionPayloadV1::try_from(response).unwrap(),
-                )
-                .unwrap()),
-                ENGINE_GET_PAYLOAD_V2 => Ok(serde_json::to_value(JsonGetPayloadResponse {
-                    execution_payload: JsonExecutionPayloadV2::try_from(response).unwrap(),
-                })
-                .unwrap()),
+                ENGINE_GET_PAYLOAD_V1 => {
+                    Ok(serde_json::to_value(JsonExecutionPayload::from(response)).unwrap())
+                }
+                ENGINE_GET_PAYLOAD_V2 => Ok(match JsonExecutionPayload::from(response) {
+                    JsonExecutionPayload::V1(execution_payload) => {
+                        serde_json::to_value(JsonGetPayloadResponseV1 {
+                            execution_payload,
+                            block_value: 0.into(),
+                        })
+                        .unwrap()
+                    }
+                    JsonExecutionPayload::V2(execution_payload) => {
+                        serde_json::to_value(JsonGetPayloadResponseV2 {
+                            execution_payload,
+                            block_value: 0.into(),
+                        })
+                        .unwrap()
+                    }
+                    _ => unreachable!(),
+                }),
                 _ => unreachable!(),
             }
         }
@@ -190,8 +202,7 @@ pub async fn handle_rpc<T: EthSpec>(
                     jpa1.map(JsonPayloadAttributes::V1)
                 }
                 ENGINE_FORKCHOICE_UPDATED_V2 => {
-                    let jpa2: Option<JsonPayloadAttributesV2> = get_param(params, 1)?;
-                    jpa2.map(JsonPayloadAttributes::V2)
+                    get_param::<Option<JsonPayloadAttributes>>(params, 1)?
                 }
                 _ => unreachable!(),
             };
@@ -204,9 +215,9 @@ pub async fn handle_rpc<T: EthSpec>(
                     .get_fork_at_timestamp(*pa.timestamp())
                 {
                     ForkName::Merge => {
-                        if pa.withdrawals().is_ok() && pa.withdrawals().unwrap().is_some() {
+                        if matches!(pa, JsonPayloadAttributes::V2(_)) {
                             return Err(format!(
-                                "{} called with `withdrawals` before capella fork!",
+                                "{} called with `JsonPayloadAttributesV2` before capella fork!",
                                 method
                             ));
                         }
@@ -215,11 +226,9 @@ pub async fn handle_rpc<T: EthSpec>(
                         if method == ENGINE_FORKCHOICE_UPDATED_V1 {
                             return Err(format!("{} called after capella fork!", method));
                         }
-                        if pa.withdrawals().is_err()
-                            || (pa.withdrawals().is_ok() && pa.withdrawals().unwrap().is_none())
-                        {
+                        if matches!(pa, JsonPayloadAttributes::V1(_)) {
                             return Err(format!(
-                                "{} called without `withdrawals` after capella fork!",
+                                "{} called with `JsonPayloadAttributesV1` after capella fork!",
                                 method
                             ));
                         }


### PR DESCRIPTION
## Issue Addressed

The [engine_api spec](https://github.com/ethereum/execution-apis/tree/main/src/engine) was recently [updated to be more explicit](https://github.com/ethereum/execution-apis/pull/337) about how the versioned methods handle versioned objects. This was largely the result of conversations between Mikhail, Adrian, Marek, and myself. The old spec was somewhat ambiguous and as a result, I was asked several times by various people to make lighthouse stop calling the `V2` methods before the `Capella` fork despite the spec allowing this behavior. 

This new implementation is fully backwards compatible with the old `engine_api` spec, but now the code matches the new `engine_api` spec. I tested a local testnet with `geth` and I synced `capella-devnet-v3` with both `geth` and `nethermind` and had no issues.

The implementation of this version seems cleaner than the old one (which is a good sign). There is now a direct mapping:
`ExecutionPayloadMerge` -> `ExecutionPayloadV1`
`ExecutionPayloadCapella` -> `ExecutionPayloadV2`
`ExecutionPayloadEip4844` -> `ExecutionPayloadV3`

## Future work

Additional work needs to be done to implement the `V3` methods for the `Eip4844` fork. These are currently blocked by:
1. The EE's probably don't support the [`V3` methods/objects](https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md#engine_newpayloadv3) yet
2. We currently enable the `V2` methods if `CAPELLA_FORK_EPOCH` is set. We'd probably do the same with the `V3` methods and `EIP4844_FORK_EPOCH`. Unfortunately the [`capella_devnet`'s](https://github.com/ethpandaops/withdrawals-testnet/blob/master/withdrawal-devnet-3/custom_config_data/config.yaml#L38) currently have `EIP4844_FORK_EPOCH` set because of a bug in lighthouse that required it (which was fixed a long time ago).