### PR TITLE
Use eth1_withdrawal_credentials in Test States

### DIFF
--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -22,7 +22,7 @@ use execution_layer::{
 };
 use fork_choice::CountUnrealized;
 use futures::channel::mpsc::Receiver;
-pub use genesis::{interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
+pub use genesis::{interop_genesis_state_with_eth1, DEFAULT_ETH1_BLOCK_HASH};
 use int_to_bytes::int_to_bytes32;
 use merkle_proof::MerkleTree;
 use parking_lot::Mutex;
@@ -191,7 +191,7 @@ impl<E: EthSpec> Builder<EphemeralHarnessType<E>> {
             .unwrap(),
         );
         let mutator = move |builder: BeaconChainBuilder<_>| {
-            let genesis_state = interop_genesis_state::<E>(
+            let genesis_state = interop_genesis_state_with_eth1::<E>(
                 &validator_keypairs,
                 HARNESS_GENESIS_TIME,
                 Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
@@ -252,7 +252,7 @@ impl<E: EthSpec> Builder<DiskHarnessType<E>> {
             .expect("cannot build without validator keypairs");
 
         let mutator = move |builder: BeaconChainBuilder<_>| {
-            let genesis_state = interop_genesis_state::<E>(
+            let genesis_state = interop_genesis_state_with_eth1::<E>(
                 &validator_keypairs,
                 HARNESS_GENESIS_TIME,
                 Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -1013,8 +1013,8 @@ fn check_shuffling_compatible(
 // Ensure blocks from abandoned forks are pruned from the Hot DB
 #[tokio::test]
 async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1123,8 +1123,8 @@ async fn prunes_abandoned_fork_between_two_finalized_checkpoints() {
 
 #[tokio::test]
 async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1255,8 +1255,8 @@ async fn pruning_does_not_touch_abandoned_block_shared_with_canonical_chain() {
 
 #[tokio::test]
 async fn pruning_does_not_touch_blocks_prior_to_finalization() {
-    const HONEST_VALIDATOR_COUNT: usize = 16;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8;
+    const HONEST_VALIDATOR_COUNT: usize = 32;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1350,8 +1350,8 @@ async fn pruning_does_not_touch_blocks_prior_to_finalization() {
 
 #[tokio::test]
 async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1495,8 +1495,8 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
 // This is to check if state outside of normal block processing are pruned correctly.
 #[tokio::test]
 async fn prunes_skipped_slots_states() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();
@@ -1624,8 +1624,8 @@ async fn prunes_skipped_slots_states() {
 // This is to check if state outside of normal block processing are pruned correctly.
 #[tokio::test]
 async fn finalizes_non_epoch_start_slot() {
-    const HONEST_VALIDATOR_COUNT: usize = 16 + 0;
-    const ADVERSARIAL_VALIDATOR_COUNT: usize = 8 - 0;
+    const HONEST_VALIDATOR_COUNT: usize = 32 + 0;
+    const ADVERSARIAL_VALIDATOR_COUNT: usize = 16 - 0;
     const VALIDATOR_COUNT: usize = HONEST_VALIDATOR_COUNT + ADVERSARIAL_VALIDATOR_COUNT;
     let validators_keypairs = types::test_utils::generate_deterministic_keypairs(VALIDATOR_COUNT);
     let honest_validators: Vec<usize> = (0..HONEST_VALIDATOR_COUNT).collect();

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -45,6 +45,7 @@ fn get_valid_sync_committee_message(
     harness: &BeaconChainHarness<EphemeralHarnessType<E>>,
     slot: Slot,
     relative_sync_committee: RelativeSyncCommittee,
+    message_index: usize,
 ) -> (SyncCommitteeMessage, usize, SecretKey, SyncSubnetId) {
     let head_state = harness.chain.head_beacon_state_cloned();
     let head_block_root = harness.chain.head_snapshot().beacon_block_root;
@@ -52,7 +53,7 @@ fn get_valid_sync_committee_message(
         .make_sync_committee_messages(&head_state, head_block_root, slot, relative_sync_committee)
         .get(0)
         .expect("sync messages should exist")
-        .get(0)
+        .get(message_index)
         .expect("first sync message should exist")
         .clone();
 
@@ -494,7 +495,7 @@ async fn unaggregated_gossip_verification() {
     let current_slot = harness.chain.slot().expect("should get slot");
 
     let (valid_sync_committee_message, expected_validator_index, validator_sk, subnet_id) =
-        get_valid_sync_committee_message(&harness, current_slot, RelativeSyncCommittee::Current);
+        get_valid_sync_committee_message(&harness, current_slot, RelativeSyncCommittee::Current, 0);
 
     macro_rules! assert_invalid {
             ($desc: tt, $attn_getter: expr, $subnet_getter: expr, $($error: pat_param) |+ $( if $guard: expr )?) => {
@@ -644,7 +645,7 @@ async fn unaggregated_gossip_verification() {
 
     // **Incorrectly** create a sync message using the current sync committee
     let (next_valid_sync_committee_message, _, _, next_subnet_id) =
-        get_valid_sync_committee_message(&harness, target_slot, RelativeSyncCommittee::Current);
+        get_valid_sync_committee_message(&harness, target_slot, RelativeSyncCommittee::Current, 1);
 
     assert_invalid!(
         "sync message on incorrect subnet",

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -19,7 +19,7 @@ use types::{
 };
 
 // Should ideally be divisible by 3.
-pub const VALIDATOR_COUNT: usize = 24;
+pub const VALIDATOR_COUNT: usize = 48;
 
 lazy_static! {
     /// A cached set of keys.

--- a/beacon_node/genesis/src/interop.rs
+++ b/beacon_node/genesis/src/interop.rs
@@ -17,7 +17,7 @@ fn bls_withdrawal_credentials(pubkey: &PublicKey, spec: &ChainSpec) -> Hash256 {
 }
 
 fn eth1_withdrawal_credentials(pubkey: &PublicKey, spec: &ChainSpec) -> Hash256 {
-    let fake_exeuction_address = &hash(&pubkey.as_ssz_bytes())[0..20];
+    let fake_execution_address = &hash(&pubkey.as_ssz_bytes())[0..20];
     let mut credentials = [0u8; 32];
     credentials[0] = spec.eth1_address_withdrawal_prefix_byte;
     credentials[12..].copy_from_slice(fake_exeuction_address);

--- a/beacon_node/genesis/src/interop.rs
+++ b/beacon_node/genesis/src/interop.rs
@@ -10,6 +10,20 @@ use types::{
 
 pub const DEFAULT_ETH1_BLOCK_HASH: &[u8] = &[0x42; 32];
 
+fn bls_withdrawal_credentials(pubkey: &PublicKey, spec: &ChainSpec) -> Hash256 {
+    let mut credentials = hash(&pubkey.as_ssz_bytes());
+    credentials[0] = spec.bls_withdrawal_prefix_byte;
+    Hash256::from_slice(&credentials)
+}
+
+fn eth1_withdrawal_credentials(pubkey: &PublicKey, spec: &ChainSpec) -> Hash256 {
+    let fake_exeuction_address = &hash(&pubkey.as_ssz_bytes())[0..20];
+    let mut credentials = [0u8; 32];
+    credentials[0] = spec.eth1_address_withdrawal_prefix_byte;
+    credentials[12..].copy_from_slice(fake_exeuction_address);
+    Hash256::from_slice(&credentials)
+}
+
 /// Builds a genesis state as defined by the Eth2 interop procedure (see below).
 ///
 /// Reference:
@@ -24,17 +38,67 @@ pub fn interop_genesis_state<T: EthSpec>(
     let eth1_timestamp = 2_u64.pow(40);
     let amount = spec.max_effective_balance;
 
-    let withdrawal_credentials = |pubkey: &PublicKey| {
-        let mut credentials = hash(&pubkey.as_ssz_bytes());
-        credentials[0] = spec.bls_withdrawal_prefix_byte;
-        Hash256::from_slice(&credentials)
-    };
-
     let datas = keypairs
         .into_par_iter()
         .map(|keypair| {
             let mut data = DepositData {
-                withdrawal_credentials: withdrawal_credentials(&keypair.pk),
+                withdrawal_credentials: bls_withdrawal_credentials(&keypair.pk, spec),
+                pubkey: keypair.pk.clone().into(),
+                amount,
+                signature: Signature::empty().into(),
+            };
+
+            data.signature = data.create_signature(&keypair.sk, spec);
+
+            data
+        })
+        .collect::<Vec<_>>();
+
+    let mut state = initialize_beacon_state_from_eth1(
+        eth1_block_hash,
+        eth1_timestamp,
+        genesis_deposits(datas, spec)?,
+        execution_payload_header,
+        spec,
+    )
+    .map_err(|e| format!("Unable to initialize genesis state: {:?}", e))?;
+
+    *state.genesis_time_mut() = genesis_time;
+
+    // Invalidate all the caches after all the manual state surgery.
+    state
+        .drop_all_caches()
+        .map_err(|e| format!("Unable to drop caches: {:?}", e))?;
+
+    Ok(state)
+}
+
+// returns an interop genesis state except every other
+// validator has eth1 withdrawal credentials
+pub fn interop_genesis_state_with_eth1<T: EthSpec>(
+    keypairs: &[Keypair],
+    genesis_time: u64,
+    eth1_block_hash: Hash256,
+    execution_payload_header: Option<ExecutionPayloadHeader<T>>,
+    spec: &ChainSpec,
+) -> Result<BeaconState<T>, String> {
+    let eth1_timestamp = 2_u64.pow(40);
+    let amount = spec.max_effective_balance;
+
+    let withdrawal_credentials = |index: usize, pubkey: &PublicKey| {
+        if index % 2 == 0 {
+            bls_withdrawal_credentials(pubkey, spec)
+        } else {
+            eth1_withdrawal_credentials(pubkey, spec)
+        }
+    };
+
+    let datas = keypairs
+        .into_par_iter()
+        .enumerate()
+        .map(|(index, keypair)| {
+            let mut data = DepositData {
+                withdrawal_credentials: withdrawal_credentials(index, &keypair.pk),
                 pubkey: keypair.pk.clone().into(),
                 amount,
                 signature: Signature::empty().into(),
@@ -119,6 +183,85 @@ mod test {
                 &hash(&v.pubkey.as_ssz_bytes())[1..],
                 "rest of withdrawal creds should be pubkey hash"
             )
+        }
+
+        assert_eq!(
+            state.balances().len(),
+            validator_count,
+            "validator balances len should be correct"
+        );
+
+        assert_eq!(
+            state.validators().len(),
+            validator_count,
+            "validator count should be correct"
+        );
+    }
+
+    #[test]
+    fn interop_state_with_eth1() {
+        let validator_count = 16;
+        let genesis_time = 42;
+        let spec = &TestEthSpec::default_spec();
+
+        let keypairs = generate_deterministic_keypairs(validator_count);
+
+        let state = interop_genesis_state_with_eth1::<TestEthSpec>(
+            &keypairs,
+            genesis_time,
+            Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),
+            None,
+            spec,
+        )
+        .expect("should build state");
+
+        assert_eq!(
+            state.eth1_data().block_hash,
+            Hash256::from_slice(&[0x42; 32]),
+            "eth1 block hash should be co-ordinated junk"
+        );
+
+        assert_eq!(
+            state.genesis_time(),
+            genesis_time,
+            "genesis time should be as specified"
+        );
+
+        for b in state.balances() {
+            assert_eq!(
+                *b, spec.max_effective_balance,
+                "validator balances should be max effective balance"
+            );
+        }
+
+        for (index, v) in state.validators().iter().enumerate() {
+            let creds = v.withdrawal_credentials.as_bytes();
+            if index % 2 == 0 {
+                assert_eq!(
+                    creds[0], spec.bls_withdrawal_prefix_byte,
+                    "first byte of withdrawal creds should be bls prefix"
+                );
+                assert_eq!(
+                    &creds[1..],
+                    &hash(&v.pubkey.as_ssz_bytes())[1..],
+                    "rest of withdrawal creds should be pubkey hash"
+                );
+            } else {
+                assert_eq!(
+                    creds[0], spec.eth1_address_withdrawal_prefix_byte,
+                    "first byte of withdrawal creds should be eth1 prefix"
+                );
+                assert_eq!(
+                    creds[1..12],
+                    [0u8; 11],
+                    "bytes [1:12] of withdrawal creds must be zero"
+                );
+                assert_eq!(
+                    &creds[12..],
+                    &hash(&v.pubkey.as_ssz_bytes())[0..20],
+                    "rest of withdrawal creds should be first 20 bytes of pubkey hash"
+                )
+            }
         }
 
         assert_eq!(

--- a/beacon_node/genesis/src/interop.rs
+++ b/beacon_node/genesis/src/interop.rs
@@ -20,7 +20,7 @@ fn eth1_withdrawal_credentials(pubkey: &PublicKey, spec: &ChainSpec) -> Hash256 
     let fake_execution_address = &hash(&pubkey.as_ssz_bytes())[0..20];
     let mut credentials = [0u8; 32];
     credentials[0] = spec.eth1_address_withdrawal_prefix_byte;
-    credentials[12..].copy_from_slice(fake_exeuction_address);
+    credentials[12..].copy_from_slice(fake_execution_address);
     Hash256::from_slice(&credentials)
 }
 

--- a/beacon_node/genesis/src/lib.rs
+++ b/beacon_node/genesis/src/lib.rs
@@ -5,5 +5,7 @@ mod interop;
 pub use eth1::Config as Eth1Config;
 pub use eth1::Eth1Endpoint;
 pub use eth1_genesis_service::{Eth1GenesisService, Statistics};
-pub use interop::{interop_genesis_state, DEFAULT_ETH1_BLOCK_HASH};
+pub use interop::{
+    interop_genesis_state, interop_genesis_state_with_eth1, DEFAULT_ETH1_BLOCK_HASH,
+};
 pub use types::test_utils::generate_deterministic_keypairs;

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -2,7 +2,7 @@
 use crate::test_utils::*;
 use crate::test_utils::{SeedableRng, XorShiftRng};
 use beacon_chain::test_utils::{
-    interop_genesis_state, test_spec, BeaconChainHarness, EphemeralHarnessType,
+    interop_genesis_state_with_eth1, test_spec, BeaconChainHarness, EphemeralHarnessType,
     DEFAULT_ETH1_BLOCK_HASH,
 };
 use beacon_chain::types::{
@@ -551,7 +551,7 @@ fn tree_hash_cache_linear_history_long_skip() {
     let spec = &test_spec::<MinimalEthSpec>();
 
     // This state has a cache that advances normally each slot.
-    let mut state: BeaconState<MinimalEthSpec> = interop_genesis_state(
+    let mut state: BeaconState<MinimalEthSpec> = interop_genesis_state_with_eth1(
         &keypairs,
         0,
         Hash256::from_slice(DEFAULT_ETH1_BLOCK_HASH),


### PR DESCRIPTION
## Issue Addressed

Our tests usually use an `interop_genesis_state` with all withdrawal credentials set to `bls`. Thus any `capella` tests we write will always have empty withdrawals which will prevent us from testing most of our `capella` code. This recently bit us when we introduced a bug in this code which wasn't caught by any test and remained in the code for 3 weeks without being found.

## Proposed Changes

I've created a new function `interop_genesis_state_with_eth1` which will make every odd validator have `eth1_withdrawal_credentials` so that all post-capella blocks can expect to have withdrawals to process. This new genesis state function is now used by default in [`fresh_ephemeral_store`](https://github.com/sigp/lighthouse/blob/26787412cd5e5447f00123b4e4afe5d779765b0f/beacon_node/beacon_chain/src/test_utils.rs#L166) which is used by most tests.

## Additional Info

I re-introduced the bug from before and it was caught with a failure of the [`base_altair_merge_capella()`](https://github.com/sigp/lighthouse/blob/26787412cd5e5447f00123b4e4afe5d779765b0f/beacon_node/beacon_chain/tests/capella.rs#L28) test which is our first test designed to probe `capella` functionality.
