### PR TITLE
only support 4844 rpc methods if on 4844

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -267,9 +267,15 @@ impl<TSpec: EthSpec> UpgradeInfo for RPCProtocol<TSpec> {
             ProtocolId::new(Protocol::Ping, Version::V1, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::MetaData, Version::V2, Encoding::SSZSnappy),
             ProtocolId::new(Protocol::MetaData, Version::V1, Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::BlobsByRoot, Version::V1, Encoding::SSZSnappy),
-            ProtocolId::new(Protocol::BlobsByRange, Version::V1, Encoding::SSZSnappy),
         ];
+
+        if let ForkName::Eip4844 = self.fork_context.current_fork() {
+            supported_protocols.extend_from_slice(&[
+                ProtocolId::new(Protocol::BlobsByRoot, Version::V1, Encoding::SSZSnappy),
+                ProtocolId::new(Protocol::BlobsByRange, Version::V1, Encoding::SSZSnappy),
+            ]);
+        }
+
         if self.enable_light_client_server {
             supported_protocols.push(ProtocolId::new(
                 Protocol::LightClientBootstrap,


### PR DESCRIPTION
## Issue Addressed

stop advertising as supported the 4844 methods before 4844
