### PR TITLE
Fix kill_process.sh bug

### DIFF
--- a/scripts/local_testnet/kill_processes.sh
+++ b/scripts/local_testnet/kill_processes.sh
@@ -11,8 +11,12 @@ if [ -f "$1" ]; then
       # handle the case of blank lines
       [[ -n "$pid" ]] || continue
 
-      echo killing $pid
-      kill $pid
+      # Kill the process if it exists 
+      # (it might not if we stopped the start script before it finished starting all processes)
+      if test -d /proc/"$pid"/; then
+        echo killing $pid
+        kill $pid
+      fi
     done < $1
 fi
 


### PR DESCRIPTION
When I CTRL-C'd the start_local_testnet.sh script before it finished executing, the `PIDS.pid` would contain PIDs that weren't actually running, so trying to kill them would cause an error. I think it's because of [this line](https://github.com/sigp/lighthouse/blob/38514c07f222ff7783834c48cf5c0a6ee7f346d0/scripts/local_testnet/start_local_testnet.sh#L81) where the script is started in the background and the PID printed already.. but not 100% sure.

Anyways adding this simple test fixes the issue.

## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
