### PR TITLE
Properly Deserialize ForkVersionedResponses

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -13,7 +13,7 @@ pub use engine_api::*;
 pub use engine_api::{http, http::deposit_methods, http::HttpJsonRpc};
 use engines::{Engine, EngineError};
 pub use engines::{EngineState, ForkchoiceState};
-use eth2::types::{builder_bid::SignedBuilderBid, ForkVersionedResponse};
+use eth2::types::builder_bid::SignedBuilderBid;
 use fork_choice::ForkchoiceUpdateParameters;
 use lru::LruCache;
 use payload_status::process_payload_status;
@@ -38,11 +38,10 @@ use tokio::{
 use tokio_stream::wrappers::WatchStream;
 use types::{AbstractExecPayload, BeaconStateError, Blob, ExecPayload, KzgCommitment};
 use types::{
-    BlindedPayload, BlockType, ChainSpec, Epoch, ExecutionBlockHash, ForkName,
-    ProposerPreparationData, PublicKeyBytes, Signature, SignedBeaconBlock, Slot, Uint256,
-};
-use types::{
-    ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadEip4844, ExecutionPayloadMerge,
+    BlindedPayload, BlockType, ChainSpec, Epoch, ExecutionBlockHash, ExecutionPayload,
+    ExecutionPayloadCapella, ExecutionPayloadEip4844, ExecutionPayloadMerge, ForkName,
+    ForkVersionedResponse, ProposerPreparationData, PublicKeyBytes, Signature, SignedBeaconBlock,
+    Slot, Uint256,
 };
 
 mod block_hash;

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -1,9 +1,9 @@
-use crate::api_types::{
-    EndpointVersion, ExecutionOptimisticForkVersionedResponse, ForkVersionedResponse,
-};
+use crate::api_types::EndpointVersion;
 use eth2::CONSENSUS_VERSION_HEADER;
 use serde::Serialize;
-use types::{ForkName, InconsistentFork};
+use types::{
+    ExecutionOptimisticForkVersionedResponse, ForkName, ForkVersionedResponse, InconsistentFork,
+};
 use warp::reply::{self, Reply, WithHeader};
 
 pub const V1: EndpointVersion = EndpointVersion(1);

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -2,14 +2,15 @@ use crate::api_types::EndpointVersion;
 use eth2::CONSENSUS_VERSION_HEADER;
 use serde::Serialize;
 use types::{
-    ExecutionOptimisticForkVersionedResponse, ForkName, ForkVersionedResponse, InconsistentFork,
+    ExecutionOptimisticForkVersionedResponse, ForkName, ForkVersionDeserialize,
+    ForkVersionedResponse, InconsistentFork,
 };
 use warp::reply::{self, Reply, WithHeader};
 
 pub const V1: EndpointVersion = EndpointVersion(1);
 pub const V2: EndpointVersion = EndpointVersion(2);
 
-pub fn fork_versioned_response<T: Serialize>(
+pub fn fork_versioned_response<T: Serialize + ForkVersionDeserialize>(
     endpoint_version: EndpointVersion,
     fork_name: ForkName,
     data: T,

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -2,15 +2,14 @@ use crate::api_types::EndpointVersion;
 use eth2::CONSENSUS_VERSION_HEADER;
 use serde::Serialize;
 use types::{
-    ExecutionOptimisticForkVersionedResponse, ForkName, ForkVersionDeserialize,
-    ForkVersionedResponse, InconsistentFork,
+    ExecutionOptimisticForkVersionedResponse, ForkName, ForkVersionedResponse, InconsistentFork,
 };
 use warp::reply::{self, Reply, WithHeader};
 
 pub const V1: EndpointVersion = EndpointVersion(1);
 pub const V2: EndpointVersion = EndpointVersion(2);
 
-pub fn fork_versioned_response<T: Serialize + ForkVersionDeserialize>(
+pub fn fork_versioned_response<T: Serialize>(
     endpoint_version: EndpointVersion,
     fork_name: ForkName,
     data: T,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -14,9 +14,8 @@ pub mod lighthouse_vc;
 pub mod mixin;
 pub mod types;
 
-use self::mixin::{RequestAccept, ResponseForkName, ResponseOptional};
+use self::mixin::{RequestAccept, ResponseOptional};
 use self::types::{Error as ResponseError, *};
-use ::types::map_fork_name_with;
 use futures::Stream;
 use futures_util::StreamExt;
 use lighthouse_network::PeerId;
@@ -683,35 +682,7 @@ impl BeaconNodeHttpClient {
             None => return Ok(None),
         };
 
-        // If present, use the fork provided in the headers to decode the block. Gracefully handle
-        // missing and malformed fork names by falling back to regular deserialisation.
-        let (block, version, execution_optimistic) = match response.fork_name_from_header() {
-            Ok(Some(fork_name)) => {
-                let (data, (version, execution_optimistic)) =
-                    map_fork_name_with!(fork_name, SignedBeaconBlock, {
-                        let ExecutionOptimisticForkVersionedResponse {
-                            version,
-                            execution_optimistic,
-                            data,
-                        } = response.json().await?;
-                        (data, (version, execution_optimistic))
-                    });
-                (data, version, execution_optimistic)
-            }
-            Ok(None) | Err(_) => {
-                let ExecutionOptimisticForkVersionedResponse {
-                    version,
-                    execution_optimistic,
-                    data,
-                } = response.json().await?;
-                (data, version, execution_optimistic)
-            }
-        };
-        Ok(Some(ExecutionOptimisticForkVersionedResponse {
-            version,
-            execution_optimistic,
-            data: block,
-        }))
+        Ok(Some(response.json().await?))
     }
 
     /// `GET v1/beacon/blinded_blocks/{block_id}`
@@ -728,35 +699,7 @@ impl BeaconNodeHttpClient {
             None => return Ok(None),
         };
 
-        // If present, use the fork provided in the headers to decode the block. Gracefully handle
-        // missing and malformed fork names by falling back to regular deserialisation.
-        let (block, version, execution_optimistic) = match response.fork_name_from_header() {
-            Ok(Some(fork_name)) => {
-                let (data, (version, execution_optimistic)) =
-                    map_fork_name_with!(fork_name, SignedBlindedBeaconBlock, {
-                        let ExecutionOptimisticForkVersionedResponse {
-                            version,
-                            execution_optimistic,
-                            data,
-                        } = response.json().await?;
-                        (data, (version, execution_optimistic))
-                    });
-                (data, version, execution_optimistic)
-            }
-            Ok(None) | Err(_) => {
-                let ExecutionOptimisticForkVersionedResponse {
-                    version,
-                    execution_optimistic,
-                    data,
-                } = response.json().await?;
-                (data, version, execution_optimistic)
-            }
-        };
-        Ok(Some(ExecutionOptimisticForkVersionedResponse {
-            version,
-            execution_optimistic,
-            data: block,
-        }))
+        Ok(Some(response.json().await?))
     }
 
     /// `GET v1/beacon/blocks` (LEGACY)

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -236,21 +236,6 @@ impl<'a, T: Serialize> From<&'a T> for GenericResponseRef<'a, T> {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ExecutionOptimisticForkVersionedResponse<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
-    pub execution_optimistic: Option<bool>,
-    pub data: T,
-}
-
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
-pub struct ForkVersionedResponse<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
-    pub data: T,
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct RootData {
     pub root: Hash256,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1113,6 +1113,30 @@ pub struct BlocksAndBlobs<T: EthSpec, Payload: AbstractExecPayload<T>> {
     pub kzg_aggregate_proof: KzgProof,
 }
 
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for BlocksAndBlobs<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(bound = "T: EthSpec")]
+        struct Helper<T: EthSpec> {
+            block: serde_json::Value,
+            blobs: Vec<Blob<T>>,
+            kzg_aggregate_proof: KzgProof,
+        }
+        let helper: Helper<T> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            block: BeaconBlock::deserialize_by_fork::<'de, D>(helper.block, fork_name)?,
+            blobs: helper.blobs,
+            kzg_aggregate_proof: helper.kzg_aggregate_proof,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -685,6 +685,41 @@ impl<E: EthSpec> From<BeaconBlock<E, FullPayload<E>>>
     }
 }
 
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for BeaconBlock<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        let convert_err =
+            |e| serde::de::Error::custom(format!("BeaconBlock failed to deserialize: {:?}", e));
+
+        Ok(match fork_name {
+            ForkName::Base => Self::Base(
+                serde_json::from_value::<BeaconBlockBase<T, Payload>>(value)
+                    .map_err(convert_err)?,
+            ),
+            ForkName::Altair => Self::Altair(
+                serde_json::from_value::<BeaconBlockAltair<T, Payload>>(value)
+                    .map_err(convert_err)?,
+            ),
+            ForkName::Merge => Self::Merge(
+                serde_json::from_value::<BeaconBlockMerge<T, Payload>>(value)
+                    .map_err(convert_err)?,
+            ),
+            ForkName::Capella => Self::Capella(
+                serde_json::from_value::<BeaconBlockCapella<T, Payload>>(value)
+                    .map_err(convert_err)?,
+            ),
+            ForkName::Eip4844 => Self::Eip4844(
+                serde_json::from_value::<BeaconBlockEip4844<T, Payload>>(value)
+                    .map_err(convert_err)?,
+            ),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -692,16 +692,14 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
         value: serde_json::value::Value,
         fork_name: ForkName,
     ) -> Result<Self, D::Error> {
-        let convert_err =
-            |e| serde::de::Error::custom(format!("BeaconBlock failed to deserialize: {:?}", e));
-
-        Ok(match fork_name {
-            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
-        })
+        Ok(map_fork_name!(
+            fork_name,
+            Self,
+            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
+                "BeaconBlock failed to deserialize: {:?}",
+                e
+            )))?
+        ))
     }
 }
 

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -696,26 +696,11 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
             |e| serde::de::Error::custom(format!("BeaconBlock failed to deserialize: {:?}", e));
 
         Ok(match fork_name {
-            ForkName::Base => Self::Base(
-                serde_json::from_value::<BeaconBlockBase<T, Payload>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Altair => Self::Altair(
-                serde_json::from_value::<BeaconBlockAltair<T, Payload>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Merge => Self::Merge(
-                serde_json::from_value::<BeaconBlockMerge<T, Payload>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Capella => Self::Capella(
-                serde_json::from_value::<BeaconBlockCapella<T, Payload>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Eip4844 => Self::Eip4844(
-                serde_json::from_value::<BeaconBlockEip4844<T, Payload>>(value)
-                    .map_err(convert_err)?,
-            ),
+            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
         })
     }
 }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1853,3 +1853,21 @@ impl<T: EthSpec> CompareFields for BeaconState<T> {
         }
     }
 }
+
+impl<T: EthSpec> ForkVersionDeserialize for BeaconState<T> {
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        let convert_err =
+            |e| serde::de::Error::custom(format!("BeaconState failed to deserialize: {:?}", e));
+
+        Ok(match fork_name {
+            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
+        })
+    }
+}

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1859,15 +1859,13 @@ impl<T: EthSpec> ForkVersionDeserialize for BeaconState<T> {
         value: serde_json::value::Value,
         fork_name: ForkName,
     ) -> Result<Self, D::Error> {
-        let convert_err =
-            |e| serde::de::Error::custom(format!("BeaconState failed to deserialize: {:?}", e));
-
-        Ok(match fork_name {
-            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
-        })
+        Ok(map_fork_name!(
+            fork_name,
+            Self,
+            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
+                "BeaconState failed to deserialize: {:?}",
+                e
+            )))?
+        ))
     }
 }

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AbstractExecPayload, ChainSpec, EthSpec, ExecPayload, ExecutionPayloadHeader, SignedRoot,
-    Uint256,
+    AbstractExecPayload, ChainSpec, EthSpec, ExecPayload, ExecutionPayloadHeader, ForkName,
+    ForkVersionDeserialize, SignedRoot, Uint256,
 };
 use bls::PublicKeyBytes;
 use bls::Signature;
@@ -32,6 +32,60 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> SignedRoot for BuilderBid<E, P
 pub struct SignedBuilderBid<E: EthSpec, Payload: AbstractExecPayload<E>> {
     pub message: BuilderBid<E, Payload>,
     pub signature: Signature,
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for BuilderBid<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        let convert_err = |_| {
+            serde::de::Error::custom(
+                "BuilderBid failed to deserialize: unable to convert payload header to payload",
+            )
+        };
+
+        #[derive(Deserialize)]
+        struct Helper {
+            header: serde_json::Value,
+            #[serde(with = "eth2_serde_utils::quoted_u256")]
+            value: Uint256,
+            pubkey: PublicKeyBytes,
+        }
+        let helper: Helper = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        let payload_header =
+            ExecutionPayloadHeader::deserialize_by_fork::<'de, D>(helper.header, fork_name)?;
+
+        Ok(Self {
+            header: Payload::try_from(payload_header).map_err(convert_err)?,
+            value: helper.value,
+            pubkey: helper.pubkey,
+            _phantom_data: Default::default(),
+        })
+    }
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for SignedBuilderBid<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        struct Helper {
+            pub message: serde_json::Value,
+            pub signature: Signature,
+        }
+        let helper: Helper = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            message: BuilderBid::deserialize_by_fork::<'de, D>(helper.message, fork_name)?,
+            signature: helper.signature,
+        })
+    }
 }
 
 struct BlindedPayloadAsHeader<E>(PhantomData<E>);

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -146,3 +146,32 @@ impl<T: EthSpec> ExecutionPayload<T> {
             + (T::max_withdrawals_per_payload() * <Withdrawal as Encode>::ssz_fixed_len())
     }
 }
+
+impl<T: EthSpec> ForkVersionDeserialize for ExecutionPayload<T> {
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!("ExecutionPayload failed to deserialize: {:?}", e))
+        };
+
+        Ok(match fork_name {
+            ForkName::Merge => Self::Merge(
+                serde_json::from_value::<ExecutionPayloadMerge<T>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Capella => Self::Capella(
+                serde_json::from_value::<ExecutionPayloadCapella<T>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Eip4844 => Self::Eip4844(
+                serde_json::from_value::<ExecutionPayloadEip4844<T>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Base | ForkName::Altair => {
+                return Err(serde::de::Error::custom(format!(
+                    "ExecutionPayload failed to deserialize: unsupported fork '{}'",
+                    fork_name
+                )));
+            }
+        })
+    }
+}

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -157,15 +157,9 @@ impl<T: EthSpec> ForkVersionDeserialize for ExecutionPayload<T> {
         };
 
         Ok(match fork_name {
-            ForkName::Merge => Self::Merge(
-                serde_json::from_value::<ExecutionPayloadMerge<T>>(value).map_err(convert_err)?,
-            ),
-            ForkName::Capella => Self::Capella(
-                serde_json::from_value::<ExecutionPayloadCapella<T>>(value).map_err(convert_err)?,
-            ),
-            ForkName::Eip4844 => Self::Eip4844(
-                serde_json::from_value::<ExecutionPayloadEip4844<T>>(value).map_err(convert_err)?,
-            ),
+            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
                 return Err(serde::de::Error::custom(format!(
                     "ExecutionPayload failed to deserialize: unsupported fork '{}'",

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -296,18 +296,9 @@ impl<T: EthSpec> ForkVersionDeserialize for ExecutionPayloadHeader<T> {
         };
 
         Ok(match fork_name {
-            ForkName::Merge => Self::Merge(
-                serde_json::from_value::<ExecutionPayloadHeaderMerge<T>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Capella => Self::Capella(
-                serde_json::from_value::<ExecutionPayloadHeaderCapella<T>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Eip4844 => Self::Eip4844(
-                serde_json::from_value::<ExecutionPayloadHeaderEip4844<T>>(value)
-                    .map_err(convert_err)?,
-            ),
+            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
             ForkName::Base | ForkName::Altair => {
                 return Err(serde::de::Error::custom(format!(
                     "ExecutionPayloadHeader failed to deserialize: unsupported fork '{}'",

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -2,13 +2,44 @@ use crate::ForkName;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
+use std::sync::Arc;
 
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+// Deserialize is only implemented for types that implement ForkVersionDeserialize
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct ExecutionOptimisticForkVersionedResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ForkName>,
     pub execution_optimistic: Option<bool>,
     pub data: T,
+}
+
+impl<'de, F> serde::Deserialize<'de> for ExecutionOptimisticForkVersionedResponse<F>
+where
+    F: ForkVersionDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            version: Option<ForkName>,
+            execution_optimistic: Option<bool>,
+            data: serde_json::Value,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        let data = match helper.version {
+            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
+            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
+        };
+
+        Ok(ExecutionOptimisticForkVersionedResponse {
+            version: helper.version,
+            execution_optimistic: helper.execution_optimistic,
+            data,
+        })
+    }
 }
 
 pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
@@ -18,11 +49,12 @@ pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
     ) -> Result<Self, D::Error>;
 }
 
+// Deserialize is only implemented for types that implement ForkVersionDeserialize
 #[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct ForkVersionedResponse<F: ForkVersionDeserialize> {
+pub struct ForkVersionedResponse<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ForkName>,
-    pub data: F,
+    pub data: T,
 }
 
 impl<'de, F> serde::Deserialize<'de> for ForkVersionedResponse<F>
@@ -49,6 +81,17 @@ where
             version: helper.version,
             data,
         })
+    }
+}
+
+impl<F: ForkVersionDeserialize> ForkVersionDeserialize for Arc<F> {
+    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+        value: Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        Ok(Arc::new(F::deserialize_by_fork::<'de, D>(
+            value, fork_name,
+        )?))
     }
 }
 

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -1,0 +1,53 @@
+use crate::ForkName;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::value::Value;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ExecutionOptimisticForkVersionedResponse<T> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<ForkName>,
+    pub execution_optimistic: Option<bool>,
+    pub data: T,
+}
+
+pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
+    fn deserialize_by_fork<'de, D: Deserializer<'de>>(
+        value: Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error>;
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize)]
+pub struct ForkVersionedResponse<F: ForkVersionDeserialize> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<ForkName>,
+    pub data: F,
+}
+
+impl<'de, F> serde::Deserialize<'de> for ForkVersionedResponse<F>
+where
+    F: ForkVersionDeserialize,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            version: Option<ForkName>,
+            data: serde_json::Value,
+        }
+
+        let helper = Helper::deserialize(deserializer)?;
+        let data = match helper.version {
+            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
+            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
+        };
+
+        Ok(ForkVersionedResponse {
+            version: helper.version,
+            data,
+        })
+    }
+}

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -51,3 +51,45 @@ where
         })
     }
 }
+
+#[cfg(test)]
+mod fork_version_response_tests {
+    use crate::{
+        ExecutionPayload, ExecutionPayloadMerge, ForkName, ForkVersionedResponse, MainnetEthSpec,
+    };
+    use serde_json::json;
+
+    #[test]
+    fn fork_versioned_response_deserialize_correct_fork() {
+        type E = MainnetEthSpec;
+
+        let response_json =
+            serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
+                version: Some(ForkName::Merge),
+                data: ExecutionPayload::Merge(ExecutionPayloadMerge::default()),
+            }))
+            .unwrap();
+
+        let result: Result<ForkVersionedResponse<ExecutionPayload<E>>, _> =
+            serde_json::from_str(&response_json);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn fork_versioned_response_deserialize_incorrect_fork() {
+        type E = MainnetEthSpec;
+
+        let response_json =
+            serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
+                version: Some(ForkName::Capella),
+                data: ExecutionPayload::Merge(ExecutionPayloadMerge::default()),
+            }))
+            .unwrap();
+
+        let result: Result<ForkVersionedResponse<ExecutionPayload<E>>, _> =
+            serde_json::from_str(&response_json);
+
+        assert!(result.is_err());
+    }
+}

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -46,6 +46,7 @@ pub mod execution_payload_header;
 pub mod fork;
 pub mod fork_data;
 pub mod fork_name;
+pub mod fork_versioned_response;
 pub mod free_attestation;
 pub mod graffiti;
 pub mod historical_batch;
@@ -150,6 +151,9 @@ pub use crate::fork::Fork;
 pub use crate::fork_context::ForkContext;
 pub use crate::fork_data::ForkData;
 pub use crate::fork_name::{ForkName, InconsistentFork};
+pub use crate::fork_versioned_response::{
+    ExecutionOptimisticForkVersionedResponse, ForkVersionedResponse,
+};
 pub use crate::free_attestation::FreeAttestation;
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};
 pub use crate::historical_batch::HistoricalBatch;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -152,7 +152,7 @@ pub use crate::fork_context::ForkContext;
 pub use crate::fork_data::ForkData;
 pub use crate::fork_name::{ForkName, InconsistentFork};
 pub use crate::fork_versioned_response::{
-    ExecutionOptimisticForkVersionedResponse, ForkVersionedResponse,
+    ExecutionOptimisticForkVersionedResponse, ForkVersionDeserialize, ForkVersionedResponse,
 };
 pub use crate::free_attestation::FreeAttestation;
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -497,23 +497,11 @@ impl<E: EthSpec> ForkVersionDeserialize for SignedBeaconBlock<E> {
         };
 
         Ok(match fork_name {
-            ForkName::Base => Self::Base(
-                serde_json::from_value::<SignedBeaconBlockBase<E>>(value).map_err(convert_err)?,
-            ),
-            ForkName::Altair => Self::Altair(
-                serde_json::from_value::<SignedBeaconBlockAltair<E>>(value).map_err(convert_err)?,
-            ),
-            ForkName::Merge => Self::Merge(
-                serde_json::from_value::<SignedBeaconBlockMerge<E>>(value).map_err(convert_err)?,
-            ),
-            ForkName::Capella => Self::Capella(
-                serde_json::from_value::<SignedBeaconBlockCapella<E>>(value)
-                    .map_err(convert_err)?,
-            ),
-            ForkName::Eip4844 => Self::Eip4844(
-                serde_json::from_value::<SignedBeaconBlockEip4844<E>>(value)
-                    .map_err(convert_err)?,
-            ),
+            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
+            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
         })
     }
 }

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -487,7 +487,9 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
     }
 }
 
-impl<E: EthSpec> ForkVersionDeserialize for SignedBeaconBlock<E> {
+impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
+    for SignedBeaconBlock<E, Payload>
+{
     fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
         value: serde_json::value::Value,
         fork_name: ForkName,

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -494,17 +494,14 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> ForkVersionDeserialize
         value: serde_json::value::Value,
         fork_name: ForkName,
     ) -> Result<Self, D::Error> {
-        let convert_err = |e| {
-            serde::de::Error::custom(format!("SignedBeaconBlock failed to deserialize: {:?}", e))
-        };
-
-        Ok(match fork_name {
-            ForkName::Base => Self::Base(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Altair => Self::Altair(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Merge => Self::Merge(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Capella => Self::Capella(serde_json::from_value(value).map_err(convert_err)?),
-            ForkName::Eip4844 => Self::Eip4844(serde_json::from_value(value).map_err(convert_err)?),
-        })
+        Ok(map_fork_name!(
+            fork_name,
+            Self,
+            serde_json::from_value(value).map_err(|e| serde::de::Error::custom(format!(
+                "SignedBeaconBlock failed to deserialize: {:?}",
+                e
+            )))?
+        ))
     }
 }
 

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -487,6 +487,37 @@ impl<E: EthSpec> SignedBeaconBlock<E> {
     }
 }
 
+impl<E: EthSpec> ForkVersionDeserialize for SignedBeaconBlock<E> {
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        let convert_err = |e| {
+            serde::de::Error::custom(format!("SignedBeaconBlock failed to deserialize: {:?}", e))
+        };
+
+        Ok(match fork_name {
+            ForkName::Base => Self::Base(
+                serde_json::from_value::<SignedBeaconBlockBase<E>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Altair => Self::Altair(
+                serde_json::from_value::<SignedBeaconBlockAltair<E>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Merge => Self::Merge(
+                serde_json::from_value::<SignedBeaconBlockMerge<E>>(value).map_err(convert_err)?,
+            ),
+            ForkName::Capella => Self::Capella(
+                serde_json::from_value::<SignedBeaconBlockCapella<E>>(value)
+                    .map_err(convert_err)?,
+            ),
+            ForkName::Eip4844 => Self::Eip4844(
+                serde_json::from_value::<SignedBeaconBlockEip4844<E>>(value)
+                    .map_err(convert_err)?,
+            ),
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
We were not actually using the fork in `ForkVersionedResponse` to deserialize the object and serde was effectively guessing until it worked. This means (for example) we could have potentially ended up with a response that said it was a `ForkName::Merge` but was deserialized as a `Capella` variant.