### PR TITLE
Revert #3875

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,7 +43,7 @@ jobs:
             VERSION: ${{ env.VERSION }}
             VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
     build-docker-single-arch:
-        name: build-docker-${{ matrix.binary }}${{ matrix.features.version_suffix }}
+        name: build-docker-${{ matrix.binary }}
         runs-on: ubuntu-22.04
         strategy:
             matrix:
@@ -51,10 +51,6 @@ jobs:
                          aarch64-portable,
                          x86_64,
                          x86_64-portable]
-                features: [
-                    {version_suffix: "", env: ""},
-                    {version_suffix: "-dev", env: "spec-minimal"}
-                ]
                 include:
                     - profile: maxperf
 
@@ -64,8 +60,6 @@ jobs:
             DOCKER_CLI_EXPERIMENTAL: enabled
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-            FEATURE_SUFFIX: ${{ matrix.features.version_suffix }}
-            FEATURES: ${{ matrix.features.env }}
         steps:
             - uses: actions/checkout@v3
             - name: Update Rust
@@ -104,9 +98,8 @@ jobs:
                   docker buildx build \
                       --platform=linux/${SHORT_ARCH} \
                       --file ./Dockerfile.cross . \
-                      --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX}${MODERNITY_SUFFIX}${FEATURE_SUFFIX} \
-                      --build-arg FEATURES=${FEATURES} \
-                      --provenance=false \                      
+                      --tag ${IMAGE_NAME}:${VERSION}-${SHORT_ARCH}${VERSION_SUFFIX}${MODERNITY_SUFFIX} \
+                      --provenance=false \
                       --push
     build-docker-multiarch:
         name: build-docker-multiarch${{ matrix.modernity }}

--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -57,7 +57,7 @@ $ docker pull sigp/lighthouse:latest-modern
 Image tags follow this format:
 
 ```
-${version}${arch}${stability}${modernity}${features}
+${version}${arch}${stability}${modernity}
 ```
 
 The `version` is:
@@ -80,12 +80,6 @@ The `modernity` is:
 
 * `-modern` for optimized builds
 * empty for a `portable` unoptimized build
-
-The `features` is:
-
-* `-dev` for a development build with `minimal-spec` preset enabled.
-* empty for a standard build with no custom feature enabled.
-
 
 Examples:
 


### PR DESCRIPTION
## Description

This PR reverts #3875 due to failed builds mentioned [here](https://github.com/sigp/lighthouse/pull/3875#issuecomment-1422089702).

I'm guessing it's something to do with the `--build-arg` flag, but I'm not sure. It's the same error I was getting [on my repo](https://github.com/sigp/lighthouse/pull/3875#issuecomment-1403345013).

If this PR merges and Docker succeeds, then we can know that #3875 was the problem and we can work on a fix by running CI in a different repository. I'm electing to merge this revert commit now so that we can make sure that `unstable` images keep getting published.