### PR TITLE
Encode blob transactions as signed blob transactions

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -52,7 +52,6 @@ use types::{
 use types::{
     ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadEip4844, ExecutionPayloadMerge,
 };
-use warp::hyper::body::HttpBody;
 
 mod block_hash;
 mod engine_api;
@@ -2074,23 +2073,22 @@ fn ethers_tx_to_bytes<T: EthSpec>(
         .as_u64();
 
     let tx = if BLOB_TX_TYPE as u64 == tx_type {
-
         let EthersTransaction {
-            hash,
+            hash: _,
             nonce,
-            block_hash,
-            block_number,
-            transaction_index,
-            from,
+            block_hash: _,
+            block_number: _,
+            transaction_index: _,
+            from: _,
             to,
             value,
-            gas_price,
+            gas_price: _,
             gas,
             input,
             v,
             r,
             s,
-            transaction_type,
+            transaction_type: _,
             access_list,
             max_priority_fee_per_gas,
             max_fee_per_gas,

--- a/consensus/types/src/transaction.rs
+++ b/consensus/types/src/transaction.rs
@@ -10,6 +10,12 @@ pub type MaxVersionedHashesListSize = U16777216;
 pub type MaxAccessListStorageKeys = U16777216;
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
+pub struct SignedBlobTransaction {
+    pub message: BlobTransaction,
+    pub signature: EcdsaSignature,
+}
+
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct BlobTransaction {
     pub chain_id: Uint256,
     pub nonce: u64,
@@ -28,4 +34,11 @@ pub struct BlobTransaction {
 pub struct AccessTuple {
     pub address: Address,
     pub storage_keys: VariableList<Hash256, MaxAccessListStorageKeys>,
+}
+
+#[derive(Debug, Clone, PartialEq, Encode, Decode)]
+pub struct EcdsaSignature {
+    pub y_parity: bool,
+    pub r: Uint256,
+    pub s: Uint256,
 }


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/pull/3941 was close but no cigar! 
- The transactions in the block are `SignedBlobTransactions` serialized to SSZ rather than `BlobTransactions` 
- Make sure we prepend the `BLOB_TX_TYPE` byte to the encoded signed blob transaction
- This additionally makes sure we length check byte slices when creating `Uint256` and `Hash256`
- removes a clone on the access list field

