### PR TITLE
[Merged by Bors] - Tweaks to reward APIs

### DIFF
--- a/common/eth2/src/lighthouse/attestation_rewards.rs
+++ b/common/eth2/src/lighthouse/attestation_rewards.rs
@@ -28,8 +28,10 @@ pub struct TotalAttestationRewards {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub head: u64,
     // attester's reward for target vote in gwei
+    #[serde(with = "eth2_serde_utils::quoted_i64")]
     pub target: i64,
     // attester's reward for source vote in gwei
+    #[serde(with = "eth2_serde_utils::quoted_i64")]
     pub source: i64,
     // TBD attester's inclusion_delay reward in gwei (phase0 only)
     // pub inclusion_delay: u64,

--- a/common/eth2/src/lighthouse/sync_committee_rewards.rs
+++ b/common/eth2/src/lighthouse/sync_committee_rewards.rs
@@ -8,5 +8,6 @@ pub struct SyncCommitteeReward {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub validator_index: u64,
     // sync committee reward in gwei for the validator
+    #[serde(with = "eth2_serde_utils::quoted_i64")]
     pub reward: i64,
 }

--- a/consensus/serde_utils/src/lib.rs
+++ b/consensus/serde_utils/src/lib.rs
@@ -12,4 +12,4 @@ pub mod u64_hex_be;
 pub mod u8_hex;
 
 pub use fixed_bytes_hex::{bytes_4_hex, bytes_8_hex};
-pub use quoted_int::{quoted_u256, quoted_u32, quoted_u64, quoted_u8};
+pub use quoted_int::{quoted_i64, quoted_u256, quoted_u32, quoted_u64, quoted_u8};


### PR DESCRIPTION
## Proposed Changes

* Return the effective balance in gwei to align with the spec ([ideal attestation rewards](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Rewards/getAttestationsRewards)).
* Use quoted `i64`s for attestation and sync committee rewards.
