### PR TITLE
[Merged by Bors] - blacklist tests in windows

### DIFF
--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -182,6 +182,7 @@ mod attestation_service {
     #[cfg(feature = "deterministic_long_lived_attnets")]
     use std::collections::HashSet;
 
+    #[cfg(not(windows))]
     use crate::subnet_service::attestation_subnets::MIN_PEER_DISCOVERY_SLOT_LOOK_AHEAD;
 
     use super::*;

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -290,6 +290,7 @@ mod attestation_service {
     }
 
     /// Test to verify that we are not unsubscribing to a subnet before a required subscription.
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_same_subnet_unsubscription() {
         // subscription config
@@ -513,6 +514,7 @@ mod attestation_service {
         assert_eq!(unexpected_msg_count, 0);
     }
 
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_subscribe_same_subnet_several_slots_apart() {
         // subscription config


### PR DESCRIPTION
## Issue Addressed
Windows tests for subscription and unsubscriptions fail in CI sporadically. We usually ignore this failures, so this PR aims to help reduce the failure noise. Associated issue is https://github.com/sigp/lighthouse/issues/3960