### PR TITLE
Quote Capella BeaconState fields

### DIFF
--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -301,8 +301,10 @@ where
 
     // Capella
     #[superstruct(only(Capella, Eip4844), partial_getter(copy))]
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub next_withdrawal_index: u64,
     #[superstruct(only(Capella, Eip4844), partial_getter(copy))]
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub next_withdrawal_validator_index: u64,
     // Deep history valid from Capella onwards.
     #[superstruct(only(Capella, Eip4844))]


### PR DESCRIPTION
## Issue Addressed

Closes #3949

## Proposed Changes

Quote the `next_withdrawal_index` and `next_withdrawal_validator_index` fields in the JSON HTTP API.