### PR TITLE
Simplify payload traits and reduce cloning

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -985,11 +985,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             })?
             .ok_or(Error::BlockHashMissingFromExecutionLayer(exec_block_hash))?;
 
-        //FIXME(sean) avoid the clone by comparing refs to headers (`as_execution_payload_header` method ?)
-        let full_payload: FullPayload<T::EthSpec> = execution_payload.clone().into();
-
         // Verify payload integrity.
-        let header_from_payload = full_payload.to_execution_payload_header();
+        let header_from_payload = ExecutionPayloadHeader::from(execution_payload.to_ref());
         if header_from_payload != execution_payload_header {
             for txn in execution_payload.transactions() {
                 debug!(

--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -67,6 +67,7 @@ pub struct OutboundRateLimiterConfig {
     pub(super) goodbye_quota: Quota,
     pub(super) blocks_by_range_quota: Quota,
     pub(super) blocks_by_root_quota: Quota,
+    pub(super) blobs_by_range_quota: Quota,
 }
 
 impl OutboundRateLimiterConfig {
@@ -77,6 +78,8 @@ impl OutboundRateLimiterConfig {
     pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota =
         Quota::n_every(methods::MAX_REQUEST_BLOCKS, 10);
     pub const DEFAULT_BLOCKS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
+    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota =
+        Quota::n_every(methods::MAX_REQUEST_BLOBS_SIDECARS, 10);
 }
 
 impl Default for OutboundRateLimiterConfig {
@@ -88,6 +91,7 @@ impl Default for OutboundRateLimiterConfig {
             goodbye_quota: Self::DEFAULT_GOODBYE_QUOTA,
             blocks_by_range_quota: Self::DEFAULT_BLOCKS_BY_RANGE_QUOTA,
             blocks_by_root_quota: Self::DEFAULT_BLOCKS_BY_ROOT_QUOTA,
+            blobs_by_range_quota: Self::DEFAULT_BLOBS_BY_RANGE_QUOTA,
         }
     }
 }
@@ -111,6 +115,7 @@ impl Debug for OutboundRateLimiterConfig {
             .field("goodbye", fmt_q!(&self.goodbye_quota))
             .field("blocks_by_range", fmt_q!(&self.blocks_by_range_quota))
             .field("blocks_by_root", fmt_q!(&self.blocks_by_root_quota))
+            .field("blobs_by_range", fmt_q!(&self.blobs_by_range_quota))
             .finish()
     }
 }
@@ -129,7 +134,6 @@ impl FromStr for OutboundRateLimiterConfig {
         let mut goodbye_quota = None;
         let mut blocks_by_range_quota = None;
         let mut blocks_by_root_quota = None;
-        // TODO(eip4844): use this blob quota
         let mut blobs_by_range_quota = None;
         for proto_def in s.split(';') {
             let ProtocolQuota { protocol, quota } = proto_def.parse()?;
@@ -154,6 +158,8 @@ impl FromStr for OutboundRateLimiterConfig {
                 .unwrap_or(Self::DEFAULT_BLOCKS_BY_RANGE_QUOTA),
             blocks_by_root_quota: blocks_by_root_quota
                 .unwrap_or(Self::DEFAULT_BLOCKS_BY_ROOT_QUOTA),
+            blobs_by_range_quota: blobs_by_range_quota
+                .unwrap_or(Self::DEFAULT_BLOBS_BY_RANGE_QUOTA),
         })
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
@@ -60,6 +60,7 @@ impl<Id: ReqId, TSpec: EthSpec> SelfRateLimiter<Id, TSpec> {
             goodbye_quota,
             blocks_by_range_quota,
             blocks_by_root_quota,
+            blobs_by_range_quota,
         } = config;
 
         let limiter = RateLimiter::builder()
@@ -69,6 +70,7 @@ impl<Id: ReqId, TSpec: EthSpec> SelfRateLimiter<Id, TSpec> {
             .set_quota(Protocol::Goodbye, goodbye_quota)
             .set_quota(Protocol::BlocksByRange, blocks_by_range_quota)
             .set_quota(Protocol::BlocksByRoot, blocks_by_root_quota)
+            .set_quota(Protocol::BlobsByRange, blobs_by_range_quota)
             // Manually set the LightClientBootstrap quota, since we use the same rate limiter for
             // inbound and outbound requests, and the LightClientBootstrap is an only inbound
             // protocol.

--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -348,8 +348,7 @@ where
         &mut self,
         block: &'a SignedBeaconBlock<T, Payload>,
     ) -> Result<()> {
-        // FIXME(capella): to improve performance we might want to decompress the withdrawal pubkeys
-        // in parallel.
+        // To improve performance we might want to decompress the withdrawal pubkeys in parallel.
         if let Ok(bls_to_execution_changes) = block.message().body().bls_to_execution_changes() {
             for bls_to_execution_change in bls_to_execution_changes {
                 self.sets.push(bls_execution_change_signature_set(

--- a/consensus/state_processing/src/per_block_processing/verify_bls_to_execution_change.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_bls_to_execution_change.rs
@@ -37,10 +37,9 @@ pub fn verify_bls_to_execution_change<T: EthSpec>(
         Invalid::NonBlsWithdrawalCredentials
     );
 
+    // Re-hashing the pubkey isn't necessary during block replay, so we may want to skip that in
+    // future.
     let pubkey_hash = hash(address_change.from_bls_pubkey.as_serialized());
-
-    // FIXME: Should this check be put inside the verify_signatures.is_true() condition?
-    //        I believe that's used for fuzzing so this is a Mehdi question..
     verify!(
         validator.withdrawal_credentials.as_bytes().get(1..) == pubkey_hash.get(1..),
         Invalid::WithdrawalCredentialsMismatch

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -279,7 +279,7 @@ impl<E: EthSpec> From<BeaconBlockBodyMerge<E, FullPayload<E>>>
                 voluntary_exits,
                 sync_aggregate,
                 execution_payload: BlindedPayloadMerge {
-                    execution_payload_header: From::from(execution_payload.clone()),
+                    execution_payload_header: From::from(&execution_payload),
                 },
             },
             Some(execution_payload),
@@ -320,7 +320,7 @@ impl<E: EthSpec> From<BeaconBlockBodyCapella<E, FullPayload<E>>>
                 voluntary_exits,
                 sync_aggregate,
                 execution_payload: BlindedPayloadCapella {
-                    execution_payload_header: From::from(execution_payload.clone()),
+                    execution_payload_header: From::from(&execution_payload),
                 },
                 bls_to_execution_changes,
             },
@@ -363,7 +363,7 @@ impl<E: EthSpec> From<BeaconBlockBodyEip4844<E, FullPayload<E>>>
                 voluntary_exits,
                 sync_aggregate,
                 execution_payload: BlindedPayloadEip4844 {
-                    execution_payload_header: From::from(execution_payload.clone()),
+                    execution_payload_header: From::from(&execution_payload),
                 },
                 bls_to_execution_changes,
                 blob_kzg_commitments,
@@ -414,7 +414,7 @@ impl<E: EthSpec> BeaconBlockBodyMerge<E, FullPayload<E>> {
             voluntary_exits: voluntary_exits.clone(),
             sync_aggregate: sync_aggregate.clone(),
             execution_payload: BlindedPayloadMerge {
-                execution_payload_header: From::from(execution_payload.clone()),
+                execution_payload_header: execution_payload.into(),
             },
         }
     }
@@ -447,7 +447,7 @@ impl<E: EthSpec> BeaconBlockBodyCapella<E, FullPayload<E>> {
             voluntary_exits: voluntary_exits.clone(),
             sync_aggregate: sync_aggregate.clone(),
             execution_payload: BlindedPayloadCapella {
-                execution_payload_header: From::from(execution_payload.clone()),
+                execution_payload_header: execution_payload.into(),
             },
             bls_to_execution_changes: bls_to_execution_changes.clone(),
         }
@@ -482,7 +482,7 @@ impl<E: EthSpec> BeaconBlockBodyEip4844<E, FullPayload<E>> {
             voluntary_exits: voluntary_exits.clone(),
             sync_aggregate: sync_aggregate.clone(),
             execution_payload: BlindedPayloadEip4844 {
-                execution_payload_header: From::from(execution_payload.clone()),
+                execution_payload_header: execution_payload.into(),
             },
             bls_to_execution_changes: bls_to_execution_changes.clone(),
             blob_kzg_commitments: blob_kzg_commitments.clone(),

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -35,7 +35,9 @@ pub type Withdrawals<T> = VariableList<Withdrawal, <T as EthSpec>::MaxWithdrawal
         arbitrary(bound = "T: EthSpec")
     ),
     cast_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
-    partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant")
+    partial_getter_error(ty = "Error", expr = "BeaconStateError::IncorrectStateVariant"),
+    map_into(FullPayload, BlindedPayload),
+    map_ref_into(ExecutionPayloadHeader)
 )]
 #[derive(
     Debug, Clone, Serialize, Encode, Deserialize, TreeHash, Derivative, arbitrary::Arbitrary,

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -159,40 +159,40 @@ impl<T: EthSpec> ExecutionPayloadHeaderCapella<T> {
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayloadMerge<T>> for ExecutionPayloadHeaderMerge<T> {
-    fn from(payload: ExecutionPayloadMerge<T>) -> Self {
+impl<'a, T: EthSpec> From<&'a ExecutionPayloadMerge<T>> for ExecutionPayloadHeaderMerge<T> {
+    fn from(payload: &'a ExecutionPayloadMerge<T>) -> Self {
         Self {
             parent_hash: payload.parent_hash,
             fee_recipient: payload.fee_recipient,
             state_root: payload.state_root,
             receipts_root: payload.receipts_root,
-            logs_bloom: payload.logs_bloom,
+            logs_bloom: payload.logs_bloom.clone(),
             prev_randao: payload.prev_randao,
             block_number: payload.block_number,
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: payload.extra_data,
+            extra_data: payload.extra_data.clone(),
             base_fee_per_gas: payload.base_fee_per_gas,
             block_hash: payload.block_hash,
             transactions_root: payload.transactions.tree_hash_root(),
         }
     }
 }
-impl<T: EthSpec> From<ExecutionPayloadCapella<T>> for ExecutionPayloadHeaderCapella<T> {
-    fn from(payload: ExecutionPayloadCapella<T>) -> Self {
+impl<'a, T: EthSpec> From<&'a ExecutionPayloadCapella<T>> for ExecutionPayloadHeaderCapella<T> {
+    fn from(payload: &'a ExecutionPayloadCapella<T>) -> Self {
         Self {
             parent_hash: payload.parent_hash,
             fee_recipient: payload.fee_recipient,
             state_root: payload.state_root,
             receipts_root: payload.receipts_root,
-            logs_bloom: payload.logs_bloom,
+            logs_bloom: payload.logs_bloom.clone(),
             prev_randao: payload.prev_randao,
             block_number: payload.block_number,
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: payload.extra_data,
+            extra_data: payload.extra_data.clone(),
             base_fee_per_gas: payload.base_fee_per_gas,
             block_hash: payload.block_hash,
             transactions_root: payload.transactions.tree_hash_root(),
@@ -200,20 +200,21 @@ impl<T: EthSpec> From<ExecutionPayloadCapella<T>> for ExecutionPayloadHeaderCape
         }
     }
 }
-impl<T: EthSpec> From<ExecutionPayloadEip4844<T>> for ExecutionPayloadHeaderEip4844<T> {
-    fn from(payload: ExecutionPayloadEip4844<T>) -> Self {
+
+impl<'a, T: EthSpec> From<&'a ExecutionPayloadEip4844<T>> for ExecutionPayloadHeaderEip4844<T> {
+    fn from(payload: &'a ExecutionPayloadEip4844<T>) -> Self {
         Self {
             parent_hash: payload.parent_hash,
             fee_recipient: payload.fee_recipient,
             state_root: payload.state_root,
             receipts_root: payload.receipts_root,
-            logs_bloom: payload.logs_bloom,
+            logs_bloom: payload.logs_bloom.clone(),
             prev_randao: payload.prev_randao,
             block_number: payload.block_number,
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: payload.extra_data,
+            extra_data: payload.extra_data.clone(),
             base_fee_per_gas: payload.base_fee_per_gas,
             excess_data_gas: payload.excess_data_gas,
             block_hash: payload.block_hash,
@@ -223,31 +224,33 @@ impl<T: EthSpec> From<ExecutionPayloadEip4844<T>> for ExecutionPayloadHeaderEip4
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayloadMerge<T>> for ExecutionPayloadHeader<T> {
-    fn from(payload: ExecutionPayloadMerge<T>) -> Self {
-        Self::Merge(ExecutionPayloadHeaderMerge::from(payload))
+// These impls are required to work around an inelegance in `to_execution_payload_header`.
+// They only clone headers so they should be relatively cheap.
+impl<'a, T: EthSpec> From<&'a Self> for ExecutionPayloadHeaderMerge<T> {
+    fn from(payload: &'a Self) -> Self {
+        payload.clone()
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayloadCapella<T>> for ExecutionPayloadHeader<T> {
-    fn from(payload: ExecutionPayloadCapella<T>) -> Self {
-        Self::Capella(ExecutionPayloadHeaderCapella::from(payload))
+impl<'a, T: EthSpec> From<&'a Self> for ExecutionPayloadHeaderCapella<T> {
+    fn from(payload: &'a Self) -> Self {
+        payload.clone()
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayloadEip4844<T>> for ExecutionPayloadHeader<T> {
-    fn from(payload: ExecutionPayloadEip4844<T>) -> Self {
-        Self::Eip4844(ExecutionPayloadHeaderEip4844::from(payload))
+impl<'a, T: EthSpec> From<&'a Self> for ExecutionPayloadHeaderEip4844<T> {
+    fn from(payload: &'a Self) -> Self {
+        payload.clone()
     }
 }
 
-impl<T: EthSpec> From<ExecutionPayload<T>> for ExecutionPayloadHeader<T> {
-    fn from(payload: ExecutionPayload<T>) -> Self {
-        match payload {
-            ExecutionPayload::Merge(payload) => Self::from(payload),
-            ExecutionPayload::Capella(payload) => Self::from(payload),
-            ExecutionPayload::Eip4844(payload) => Self::from(payload),
-        }
+impl<'a, T: EthSpec> From<ExecutionPayloadRef<'a, T>> for ExecutionPayloadHeader<T> {
+    fn from(payload: ExecutionPayloadRef<'a, T>) -> Self {
+        map_execution_payload_ref_into_execution_payload_header!(
+            &'a _,
+            payload,
+            |inner, cons| cons(inner.into())
+        )
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

I set out to remove some `FIXME`s that I noticed while reviewing, and ended up removing some redundant `clone`s as well.

- Refactored the payload types so that we prefer to create payload headers from payloads _without cloning_. Some extra cloning had snuck in to the previous implementation. Fixing this resolved several FIXMEs as well.
- Used some more superstruct mapping macros throughout.
- Removed some `FIXME` comments related to optimisations. IMO these are non-urgent and can be picked up in due time. I don't think any of the removed comments warrant their own issues.

