### PR TITLE
[Merged by Bors] - Fix exec integration tests for Geth v1.11.0

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -283,7 +283,7 @@ jobs:
         go-version: '1.20'
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.200'
+        dotnet-version: '6.0.201'
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -280,10 +280,10 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.20'
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.201'
+        dotnet-version: '7.0.200'
     - name: Get latest version of stable Rust
       run: rustup update stable
     - name: Install Protoc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,6 +2463,7 @@ dependencies = [
  "fork_choice",
  "futures",
  "hex",
+ "logging",
  "reqwest",
  "sensitive_url",
  "serde_json",

--- a/testing/execution_engine_integration/Cargo.toml
+++ b/testing/execution_engine_integration/Cargo.toml
@@ -21,3 +21,4 @@ deposit_contract = { path = "../../common/deposit_contract" }
 reqwest = { version = "0.11.0", features = ["json"] }
 hex = "0.4.2"
 fork_choice = { path = "../../consensus/fork_choice" }
+logging = { path = "../../common/logging" }


### PR DESCRIPTION
## Proposed Changes

* Bump Go from 1.17 to 1.20. The latest Geth release v1.11.0 requires 1.18 minimum.
* Prevent a cache miss during payload building by using the right fee recipient. This prevents Geth v1.11.0 from building a block with 0 transactions. The payload building mechanism is overhauled in the new Geth to improve the payload every 2s, and the tests were failing because we were falling back on a `getPayload` call with no lookahead due to `get_payload_id` cache miss caused by the mismatched fee recipient. Alternatively we could hack the tests to send `proposer_preparation_data`, but I think the static fee recipient is simpler for now.
* Add support for optionally enabling Lighthouse logs in the integration tests. Enable using `cargo run --release --features logging/test_logger`. This was very useful for debugging.