### PR TITLE
Suggestions for Capella `execution_layer`

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 use std::collections::HashSet;
 use tokio::sync::Mutex;
 
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant};
 use types::EthSpec;
 
 pub use deposit_log::{DepositLog, Log};
@@ -559,14 +559,14 @@ pub mod deposit_methods {
 #[derive(Clone, Debug)]
 pub struct CapabilitiesCacheEntry {
     engine_capabilities: EngineCapabilities,
-    fetch_time: SystemTime,
+    fetch_time: Instant,
 }
 
 impl CapabilitiesCacheEntry {
     pub fn new(engine_capabilities: EngineCapabilities) -> Self {
         Self {
             engine_capabilities,
-            fetch_time: SystemTime::now(),
+            fetch_time: Instant::now(),
         }
     }
 
@@ -575,15 +575,7 @@ impl CapabilitiesCacheEntry {
     }
 
     pub fn age(&self) -> Duration {
-        // duration_since() may fail because measurements taken earlier
-        // are not guaranteed to always be before later measurements
-        // due to anomalies such as the system clock being adjusted
-        // either forwards or backwards
-        //
-        // In such cases, we'll just say the age is zero
-        SystemTime::now()
-            .duration_since(self.fetch_time)
-            .unwrap_or(Duration::ZERO)
+        Instant::now().duration_since(self.fetch_time)
     }
 
     /// returns `true` if the entry's age is >= age_limit

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -145,7 +145,6 @@ impl<T: EthSpec> From<ExecutionPayloadCapella<T>> for JsonExecutionPayloadV2<T> 
             withdrawals: payload
                 .withdrawals
                 .into_iter()
-                .cloned()
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),
@@ -173,7 +172,6 @@ impl<T: EthSpec> From<ExecutionPayloadEip4844<T>> for JsonExecutionPayloadV3<T> 
             withdrawals: payload
                 .withdrawals
                 .into_iter()
-                .cloned()
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),
@@ -231,7 +229,6 @@ impl<T: EthSpec> From<JsonExecutionPayloadV2<T>> for ExecutionPayloadCapella<T> 
             withdrawals: payload
                 .withdrawals
                 .into_iter()
-                .cloned()
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),
@@ -259,7 +256,6 @@ impl<T: EthSpec> From<JsonExecutionPayloadV3<T>> for ExecutionPayloadEip4844<T> 
             withdrawals: payload
                 .withdrawals
                 .into_iter()
-                .cloned()
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),

--- a/beacon_node/execution_layer/src/engines.rs
+++ b/beacon_node/execution_layer/src/engines.rs
@@ -342,7 +342,7 @@ impl Engine {
     /// deadlock.
     pub async fn request<'a, F, G, H>(self: &'a Arc<Self>, func: F) -> Result<H, EngineError>
     where
-        F: Fn(&'a Engine) -> G,
+        F: FnOnce(&'a Engine) -> G,
         G: Future<Output = Result<H, EngineApiError>>,
     {
         match func(self).await {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1718,7 +1718,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     capella_block
                         .withdrawals
                         .into_iter()
-                        .map(|w| w.into())
+                        .map(Into::into)
                         .collect(),
                 )
                 .map_err(ApiError::DeserializeWithdrawals)?;
@@ -1745,7 +1745,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     eip4844_block
                         .withdrawals
                         .into_iter()
-                        .map(|w| w.into())
+                        .map(Into::into)
                         .collect(),
                 )
                 .map_err(ApiError::DeserializeWithdrawals)?;

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1348,16 +1348,11 @@ impl<T: EthSpec> ExecutionLayer<T> {
             .set_latest_forkchoice_state(forkchoice_state)
             .await;
 
-        let payload_attributes_ref = &payload_attributes;
         let result = self
             .engine()
             .request(|engine| async move {
                 engine
-                    .notify_forkchoice_updated(
-                        forkchoice_state,
-                        payload_attributes_ref.clone(),
-                        self.log(),
-                    )
+                    .notify_forkchoice_updated(forkchoice_state, payload_attributes, self.log())
                     .await
             })
             .await;

--- a/consensus/ssz_types/src/variable_list.rs
+++ b/consensus/ssz_types/src/variable_list.rs
@@ -176,6 +176,15 @@ impl<'a, T, N: Unsigned> IntoIterator for &'a VariableList<T, N> {
     }
 }
 
+impl<T, N: Unsigned> IntoIterator for VariableList<T, N> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
 impl<T, N: Unsigned> tree_hash::TreeHash for VariableList<T, N>
 where
     T: tree_hash::TreeHash,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

These are some minor suggestions/nit I have after my [review](https://github.com/sigp/lighthouse/pull/3763#pullrequestreview-1300521945) on the `execution_layer` crate of #3763.

1. 300ca74690ceaa2e5497c57ad1d1e818cb66bf39: avoid a clone by restricting a closure to `FnOnce` rather than just `Fn`.
1. 262784410a7f74b0810ee3bce4d9d0fc8f9d0432: super minor nit that I would have expected clippy to catch.
1. 3d1f874d290bd2afdf35ceb2beed971a5b857004: avoid some cloning by adding a proper `IntoIterator` implementation for `VariableList` (previously we only had the impl for `&VariableList`).
1. 1a90fca478777bf05cc4736ab4ec00ad9e086678: Removes some complexity in `CapabilitiesCacheEntry` by using `std::time::Instant` rather than `std::time::SystemTime`. `Instant` is "a monotonically nondecreasing clock", which avoids some funkiness in the `age` function.

## Additional Info

NA