### PR TITLE
[Merged by Bors] - Fix doppelganger script

### DIFF
--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -45,7 +45,7 @@ SECONDS_PER_SLOT=3
 SECONDS_PER_ETH1_BLOCK=1
 
 # Proposer score boost percentage
-PROPOSER_SCORE_BOOST=70
+PROPOSER_SCORE_BOOST=40
 
 # Command line arguments for validator client
 VC_ARGS=""

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -85,7 +85,7 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
 
     # We expect to find a doppelganger, exit with success error code if doppelganger was found
     # and failure if no doppelganger was found.
-    if [[ $DOPPELGANGER_EXIT -eq 124 ]]; then
+    if [[ $DOPPELGANGER_EXIT -eq 1 ]]; then
         exit 0
     else
         exit 1

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -2,7 +2,6 @@
 
 # Requires `lighthouse`, ``lcli`, `ganache`, `curl`, `jq`
 
-set -Eeuo pipefail
 
 BEHAVIOR=$1
 
@@ -11,13 +10,22 @@ if [[ "$BEHAVIOR" != "success" ]] && [[ "$BEHAVIOR" != "failure" ]]; then
     exit 1
 fi
 
+exit_if_fails() {
+    echo $@
+    $@
+    EXIT_CODE=$?
+    if [[ $EXIT_CODE -eq 1 ]]; then
+        exit 111
+    fi
+}
+
 source ./vars.env
 
-../local_testnet/clean.sh
+exit_if_fails ../local_testnet/clean.sh
 
 echo "Starting ganache"
 
-../local_testnet/ganache_test_node.sh &> /dev/null &
+exit_if_fails ../local_testnet/ganache_test_node.sh &> /dev/null &
 GANACHE_PID=$!
 
 # Wait for ganache to start
@@ -25,14 +33,14 @@ sleep 5
 
 echo "Setting up local testnet"
 
-../local_testnet/setup.sh
+exit_if_fails ../local_testnet/setup.sh
 
 # Duplicate this directory so slashing protection doesn't keep us from re-using validator keys
-cp -R $HOME/.lighthouse/local-testnet/node_1 $HOME/.lighthouse/local-testnet/node_1_doppelganger
+exit_if_fails cp -R $HOME/.lighthouse/local-testnet/node_1 $HOME/.lighthouse/local-testnet/node_1_doppelganger
 
 echo "Starting bootnode"
 
-../local_testnet/bootnode.sh &> /dev/null &
+exit_if_fails ../local_testnet/bootnode.sh &> /dev/null &
 BOOT_PID=$!
 
 # wait for the bootnode to start
@@ -40,20 +48,20 @@ sleep 10
 
 echo "Starting local beacon nodes"
 
-../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_1 9000 8000 &> /dev/null &
+exit_if_fails ../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_1 9000 8000 &> /dev/null &
 BEACON_PID=$!
-../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_2 9100 8100 &> /dev/null &
+exit_if_fails ../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_2 9100 8100 &> /dev/null &
 BEACON_PID2=$!
-../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_3 9200 8200 &> /dev/null &
+exit_if_fails ../local_testnet/beacon_node.sh $HOME/.lighthouse/local-testnet/node_3 9200 8200 &> /dev/null &
 BEACON_PID3=$!
 
 echo "Starting local validator clients"
 
-../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_1 http://localhost:8000 &> /dev/null &
+exit_if_fails ../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_1 http://localhost:8000 &> /dev/null &
 VALIDATOR_1_PID=$!
-../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_2 http://localhost:8100 &> /dev/null &
+exit_if_fails ../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_2 http://localhost:8100 &> /dev/null &
 VALIDATOR_2_PID=$!
-../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_3 http://localhost:8200 &> /dev/null &
+exit_if_fails ../local_testnet/validator_client.sh $HOME/.lighthouse/local-testnet/node_3 http://localhost:8200 &> /dev/null &
 VALIDATOR_3_PID=$!
 
 echo "Waiting an epoch before starting the next validator client"
@@ -75,9 +83,14 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
 
     echo "Done"
 
+    # We expect to find a doppelganger, exit with success error code if doppelganger was found
+    # and failure if no doppelganger was found.
     if [[ $DOPPELGANGER_EXIT -eq 124 ]]; then
+        exit 0
+    else
         exit 1
     fi
+
 fi
 
 if [[ "$BEHAVIOR" == "success" ]]; then

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -2,6 +2,8 @@
 
 # Requires `lighthouse`, ``lcli`, `ganache`, `curl`, `jq`
 
+set -Eeuo pipefail
+
 BEHAVIOR=$1
 
 if [[ "$BEHAVIOR" != "success" ]] && [[ "$BEHAVIOR" != "failure" ]]; then

--- a/scripts/tests/vars.env
+++ b/scripts/tests/vars.env
@@ -45,7 +45,7 @@ SECONDS_PER_SLOT=3
 SECONDS_PER_ETH1_BLOCK=1
 
 # Proposer score boost percentage
-PROPOSER_SCORE_BOOST=70
+PROPOSER_SCORE_BOOST=40
 
 # Enable doppelganger detection
 VC_ARGS=" --enable-doppelganger-protection "

--- a/scripts/tests/vars.env
+++ b/scripts/tests/vars.env
@@ -44,5 +44,8 @@ SECONDS_PER_SLOT=3
 # Seconds per Eth1 block
 SECONDS_PER_ETH1_BLOCK=1
 
+# Proposer score boost percentage
+PROPOSER_SCORE_BOOST=70
+
 # Enable doppelganger detection
 VC_ARGS=" --enable-doppelganger-protection "


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The doppelganger tests were failing silently since the `PROPOSER_BOOST` config was not set. Sets the config and script returns an error if any subprocess fails. 
