### PR TITLE
[Merged by Bors] - v3.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -785,7 +785,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -3719,7 +3719,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2021"
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v3.4.0-",
-    fallback = "Lighthouse/v3.4.0"
+    prefix = "Lighthouse/v3.5.0-",
+    fallback = "Lighthouse/v3.5.0"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Bump versions

## Sepolia Capella Upgrade

This release will enable the Capella fork on Sepolia. We are planning to publish this release on the 23rd of Feb 2023.

Users who can build from source and wish to do pre-release testing can use this branch.

## Additional Info

NA