### PR TITLE
[Merged by Bors] - Added warning when new jwt is generated

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -228,7 +228,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 .map_err(Error::InvalidJWTSecret)
         } else {
             // Create a new file and write a randomly generated secret to it if file does not exist
-            warn!(log, "No JWT found given path. Generating" ; "path" =>default_datadir.join(&secret_file).as_path().to_str().unwrap());
+            warn!(log, "No JWT found on disk. Generating"; "path" => %secret_file.display());
             std::fs::File::options()
                 .write(true)
                 .create_new(true)

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -228,6 +228,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 .map_err(Error::InvalidJWTSecret)
         } else {
             // Create a new file and write a randomly generated secret to it if file does not exist
+            warn!(log, "No JWT found given path. Generating" ; "path" =>default_datadir.join(&secret_file).as_path().to_str().unwrap());
             std::fs::File::options()
                 .write(true)
                 .create_new(true)


### PR DESCRIPTION
## Issue Addressed
#3435

## Proposed Changes
Fire a warning with the path of JWT to be created when the path given by --execution-jwt is not found
Currently, the same error is logged if the jwt is found but doesn't match the execution client's jwt, and if no jwt was found at the given path. This makes it very hard to tell if you accidentally typed the wrong path, as a new jwt is created silently that won't match the execution client's jwt. So instead, it will now fire a warning stating that a jwt is being generated at the given path.

## Additional Info
In the future, it may be smarter to handle this case by adding an InvalidJWTPath member to the Error enum in lib.rs or auth.rs
that can be handled during upcheck()

This is my first PR and first project with rust. so thanks to anyone who looks at this for their patience and help!