### PR TITLE
[Merged by Bors] - Register disconnected peers when temporarily banned

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -847,6 +847,10 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                     PeerConnectionStatus::Disconnecting { .. } => {
                         // The peer has been disconnected but not banned. Inform the peer manager
                         // that this peer could be eligible for a temporary ban.
+                        self.disconnected_peers += 1;
+                        info.set_connection_status(PeerConnectionStatus::Disconnected {
+                            since: Instant::now(),
+                        });
                         return Some(BanOperation::TemporaryBan);
                     }
                     PeerConnectionStatus::Unknown


### PR DESCRIPTION
This is a correction to #3757. 

The correction registers a peer that is being disconnected in the local peer manager db to ensure we are tracking the correct state. 