### PR TITLE
[Merged by Bors] - Add debug fork choice api

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2171,7 +2171,7 @@ pub fn serve<T: BeaconChainTypes>(
                             None
                         };
 
-                        Ok(ForkChoiceNode {
+                        ForkChoiceNode {
                             slot: node.slot,
                             block_root: node.root,
                             parent_root: node
@@ -2190,13 +2190,13 @@ pub fn serve<T: BeaconChainTypes>(
                                 .execution_status
                                 .block_hash()
                                 .map(|block_hash| block_hash.into_root()),
-                        })
+                        }
                     })
-                    .collect::<Result<Vec<_>, warp::Rejection>>();
+                    .collect::<Vec<_>>();
                 Ok(ForkChoice {
                     justified_checkpoint: proto_array.justified_checkpoint,
                     finalized_checkpoint: proto_array.finalized_checkpoint,
-                    fork_choice_nodes: fork_choice_nodes?,
+                    fork_choice_nodes,
                 })
             })
         });

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -8,7 +8,7 @@ use environment::null_logger;
 use eth2::{
     mixin::{RequestAccept, ResponseForkName, ResponseOptional},
     reqwest::RequestBuilder,
-    types::{BlockId as CoreBlockId, StateId as CoreStateId, *},
+    types::{BlockId as CoreBlockId, ForkChoiceNode, StateId as CoreStateId, *},
     BeaconNodeHttpClient, Error, StatusCode, Timeouts,
 };
 use execution_layer::test_utils::TestingBuilder;
@@ -1680,24 +1680,54 @@ impl ApiTester {
     }
 
     pub async fn test_get_debug_fork_choice(self) -> Self {
-        let result = self
-            .client
-            .get_debug_fork_choice()
-            .await
-            .unwrap();
+        let result = self.client.get_debug_fork_choice().await.unwrap();
 
-        let beacon_fork_choice = self
-            .chain
-            .canonical_head
-            .fork_choice_read_lock();
+        let beacon_fork_choice = self.chain.canonical_head.fork_choice_read_lock();
 
-        let expected = beacon_fork_choice
-            .proto_array()
-            .core_proto_array();
+        let expected_proto_array = beacon_fork_choice.proto_array().core_proto_array();
 
-        assert_eq!(result.justified_checkpoint, expected.justified_checkpoint);
-        assert_eq!(result.finalized_checkpoint, expected.finalized_checkpoint);
+        assert_eq!(
+            result.justified_checkpoint,
+            expected_proto_array.justified_checkpoint
+        );
+        assert_eq!(
+            result.finalized_checkpoint,
+            expected_proto_array.finalized_checkpoint
+        );
 
+        let expected_fork_choice_nodes: Vec<ForkChoiceNode> = expected_proto_array
+            .nodes
+            .iter()
+            .map(|node| {
+                let execution_status = if node.execution_status.is_execution_enabled() {
+                    Some(node.execution_status.to_string())
+                } else {
+                    None
+                };
+                ForkChoiceNode {
+                    slot: node.slot,
+                    block_root: node.root,
+                    parent_root: node
+                        .parent
+                        .and_then(|index| expected_proto_array.nodes.get(index))
+                        .map(|parent| parent.root),
+                    justified_epoch: node.justified_checkpoint.map(|checkpoint| checkpoint.epoch),
+                    finalized_epoch: node.finalized_checkpoint.map(|checkpoint| checkpoint.epoch),
+                    weight: node.weight,
+                    validity: execution_status,
+                    execution_block_hash: node
+                        .execution_status
+                        .block_hash()
+                        .map(|block_hash| block_hash.into_root()),
+                }
+            })
+            .collect();
+
+        assert_eq!(result.fork_choice_nodes, expected_fork_choice_nodes);
+
+        // need to drop beacon_fork_choice here, else borrow checker will complain
+        // that self cannot be moved out since beacon_fork_choice borrowed self.chain
+        // and might still live after self is moved out
         drop(beacon_fork_choice);
         self
     }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1679,6 +1679,29 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_get_debug_fork_choice(self) -> Self {
+        let result = self
+            .client
+            .get_debug_fork_choice()
+            .await
+            .unwrap();
+
+        let beacon_fork_choice = self
+            .chain
+            .canonical_head
+            .fork_choice_read_lock();
+
+        let expected = beacon_fork_choice
+            .proto_array()
+            .core_proto_array();
+
+        assert_eq!(result.justified_checkpoint, expected.justified_checkpoint);
+        assert_eq!(result.finalized_checkpoint, expected.finalized_checkpoint);
+
+        drop(beacon_fork_choice);
+        self
+    }
+
     fn validator_count(&self) -> usize {
         self.chain.head_snapshot().beacon_state.validators().len()
     }
@@ -4148,6 +4171,8 @@ async fn debug_get() {
         .test_get_debug_beacon_states()
         .await
         .test_get_debug_beacon_heads()
+        .await
+        .test_get_debug_fork_choice()
         .await;
 }
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1334,6 +1334,20 @@ impl BeaconNodeHttpClient {
         self.get(path).await
     }
 
+    /// `GET v1/debug/fork_choice`
+    pub async fn get_debug_fork_choice(
+        &self,
+    ) -> Result<ForkChoice, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("debug")
+            .push("fork_choice");
+
+        self.get(path).await
+    }
+
     /// `GET validator/duties/proposer/{epoch}`
     pub async fn get_validator_duties_proposer(
         &self,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1335,9 +1335,7 @@ impl BeaconNodeHttpClient {
     }
 
     /// `GET v1/debug/fork_choice`
-    pub async fn get_debug_fork_choice(
-        &self,
-    ) -> Result<ForkChoice, Error> {
+    pub async fn get_debug_fork_choice(&self) -> Result<ForkChoice, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -10,7 +10,6 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;
-use proto_array::ExecutionStatus;
 pub use types::*;
 
 #[cfg(feature = "lighthouse")]
@@ -1209,12 +1208,13 @@ pub struct ForkChoice {
 pub struct ForkChoiceNode {
     pub slot: Slot,
     pub block_root: Hash256,
-    pub parent_root: Option<usize>,
+    pub parent_root: Option<Hash256>,
     pub justified_epoch: Option<Epoch>,
     pub finalized_epoch: Option<Epoch>,
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub weight: u64,
-    pub validity: Option<ExecutionStatus>,
-    pub execution_block_hash: Option<ExecutionBlockHash>,
+    pub validity: Option<String>,
+    pub execution_block_hash: Option<Hash256>,
 }
 
 #[cfg(test)]

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1204,7 +1204,7 @@ pub struct ForkChoice {
     pub fork_choice_nodes: Vec<ForkChoiceNode>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ForkChoiceNode {
     pub slot: Slot,
     pub block_root: Hash256,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -10,6 +10,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;
+use proto_array::ExecutionStatus;
 pub use types::*;
 
 #[cfg(feature = "lighthouse")]
@@ -1195,6 +1196,25 @@ pub struct LivenessResponseData {
     pub index: u64,
     pub epoch: Epoch,
     pub is_live: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ForkChoice {
+    pub justified_checkpoint: Checkpoint,
+    pub finalized_checkpoint: Checkpoint,
+    pub fork_choice_nodes: Vec<ForkChoiceNode>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ForkChoiceNode {
+    pub slot: Slot,
+    pub block_root: Hash256,
+    pub parent_root: Option<usize>,
+    pub justified_epoch: Option<Epoch>,
+    pub finalized_epoch: Option<Epoch>,
+    pub weight: u64,
+    pub validity: Option<ExecutionStatus>,
+    pub execution_block_hash: Option<ExecutionBlockHash>,
 }
 
 #[cfg(test)]

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -10,7 +10,10 @@ use crate::{
 use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt,
+};
 use types::{
     AttestationShufflingId, ChainSpec, Checkpoint, Epoch, EthSpec, ExecutionBlockHash, Hash256,
     Slot,
@@ -122,6 +125,17 @@ impl ExecutionStatus {
     /// - Does not have execution enabled (before or after Bellatrix fork)
     pub fn is_irrelevant(&self) -> bool {
         matches!(self, ExecutionStatus::Irrelevant(_))
+    }
+}
+
+impl fmt::Display for ExecutionStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExecutionStatus::Valid(_) => write!(f, "valid"),
+            ExecutionStatus::Invalid(_) => write!(f, "invalid"),
+            ExecutionStatus::Optimistic(_) => write!(f, "optimistic"),
+            ExecutionStatus::Irrelevant(_) => write!(f, "irrelevant"),
+        }
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?
https://github.com/sigp/lighthouse/issues/3669

## Proposed Changes

Please list or describe the changes introduced by this PR.
- A new API to fetch fork choice data, as specified [here](https://github.com/ethereum/beacon-APIs/pull/232)
- A new integration test to test the new API

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.

- `extra_data` field specified in the beacon-API spec is not implemented, please let me know if I should instead.