### PR TITLE
Customisable shuffling cache size

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -765,6 +765,7 @@ where
         let genesis_time = head_snapshot.beacon_state.genesis_time();
         let head_for_snapshot_cache = head_snapshot.clone();
         let canonical_head = CanonicalHead::new(fork_choice, Arc::new(head_snapshot));
+        let shuffling_cache_size = self.chain_config.shuffling_cache_size;
 
         let beacon_chain = BeaconChain {
             spec: self.spec,
@@ -817,7 +818,7 @@ where
                 DEFAULT_SNAPSHOT_CACHE_SIZE,
                 head_for_snapshot_cache,
             )),
-            shuffling_cache: TimeoutRwLock::new(ShufflingCache::new()),
+            shuffling_cache: TimeoutRwLock::new(ShufflingCache::new(shuffling_cache_size)),
             eth1_finalization_cache: TimeoutRwLock::new(Eth1FinalizationCache::new(log.clone())),
             beacon_proposer_cache: <_>::default(),
             block_times_cache: <_>::default(),

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -67,6 +67,8 @@ pub struct ChainConfig {
     pub prepare_payload_lookahead: Duration,
     /// Use EL-free optimistic sync for the finalized part of the chain.
     pub optimistic_finalized_sync: bool,
+    /// The size of the shuffling cache,
+    pub shuffling_cache_size: usize,
 }
 
 impl Default for ChainConfig {
@@ -92,6 +94,7 @@ impl Default for ChainConfig {
             checkpoint_sync_url_timeout: 60,
             prepare_payload_lookahead: Duration::from_secs(4),
             optimistic_finalized_sync: true,
+            shuffling_cache_size: crate::shuffling_cache::DEFAULT_CACHE_SIZE,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -39,7 +39,7 @@ mod persisted_fork_choice;
 mod pre_finalization_cache;
 pub mod proposer_prep_service;
 pub mod schema_change;
-mod shuffling_cache;
+pub mod shuffling_cache;
 mod snapshot_cache;
 pub mod state_advance_timer;
 pub mod sync_committee_rewards;

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -9,7 +9,7 @@ use types::{beacon_state::CommitteeCache, AttestationShufflingId, Epoch, Hash256
 /// Each entry should be `8 + 800,000 = 800,008` bytes in size with 100k validators. (8-byte hash +
 /// 100k indices). Therefore, this cache should be approx `16 * 800,008 = 12.8 MB`. (Note: this
 /// ignores a few extra bytes in the caches that should be insignificant compared to the indices).
-const CACHE_SIZE: usize = 16;
+const CACHE_SIZE: usize = 8000;
 
 /// The maximum number of concurrent committee cache "promises" that can be issued. In effect, this
 /// limits the number of concurrent states that can be loaded into memory for the committee cache.
@@ -20,7 +20,7 @@ const CACHE_SIZE: usize = 16;
 /// always be inserted during block import. Unstable networks with a high degree of forking might
 /// see some attestations dropped due to this concurrency limit, however I propose that this is
 /// better than low-resource nodes going OOM.
-const MAX_CONCURRENT_PROMISES: usize = 2;
+const MAX_CONCURRENT_PROMISES: usize = 20;
 
 #[derive(Clone)]
 pub enum CacheItem {

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -20,7 +20,7 @@ pub const DEFAULT_CACHE_SIZE: usize = 16;
 /// always be inserted during block import. Unstable networks with a high degree of forking might
 /// see some attestations dropped due to this concurrency limit, however I propose that this is
 /// better than low-resource nodes going OOM.
-const MAX_CONCURRENT_PROMISES: usize = 20;
+const MAX_CONCURRENT_PROMISES: usize = 2;
 
 #[derive(Clone)]
 pub enum CacheItem {

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -9,7 +9,7 @@ use types::{beacon_state::CommitteeCache, AttestationShufflingId, Epoch, Hash256
 /// Each entry should be `8 + 800,000 = 800,008` bytes in size with 100k validators. (8-byte hash +
 /// 100k indices). Therefore, this cache should be approx `16 * 800,008 = 12.8 MB`. (Note: this
 /// ignores a few extra bytes in the caches that should be insignificant compared to the indices).
-const CACHE_SIZE: usize = 8000;
+pub const DEFAULT_CACHE_SIZE: usize = 16;
 
 /// The maximum number of concurrent committee cache "promises" that can be issued. In effect, this
 /// limits the number of concurrent states that can be loaded into memory for the committee cache.
@@ -54,9 +54,9 @@ pub struct ShufflingCache {
 }
 
 impl ShufflingCache {
-    pub fn new() -> Self {
+    pub fn new(cache_size: usize) -> Self {
         Self {
-            cache: LruCache::new(CACHE_SIZE),
+            cache: LruCache::new(cache_size),
         }
     }
 
@@ -172,7 +172,7 @@ impl ToArcCommitteeCache for Arc<CommitteeCache> {
 
 impl Default for ShufflingCache {
     fn default() -> Self {
-        Self::new()
+        Self::new(DEFAULT_CACHE_SIZE)
     }
 }
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -853,7 +853,7 @@ pub fn serve<T: BeaconChainTypes>(
                                                 },
                                             )?;
 
-                                        let owned_cache = possibly_built_cache.into_owned();
+                                        let owned_cache = Arc::new(possibly_built_cache.into_owned());
                                         // Attempt to write to the beacon cache
                                         if let Some(mut cache_write) = chain
                                             .shuffling_cache
@@ -862,7 +862,7 @@ pub fn serve<T: BeaconChainTypes>(
                                             cache_write
                                                 .insert_committee_cache(shuffling_id, &owned_cache);
                                         }
-                                        Arc::new(owned_cache)
+                                        owned_cache
                                     }
                                 };
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -787,25 +787,30 @@ pub fn serve<T: BeaconChainTypes>(
                                     .end_slot(T::EthSpec::slots_per_epoch());
                                 // Find the decision block and skip to another method on any kind
                                 // of failure
-                                let shuffling_id = if let Ok(Some(shuffling_decision_block)) = chain
-                                    .block_root_at_slot(decision_slot, WhenSlotSkipped::Prev) {
+                                let shuffling_id = if let Ok(Some(shuffling_decision_block)) =
+                                    chain.block_root_at_slot(decision_slot, WhenSlotSkipped::Prev)
+                                {
                                     Some(AttestationShufflingId {
                                         shuffling_epoch: epoch,
                                         shuffling_decision_block,
                                     })
-                                    } else {
-                                        None
-                                    };
+                                } else {
+                                    None
+                                };
 
-                                    // Attempt to read from the chain cache if there exists a
-                                    // shuffling_id
-                                    let maybe_cached_shuffling = if let Some(shuffling_id) = shuffling_id.as_ref() {
+                                // Attempt to read from the chain cache if there exists a
+                                // shuffling_id
+                                let maybe_cached_shuffling = if let Some(shuffling_id) =
+                                    shuffling_id.as_ref()
+                                {
                                     chain
                                         .shuffling_cache
                                         .try_write_for(std::time::Duration::from_secs(1))
                                         .and_then(|mut cache_write| cache_write.get(&shuffling_id))
                                         .and_then(|cache_item| cache_item.wait().ok())
-                                    } else { None };
+                                } else {
+                                    None
+                                };
 
                                 let committee_cache = match maybe_cached_shuffling {
                                     Some(shuffling) => shuffling,
@@ -859,18 +864,24 @@ pub fn serve<T: BeaconChainTypes>(
                                                 },
                                             )?;
 
-                                        let owned_cache = Arc::new(possibly_built_cache.into_owned());
+                                        let owned_cache =
+                                            Arc::new(possibly_built_cache.into_owned());
 
                                         // Attempt to write to the beacon cache (only if the cache
                                         // size is not the default value
-                                        if chain.config.shuffling_cache_size != beacon_chain::shuffling_cache::DEFAULT_CACHE_SIZE {
+                                        if chain.config.shuffling_cache_size
+                                            != beacon_chain::shuffling_cache::DEFAULT_CACHE_SIZE
+                                        {
                                             if let Some(shuffling_id) = shuffling_id {
-                                                if let Some(mut cache_write) = chain
-                                                    .shuffling_cache
-                                                    .try_write_for(std::time::Duration::from_secs(1))
+                                                if let Some(mut cache_write) =
+                                                    chain.shuffling_cache.try_write_for(
+                                                        std::time::Duration::from_secs(1),
+                                                    )
                                                 {
-                                                    cache_write
-                                                        .insert_committee_cache(shuffling_id, &owned_cache);
+                                                    cache_write.insert_committee_cache(
+                                                        shuffling_id,
+                                                        &owned_cache,
+                                                    );
                                                 }
                                             }
                                         }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -53,8 +53,8 @@ use system_health::observe_system_health_bn;
 use tokio::sync::mpsc::{Sender, UnboundedSender};
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 use types::{
-    Attestation, AttestationData, AttesterSlashing, BeaconStateError, BlindedPayload,
-    CommitteeCache, ConfigAndPreset, Epoch, EthSpec, ForkName, FullPayload,
+    Attestation, AttestationData, AttestationShufflingId, AttesterSlashing, BeaconStateError,
+    BlindedPayload, CommitteeCache, ConfigAndPreset, Epoch, EthSpec, ForkName, FullPayload,
     ProposerPreparationData, ProposerSlashing, RelativeEpoch, SignedAggregateAndProof,
     SignedBeaconBlock, SignedBlindedBeaconBlock, SignedContributionAndProof,
     SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SyncCommitteeMessage,
@@ -782,39 +782,89 @@ pub fn serve<T: BeaconChainTypes>(
                                 let current_epoch = state.current_epoch();
                                 let epoch = query.epoch.unwrap_or(current_epoch);
 
-                                let committee_cache =
-                                    match RelativeEpoch::from_epoch(current_epoch, epoch) {
-                                        Ok(relative_epoch)
-                                            if state
-                                                .committee_cache_is_initialized(relative_epoch) =>
-                                        {
-                                            state.committee_cache(relative_epoch).map(Cow::Borrowed)
-                                        }
-                                        _ => CommitteeCache::initialized(state, epoch, &chain.spec)
-                                            .map(Cow::Owned),
-                                    }
-                                    .map_err(|e| match e {
-                                        BeaconStateError::EpochOutOfBounds => {
-                                            let max_sprp =
-                                                T::EthSpec::slots_per_historical_root() as u64;
-                                            let first_subsequent_restore_point_slot = ((epoch
-                                                .start_slot(T::EthSpec::slots_per_epoch())
-                                                / max_sprp)
-                                                + 1)
-                                                * max_sprp;
-                                            if epoch < current_epoch {
-                                                warp_utils::reject::custom_bad_request(format!(
+                                // Attempt to obtain the committee_cache from the beacon chain
+                                let decision_slot = (epoch.saturating_sub(2u64))
+                                    .end_slot(T::EthSpec::slots_per_epoch());
+                                let shuffling_decision_block = chain
+                                    .block_root_at_slot(decision_slot, WhenSlotSkipped::Prev)
+                                    .expect("First failure")
+                                    .expect("Second Failure");
+                                let shuffling_id = AttestationShufflingId {
+                                    shuffling_epoch: epoch,
+                                    shuffling_decision_block,
+                                };
+
+                                // Attempt to read from the chain cache
+                                let maybe_cached_shuffling = chain
+                                    .shuffling_cache
+                                    .try_write_for(std::time::Duration::from_secs(1))
+                                    .and_then(|mut cache_write| cache_write.get(&shuffling_id))
+                                    .and_then(|cache_item| cache_item.wait().ok());
+
+                                let committee_cache = match maybe_cached_shuffling {
+                                    Some(shuffling) => shuffling,
+                                    None => {
+                                        let possibly_built_cache =
+                                            match RelativeEpoch::from_epoch(current_epoch, epoch) {
+                                                Ok(relative_epoch)
+                                                    if state.committee_cache_is_initialized(
+                                                        relative_epoch,
+                                                    ) =>
+                                                {
+                                                    state
+                                                        .committee_cache(relative_epoch)
+                                                        .map(Cow::Borrowed)
+                                                }
+                                                _ => CommitteeCache::initialized(
+                                                    state,
+                                                    epoch,
+                                                    &chain.spec,
+                                                )
+                                                .map(Cow::Owned),
+                                            }
+                                            .map_err(
+                                                |e| match e {
+                                                    BeaconStateError::EpochOutOfBounds => {
+                                                        let max_sprp =
+                                                            T::EthSpec::slots_per_historical_root()
+                                                                as u64;
+                                                        let first_subsequent_restore_point_slot =
+                                                            ((epoch.start_slot(
+                                                                T::EthSpec::slots_per_epoch(),
+                                                            ) / max_sprp)
+                                                                + 1)
+                                                                * max_sprp;
+                                                        if epoch < current_epoch {
+                                                            warp_utils::reject::custom_bad_request(
+                                                                format!(
                                                     "epoch out of bounds, try state at slot {}",
                                                     first_subsequent_restore_point_slot,
-                                                ))
-                                            } else {
-                                                warp_utils::reject::custom_bad_request(
+                                                ),
+                                                            )
+                                                        } else {
+                                                            warp_utils::reject::custom_bad_request(
                                                     "epoch out of bounds, too far in future".into(),
                                                 )
-                                            }
+                                                        }
+                                                    }
+                                                    _ => warp_utils::reject::beacon_chain_error(
+                                                        e.into(),
+                                                    ),
+                                                },
+                                            )?;
+
+                                        let owned_cache = possibly_built_cache.into_owned();
+                                        // Attempt to write to the beacon cache
+                                        if let Some(mut cache_write) = chain
+                                            .shuffling_cache
+                                            .try_write_for(std::time::Duration::from_secs(1))
+                                        {
+                                            cache_write
+                                                .insert_committee_cache(shuffling_id, &owned_cache);
                                         }
-                                        _ => warp_utils::reject::beacon_chain_error(e.into()),
-                                    })?;
+                                        Arc::new(owned_cache)
+                                    }
+                                };
 
                                 // Use either the supplied slot or all slots in the epoch.
                                 let slots =

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -323,7 +323,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             .long("shuffling-cache-size")
             .help("Some HTTP API requests can be optimised by caching the shufflings at each epoch. \
             This flag allows the user to set the shuffling cache size in epochs. \
-            Shufflings are dependent on validator count and setting this value to a large number can consume are large amount of memory.")
+            Shufflings are dependent on validator count and setting this value to a large number can consume a large amount of memory.")
             .takes_value(true)
         ) 
 

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -318,6 +318,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     address of this server (e.g., http://localhost:5054).")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("shuffling-cache-size")
+            .long("shuffling-cache-size")
+            .help("Some HTTP API requests can be optimised by caching the shufflings at each epoch. \
+            This flag allows the user to set the shuffling cache size in epochs. \
+            Shufflings are dependent on validator count and setting this value to a large number can consume are large amount of memory.")
+            .takes_value(true)
+        ) 
 
         /*
          * Monitoring metrics

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -325,7 +325,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             This flag allows the user to set the shuffling cache size in epochs. \
             Shufflings are dependent on validator count and setting this value to a large number can consume a large amount of memory.")
             .takes_value(true)
-        ) 
+        )
 
         /*
          * Monitoring metrics

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -155,6 +155,12 @@ pub fn get_config<E: EthSpec>(
         client_config.http_api.allow_sync_stalled = true;
     }
 
+    if let Some(cache_size) = cli_args.value_of("shuffling-cache-size") {
+        client_config.chain.shuffling_cache_size = cache_size
+            .parse::<usize>()
+            .map_err(|_| "cache size is not a valid u64")?;
+    }
+
     /*
      * Prometheus metrics HTTP server
      */


### PR DESCRIPTION
This PR enables the user to adjust the shuffling cache size. 

This is useful for some HTTP API requests which require re-computing old shufflings. This PR currently optimizes the 
`beacon/states/{state_id}/committees` HTTP API by first checking the cache before re-building shuffling.

If the shuffling is set to a non-default value, then the HTTP API request will also fill the cache when as it constructs new shufflings. 

If the CLI flag is not present or the value is set to the default of `16` the default behaviour is observed. 
