### PR TITLE
Fix post-Bellatrix checkpoint sync

### DIFF
--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -414,8 +414,8 @@ where
                 .map_err(Error::BeaconStateError)?;
 
         let execution_status = anchor_block.message().execution_payload().map_or_else(
-            // If the block doens't have an execution payload then it can't
-            // have execution enabled.
+            // If the block doesn't have an execution payload then it can't have
+            // execution enabled.
             |_| ExecutionStatus::irrelevant(),
             |execution_payload| {
                 if execution_payload == &<_>::default() {

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -413,21 +413,25 @@ where
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
-        // Default any non-merge execution block hashes to 0x000..000.
-        let execution_status = anchor_block.message_merge().map_or_else(
-            |()| ExecutionStatus::irrelevant(),
-            |message| {
-                let execution_payload = &message.body.execution_payload;
-                if execution_payload == &<_>::default() {
-                    // A default payload does not have execution enabled.
-                    ExecutionStatus::irrelevant()
-                } else {
-                    // Assume that this payload is valid, since the anchor should be a trusted block and
-                    // state.
-                    ExecutionStatus::Valid(message.body.execution_payload.block_hash())
-                }
-            },
-        );
+        let execution_status = anchor_block
+            .message()
+            .body()
+            .execution_payload()
+            .map_or_else(
+                // If the block doens't have an execution payload then it can't
+                // have execution enabled.
+                |_| ExecutionStatus::irrelevant(),
+                |execution_payload| {
+                    if execution_payload == &<_>::default() {
+                        // A default payload does not have execution enabled.
+                        ExecutionStatus::irrelevant()
+                    } else {
+                        // Assume that this payload is valid, since the anchor should be a trusted block and
+                        // state.
+                        ExecutionStatus::Valid(execution_payload.block_hash())
+                    }
+                },
+            );
 
         // If the current slot is not provided, use the value that was last provided to the store.
         let current_slot = current_slot.unwrap_or_else(|| fc_store.get_current_slot());

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -413,25 +413,21 @@ where
             AttestationShufflingId::new(anchor_block_root, anchor_state, RelativeEpoch::Next)
                 .map_err(Error::BeaconStateError)?;
 
-        let execution_status = anchor_block
-            .message()
-            .body()
-            .execution_payload()
-            .map_or_else(
-                // If the block doens't have an execution payload then it can't
-                // have execution enabled.
-                |_| ExecutionStatus::irrelevant(),
-                |execution_payload| {
-                    if execution_payload == &<_>::default() {
-                        // A default payload does not have execution enabled.
-                        ExecutionStatus::irrelevant()
-                    } else {
-                        // Assume that this payload is valid, since the anchor should be a trusted block and
-                        // state.
-                        ExecutionStatus::Valid(execution_payload.block_hash())
-                    }
-                },
-            );
+        let execution_status = anchor_block.message().execution_payload().map_or_else(
+            // If the block doens't have an execution payload then it can't
+            // have execution enabled.
+            |_| ExecutionStatus::irrelevant(),
+            |execution_payload| {
+                if execution_payload == &<_>::default() {
+                    // A default payload does not have execution enabled.
+                    ExecutionStatus::irrelevant()
+                } else {
+                    // Assume that this payload is valid, since the anchor should be a trusted block and
+                    // state.
+                    ExecutionStatus::Valid(execution_payload.block_hash())
+                }
+            },
+        );
 
         // If the current slot is not provided, use the value that was last provided to the store.
         let current_slot = current_slot.unwrap_or_else(|| fc_store.get_current_slot());

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -418,7 +418,7 @@ where
             // execution enabled.
             |_| ExecutionStatus::irrelevant(),
             |execution_payload| {
-                if execution_payload == &<_>::default() {
+                if execution_payload.is_default_with_empty_roots() {
                     // A default payload does not have execution enabled.
                     ExecutionStatus::irrelevant()
                 } else {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Using the `message_merge()` function lead us to think that any post-Bellatrix (Capella, 4844) blocks had an "irrelevant" execution status, meaning that they couldn't possibly have execution enabled.

This caused false-positives on the "fork choice poisoning" defenses, like this one:

```
Feb 21 05:38:17.590 DEBG Execution layer verification failed     err: ExecutionPayloadError(UnverifiedNonOptimisticCandidate), outcome: pausing sync
Feb 21 05:38:17.590 DEBG Batch processing failed                 service: sync, error: Execution layer offline. Reason: ExecutionPayloadError(UnverifiedNonOptimisticCandidate), imported_blocks: 0, last_block_slot: 141184, chain: 9006646540500303522, first_block_slot: 141121, batch_epoch: 4410
```

## Additional Info

NA
