### PR TITLE
Don't subscribe to 4844 topics

### DIFF
--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -23,9 +23,8 @@ pub const BLS_TO_EXECUTION_CHANGE_TOPIC: &str = "bls_to_execution_change";
 pub const LIGHT_CLIENT_FINALITY_UPDATE: &str = "light_client_finality_update";
 pub const LIGHT_CLIENT_OPTIMISTIC_UPDATE: &str = "light_client_optimistic_update";
 
-pub const CORE_TOPICS: [GossipKind; 8] = [
+pub const CORE_TOPICS: [GossipKind; 7] = [
     GossipKind::BeaconBlock,
-    GossipKind::BeaconBlocksAndBlobsSidecar,
     GossipKind::BeaconAggregateAndProof,
     GossipKind::VoluntaryExit,
     GossipKind::ProposerSlashing,


### PR DESCRIPTION
## Issue Addressed

Resolves https://github.com/sigp/lighthouse/issues/4006

## Proposed Changes

Remove the `BeaconBlocksAndBlobsSidecar` topic from core topics. This topic is no longer present in the 4844 specs after moving to the decoupled approach. So I think it's not worth it to handle the subscription for this topic based on if the 4844 fork is activated or not.

Happy to change it if it's somehow clearer or consistent with the current capella branch,