### PR TITLE
Disable debug info on CI (Capella)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,7 +10,8 @@ on:
   pull_request:
 env:
   # Deny warnings in CI
-  RUSTFLAGS: "-D warnings"
+  # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
+  RUSTFLAGS: "-D warnings -C debuginfo=0"
   # The Nightly version used for cargo-udeps, might need updating from time to time.
   PINNED_NIGHTLY: nightly-2022-12-15
   # Prevent Github API rate limiting.


### PR DESCRIPTION
## Issue Addressed

Closes #4005 🤞 

## Proposed Changes

Turn off debug info on CI only. It's already off for the release profile, so this will only affect the debug tests.

Don't merge until we see it pass CI (perhaps we can run it a few times).
