### PR TITLE
[Merged by Bors] - Disable debug info on CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -10,7 +10,8 @@ on:
   pull_request:
 env:
   # Deny warnings in CI
-  RUSTFLAGS: "-D warnings"
+  # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
+  RUSTFLAGS: "-D warnings -C debuginfo=0"
   # The Nightly version used for cargo-udeps, might need updating from time to time.
   PINNED_NIGHTLY: nightly-2022-12-15
   # Prevent Github API rate limiting.


### PR DESCRIPTION
## Issue Addressed

Closes #4005

Alternative to #4017

## Proposed Changes

Disable debug info on CI to save RAM and disk space.
