### PR TITLE
[Merged by Bors] - Use consensus-spec-tests `v1.3.0-rc.3`

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.3.0-rc.1
+TESTS_TAG := v1.3.0-rc.3
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -55,8 +55,10 @@ excluded_paths = [
     "bls12-381-tests/hash_to_G2"
 ]
 
+
 def normalize_path(path):
     return path.split("consensus-spec-tests/")[1]
+
 
 # Determine the list of filenames which were accessed during tests.
 passed = set()
@@ -90,4 +92,5 @@ for root, dirs, files in os.walk(tests_dir_filename):
 # Exit with an error if there were any files missed.
 assert len(missed) == 0, "{} missed files".format(len(missed))
 
-print("Accessed {} files ({} intentionally excluded)".format(accessed_files, excluded_files))
+print("Accessed {} files ({} intentionally excluded)".format(
+    accessed_files, excluded_files))

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -41,8 +41,8 @@ excluded_paths = [
     "tests/.*/.*/ssz_static/LightClientFinalityUpdate",
     # LightClientHeader
     "tests/.*/.*/ssz_static/LightClientHeader",
-    # Eip4844 tests are disabled for now.
-    "tests/.*/eip4844",
+    # Deneb (previously known as eip4844) tests are disabled for now.
+    "tests/.*/deneb",
     # One of the EF researchers likes to pack the tarballs on a Mac
     ".*\.DS_Store.*",
     # More Mac weirdness.

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -649,7 +649,7 @@ impl<E: EthSpec + TypeName> Handler for MerkleProofValidityHandler<E> {
     }
 
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        fork_name != ForkName::Base
+        fork_name != ForkName::Base && fork_name != ForkName::Capella
     }
 }
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -649,7 +649,12 @@ impl<E: EthSpec + TypeName> Handler for MerkleProofValidityHandler<E> {
     }
 
     fn is_enabled_for_fork(&self, fork_name: ForkName) -> bool {
-        fork_name != ForkName::Base && fork_name != ForkName::Capella
+        fork_name != ForkName::Base
+            // Test is skipped due to some changes in the Capella light client
+            // spec.
+            //
+            // https://github.com/sigp/lighthouse/issues/4022
+            && fork_name != ForkName::Capella
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Updates our `ef_tests` to use: https://github.com/ethereum/consensus-specs/releases/tag/v1.3.0-rc.3

This required:

- Skipping a `merkle_proof_validity` test (see #4022)
- Account for the `eip4844` tests changing name to `deneb`
    - My IDE did some Python linting during this change. It seemed simple and nice so I left it there.

## Additional Info

NA
