### PR TITLE
[Merged by Bors] - Log a debug message when a request fails for a beacon node candidate

### DIFF
--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -7,7 +7,7 @@ use crate::http_metrics::metrics::{inc_counter_vec, ENDPOINT_ERRORS, ENDPOINT_RE
 use environment::RuntimeContext;
 use eth2::BeaconNodeHttpClient;
 use futures::future;
-use slog::{error, info, warn, Logger};
+use slog::{debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
 use std::fmt;
 use std::fmt::Debug;
@@ -413,6 +413,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
         let mut errors = vec![];
         let mut to_retry = vec![];
         let mut retry_unsynced = vec![];
+        let log = &self.log.clone();
 
         // Run `func` using a `candidate`, returning the value or capturing errors.
         //
@@ -427,6 +428,11 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
                 match func(&$candidate.beacon_node).await {
                     Ok(val) => return Ok(val),
                     Err(e) => {
+                        debug!(
+                            log,
+                            "Request failed for candidate beacon node {}. BN candidate may not be ready.",
+                            $candidate.beacon_node.to_string(),
+                        );
                         // If we have an error on this function, make the client as not-ready.
                         //
                         // There exists a race condition where the candidate may have been marked

--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -409,6 +409,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
     where
         F: Fn(&'a BeaconNodeHttpClient) -> R,
         R: Future<Output = Result<O, Err>>,
+        Err: Debug,
     {
         let mut errors = vec![];
         let mut to_retry = vec![];
@@ -430,8 +431,9 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
                     Err(e) => {
                         debug!(
                             log,
-                            "Request failed for candidate beacon node {}. BN candidate may not be ready.",
-                            $candidate.beacon_node.to_string(),
+                            "Request to beacon node failed";
+                            "node" => $candidate.beacon_node.to_string(),
+                            "error" => ?e,
                         );
                         // If we have an error on this function, make the client as not-ready.
                         //
@@ -632,6 +634,7 @@ impl<T: SlotClock, E: EthSpec> BeaconNodeFallback<T, E> {
     where
         F: Fn(&'a BeaconNodeHttpClient) -> R,
         R: Future<Output = Result<(), Err>>,
+        Err: Debug,
     {
         if self.disable_run_on_all {
             self.first_success(require_synced, offline_on_failure, func)


### PR DESCRIPTION
## Issue Addressed
#3985

## Proposed Changes

Log a debug message when a BN candidate returns an error.

`Mar 01 16:40:24.011 DEBG Request to beacon node failed           error: ServerMessage(ErrorMessage { code: 503, message: "SERVICE_UNAVAILABLE: beacon node is syncing: head slot is 8416, current slot is 5098402", stacktraces: [] }), node: http://localhost:5052/`
