### PR TITLE
[Merged by Bors] - Log a `WARN` in the VC for a mismatched Capella fork epoch

### DIFF
--- a/validator_client/src/beacon_node_fallback.rs
+++ b/validator_client/src/beacon_node_fallback.rs
@@ -18,6 +18,9 @@ use std::time::Duration;
 use tokio::{sync::RwLock, time::sleep};
 use types::{ChainSpec, Config, EthSpec};
 
+/// Message emitted when the VC detects the BN is using a different spec.
+const UPDATE_REQUIRED_LOG_HINT: &str = "this VC or the remote BN may need updating";
+
 /// The number of seconds *prior* to slot start that we will try and update the state of fallback
 /// nodes.
 ///
@@ -262,6 +265,7 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
                 "Beacon node has mismatched Altair fork epoch";
                 "endpoint" => %self.beacon_node,
                 "endpoint_altair_fork_epoch" => ?beacon_node_spec.altair_fork_epoch,
+                "hint" => UPDATE_REQUIRED_LOG_HINT,
             );
         } else if beacon_node_spec.bellatrix_fork_epoch != spec.bellatrix_fork_epoch {
             warn!(
@@ -269,6 +273,15 @@ impl<E: EthSpec> CandidateBeaconNode<E> {
                 "Beacon node has mismatched Bellatrix fork epoch";
                 "endpoint" => %self.beacon_node,
                 "endpoint_bellatrix_fork_epoch" => ?beacon_node_spec.bellatrix_fork_epoch,
+                "hint" => UPDATE_REQUIRED_LOG_HINT,
+            );
+        } else if beacon_node_spec.capella_fork_epoch != spec.capella_fork_epoch {
+            warn!(
+                log,
+                "Beacon node has mismatched Capella fork epoch";
+                "endpoint" => %self.beacon_node,
+                "endpoint_capella_fork_epoch" => ?beacon_node_spec.capella_fork_epoch,
+                "hint" => UPDATE_REQUIRED_LOG_HINT,
             );
         }
 


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

- Adds a `WARN` statement for Capella, just like the previous forks.
- Adds a hint message to all those WARNs to suggest the user update the BN or VC.

## Additional Info

NA
