### PR TITLE
[Merged by Bors] - Add VC metric for primary BN latency

### DIFF
--- a/validator_client/src/http_metrics/metrics.rs
+++ b/validator_client/src/http_metrics/metrics.rs
@@ -191,6 +191,10 @@ lazy_static::lazy_static! {
         "Round-trip latency for a simple API endpoint on each BN",
         &["endpoint"]
     );
+    pub static ref VC_BEACON_NODE_LATENCY_PRIMARY_ENDPOINT: Result<Histogram> = try_create_histogram(
+        "vc_beacon_node_latency_primary_endpoint",
+        "Round-trip latency for the primary BN endpoint",
+    );
 }
 
 pub fn gather_prometheus_metrics<T: EthSpec>(

--- a/validator_client/src/latency.rs
+++ b/validator_client/src/latency.rs
@@ -36,7 +36,7 @@ pub fn start_latency_service<T: SlotClock + 'static, E: EthSpec>(
             // Sleep until it's time to perform the measurement.
             sleep(sleep_time).await;
 
-            for measurement in beacon_nodes.measure_latency().await {
+            for (i, measurement) in beacon_nodes.measure_latency().await.iter().enumerate() {
                 if let Some(latency) = measurement.latency {
                     debug!(
                         log,
@@ -48,7 +48,13 @@ pub fn start_latency_service<T: SlotClock + 'static, E: EthSpec>(
                         &metrics::VC_BEACON_NODE_LATENCY,
                         &[&measurement.beacon_node_id],
                         latency,
-                    )
+                    );
+                    if i == 0 {
+                        metrics::observe_duration(
+                            &metrics::VC_BEACON_NODE_LATENCY_PRIMARY_ENDPOINT,
+                            latency,
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

In #4024 we added metrics to expose the latency measurements from a VC to each BN. Whilst playing with these new metrics on our infra I realised it would be great to have a single metric to make sure that the primary BN for each VC has a reasonable latency. With the current "metrics for all BNs" it's hard to tell which is the primary.

## Additional Info

NA