### PR TITLE
[Merged by Bors] - Add a flag to always use payloads from builders

### DIFF
--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -80,9 +80,6 @@ pub struct Config {
     pub slasher: Option<slasher::Config>,
     pub logger_config: LoggerConfig,
     pub always_prefer_builder_payload: bool,
-    /// Ammount of ETH the local builder's value has to be greater than the builder's profit for the beacon
-    /// node to use the payload from the local builder instead of the builder's payload.
-    pub builder_profit_margin: i128,
 }
 
 impl Default for Config {
@@ -110,9 +107,6 @@ impl Default for Config {
             validator_monitor_individual_tracking_threshold: DEFAULT_INDIVIDUAL_TRACKING_THRESHOLD,
             logger_config: LoggerConfig::default(),
             always_prefer_builder_payload: false,
-            // Default value is 0 because the payload is decided by adding this value to the local
-            // builder value.
-            builder_profit_margin: 0,
         }
     }
 }

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -79,6 +79,10 @@ pub struct Config {
     pub monitoring_api: Option<monitoring_api::Config>,
     pub slasher: Option<slasher::Config>,
     pub logger_config: LoggerConfig,
+    pub always_prefer_builder_payload: bool,
+    /// Ammount of ETH the local builder's value has to be greater than the builder's profit for the beacon
+    /// node to use the payload from the local builder instead of the builder's payload.
+    pub builder_profit_margin: i128,
 }
 
 impl Default for Config {
@@ -105,6 +109,10 @@ impl Default for Config {
             validator_monitor_pubkeys: vec![],
             validator_monitor_individual_tracking_threshold: DEFAULT_INDIVIDUAL_TRACKING_THRESHOLD,
             logger_config: LoggerConfig::default(),
+            always_prefer_builder_payload: false,
+            // Default value is 0 because the payload is decided by adding this value to the local
+            // builder value.
+            builder_profit_margin: 0,
         }
     }
 }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -332,11 +332,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
             .transpose()?;
 
         let always_prefer_builder_payload =
-            if always_prefer_builder_payload || builder_profit_margin == i128::MIN {
-                true
-            } else {
-                false
-            };
+            always_prefer_builder_payload || builder_profit_margin == i128::MIN;
 
         let inner = Inner {
             engine: Arc::new(engine),
@@ -814,7 +810,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             let relay_value = relay.data.message.value;
                             let local_value = *local.block_value();
                             if !self.inner.always_prefer_builder_payload
-                                && !(relay_value >= local_value + self.inner.builder_profit_margin)
+                                && relay_value < local_value + self.inner.builder_profit_margin
                             {
                                 info!(
                                     self.log(),

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -957,4 +957,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                       This is equivalent to --http and --validator-monitor-auto.")
                 .takes_value(false)
         )
+        .arg(
+            Arg::with_name("always-prefer-builder-payload")
+            .long("always-prefer-builder-payload")
+            .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")
+            // The builder profit threshold flag is used to provide preference
+            // to local payloads, therefore it fundamentally conflicts with
+            // always using the builder.
+            .conflicts_with("builder-profit-threshold")
+        )
 }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -753,6 +753,17 @@ pub fn get_config<E: EthSpec>(
     client_config.chain.optimistic_finalized_sync =
         !cli_args.is_present("disable-optimistic-finalized-sync");
 
+    // Payload selection configs
+    if cli_args.is_present("always-prefer-builder-payload") {
+        client_config.always_prefer_builder_payload = true;
+    }
+
+    if let Some(margin) = cli_args.value_of("builder-profit-margin") {
+        client_config.builder_profit_margin = margin
+            .parse::<i128>()
+            .map_err(|_| "builder-profit-margin is not a valid i128")?;
+    }
+
     Ok(client_config)
 }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -758,12 +758,6 @@ pub fn get_config<E: EthSpec>(
         client_config.always_prefer_builder_payload = true;
     }
 
-    if let Some(margin) = cli_args.value_of("builder-profit-margin") {
-        client_config.builder_profit_margin = margin
-            .parse::<i128>()
-            .map_err(|_| "builder-profit-margin is not a valid i128")?;
-    }
-
     Ok(client_config)
 }
 

--- a/beacon_node/tests/test.rs
+++ b/beacon_node/tests/test.rs
@@ -1,5 +1,5 @@
 #![cfg(test)]
-#![recursion_limit = "256"]
+#![recursion_limit = "512"]
 
 use beacon_chain::StateSkipConfig;
 use node_test_rig::{

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -316,7 +316,7 @@ fn main() {
             Arg::with_name("always-prefer-builder-payload")
             .long("always-prefer-builder-payload")
             .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")
-            .global(false)
+            .global(true)
         )
         .subcommand(beacon_node::cli_app())
         .subcommand(boot_node::cli_app())

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -313,16 +313,6 @@ fn main() {
                 .global(true)
         )
         .arg(
-            Arg::with_name("builder-profit-margin")
-            .long("builder-profit-margin")
-            .value_name("INTEGER")
-            .help("Used to set the ammount of ETH the local builder's value has to be greater than the builder's \
-            value for the beacon node to use the payload from the local builder instead of the \
-            builder's payload.")
-            .takes_value(true)
-            .global(true)
-        )
-        .arg(
             Arg::with_name("always-prefer-builder-payload")
             .long("always-prefer-builder-payload")
             .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -312,6 +312,24 @@ fn main() {
                 .takes_value(true)
                 .global(true)
         )
+        .arg(
+            Arg::with_name("builder-profit-margin")
+            .long("builder-profit-margin")
+            .value_name("INTEGER")
+            .help("Used to set the ammount of ETH the local builder's value has to be greater than the builder's \
+            value for the beacon node to use the payload from the local builder instead of the \
+            builder's payload.")
+            .takes_value(true)
+            .global(true)
+        )
+        .arg(
+            Arg::with_name("always-prefer-builder-payload")
+            .long("always-prefer-builder-payload")
+            .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")
+            .value_name("BOOL")
+            .takes_value(true)
+            .global(false)
+        )
         .subcommand(beacon_node::cli_app())
         .subcommand(boot_node::cli_app())
         .subcommand(validator_client::cli_app())

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -312,12 +312,6 @@ fn main() {
                 .takes_value(true)
                 .global(true)
         )
-        .arg(
-            Arg::with_name("always-prefer-builder-payload")
-            .long("always-prefer-builder-payload")
-            .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")
-            .global(true)
-        )
         .subcommand(beacon_node::cli_app())
         .subcommand(boot_node::cli_app())
         .subcommand(validator_client::cli_app())

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -316,8 +316,6 @@ fn main() {
             Arg::with_name("always-prefer-builder-payload")
             .long("always-prefer-builder-payload")
             .help("If set, the beacon node always uses the payload from the builder instead of the local payload.")
-            .value_name("BOOL")
-            .takes_value(true)
             .global(false)
         )
         .subcommand(beacon_node::cli_app())

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -343,7 +343,7 @@ fn trusted_peers_flag() {
 #[test]
 fn always_prefer_builder_payload_flag() {
     CommandLineTest::new()
-        .flag("always_prefer_builder_payload", None)
+        .flag("always-prefer-builder-payload", None)
         .run_with_zero_port()
         .with_config(|config| assert!(config.always_prefer_builder_payload));
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -348,6 +348,13 @@ fn always_prefer_builder_payload_flag() {
         .with_config(|config| assert!(config.always_prefer_builder_payload));
 }
 
+#[test]
+fn no_flag_sets_always_prefer_builder_payload_to_false() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| assert!(!config.always_prefer_builder_payload));
+}
+
 // Tests for Eth1 flags.
 #[test]
 fn dummy_eth1_flag() {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -340,6 +340,14 @@ fn trusted_peers_flag() {
         });
 }
 
+#[test]
+fn always_prefer_builder_payload_flag() {
+    CommandLineTest::new()
+        .flag("always_prefer_builder_payload", None)
+        .run_with_zero_port()
+        .with_config(|config| assert!(config.always_prefer_builder_payload));
+}
+
 // Tests for Eth1 flags.
 #[test]
 fn dummy_eth1_flag() {


### PR DESCRIPTION
## Issue Addressed

#4040 

## Proposed Changes

- Add the `always_prefer_builder_payload`  field to `Config` in `beacon_node/client/src/config.rs`.
- Add that same field to `Inner` in `beacon_node/execution_layer/src/lib.rs`
- Modify the logic for picking the payload in `beacon_node/execution_layer/src/lib.rs`
- Add the `always-prefer-builder-payload` flag to the beacon node CLI
- Test the new flags in `lighthouse/tests/beacon_node.rs`