### PR TITLE
[Merged by Bors] - Add parent_block_number to payload SSE

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -167,6 +167,17 @@ impl<E: EthSpec> CachedHead<E> {
             .map(|payload| payload.prev_randao())
     }
 
+    /// Returns the execution block number of the block at the head of the chain.
+    ///
+    /// Returns an error if the chain is prior to Bellatrix.
+    pub fn head_block_number(&self) -> Result<u64, BeaconStateError> {
+        self.snapshot
+            .beacon_block
+            .message()
+            .execution_payload()
+            .map(|payload| payload.block_number())
+    }
+
     /// Returns the active validator count for the current epoch of the head state.
     ///
     /// Should only return `None` if the caches have not been built on the head state (this should

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -47,7 +47,7 @@ use types::{
 
 mod block_hash;
 mod engine_api;
-mod engines;
+pub mod engines;
 mod keccak;
 mod metrics;
 pub mod payload_cache;

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -921,6 +921,8 @@ pub struct SseExtendedPayloadAttributesGeneric<T> {
     #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub proposer_index: u64,
     pub parent_block_root: Hash256,
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
+    pub parent_block_number: u64,
     pub parent_block_hash: ExecutionBlockHash,
     pub payload_attributes: T,
 }
@@ -958,6 +960,7 @@ impl ForkVersionDeserialize for SseExtendedPayloadAttributes {
             proposal_slot: helper.proposal_slot,
             proposer_index: helper.proposer_index,
             parent_block_root: helper.parent_block_root,
+            parent_block_number: helper.parent_block_number,
             parent_block_hash: helper.parent_block_hash,
             payload_attributes: SsePayloadAttributes::deserialize_by_fork::<D>(
                 helper.payload_attributes,


### PR DESCRIPTION
## Issue Addressed

In #4027 I forgot to add the `parent_block_number` to the payload attributes SSE.

## Proposed Changes

Compute the parent block number while computing the pre-payload attributes. Pass it on to the SSE stream.

## Additional Info

Not essential for v3.5.1 as I suspect most builders don't need the `parent_block_root`. I would like to use it for my dummy no-op builder however.
