### PR TITLE
Expand attestation related queues

### DIFF
--- a/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
+++ b/beacon_node/beacon_chain/src/naive_aggregation_pool.rs
@@ -19,7 +19,7 @@ const SLOTS_RETAINED: usize = 3;
 /// The maximum number of distinct `AttestationData` that will be stored in each slot.
 ///
 /// This is a DoS protection measure.
-const MAX_ATTESTATIONS_PER_SLOT: usize = 16_384;
+const MAX_ATTESTATIONS_PER_SLOT: usize = 32_768;
 
 /// Returned upon successfully inserting an item into the pool.
 #[derive(Debug, PartialEq)]

--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -83,7 +83,7 @@ pub use worker::{ChainSegmentProcessId, GossipAggregatePackage, GossipAttestatio
 /// The maximum size of the channel for work events to the `BeaconProcessor`.
 ///
 /// Setting this too low will cause consensus messages to be dropped.
-pub const MAX_WORK_EVENT_QUEUE_LEN: usize = 16_384;
+pub const MAX_WORK_EVENT_QUEUE_LEN: usize = 32_768;
 
 /// The maximum size of the channel for idle events to the `BeaconProcessor`.
 ///
@@ -92,15 +92,15 @@ pub const MAX_WORK_EVENT_QUEUE_LEN: usize = 16_384;
 const MAX_IDLE_QUEUE_LEN: usize = 16_384;
 
 /// The maximum size of the channel for re-processing work events.
-const MAX_SCHEDULED_WORK_QUEUE_LEN: usize = 3 * MAX_WORK_EVENT_QUEUE_LEN / 4;
+const MAX_SCHEDULED_WORK_QUEUE_LEN: usize = MAX_WORK_EVENT_QUEUE_LEN;
 
 /// The maximum number of queued `Attestation` objects that will be stored before we start dropping
 /// them.
-const MAX_UNAGGREGATED_ATTESTATION_QUEUE_LEN: usize = 16_384;
+const MAX_UNAGGREGATED_ATTESTATION_QUEUE_LEN: usize = 32_768;
 
-/// The maximum number of queued `Attestation` objects that will be stored before we start dropping
-/// them.
-const MAX_UNAGGREGATED_ATTESTATION_REPROCESS_QUEUE_LEN: usize = 8_192;
+/// The maximum number of queued `Attestation` objects that reference an unknown
+/// block that will be stored before we start dropping them.
+const MAX_UNAGGREGATED_ATTESTATION_REPROCESS_QUEUE_LEN: usize = 32_768;
 
 /// The maximum number of queued `SignedAggregateAndProof` objects that will be stored before we
 /// start dropping them.

--- a/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
+++ b/beacon_node/network/src/beacon_processor/work_reprocessing_queue.rs
@@ -60,7 +60,7 @@ pub const QUEUED_RPC_BLOCK_DELAY: Duration = Duration::from_secs(3);
 const MAXIMUM_QUEUED_BLOCKS: usize = 16;
 
 /// How many attestations we keep before new ones get dropped.
-const MAXIMUM_QUEUED_ATTESTATIONS: usize = 16_384;
+const MAXIMUM_QUEUED_ATTESTATIONS: usize = 32_768;
 
 /// How many light client updates we keep before new ones get dropped.
 const MAXIMUM_QUEUED_LIGHT_CLIENT_UPDATES: usize = 128;


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

We've used 16,384 as the maximum length for a bunch of queues since we didn't really expect to see more than that many attestations per slot.

We would see 16,384 attestations per slot once we reach `16384 * 32 = 524288` validators. We're now at ~542k 😬 

Having small queues is not a big deal, since the queues only fill up if we're not processing attestations. However, it does result in a bunch of `ERRO Failed to send scheduled attestation` when we see a block later than the rest of the network.

"Why 32,768?", you may ask. It's the next power-of-two and it seems like a decent long-shot for the validator count in the future. I'm open to other suggestions.

## Additional Info

I also ended up increasing the max size of the naive aggregation pool. I don't think this will have any effect since we don't actually expect to hit these limits. I just though it would be nice to be consistent.
