### PR TITLE
[Merged by Bors] - Correct /lighthouse/nat implementation

### DIFF
--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -159,7 +159,7 @@ pub fn check_nat() {
     if NAT_OPEN.as_ref().map(|v| v.get()).unwrap_or(0) != 0 {
         return;
     }
-    if ADDRESS_UPDATE_COUNT.as_ref().map(|v| v.get()).unwrap_or(0) == 0
+    if ADDRESS_UPDATE_COUNT.as_ref().map(|v| v.get()).unwrap_or(0) != 0
         || NETWORK_INBOUND_PEERS.as_ref().map(|v| v.get()).unwrap_or(0) != 0_i64
     {
         inc_counter(&NAT_OPEN);


### PR DESCRIPTION
## Proposed Changes

The current `/lighthouse/nat` implementation checks for _zero_ address updated messages, when it should check for a _non-zero_ number. This was spotted while debugging an issue on Discord where a user's ports weren't forwarded but `/lighthouse/nat` was still returning `true`.
