### PR TITLE
Implement POST beacon block for EIP-4844

### DIFF
--- a/beacon_node/beacon_chain/src/blob_cache.rs
+++ b/beacon_node/beacon_chain/src/blob_cache.rs
@@ -1,12 +1,12 @@
 use lru::LruCache;
 use parking_lot::Mutex;
-use types::{BlobsSidecar, EthSpec, Hash256};
+use types::{BlobSidecars, EthSpec, Hash256};
 
 pub const DEFAULT_BLOB_CACHE_SIZE: usize = 10;
 
 /// A cache blobs by beacon block root.
 pub struct BlobCache<T: EthSpec> {
-    blobs: Mutex<LruCache<BlobCacheId, BlobsSidecar<T>>>,
+    blobs: Mutex<LruCache<BlobCacheId, BlobSidecars<T>>>,
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -21,11 +21,11 @@ impl<T: EthSpec> Default for BlobCache<T> {
 }
 
 impl<T: EthSpec> BlobCache<T> {
-    pub fn put(&self, beacon_block: Hash256, blobs: BlobsSidecar<T>) -> Option<BlobsSidecar<T>> {
+    pub fn put(&self, beacon_block: Hash256, blobs: BlobSidecars<T>) -> Option<BlobSidecars<T>> {
         self.blobs.lock().put(BlobCacheId(beacon_block), blobs)
     }
 
-    pub fn pop(&self, root: &Hash256) -> Option<BlobsSidecar<T>> {
+    pub fn pop(&self, root: &Hash256) -> Option<BlobSidecars<T>> {
         self.blobs.lock().pop(&BlobCacheId(*root))
     }
 }

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -266,6 +266,7 @@ pub enum BlockProductionError {
         blob_block_hash: ExecutionBlockHash,
         payload_block_hash: ExecutionBlockHash,
     },
+    NoBlobsCached,
     FailedToReadFinalizedBlock(store::Error),
     MissingFinalizedBlock(Hash256),
     BlockTooLarge(usize),

--- a/beacon_node/http_api/src/build_block_contents.rs
+++ b/beacon_node/http_api/src/build_block_contents.rs
@@ -1,0 +1,34 @@
+use beacon_chain::{BeaconChain, BeaconChainTypes, BlockProductionError};
+use std::sync::Arc;
+use types::{
+    AbstractExecPayload, BeaconBlock, BeaconBlockAndBlobSidecars, BlockContents, ForkName,
+};
+
+type Error = warp::reject::Rejection;
+
+pub fn build_block_contents<T: BeaconChainTypes, Payload: AbstractExecPayload<T::EthSpec>>(
+    fork_name: ForkName,
+    chain: Arc<BeaconChain<T>>,
+    block: BeaconBlock<T::EthSpec, Payload>,
+) -> Result<BlockContents<T::EthSpec, Payload>, Error> {
+    match fork_name {
+        ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
+            Ok(BlockContents::Block(block))
+        }
+        ForkName::Eip4844 => {
+            let block_root = &block.canonical_root();
+            if let Some(blob_sidecars) = chain.blob_cache.pop(block_root) {
+                let block_and_blobs = BeaconBlockAndBlobSidecars {
+                    block,
+                    blob_sidecars,
+                };
+
+                Ok(BlockContents::BlockAndBlobSidecars(block_and_blobs))
+            } else {
+                return Err(warp_utils::reject::block_production_error(
+                    BlockProductionError::NoBlobsCached,
+                ));
+            }
+        }
+    }
+}

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -11,6 +11,7 @@ mod attester_duties;
 mod block_id;
 mod block_packing_efficiency;
 mod block_rewards;
+mod build_block_contents;
 mod database;
 mod metrics;
 mod proposer_duties;
@@ -2421,7 +2422,10 @@ pub fn serve<T: BeaconChainTypes>(
                     .fork_name(&chain.spec)
                     .map_err(inconsistent_fork_rejection)?;
 
-                fork_versioned_response(endpoint_version, fork_name, block)
+                let block_contents =
+                    build_block_contents::build_block_contents(fork_name, chain, block);
+
+                fork_versioned_response(endpoint_version, fork_name, block_contents?)
                     .map(|response| warp::reply::json(&response))
             },
         );

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -60,7 +60,7 @@ use types::{
     ProposerPreparationData, ProposerSlashing, RelativeEpoch, SignedAggregateAndProof,
     SignedBeaconBlock, SignedBlindedBeaconBlock, SignedBlsToExecutionChange,
     SignedContributionAndProof, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot,
-    SyncCommitteeMessage, SyncContributionData,
+    SyncCommitteeMessage, SyncContributionData, SignedBlockContents,
 };
 use version::{
     add_consensus_version_header, execution_optimistic_fork_versioned_response,
@@ -1120,11 +1120,11 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .and_then(
-            |block: Arc<SignedBeaconBlock<T::EthSpec>>,
+            |block_contents: SignedBlockContents<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
              log: Logger| async move {
-                publish_blocks::publish_block(None, block, chain, &network_tx, log)
+                publish_blocks::publish_block(None, block_contents, chain, &network_tx, log)
                     .await
                     .map(|()| warp::reply())
             },

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -10,21 +10,20 @@ use slot_clock::SlotClock;
 use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tree_hash::TreeHash;
-use types::{
-    AbstractExecPayload, BlindedPayload, EthSpec, ExecPayload, ExecutionBlockHash, FullPayload,
-    Hash256, SignedBeaconBlock,
-};
+use types::{AbstractExecPayload, BlindedPayload, EthSpec, ExecPayload, ExecutionBlockHash, FullPayload, Hash256, SignedBeaconBlock, SignedBlockContents};
 use warp::Rejection;
 
 /// Handles a request from the HTTP API for full blocks.
 pub async fn publish_block<T: BeaconChainTypes>(
     block_root: Option<Hash256>,
-    block: Arc<SignedBeaconBlock<T::EthSpec>>,
+    block_contents: SignedBlockContents<T::EthSpec>,
     chain: Arc<BeaconChain<T>>,
     network_tx: &UnboundedSender<NetworkMessage<T::EthSpec>>,
     log: Logger,
 ) -> Result<(), Rejection> {
     let seen_timestamp = timestamp_now();
+    let (block, _maybe_blobs) = block_contents.deconstruct();
+    let block = Arc::new(block);
 
     //FIXME(sean) have to move this to prior to publishing because it's included in the blobs sidecar message.
     //this may skew metrics
@@ -38,20 +37,8 @@ pub async fn publish_block<T: BeaconChainTypes>(
     // Send the block, regardless of whether or not it is valid. The API
     // specification is very clear that this is the desired behaviour.
     let wrapped_block: BlockWrapper<T::EthSpec> =
-        if matches!(block.as_ref(), &SignedBeaconBlock::Eip4844(_)) {
-            if let Some(sidecar) = chain.blob_cache.pop(&block_root) {
-                // TODO: Needs to be adjusted
-                // let block_and_blobs = SignedBeaconBlockAndBlobsSidecar {
-                //     beacon_block: block,
-                //     blobs_sidecar: Arc::new(sidecar),
-                // };
-                unimplemented!("Needs to be adjusted")
-            } else {
-                //FIXME(sean): This should probably return a specific no-blob-cached error code, beacon API coordination required
-                return Err(warp_utils::reject::broadcast_without_import(
-                    "no blob cached for block".into(),
-                ));
-            }
+        if matches!(block.as_ref(), SignedBeaconBlock::Eip4844(_)) {
+            todo!("to be implemented")
         } else {
             crate::publish_pubsub_message(network_tx, PubsubMessage::BeaconBlock(block.clone()))?;
             block.into()
@@ -180,7 +167,7 @@ pub async fn publish_blinded_block<T: BeaconChainTypes>(
     let full_block = reconstruct_block(chain.clone(), block_root, block, log.clone()).await?;
     publish_block::<T>(
         Some(block_root),
-        Arc::new(full_block),
+        SignedBlockContents::Block(full_block),
         chain,
         network_tx,
         log,

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -12,7 +12,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tree_hash::TreeHash;
 use types::{
     AbstractExecPayload, BlindedPayload, EthSpec, ExecPayload, ExecutionBlockHash, FullPayload,
-    Hash256, SignedBeaconBlock, SignedBeaconBlockAndBlobsSidecar,
+    Hash256, SignedBeaconBlock,
 };
 use warp::Rejection;
 
@@ -40,10 +40,11 @@ pub async fn publish_block<T: BeaconChainTypes>(
     let wrapped_block: BlockWrapper<T::EthSpec> =
         if matches!(block.as_ref(), &SignedBeaconBlock::Eip4844(_)) {
             if let Some(sidecar) = chain.blob_cache.pop(&block_root) {
-                let block_and_blobs = SignedBeaconBlockAndBlobsSidecar {
-                    beacon_block: block,
-                    blobs_sidecar: Arc::new(sidecar),
-                };
+                // TODO: Needs to be adjusted
+                // let block_and_blobs = SignedBeaconBlockAndBlobsSidecar {
+                //     beacon_block: block,
+                //     blobs_sidecar: Arc::new(sidecar),
+                // };
                 unimplemented!("Needs to be adjusted")
             } else {
                 //FIXME(sean): This should probably return a specific no-blob-cached error code, beacon API coordination required

--- a/beacon_node/lighthouse_network/src/types/pubsub.rs
+++ b/beacon_node/lighthouse_network/src/types/pubsub.rs
@@ -320,7 +320,7 @@ impl<T: EthSpec> std::fmt::Display for PubsubMessage<T> {
             PubsubMessage::BlobSidecar(data) => write!(
                 f,
                 "BlobSidecar: slot: {}, blob index: {}",
-                data.1.blob.slot, data.1.blob.index,
+                data.1.message.slot, data.1.message.index,
             ),
             PubsubMessage::AggregateAndProofAttestation(att) => write!(
                 f,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -664,8 +664,8 @@ impl<T: BeaconChainTypes> Worker<T> {
            "peer_id" => %peer_id,
            "client" => %peer_client,
            "blob_topic" => blob_index,
-           "blob_index" => signed_blob.blob.index,
-           "blob_slot" => signed_blob.blob.slot
+           "blob_index" => signed_blob.message.index,
+           "blob_slot" => signed_blob.message.slot
         );
     }
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -612,7 +612,7 @@ impl BeaconNodeHttpClient {
     /// Returns `Ok(None)` on a 404 error.
     pub async fn post_beacon_blocks<T: EthSpec, Payload: AbstractExecPayload<T>>(
         &self,
-        block: &SignedBeaconBlock<T, Payload>,
+        block_contents: &SignedBlockContents<T, Payload>,
     ) -> Result<(), Error> {
         let mut path = self.eth_path(V1)?;
 
@@ -621,7 +621,7 @@ impl BeaconNodeHttpClient {
             .push("beacon")
             .push("blocks");
 
-        self.post_with_timeout(path, block, self.timeouts.proposal)
+        self.post_with_timeout(path, block_contents, self.timeouts.proposal)
             .await?;
 
         Ok(())

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1388,7 +1388,7 @@ impl BeaconNodeHttpClient {
         slot: Slot,
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
-    ) -> Result<ForkVersionedResponse<BeaconBlock<T, Payload>>, Error> {
+    ) -> Result<ForkVersionedResponse<BlockContents<T, Payload>>, Error> {
         self.get_validator_blocks_modular(slot, randao_reveal, graffiti, SkipRandaoVerification::No)
             .await
     }
@@ -1400,7 +1400,7 @@ impl BeaconNodeHttpClient {
         randao_reveal: &SignatureBytes,
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
-    ) -> Result<ForkVersionedResponse<BeaconBlock<T, Payload>>, Error> {
+    ) -> Result<ForkVersionedResponse<BlockContents<T, Payload>>, Error> {
         let mut path = self.eth_path(V2)?;
 
         path.path_segments_mut()

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -731,6 +731,17 @@ impl<E: EthSpec> From<BeaconBlock<E, FullPayload<E>>>
     }
 }
 
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> From<BlockContents<T, Payload>>
+    for BeaconBlock<T, Payload>
+{
+    fn from(block_contents: BlockContents<T, Payload>) -> Self {
+        match block_contents {
+            BlockContents::BlockAndBlobSidecars(block_and_sidecars) => block_and_sidecars.block,
+            BlockContents::Block(block) => block,
+        }
+    }
+}
+
 impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
     for BeaconBlock<T, Payload>
 {

--- a/consensus/types/src/beacon_block_and_blob_sidecars.rs
+++ b/consensus/types/src/beacon_block_and_blob_sidecars.rs
@@ -1,0 +1,37 @@
+use crate::{
+    AbstractExecPayload, BeaconBlock, BlobSidecars, EthSpec, ForkName, ForkVersionDeserialize,
+};
+use derivative::Derivative;
+use serde_derive::{Deserialize, Serialize};
+use ssz_derive::Encode;
+use tree_hash_derive::TreeHash;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
+#[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
+#[serde(bound = "T: EthSpec, Payload: AbstractExecPayload<T>")]
+pub struct BeaconBlockAndBlobSidecars<T: EthSpec, Payload: AbstractExecPayload<T>> {
+    pub block: BeaconBlock<T, Payload>,
+    pub blob_sidecars: BlobSidecars<T>,
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for BeaconBlockAndBlobSidecars<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        #[derive(Deserialize)]
+        #[serde(bound = "T: EthSpec")]
+        struct Helper<T: EthSpec> {
+            block: serde_json::Value,
+            blob_sidecars: BlobSidecars<T>,
+        }
+        let helper: Helper<T> = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+
+        Ok(Self {
+            block: BeaconBlock::deserialize_by_fork::<'de, D>(helper.block, fork_name)?,
+            blob_sidecars: helper.blob_sidecars,
+        })
+    }
+}

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -5,6 +5,7 @@ use kzg::{KzgCommitment, KzgProof};
 use serde_derive::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
+use ssz_types::VariableList;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
@@ -34,14 +35,19 @@ pub struct BlobIdentifier {
 pub struct BlobSidecar<T: EthSpec> {
     pub block_root: Hash256,
     // TODO: fix the type, should fit in u8 as well
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub index: u64,
     pub slot: Slot,
     pub block_parent_root: Hash256,
+    #[serde(with = "eth2_serde_utils::quoted_u64")]
     pub proposer_index: u64,
+    #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
     pub blob: Blob<T>,
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
 }
+
+pub type BlobSidecars<T> = VariableList<BlobSidecar<T>, <T as EthSpec>::MaxBlobsPerBlock>;
 
 impl<T: EthSpec> SignedRoot for BlobSidecar<T> {}
 

--- a/consensus/types/src/block_contents.rs
+++ b/consensus/types/src/block_contents.rs
@@ -1,0 +1,56 @@
+use crate::{
+    AbstractExecPayload, BeaconBlock, BeaconBlockAndBlobSidecars, BlobSidecars, EthSpec, ForkName,
+    ForkVersionDeserialize,
+};
+use derivative::Derivative;
+use serde_derive::{Deserialize, Serialize};
+
+/// A wrapper over a [`BeaconBlock`] or a [`BeaconBlockAndBlobSidecars`].
+#[derive(Clone, Debug, Derivative, Serialize, Deserialize)]
+#[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
+#[serde(untagged)]
+#[serde(bound = "T: EthSpec")]
+pub enum BlockContents<T: EthSpec, Payload: AbstractExecPayload<T>> {
+    BlockAndBlobSidecars(BeaconBlockAndBlobSidecars<T, Payload>),
+    Block(BeaconBlock<T, Payload>),
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockContents<T, Payload> {
+    pub fn block(&self) -> &BeaconBlock<T, Payload> {
+        match self {
+            BlockContents::BlockAndBlobSidecars(block_and_sidecars) => &block_and_sidecars.block,
+            BlockContents::Block(block) => block,
+        }
+    }
+
+    pub fn deconstruct(self) -> (BeaconBlock<T, Payload>, Option<BlobSidecars<T>>) {
+        match self {
+            BlockContents::BlockAndBlobSidecars(block_and_sidecars) => (
+                block_and_sidecars.block,
+                Some(block_and_sidecars.blob_sidecars),
+            ),
+            BlockContents::Block(block) => (block, None),
+        }
+    }
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
+    for BlockContents<T, Payload>
+{
+    fn deserialize_by_fork<'de, D: serde::Deserializer<'de>>(
+        value: serde_json::value::Value,
+        fork_name: ForkName,
+    ) -> Result<Self, D::Error> {
+        match fork_name {
+            ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
+                Ok(BlockContents::Block(BeaconBlock::deserialize_by_fork::<
+                    'de,
+                    D,
+                >(value, fork_name)?))
+            }
+            ForkName::Eip4844 => Ok(BlockContents::BlockAndBlobSidecars(
+                BeaconBlockAndBlobSidecars::deserialize_by_fork::<'de, D>(value, fork_name)?,
+            )),
+        }
+    }
+}

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -99,8 +99,10 @@ pub mod slot_data;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+pub mod beacon_block_and_blob_sidecars;
 pub mod blob_sidecar;
 pub mod blobs_sidecar;
+pub mod block_contents;
 pub mod signed_blob;
 pub mod signed_block_and_blobs;
 pub mod transaction;
@@ -116,6 +118,7 @@ pub use crate::beacon_block::{
     BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockCapella, BeaconBlockEip4844,
     BeaconBlockMerge, BeaconBlockRef, BeaconBlockRefMut, BlindedBeaconBlock, EmptyBlock,
 };
+pub use crate::beacon_block_and_blob_sidecars::BeaconBlockAndBlobSidecars;
 pub use crate::beacon_block_body::{
     BeaconBlockBody, BeaconBlockBodyAltair, BeaconBlockBodyBase, BeaconBlockBodyCapella,
     BeaconBlockBodyEip4844, BeaconBlockBodyMerge, BeaconBlockBodyRef, BeaconBlockBodyRefMut,
@@ -123,8 +126,9 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
-pub use crate::blob_sidecar::BlobSidecar;
+pub use crate::blob_sidecar::{BlobSidecar, BlobSidecars};
 pub use crate::blobs_sidecar::{Blobs, BlobsSidecar};
+pub use crate::block_contents::BlockContents;
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
 pub use crate::chain_spec::{ChainSpec, Config, Domain};
 pub use crate::checkpoint::Checkpoint;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -106,6 +106,7 @@ pub mod block_contents;
 pub mod signed_blob;
 pub mod signed_block_and_blobs;
 pub mod transaction;
+pub mod signed_block_contents;
 
 use ethereum_types::{H160, H256};
 
@@ -187,8 +188,8 @@ pub use crate::signed_beacon_block::{
 };
 pub use crate::signed_beacon_block_header::SignedBeaconBlockHeader;
 pub use crate::signed_blob::*;
-pub use crate::signed_block_and_blobs::SignedBeaconBlockAndBlobsSidecar;
-pub use crate::signed_block_and_blobs::SignedBeaconBlockAndBlobsSidecarDecode;
+pub use crate::signed_block_and_blobs::{SignedBeaconBlockAndBlobsSidecar, SignedBeaconBlockAndBlobsSidecarDecode, SignedBeaconBlockAndBlobSidecars};
+pub use crate::signed_block_contents::SignedBlockContents;
 pub use crate::signed_bls_to_execution_change::SignedBlsToExecutionChange;
 pub use crate::signed_contribution_and_proof::SignedContributionAndProof;
 pub use crate::signed_voluntary_exit::SignedVoluntaryExit;

--- a/consensus/types/src/signed_blob.rs
+++ b/consensus/types/src/signed_blob.rs
@@ -3,6 +3,7 @@ use serde_derive::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
+use derivative::Derivative;
 
 #[derive(
     Debug,
@@ -14,10 +15,12 @@ use tree_hash_derive::TreeHash;
     Decode,
     TestRandom,
     TreeHash,
+    Derivative,
     arbitrary::Arbitrary,
 )]
 #[serde(bound = "T: EthSpec")]
 #[arbitrary(bound = "T: EthSpec")]
+#[derivative(Hash(bound = "T: EthSpec"))]
 pub struct SignedBlobSidecar<T: EthSpec> {
     pub message: BlobSidecar<T>,
     pub signature: Signature,

--- a/consensus/types/src/signed_blob.rs
+++ b/consensus/types/src/signed_blob.rs
@@ -19,6 +19,6 @@ use tree_hash_derive::TreeHash;
 #[serde(bound = "T: EthSpec")]
 #[arbitrary(bound = "T: EthSpec")]
 pub struct SignedBlobSidecar<T: EthSpec> {
-    pub blob: BlobSidecar<T>,
+    pub message: BlobSidecar<T>,
     pub signature: Signature,
 }

--- a/consensus/types/src/signed_block_and_blobs.rs
+++ b/consensus/types/src/signed_block_and_blobs.rs
@@ -1,10 +1,13 @@
-use crate::{AbstractExecPayload, BlobsSidecar, EthSpec, SignedBeaconBlock, SignedBeaconBlockEip4844, SignedBlobSidecar};
+use crate::{
+    AbstractExecPayload, BlobsSidecar, EthSpec, SignedBeaconBlock, SignedBeaconBlockEip4844,
+    SignedBlobSidecar,
+};
 use derivative::Derivative;
 use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
-use std::sync::Arc;
 use ssz_types::VariableList;
+use std::sync::Arc;
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, PartialEq)]

--- a/consensus/types/src/signed_block_and_blobs.rs
+++ b/consensus/types/src/signed_block_and_blobs.rs
@@ -1,9 +1,10 @@
-use crate::{BlobsSidecar, EthSpec, SignedBeaconBlock, SignedBeaconBlockEip4844};
+use crate::{AbstractExecPayload, BlobsSidecar, EthSpec, SignedBeaconBlock, SignedBeaconBlockEip4844, SignedBlobSidecar};
 use derivative::Derivative;
 use serde_derive::{Deserialize, Serialize};
 use ssz::{Decode, DecodeError};
 use ssz_derive::{Decode, Encode};
 use std::sync::Arc;
+use ssz_types::VariableList;
 use tree_hash_derive::TreeHash;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, Decode, TreeHash, PartialEq)]
@@ -13,6 +14,7 @@ pub struct SignedBeaconBlockAndBlobsSidecarDecode<T: EthSpec> {
     pub blobs_sidecar: BlobsSidecar<T>,
 }
 
+// TODO: will be removed once we decouple blobs in Gossip
 #[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
 #[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
 pub struct SignedBeaconBlockAndBlobsSidecar<T: EthSpec> {
@@ -31,4 +33,12 @@ impl<T: EthSpec> SignedBeaconBlockAndBlobsSidecar<T> {
             blobs_sidecar: Arc::new(blobs_sidecar),
         })
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Encode, TreeHash, Derivative)]
+#[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
+#[serde(bound = "T: EthSpec")]
+pub struct SignedBeaconBlockAndBlobSidecars<T: EthSpec, Payload: AbstractExecPayload<T>> {
+    pub signed_block: SignedBeaconBlock<T, Payload>,
+    pub signed_blob_sidecars: VariableList<SignedBlobSidecar<T>, <T as EthSpec>::MaxBlobsPerBlock>,
 }

--- a/consensus/types/src/signed_block_contents.rs
+++ b/consensus/types/src/signed_block_contents.rs
@@ -1,0 +1,40 @@
+use crate::{AbstractExecPayload, EthSpec, FullPayload, SignedBeaconBlock, SignedBlobSidecar};
+use crate::signed_block_and_blobs::SignedBeaconBlockAndBlobSidecars;
+use derivative::Derivative;
+use serde_derive::{Deserialize, Serialize};
+use ssz_types::VariableList;
+
+/// A wrapper over a [`SignedBeaconBlock`] or a [`SignedBeaconBlockAndBlobSidecars`].
+#[derive(Clone, Debug, Derivative, Serialize, Deserialize)]
+#[derivative(PartialEq, Hash(bound = "T: EthSpec"))]
+#[serde(untagged)]
+#[serde(bound = "T: EthSpec")]
+pub enum SignedBlockContents<T: EthSpec, Payload: AbstractExecPayload<T> = FullPayload<T>> {
+    BlockAndBlobSidecars(SignedBeaconBlockAndBlobSidecars<T, Payload>),
+    Block(SignedBeaconBlock<T, Payload>),
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> SignedBlockContents<T, Payload> {
+    pub fn signed_block(&self) -> &SignedBeaconBlock<T, Payload> {
+        match self {
+            SignedBlockContents::BlockAndBlobSidecars(block_and_sidecars) => &block_and_sidecars.signed_block,
+            SignedBlockContents::Block(block) => block,
+        }
+    }
+
+    pub fn deconstruct(self) -> (SignedBeaconBlock<T, Payload>, Option<VariableList<SignedBlobSidecar<T>, <T as EthSpec>::MaxBlobsPerBlock>>) {
+        match self {
+            SignedBlockContents::BlockAndBlobSidecars(block_and_sidecars) => (
+                block_and_sidecars.signed_block,
+                Some(block_and_sidecars.signed_blob_sidecars),
+            ),
+            SignedBlockContents::Block(block) => (block, None),
+        }
+    }
+}
+
+impl<T: EthSpec, Payload: AbstractExecPayload<T>> From<SignedBeaconBlock<T, Payload>> for SignedBlockContents<T, Payload> {
+    fn from(block: SignedBeaconBlock<T, Payload>) -> Self {
+        SignedBlockContents::Block(block)
+    }
+}

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::sleep;
 use types::{
-    AbstractExecPayload, BlindedPayload, BlockType, EthSpec, FullPayload, Graffiti, PublicKeyBytes,
-    Slot,
+    AbstractExecPayload, BeaconBlock, BlindedPayload, BlockType, EthSpec, FullPayload, Graffiti,
+    PublicKeyBytes, Slot,
 };
 
 #[derive(Debug)]
@@ -347,7 +347,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                 RequireSynced::No,
                 OfflineOnFailure::Yes,
                 |beacon_node| async move {
-                    let block = match Payload::block_type() {
+                    let block: BeaconBlock<E, Payload> = match Payload::block_type() {
                         BlockType::Full => {
                             let _get_timer = metrics::start_timer_vec(
                                 &metrics::BLOCK_SERVICE_TIMES,
@@ -367,6 +367,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                                     ))
                                 })?
                                 .data
+                                .into()
                         }
                         BlockType::Blinded => {
                             let _get_timer = metrics::start_timer_vec(
@@ -387,6 +388,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                                     ))
                                 })?
                                 .data
+                                .into()
                         }
                     };
 


### PR DESCRIPTION
## Issue Addressed

Addresses #3993, block & blob publish endpoint for the unblinded route.

## Proposed Changes

- POST `beacon/blocks` endpoint to accept `SignedBeaconBlock` and `SignedBlobSidecars` (See [spec PR](https://github.com/ethereum/beacon-APIs/pull/302/files#diff-2277a8cd1e01bbcf1f2838e186546ef8d86cb1f97affb94bfcfe38faabb4f320R20))

## Additional Info

- built on top of #4075 , the relevant commit for this PR is a8978a5f69e9752f283b1598b438acb6d6f7d89d and 775ca89801d7fb05b94a685d77e9e2956aaffb6a
- ~~TODO: publish block and blobs to the network~~