### PR TITLE
Temporarily allow warnings on CI (4844 branch only)

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -11,7 +11,8 @@ on:
 env:
   # Deny warnings in CI
   # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
-  RUSTFLAGS: "-D warnings -C debuginfo=0"
+  # FIXME: temporarily allow warnings on 4844 branch. Revert to original later: RUSTFLAGS: "-D warnings -C debuginfo=0"
+  RUSTFLAGS: "-C debuginfo=0"
   # The Nightly version used for cargo-udeps, might need updating from time to time.
   PINNED_NIGHTLY: nightly-2022-12-15
   # Prevent Github API rate limiting.


### PR DESCRIPTION
Currently we have lots of warnings on things like "unused variables" on the `deneb-free-blobs` branch - these warnings are useful in helping us track missing pieces (e.g. code that we haven't implemented) but this sometimes make it difficult to reveal compilation errors. 

This PR temporarily allow warnings so we can tackle compilation error first on feature branches. Once we get to a better state, we can reinstate the warnings check.