### PR TITLE
[Merged by Bors] - Use efficient payload reconstruction for HTTP API

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1043,7 +1043,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .execution_layer
             .as_ref()
             .ok_or(Error::ExecutionLayerMissing)?
-            .get_payload_by_block_hash(exec_block_hash, fork)
+            .get_payload_for_header(&execution_payload_header, fork)
             .await
             .map_err(|e| {
                 Error::ExecutionLayerErrorPayloadReconstruction(exec_block_hash, Box::new(e))

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -626,35 +626,35 @@ async fn check_payload_reconstruction<E: GenericExecutionEngine>(
     ee: &ExecutionPair<E, MainnetEthSpec>,
     payload: &ExecutionPayload<MainnetEthSpec>,
 ) {
-    // check that the engine supports the payload bodies methods
+    // check via legacy eth_getBlockByHash
+    let reconstructed = ee
+        .execution_layer
+        .get_payload_by_hash_legacy(payload.block_hash(), payload.fork_name())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reconstructed, *payload);
+    // also check via payload bodies method
     let capabilities = ee
         .execution_layer
         .get_engine_capabilities(None)
         .await
         .unwrap();
     assert!(
+        // if the engine doesn't have these capabilities, we need to update the client in our tests
         capabilities.get_payload_bodies_by_hash_v1 && capabilities.get_payload_bodies_by_range_v1,
         "Testing engine does not support payload bodies methods"
     );
-
-    // reconstruct using `get_payload_for_header`, which will use `getPayloadBodiesByRange`
+    let mut bodies = ee
+        .execution_layer
+        .get_payload_bodies_by_hash(vec![payload.block_hash()])
+        .await
+        .unwrap();
+    assert_eq!(bodies.len(), 1);
+    let body = bodies.pop().unwrap().unwrap();
     let header = ExecutionPayloadHeader::from(payload.to_ref());
-    let reconstructed = ee
-        .execution_layer
-        .get_payload_for_header(&header, payload.fork_name())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(reconstructed, *payload);
-
-    // also check via legacy `getBlockByHash` method
-    let reconstructed_by_hash = ee
-        .execution_layer
-        .get_payload_by_hash_legacy(payload.block_hash(), payload.fork_name())
-        .await
-        .unwrap()
-        .unwrap();
-    assert_eq!(reconstructed_by_hash, *payload);
+    let reconstructed_from_body = body.to_payload(header).unwrap();
+    assert_eq!(reconstructed_from_body, *payload);
 }
 
 /// Returns the duration since the unix epoch.


### PR DESCRIPTION
## Proposed Changes

Builds on #4028 to use the new payload bodies methods in the HTTP API as well.

## Caveats

The payloads by range method only works for the finalized chain, so it can't be used in the execution engine integration tests because we try to reconstruct unfinalized payloads there.
