### PR TITLE
Update get blobs endpoint to return a list of BlobSidecars

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1065,7 +1065,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         _block_root: &Hash256,
         _data_availability_boundary: Epoch,
     ) -> Result<Option<BlobSidecarList<T::EthSpec>>, Error> {
-        unimplemented!("`get_blobs` method below to be updated to return `BlobSidecarList`")
+        unimplemented!("update to use the updated `get_blobs` method instead once this PR is merged: https://github.com/sigp/lighthouse/pull/4104")
     }
 
     /// Returns the blobs at the given root, if any.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1064,7 +1064,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         _block_root: &Hash256,
         _data_availability_boundary: Epoch,
-    ) -> Result<Option<BlobSidecarList<T::EthSpec>>, Error> {
+    ) -> Result<
+        Option<
+            VariableList<Arc<BlobSidecar<T::EthSpec>>, <T::EthSpec as EthSpec>::MaxBlobsPerBlock>,
+        >,
+        Error,
+    > {
         unimplemented!("update to use the updated `get_blobs` method instead once this PR is merged: https://github.com/sigp/lighthouse/pull/4104")
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1060,6 +1060,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     // FIXME(jimmy): temporary method added to unblock API work. This method will be replaced by
     // the `get_blobs` method below once the new blob sidecar structure (`BlobSidecarList`) is
     // implemented in that method.
+    #[allow(clippy::type_complexity)] // FIXME: this will be fixed by the `BlobSidecarList` alias in Sean's PR
     pub fn get_blob_sidecar_list(
         &self,
         _block_root: &Hash256,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1057,6 +1057,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .map(Some)
     }
 
+    // FIXME(jimmy): temporary method added to unblock API work. This method will be replaced by
+    // the `get_blobs` method below once the new blob sidecar structure (`BlobSidecarList`) is
+    // implemented in that method.
+    pub fn get_blob_sidecar_list(
+        &self,
+        _block_root: &Hash256,
+        _data_availability_boundary: Epoch,
+    ) -> Result<Option<BlobSidecarList<T::EthSpec>>, Error> {
+        unimplemented!("`get_blobs` method below to be updated to return `BlobSidecarList`")
+    }
+
     /// Returns the blobs at the given root, if any.
     ///
     /// Returns `Ok(None)` if the blobs and associated block are not found.

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -4,7 +4,7 @@ use eth2::types::BlockId as CoreBlockId;
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
-use types::{BlobsSidecar, Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot};
+use types::{BlobSidecarList, Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot};
 
 /// Wraps `eth2::types::BlockId` and provides a simple way to obtain a block or root for a given
 /// `BlockId`.
@@ -212,19 +212,19 @@ impl BlockId {
         }
     }
 
-    /// Return the `BlobsSidecar` identified by `self`.
-    pub async fn blobs_sidecar<T: BeaconChainTypes>(
+    /// Return the `BlobSidecarList` identified by `self`.
+    pub async fn blob_sidecar_list<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
-    ) -> Result<Arc<BlobsSidecar<T::EthSpec>>, warp::Rejection> {
+    ) -> Result<Arc<BlobSidecarList<T::EthSpec>>, warp::Rejection> {
         let root = self.root(chain)?.0;
         let Some(data_availability_boundary) = chain.data_availability_boundary() else {
-            return Err(warp_utils::reject::custom_not_found("Eip4844 fork disabled".into()));
+            return Err(warp_utils::reject::custom_not_found("Deneb fork disabled".into()));
         };
-        match chain.get_blobs(&root, data_availability_boundary) {
-            Ok(Some(blob)) => Ok(Arc::new(blob)),
+        match chain.get_blob_sidecar_list(&root, data_availability_boundary) {
+            Ok(Some(blobs)) => Ok(Arc::new(blobs)),
             Ok(None) => Err(warp_utils::reject::custom_not_found(format!(
-                "Blob with block root {} is not in the store",
+                "No blobs with block root {} found in the store",
                 root
             ))),
             Err(e) => Err(warp_utils::reject::beacon_chain_error(e)),

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -1,10 +1,10 @@
 use crate::{state_id::checkpoint_slot_and_execution_optimistic, ExecutionOptimistic};
 use beacon_chain::{BeaconChain, BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
-use eth2::types::BlockId as CoreBlockId;
+use eth2::types::{BlockId as CoreBlockId, VariableList};
 use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
-use types::{BlobSidecarList, Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot};
+use types::{BlobSidecar, EthSpec, Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot};
 
 /// Wraps `eth2::types::BlockId` and provides a simple way to obtain a block or root for a given
 /// `BlockId`.
@@ -216,7 +216,10 @@ impl BlockId {
     pub async fn blob_sidecar_list<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
-    ) -> Result<BlobSidecarList<T::EthSpec>, warp::Rejection> {
+    ) -> Result<
+        VariableList<Arc<BlobSidecar<T::EthSpec>>, <T::EthSpec as EthSpec>::MaxBlobsPerBlock>,
+        warp::Rejection,
+    > {
         let root = self.root(chain)?.0;
         let Some(data_availability_boundary) = chain.data_availability_boundary() else {
             return Err(warp_utils::reject::custom_not_found("Deneb fork disabled".into()));

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -216,13 +216,13 @@ impl BlockId {
     pub async fn blob_sidecar_list<T: BeaconChainTypes>(
         &self,
         chain: &BeaconChain<T>,
-    ) -> Result<Arc<BlobSidecarList<T::EthSpec>>, warp::Rejection> {
+    ) -> Result<BlobSidecarList<T::EthSpec>, warp::Rejection> {
         let root = self.root(chain)?.0;
         let Some(data_availability_boundary) = chain.data_availability_boundary() else {
             return Err(warp_utils::reject::custom_not_found("Deneb fork disabled".into()));
         };
         match chain.get_blob_sidecar_list(&root, data_availability_boundary) {
-            Ok(Some(blobs)) => Ok(Arc::new(blobs)),
+            Ok(Some(blobs)) => Ok(blobs),
             Ok(None) => Err(warp_utils::reject::custom_not_found(format!(
                 "No blobs with block root {} found in the store",
                 root

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -658,15 +658,13 @@ impl BeaconNodeHttpClient {
         Ok(path)
     }
 
-    /// Path for `lighthouse/beacon/blobs_sidecars/{block_id}`
-    pub fn get_blobs_sidecar_path(&self, block_id: BlockId) -> Result<Url, Error> {
-        let mut path = self.server.full.clone();
-
+    /// Path for `v1/beacon/blobs/{block_id}`
+    pub fn get_blobs_path(&self, block_id: BlockId) -> Result<Url, Error> {
+        let mut path = self.eth_path(V1)?;
         path.path_segments_mut()
             .map_err(|()| Error::InvalidUrl(self.server.clone()))?
-            .push("lighthouse")
             .push("beacon")
-            .push("blobs_sidecars")
+            .push("blobs")
             .push(&block_id.to_string());
         Ok(path)
     }
@@ -698,14 +696,14 @@ impl BeaconNodeHttpClient {
         Ok(Some(response.json().await?))
     }
 
-    /// `GET lighthouse/beacon/blobs_sidecars/{block_id}`
+    /// `GET v1/beacon/blobs/{block_id}`
     ///
     /// Returns `Ok(None)` on a 404 error.
-    pub async fn get_blobs_sidecar<T: EthSpec>(
+    pub async fn get_blobs<T: EthSpec>(
         &self,
         block_id: BlockId,
-    ) -> Result<Option<GenericResponse<BlobsSidecar<T>>>, Error> {
-        let path = self.get_blobs_sidecar_path(block_id)?;
+    ) -> Result<Option<GenericResponse<BlobSidecarList<T>>>, Error> {
+        let path = self.get_blobs_path(block_id)?;
         let response = match self.get_response(path, |b| b).await.optional()? {
             Some(res) => res,
             None => return Ok(None),


### PR DESCRIPTION
## Issue Addressed

Addresses #4106

## Proposed Changes

- updated path to `GET /eth/v1/beacon/blobs/{block_id}`
- updated response to list of `BlobSidecar`s

## Additional Info

I've stubbed the `beacon_chain.get_blobs` method for now,  which is currently being worked on in #4104 
