### PR TITLE
[Merged by Bors] - Update Rust version in lcli Dockerfile

### DIFF
--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.65.0-bullseye AS builder
+FROM rust:1.66.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG PORTABLE


### PR DESCRIPTION
## Issue Addressed

The minimum supported Rust version has been set to 1.66 as of Lighthouse v4.0.0.  This PR updates Rust to 1.66 in lcli Dockerfile. 