### PR TITLE
Cleanup TODO: not optimizing blob storage

### DIFF
--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -159,7 +159,6 @@ pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'stati
 pub enum StoreOp<'a, E: EthSpec> {
     PutBlock(Hash256, Arc<SignedBeaconBlock<E>>),
     PutState(Hash256, &'a BeaconState<E>),
-    // TODO (mark): space can be optimized here by de-duplicating data
     PutBlobs(Hash256, BlobSidecarList<E>),
     PutOrphanedBlobsKey(Hash256),
     PutStateSummary(Hash256, HotStateSummary),


### PR DESCRIPTION
For each block in the database, we're storing a `Vec<BlobSidecar<T>>`:
```rust
pub struct BlobSidecar<T: EthSpec> {
    pub block_root: Hash256,
    // TODO: fix the type, should fit in u8 as well
    #[serde(with = "eth2_serde_utils::quoted_u64")]
    pub index: u64,
    pub slot: Slot,
    pub block_parent_root: Hash256,
    #[serde(with = "eth2_serde_utils::quoted_u64")]
    pub proposer_index: u64,
    #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
    pub blob: Blob<T>,
    pub kzg_commitment: KzgCommitment,
    pub kzg_proof: KzgProof,
}
```
I originally thought we could optimize space by de-duplicating the `block_root`, `slot`, `parent_root`, & `proposer_index` fields when storing this in the database since all of these fields are the same for blobs of the same block. But after calculating it out, assuming we use max blobs per block and no skipped slots, the most we could save over the entire retention period is 32 MB.. not worth the added complexity and computational time.