### PR TITLE
use block wrapper in sync pairing

### DIFF
--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -446,7 +446,7 @@ impl<E: EthSpec> AsBlock<E> for &MaybeAvailableBlock<E> {
 #[derivative(Hash(bound = "E: EthSpec"))]
 pub enum BlockWrapper<E: EthSpec> {
     Block(Arc<SignedBeaconBlock<E>>),
-    BlockAndBlobs(Arc<SignedBeaconBlock<E>>, BlobSidecarList<E>),
+    BlockAndBlobs(Arc<SignedBeaconBlock<E>>, Vec<Arc<BlobSidecar<E>>>),
 }
 
 impl<E: EthSpec> AsBlock<E> for BlockWrapper<E> {

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -240,7 +240,7 @@ impl<T: EthSpec, S: SlotClock> DataAvailabilityChecker<T, S> {
                     .kzg
                     .as_ref()
                     .ok_or(AvailabilityCheckError::KzgNotInitialized)?;
-                let verified_blobs = verify_kzg_for_blob_list(blob_list, kzg)?;
+                let verified_blobs = verify_kzg_for_blob_list(VariableList::new(blob_list)?, kzg)?;
 
                 Ok(MaybeAvailableBlock::Available(
                     self.check_availability_with_blobs(block, verified_blobs)?,
@@ -508,7 +508,7 @@ impl<E: EthSpec> AsBlock<E> for AvailableBlock<E> {
     fn into_block_wrapper(self) -> BlockWrapper<E> {
         let (block, blobs_opt) = self.deconstruct();
         if let Some(blobs) = blobs_opt {
-            BlockWrapper::BlockAndBlobs(block, blobs)
+            BlockWrapper::BlockAndBlobs(block, blobs.to_vec())
         } else {
             BlockWrapper::Block(block)
         }

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -4,7 +4,7 @@ use beacon_chain::blob_verification::{AsBlock, BlockWrapper};
 use beacon_chain::validator_monitor::{get_block_delay_ms, timestamp_now};
 use beacon_chain::{AvailabilityProcessingStatus, NotifyExecutionLayer};
 use beacon_chain::{BeaconChain, BeaconChainTypes, BlockError, CountUnrealized};
-use eth2::types::{SignedBlockContents, VariableList};
+use eth2::types::SignedBlockContents;
 use execution_layer::ProvenancedPayload;
 use lighthouse_network::PubsubMessage;
 use network::NetworkMessage;
@@ -77,10 +77,7 @@ pub async fn publish_block<T: BeaconChainTypes>(
                         PubsubMessage::BlobSidecar(Box::new((blob_index as u64, blob))),
                     )?;
                 }
-                let blobs_vec = signed_blobs.into_iter().map(|blob| blob.message).collect();
-                let blobs = VariableList::new(blobs_vec).map_err(|e| {
-                    warp_utils::reject::custom_server_error(format!("Invalid blobs length: {e:?}"))
-                })?;
+                let blobs = signed_blobs.into_iter().map(|blob| blob.message).collect();
                 BlockWrapper::BlockAndBlobs(block, blobs)
             } else {
                 block.into()

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,4 +1,4 @@
-use super::network_context::TempBlockWrapper;
+use beacon_chain::blob_verification::BlockWrapper;
 use std::{collections::VecDeque, sync::Arc};
 use types::{BlobSidecar, EthSpec, SignedBeaconBlock};
 
@@ -29,7 +29,7 @@ impl<T: EthSpec> BlocksAndBlobsRequestInfo<T> {
         }
     }
 
-    pub fn into_responses(self) -> Result<Vec<TempBlockWrapper<T>>, &'static str> {
+    pub fn into_responses(self) -> Result<Vec<BlockWrapper<T>>, &'static str> {
         let BlocksAndBlobsRequestInfo {
             accumulated_blocks,
             accumulated_sidecars,
@@ -53,9 +53,9 @@ impl<T: EthSpec> BlocksAndBlobsRequestInfo<T> {
             }
 
             if blob_list.is_empty() {
-                responses.push(TempBlockWrapper::Block(block))
+                responses.push(BlockWrapper::Block(block))
             } else {
-                responses.push(TempBlockWrapper::BlockAndBlobList(block, blob_list))
+                responses.push(BlockWrapper::BlockAndBlobs(block, blob_list))
             }
         }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -20,12 +20,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use types::{BlobSidecar, EthSpec, SignedBeaconBlock};
 
-// Temporary struct to handle incremental changes in the meantime.
-pub enum TempBlockWrapper<T: EthSpec> {
-    Block(Arc<SignedBeaconBlock<T>>),
-    BlockAndBlobList(Arc<SignedBeaconBlock<T>>, Vec<Arc<BlobSidecar<T>>>),
-}
-
 pub struct BlocksAndBlobsByRangeResponse<T: EthSpec> {
     pub batch_id: BatchId,
     pub responses: Result<Vec<BlockWrapper<T>>, &'static str>,
@@ -328,26 +322,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                         batch_id,
                         block_blob_info,
                     } = entry.remove();
-
-                    let responses = block_blob_info.into_responses();
-                    let unimplemented_info = match responses {
-                        Ok(responses) => {
-                            let infos = responses
-                                .into_iter()
-                                .map(|temp_block_wrapper| match temp_block_wrapper {
-                                    TempBlockWrapper::Block(block) => {
-                                        format!("slot{}", block.slot())
-                                    }
-                                    TempBlockWrapper::BlockAndBlobList(block, blob_list) => {
-                                        format!("slot{}({} blobs)", block.slot(), blob_list.len())
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-                            infos.join(", ")
-                        }
-                        Err(e) => format!("Error: {e}"),
-                    };
-                    unimplemented!("Here we are supposed to return a block possibly paired with a Bundle of blobs, but only have a list of individual blobs. This is what we got from the network: ChainId[{chain_id}] BatchId[{batch_id}] {unimplemented_info}")
+                    Some((
+                        chain_id,
+                        BlocksAndBlobsByRangeResponse {
+                            batch_id,
+                            responses: block_blob_info.into_responses(),
+                        },
+                    ))
                 } else {
                     None
                 }
@@ -416,24 +397,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     let (batch_id, info) = entry.remove();
 
                     let responses = info.into_responses();
-                    let unimplemented_info = match responses {
-                        Ok(responses) => {
-                            let infos = responses
-                                .into_iter()
-                                .map(|temp_block_wrapper| match temp_block_wrapper {
-                                    TempBlockWrapper::Block(block) => {
-                                        format!("slot{}", block.slot())
-                                    }
-                                    TempBlockWrapper::BlockAndBlobList(block, blob_list) => {
-                                        format!("slot{}({} blobs)", block.slot(), blob_list.len())
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-                            infos.join(", ")
-                        }
-                        Err(e) => format!("Error: {e}"),
-                    };
-                    unimplemented!("Here we are supposed to return a block possibly paired with a Bundle of blobs for backfill, but only have a list of individual blobs. This is what we got from the network: BatchId[{batch_id}]{unimplemented_info}")
+                    Some(BlocksAndBlobsByRangeResponse {
+                        batch_id,
+                        responses,
+                    })
                 } else {
                     None
                 }


### PR DESCRIPTION
## Issue Addressed

Removes the `TempBlockWrapper` and replaces it with the `BlockWrapper` now that #4092 is merged

