### PR TITLE
[Merged by Bors] - Add a flag to disable peer scoring

### DIFF
--- a/beacon_node/http_api/tests/common.rs
+++ b/beacon_node/http_api/tests/common.rs
@@ -155,6 +155,7 @@ pub async fn create_api_server_on_port<T: BeaconChainTypes>(
         None,
         meta_data,
         vec![],
+        false,
         &log,
     ));
 

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -101,6 +101,9 @@ pub struct Config {
     /// List of trusted libp2p nodes which are not scored.
     pub trusted_peers: Vec<PeerIdSerialized>,
 
+    /// Disables peer scoring altogether.
+    pub disable_peer_scoring: bool,
+
     /// Client version
     pub client_version: String,
 
@@ -309,6 +312,7 @@ impl Default for Config {
             boot_nodes_multiaddr: vec![],
             libp2p_nodes: vec![],
             trusted_peers: vec![],
+            disable_peer_scoring: false,
             client_version: lighthouse_version::version_with_platform(),
             disable_discovery: false,
             upnp_enabled: true,

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1162,6 +1162,7 @@ mod tests {
                 syncnets: Default::default(),
             }),
             vec![],
+            false,
             &log,
         );
         Discovery::new(&keypair, &config, Arc::new(globals), &log)

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -171,6 +171,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     .iter()
                     .map(|x| PeerId::from(x.clone()))
                     .collect(),
+                config.disable_peer_scoring,
                 &log,
             );
             Arc::new(globals)

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -39,6 +39,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         listen_port_tcp6: Option<u16>,
         local_metadata: MetaData<TSpec>,
         trusted_peers: Vec<PeerId>,
+        disable_peer_scoring: bool,
         log: &slog::Logger,
     ) -> Self {
         NetworkGlobals {
@@ -48,7 +49,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
             listen_port_tcp4,
             listen_port_tcp6,
             local_metadata: RwLock::new(local_metadata),
-            peers: RwLock::new(PeerDB::new(trusted_peers, log)),
+            peers: RwLock::new(PeerDB::new(trusted_peers, disable_peer_scoring, log)),
             gossipsub_subscriptions: RwLock::new(HashSet::new()),
             sync_state: RwLock::new(SyncState::Stalled),
             backfill_state: RwLock::new(BackFillState::NotRequired),
@@ -144,6 +145,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
                 syncnets: Default::default(),
             }),
             vec![],
+            false,
             log,
         )
     }

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -180,6 +180,7 @@ impl TestRig {
             None,
             meta_data,
             vec![],
+            false,
             &log,
         ));
 

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -238,7 +238,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("disable-peer-scoring")
                 .help("Disables peer scoring in lighthouse. WARNING: This is a dev only flag is only meant to be used in local testing scenarios \
                         Using this flag on a real network may cause your node to become eclipsed and see a different view of the network")
-                .takes_value(false),
+                .takes_value(false)
+                .hidden(true),
         )
         .arg(
             Arg::with_name("trusted-peers")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -234,6 +234,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(false),
         )
         .arg(
+            Arg::with_name("disable-peer-scoring")
+                .long("disable-peer-scoring")
+                .help("Disables peer scoring in lighthouse. WARNING: This is a dev only flag is only meant to be used in local testing scenarios \
+                        Using this flag on a real network may cause your node to become eclipsed and see a different view of the network")
+                .takes_value(false),
+        )
+        .arg(
             Arg::with_name("trusted-peers")
                 .long("trusted-peers")
                 .value_name("TRUSTED_PEERS")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1004,6 +1004,10 @@ pub fn set_network_config(
             .collect::<Result<Vec<Multiaddr>, _>>()?;
     }
 
+    if cli_args.is_present("disable-peer-scoring") {
+        config.disable_peer_scoring = true;
+    }
+
     if let Some(trusted_peers_str) = cli_args.value_of("trusted-peers") {
         config.trusted_peers = trusted_peers_str
             .split(',')

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1045,6 +1045,13 @@ fn disable_discovery_flag() {
         .with_config(|config| assert!(config.network.disable_discovery));
 }
 #[test]
+fn disable_peer_scoring_flag() {
+    CommandLineTest::new()
+        .flag("disable-peer-scoring", None)
+        .run_with_zero_port()
+        .with_config(|config| assert!(config.network.disable_peer_scoring));
+}
+#[test]
 fn disable_upnp_flag() {
     CommandLineTest::new()
         .flag("disable-upnp", None)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Adds a flag for disabling peer scoring. This is useful for local testing and testing small networks for new features.