### PR TITLE
clean up blobs by range response

### DIFF
--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1971,7 +1971,6 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 request,
             } => task_spawner.spawn_blocking_with_manual_send_idle(move |send_idle_on_drop| {
                 worker.handle_blobs_by_range_request(
-                    sub_executor,
                     send_idle_on_drop,
                     peer_id,
                     request_id,


### PR DESCRIPTION
## Issue Addressed

- remove unused param `_executor: TaskExecutor,`
- when we get `Ok(None)` from `chain.get_blobs` we no longer error. `Ok(None)` here represents no blobs for a given block root which is valid. We now skip as described here: https://github.com/ethereum/consensus-specs/pull/3242
- We had some convoluted logic around where to start a response from, and this PR simplifies it. The new logic is to first check whether the `oldest_blob_slot` in our database (this is the point to where we have pruned blobs which should be the data availability boundary plus some margin) is older than the request start slot. If it is *not* we then check whether our `oldest_blobs_slot` is within the `data_availability_boundary`. If it is, this means we pruned blocks when we shouldn't have, so we return `RESOURCE_UNAVAILABLE`. Otherwise the request is too old. 
 
