### PR TITLE
[Merged by Bors] - add attestation inclusion distance in http api

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -199,7 +199,7 @@ pub struct ValidatorMetrics {
     pub attestation_head_misses: u64,
     pub attestation_target_hits: u64,
     pub attestation_target_misses: u64,
-    pub attestation_inclusion_distance: u64,
+    pub latest_attestation_inclusion_distance: u64,
 }
 
 impl ValidatorMetrics {
@@ -227,8 +227,8 @@ impl ValidatorMetrics {
         self.attestation_head_misses += 1;
     }
 
-    pub fn set_inclusion_distance(&mut self, distance: u64) {
-        self.attestation_inclusion_distance = distance;
+    pub fn set_latest_inclusion_distance(&mut self, distance: u64) {
+        self.latest_attestation_inclusion_distance = distance;
     }
 }
 
@@ -697,7 +697,7 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                             &[id],
                             inclusion_delay as i64,
                         );
-                        validator_metrics.set_inclusion_distance(inclusion_delay);
+                        validator_metrics.set_latest_inclusion_distance(inclusion_delay);
                     }
                 }
                 drop(validator_metrics);

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -199,6 +199,7 @@ pub struct ValidatorMetrics {
     pub attestation_head_misses: u64,
     pub attestation_target_hits: u64,
     pub attestation_target_misses: u64,
+    pub attestation_inclusion_distance: u64,
 }
 
 impl ValidatorMetrics {
@@ -224,6 +225,10 @@ impl ValidatorMetrics {
 
     pub fn increment_head_misses(&mut self) {
         self.attestation_head_misses += 1;
+    }
+
+    pub fn set_inclusion_distance(&mut self, distance: u64) {
+        self.attestation_inclusion_distance = distance;
     }
 }
 
@@ -568,7 +573,6 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                 } else {
                     validator_metrics.increment_misses()
                 }
-                drop(validator_metrics);
 
                 // Indicates if any attestation made it on-chain.
                 //
@@ -693,8 +697,10 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                             &[id],
                             inclusion_delay as i64,
                         );
+                        validator_metrics.set_inclusion_distance(inclusion_delay);
                     }
                 }
+                drop(validator_metrics);
 
                 // Indicates the number of sync committee signatures that made it into
                 // a sync aggregate in the current_epoch (state.epoch - 1).

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -211,7 +211,8 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
                 let attestation_head_misses = val_metrics.attestation_head_misses;
                 let attestation_target_hits = val_metrics.attestation_target_hits;
                 let attestation_target_misses = val_metrics.attestation_target_misses;
-                let latest_attestation_inclusion_distance = val_metrics.latest_attestation_inclusion_distance;
+                let latest_attestation_inclusion_distance =
+                    val_metrics.latest_attestation_inclusion_distance;
                 drop(val_metrics);
 
                 let attestations = attestation_hits + attestation_misses;

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -165,7 +165,7 @@ pub struct ValidatorMetrics {
     attestation_target_hits: u64,
     attestation_target_misses: u64,
     attestation_target_hit_percentage: f64,
-    attestation_inclusion_distance: u64,
+    latest_attestation_inclusion_distance: u64,
 }
 
 #[derive(PartialEq, Serialize, Deserialize)]
@@ -211,7 +211,7 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
                 let attestation_head_misses = val_metrics.attestation_head_misses;
                 let attestation_target_hits = val_metrics.attestation_target_hits;
                 let attestation_target_misses = val_metrics.attestation_target_misses;
-                let attestation_inclusion_distance = val_metrics.attestation_inclusion_distance;
+                let latest_attestation_inclusion_distance = val_metrics.latest_attestation_inclusion_distance;
                 drop(val_metrics);
 
                 let attestations = attestation_hits + attestation_misses;
@@ -244,7 +244,7 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
                     attestation_target_hits,
                     attestation_target_misses,
                     attestation_target_hit_percentage,
-                    attestation_inclusion_distance,
+                    latest_attestation_inclusion_distance,
                 };
 
                 validators.insert(id.clone(), metrics);

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -165,6 +165,7 @@ pub struct ValidatorMetrics {
     attestation_target_hits: u64,
     attestation_target_misses: u64,
     attestation_target_hit_percentage: f64,
+    attestation_inclusion_distance: u64,
 }
 
 #[derive(PartialEq, Serialize, Deserialize)]
@@ -210,6 +211,7 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
                 let attestation_head_misses = val_metrics.attestation_head_misses;
                 let attestation_target_hits = val_metrics.attestation_target_hits;
                 let attestation_target_misses = val_metrics.attestation_target_misses;
+                let attestation_inclusion_distance = val_metrics.attestation_inclusion_distance;
                 drop(val_metrics);
 
                 let attestations = attestation_hits + attestation_misses;
@@ -242,6 +244,7 @@ pub fn post_validator_monitor_metrics<T: BeaconChainTypes>(
                     attestation_target_hits,
                     attestation_target_misses,
                     attestation_target_hit_percentage,
+                    attestation_inclusion_distance,
                 };
 
                 validators.insert(id.clone(), metrics);

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -142,7 +142,7 @@ curl -X POST "http://localhost:5052/lighthouse/ui/validator_metrics" -d '{"indic
         "attestation_target_hits": 5,
         "attestation_target_misses": 5,
         "attestation_target_hit_percentage": 50,
-        "attestation_inclusion_distance": 1
+        "latest_attestation_inclusion_distance": 1
       }
     }
   }

--- a/book/src/api-lighthouse.md
+++ b/book/src/api-lighthouse.md
@@ -141,7 +141,8 @@ curl -X POST "http://localhost:5052/lighthouse/ui/validator_metrics" -d '{"indic
         "attestation_head_hit_percentage": 100,
         "attestation_target_hits": 5,
         "attestation_target_misses": 5,
-        "attestation_target_hit_percentage": 50
+        "attestation_target_hit_percentage": 50,
+        "attestation_inclusion_distance": 1
       }
     }
   }


### PR DESCRIPTION
## Issue Addressed

#4097

## Proposed Changes

Add attestation inclusion distance in http api, extend `/lighthouse/ui/validator_metrics` to include it.

## Usage
```
curl -X POST "http://localhost:8001/lighthouse/ui/validator_metrics" -d '{"indices": [1]}' -H "Content-Type: application/json" | jq
```

```
{
  "data": {
    "validators": {
      "1": {
        "attestation_hits": 3,
        "attestation_misses": 1,
        "attestation_hit_percentage": 75,
        "attestation_head_hits": 3,
        "attestation_head_misses": 0,
        "attestation_head_hit_percentage": 100,
        "attestation_target_hits": 3,
        "attestation_target_misses": 0,
        "attestation_target_hit_percentage": 100,
        "attestation_inclusion_distance": 1
      }
    }
  }
}
```

## Additional Info

NA
