### PR TITLE
builder-profit-threshold used in local payload comparison

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -815,7 +815,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                                     self.log(),
                                     "Local block plus profit threshold is more profitable than relay block";
                                     "local_block_value" => %local_value,
-                                    "profit_threshold" => %profit_threshold
+                                    "profit_threshold" => %profit_threshold,
                                     "relay_value" => %relay_value
                                 );
                                 return Ok(ProvenancedPayload::Local(local));

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -815,7 +815,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                                     self.log(),
                                     "Local block plus profit threshold is more profitable than relay block";
                                     "local_block_value" => %local_value,
-                                    "local_boosted_value" => %boosted_local,
+                                    "profit_threshold" => %profit_threshold
                                     "relay_value" => %relay_value
                                 );
                                 return Ok(ProvenancedPayload::Local(local));

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -371,7 +371,7 @@ impl ApiTester {
             .unwrap()
             .builder
             .add_operation(Operation::Value(Uint256::from(
-                DEFAULT_BUILDER_THRESHOLD_WEI,
+                DEFAULT_BUILDER_THRESHOLD_WEI + DEFAULT_BUILDER_PAYLOAD_VALUE_WEI + 1,
             )));
         tester
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -953,12 +953,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("WEI_VALUE")
                 .help("The minimum reward in wei provided to the proposer by a block builder for \
                     an external payload to be considered for inclusion in a proposal. If this \
-                    threshold is not met, the local EE's payload will be used. This is currently \
-                    *NOT* in comparison to the value of the local EE's payload. It simply checks \
-                    whether the total proposer reward from an external payload is equal to or \
-                    greater than this value. In the future, a comparison to a local payload is \
-                    likely to be added. Example: Use 250000000000000000 to set the threshold to \
-                     0.25 ETH.")
+                    threshold is not met, the local EE's payload will be used. This is in comparison \
+                    to the value of the local EE's payload. It checks whether the total proposer \
+                    reward from an external payload is equal to or greater than this value plus the \
+                    local payload's value. Example: Use 250000000000000000 to set the threshold to \
+                     0.25 ETH. This means the builder's payload must exceed the local payload's reward \
+                     by 0.25 ETH.")
                 .default_value("0")
                 .takes_value(true)
         )

--- a/book/src/builders.md
+++ b/book/src/builders.md
@@ -164,12 +164,12 @@ consider using it for the chance of out-sized rewards, this flag may be useful:
 
 `--builder-profit-threshold <WEI_VALUE>`
 
-The number provided indicates the minimum reward that an external payload must provide the proposer for it to be considered
-for inclusion in a proposal. For example, if you'd only like to use an external payload for a reward of >= 0.25 ETH, you
-would provide your beacon node with `--builder-profit-threshold 250000000000000000`. If it's your turn to propose and the
-most valuable payload offered by builders is only 0.1 ETH, the local execution engine's payload will be used. Currently,
-this threshold just looks at the value of the external payload. No comparison to the local payload is made, although
-this feature will likely be added in the future.
+The number provided indicates the minimum reward that an external payload must provide the proposer in excess of the 
+local payload for it to be considered for inclusion in a proposal. For example, if you'd only like to use an external 
+payload for a reward of >= 0.25 ETH + local payaload reward, you would provide your beacon node with 
+`--builder-profit-threshold 250000000000000000`. If it's your turn to propose and the
+most valuable payload offered by builders is only 0.1 ETH greater than the local execution payloads value, the local 
+execution engine's payload will be used. 
 
 ## Checking your builder config
 


### PR DESCRIPTION
## Issue Addressed

Final piece of the puzzle for https://github.com/sigp/lighthouse/issues/3699

## Description

- `--builder-profit-threshold` is not yet used in local payload comparison, this adds that. Currently the flag just compares the relay value to a provided value and picks the local payload if the provided value is not met. 

- this also logs out a bit more about the values, and threshold to make the comparison clear (currently we only log out information about the value if a local payload is chosen)