### PR TITLE
[Merged by Bors] - Remove the unused `ExecutionOptimisticForkVersionedResponse` type

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1875,21 +1875,6 @@ impl ApiTester {
                 .unwrap();
             assert_eq!(result_ssz, expected, "{:?}", state_id);
 
-            // Check legacy v1 API.
-            let result_v1 = self
-                .client
-                .get_debug_beacon_states_v1(state_id.0)
-                .await
-                .unwrap();
-
-            if let (Some(json), Some(expected)) = (&result_v1, &expected) {
-                assert_eq!(json.version, None);
-                assert_eq!(json.data, *expected, "{:?}", state_id);
-            } else {
-                assert_eq!(result_v1, None);
-                assert_eq!(expected, None);
-            }
-
             // Check that version headers are provided.
             let url = self
                 .client

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1280,23 +1280,6 @@ impl BeaconNodeHttpClient {
         self.get_opt(path).await
     }
 
-    /// `GET v1/debug/beacon/states/{state_id}` (LEGACY)
-    pub async fn get_debug_beacon_states_v1<T: EthSpec>(
-        &self,
-        state_id: StateId,
-    ) -> Result<Option<ExecutionOptimisticForkVersionedResponse<BeaconState<T>>>, Error> {
-        let mut path = self.eth_path(V1)?;
-
-        path.path_segments_mut()
-            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
-            .push("debug")
-            .push("beacon")
-            .push("states")
-            .push(&state_id.to_string());
-
-        self.get_opt(path).await
-    }
-
     /// `GET debug/beacon/states/{state_id}`
     /// `-H "accept: application/octet-stream"`
     pub async fn get_debug_beacon_states_ssz<T: EthSpec>(

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -45,43 +45,6 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct ExecutionOptimisticForkVersionedResponse<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
-    pub execution_optimistic: Option<bool>,
-    pub data: T,
-}
-
-impl<'de, F> serde::Deserialize<'de> for ExecutionOptimisticForkVersionedResponse<F>
-where
-    F: ForkVersionDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            version: Option<ForkName>,
-            execution_optimistic: Option<bool>,
-            data: serde_json::Value,
-        }
-
-        let helper = Helper::deserialize(deserializer)?;
-        let data = match helper.version {
-            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
-            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
-        };
-
-        Ok(ExecutionOptimisticForkVersionedResponse {
-            version: helper.version,
-            execution_optimistic: helper.execution_optimistic,
-            data,
-        })
-    }
-}
-
 pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
     fn deserialize_by_fork<'de, D: Deserializer<'de>>(
         value: Value,

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -143,9 +143,7 @@ pub use crate::fork::Fork;
 pub use crate::fork_context::ForkContext;
 pub use crate::fork_data::ForkData;
 pub use crate::fork_name::{ForkName, InconsistentFork};
-pub use crate::fork_versioned_response::{
-    ExecutionOptimisticForkVersionedResponse, ForkVersionDeserialize, ForkVersionedResponse,
-};
+pub use crate::fork_versioned_response::{ForkVersionDeserialize, ForkVersionedResponse};
 pub use crate::graffiti::{Graffiti, GRAFFITI_BYTES_LEN};
 pub use crate::historical_batch::HistoricalBatch;
 pub use crate::indexed_attestation::IndexedAttestation;


### PR DESCRIPTION
## Issue Addressed

#4146 

## Proposed Changes

Removes the `ExecutionOptimisticForkVersionedResponse` type and the associated Beacon API endpoint which is now deprecated. Also removes the test associated with the endpoint.
