### PR TITLE
[Merged by Bors] - Logfile no restrict help text for windows

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -152,7 +152,8 @@ fn main() {
                 .help(
                     "If present, log files will be generated as world-readable meaning they can be read by \
                     any user on the machine. Note that logs can often contain sensitive information \
-                    about your validator and so this flag should be used with caution.")
+                    about your validator and so this flag should be used with caution. For Windows users, \
+                    the log file permissions will be inherited from the parent folder")
                 .global(true),
         )
         .arg(

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -153,7 +153,7 @@ fn main() {
                     "If present, log files will be generated as world-readable meaning they can be read by \
                     any user on the machine. Note that logs can often contain sensitive information \
                     about your validator and so this flag should be used with caution. For Windows users, \
-                    the log file permissions will be inherited from the parent folder")
+                    the log file permissions will be inherited from the parent folder.")
                 .global(true),
         )
         .arg(


### PR DESCRIPTION
## Issue Addressed

[#4162](https://github.com/sigp/lighthouse/issues/4162)

## Proposed Changes

update `--logfile-no-restricted-perms` flag help text to indicate that, for Windows users, the file permissions are inherited from the parent folder

## Additional Info

N/A