### PR TITLE
[Merged by Bors] - Remove Redundant Trait Bound

### DIFF
--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -1,6 +1,6 @@
 //! Implementation of historic state reconstruction (given complete block history).
 use crate::hot_cold_store::{HotColdDB, HotColdDBError};
-use crate::{Error, ItemStore, KeyValueStore};
+use crate::{Error, ItemStore};
 use itertools::{process_results, Itertools};
 use slog::info;
 use state_processing::{
@@ -13,8 +13,8 @@ use types::{EthSpec, Hash256};
 impl<E, Hot, Cold> HotColdDB<E, Hot, Cold>
 where
     E: EthSpec,
-    Hot: KeyValueStore<E> + ItemStore<E>,
-    Cold: KeyValueStore<E> + ItemStore<E>,
+    Hot: ItemStore<E>,
+    Cold: ItemStore<E>,
 {
     pub fn reconstruct_historic_states(self: &Arc<Self>) -> Result<(), Error> {
         let mut anchor = if let Some(anchor) = self.get_anchor_info() {


### PR DESCRIPTION
I realized this is redundant while reasoning about how the `store` is implemented given the [definition of `ItemStore`](https://github.com/sigp/lighthouse/blob/v4.0.1/beacon_node/store/src/lib.rs#L107)
```rust
pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'static {
    ...
}
```