### PR TITLE
Use Rust 1.66 to fix build failure in lcli container

### DIFF
--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.65.0-bullseye AS builder
+FROM rust:1.66.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG PORTABLE


### PR DESCRIPTION
Consistent with [Rust version used](https://github.com/sigp/lighthouse/blob/stable/Dockerfile#L1) to build `sigp/lighthouse` container.

Fixes: https://github.com/sigp/lighthouse/issues/4174