### PR TITLE
[Merged by Bors] - Address observed proposers behaviour

### DIFF
--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -32,7 +32,7 @@ pub mod migrate;
 mod naive_aggregation_pool;
 mod observed_aggregates;
 mod observed_attesters;
-mod observed_block_producers;
+pub mod observed_block_producers;
 pub mod observed_operations;
 pub mod otb_verification_service;
 mod persisted_beacon_chain;

--- a/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/sync_methods.rs
@@ -9,8 +9,8 @@ use crate::sync::manager::{BlockProcessType, SyncMessage};
 use crate::sync::{BatchProcessResult, ChainId};
 use beacon_chain::CountUnrealized;
 use beacon_chain::{
-    BeaconChainError, BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError,
-    NotifyExecutionLayer,
+    observed_block_producers::Error as ObserveError, BeaconChainError, BeaconChainTypes,
+    BlockError, ChainSegmentResult, HistoricalBlockError, NotifyExecutionLayer,
 };
 use lighthouse_network::PeerAction;
 use slog::{debug, error, info, warn};
@@ -85,21 +85,18 @@ impl<T: BeaconChainTypes> Worker<T> {
         };
         // Check if a block from this proposer is already known. If so, defer processing until later
         // to avoid wasting time processing duplicates.
-        let proposal_already_known = self
+        let proposal_already_known = match self
             .chain
             .observed_block_producers
             .read()
             .proposer_has_been_observed(block.message())
-            .map_err(|e| {
-                error!(
-                    self.log,
-                    "Failed to check observed proposers";
-                    "error" => ?e,
-                    "source" => "rpc",
-                    "block_root" => %block_root
-                );
-            })
-            .unwrap_or(true);
+        {
+            Ok(is_observed) => is_observed,
+            // Both of these blocks will be rejected, so reject them now rather
+            // than re-queuing them.
+            Err(ObserveError::FinalizedBlock { .. })
+            | Err(ObserveError::ValidatorIndexTooHigh { .. }) => false,
+        };
         if proposal_already_known {
             debug!(
                 self.log,


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Apply two changes to code introduced in #4179:

1. Remove the `ERRO` log for when we error on `proposer_has_been_observed()`. We were seeing a lot of this in our logs for finalized blocks and it's a bit noisy.
1. Use `false` rather than `true` for `proposal_already_known` when there is an error. If a block raises an error in `proposer_has_been_observed()` then the block must be invalid, so we should process (and reject) it now rather than queuing it.

For reference, here is one of the offending `ERRO` logs:

```
ERRO Failed to check observed proposers block_root: 0x5845…878e, source: rpc, error: FinalizedBlock { slot: Slot(5410983), finalized_slot: Slot(5411232) }
```

## Additional Info

NA
