### PR TITLE
[Merged by Bors] - Set user agent on requests to builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,7 @@ name = "builder_client"
 version = "0.1.0"
 dependencies = [
  "eth2",
+ "lighthouse_version",
  "reqwest",
  "sensitive_url",
  "serde",

--- a/beacon_node/builder_client/Cargo.toml
+++ b/beacon_node/builder_client/Cargo.toml
@@ -10,3 +10,4 @@ sensitive_url = { path = "../../common/sensitive_url" }
 eth2 = { path = "../../common/eth2" }
 serde = { version = "1.0.116", features = ["derive"] }
 serde_json = "1.0.58"
+lighthouse_version = { path = "../../common/lighthouse_version" }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -329,7 +329,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     "Connected to external block builder";
                     "builder_url" => ?url,
                     "builder_profit_threshold" => builder_profit_threshold,
-                    "user_agent" => builder_client.get_user_agent(),
+                    "local_user_agent" => builder_client.get_user_agent(),
                 );
                 Ok::<_, Error>(builder_client)
             })

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1001,6 +1001,15 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("builder-user-agent")
+                .long("builder-user-agent")
+                .value_name("STRING")
+                .help("The HTTP user agent to send alongside requests to the builder URL. The \
+                       default is Lighthouse's version string.")
+                .requires("builder")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("count-unrealized")
                 .long("count-unrealized")
                 .hidden(true)

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -329,6 +329,9 @@ pub fn get_config<E: EthSpec>(
             let payload_builder =
                 parse_only_one_value(endpoint, SensitiveUrl::parse, "--builder", log)?;
             el_config.builder_url = Some(payload_builder);
+
+            el_config.builder_user_agent =
+                clap_utils::parse_optional(cli_args, "builder-user-agent")?;
         }
 
         // Set config values from parse values.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -716,6 +716,40 @@ fn builder_fallback_flags() {
     );
 }
 
+#[test]
+fn builder_user_agent() {
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        None,
+        None,
+        |config| {
+            assert_eq!(
+                config.execution_layer.as_ref().unwrap().builder_user_agent,
+                None
+            );
+        },
+    );
+    run_payload_builder_flag_test_with_config(
+        "builder",
+        "http://meow.cats",
+        Some("builder-user-agent"),
+        Some("anon"),
+        |config| {
+            assert_eq!(
+                config
+                    .execution_layer
+                    .as_ref()
+                    .unwrap()
+                    .builder_user_agent
+                    .as_ref()
+                    .unwrap(),
+                "anon"
+            );
+        },
+    );
+}
+
 fn run_jwt_optional_flags_test(jwt_flag: &str, jwt_id_flag: &str, jwt_version_flag: &str) {
     use sensitive_url::SensitiveUrl;
 


### PR DESCRIPTION
## Issue Addressed

Closes #4185

## Proposed Changes

- Set user agent to `Lighthouse/vX.Y.Z-<commit hash>` by default
- Allow tweaking user agent via `--builder-user-agent "agent"`
