### PR TITLE
Convert LRU Time Cache to use a hashset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4707,10 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "lru_cache"
-version = "0.1.0"
-dependencies = [
- "fnv",
-]
+version = "0.1.1"
 
 [[package]]
 name = "mach"

--- a/common/lru_cache/Cargo.toml
+++ b/common/lru_cache/Cargo.toml
@@ -1,8 +1,5 @@
 [package]
 name = "lru_cache"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
-
-[dependencies]
-fnv = "1.0.7"

--- a/common/lru_cache/src/time.rs
+++ b/common/lru_cache/src/time.rs
@@ -1,6 +1,5 @@
 ///! This implements a time-based LRU cache for fast checking of duplicates
-use fnv::FnvHashSet;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::time::{Duration, Instant};
 
 struct Element<Key> {
@@ -12,7 +11,7 @@ struct Element<Key> {
 
 pub struct LRUTimeCache<Key> {
     /// The duplicate cache.
-    map: FnvHashSet<Key>,
+    map: HashSet<Key>,
     /// An ordered list of keys by insert time.
     list: VecDeque<Element<Key>>,
     /// The time elements remain in the cache.
@@ -25,7 +24,7 @@ where
 {
     pub fn new(ttl: Duration) -> Self {
         LRUTimeCache {
-            map: FnvHashSet::default(),
+            map: HashSet::default(),
             list: VecDeque::new(),
             ttl,
         }


### PR DESCRIPTION
There is potentially an issue with using FNV hasher with PeerIds. 

A safe approach is to convert to the standard HashSet in the standard library to ensure there are no issues with hashing peer-ids. 