### PR TITLE
update blob transaction

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2081,7 +2081,7 @@ pub enum BlobTxConversionError {
     /// Missing the `max_fee_per_data_gas` field.
     MaxFeePerDataGasMissing,
     /// Missing the `versioned_hashes` field.
-    BlobVersionedHashesMissing,
+    VersionedHashesMissing,
     /// `y_parity` field was greater than one.
     InvalidYParity,
     /// There was an error converting the transaction to SSZ.
@@ -2207,18 +2207,18 @@ fn ethers_tx_to_bytes<T: EthSpec>(
         )
         .map_err(BlobTxConversionError::FromStrRadix)?;
 
-        // blobVersionedHashes
+        // versionedHashes
         let versioned_hashes = other
-            .get("blobVersionedHashes")
-            .ok_or(BlobTxConversionError::BlobVersionedHashesMissing)?
+            .get("versionedHashes")
+            .ok_or(BlobTxConversionError::VersionedHashesMissing)?
             .as_array()
-            .ok_or(BlobTxConversionError::BlobVersionedHashesMissing)?
+            .ok_or(BlobTxConversionError::VersionedHashesMissing)?
             .iter()
             .map(|versioned_hash| {
                 let hash_bytes = eth2_serde_utils::hex::decode(
                     versioned_hash
                         .as_str()
-                        .ok_or(BlobTxConversionError::BlobVersionedHashesMissing)?,
+                        .ok_or(BlobTxConversionError::VersionedHashesMissing)?,
                 )
                 .map_err(BlobTxConversionError::FromHex)?;
                 if hash_bytes.len() != Hash256::ssz_fixed_len() {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2239,7 +2239,7 @@ fn ethers_tx_to_bytes<T: EthSpec>(
             data,
             access_list,
             max_fee_per_data_gas,
-            blob_versioned_hashes: VariableList::new(blob_versioned_hashes)?,
+            versioned_hashes: VariableList::new(blob_versioned_hashes)?,
         };
 
         // ******************** EcdsaSignature fields ********************

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2080,7 +2080,7 @@ pub enum BlobTxConversionError {
     AccessListMissing,
     /// Missing the `max_fee_per_data_gas` field.
     MaxFeePerDataGasMissing,
-    /// Missing the `blob_versioned_hashes` field.
+    /// Missing the `versioned_hashes` field.
     BlobVersionedHashesMissing,
     /// `y_parity` field was greater than one.
     InvalidYParity,
@@ -2208,7 +2208,7 @@ fn ethers_tx_to_bytes<T: EthSpec>(
         .map_err(BlobTxConversionError::FromStrRadix)?;
 
         // blobVersionedHashes
-        let blob_versioned_hashes = other
+        let versioned_hashes = other
             .get("blobVersionedHashes")
             .ok_or(BlobTxConversionError::BlobVersionedHashesMissing)?
             .as_array()
@@ -2239,7 +2239,7 @@ fn ethers_tx_to_bytes<T: EthSpec>(
             data,
             access_list,
             max_fee_per_data_gas,
-            versioned_hashes: VariableList::new(blob_versioned_hashes)?,
+            versioned_hashes: VariableList::new(versioned_hashes)?,
         };
 
         // ******************** EcdsaSignature fields ********************

--- a/consensus/state_processing/src/per_block_processing/deneb/deneb.rs
+++ b/consensus/state_processing/src/per_block_processing/deneb/deneb.rs
@@ -42,7 +42,7 @@ pub fn verify_kzg_commitments_against_transactions<T: EthSpec>(
                 .map(|tx_type| *tx_type == BLOB_TX_TYPE)
                 .unwrap_or(false)
         })
-        .map(|tx| tx_peek_blob_versioned_hashes::<T>(tx));
+        .map(|tx| tx_peek_versioned_hashes::<T>(tx));
 
     itertools::process_results(nested_iter, |iter| {
         let zipped_iter = iter
@@ -76,7 +76,7 @@ pub fn verify_kzg_commitments_against_transactions<T: EthSpec>(
 }
 
 /// Only transactions of type `BLOB_TX_TYPE` should be passed into this function.
-fn tx_peek_blob_versioned_hashes<T: EthSpec>(
+fn tx_peek_versioned_hashes<T: EthSpec>(
     opaque_tx: &Transaction<T::MaxBytesPerTransaction>,
 ) -> Result<
     impl IntoIterator<Item = Result<VersionedHash, BlockProcessingError>> + '_,
@@ -93,7 +93,7 @@ fn tx_peek_blob_versioned_hashes<T: EthSpec>(
     let message_offset_usize = message_offset as usize;
 
     // field offset: 32 + 8 + 32 + 32 + 8 + 4 + 32 + 4 + 4 + 32 = 188
-    let blob_versioned_hashes_offset = message_offset.safe_add(u32::from_ssz_bytes(
+    let versioned_hashes_offset = message_offset.safe_add(u32::from_ssz_bytes(
         opaque_tx
             .get(message_offset_usize.safe_add(188)?..message_offset_usize.safe_add(192)?)
             .ok_or(BlockProcessingError::BlobVersionHashIndexOutOfBounds {
@@ -103,12 +103,12 @@ fn tx_peek_blob_versioned_hashes<T: EthSpec>(
     )?)?;
 
     let num_hashes = tx_len
-        .safe_sub(blob_versioned_hashes_offset as usize)?
+        .safe_sub(versioned_hashes_offset as usize)?
         .safe_div(32)?;
 
     Ok((0..num_hashes).map(move |i| {
         let next_version_hash_index =
-            (blob_versioned_hashes_offset as usize).safe_add(i.safe_mul(32)?)?;
+            (versioned_hashes_offset as usize).safe_add(i.safe_mul(32)?)?;
         let bytes = opaque_tx
             .get(next_version_hash_index..next_version_hash_index.safe_add(32)?)
             .ok_or(BlockProcessingError::BlobVersionHashIndexOutOfBounds {

--- a/consensus/types/src/transaction.rs
+++ b/consensus/types/src/transaction.rs
@@ -1,13 +1,13 @@
 use crate::{Hash256, Uint256, VersionedHash};
 use ethereum_types::Address;
 use ssz_derive::{Decode, Encode};
-use ssz_types::typenum::U16777216;
+use ssz_types::typenum::{U16777216, U4096};
 use ssz_types::VariableList;
 
 pub type MaxCalldataSize = U16777216;
 pub type MaxAccessListSize = U16777216;
-pub type MaxVersionedHashesListSize = U16777216;
 pub type MaxAccessListStorageKeys = U16777216;
+pub type MaxVersionedHashesListSize = U4096;
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct SignedBlobTransaction {
@@ -27,7 +27,7 @@ pub struct BlobTransaction {
     pub data: VariableList<u8, MaxCalldataSize>,
     pub access_list: VariableList<AccessTuple, MaxAccessListSize>,
     pub max_fee_per_data_gas: Uint256,
-    pub blob_versioned_hashes: VariableList<VersionedHash, MaxVersionedHashesListSize>,
+    pub versioned_hashes: VariableList<VersionedHash, MaxVersionedHashesListSize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]


### PR DESCRIPTION
Updates related to decoupling EIP 4844 https://github.com/ethereum/EIPs/pull/6610

- rename ` blob_versioned_hashes` to `versioned_hashes`
- reduce max size of this field in the blob tx type to 4096