### PR TITLE
[Merged by Bors] - Update LLVM version to 15.0 in CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             - uses: KyleMayes/install-llvm-action@v1
               if: startsWith(matrix.arch, 'x86_64-windows')
               with:
-                version: "13.0"
+                version: "14.0"
                 directory: ${{ runner.temp }}/llvm
             - name: Set LIBCLANG_PATH
               if: startsWith(matrix.arch, 'x86_64-windows')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             - uses: KyleMayes/install-llvm-action@v1
               if: startsWith(matrix.arch, 'x86_64-windows')
               with:
-                version: "14.0"
+                version: "15.0"
                 directory: ${{ runner.temp }}/llvm
             - name: Set LIBCLANG_PATH
               if: startsWith(matrix.arch, 'x86_64-windows')

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -83,7 +83,7 @@ jobs:
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
       with:
-        version: "14.0"
+        version: "15.0"
         directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -83,7 +83,7 @@ jobs:
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
       with:
-        version: "13.0"
+        version: "14.0"
         directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
## Issue Addressed

The latest stable version (1.69.0) of Rust was released on 20 April and contains this change:
- [Update the minimum external LLVM to 14.](https://github.com/rust-lang/rust/pull/107573/)

This impacts some of our CI workflows (build and release-test-windows) that uses LLVM 13.0. This  PR updates the workflows to install LLVM 15.0.

**UPDATE**: Also updated `h2` to address [this issue](https://github.com/advisories/GHSA-f8vr-r385-rh5r)
