### PR TITLE
Update `engine_api` to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,6 +2647,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "keccak-hash",
+ "kzg",
  "lazy_static",
  "lighthouse_metrics",
  "lru 0.7.8",

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -12,12 +12,13 @@ use crate::data_availability_checker::{
 };
 use crate::kzg_utils::{validate_blob, validate_blobs};
 use crate::BeaconChainError;
+use eth2::types::BlockContentsTuple;
 use kzg::Kzg;
 use std::borrow::Cow;
 use types::{
     BeaconBlockRef, BeaconState, BeaconStateError, BlobSidecar, BlobSidecarList, ChainSpec,
-    CloneConfig, Epoch, EthSpec, Hash256, KzgCommitment, RelativeEpoch, SignedBeaconBlock,
-    SignedBeaconBlockHeader, SignedBlobSidecar, Slot,
+    CloneConfig, Epoch, EthSpec, FullPayload, Hash256, KzgCommitment, RelativeEpoch,
+    SignedBeaconBlock, SignedBeaconBlockHeader, SignedBlobSidecar, Slot,
 };
 
 #[derive(Debug)]
@@ -641,5 +642,20 @@ impl<E: EthSpec> From<Arc<SignedBeaconBlock<E>>> for BlockWrapper<E> {
 impl<E: EthSpec> From<SignedBeaconBlock<E>> for BlockWrapper<E> {
     fn from(value: SignedBeaconBlock<E>) -> Self {
         Self::Block(Arc::new(value))
+    }
+}
+
+impl<E: EthSpec> From<BlockContentsTuple<E, FullPayload<E>>> for BlockWrapper<E> {
+    fn from(value: BlockContentsTuple<E, FullPayload<E>>) -> Self {
+        match value.1 {
+            Some(variable_list) => Self::BlockAndBlobs(
+                Arc::new(value.0),
+                Vec::from(variable_list)
+                    .into_iter()
+                    .map(|signed_blob| signed_blob.message)
+                    .collect::<Vec<_>>(),
+            ),
+            None => Self::Block(Arc::new(value.0)),
+        }
     }
 }

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -815,7 +815,7 @@ where
             SignedBeaconBlock::Base(_)
             | SignedBeaconBlock::Altair(_)
             | SignedBeaconBlock::Merge(_)
-            | SignedBeaconBlock::Capella(_) => BlockContentsTuple::from((signed_block, None)),
+            | SignedBeaconBlock::Capella(_) => (signed_block, None),
             SignedBeaconBlock::Deneb(_) => {
                 if let Some(blobs) = self
                     .chain
@@ -834,10 +834,10 @@ where
                         })
                         .collect::<Vec<_>>()
                         .into();
-                    BlockContentsTuple::from((signed_block, Some(signed_blobs)))
+                    (signed_block, Some(signed_blobs))
                 } else {
                     // idk what else to put here..
-                    BlockContentsTuple::from((signed_block, None))
+                    (signed_block, None)
                 }
             }
         };

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -767,11 +767,11 @@ where
         state.get_block_root(slot).unwrap() == state.get_block_root(slot - 1).unwrap()
     }
 
-    pub async fn make_block<Payload: AbstractExecPayload<E> + 'static>(
+    pub async fn make_block(
         &self,
         mut state: BeaconState<E>,
         slot: Slot,
-    ) -> (BlockContentsTuple<E, Payload>, BeaconState<E>) {
+    ) -> (BlockContentsTuple<E, FullPayload<E>>, BeaconState<E>) {
         assert_ne!(slot, 0, "can't produce a block at slot 0");
         assert!(slot >= state.slot());
 
@@ -811,7 +811,7 @@ where
             &self.spec,
         );
 
-        let block_contents: BlockContentsTuple<E, Payload> = match &signed_block {
+        let block_contents: BlockContentsTuple<E, FullPayload<E>> = match &signed_block {
             SignedBeaconBlock::Base(_)
             | SignedBeaconBlock::Altair(_)
             | SignedBeaconBlock::Merge(_)
@@ -836,7 +836,6 @@ where
                         .into();
                     (signed_block, Some(signed_blobs))
                 } else {
-                    // idk what else to put here..
                     (signed_block, None)
                 }
             }
@@ -2097,12 +2096,12 @@ where
     /// Deprecated: Use make_block() instead
     ///
     /// Returns a newly created block, signed by the proposer for the given slot.
-    pub async fn build_block<Payload: AbstractExecPayload<E> + 'static>(
+    pub async fn build_block(
         &self,
         state: BeaconState<E>,
         slot: Slot,
         _block_strategy: BlockStrategy,
-    ) -> (BlockContentsTuple<E, Payload>, BeaconState<E>) {
+    ) -> (BlockContentsTuple<E, FullPayload<E>>, BeaconState<E>) {
         self.make_block(state, slot).await
     }
 

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1025,8 +1025,8 @@ async fn verify_block_for_gossip_slashing_detection() {
     harness.advance_slot();
 
     let state = harness.get_current_state();
-    let (block1, _) = harness.make_block(state.clone(), Slot::new(1)).await;
-    let (block2, _) = harness.make_block(state, Slot::new(1)).await;
+    let ((block1, _), _) = harness.make_block(state.clone(), Slot::new(1)).await;
+    let ((block2, _), _) = harness.make_block(state, Slot::new(1)).await;
 
     let verified_block = harness
         .chain
@@ -1065,7 +1065,7 @@ async fn verify_block_for_gossip_doppelganger_detection() {
     let harness = get_harness(VALIDATOR_COUNT);
 
     let state = harness.get_current_state();
-    let (block, _) = harness.make_block(state.clone(), Slot::new(1)).await;
+    let ((block, _), _) = harness.make_block(state.clone(), Slot::new(1)).await;
 
     let verified_block = harness
         .chain
@@ -1152,7 +1152,7 @@ async fn add_base_block_to_altair_chain() {
     // Produce an Altair block.
     let state = harness.get_current_state();
     let slot = harness.get_current_slot();
-    let (altair_signed_block, _) = harness.make_block(state.clone(), slot).await;
+    let ((altair_signed_block, _), _) = harness.make_block(state.clone(), slot).await;
     let altair_block = &altair_signed_block
         .as_altair()
         .expect("test expects an altair block")
@@ -1289,7 +1289,7 @@ async fn add_altair_block_to_base_chain() {
     // Produce an altair block.
     let state = harness.get_current_state();
     let slot = harness.get_current_slot();
-    let (base_signed_block, _) = harness.make_block(state.clone(), slot).await;
+    let ((base_signed_block, _), _) = harness.make_block(state.clone(), slot).await;
     let base_block = &base_signed_block
         .as_base()
         .expect("test expects a base block")

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -223,7 +223,7 @@ impl InvalidPayloadRig {
         let head = self.harness.chain.head_snapshot();
         let state = head.beacon_state.clone_with_only_committee_caches();
         let slot = slot_override.unwrap_or(state.slot() + 1);
-        let (block, post_state) = self.harness.make_block(state, slot).await;
+        let ((block, _), post_state) = self.harness.make_block(state, slot).await;
         let block_root = block.canonical_root();
 
         let set_new_payload = |payload: Payload| match payload {
@@ -691,7 +691,8 @@ async fn invalidates_all_descendants() {
         .state_at_slot(fork_parent_slot, StateSkipConfig::WithStateRoots)
         .unwrap();
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
-    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot).await;
+    let ((fork_block, _), _fork_post_state) =
+        rig.harness.make_block(fork_parent_state, fork_slot).await;
     let fork_block_root = rig
         .harness
         .chain
@@ -789,7 +790,8 @@ async fn switches_heads() {
         .state_at_slot(fork_parent_slot, StateSkipConfig::WithStateRoots)
         .unwrap();
     assert_eq!(fork_parent_state.slot(), fork_parent_slot);
-    let (fork_block, _fork_post_state) = rig.harness.make_block(fork_parent_state, fork_slot).await;
+    let ((fork_block, _), _fork_post_state) =
+        rig.harness.make_block(fork_parent_state, fork_slot).await;
     let fork_parent_root = fork_block.parent_root();
     let fork_block_root = rig
         .harness
@@ -1033,8 +1035,8 @@ async fn invalid_parent() {
     // Produce another block atop the parent, but don't import yet.
     let slot = parent_block.slot() + 1;
     rig.harness.set_current_slot(slot);
-    let (block, state) = rig.harness.make_block(parent_state, slot).await;
-    let block = Arc::new(block);
+    let (block_tuple, state) = rig.harness.make_block(parent_state, slot).await;
+    let block = Arc::new(block_tuple.0);
     let block_root = block.canonical_root();
     assert_eq!(block.parent_root(), parent_root);
 
@@ -1850,8 +1852,8 @@ impl InvalidHeadSetup {
                     .chain
                     .state_at_slot(slot - 1, StateSkipConfig::WithStateRoots)
                     .unwrap();
-                let (fork_block, _) = rig.harness.make_block(parent_state, slot).await;
-                opt_fork_block = Some(Arc::new(fork_block));
+                let (fork_block_tuple, _) = rig.harness.make_block(parent_state, slot).await;
+                opt_fork_block = Some(Arc::new(fork_block_tuple.0));
             } else {
                 // Skipped slot.
             };

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2022,7 +2022,7 @@ async fn garbage_collect_temp_states_from_failed_block() {
 
         let genesis_state = harness.get_current_state();
         let block_slot = Slot::new(2 * slots_per_epoch);
-        let (signed_block, state) = harness.make_block(genesis_state, block_slot).await;
+        let ((signed_block, _), state) = harness.make_block(genesis_state, block_slot).await;
 
         let (mut block, _) = signed_block.deconstruct();
 
@@ -2422,7 +2422,7 @@ async fn revert_minority_fork_on_resume() {
         harness1.process_attestations(attestations.clone());
         harness2.process_attestations(attestations);
 
-        let (block, new_state) = harness1.make_block(state, slot).await;
+        let ((block, _), new_state) = harness1.make_block(state, slot).await;
 
         harness1
             .process_block(slot, block.canonical_root(), block.clone())
@@ -2463,7 +2463,7 @@ async fn revert_minority_fork_on_resume() {
         harness2.process_attestations(attestations);
 
         // Minority chain block (no attesters).
-        let (block1, new_state1) = harness1.make_block(state1, slot).await;
+        let ((block1, _), new_state1) = harness1.make_block(state1, slot).await;
         harness1
             .process_block(slot, block1.canonical_root(), block1)
             .await
@@ -2471,7 +2471,7 @@ async fn revert_minority_fork_on_resume() {
         state1 = new_state1;
 
         // Majority chain block (all attesters).
-        let (block2, new_state2) = harness2.make_block(state2, slot).await;
+        let ((block2, _), new_state2) = harness2.make_block(state2, slot).await;
         harness2
             .process_block(slot, block2.canonical_root(), block2.clone())
             .await

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.2"
 eth2_ssz = "0.4.1"
 eth2_ssz_types = "0.2.2"
 eth2 = { path = "../../common/eth2" }
+kzg = { path = "../../crypto/kzg" }
 state_processing = { path = "../../consensus/state_processing" }
 superstruct = "0.6.0"
 lru = "0.7.1"

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -379,6 +379,8 @@ pub struct GetPayloadResponse<T: EthSpec> {
     #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
     pub execution_payload: ExecutionPayloadDeneb<T>,
     pub block_value: Uint256,
+    #[superstruct(only(Deneb))]
+    pub blobs_bundle: BlobsBundleV1<T>,
 }
 
 impl<'a, T: EthSpec> From<GetPayloadResponseRef<'a, T>> for ExecutionPayloadRef<'a, T> {
@@ -397,20 +399,25 @@ impl<T: EthSpec> From<GetPayloadResponse<T>> for ExecutionPayload<T> {
     }
 }
 
-impl<T: EthSpec> From<GetPayloadResponse<T>> for (ExecutionPayload<T>, Uint256) {
+impl<T: EthSpec> From<GetPayloadResponse<T>>
+    for (ExecutionPayload<T>, Uint256, Option<BlobsBundleV1<T>>)
+{
     fn from(response: GetPayloadResponse<T>) -> Self {
         match response {
             GetPayloadResponse::Merge(inner) => (
                 ExecutionPayload::Merge(inner.execution_payload),
                 inner.block_value,
+                None,
             ),
             GetPayloadResponse::Capella(inner) => (
                 ExecutionPayload::Capella(inner.execution_payload),
                 inner.block_value,
+                None,
             ),
             GetPayloadResponse::Deneb(inner) => (
                 ExecutionPayload::Deneb(inner.execution_payload),
                 inner.block_value,
+                Some(inner.blobs_bundle),
             ),
         }
     }

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -515,7 +515,7 @@ impl<E: EthSpec> ExecutionPayloadBodyV1<E> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq)]
 pub struct BlobsBundleV1<E: EthSpec> {
     pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -1,7 +1,7 @@
 use crate::engines::ForkchoiceState;
 use crate::http::{
     ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1, ENGINE_FORKCHOICE_UPDATED_V1,
-    ENGINE_FORKCHOICE_UPDATED_V2, ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
+    ENGINE_FORKCHOICE_UPDATED_V2, ENGINE_GET_BLOBS_BUNDLE_V1, ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
     ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1, ENGINE_GET_PAYLOAD_V1, ENGINE_GET_PAYLOAD_V2,
     ENGINE_GET_PAYLOAD_V3, ENGINE_NEW_PAYLOAD_V1, ENGINE_NEW_PAYLOAD_V2, ENGINE_NEW_PAYLOAD_V3,
 };
@@ -16,12 +16,14 @@ use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
+use types::beacon_block_body::KzgCommitments;
+use types::blob_sidecar::Blobs;
 pub use types::{
     Address, EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadHeader,
     ExecutionPayloadRef, FixedVector, ForkName, Hash256, Transactions, Uint256, VariableList,
     Withdrawal, Withdrawals,
 };
-use types::{ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge};
+use types::{ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge, KzgProofs};
 
 pub mod auth;
 pub mod http;
@@ -513,6 +515,13 @@ impl<E: EthSpec> ExecutionPayloadBodyV1<E> {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct BlobsBundleV1<E: EthSpec> {
+    pub commitments: KzgCommitments<E>,
+    pub proofs: KzgProofs<E>,
+    pub blobs: Blobs<E>,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct EngineCapabilities {
     pub new_payload_v1: bool,
@@ -526,6 +535,7 @@ pub struct EngineCapabilities {
     pub get_payload_v2: bool,
     pub get_payload_v3: bool,
     pub exchange_transition_configuration_v1: bool,
+    pub get_blobs_bundle_v1: bool,
 }
 
 impl EngineCapabilities {
@@ -563,6 +573,9 @@ impl EngineCapabilities {
         }
         if self.exchange_transition_configuration_v1 {
             response.push(ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1);
+        }
+        if self.get_blobs_bundle_v1 {
+            response.push(ENGINE_GET_BLOBS_BUNDLE_V1);
         }
 
         response

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -1,7 +1,7 @@
 use crate::engines::ForkchoiceState;
 use crate::http::{
     ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1, ENGINE_FORKCHOICE_UPDATED_V1,
-    ENGINE_FORKCHOICE_UPDATED_V2, ENGINE_GET_BLOBS_BUNDLE_V1, ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
+    ENGINE_FORKCHOICE_UPDATED_V2, ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
     ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1, ENGINE_GET_PAYLOAD_V1, ENGINE_GET_PAYLOAD_V2,
     ENGINE_GET_PAYLOAD_V3, ENGINE_NEW_PAYLOAD_V1, ENGINE_NEW_PAYLOAD_V2, ENGINE_NEW_PAYLOAD_V3,
 };
@@ -542,7 +542,6 @@ pub struct EngineCapabilities {
     pub get_payload_v2: bool,
     pub get_payload_v3: bool,
     pub exchange_transition_configuration_v1: bool,
-    pub get_blobs_bundle_v1: bool,
 }
 
 impl EngineCapabilities {
@@ -580,9 +579,6 @@ impl EngineCapabilities {
         }
         if self.exchange_transition_configuration_v1 {
             response.push(ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1);
-        }
-        if self.get_blobs_bundle_v1 {
-            response.push(ENGINE_GET_BLOBS_BUNDLE_V1);
         }
 
         response

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -76,6 +76,7 @@ pub static LIGHTHOUSE_CAPABILITIES: &[&str] = &[
     ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
     ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
     ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1,
+    ENGINE_GET_BLOBS_BUNDLE_V1,
 ];
 
 /// This is necessary because a user might run a capella-enabled version of
@@ -94,6 +95,7 @@ pub static PRE_CAPELLA_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilit
     get_payload_v2: false,
     get_payload_v3: false,
     exchange_transition_configuration_v1: true,
+    get_blobs_bundle_v1: false,
 };
 
 /// Contains methods to convert arbitrary bytes to an ETH2 deposit contract object.
@@ -930,10 +932,10 @@ impl HttpJsonRpc {
     pub async fn get_blobs_bundle_v1<T: EthSpec>(
         &self,
         payload_id: PayloadId,
-    ) -> Result<JsonBlobsBundle<T>, Error> {
+    ) -> Result<BlobsBundleV1<T>, Error> {
         let params = json!([JsonPayloadIdRequest::from(payload_id)]);
 
-        let response: JsonBlobsBundle<T> = self
+        let response: JsonBlobsBundleV1<T> = self
             .rpc_request(
                 ENGINE_GET_BLOBS_BUNDLE_V1,
                 params,
@@ -941,7 +943,7 @@ impl HttpJsonRpc {
             )
             .await?;
 
-        Ok(response)
+        Ok(response.into())
     }
 
     pub async fn forkchoice_updated_v1(
@@ -1082,6 +1084,7 @@ impl HttpJsonRpc {
                 get_payload_v3: capabilities.contains(ENGINE_GET_PAYLOAD_V3),
                 exchange_transition_configuration_v1: capabilities
                     .contains(ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1),
+                get_blobs_bundle_v1: capabilities.contains(ENGINE_GET_BLOBS_BUNDLE_V1),
             }),
         }
     }

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -40,9 +40,6 @@ pub const ENGINE_GET_PAYLOAD_V2: &str = "engine_getPayloadV2";
 pub const ENGINE_GET_PAYLOAD_V3: &str = "engine_getPayloadV3";
 pub const ENGINE_GET_PAYLOAD_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub const ENGINE_GET_BLOBS_BUNDLE_V1: &str = "engine_getBlobsBundleV1";
-pub const ENGINE_GET_BLOBS_BUNDLE_TIMEOUT: Duration = Duration::from_secs(2);
-
 pub const ENGINE_FORKCHOICE_UPDATED_V1: &str = "engine_forkchoiceUpdatedV1";
 pub const ENGINE_FORKCHOICE_UPDATED_V2: &str = "engine_forkchoiceUpdatedV2";
 pub const ENGINE_FORKCHOICE_UPDATED_TIMEOUT: Duration = Duration::from_secs(8);
@@ -76,7 +73,6 @@ pub static LIGHTHOUSE_CAPABILITIES: &[&str] = &[
     ENGINE_GET_PAYLOAD_BODIES_BY_HASH_V1,
     ENGINE_GET_PAYLOAD_BODIES_BY_RANGE_V1,
     ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1,
-    ENGINE_GET_BLOBS_BUNDLE_V1,
 ];
 
 /// This is necessary because a user might run a capella-enabled version of
@@ -95,7 +91,6 @@ pub static PRE_CAPELLA_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilit
     get_payload_v2: false,
     get_payload_v3: false,
     exchange_transition_configuration_v1: true,
-    get_blobs_bundle_v1: false,
 };
 
 /// Contains methods to convert arbitrary bytes to an ETH2 deposit contract object.
@@ -929,23 +924,6 @@ impl HttpJsonRpc {
         }
     }
 
-    pub async fn get_blobs_bundle_v1<T: EthSpec>(
-        &self,
-        payload_id: PayloadId,
-    ) -> Result<BlobsBundleV1<T>, Error> {
-        let params = json!([JsonPayloadIdRequest::from(payload_id)]);
-
-        let response: JsonBlobsBundleV1<T> = self
-            .rpc_request(
-                ENGINE_GET_BLOBS_BUNDLE_V1,
-                params,
-                ENGINE_GET_BLOBS_BUNDLE_TIMEOUT,
-            )
-            .await?;
-
-        Ok(response.into())
-    }
-
     pub async fn forkchoice_updated_v1(
         &self,
         forkchoice_state: ForkchoiceState,
@@ -1084,7 +1062,6 @@ impl HttpJsonRpc {
                 get_payload_v3: capabilities.contains(ENGINE_GET_PAYLOAD_V3),
                 exchange_transition_configuration_v1: capabilities
                     .contains(ENGINE_EXCHANGE_TRANSITION_CONFIGURATION_V1),
-                get_blobs_bundle_v1: capabilities.contains(ENGINE_GET_BLOBS_BUNDLE_V1),
             }),
         }
     }

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -291,6 +291,8 @@ pub struct JsonGetPayloadResponse<T: EthSpec> {
     pub execution_payload: JsonExecutionPayloadV3<T>,
     #[serde(with = "eth2_serde_utils::u256_hex_be")]
     pub block_value: Uint256,
+    #[superstruct(only(V3))]
+    pub blobs_bundle: JsonBlobsBundleV1<T>,
 }
 
 impl<T: EthSpec> From<JsonGetPayloadResponse<T>> for GetPayloadResponse<T> {
@@ -312,6 +314,7 @@ impl<T: EthSpec> From<JsonGetPayloadResponse<T>> for GetPayloadResponse<T> {
                 GetPayloadResponse::Deneb(GetPayloadResponseDeneb {
                     execution_payload: response.execution_payload.into(),
                     block_value: response.block_value,
+                    blobs_bundle: response.blobs_bundle.into(),
                 })
             }
         }

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -409,12 +409,31 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-#[serde(bound = "T: EthSpec", rename_all = "camelCase")]
-pub struct JsonBlobsBundle<T: EthSpec> {
-    pub block_hash: ExecutionBlockHash,
-    pub kzgs: KzgCommitments<T>,
+#[serde(bound = "E: EthSpec", rename_all = "camelCase")]
+pub struct JsonBlobsBundleV1<E: EthSpec> {
+    pub commitments: KzgCommitments<E>,
+    pub proofs: KzgProofs<E>,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
-    pub blobs: Blobs<T>,
+    pub blobs: Blobs<E>,
+}
+
+impl<E: EthSpec> From<BlobsBundleV1<E>> for JsonBlobsBundleV1<E> {
+    fn from(blobs_bundle: BlobsBundleV1<E>) -> Self {
+        Self {
+            commitments: blobs_bundle.commitments,
+            proofs: blobs_bundle.proofs,
+            blobs: blobs_bundle.blobs,
+        }
+    }
+}
+impl<E: EthSpec> From<JsonBlobsBundleV1<E>> for BlobsBundleV1<E> {
+    fn from(json_blobs_bundle: JsonBlobsBundleV1<E>) -> Self {
+        Self {
+            commitments: json_blobs_bundle.commitments,
+            proofs: json_blobs_bundle.proofs,
+            blobs: json_blobs_bundle.blobs,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -45,12 +45,12 @@ use types::beacon_block_body::KzgCommitments;
 use types::blob_sidecar::Blobs;
 use types::consts::deneb::BLOB_TX_TYPE;
 use types::transaction::{AccessTuple, BlobTransaction, EcdsaSignature, SignedBlobTransaction};
-use types::Withdrawals;
 use types::{AbstractExecPayload, BeaconStateError, ExecPayload, VersionedHash};
 use types::{
     BlindedPayload, BlockType, ChainSpec, Epoch, ExecutionBlockHash, ExecutionPayload,
     ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge, ForkName,
 };
+use types::{KzgProofs, Withdrawals};
 use types::{
     ProposerPreparationData, PublicKeyBytes, Signature, SignedBeaconBlock, Slot, Transaction,
     Uint256,
@@ -141,22 +141,32 @@ pub enum BlockProposalContents<T: EthSpec, Payload: AbstractExecPayload<T>> {
         block_value: Uint256,
         kzg_commitments: KzgCommitments<T>,
         blobs: Blobs<T>,
+        proofs: KzgProofs<T>,
     },
 }
 
+#[allow(clippy::type_complexity)]
 impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockProposalContents<T, Payload> {
-    pub fn deconstruct(self) -> (Payload, Option<KzgCommitments<T>>, Option<Blobs<T>>) {
+    pub fn deconstruct(
+        self,
+    ) -> (
+        Payload,
+        Option<KzgCommitments<T>>,
+        Option<Blobs<T>>,
+        Option<KzgProofs<T>>,
+    ) {
         match self {
             Self::Payload {
                 payload,
                 block_value: _,
-            } => (payload, None, None),
+            } => (payload, None, None, None),
             Self::PayloadAndBlobs {
                 payload,
                 block_value: _,
                 kzg_commitments,
                 blobs,
-            } => (payload, Some(kzg_commitments), Some(blobs)),
+                proofs,
+            } => (payload, Some(kzg_commitments), Some(blobs), Some(proofs)),
         }
     }
 
@@ -171,6 +181,7 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockProposalContents<T, Paylo
                 block_value: _,
                 kzg_commitments: _,
                 blobs: _,
+                proofs: _,
             } => payload,
         }
     }
@@ -185,6 +196,7 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockProposalContents<T, Paylo
                 block_value: _,
                 kzg_commitments: _,
                 blobs: _,
+                proofs: _,
             } => payload,
         }
     }
@@ -199,6 +211,7 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockProposalContents<T, Paylo
                 block_value,
                 kzg_commitments: _,
                 blobs: _,
+                proofs: _,
             } => block_value,
         }
     }
@@ -215,6 +228,7 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> BlockProposalContents<T, Paylo
                 block_value: Uint256::zero(),
                 blobs: VariableList::default(),
                 kzg_commitments: VariableList::default(),
+                proofs: VariableList::default(),
             },
         })
     }
@@ -1145,7 +1159,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     );
                     engine.api.get_payload::<T>(current_fork, payload_id).await
                 };
-                let (blob, payload_response) = tokio::join!(blob_fut, payload_fut);
+                let (blobs_bundle, payload_response) = tokio::join!(blob_fut, payload_fut);
                 let (execution_payload, block_value) = payload_response.map(|payload_response| {
                     if payload_response.execution_payload_ref().fee_recipient() != payload_attributes.suggested_fee_recipient() {
                         error!(
@@ -1169,13 +1183,14 @@ impl<T: EthSpec> ExecutionLayer<T> {
                     }
                     payload_response.into()
                 })?;
-                if let Some(blob) = blob.transpose()? {
+                if let Some(bundle) = blobs_bundle.transpose()? {
                     // FIXME(sean) cache blobs
                     Ok(BlockProposalContents::PayloadAndBlobs {
                         payload: execution_payload.into(),
                         block_value,
-                        blobs: blob.blobs,
-                        kzg_commitments: blob.kzgs,
+                        blobs: bundle.blobs,
+                        kzg_commitments: bundle.commitments,
+                        proofs: bundle.proofs,
                     })
                 } else {
                     Ok(BlockProposalContents::Payload {

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -672,7 +672,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
                 data: Default::default(),
                 access_list: Default::default(),
                 max_fee_per_data_gas: Default::default(),
-                blob_versioned_hashes: vec![versioned_hash].into(),
+                versioned_hashes: vec![versioned_hash].into(),
             };
             let bad_signature = EcdsaSignature {
                 y_parity: false,

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -590,7 +590,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
                             execution_payload
                                 .transactions_mut()
                                 .push(tx)
-                                .map_err(|_| format!("transactions are full"))?;
+                                .map_err(|_| "transactions are full".to_string())?;
                         }
                         self.blobs_bundles.insert(id, bundle);
                     }

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -224,6 +224,8 @@ pub async fn handle_rpc<T: EthSpec>(
                     )
                 })?;
 
+            let maybe_blobs = ctx.execution_block_generator.write().get_blobs_bundle(&id);
+
             // validate method called correctly according to shanghai fork time
             if ctx
                 .execution_block_generator
@@ -291,6 +293,12 @@ pub async fn handle_rpc<T: EthSpec>(
                         serde_json::to_value(JsonGetPayloadResponseV3 {
                             execution_payload,
                             block_value: DEFAULT_MOCK_EL_PAYLOAD_VALUE_WEI.into(),
+                            blobs_bundle: maybe_blobs
+                                .ok_or((
+                                    "No blobs returned despite V3 Payload".to_string(),
+                                    GENERIC_ERROR_CODE,
+                                ))?
+                                .into(),
                         })
                         .unwrap()
                     }

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -492,23 +492,6 @@ pub async fn handle_rpc<T: EthSpec>(
 
             Ok(serde_json::to_value(response).unwrap())
         }
-        ENGINE_GET_BLOBS_BUNDLE_V1 => {
-            let request: JsonPayloadIdRequest =
-                get_param(params, 0).map_err(|s| (s, BAD_PARAMS_ERROR_CODE))?;
-            let id = request.into();
-
-            let response = ctx
-                .execution_block_generator
-                .write()
-                .get_blobs_bundle(&id)
-                .ok_or_else(|| {
-                    (
-                        format!("no bundle for id {:?}", id),
-                        UNKNOWN_PAYLOAD_ERROR_CODE,
-                    )
-                })?;
-            Ok(serde_json::to_value(JsonBlobsBundleV1::from(response)).unwrap())
-        }
         other => Err((
             format!("The method {} does not exist/is not available", other),
             METHOD_NOT_FOUND_CODE,

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     Config, *,
 };
+use kzg::Kzg;
 use sensitive_url::SensitiveUrl;
 use task_executor::TaskExecutor;
 use tempfile::NamedTempFile;
@@ -33,6 +34,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
             Some(JwtKey::from_slice(&DEFAULT_JWT_SECRET).unwrap()),
             spec,
             None,
+            None,
         )
     }
 
@@ -46,6 +48,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         jwt_key: Option<JwtKey>,
         spec: ChainSpec,
         builder_url: Option<SensitiveUrl>,
+        kzg: Option<Kzg>,
     ) -> Self {
         let handle = executor.handle().unwrap();
 
@@ -58,6 +61,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
             spec.terminal_block_hash,
             shanghai_time,
             deneb_time,
+            kzg,
         );
 
         let url = SensitiveUrl::parse(&server.url()).unwrap();

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use environment::null_logger;
 use execution_block_generator::PoWBlock;
 use handle_rpc::handle_rpc;
+use kzg::Kzg;
 use parking_lot::{Mutex, RwLock, RwLockWriteGuard};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -46,6 +47,7 @@ pub const DEFAULT_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilities {
     get_payload_v2: true,
     get_payload_v3: true,
     exchange_transition_configuration_v1: true,
+    get_blobs_bundle_v1: true,
 };
 
 mod execution_block_generator;
@@ -96,10 +98,15 @@ impl<T: EthSpec> MockServer<T> {
             ExecutionBlockHash::zero(),
             None, // FIXME(capella): should this be the default?
             None, // FIXME(deneb): should this be the default?
+            None, // FIXME(deneb): should this be the default?
         )
     }
 
-    pub fn new_with_config(handle: &runtime::Handle, config: MockExecutionConfig) -> Self {
+    pub fn new_with_config(
+        handle: &runtime::Handle,
+        config: MockExecutionConfig,
+        kzg: Option<Kzg>,
+    ) -> Self {
         let MockExecutionConfig {
             jwt_key,
             terminal_difficulty,
@@ -117,6 +124,7 @@ impl<T: EthSpec> MockServer<T> {
             terminal_block_hash,
             shanghai_time,
             deneb_time,
+            kzg,
         );
 
         let ctx: Arc<Context<T>> = Arc::new(Context {
@@ -168,6 +176,7 @@ impl<T: EthSpec> MockServer<T> {
         *self.ctx.engine_capabilities.write() = engine_capabilities;
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handle: &runtime::Handle,
         jwt_key: JwtKey,
@@ -176,6 +185,7 @@ impl<T: EthSpec> MockServer<T> {
         terminal_block_hash: ExecutionBlockHash,
         shanghai_time: Option<u64>,
         deneb_time: Option<u64>,
+        kzg: Option<Kzg>,
     ) -> Self {
         Self::new_with_config(
             handle,
@@ -188,6 +198,7 @@ impl<T: EthSpec> MockServer<T> {
                 shanghai_time,
                 deneb_time,
             },
+            kzg,
         )
     }
 

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -47,7 +47,6 @@ pub const DEFAULT_ENGINE_CAPABILITIES: EngineCapabilities = EngineCapabilities {
     get_payload_v2: true,
     get_payload_v3: true,
     exchange_transition_configuration_v1: true,
-    get_blobs_bundle_v1: true,
 };
 
 mod execution_block_generator;

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -480,7 +480,7 @@ pub async fn proposer_boost_re_org_test(
 
     // Produce block B and process it halfway through the slot.
     let (block_b, mut state_b) = harness.make_block(state_a.clone(), slot_b).await;
-    let block_b_root = block_b.canonical_root();
+    let block_b_root = block_b.0.canonical_root();
 
     let obs_time = slot_clock.start_of(slot_b).unwrap() + slot_clock.slot_duration() / 2;
     slot_clock.set_current_time(obs_time);
@@ -573,8 +573,18 @@ pub async fn proposer_boost_re_org_test(
 
     // Check the fork choice updates that were sent.
     let forkchoice_updates = forkchoice_updates.lock();
-    let block_a_exec_hash = block_a.message().execution_payload().unwrap().block_hash();
-    let block_b_exec_hash = block_b.message().execution_payload().unwrap().block_hash();
+    let block_a_exec_hash = block_a
+        .0
+        .message()
+        .execution_payload()
+        .unwrap()
+        .block_hash();
+    let block_b_exec_hash = block_b
+        .0
+        .message()
+        .execution_payload()
+        .unwrap()
+        .block_hash();
 
     let block_c_timestamp = block_c.message().execution_payload().unwrap().timestamp();
 
@@ -679,7 +689,7 @@ pub async fn fork_choice_before_proposal() {
     let state_a = harness.get_current_state();
     let (block_b, state_b) = harness.make_block(state_a.clone(), slot_b).await;
     let block_root_b = harness
-        .process_block(slot_b, block_b.canonical_root(), block_b)
+        .process_block(slot_b, block_b.0.canonical_root(), block_b)
         .await
         .unwrap();
 
@@ -694,7 +704,7 @@ pub async fn fork_choice_before_proposal() {
 
     let (block_c, state_c) = harness.make_block(state_a, slot_c).await;
     let block_root_c = harness
-        .process_block(slot_c, block_c.canonical_root(), block_c.clone())
+        .process_block(slot_c, block_c.0.canonical_root(), block_c.clone())
         .await
         .unwrap();
 

--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -107,7 +107,7 @@ impl TestRig {
             "precondition: current slot is one after head"
         );
 
-        let (next_block, next_state) = harness
+        let (next_block_tuple, next_state) = harness
             .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
             .await;
 
@@ -133,9 +133,9 @@ impl TestRig {
             .get_unaggregated_attestations(
                 &AttestationStrategy::AllValidators,
                 &next_state,
-                next_block.state_root(),
-                next_block.canonical_root(),
-                next_block.slot(),
+                next_block_tuple.0.state_root(),
+                next_block_tuple.0.canonical_root(),
+                next_block_tuple.0.slot(),
             )
             .into_iter()
             .flatten()
@@ -145,9 +145,9 @@ impl TestRig {
             .make_attestations(
                 &harness.get_all_validators(),
                 &next_state,
-                next_block.state_root(),
-                next_block.canonical_root().into(),
-                next_block.slot(),
+                next_block_tuple.0.state_root(),
+                next_block_tuple.0.canonical_root().into(),
+                next_block_tuple.0.slot(),
             )
             .into_iter()
             .filter_map(|(_, aggregate_opt)| aggregate_opt)
@@ -209,7 +209,7 @@ impl TestRig {
 
         Self {
             chain,
-            next_block: Arc::new(next_block),
+            next_block: Arc::new(next_block_tuple.0),
             attestations,
             next_block_attestations,
             next_block_aggregate_attestations,

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -179,15 +179,15 @@ impl ForkChoiceTest {
             let slot = self.harness.get_current_slot();
             let (block, state_) = self.harness.make_block(state, slot).await;
             state = state_;
-            if !predicate(block.message(), &state) {
+            if !predicate(block.0.message(), &state) {
                 break;
             }
             if let Ok(block_hash) = self.harness.process_block_result(block.clone()).await {
                 self.harness.attest_block(
                     &state,
-                    block.state_root(),
+                    block.0.state_root(),
                     block_hash,
-                    &block,
+                    &block.0,
                     &validators,
                 );
                 self.harness.advance_slot();
@@ -273,8 +273,8 @@ impl ForkChoiceTest {
             )
             .unwrap();
         let slot = self.harness.get_current_slot();
-        let (mut signed_block, mut state) = self.harness.make_block(state, slot).await;
-        func(&mut signed_block, &mut state);
+        let (mut block_tuple, mut state) = self.harness.make_block(state, slot).await;
+        func(&mut block_tuple.0, &mut state);
         let current_slot = self.harness.get_current_slot();
         self.harness
             .chain
@@ -282,8 +282,8 @@ impl ForkChoiceTest {
             .fork_choice_write_lock()
             .on_block(
                 current_slot,
-                signed_block.message(),
-                signed_block.canonical_root(),
+                block_tuple.0.message(),
+                block_tuple.0.canonical_root(),
                 Duration::from_secs(0),
                 &state,
                 PayloadVerificationStatus::Verified,
@@ -315,8 +315,8 @@ impl ForkChoiceTest {
             )
             .unwrap();
         let slot = self.harness.get_current_slot();
-        let (mut signed_block, mut state) = self.harness.make_block(state, slot).await;
-        mutation_func(&mut signed_block, &mut state);
+        let (mut block_tuple, mut state) = self.harness.make_block(state, slot).await;
+        mutation_func(&mut block_tuple.0, &mut state);
         let current_slot = self.harness.get_current_slot();
         let err = self
             .harness
@@ -325,8 +325,8 @@ impl ForkChoiceTest {
             .fork_choice_write_lock()
             .on_block(
                 current_slot,
-                signed_block.message(),
-                signed_block.canonical_root(),
+                block_tuple.0.message(),
+                block_tuple.0.canonical_root(),
                 Duration::from_secs(0),
                 &state,
                 PayloadVerificationStatus::Verified,

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -72,7 +72,7 @@ impl<T: EthSpec> Ord for BlobSidecar<T> {
 }
 
 pub type BlobSidecarList<T> = VariableList<Arc<BlobSidecar<T>>, <T as EthSpec>::MaxBlobsPerBlock>;
-pub type Blobs<T> = VariableList<Blob<T>, <T as EthSpec>::MaxExtraDataBytes>;
+pub type Blobs<T> = VariableList<Blob<T>, <T as EthSpec>::MaxBlobsPerBlock>;
 
 impl<T: EthSpec> SignedRoot for BlobSidecar<T> {}
 

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,5 +1,6 @@
 use crate::test_utils::TestRandom;
-use crate::{Blob, EthSpec, Hash256, SignedRoot, Slot};
+use crate::{Blob, ChainSpec, Domain, EthSpec, Fork, Hash256, SignedBlobSidecar, SignedRoot, Slot};
+use bls::SecretKey;
 use derivative::Derivative;
 use kzg::{KzgCommitment, KzgProof};
 use serde_derive::{Deserialize, Serialize};
@@ -92,5 +93,29 @@ impl<T: EthSpec> BlobSidecar<T> {
     pub fn max_size() -> usize {
         // Fixed part
         Self::empty().as_ssz_bytes().len()
+    }
+
+    // this is mostly not used except for in testing
+    pub fn sign(
+        self: Arc<Self>,
+        secret_key: &SecretKey,
+        fork: &Fork,
+        genesis_validators_root: Hash256,
+        spec: &ChainSpec,
+    ) -> SignedBlobSidecar<T> {
+        let signing_epoch = self.slot.epoch(T::slots_per_epoch());
+        let domain = spec.get_domain(
+            signing_epoch,
+            Domain::BlobSidecar,
+            fork,
+            genesis_validators_root,
+        );
+        let message = self.signing_root(domain);
+        let signature = secret_key.sign(message);
+
+        SignedBlobSidecar {
+            message: self,
+            signature,
+        }
     }
 }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -204,6 +204,7 @@ pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 pub type BLSFieldElement = Uint256;
 pub type Blob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
+pub type KzgProofs<T> = VariableList<KzgProof, <T as EthSpec>::MaxBlobsPerBlock>;
 pub type VersionedHash = Hash256;
 pub type Hash64 = ethereum_types::H64;
 

--- a/crypto/kzg/src/kzg_commitment.rs
+++ b/crypto/kzg/src/kzg_commitment.rs
@@ -1,17 +1,31 @@
 use c_kzg::{Bytes48, BYTES_PER_COMMITMENT};
 use derivative::Derivative;
+use eth2_hashing::hash;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use ssz_derive::{Decode, Encode};
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
-use tree_hash::{PackedEncoding, TreeHash};
+use tree_hash::{Hash256, PackedEncoding, TreeHash};
+
+pub const BLOB_COMMITMENT_VERSION_KZG: u8 = 0x01;
 
 #[derive(Derivative, Clone, Copy, Encode, Decode)]
 #[derivative(PartialEq, Eq, Hash)]
 #[ssz(struct_behaviour = "transparent")]
 pub struct KzgCommitment(pub [u8; BYTES_PER_COMMITMENT]);
+
+impl KzgCommitment {
+    pub fn calculate_versioned_hash(&self) -> Hash256 {
+        let mut versioned_hash = hash(&self.0);
+        versioned_hash
+            .first_mut()
+            .map(|first_byte| *first_byte = BLOB_COMMITMENT_VERSION_KZG)
+            .expect("hash should have at least one byte");
+        Hash256::from_slice(versioned_hash.as_slice())
+    }
+}
 
 impl From<KzgCommitment> for Bytes48 {
     fn from(value: KzgCommitment) -> Self {

--- a/crypto/kzg/src/kzg_commitment.rs
+++ b/crypto/kzg/src/kzg_commitment.rs
@@ -1,6 +1,6 @@
 use c_kzg::{Bytes48, BYTES_PER_COMMITMENT};
 use derivative::Derivative;
-use eth2_hashing::hash;
+use eth2_hashing::hash_fixed;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use ssz_derive::{Decode, Encode};
@@ -18,11 +18,8 @@ pub struct KzgCommitment(pub [u8; BYTES_PER_COMMITMENT]);
 
 impl KzgCommitment {
     pub fn calculate_versioned_hash(&self) -> Hash256 {
-        let mut versioned_hash = hash(&self.0);
-        versioned_hash
-            .first_mut()
-            .map(|first_byte| *first_byte = BLOB_COMMITMENT_VERSION_KZG)
-            .expect("hash should have at least one byte");
+        let mut versioned_hash = hash_fixed(&self.0);
+        versioned_hash[0] = BLOB_COMMITMENT_VERSION_KZG;
         Hash256::from_slice(versioned_hash.as_slice())
     }
 }

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -20,6 +20,7 @@ pub enum Error {
 }
 
 /// A wrapper over a kzg library that holds the trusted setup parameters.
+#[derive(Debug)]
 pub struct Kzg {
     trusted_setup: KzgSettings,
 }

--- a/testing/node_test_rig/src/lib.rs
+++ b/testing/node_test_rig/src/lib.rs
@@ -236,7 +236,7 @@ impl<E: EthSpec> LocalExecutionNode<E> {
             panic!("Failed to write jwt file {}", e);
         }
         Self {
-            server: MockServer::new_with_config(&context.executor.handle().unwrap(), config),
+            server: MockServer::new_with_config(&context.executor.handle().unwrap(), config, None),
             datadir,
         }
     }


### PR DESCRIPTION
## Issue Addressed

Updated the `engine_api` methods to match the latest version & updated the `mock_execution_layer` to produce blobs and now the testing harness works properly on the `deneb` fork. Created tests using these changes on my `overflow_lru_cache` branch that uses these changes and they seem to work.