### PR TITLE
[Merged by Bors] - Enable build profiles for Docker source builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM rust:1.68.2-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG FEATURES
+ARG PROFILE
 ENV FEATURES $FEATURES
+ENV PROFILE $PROFILE
 RUN cd lighthouse && make
 
 FROM ubuntu:22.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.68.2-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG FEATURES
-ARG PROFILE
+ARG PROFILE=release
 ENV FEATURES $FEATURES
 ENV PROFILE $PROFILE
 RUN cd lighthouse && make

--- a/lighthouse/build.rs
+++ b/lighthouse/build.rs
@@ -1,0 +1,2 @@
+// This is a stub for determining the build profile, see `build_profile_name`.
+fn main() {}

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -37,6 +37,17 @@ fn allocator_name() -> &'static str {
     }
 }
 
+fn build_profile_name() -> String {
+    // Nice hack from https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime
+    // The profile name is always the 3rd last part of the path (with 1 based indexing).
+    // e.g. /code/core/target/cli/build/my-build-info-9f91ba6f99d7a061/out
+    std::env!("OUT_DIR")
+        .split(std::path::MAIN_SEPARATOR)
+        .nth_back(3)
+        .unwrap_or_else(|| "unknown")
+        .to_string()
+}
+
 fn main() {
     // Enable backtraces unless a RUST_BACKTRACE value has already been explicitly provided.
     if std::env::var("RUST_BACKTRACE").is_err() {
@@ -58,11 +69,13 @@ fn main() {
                  BLS library: {}\n\
                  SHA256 hardware acceleration: {}\n\
                  Allocator: {}\n\
+                 Profile: {}\n\
                  Specs: mainnet (true), minimal ({}), gnosis ({})",
                  VERSION.replace("Lighthouse/", ""),
                  bls_library_name(),
                  have_sha_extensions(),
                  allocator_name(),
+                 build_profile_name(),
                  cfg!(feature = "spec-minimal"),
                  cfg!(feature = "gnosis"),
             ).as_str()


### PR DESCRIPTION
## Proposed Changes

- Allow Docker images to be built with different profiles via e.g. `--build-arg PROFILE=maxperf`.
- Include the build profile in `lighthouse --version`.

## Additional Info

This only affects Docker images built from source. Our published Docker images use `cross`-compiled binaries that get copied into place.
