### PR TITLE
Prepare CI for merge queues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - unstable
             - stable
-            - capella
         tags:
             - v*
 
@@ -35,11 +34,6 @@ jobs:
               run: |
                     echo "VERSION=latest" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
-            - name: Extract version (if capella)
-              if: github.event.ref == 'refs/heads/capella'
-              run: |
-                    echo "VERSION=capella" >> $GITHUB_ENV
-                    echo "VERSION_SUFFIX=" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')
               run: |

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'book/**'
+  merge_group:
 
 jobs:
   linkcheck:

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - unstable
   pull_request:
+  merge_group:
 
 jobs:
   run-local-testnet:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -21,7 +21,7 @@ jobs:
   target-branch-check:
     name: target-branch-check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' or github.event_name == "merge_group"
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
         - name: Check that the pull request is not targeting the stable branch
           run: test ${{ github.base_ref }} != "stable"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,6 +8,7 @@ on:
       - trying
       - 'pr/*'
   pull_request:
+  merge_group:
 env:
   # Deny warnings in CI
   # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
@@ -20,7 +21,7 @@ jobs:
   target-branch-check:
     name: target-branch-check
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' or github.event_name == "merge_group"
     steps:
         - name: Check that the pull request is not targeting the stable branch
           run: test ${{ github.base_ref }} != "stable"


### PR DESCRIPTION
## Issue Addressed

Addresses https://github.com/sigp/lighthouse/issues/4251

## Proposed Changes

- Run `test-suite`, `local-testnet` and `linkcheck` on merge queue batches.
- Run branch check job to ensure merge queues don't target `stable` accidentally.
- Delete some references to the old `capella` branch.

## Additional Info

Once merge queues are enabled we can try merging this PR using the queue to check that things run as expected.