### PR TITLE
[Merged by Bors] - Fix log on initializing external block builder

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -328,7 +328,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
 
                 info!(
                     log,
-                    "Connected to external block builder";
+                    "Using external block builder";
                     "builder_url" => ?url,
                     "builder_profit_threshold" => builder_profit_threshold,
                     "local_user_agent" => builder_client.get_user_agent(),

--- a/book/src/builders.md
+++ b/book/src/builders.md
@@ -178,7 +178,7 @@ You can check that your builder is configured correctly by looking for these log
 On start-up, the beacon node will log if a builder is configured:
 
 ```
-INFO Connected to external block builder
+INFO Using external block builder
 ```
 
 At regular intervals the validator client will log that it successfully registered its validators


### PR DESCRIPTION
## Issue Addressed

#4266 

## Proposed Changes

- Log `Using external block builder` instead of `Connected to external block builder` on its initialization to resolve the confusion (there's no actual connection there)

## Additional Info

The log is mentioned in builders docs, so it's changed there too.
