### PR TITLE
[Merged by Bors] - Add branching instructions to the contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ questions.
 2. **Work in a feature branch** of your personal fork
    (github.com/YOUR_NAME/lighthouse) of the main repository
    (github.com/sigp/lighthouse).
-3. Once you feel you have addressed the issue, **create a pull-request** to merge
-   your changes into the main repository.
+3. Once you feel you have addressed the issue, **create a pull-request** with
+   `unstable` as the base branch to merge your changes into the main repository.
 4. Wait for the repository maintainers to **review your changes** to ensure the
    issue is addressed satisfactorily. Optionally, mention your PR on
 [discord](https://discord.gg/cyAszAh).


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

 - Add an explicit base branch name (i.e., `unstable`) to the [contributing guide](https://github.com/sigp/lighthouse/blob/stable/CONTRIBUTING.md).

## Additional Info

N/A
