### PR TITLE
[Merged by Bors] - Add `libpq-dev` and `docker` to the to the list of additional requirements for developers in the Book

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -18,7 +18,8 @@ The additional requirements for developers are:
   the networking stack.
 - [`java 11 runtime`](https://openjdk.java.net/projects/jdk/). 11 is the minimum,
   used by web3signer_tests.
-
+- [`libpq-dev`](https://www.postgresql.org/docs/devel/libpq.html). Also know as
+  `libpq-devel` on some systems. 
 
 ## Using `make`
 Commands to run the test suite are available via the `Makefile` in the

--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -20,6 +20,7 @@ The additional requirements for developers are:
   used by web3signer_tests.
 - [`libpq-dev`](https://www.postgresql.org/docs/devel/libpq.html). Also know as
   `libpq-devel` on some systems. 
+- [`docker`](https://www.docker.com/). Some tests need docker installed and **running**.
 
 ## Using `make`
 Commands to run the test suite are available via the `Makefile` in the


### PR DESCRIPTION
## Issue Addressed

Realized this was missing while discussing #4280 

## Proposed Changes

Add an Item to the list of additional requirements for developers.
