### PR TITLE
Revive gossipsub tests

### DIFF
--- a/beacon_node/lighthouse_network/src/service/behaviour.rs
+++ b/beacon_node/lighthouse_network/src/service/behaviour.rs
@@ -17,7 +17,7 @@ pub type SubscriptionFilter = MaxCountSubscriptionFilter<WhitelistSubscriptionFi
 pub type Gossipsub = BaseGossipsub<SnappyTransform, SubscriptionFilter>;
 
 #[derive(NetworkBehaviour)]
-pub(crate) struct Behaviour<AppReqId: ReqId, TSpec: EthSpec> {
+pub struct Behaviour<AppReqId: ReqId, TSpec: EthSpec> {
     /// The routing pub-sub mechanism for eth2.
     pub gossipsub: Gossipsub,
     /// The Eth2 RPC specified in the wire-0 protocol.

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -381,6 +381,10 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
         Ok((network, network_globals))
     }
 
+    pub fn swarm_mut(&mut self) -> &mut libp2p::swarm::Swarm<Behaviour<AppReqId, TSpec>> {
+        &mut self.swarm
+    }
+
     /// Starts the network:
     ///
     /// - Starts listening in the given ports.

--- a/beacon_node/lighthouse_network/tests/common.rs
+++ b/beacon_node/lighthouse_network/tests/common.rs
@@ -125,7 +125,6 @@ pub fn get_enr(node: &LibP2PService<ReqId, E>) -> Enr {
 
 // Returns `n` libp2p peers in fully connected topology.
 #[allow(dead_code)]
-/*
 pub async fn build_full_mesh(
     rt: Weak<Runtime>,
     log: slog::Logger,
@@ -144,7 +143,7 @@ pub async fn build_full_mesh(
     for (i, node) in nodes.iter_mut().enumerate().take(n) {
         for (j, multiaddr) in multiaddrs.iter().enumerate().skip(i) {
             if i != j {
-                match libp2p::Swarm::dial(&mut node.swarm, multiaddr.clone()) {
+                match libp2p::Swarm::dial(node.swarm_mut(), multiaddr.clone()) {
                     Ok(()) => debug!(log, "Connected"),
                     Err(_) => error!(log, "Failed to connect"),
                 };
@@ -152,7 +151,8 @@ pub async fn build_full_mesh(
         }
     }
     nodes
-}*/
+}
+
 // Constructs a pair of nodes with separate loggers. The sender dials the receiver.
 // This returns a (sender, receiver) pair.
 #[allow(dead_code)]

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -1,7 +1,3 @@
-/* These are temporarily disabled due to their non-deterministic behaviour and impending update to
- * gossipsub 1.1. We leave these here as a template for future test upgrades
-
-
 #![cfg(test)]
 use crate::types::GossipEncoding;
 use ::types::{BeaconBlock, EthSpec, MinimalEthSpec, Signature, SignedBeaconBlock};
@@ -168,4 +164,3 @@ async fn test_gossipsub_full_mesh_publish() {
             }
     }
 }
-*/

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -65,8 +65,7 @@ async fn test_gossipsub_forward() {
                         // Assert message received is the correct one
                         assert_eq!(message, pubsub_message.clone());
                         received_count += 1;
-                        // Since `propagate_message` is false, need to propagate manually
-                        node.swarm.propagate_message(&source, id);
+                        node.publish(vec![message]);
                         // Test should succeed if all nodes except the publisher receive the message
                         if received_count == num_nodes - 1 {
                             debug!(log.clone(), "Received message at {} nodes", num_nodes - 1);

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -114,11 +114,11 @@ async fn test_gossipsub_full_mesh_publish() {
         .clone()
         .into();
 
-    /* build our nodes -- in a linear network topology */
+    /* build our nodes -- in a mesh network topology */
     let runtime: Arc<Runtime> = Arc::new(Runtime::new().unwrap());
     let num_nodes = 20;
     let mut nodes: Vec<common::Libp2pInstance> =
-        common::build_linear(Arc::downgrade(&runtime), log.clone(), num_nodes, FORK).await;
+        common::build_full_mesh(Arc::downgrade(&runtime), log.clone(), num_nodes, FORK).await;
 
     /* counters for our main loop */
     let mut received_count = 0;

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -1,4 +1,14 @@
 #![cfg(test)]
+/// Gossipsub tests
+///
+/// Note: The aim of these tests is not to test the robustness of the gossip network
+/// but to check if the gossipsub implementation is behaving according to the specifications.
+
+/// Test if gossipsub message are forwarded by nodes with a simple linear topology.
+///
+///                Topology used in test
+///
+/// node1 <-> node2 <-> node3 ..... <-> node(n-1) <-> node(n)
 use std::sync::Arc;
 
 use crate::types::GossipEncoding;
@@ -13,16 +23,6 @@ mod common;
 
 /// The fork to use for this test module
 const FORK: ForkName = ForkName::Capella;
-
-/* Gossipsub tests */
-// Note: The aim of these tests is not to test the robustness of the gossip network
-// but to check if the gossipsub implementation is behaving according to the specifications.
-
-// Test if gossipsub message are forwarded by nodes with a simple linear topology.
-//
-//                Topology used in test
-//
-// node1 <-> node2 <-> node3 ..... <-> node(n-1) <-> node(n)
 
 #[tokio::test]
 async fn test_gossipsub_forward() {

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -88,7 +88,7 @@ async fn test_gossipsub_forward() {
 
     tokio::select! {
         _ = fut => {}
-        _ = tokio::time::delay_for(tokio::time::Duration::from_millis(800)) => {
+        _ = tokio::time::sleep(tokio::time::Duration::from_millis(800)) => {
             panic!("Future timed out");
         }
     }
@@ -159,7 +159,7 @@ async fn test_gossipsub_full_mesh_publish() {
     };
     tokio::select! {
             _ = fut => {}
-            _ = tokio::time::delay_for(tokio::time::Duration::from_millis(800)) => {
+            _ = tokio::time::sleep(tokio::time::Duration::from_millis(800)) => {
                 panic!("Future timed out");
             }
     }

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -73,16 +73,16 @@ async fn test_gossipsub_forward() {
                             return;
                         }
                     }
-//                    BehaviourEvent::PeerSubscribed(_, topic) => {
-//                        // Publish on beacon block topic
-//                        if topic == TopicHash::from_raw(publishing_topic.clone()) {
-//                            subscribed_count += 1;
-//                            // Every node except the corner nodes are connected to 2 nodes.
-//                            if subscribed_count == (num_nodes * 2) - 2 {
-//                                node.swarm.publish(vec![pubsub_message.clone()]);
-//                            }
-//                        }
-//                    }
+                    //                    BehaviourEvent::PeerSubscribed(_, topic) => {
+                    //                        // Publish on beacon block topic
+                    //                        if topic == TopicHash::from_raw(publishing_topic.clone()) {
+                    //                            subscribed_count += 1;
+                    //                            // Every node except the corner nodes are connected to 2 nodes.
+                    //                            if subscribed_count == (num_nodes * 2) - 2 {
+                    //                                node.swarm.publish(vec![pubsub_message.clone()]);
+                    //                            }
+                    //                        }
+                    //                    }
                     _ => break,
                 }
             }

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -57,8 +57,8 @@ async fn test_gossipsub_forward() {
                     NetworkEvent::PubsubMessage {
                         topic,
                         message,
-                        source,
-                        id,
+                        source: _,
+                        id: _,
                     } => {
                         // Assert topic is the published topic
                         assert_eq!(topic, TopicHash::from_raw(publishing_topic.clone()));

--- a/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
+++ b/beacon_node/lighthouse_network/tests/gossipsub_tests.rs
@@ -48,7 +48,6 @@ async fn test_gossipsub_forward() {
 
     /* counters for our main loop */
     let mut received_count = 0;
-    let mut subscribed_count = 0;
 
     let fut = async move {
         for node in nodes.iter_mut() {
@@ -72,16 +71,6 @@ async fn test_gossipsub_forward() {
                             return;
                         }
                     }
-                    //                    BehaviourEvent::PeerSubscribed(_, topic) => {
-                    //                        // Publish on beacon block topic
-                    //                        if topic == TopicHash::from_raw(publishing_topic.clone()) {
-                    //                            subscribed_count += 1;
-                    //                            // Every node except the corner nodes are connected to 2 nodes.
-                    //                            if subscribed_count == (num_nodes * 2) - 2 {
-                    //                                node.swarm.publish(vec![pubsub_message.clone()]);
-                    //                            }
-                    //                        }
-                    //                    }
                     _ => break,
                 }
             }
@@ -122,7 +111,6 @@ async fn test_gossipsub_full_mesh_publish() {
 
     /* counters for our main loop */
     let mut received_count = 0;
-    let mut subscribed_count = 0;
 
     let fut = async move {
         for node in nodes.iter_mut() {
@@ -137,17 +125,6 @@ async fn test_gossipsub_full_mesh_publish() {
                 }
             }
         }
-        //        while let NetworkEvent::PeerSubscribed(_, topic) =
-        //            publishing_node.next_event().await
-        //        {
-        //            // Publish on beacon block topic
-        //            if topic == TopicHash::from_raw(publishing_topic.clone()) {
-        //                subscribed_count += 1;
-        //                if subscribed_count == num_nodes - 1 {
-        //                    publishing_node.swarm.publish(vec![pubsub_message.clone()]);
-        //                }
-        //            }
-        //        }
     };
     tokio::select! {
             _ = fut => {}


### PR DESCRIPTION
## Issue Addressed

#2335 

## Proposed Changes

 - Revive two unit tests targeting gossipsub:
   - `test_gossipsub_forward`
   - `test_gossipsub_full_mesh_publish`
  - Revive test helper `common::build_full_mesh` to support the these

## Additional Info
N/A
