### PR TITLE
[Merged by Bors] - Enshrine head state shuffling in the `shuffling_cache`

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -395,7 +395,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache dedicated to block processing.
     pub(crate) snapshot_cache: TimeoutRwLock<SnapshotCache<T::EthSpec>>,
     /// Caches the attester shuffling for a given epoch and shuffling key root.
-    pub shuffling_cache: TimeoutRwLock<ShufflingCache>,
+    pub shuffling_cache: TimeoutRwLock<ShufflingCache<T>>,
     /// A cache of eth1 deposit data at epoch boundaries for deposit finalization
     pub eth1_finalization_cache: TimeoutRwLock<Eth1FinalizationCache>,
     /// Caches the beacon block proposer shuffling for a given epoch and shuffling key root.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -395,7 +395,7 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// A cache dedicated to block processing.
     pub(crate) snapshot_cache: TimeoutRwLock<SnapshotCache<T::EthSpec>>,
     /// Caches the attester shuffling for a given epoch and shuffling key root.
-    pub shuffling_cache: TimeoutRwLock<ShufflingCache<T>>,
+    pub shuffling_cache: TimeoutRwLock<ShufflingCache>,
     /// A cache of eth1 deposit data at epoch boundaries for deposit finalization
     pub eth1_finalization_cache: TimeoutRwLock<Eth1FinalizationCache>,
     /// Caches the beacon block proposer shuffling for a given epoch and shuffling key root.

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5476,6 +5476,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let shuffling_id = BlockShufflingIds {
             current: head_block.current_epoch_shuffling_id.clone(),
             next: head_block.next_epoch_shuffling_id.clone(),
+            previous: None,
             block_root: head_block.root,
         }
         .id_for_epoch(shuffling_epoch)

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -805,7 +805,7 @@ where
                 .task_executor
                 .ok_or("Cannot build without task executor")?,
             store_migrator,
-            slot_clock: slot_clock.clone(),
+            slot_clock,
             op_pool: self.op_pool.ok_or("Cannot build without op pool")?,
             // TODO: allow for persisting and loading the pool from disk.
             naive_aggregation_pool: <_>::default(),

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -160,8 +160,7 @@ impl<T: BeaconChainTypes> ShufflingCache<T> {
 
     /// Prunes the `cache` to keep the size below the `cache_size` limit, based on the following preferences:
     /// - Entries from more recent epochs are preferred over older ones.
-    /// - Entries in the canonical chain are preferred,when two entries have the same epoch.
-    /// - "Enshrined" shuffling (i.e. shuffling key the head block at the current wall-clock epoch)
+    /// - "Enshrined" shuffling (i.e. shuffling id for the head block at the current wall-clock epoch)
     ///   must not be pruned.
     fn prune_cache(&mut self) {
         if self.cache.len() >= self.cache_size {
@@ -169,7 +168,6 @@ impl<T: BeaconChainTypes> ShufflingCache<T> {
             let shuffling_ids_to_prune = self
                 .cache
                 .keys()
-                .cloned()
                 .sorted_by_key(|key| key.shuffling_epoch)
                 .filter(|key| {
                     if let Some(current_epoch) = self.get_current_epoch() {
@@ -180,6 +178,7 @@ impl<T: BeaconChainTypes> ShufflingCache<T> {
                     }
                 })
                 .take(prune_count)
+                .cloned()
                 .collect::<Vec<_>>();
 
             for shuffling_id in shuffling_ids_to_prune.iter() {
@@ -567,8 +566,4 @@ mod test {
             "should limit cache size"
         );
     }
-
-    #[test]
-    #[ignore = "not implemented yet"]
-    fn should_prune_committee_cache_prefer_canonical_chain_entries() {}
 }

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -166,11 +166,12 @@ impl ShufflingCache {
                 .keys()
                 .sorted_by_key(|key| key.shuffling_epoch)
                 .filter(|shuffling_id| {
-                    self.head_shuffling_ids
-                        .id_for_epoch(shuffling_id.shuffling_epoch)
-                        .map_or(true, |head_shuffling_id| {
-                            &&head_shuffling_id != shuffling_id
-                        })
+                    Some(shuffling_id)
+                        != self
+                            .head_shuffling_ids
+                            .id_for_epoch(shuffling_id.shuffling_epoch)
+                            .as_ref()
+                            .as_ref()
                 })
                 .take(prune_count)
                 .cloned()

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -250,11 +250,10 @@ impl BlockShufflingIds {
     pub fn id_for_epoch(&self, epoch: Epoch) -> Option<AttestationShufflingId> {
         if epoch == self.current.shuffling_epoch {
             Some(self.current.clone())
-        } else if Some(epoch)
-            == self
-                .previous
-                .as_ref()
-                .map(|shuffling_id| shuffling_id.shuffling_epoch)
+        } else if self
+            .previous
+            .as_ref()
+            .map_or(false, |id| id.shuffling_epoch == epoch)
         {
             self.previous.clone()
         } else if epoch == self.next.shuffling_epoch {

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -265,7 +265,7 @@ impl BlockShufflingIds {
         head_state: &BeaconState<T>,
     ) -> Result<Self, String> {
         let current =
-            AttestationShufflingId::new(head_block_root, &head_state, RelativeEpoch::Current)
+            AttestationShufflingId::new(head_block_root, head_state, RelativeEpoch::Current)
                 .map_err(|e| {
                     format!(
                 "Unable to get attester shuffling decision slot for the current epoch: {:?}",
@@ -273,13 +273,13 @@ impl BlockShufflingIds {
             )
                 })?;
 
-        let next = AttestationShufflingId::new(head_block_root, &head_state, RelativeEpoch::Next)
+        let next = AttestationShufflingId::new(head_block_root, head_state, RelativeEpoch::Next)
             .map_err(|e| {
-            format!(
-                "Unable to get attester shuffling decision slot for the next epoch: {:?}",
-                e
-            )
-        })?;
+                format!(
+                    "Unable to get attester shuffling decision slot for the next epoch: {:?}",
+                    e
+                )
+            })?;
 
         Ok(Self {
             current,

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -153,11 +153,11 @@ impl ShufflingCache {
         self.cache.insert(key, cache_item);
     }
 
-    /// Prunes the `cache` to keep the size below the `cache_size` limit, based on the following preferences:
+    /// Prunes the `cache` to keep the size below the `cache_size` limit, based on the following
+    /// preferences:
     /// - Entries from more recent epochs are preferred over older ones.
-    /// - "Enshrined" shuffling (i.e. shuffling id for the head block at the current wall-clock epoch)
-    ///   must not be pruned.
-    /// TODO: update comment
+    /// - Entries with shuffling ids matching the head's previous, current, and future epochs must
+    ///   not be pruned.
     fn prune_cache(&mut self) {
         if self.cache.len() >= self.cache_size {
             let prune_count = self.cache.len() - self.cache_size + 1;
@@ -206,11 +206,10 @@ impl ShufflingCache {
         Ok(sender)
     }
 
-    /// Inform the cache that the shuffling decision root for the head has changed.
+    /// Inform the cache that the shuffling decision roots for the head has changed.
     ///
-    /// The shuffling that matches this `head_shuffling_decision_root` and the current epoch will
-    /// never be ejected from the cache during `Self::insert_cache_item`.
-    /// TODO: update comment
+    /// The shufflings for the head's previous, current, and future epochs will never be ejected from
+    /// the cache during `Self::insert_cache_item`.
     pub fn update_head_shuffling_ids(&mut self, head_shuffling_ids: BlockShufflingIds) {
         self.head_shuffling_ids = head_shuffling_ids;
     }
@@ -245,7 +244,8 @@ pub struct BlockShufflingIds {
 impl BlockShufflingIds {
     /// Returns the shuffling ID for the given epoch.
     ///
-    /// Returns `None` if `epoch` is prior to `self.current.shuffling_epoch`.
+    /// Returns `None` if `epoch` is prior to `self.previous?.shuffling_epoch` or
+    /// `self.current.shuffling_epoch` (if `previous` is `None`).
     pub fn id_for_epoch(&self, epoch: Epoch) -> Option<AttestationShufflingId> {
         if epoch == self.current.shuffling_epoch {
             Some(self.current.clone())

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -159,8 +159,8 @@ impl ShufflingCache {
     /// - Entries with shuffling ids matching the head's previous, current, and future epochs must
     ///   not be pruned.
     fn prune_cache(&mut self) {
-        if self.cache.len() >= self.cache_size {
-            let prune_count = self.cache.len() - self.cache_size + 1;
+        let target_cache_size = self.cache_size.saturating_sub(1);
+        if let Some(prune_count) = self.cache.len().checked_sub(target_cache_size) {
             let shuffling_ids_to_prune = self
                 .cache
                 .keys()

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -178,14 +178,14 @@ impl ShufflingCache {
                 .collect::<Vec<_>>();
 
             for shuffling_id in shuffling_ids_to_prune.iter() {
+                debug!(
+                    self.logger,
+                    "Removing old shuffling from cache";
+                    "shuffling_epoch" => shuffling_id.shuffling_epoch,
+                    "shuffling_decision_block" => ?shuffling_id.shuffling_decision_block
+                );
                 self.cache.remove(shuffling_id);
             }
-
-            debug!(
-                self.logger,
-                "Removed old shuffling from cache";
-                "count" => shuffling_ids_to_prune.len()
-            );
         }
     }
 

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -538,7 +538,7 @@ mod test {
             cache.insert_committee_cache(shuffling_id, &committee_cache);
         }
 
-        // Now, update the Set head shuffling ids
+        // Now, update the head shuffling ids
         let head_shuffling_ids = BlockShufflingIds {
             current: shuffling_id(current_epoch),
             next: shuffling_id(current_epoch + 1),

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -308,10 +308,11 @@ mod test {
 
     // Creates a new shuffling cache for testing
     fn new_shuffling_cache() -> ShufflingCache {
+        let current_epoch = 8;
         let head_shuffling_ids = BlockShufflingIds {
-            current: shuffling_id(1),
-            next: shuffling_id(2),
-            previous: Some(shuffling_id(0)),
+            current: shuffling_id(current_epoch),
+            next: shuffling_id(current_epoch + 1),
+            previous: Some(shuffling_id(current_epoch - 1)),
             block_root: Hash256::from_low_u64_le(0),
         };
         let logger = null_logger().unwrap();


### PR DESCRIPTION
## Issue Addressed

#4281 

## Proposed Changes

- Change `ShufflingCache` implementation from using `LruCache` to a custom cache that removes entry with lowest epoch instead of oldest insertion time.
- Protect the "enshrined" head shufflings when inserting new committee cache entries. The shuffling ids matching the head's previous, current, and future epochs will never be ejected from the cache during `Self::insert_cache_item`.

## Additional Info

There is a bonus point on shuffling preferences in the issue description that hasn't been implemented yet, as I haven't figured out a good way to do this:

> However I'm not convinced since there are some complexities around tie-breaking when two entries have the same epoch. Perhaps preferring entries in the canonical chain is best? 

We should be able to check if a block is on the canonical chain by:

```rust
canonical_head
        .fork_choice_read_lock()
        .contains_block(root)
```

However we need to interleave the shuffling and fork choice locks, which may cause deadlocks if we're not careful (mentioned by @paulhauner). Alternatively, we could use the `state.block_roots` field of the `chain.canonical_head.snapshot.beacon_state`, which avoids deadlock but requires more work.

I'd like to get some feedback on review & testing before I dig deeper into the preferences stuff, as having the canonical head preference may already be quite useful in preventing the issue raised.
