### PR TITLE
Fix db startup

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -260,8 +260,7 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
                 db.blobs_db = Some(LevelDB::open(path.as_path())?);
             }
         }
-        let blob_info = blob_info.unwrap_or_else(|| db.get_blob_info());
-        db.compare_and_set_blob_info_with_write(blob_info, new_blob_info)?;
+        db.compare_and_set_blob_info_with_write(<_>::default(), new_blob_info)?;
         info!(
             db.log,
             "Blobs DB initialized";


### PR DESCRIPTION
From what I can tell, the startup logic is broken as soon as we're actually storing a non-default `BlobInfo`, (when we have a chain older than the data availability period and are actually pruning blobs).  It looks like we were always comparing the `BlobInfo` in the db with the one in memory, but on initialization the one in memory is always set to `BlobInfo::default` until the first update. 