### PR TITLE
Handle missing slasher backend in tests

### DIFF
--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -993,9 +993,7 @@ async fn verify_block_for_gossip_slashing_detection() {
 
     // The slasher should only instantiate if a backend feature-flag has been
     // provided.
-    //
-    // For example: `--features slasher/lmdb`
-    let slasher = if cfg!(any(feature = "mdbx", feature = "lmdb")) {
+    let slasher = if Slasher::any_backend_feature_flag_is_present() {
         Arc::new(slasher_result.unwrap())
     } else {
         assert!(matches!(

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -987,9 +987,23 @@ async fn block_gossip_verification() {
 #[tokio::test]
 async fn verify_block_for_gossip_slashing_detection() {
     let slasher_dir = tempdir().unwrap();
-    let slasher = Arc::new(
-        Slasher::open(SlasherConfig::new(slasher_dir.path().into()), test_logger()).unwrap(),
-    );
+
+    let slasher_result =
+        Slasher::open(SlasherConfig::new(slasher_dir.path().into()), test_logger());
+
+    // The slasher should only instantiate if a backend feature-flag has been
+    // provided.
+    //
+    // For example: `--features slasher/lmdb`
+    let slasher = if cfg!(any(feature = "mdbx", feature = "lmdb")) {
+        Arc::new(slasher_result.unwrap())
+    } else {
+        assert!(matches!(
+            slasher_result,
+            Err(slasher::Error::SlasherDatabaseBackendDisabled)
+        ));
+        return;
+    };
 
     let inner_slasher = slasher.clone();
     let harness = BeaconChainHarness::builder(MainnetEthSpec)

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -993,7 +993,7 @@ async fn verify_block_for_gossip_slashing_detection() {
 
     // The slasher should only instantiate if a backend feature-flag has been
     // provided.
-    let slasher = if Slasher::any_backend_feature_flag_is_present() {
+    let slasher = if Slasher::<E>::any_backend_feature_flag_is_present() {
         Arc::new(slasher_result.unwrap())
     } else {
         assert!(matches!(

--- a/slasher/src/slasher.rs
+++ b/slasher/src/slasher.rs
@@ -47,6 +47,14 @@ impl<E: EthSpec> Slasher<E> {
         })
     }
 
+    // Returns `true` if any of the backend feature flags have been enabled.
+    //
+    // For example, returns `true` Lighthouse has been compiled with `--features
+    // slasher/lmdb` or `--features slasher/mdbx`.
+    pub const fn any_backend_feature_flag_is_present() -> bool {
+        cfg!(any(feature = "mdbx", feature = "lmdb"))
+    }
+
     /// Harvest all attester slashings found, removing them from the slasher.
     pub fn get_attester_slashings(&self) -> HashSet<AttesterSlashing<E>> {
         std::mem::take(&mut self.attester_slashings.lock())


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Gracefully handle the case where a slasher backend feature-flag has not been provided.

This prevents a failure when running:

```bash
cd beacon_node/beacon_chain
cargo test --release
```

## Additional Info

NA
