### PR TITLE
[Merged by Bors] - Add `db inspect --output values` option to support dumping raw db values

### DIFF
--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -180,7 +180,7 @@ fn parse_inspect_config(cli_args: &ArgMatches) -> Result<InspectConfig, String> 
     let column = clap_utils::parse_required(cli_args, "column")?;
     let target = clap_utils::parse_required(cli_args, "output")?;
     let output_dir: PathBuf =
-        clap_utils::parse_optional(cli_args, "output-dir")?.unwrap_or_else(|| PathBuf::new());
+        clap_utils::parse_optional(cli_args, "output-dir")?.unwrap_or_else(PathBuf::new);
     Ok(InspectConfig {
         column,
         target,
@@ -231,7 +231,7 @@ pub fn inspect_db<E: EthSpec>(
                     .open(&file_path)
                     .map_err(|e| format!("Failed to open file: {:?}", e))
                     .map(|mut file| {
-                        file.write_all(&*value)
+                        file.write_all(&value)
                             .map_err(|e| format!("Failed to write file: {:?}", e))
                     });
                 if let Err(e) = write_result {

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -7,9 +7,8 @@ use clap::{App, Arg, ArgMatches};
 use environment::{Environment, RuntimeContext};
 use slog::{info, Logger};
 use std::fs;
-use std::fs::create_dir_all;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use store::{
     errors::Error,
     metadata::{SchemaVersion, CURRENT_SCHEMA_VERSION},
@@ -351,15 +350,4 @@ pub fn run<T: EthSpec>(cli_args: &ArgMatches<'_>, env: Environment<T>) -> Result
         }
     }
     .map_err(|e| format!("Fatal error: {:?}", e))
-}
-
-/// Checks if a directory exists in the given path and creates a directory if it does not exist.
-pub fn ensure_dir_exists<P: AsRef<Path>>(path: P) -> Result<(), String> {
-    let path = path.as_ref();
-
-    if !path.exists() {
-        create_dir_all(path).map_err(|e| format!("Unable to create {:?}: {:?}", path, e))?;
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
## Issue Addressed

Add a new `--output values` option to `db inspect` for dumping raw database values to SSZ files.

This could be useful for inspecting the database when we're unable to start the beacon node.

Example usage:

```
# Output the `ForkChoice` column to an SSZ file
lighthouse db inspect --column frk --output values
```

By default, it stores the output files in the current directory, and can be overriden with `--ouput-dir`.

List of columns can be found here:
https://github.com/sigp/lighthouse/blob/c547a11b0da48db6fdd03bca2c6ce2448bbcc3a9/beacon_node/store/src/lib.rs#L169-L216


