### PR TITLE
Store equivocating blocks on disk

### DIFF
--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -1839,15 +1839,19 @@ impl<T: BeaconChainTypes> BeaconProcessor<T> {
                 seen_timestamp,
                 process_type,
                 should_process,
-            } => task_spawner.spawn_async(worker.process_rpc_block(
-                block_root,
-                block,
-                seen_timestamp,
-                process_type,
-                work_reprocessing_tx,
-                duplicate_cache,
-                should_process,
-            )),
+            } => {
+                let invalid_block_storage = self.invalid_block_storage.clone();
+                task_spawner.spawn_async(worker.process_rpc_block(
+                    block_root,
+                    block,
+                    seen_timestamp,
+                    process_type,
+                    work_reprocessing_tx,
+                    duplicate_cache,
+                    invalid_block_storage,
+                    should_process,
+                ))
+            }
             /*
              * Verification for a chain segment (multiple blocks).
              */


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Stores `RepeatProposal` blocks on disk if the `--invalid-gossip-verified-blocks-path` flag is provided.

We only store these blocks when they're received on gossip or are the result of a block lookup via RPC. Duplicates received via a batch sync won't be stored on disk. This is primarily for simplicity; we should see the blocks via gossip or on an RPC lookup if we're following the head. This feature is a debugging assistance tool, rather than a surefire way to catch slashings (use a slasher for that).

## Additional Info

NA
