### PR TITLE
Use cached withdrawals in block production

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -407,6 +407,7 @@ pub fn get_execution_payload<
     state: &BeaconState<T::EthSpec>,
     proposer_index: u64,
     builder_params: BuilderParams,
+    withdrawals: Option<Vec<Withdrawal>>,
 ) -> Result<PreparePayloadHandle<T::EthSpec, Payload>, BlockProductionError> {
     // Compute all required values from the `state` now to avoid needing to pass it into a spawned
     // task.
@@ -419,7 +420,10 @@ pub fn get_execution_payload<
     let latest_execution_payload_header_block_hash =
         state.latest_execution_payload_header()?.block_hash();
     let withdrawals = match state {
-        &BeaconState::Capella(_) => Some(get_expected_withdrawals(state, spec)?.into()),
+        // FIXME(sproul): unwrap
+        &BeaconState::Capella(_) => {
+            withdrawals.or_else(|| Some(get_expected_withdrawals(state, spec).unwrap().into()))
+        }
         &BeaconState::Merge(_) => None,
         // These shouldn't happen but they're here to make the pattern irrefutable
         &BeaconState::Base(_) | &BeaconState::Altair(_) => None,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1229,6 +1229,25 @@ impl<T: EthSpec> ExecutionLayer<T> {
         Some(proposer.payload_attributes)
     }
 
+    pub fn payload_attributes_blocking(
+        &self,
+        current_slot: Slot,
+        head_block_root: Hash256,
+    ) -> Option<PayloadAttributes> {
+        let proposers_key = ProposerKey {
+            slot: current_slot,
+            head_block_root,
+        };
+
+        let proposer = self
+            .proposers()
+            .blocking_read()
+            .get(&proposers_key)
+            .cloned()?;
+
+        Some(proposer.payload_attributes)
+    }
+
     /// Maps to the `engine_consensusValidated` JSON-RPC call.
     pub async fn notify_forkchoice_updated(
         &self,


### PR DESCRIPTION
## Issue Addressed

Another optimisation similar to https://github.com/sigp/lighthouse/issues/4314 and https://github.com/sigp/lighthouse/issues/4313.

## Proposed Changes

Avoid re-computing the withdrawals during block production if they are already cached.

I need to benchmark this change before cleaning it up, as I think `get_expected_withdrawals` should actually be very fast already, and using the cache is probably an unnecessary complication.
