### PR TITLE
[Merged by Bors] - Fix geth scripts

### DIFF
--- a/scripts/local_testnet/genesis.json
+++ b/scripts/local_testnet/genesis.json
@@ -13,7 +13,8 @@
     "londonBlock": 0,
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 0,
-    "terminalTotalDifficulty": 0
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true
   },
   "alloc": {
     "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {

--- a/scripts/tests/genesis.json
+++ b/scripts/tests/genesis.json
@@ -12,7 +12,8 @@
     "berlinBlock": 0,
     "londonBlock": 0,
     "mergeForkBlock": 0,
-    "terminalTotalDifficulty": 0
+    "terminalTotalDifficulty": 0,
+    "terminalTotalDifficultyPassed": true
   },
   "alloc": {
     "0x0000000000000000000000000000000000000000": {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Geth's latest release breaks our CI with the following message
```
Fatal: Failed to register the Ethereum service: ethash is only supported as a historical component of already merged networks
Shutting down
```
Latest geth version has removed support for PoW networks. Hence, we need to add an extra `terminalTotalDifficultyPassed ` parameter in the genesis config to start from a merged network.