### PR TITLE
[Merged by Bors] - Fix Rust 1.71.0 warnings

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -1266,7 +1266,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     );
                 }
 
-                let mut score_peers: &mut (f64, usize) = avg_score_per_client
+                let score_peers: &mut (f64, usize) = avg_score_per_client
                     .entry(peer_info.client().kind.to_string())
                     .or_default();
                 score_peers.0 += peer_info.score().score();


### PR DESCRIPTION
## Issue Addressed

The Rust 1.70 release is imminent, so CI is using 1.71 for the Beta compiler, which is failing with a warning.
