### PR TITLE
Always log a comparison of the value of relay and local blocks

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -827,16 +827,28 @@ impl<T: EthSpec> ExecutionLayer<T> {
                             let relay_value = relay.data.message.value;
                             let local_value = *local.block_value();
                             if !self.inner.always_prefer_builder_payload
-                                && local_value >= relay_value
                             {
-                                info!(
-                                    self.log(),
-                                    "Local block is more profitable than relay block";
-                                    "local_block_value" => %local_value,
-                                    "relay_value" => %relay_value
-                                );
-                                return Ok(ProvenancedPayload::Local(local));
+                                if local_value >= relay_value
+                                {
+                                    info!(
+                                        self.log(),
+                                        "Local block is more profitable than relay block";
+                                        "local_block_value" => %local_value,
+                                        "relay_value" => %relay_value
+                                    );
+                                    return Ok(ProvenancedPayload::Local(local));
+                                }
+                                else
+                                {
+                                    info!(
+                                        self.log(),
+                                        "Relay block is more profitable than local block";
+                                        "local_block_value" => %local_value,
+                                        "relay_value" => %relay_value
+                                    );
+                                }
                             }
+
 
                             match verify_builder_bid(
                                 &relay,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

This change will log the value of the relay block and the local block when the relay block is more profitable.

## Additional Info

This change will help validators understand the block selection (as it looks like the execution reward sometimes is higher that the MEV-reward).

The rationale for this change is to aid operators to better understand why a relay-block was chosen over a local block.
Looking at produced blocks (at beaconcha.in for example) it sometimes looks like the builder is making a profit just from the execution reward vs the MEV-reward, and creates the nagging question: "Could i have built this block and made that extra profit?"... The answer is probably "No, not without the extra transactions included by the relay", but by logging the value of the local block-candidate, this will no longer be an issue.. 


### Example (Mainnet)
https://beaconcha.in/block/17370329
MEV Block Reward: 0.17122 Ether to 0xE35bBaFa0266089f95d745d348b468622805D82B
Execution Reward: 0.17528 Ether to 0x1f9090aaE28b8a3dCeaDf281B0F12828e676c326
Difference: 0.00406 Ether

### Examples (Goerli)

https://goerli.beaconcha.in/block/9040065
MEV Block Reward: 0.56423 Ether to 0xF5794543CF6055Ae710E9c8E99E31343Cea004a8
Execution Reward: 0.56488 Ether to 0xfC0157aA4F5DB7177830ACddB3D5a9BB5BE9cc5e
Difference: 0.00065 Ether

https://goerli.beaconcha.in/block/9019921
MEV Block Reward: 1.39440 Ether to 0xF5794543CF6055Ae710E9c8E99E31343Cea004a8
Execution Reward: 1.39469 Ether to 0xfC0157aA4F5DB7177830ACddB3D5a9BB5BE9cc5e
Difference: 0.00029 Ether

https://goerli.beaconcha.in/block/9015583
MEV Block Reward: 1.04356 Ether to 0xF5794543CF6055Ae710E9c8E99E31343Cea004a8
Execution Reward: 1.04896 Ether to 0xfC0157aA4F5DB7177830ACddB3D5a9BB5BE9cc5e
Difference: 0.0054 Ether