### PR TITLE
Added changes to handle default slasher broadcast. 

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -778,6 +778,8 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Broadcast slashings found by the slasher to the rest of the network \
                        [disabled by default].")
                 .requires("slasher")
+                .takes_value(true)
+                .default_value("true")
         )
         .arg(
             Arg::with_name("slasher-backend")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -776,7 +776,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("slasher-broadcast")
                 .long("slasher-broadcast")
                 .help("Broadcast slashings found by the slasher to the rest of the network \
-                       [disabled by default].")
+                       [Enabled by default].")
                 .requires("slasher")
                 .takes_value(true)
                 .default_value("true")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -632,8 +632,8 @@ pub fn get_config<E: EthSpec>(
         {
             slasher_config.validator_chunk_size = validator_chunk_size;
         }
-
-        slasher_config.broadcast = cli_args.is_present("slasher-broadcast");
+        
+        slasher_config.broadcast = clap_utils::parse_required::<bool>(cli_args, "slasher-broadcast");
 
         if let Some(backend) = clap_utils::parse_optional(cli_args, "slasher-backend")? {
             slasher_config.backend = backend;

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -632,11 +632,11 @@ pub fn get_config<E: EthSpec>(
         {
             slasher_config.validator_chunk_size = validator_chunk_size;
         }
-        
-        if let Some(broadcast) = clap_utils::parse_optional::<bool>(cli_args, "slasher-broadcast")? {
+
+        if let Some(broadcast) = clap_utils::parse_optional::<bool>(cli_args, "slasher-broadcast")?
+        {
             slasher_config.broadcast = broadcast;
         }
-        
 
         if let Some(backend) = clap_utils::parse_optional(cli_args, "slasher-backend")? {
             slasher_config.backend = backend;

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -633,7 +633,10 @@ pub fn get_config<E: EthSpec>(
             slasher_config.validator_chunk_size = validator_chunk_size;
         }
         
-        slasher_config.broadcast = clap_utils::parse_required::<bool>(cli_args, "slasher-broadcast");
+        if let Some(broadcast) = clap_utils::parse_optional::<bool>(cli_args, "slasher-broadcast")? {
+            slasher_config.broadcast = broadcast;
+        }
+        
 
         if let Some(backend) = clap_utils::parse_optional(cli_args, "slasher-backend")? {
             slasher_config.backend = backend;


### PR DESCRIPTION
## Issue Addressed
This PR addresses issue #4350 

## Proposed Changes

This change will enable slasher broadcast by default.

## Additional Info

This change will enable slasher broadcast in the following cases:
No flag is passed,
`--slasher-broadcast` is passed and,
`--slasher-broadcast=true` is passed.

Only when an explicit false value is passed the slasher does not broadcast.(`--slasher-broadcast=false`).


TODO

- [ ]  Modify CLI parsing logic
- [ ] Write test

