### PR TITLE
[Merged by Bors] - Re-enable maxperf for Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,17 +134,11 @@ jobs:
 
             - name: Build Lighthouse for Windows portable
               if:   matrix.arch == 'x86_64-windows-portable'
-              # NOTE: profile set to release until this rustc issue is fixed:
-              #
-              # https://github.com/rust-lang/rust/issues/107781
-              #
-              # tracked at: https://github.com/sigp/lighthouse/issues/3964
-              run:  cargo install --path lighthouse --force --locked --features portable,gnosis --profile release
+              run:  cargo install --path lighthouse --force --locked --features portable,gnosis --profile ${{ matrix.profile }}
 
             - name: Build Lighthouse for Windows modern
               if:   matrix.arch == 'x86_64-windows'
-              # NOTE: profile set to release (see above)
-              run:  cargo install --path lighthouse --force --locked --features modern,gnosis --profile release
+              run:  cargo install --path lighthouse --force --locked --features modern,gnosis --profile ${{ matrix.profile }}
 
             - name: Configure GPG and create artifacts
               if: startsWith(matrix.arch, 'x86_64-windows') != true


### PR DESCRIPTION
## Issue Addressed

Closes #3964

## Proposed Changes

Use the `maxperf` profile to build Windows binaries, now that Rust 1.70.0 fixed the underlying issue.
