### PR TITLE
Revert "Temporarily allow Rust check warnings on 4844 branch. (#4088)"

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,8 +12,7 @@ on:
 env:
   # Deny warnings in CI
   # Disable debug info (see https://github.com/sigp/lighthouse/issues/4005)
-  # FIXME: temporarily allow warnings on 4844 branch. Revert to original later: RUSTFLAGS: "-D warnings -C debuginfo=0"
-  RUSTFLAGS: "-C debuginfo=0"
+  RUSTFLAGS: "-D warnings -C debuginfo=0"
   # The Nightly version used for cargo-udeps, might need updating from time to time.
   PINNED_NIGHTLY: nightly-2023-04-16
   # Prevent Github API rate limiting.


### PR DESCRIPTION
This reverts commit fa9baab0f7e534a38bbee27ceafb222b4a9f3b7f.

## Issue Addressed

Which issue # does this PR address?

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
