### PR TITLE
Abstract over minimal vs mainnet KZG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,20 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf#fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf"
+source = "git+https://github.com/michaelsproul//c-kzg-4844?rev=e652ce854a5f1855174cc89ce588513529656588#e652ce854a5f1855174cc89ce588513529656588"
+dependencies = [
+ "bindgen 0.64.0",
+ "cc",
+ "glob",
+ "hex",
+ "libc",
+ "serde",
+]
+
+[[package]]
+name = "c-kzg"
+version = "0.1.0"
+source = "git+https://github.com/michaelsproul/c-kzg-4844?rev=e652ce854a5f1855174cc89ce588513529656588#e652ce854a5f1855174cc89ce588513529656588"
 dependencies = [
  "bindgen 0.64.0",
  "cc",
@@ -3930,7 +3943,8 @@ name = "kzg"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "c-kzg",
+ "c-kzg 0.1.0 (git+https://github.com/michaelsproul//c-kzg-4844?rev=e652ce854a5f1855174cc89ce588513529656588)",
+ "c-kzg 0.1.0 (git+https://github.com/michaelsproul/c-kzg-4844?rev=e652ce854a5f1855174cc89ce588513529656588)",
  "derivative",
  "ethereum_hashing",
  "ethereum_serde_utils",

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -48,7 +48,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         jwt_key: Option<JwtKey>,
         spec: ChainSpec,
         builder_url: Option<SensitiveUrl>,
-        kzg: Option<Kzg>,
+        kzg: Option<Kzg<T::Kzg>>,
     ) -> Self {
         let handle = executor.handle().unwrap();
 

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -104,7 +104,7 @@ impl<T: EthSpec> MockServer<T> {
     pub fn new_with_config(
         handle: &runtime::Handle,
         config: MockExecutionConfig,
-        kzg: Option<Kzg>,
+        kzg: Option<Kzg<T::Kzg>>,
     ) -> Self {
         let MockExecutionConfig {
             jwt_key,
@@ -185,7 +185,7 @@ impl<T: EthSpec> MockServer<T> {
         terminal_block_hash: ExecutionBlockHash,
         shanghai_time: Option<u64>,
         deneb_time: Option<u64>,
-        kzg: Option<Kzg>,
+        kzg: Option<Kzg<T::Kzg>>,
     ) -> Self {
         Self::new_with_config(
             handle,

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+use kzg::{BlobTrait, KzgPreset, MainnetKzgPreset, MinimalKzgPreset};
 use safe_arith::SafeArith;
 use serde_derive::{Deserialize, Serialize};
 use ssz_types::typenum::{
@@ -51,6 +52,8 @@ impl fmt::Display for EthSpecId {
 pub trait EthSpec:
     'static + Default + Sync + Send + Clone + Debug + PartialEq + Eq + for<'a> arbitrary::Arbitrary<'a>
 {
+    type Kzg: KzgPreset;
+
     /*
      * Constants
      */
@@ -255,6 +258,10 @@ pub trait EthSpec:
     fn max_blobs_per_block() -> usize {
         Self::MaxBlobsPerBlock::to_usize()
     }
+
+    fn blob_from_bytes(bytes: &[u8]) -> Result<<Self::Kzg as KzgPreset>::Blob, kzg::Error> {
+        <Self::Kzg as KzgPreset>::Blob::from_bytes(bytes)
+    }
 }
 
 /// Macro to inherit some type values from another EthSpec.
@@ -270,6 +277,8 @@ macro_rules! params_from_eth_spec {
 pub struct MainnetEthSpec;
 
 impl EthSpec for MainnetEthSpec {
+    type Kzg = MainnetKzgPreset;
+
     type JustificationBitsLength = U4;
     type SubnetBitfieldLength = U64;
     type MaxValidatorsPerCommittee = U2048;
@@ -318,6 +327,8 @@ impl EthSpec for MainnetEthSpec {
 pub struct MinimalEthSpec;
 
 impl EthSpec for MinimalEthSpec {
+    type Kzg = MinimalKzgPreset;
+
     type SlotsPerEpoch = U8;
     type EpochsPerEth1VotingPeriod = U4;
     type SlotsPerHistoricalRoot = U64;
@@ -369,6 +380,8 @@ impl EthSpec for MinimalEthSpec {
 pub struct GnosisEthSpec;
 
 impl EthSpec for GnosisEthSpec {
+    type Kzg = MainnetKzgPreset;
+
     type JustificationBitsLength = U4;
     type SubnetBitfieldLength = U64;
     type MaxValidatorsPerCommittee = U2048;

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -16,7 +16,8 @@ serde_derive = "1.0.116"
 ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
-c-kzg = {git = "https://github.com/ethereum/c-kzg-4844", rev = "fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf" }
+c-kzg = { git = "https://github.com/michaelsproul/c-kzg-4844", rev = "e652ce854a5f1855174cc89ce588513529656588" }
+c_kzg_min = { package = "c-kzg", git = "https://github.com/michaelsproul//c-kzg-4844", rev = "e652ce854a5f1855174cc89ce588513529656588" }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/crypto/kzg/src/kzg_commitment.rs
+++ b/crypto/kzg/src/kzg_commitment.rs
@@ -1,4 +1,4 @@
-use c_kzg::{Bytes48, BYTES_PER_COMMITMENT};
+use c_kzg::BYTES_PER_COMMITMENT;
 use derivative::Derivative;
 use ethereum_hashing::hash_fixed;
 use serde::de::{Deserialize, Deserializer};
@@ -14,7 +14,7 @@ pub const BLOB_COMMITMENT_VERSION_KZG: u8 = 0x01;
 #[derive(Derivative, Clone, Copy, Encode, Decode)]
 #[derivative(PartialEq, Eq, Hash)]
 #[ssz(struct_behaviour = "transparent")]
-pub struct KzgCommitment(pub [u8; BYTES_PER_COMMITMENT]);
+pub struct KzgCommitment(pub [u8; c_kzg::BYTES_PER_COMMITMENT]);
 
 impl KzgCommitment {
     pub fn calculate_versioned_hash(&self) -> Hash256 {
@@ -24,7 +24,13 @@ impl KzgCommitment {
     }
 }
 
-impl From<KzgCommitment> for Bytes48 {
+impl From<KzgCommitment> for c_kzg::Bytes48 {
+    fn from(value: KzgCommitment) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<KzgCommitment> for c_kzg_min::Bytes48 {
     fn from(value: KzgCommitment) -> Self {
         value.0.into()
     }

--- a/crypto/kzg/src/kzg_proof.rs
+++ b/crypto/kzg/src/kzg_proof.rs
@@ -1,4 +1,4 @@
-use c_kzg::{Bytes48, BYTES_PER_PROOF};
+use c_kzg::BYTES_PER_PROOF;
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::{Serialize, Serializer};
 use ssz_derive::{Decode, Encode};
@@ -11,7 +11,13 @@ use tree_hash::{PackedEncoding, TreeHash};
 #[ssz(struct_behaviour = "transparent")]
 pub struct KzgProof(pub [u8; BYTES_PER_PROOF]);
 
-impl From<KzgProof> for Bytes48 {
+impl From<KzgProof> for c_kzg::Bytes48 {
+    fn from(value: KzgProof) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<KzgProof> for c_kzg_min::Bytes48 {
     fn from(value: KzgProof) -> Self {
         value.0.into()
     }


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/4376.

## Proposed Changes

Add new trait `KzgPreset` that abstracts over minimal/mainnet. So far it looks like the fallout isn't too bad. Something is broken in the mock EL server that I'll fix next week.
