### PR TITLE
Update max blobs per block

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -5,7 +5,7 @@ use regex::bytes::Regex;
 use serde::Serialize;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{
-    typenum::{U1024, U256, U512},
+    typenum::{U1024, U256, U768},
     VariableList,
 };
 use std::ops::Deref;
@@ -31,9 +31,9 @@ pub const MAX_REQUEST_BLOCKS_DENEB: u64 = 128;
 // TODO: this is calculated as MAX_REQUEST_BLOCKS_DENEB * MAX_BLOBS_PER_BLOCK and
 // MAX_BLOBS_PER_BLOCK comes from the spec.
 // MAX_REQUEST_BLOCKS_DENEB = 128
-// MAX_BLOBS_PER_BLOCK = 4
-pub type MaxRequestBlobSidecars = U512;
-pub const MAX_REQUEST_BLOB_SIDECARS: u64 = 512;
+// MAX_BLOBS_PER_BLOCK = 6
+pub type MaxRequestBlobSidecars = U768;
+pub const MAX_REQUEST_BLOB_SIDECARS: u64 = 768;
 
 /// Wrapper over SSZ List to represent error message in rpc responses.
 #[derive(Debug, Clone)]

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -44,6 +44,7 @@ use std::{
 use types::ForkName;
 use types::{
     consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
+    consts::deneb::MAX_BLOBS_PER_BLOCK,
 };
 use utils::{build_transport, strip_peer_id, Context as ServiceContext, MAX_CONNECTIONS_PER_PEER};
 
@@ -236,10 +237,11 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     possible_fork_digests,
                     ctx.chain_spec.attestation_subnet_count,
                     SYNC_COMMITTEE_SUBNET_COUNT,
-                    4, // TODO(pawan): get this from chainspec
+                    MAX_BLOBS_PER_BLOCK,
                 ),
                 max_subscribed_topics: 200,
-                max_subscriptions_per_request: 150, // 148 in theory = (64 attestation + 4 sync committee + 6 core topics) * 2
+                // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
+                max_subscriptions_per_request: 160,
             };
 
             config.gs_config = gossipsub_config(config.network_load, ctx.fork_context.clone());

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -44,7 +44,7 @@ use std::{
 use types::ForkName;
 use types::{
     consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
-    consts::deneb::MAX_BLOBS_PER_BLOCK,
+    consts::deneb::BLOB_SIDECAR_SUBNET_COUNT,
 };
 use utils::{build_transport, strip_peer_id, Context as ServiceContext, MAX_CONNECTIONS_PER_PEER};
 
@@ -237,7 +237,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     possible_fork_digests,
                     ctx.chain_spec.attestation_subnet_count,
                     SYNC_COMMITTEE_SUBNET_COUNT,
-                    MAX_BLOBS_PER_BLOCK,
+                    BLOB_SIDECAR_SUBNET_COUNT,
                 ),
                 max_subscribed_topics: 200,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -43,8 +43,8 @@ use std::{
 };
 use types::ForkName;
 use types::{
-    consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
-    consts::deneb::BLOB_SIDECAR_SUBNET_COUNT,
+    consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, consts::deneb::BLOB_SIDECAR_SUBNET_COUNT,
+    EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
 };
 use utils::{build_transport, strip_peer_id, Context as ServiceContext, MAX_CONNECTIONS_PER_PEER};
 

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -2,6 +2,7 @@ use libp2p::gossipsub::{IdentTopic as Topic, TopicHash};
 use serde_derive::{Deserialize, Serialize};
 use strum::AsRefStr;
 use types::{EthSpec, ForkName, SubnetId, SyncSubnetId};
+use types::consts::deneb::BLOB_SIDECAR_SUBNET_COUNT;
 
 use crate::Subnet;
 
@@ -52,7 +53,7 @@ pub fn fork_core_topics<T: EthSpec>(fork_name: &ForkName) -> Vec<GossipKind> {
         ForkName::Deneb => {
             // All of deneb blob topics are core topics
             let mut deneb_blob_topics = Vec::new();
-            for i in 0..T::max_blobs_per_block() {
+            for i in 0..BLOB_SIDECAR_SUBNET_COUNT {
                 deneb_blob_topics.push(GossipKind::BlobSidecar(i as u64));
             }
             let mut deneb_topics = DENEB_CORE_TOPICS.to_vec();

--- a/beacon_node/lighthouse_network/src/types/topics.rs
+++ b/beacon_node/lighthouse_network/src/types/topics.rs
@@ -1,8 +1,8 @@
 use libp2p::gossipsub::{IdentTopic as Topic, TopicHash};
 use serde_derive::{Deserialize, Serialize};
 use strum::AsRefStr;
-use types::{EthSpec, ForkName, SubnetId, SyncSubnetId};
 use types::consts::deneb::BLOB_SIDECAR_SUBNET_COUNT;
+use types::{EthSpec, ForkName, SubnetId, SyncSubnetId};
 
 use crate::Subnet;
 
@@ -54,7 +54,7 @@ pub fn fork_core_topics<T: EthSpec>(fork_name: &ForkName) -> Vec<GossipKind> {
             // All of deneb blob topics are core topics
             let mut deneb_blob_topics = Vec::new();
             for i in 0..BLOB_SIDECAR_SUBNET_COUNT {
-                deneb_blob_topics.push(GossipKind::BlobSidecar(i as u64));
+                deneb_blob_topics.push(GossipKind::BlobSidecar(i));
             }
             let mut deneb_topics = DENEB_CORE_TOPICS.to_vec();
             deneb_topics.append(&mut deneb_blob_topics);

--- a/consensus/types/src/consts.rs
+++ b/consensus/types/src/consts.rs
@@ -36,4 +36,5 @@ pub mod deneb {
     }
     pub const BLOB_TX_TYPE: u8 = 3;
     pub const VERSIONED_HASH_VERSION_KZG: u8 = 1;
+    pub const MAX_BLOBS_PER_BLOCK: u64 = 6;
 }

--- a/consensus/types/src/consts.rs
+++ b/consensus/types/src/consts.rs
@@ -36,5 +36,5 @@ pub mod deneb {
     }
     pub const BLOB_TX_TYPE: u8 = 3;
     pub const VERSIONED_HASH_VERSION_KZG: u8 = 1;
-    pub const MAX_BLOBS_PER_BLOCK: u64 = 6;
+    pub const BLOB_SIDECAR_SUBNET_COUNT: u64 = 6;
 }

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -4,7 +4,7 @@ use safe_arith::SafeArith;
 use serde_derive::{Deserialize, Serialize};
 use ssz_types::typenum::{
     bit::B0, UInt, Unsigned, U0, U1024, U1048576, U1073741824, U1099511627776, U128, U131072, U16,
-    U16777216, U2, U2048, U256, U32, U4, U4096, U512, U625, U64, U65536, U8, U8192,
+    U16777216, U2, U2048, U256, U32, U4, U4096, U512, U6, U625, U64, U65536, U8, U8192,
 };
 use std::fmt::{self, Debug};
 use std::str::FromStr;
@@ -294,7 +294,7 @@ impl EthSpec for MainnetEthSpec {
     type GasLimitDenominator = U1024;
     type MinGasLimit = U5000;
     type MaxExtraDataBytes = U32;
-    type MaxBlobsPerBlock = U4;
+    type MaxBlobsPerBlock = U6;
     type BytesPerFieldElement = U32;
     type FieldElementsPerBlob = U4096;
     type BytesPerBlob = U131072;
@@ -398,7 +398,7 @@ impl EthSpec for GnosisEthSpec {
     type SlotsPerEth1VotingPeriod = U1024; // 64 epochs * 16 slots per epoch
     type MaxBlsToExecutionChanges = U16;
     type MaxWithdrawalsPerPayload = U8;
-    type MaxBlobsPerBlock = U4;
+    type MaxBlobsPerBlock = U6;
     type FieldElementsPerBlob = U4096;
     type BytesPerFieldElement = U32;
     type BytesPerBlob = U131072;


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/pull/3410

## Proposed Changes

Update `MaxBlobsPerBlock` in EthSpec to 6 and also add a new deneb const `BLOB_SIDECAR_SUBNET_COUNT ` which should be same as `MaxBlobsPerBlock`.

