### PR TITLE
[Merged by Bors] - Remove legacy `max-skip-slots` checks

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -141,8 +141,6 @@ pub enum BlockError<T: EthSpec> {
     /// It's unclear if this block is valid, but it cannot be processed without already knowing
     /// its parent.
     ParentUnknown(Arc<SignedBeaconBlock<T>>),
-    /// The block skips too many slots and is a DoS risk.
-    TooManySkippedSlots { parent_slot: Slot, block_slot: Slot },
     /// The block slot is greater than the present slot.
     ///
     /// ## Peer scoring
@@ -786,9 +784,6 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
                 parent_block.root
             };
 
-        // Reject any block that exceeds our limit on skipped slots.
-        check_block_skip_slots(chain, parent_block.slot, block.message())?;
-
         // We assign to a variable instead of using `if let Some` directly to ensure we drop the
         // write lock before trying to acquire it again in the `else` clause.
         let proposer_opt = chain
@@ -941,9 +936,6 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
         check_block_against_anchor_slot(block.message(), chain)?;
 
         let (mut parent, block) = load_parent(block_root, block, chain)?;
-
-        // Reject any block that exceeds our limit on skipped slots.
-        check_block_skip_slots(chain, parent.beacon_block.slot(), block.message())?;
 
         let state = cheap_state_advance_to_obtain_committees(
             &mut parent.pre_state,
@@ -1134,9 +1126,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             //  genesis).
             return Err(BlockError::ParentUnknown(block));
         }
-
-        // Reject any block that exceeds our limit on skipped slots.
-        check_block_skip_slots(chain, parent.beacon_block.slot(), block.message())?;
 
         /*
          *  Perform cursory checks to see if the block is even worth processing.
@@ -1490,30 +1479,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             payload_verification_handle,
         })
     }
-}
-
-/// Check that the count of skip slots between the block and its parent does not exceed our maximum
-/// value.
-///
-/// Whilst this is not part of the specification, we include this to help prevent us from DoS
-/// attacks. In times of dire network circumstance, the user can configure the
-/// `import_max_skip_slots` value.
-fn check_block_skip_slots<T: BeaconChainTypes>(
-    chain: &BeaconChain<T>,
-    parent_slot: Slot,
-    block: BeaconBlockRef<'_, T::EthSpec>,
-) -> Result<(), BlockError<T::EthSpec>> {
-    // Reject any block that exceeds our limit on skipped slots.
-    if let Some(max_skip_slots) = chain.config.import_max_skip_slots {
-        if block.slot() > parent_slot + max_skip_slots {
-            return Err(BlockError::TooManySkippedSlots {
-                parent_slot,
-                block_slot: block.slot(),
-            });
-        }
-    }
-
-    Ok(())
 }
 
 /// Returns `Ok(())` if the block's slot is greater than the anchor block's slot (if any).

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -17,8 +17,7 @@ pub const FORK_CHOICE_LOOKAHEAD_FACTOR: u32 = 24;
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct ChainConfig {
-    /// Maximum number of slots to skip when importing a consensus message (e.g., block,
-    /// attestation, etc).
+    /// Maximum number of slots to skip when importing an attestation.
     ///
     /// If `None`, there is no limit.
     pub import_max_skip_slots: Option<u64>,

--- a/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
+++ b/beacon_node/network/src/beacon_processor/worker/gossip_methods.rs
@@ -835,7 +835,6 @@ impl<T: BeaconChainTypes> Worker<T> {
             | Err(e @ BlockError::NonLinearParentRoots)
             | Err(e @ BlockError::BlockIsNotLaterThanParent { .. })
             | Err(e @ BlockError::InvalidSignature)
-            | Err(e @ BlockError::TooManySkippedSlots { .. })
             | Err(e @ BlockError::WeakSubjectivityConflict)
             | Err(e @ BlockError::InconsistentFork(_))
             | Err(e @ BlockError::ExecutionPayloadError(_))

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -685,7 +685,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("max-skip-slots")
                 .long("max-skip-slots")
                 .help(
-                    "Refuse to skip more than this many slots when processing a block or attestation. \
+                    "Refuse to skip more than this many slots when processing an attestation. \
                     This prevents nodes on minority forks from wasting our time and disk space, \
                     but could also cause unnecessary consensus failures, so is disabled by default."
                 )


### PR DESCRIPTION
## Proposed Changes

Remove `max-skip-slots` checks when processing blocks.
This was legacy code which was previously used in the Medalla testnet to sync to the correct fork.
With the addition of checkpoint sync which allows us to sync to any arbitrary fork, this is no longer a necessary feature, so it has been removed for simplicity.

## Additional Notes
The CLI flag and checks for attestation processing have been retained as it still may have uses in DoS protection.
