### PR TITLE
Eliminate blob clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,7 +969,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf#fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf"
+source = "git+https://github.com/ethDreamer/c-kzg-4844?rev=e06bf99e6ef40afd692f7b330926b0151f8e160c#e06bf99e6ef40afd692f7b330926b0151f8e160c"
 dependencies = [
  "bindgen 0.64.0",
  "cc",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4951,13 +4951,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 Self::compute_blob_kzg_proofs(kzg, &blobs, expected_kzg_commitments, slot)?
             };
 
-            kzg_utils::validate_blobs::<T::EthSpec>(
-                kzg,
-                expected_kzg_commitments,
-                &blobs,
-                &kzg_proofs,
-            )
-            .map_err(BlockProductionError::KzgError)?;
+            kzg_utils::validate_blobs(kzg, expected_kzg_commitments, &blobs, &kzg_proofs)
+                .map_err(BlockProductionError::KzgError)?;
 
             let blob_sidecars = BlobSidecarList::from(
                 blobs
@@ -4981,6 +4976,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             blob,
                             kzg_commitment: *kzg_commitment,
                             kzg_proof: *kzg_proof,
+                            _phantom: Default::default(),
                         }))
                     })
                     .collect::<Result<Vec<_>, BlockProductionError>>()?,
@@ -5020,7 +5016,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     )),
                 )?;
 
-                kzg_utils::compute_blob_kzg_proof::<T::EthSpec>(kzg, blob, *kzg_commitment)
+                kzg_utils::compute_blob_kzg_proof(kzg, blob, *kzg_commitment)
                     .map_err(BlockProductionError::KzgError)
             })
             .collect::<Result<Vec<KzgProof>, BlockProductionError>>()

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -451,8 +451,7 @@ pub fn verify_kzg_for_blob<T: EthSpec>(
     blob: Arc<BlobSidecar<T>>,
     kzg: &Kzg,
 ) -> Result<KzgVerifiedBlob<T>, AvailabilityCheckError> {
-    //TODO(sean) remove clone
-    if validate_blob::<T>(kzg, blob.blob.clone(), blob.kzg_commitment, blob.kzg_proof)
+    if validate_blob(kzg, &blob.blob, blob.kzg_commitment, blob.kzg_proof)
         .map_err(AvailabilityCheckError::Kzg)?
     {
         Ok(KzgVerifiedBlob { blob })
@@ -476,7 +475,7 @@ pub fn verify_kzg_for_blob_list<T: EthSpec>(
         //TODO(sean) remove clone
         .map(|blob| (blob.blob.clone(), (blob.kzg_commitment, blob.kzg_proof)))
         .unzip();
-    if validate_blobs::<T>(
+    if validate_blobs(
         kzg,
         commitments.as_slice(),
         blobs.as_slice(),

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,70 +1,55 @@
-use kzg::{Error as KzgError, Kzg, BYTES_PER_BLOB};
+use kzg::{Error as KzgError, Kzg};
 use types::{Blob, EthSpec, Hash256, KzgCommitment, KzgProof};
 
-/// Converts a blob ssz List object to an array to be used with the kzg
-/// crypto library.
-fn ssz_blob_to_crypto_blob<T: EthSpec>(blob: Blob<T>) -> kzg::Blob {
-    let blob_vec: Vec<u8> = blob.into();
-    let mut arr = [0; BYTES_PER_BLOB];
-    arr.copy_from_slice(&blob_vec);
-    arr.into()
-}
-
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.
-pub fn validate_blob<T: EthSpec>(
+pub fn validate_blob(
     kzg: &Kzg,
-    blob: Blob<T>,
+    blob: &Blob,
     kzg_commitment: KzgCommitment,
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
-    kzg.verify_blob_kzg_proof(
-        ssz_blob_to_crypto_blob::<T>(blob),
-        kzg_commitment,
-        kzg_proof,
-    )
+    kzg.verify_blob_kzg_proof(blob.c_kzg_blob(), kzg_commitment, kzg_proof)
 }
 
 /// Validate a batch of blob-commitment-proof triplets from multiple `BlobSidecars`.
-pub fn validate_blobs<T: EthSpec>(
+pub fn validate_blobs(
     kzg: &Kzg,
     expected_kzg_commitments: &[KzgCommitment],
-    blobs: &[Blob<T>],
+    blobs: &[Blob],
     kzg_proofs: &[KzgProof],
 ) -> Result<bool, KzgError> {
     let blobs = blobs
         .iter()
-        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob.clone())) // Avoid this clone
+        // unfortunately we can't avoid this clone until we have a better API
+        .map(|blob| blob.c_kzg_blob().clone())
         .collect::<Vec<_>>();
 
     kzg.verify_blob_kzg_proof_batch(&blobs, expected_kzg_commitments, kzg_proofs)
 }
 
 /// Compute the kzg proof given an ssz blob and its kzg commitment.
-pub fn compute_blob_kzg_proof<T: EthSpec>(
+pub fn compute_blob_kzg_proof(
     kzg: &Kzg,
-    blob: &Blob<T>,
+    blob: &Blob,
     kzg_commitment: KzgCommitment,
 ) -> Result<KzgProof, KzgError> {
     // Avoid this blob clone
-    kzg.compute_blob_kzg_proof(ssz_blob_to_crypto_blob::<T>(blob.clone()), kzg_commitment)
+    kzg.compute_blob_kzg_proof(blob.c_kzg_blob(), kzg_commitment)
 }
 
 /// Compute the kzg commitment for a given blob.
-pub fn blob_to_kzg_commitment<T: EthSpec>(
-    kzg: &Kzg,
-    blob: Blob<T>,
-) -> Result<KzgCommitment, KzgError> {
-    kzg.blob_to_kzg_commitment(ssz_blob_to_crypto_blob::<T>(blob))
+pub fn blob_to_kzg_commitment(kzg: &Kzg, blob: Blob) -> Result<KzgCommitment, KzgError> {
+    kzg.blob_to_kzg_commitment(blob.c_kzg_blob().clone())
 }
 
 /// Compute the kzg proof for a given blob and an evaluation point z.
 pub fn compute_kzg_proof<T: EthSpec>(
     kzg: &Kzg,
-    blob: Blob<T>,
+    blob: &Blob,
     z: Hash256,
 ) -> Result<(KzgProof, Hash256), KzgError> {
     let z = z.0.into();
-    kzg.compute_kzg_proof(ssz_blob_to_crypto_blob::<T>(blob), z)
+    kzg.compute_kzg_proof(blob.c_kzg_blob(), z)
         .map(|(proof, z)| (proof, Hash256::from_slice(&z.to_vec())))
 }
 

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -3,10 +3,10 @@ use serde::{Deserialize, Serialize};
 use strum::EnumString;
 use superstruct::superstruct;
 use types::beacon_block_body::KzgCommitments;
-use types::blob_sidecar::Blobs;
 use types::{
-    EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadDeneb,
-    ExecutionPayloadMerge, FixedVector, Transactions, Unsigned, VariableList, Withdrawal,
+    Blobs, EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadCapella,
+    ExecutionPayloadDeneb, ExecutionPayloadMerge, FixedVector, Transactions, Unsigned,
+    VariableList, Withdrawal,
 };
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -416,7 +416,6 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
 pub struct JsonBlobsBundleV1<E: EthSpec> {
     pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
-    #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub blobs: Blobs<E>,
 }
 

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -645,15 +645,13 @@ pub fn generate_random_blobs<T: EthSpec>(
             blob_bytes[i * BYTES_PER_FIELD_ELEMENT + BYTES_PER_FIELD_ELEMENT - 1] = 0;
         }
 
-        let blob = Blob::<T>::new(Vec::from(blob_bytes))
-            .map_err(|e| format!("error constructing random blob: {:?}", e))?;
-
+        let blob = Blob::from(blob_bytes);
         let commitment = kzg
             .blob_to_kzg_commitment(blob_bytes.into())
             .map_err(|e| format!("error computing kzg commitment: {:?}", e))?;
 
         let proof = kzg
-            .compute_blob_kzg_proof(blob_bytes.into(), commitment)
+            .compute_blob_kzg_proof(blob.c_kzg_blob(), commitment)
             .map_err(|e| format!("error computing kzg proof: {:?}", e))?;
 
         let versioned_hash = commitment.calculate_versioned_hash();

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -69,3 +69,4 @@ sqlite = ["rusqlite"]
 # The `arbitrary-fuzz` feature is a no-op provided for backwards compatibility.
 # For simplicity `Arbitrary` is now derived regardless of the feature's presence.
 arbitrary-fuzz = []
+spec-minimal = ["kzg/minimal-spec"]

--- a/consensus/types/src/blob.rs
+++ b/consensus/types/src/blob.rs
@@ -1,0 +1,238 @@
+use arbitrary::{Arbitrary, Unstructured};
+use kzg::{self, BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB};
+use safe_arith::SafeArith;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use ssz::{Decode, DecodeError, Encode};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use tree_hash::{PackedEncoding, TreeHash};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Blob(Arc<kzg::Blob>);
+
+impl Blob {
+    pub fn from_hex(hex: &str) -> Result<Self, String> {
+        Ok(Self(Arc::new(
+            kzg::Blob::from_hex(hex).map_err(|e| format!("invalid hex: {:?}", e))?,
+        )))
+    }
+
+    pub fn c_kzg_blob(&self) -> &kzg::Blob {
+        self.0.as_ref()
+    }
+}
+
+impl From<[u8; BYTES_PER_BLOB]> for Blob {
+    fn from(bytes: [u8; BYTES_PER_BLOB]) -> Self {
+        Blob(Arc::new(kzg::Blob::from(bytes)))
+    }
+}
+
+impl TryFrom<Vec<u8>> for Blob {
+    type Error = String;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let length = bytes.len();
+        let fixed: [u8; BYTES_PER_BLOB] = bytes.try_into().map_err(|_| {
+            format!(
+                "Invalid blob length: {} bytes, expected {}",
+                length, BYTES_PER_BLOB
+            )
+        })?;
+        Ok(Self(Arc::new(kzg::Blob::from(fixed))))
+    }
+}
+
+impl TreeHash for Blob {
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::Vector
+    }
+
+    fn tree_hash_packed_encoding(&self) -> PackedEncoding {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> tree_hash::Hash256 {
+        let num_leaves = BYTES_PER_BLOB
+            .safe_add(u8::tree_hash_packing_factor())
+            .and_then(|n| n.safe_sub(1))
+            .and_then(|n| n.safe_div(u8::tree_hash_packing_factor()))
+            .expect("unsafe math in tree_hash_root of Blob");
+        let mut hasher = tree_hash::MerkleHasher::with_leaves(num_leaves);
+
+        for byte in self.0.as_ref().as_ref() {
+            hasher
+                .write(&byte.tree_hash_packed_encoding())
+                .expect("ssz_types variable vec should not contain more elements than max");
+        }
+
+        hasher
+            .finish()
+            .expect("ssz_types variable vec should not have a remaining buffer")
+    }
+}
+
+impl Default for Blob {
+    fn default() -> Self {
+        Blob(Arc::new(kzg::Blob::from([0; BYTES_PER_BLOB])))
+    }
+}
+
+impl<'a> Arbitrary<'a> for Blob {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut bytes = [0; BYTES_PER_BLOB];
+        u.fill_buffer(&mut bytes)?;
+        // Ensure that the blob is canonical by ensuring that
+        // each field element contained in the blob is < BLS_MODULUS
+        for i in 0..FIELD_ELEMENTS_PER_BLOB {
+            let offset = i.safe_mul(BYTES_PER_FIELD_ELEMENT).expect("overflow");
+            if let Some(range) =
+                bytes.get_mut(offset..offset.safe_add(BYTES_PER_FIELD_ELEMENT).expect("overflow"))
+            {
+                range.fill(0)
+            }
+        }
+        Ok(Self(Arc::new(kzg::Blob::from(bytes))))
+    }
+}
+
+impl AsRef<[u8]> for Blob {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref().as_ref()
+    }
+}
+
+impl Encode for Blob {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self.0.as_ref().as_ref())
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        BYTES_PER_BLOB
+    }
+}
+
+impl Decode for Blob {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        if bytes.len() != BYTES_PER_BLOB {
+            return Err(DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: BYTES_PER_BLOB,
+            });
+        }
+
+        let mut array = [0; BYTES_PER_BLOB];
+        array[..].copy_from_slice(bytes);
+
+        Ok(Self(Arc::new(kzg::Blob::from(array))))
+    }
+}
+
+impl Hash for Blob {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ref().as_ref().hash(state)
+    }
+}
+
+impl Serialize for Blob {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_string = format!("0x{}", hex::encode(self.0.as_ref().as_ref()));
+        serializer.serialize_str(&hex_string)
+    }
+}
+
+impl<'de> Deserialize<'de> for Blob {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BlobVisitor;
+
+        impl<'de> Visitor<'de> for BlobVisitor {
+            type Value = Blob;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex-encoded string representing a blob")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let hex_value = value
+                    .strip_prefix("0x")
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Str(value), &self))?;
+
+                let bytes = hex::decode(hex_value)
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &self))?;
+
+                if bytes.len() != BYTES_PER_BLOB {
+                    return Err(de::Error::invalid_length(
+                        bytes.len(),
+                        &"a blob with the correct byte length",
+                    ));
+                }
+
+                let mut array = [0; BYTES_PER_BLOB];
+                array[..].copy_from_slice(&bytes);
+
+                Ok(Blob(Arc::new(kzg::Blob::from(array))))
+            }
+        }
+
+        deserializer.deserialize_str(BlobVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestRandom;
+    use crate::{EthSpec, FixedVector, MainnetEthSpec};
+
+    type OldBlob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
+
+    #[test]
+    fn tree_hash_equivalence() {
+        let new_blob = Blob::random_for_test(&mut rand::thread_rng());
+        let old_blob = OldBlob::<MainnetEthSpec>::new(Vec::from(new_blob.as_ref())).unwrap();
+
+        // test that their tree_hash_roots are the same
+        assert_eq!(
+            old_blob.tree_hash_root(),
+            new_blob.tree_hash_root(),
+            "Tree Hash Roots should be the same"
+        );
+    }
+
+    #[test]
+    fn ssz_equivalence() {
+        let new_blob = Blob::random_for_test(&mut rand::thread_rng());
+        let old_blob = OldBlob::<MainnetEthSpec>::new(Vec::from(new_blob.as_ref())).unwrap();
+
+        // test that their ssz encodings are the same
+        assert_eq!(
+            old_blob.as_ssz_bytes(),
+            new_blob.as_ssz_bytes(),
+            "SSZ encodings should be the same"
+        );
+    }
+
+    ssz_and_tree_hash_tests!(Blob);
+}

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -3,7 +3,7 @@ use crate::{Blob, ChainSpec, Domain, EthSpec, Fork, Hash256, SignedBlobSidecar, 
 use bls::SecretKey;
 use derivative::Derivative;
 use kzg::{KzgCommitment, KzgProof};
-use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
@@ -56,7 +56,6 @@ pub struct BlobSidecar<T: EthSpec> {
     pub block_parent_root: Hash256,
     #[serde(with = "serde_utils::quoted_u64")]
     pub proposer_index: u64,
-    #[serde(with = "serde_kzg_blob")]
     pub blob: Blob,
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
@@ -128,23 +127,147 @@ impl<T: EthSpec> BlobSidecar<T> {
     }
 }
 
-pub mod serde_kzg_blob {
+#[cfg(test)]
+mod tests {
     use super::*;
+    use crate::EthSpec;
+    use ssz::{Decode, Encode};
+    use tree_hash::TreeHash;
 
-    pub fn serialize<S>(blob: &Blob, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&serde_utils::hex::encode(blob))
+    type OldBlob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
+    #[cfg(feature = "spec-minimal")]
+    type E = crate::MinimalEthSpec;
+    #[cfg(not(feature = "spec-minimal"))]
+    type E = crate::MainnetEthSpec;
+
+    #[derive(
+        Debug,
+        Clone,
+        Serialize,
+        Deserialize,
+        Encode,
+        Decode,
+        TreeHash,
+        Default,
+        TestRandom,
+        Derivative,
+        arbitrary::Arbitrary,
+    )]
+    #[serde(bound = "E: EthSpec")]
+    #[arbitrary(bound = "E: EthSpec")]
+    #[derivative(PartialEq, Eq, Hash(bound = "E: EthSpec"))]
+    pub struct OldBlobSidecar<E: EthSpec> {
+        pub block_root: Hash256,
+        #[serde(with = "serde_utils::quoted_u64")]
+        pub index: u64,
+        pub slot: Slot,
+        pub block_parent_root: Hash256,
+        #[serde(with = "serde_utils::quoted_u64")]
+        pub proposer_index: u64,
+        #[serde(with = "ssz_types::serde_utils::hex_fixed_vec")]
+        pub blob: OldBlob<E>,
+        pub kzg_commitment: KzgCommitment,
+        pub kzg_proof: KzgProof,
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Blob, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: String = Deserialize::deserialize(deserializer)?;
-        Blob::from_hex(&s)
-            .map_err(|e| format!("invalid hex: {:?}", e))
-            .map_err(D::Error::custom)
+    impl<E: EthSpec> OldBlobSidecar<E> {
+        fn from_new_sidecar(new_sidecar: &BlobSidecar<E>) -> Self {
+            let old_blob = OldBlob::<E>::new(Vec::from(new_sidecar.blob.as_ref())).unwrap();
+            Self {
+                block_root: new_sidecar.block_root,
+                index: new_sidecar.index,
+                slot: new_sidecar.slot,
+                block_parent_root: new_sidecar.block_parent_root,
+                proposer_index: new_sidecar.proposer_index,
+                blob: old_blob,
+                kzg_commitment: new_sidecar.kzg_commitment,
+                kzg_proof: new_sidecar.kzg_proof,
+            }
+        }
     }
+
+    fn same_bytes(a: &[u8], b: &[u8]) -> bool {
+        a.iter().zip(b.iter()).all(|(a, b)| a == b)
+    }
+
+    #[test]
+    fn ssz_equivalence() {
+        let new_sidecar = BlobSidecar::random_for_test(&mut rand::thread_rng());
+        let old_sidecar = OldBlobSidecar::<E>::from_new_sidecar(&new_sidecar);
+
+        // test that the blobs have the same bytes
+        assert!(
+            same_bytes(new_sidecar.blob.as_ref(), old_sidecar.blob.as_ref()),
+            "blobs should have the same bytes"
+        );
+
+        // test that their ssz encodings are the same
+        assert_eq!(
+            new_sidecar.as_ssz_bytes(),
+            old_sidecar.as_ssz_bytes(),
+            "ssz encoding of new and old sidecars should be the same"
+        );
+        // test that you can recover the old sidecar from the new one
+        let recovered_old_sidecar =
+            OldBlobSidecar::<E>::from_ssz_bytes(&new_sidecar.as_ssz_bytes()).unwrap();
+        assert_eq!(
+            recovered_old_sidecar, old_sidecar,
+            "recovered old sidecar should be the same as the old sidecar"
+        );
+        // test that you can recover the new sidecar from the old one
+        let recovered_new_sidecar =
+            BlobSidecar::<E>::from_ssz_bytes(&old_sidecar.as_ssz_bytes()).unwrap();
+        assert_eq!(
+            recovered_new_sidecar, new_sidecar,
+            "recovered new sidecar should be the same as the new sidecar"
+        );
+    }
+
+    #[test]
+    fn tree_hash_equivalence() {
+        let new_sidecar = BlobSidecar::random_for_test(&mut rand::thread_rng());
+        let old_sidecar = OldBlobSidecar::<E>::from_new_sidecar(&new_sidecar);
+
+        // test that their tree hashes are the same
+        assert_eq!(
+            new_sidecar.tree_hash_root(),
+            old_sidecar.tree_hash_root(),
+            "tree hash of new and old sidecars should be the same"
+        );
+    }
+
+    #[test]
+    fn serde_equivalence() {
+        let new_sidecar = BlobSidecar::random_for_test(&mut rand::thread_rng());
+        let old_sidecar = OldBlobSidecar::<E>::from_new_sidecar(&new_sidecar);
+
+        // test that the blobs have the same bytes
+        assert!(
+            same_bytes(new_sidecar.blob.as_ref(), old_sidecar.blob.as_ref()),
+            "blobs should have the same bytes"
+        );
+
+        // test that their serde encodings are the same
+        assert_eq!(
+            serde_json::to_string(&new_sidecar).unwrap(),
+            serde_json::to_string(&old_sidecar).unwrap(),
+            "serde encoding of new and old sidecars should be the same"
+        );
+        // test that you can recover the old sidecar from the new one
+        let recovered_old_sidecar: OldBlobSidecar<E> =
+            serde_json::from_str(&serde_json::to_string(&new_sidecar).unwrap()).unwrap();
+        assert_eq!(
+            recovered_old_sidecar, old_sidecar,
+            "recovered old sidecar should be the same as the old sidecar"
+        );
+        // test that you can recover the new sidecar from the old one
+        let recovered_new_sidecar: BlobSidecar<E> =
+            serde_json::from_str(&serde_json::to_string(&old_sidecar).unwrap()).unwrap();
+        assert_eq!(
+            recovered_new_sidecar, new_sidecar,
+            "recovered new sidecar should be the same as the new sidecar"
+        );
+    }
+
+    ssz_and_tree_hash_tests!(BlobSidecar<E>);
 }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -97,6 +97,7 @@ pub mod slot_data;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+pub mod blob;
 pub mod blob_sidecar;
 pub mod signed_blob;
 pub mod transaction;
@@ -119,7 +120,8 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
-pub use crate::blob_sidecar::{BlobSidecar, BlobSidecarList};
+pub use crate::blob::Blob;
+pub use crate::blob_sidecar::{BlobSidecar, BlobSidecarList, Blobs};
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
 pub use crate::chain_spec::{ChainSpec, Config, Domain};
 pub use crate::checkpoint::Checkpoint;
@@ -203,7 +205,6 @@ pub type Uint256 = ethereum_types::U256;
 pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 pub type BLSFieldElement = Uint256;
-pub type Blob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
 pub type KzgProofs<T> = VariableList<KzgProof, <T as EthSpec>::MaxBlobsPerBlock>;
 pub type VersionedHash = Hash256;
 pub type Hash64 = ethereum_types::H64;

--- a/consensus/types/src/test_utils/test_random.rs
+++ b/consensus/types/src/test_utils/test_random.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 mod address;
 mod aggregate_signature;
 mod bitfield;
+mod blob;
 mod hash256;
 mod kzg_commitment;
 mod kzg_proof;

--- a/consensus/types/src/test_utils/test_random/blob.rs
+++ b/consensus/types/src/test_utils/test_random/blob.rs
@@ -1,0 +1,22 @@
+use super::*;
+use crate::Blob;
+use kzg::{BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT, FIELD_ELEMENTS_PER_BLOB};
+use safe_arith::SafeArith;
+
+impl TestRandom for Blob {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut bytes = [0u8; BYTES_PER_BLOB];
+        rng.fill_bytes(&mut bytes);
+        // Ensure that the blob is canonical by ensuring that
+        // each field element contained in the blob is < BLS_MODULUS
+        for i in 0..FIELD_ELEMENTS_PER_BLOB {
+            let offset = i.safe_mul(BYTES_PER_FIELD_ELEMENT).expect("overflow");
+            if let Some(range) =
+                bytes.get_mut(offset..offset.safe_add(BYTES_PER_FIELD_ELEMENT).expect("overflow"))
+            {
+                range.fill(0)
+            }
+        }
+        Self::from(bytes)
+    }
+}

--- a/consensus/types/src/test_utils/test_random/blob.rs
+++ b/consensus/types/src/test_utils/test_random/blob.rs
@@ -10,11 +10,13 @@ impl TestRandom for Blob {
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
         for i in 0..FIELD_ELEMENTS_PER_BLOB {
-            let offset = i.safe_mul(BYTES_PER_FIELD_ELEMENT).expect("overflow");
-            if let Some(range) =
-                bytes.get_mut(offset..offset.safe_add(BYTES_PER_FIELD_ELEMENT).expect("overflow"))
-            {
-                range.fill(0)
+            let offset = i
+                .safe_mul(BYTES_PER_FIELD_ELEMENT)
+                .and_then(|o| o.safe_add(BYTES_PER_FIELD_ELEMENT))
+                .and_then(|o| o.safe_sub(1))
+                .expect("unsafe math while generating random blob");
+            if let Some(byte) = bytes.get_mut(offset) {
+                *byte = 0;
             }
         }
         Self::from(bytes)

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -16,7 +16,7 @@ serde_derive = "1.0.116"
 ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
-c-kzg = {git = "https://github.com/ethereum/c-kzg-4844", rev = "fd24cf8e1e2f09a96b4e62a595b4e49f046ce6cf" }
+c-kzg = { git = "https://github.com/ethDreamer/c-kzg-4844", rev = "e06bf99e6ef40afd692f7b330926b0151f8e160c" }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [features]

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -56,7 +56,7 @@ impl Kzg {
     /// Compute the kzg proof given a blob and its kzg commitment.
     pub fn compute_blob_kzg_proof(
         &self,
-        blob: Blob,
+        blob: &Blob,
         kzg_commitment: KzgCommitment,
     ) -> Result<KzgProof, Error> {
         c_kzg::KzgProof::compute_blob_kzg_proof(blob, kzg_commitment.into(), &self.trusted_setup)
@@ -67,7 +67,7 @@ impl Kzg {
     /// Verify a kzg proof given the blob, kzg commitment and kzg proof.
     pub fn verify_blob_kzg_proof(
         &self,
-        blob: Blob,
+        blob: &Blob,
         kzg_commitment: KzgCommitment,
         kzg_proof: KzgProof,
     ) -> Result<bool, Error> {
@@ -118,7 +118,7 @@ impl Kzg {
     }
 
     /// Computes the kzg proof for a given `blob` and an evaluation point `z`
-    pub fn compute_kzg_proof(&self, blob: Blob, z: Bytes32) -> Result<(KzgProof, Bytes32), Error> {
+    pub fn compute_kzg_proof(&self, blob: &Blob, z: Bytes32) -> Result<(KzgProof, Bytes32), Error> {
         c_kzg::KzgProof::compute_kzg_proof(blob, z, &self.trusted_setup)
             .map_err(Error::KzgProofComputationFailed)
             .map(|(proof, y)| (KzgProof(proof.to_bytes().into_inner()), y))

--- a/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
+++ b/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
@@ -33,8 +33,8 @@ impl<E: EthSpec> Case for KZGBlobToKZGCommitment<E> {
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let kzg = get_kzg()?;
 
-        let commitment = parse_blob::<E>(&self.input.blob).and_then(|blob| {
-            blob_to_kzg_commitment::<E>(&kzg, blob).map_err(|e| {
+        let commitment = parse_blob(&self.input.blob).and_then(|blob| {
+            blob_to_kzg_commitment(&kzg, blob).map_err(|e| {
                 Error::InternalError(format!("Failed to compute kzg commitment: {:?}", e))
             })
         });

--- a/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
@@ -33,14 +33,14 @@ impl<E: EthSpec> Case for KZGComputeBlobKZGProof<E> {
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGComputeBlobKZGProofInput| -> Result<_, Error> {
-            let blob = parse_blob::<E>(&input.blob)?;
+            let blob = parse_blob(&input.blob)?;
             let commitment = parse_commitment(&input.commitment)?;
             Ok((blob, commitment))
         };
 
         let kzg = get_kzg()?;
         let proof = parse_input(&self.input).and_then(|(blob, commitment)| {
-            compute_blob_kzg_proof::<E>(&kzg, &blob, commitment)
+            compute_blob_kzg_proof(&kzg, &blob, commitment)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
@@ -40,14 +40,14 @@ impl<E: EthSpec> Case for KZGComputeKZGProof<E> {
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGComputeKZGProofInput| -> Result<_, Error> {
-            let blob = parse_blob::<E>(&input.blob)?;
+            let blob = parse_blob(&input.blob)?;
             let z = parse_point(&input.z)?;
             Ok((blob, z))
         };
 
         let kzg = get_kzg()?;
         let proof = parse_input(&self.input).and_then(|(blob, z)| {
-            compute_kzg_proof::<E>(&kzg, blob, z)
+            compute_kzg_proof::<E>(&kzg, &blob, z)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -36,7 +36,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
             let blobs = input
                 .blobs
                 .iter()
-                .map(|s| parse_blob::<E>(s))
+                .map(|s| parse_blob(s))
                 .collect::<Result<Vec<_>, _>>()?;
             let commitments = input
                 .commitments
@@ -53,7 +53,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
 
         let kzg = get_kzg()?;
         let result = parse_input(&self.input).and_then(|(commitments, blobs, proofs)| {
-            validate_blobs::<E>(&kzg, &commitments, &blobs, &proofs)
+            validate_blobs(&kzg, &commitments, &blobs, &proofs)
                 .map_err(|e| Error::InternalError(format!("Failed to validate blobs: {:?}", e)))
         });
 


### PR DESCRIPTION
Reduces the need to clone blobs by always storing them as `kzg::Blob` types.