### PR TITLE
Use rebasing to minimise BeaconState mem usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5047,16 +5047,18 @@ dependencies = [
 
 [[package]]
 name = "metastruct"
-version = "0.1.0"
-source = "git+https://github.com/sigp/metastruct?branch=bimapping#4095d62b5c97b2a34e829c02a75fe1e8129cbe84"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfbb8826226b09b05bb62a0937cf6abb16f1f7d4b746eb95a83db14aec60f06"
 dependencies = [
  "metastruct_macro",
 ]
 
 [[package]]
 name = "metastruct_macro"
-version = "0.1.0"
-source = "git+https://github.com/sigp/metastruct?branch=bimapping#4095d62b5c97b2a34e829c02a75fe1e8129cbe84"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37cb4045d5677b7da537f8cb5d0730d5b6414e3cc81c61e4b50e1f0cbdc73909"
 dependencies = [
  "darling 0.13.4",
  "itertools",
@@ -5119,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "milhouse"
 version = "0.1.0"
-source = "git+https://github.com/sigp/milhouse?branch=rebase#f95d2322f47b9072257ffa76def736528d0aafbf"
+source = "git+https://github.com/sigp/milhouse?branch=main#248bc353849c113bdf078c5a81e629285c1c0589"
 dependencies = [
  "arbitrary",
  "derivative",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5048,8 +5048,7 @@ dependencies = [
 [[package]]
 name = "metastruct"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734788dec2091fe9afa39530ca2ea7994f4a2c9aff3dbfebb63f2c1945c6f10b"
+source = "git+https://github.com/sigp/metastruct?branch=bimapping#4095d62b5c97b2a34e829c02a75fe1e8129cbe84"
 dependencies = [
  "metastruct_macro",
 ]
@@ -5057,8 +5056,7 @@ dependencies = [
 [[package]]
 name = "metastruct_macro"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ded15e7570c2a507a23e6c3a1c8d74507b779476e43afe93ddfc261d44173d"
+source = "git+https://github.com/sigp/metastruct?branch=bimapping#4095d62b5c97b2a34e829c02a75fe1e8129cbe84"
 dependencies = [
  "darling 0.13.4",
  "itertools",
@@ -5121,7 +5119,7 @@ dependencies = [
 [[package]]
 name = "milhouse"
 version = "0.1.0"
-source = "git+https://github.com/sigp/milhouse?branch=main#4035d254ad538dd642fe031fbecfae55d9a4f31d"
+source = "git+https://github.com/sigp/milhouse?branch=rebase#f95d2322f47b9072257ffa76def736528d0aafbf"
 dependencies = [
  "arbitrary",
  "derivative",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ resolver = "2"
 [patch.crates-io]
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="f002b99989b561ddce62e4cf2887b0f8860ae991" }
+metastruct = { git = "https://github.com/sigp/metastruct", branch = "bimapping" }
+metastruct_macro = { git = "https://github.com/sigp/metastruct", branch = "bimapping" }
 
 [patch."https://github.com/ralexstokes/mev-rs"]
 mev-rs = { git = "https://github.com/ralexstokes//mev-rs", rev = "7813d4a4a564e0754e9aaab2d95520ba437c3889" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,6 @@ resolver = "2"
 [patch.crates-io]
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="f002b99989b561ddce62e4cf2887b0f8860ae991" }
-metastruct = { git = "https://github.com/sigp/metastruct", branch = "bimapping" }
-metastruct_macro = { git = "https://github.com/sigp/metastruct", branch = "bimapping" }
 
 [patch."https://github.com/ralexstokes/mev-rs"]
 mev-rs = { git = "https://github.com/ralexstokes//mev-rs", rev = "7813d4a4a564e0754e9aaab2d95520ba437c3889" }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -50,7 +50,7 @@ superstruct = "0.7.0"
 metastruct = "0.1.0"
 serde_json = "1.0.74"
 smallvec = "1.8.0"
-milhouse = { git = "https://github.com/sigp/milhouse", branch = "main" }
+milhouse = { git = "https://github.com/sigp/milhouse", branch = "rebase" }
 rpds = "0.11.0"
 serde_with = "1.13.0"
 maplit = "1.0.2"

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -50,7 +50,7 @@ superstruct = "0.7.0"
 metastruct = "0.1.1"
 serde_json = "1.0.74"
 smallvec = "1.8.0"
-milhouse = { git = "https://github.com/sigp/milhouse", branch = "rebase" }
+milhouse = { git = "https://github.com/sigp/milhouse", branch = "main" }
 rpds = "0.11.0"
 serde_with = "1.13.0"
 maplit = "1.0.2"

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -47,7 +47,7 @@ lazy_static = "1.4.0"
 parking_lot = "0.12.0"
 itertools = "0.10.0"
 superstruct = "0.7.0"
-metastruct = "0.1.0"
+metastruct = "0.1.1"
 serde_json = "1.0.74"
 smallvec = "1.8.0"
 milhouse = { git = "https://github.com/sigp/milhouse", branch = "rebase" }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1765,6 +1765,101 @@ impl<T: EthSpec> BeaconState<T> {
         };
         Ok(sync_committee)
     }
+
+    // FIXME(sproul): missing eth1 data votes, they would need a ResetListDiff
+    #[allow(clippy::integer_arithmetic)]
+    pub fn rebase_on(&mut self, base: &Self, spec: &ChainSpec) -> Result<(), Error> {
+        // Required for macros (which use type-hints internally).
+        type GenericValidator = Validator;
+
+        match (&mut *self, base) {
+            (Self::Base(self_inner), Self::Base(base_inner)) => {
+                bimap_beacon_state_base_tree_list_fields!(
+                    self_inner,
+                    base_inner,
+                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
+                );
+            }
+            (Self::Altair(self_inner), Self::Altair(base_inner)) => {
+                bimap_beacon_state_altair_tree_list_fields!(
+                    self_inner,
+                    base_inner,
+                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
+                );
+            }
+            (Self::Merge(self_inner), Self::Merge(base_inner)) => {
+                bimap_beacon_state_merge_tree_list_fields!(
+                    self_inner,
+                    base_inner,
+                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
+                );
+            }
+            (Self::Capella(self_inner), Self::Capella(base_inner)) => {
+                bimap_beacon_state_capella_tree_list_fields!(
+                    self_inner,
+                    base_inner,
+                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
+                );
+            }
+            // Do not rebase across forks, this should be OK for most situations.
+            _ => {}
+        }
+
+        // Use sync committees from `base` if they are equal.
+        if let Ok(current_sync_committee) = self.current_sync_committee_mut() {
+            if let Ok(base_sync_committee) = base.current_sync_committee() {
+                if current_sync_committee == base_sync_committee {
+                    *current_sync_committee = base_sync_committee.clone();
+                }
+            }
+        }
+        if let Ok(next_sync_committee) = self.next_sync_committee_mut() {
+            if let Ok(base_sync_committee) = base.next_sync_committee() {
+                if next_sync_committee == base_sync_committee {
+                    *next_sync_committee = base_sync_committee.clone();
+                }
+            }
+        }
+
+        // Rebase caches like the committee caches and the pubkey cache, which are expensive to
+        // rebuild and likely to be re-usable from the base state.
+        self.rebase_caches_on(base, spec)?;
+
+        Ok(())
+    }
+
+    pub fn rebase_caches_on(&mut self, base: &Self, spec: &ChainSpec) -> Result<(), Error> {
+        // Use pubkey cache from `base` if it contains superior information (likely if our cache is
+        // uninitialized).
+        let num_validators = self.validators().len();
+        let pubkey_cache = self.pubkey_cache_mut();
+        let base_pubkey_cache = base.pubkey_cache();
+        if pubkey_cache.len() < base_pubkey_cache.len() && pubkey_cache.len() < num_validators {
+            *pubkey_cache = base_pubkey_cache.clone();
+        }
+
+        // Use committee caches from `base` if they are relevant.
+        let epochs = [
+            self.previous_epoch(),
+            self.current_epoch(),
+            self.next_epoch()?,
+        ];
+        for (index, epoch) in epochs.into_iter().enumerate() {
+            if let Ok(base_relative_epoch) = RelativeEpoch::from_epoch(base.current_epoch(), epoch)
+            {
+                *self.committee_cache_at_index_mut(index)? =
+                    base.committee_cache(base_relative_epoch)?.clone();
+
+                // Ensure total active balance cache remains built whenever current committee
+                // cache is built.
+                if epoch == self.current_epoch() {
+                    self.build_total_active_balance_cache(spec)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<T: EthSpec, GenericValidator: ValidatorTrait> BeaconState<T, GenericValidator> {
@@ -1817,43 +1912,6 @@ impl<T: EthSpec, GenericValidator: ValidatorTrait> BeaconState<T, GenericValidat
             }
         }
         self.eth1_data_votes_mut().apply_updates()?;
-        Ok(())
-    }
-
-    // FIXME(sproul): missing eth1 data votes, they would need a ResetListDiff
-    pub fn rebase_on(&mut self, base: &Self) -> Result<(), Error> {
-        match (self, base) {
-            (Self::Base(self_inner), Self::Base(base_inner)) => {
-                bimap_beacon_state_base_tree_list_fields!(
-                    self_inner,
-                    base_inner,
-                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
-                );
-            }
-            (Self::Altair(self_inner), Self::Altair(base_inner)) => {
-                bimap_beacon_state_altair_tree_list_fields!(
-                    self_inner,
-                    base_inner,
-                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
-                );
-            }
-            (Self::Merge(self_inner), Self::Merge(base_inner)) => {
-                bimap_beacon_state_merge_tree_list_fields!(
-                    self_inner,
-                    base_inner,
-                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
-                );
-            }
-            (Self::Capella(self_inner), Self::Capella(base_inner)) => {
-                bimap_beacon_state_capella_tree_list_fields!(
-                    self_inner,
-                    base_inner,
-                    |_, self_field, base_field| { self_field.rebase_on(base_field) }
-                );
-            }
-            // Do not rebase across forks, this should be OK for most situations.
-            _ => {}
-        }
         Ok(())
     }
 


### PR DESCRIPTION
## Issue Addressed

Minimise tree-states memory usage by "rebasing" states on their base state when applying diffs. This should lead to less memory usage overall, although it isn't perfect.

This form of rebasing doesn't cover the case where we load two states that are a diff apart (e.g. 4 epochs) and then later load the states between them. E.g. if we loaded the states at slot 0, then 128, then 1-127, there would be _some_ sharing between 0 & 128, but less sharing between 127 and 128, and some duplication.

I'm still thinking about the best way to address this. Perhaps having a pass that runs over the whole state cache periodically and rebases it would be the best, although that seems quite aggressive and heavy-handed.
