### PR TITLE
[Merged by Bors] - Update Lighthouse book on Doppelganger Protection

### DIFF
--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -386,7 +386,7 @@ For these reasons, we recommend that you make your node publicly accessible.
 
 Lighthouse supports UPnP. If you are behind a NAT with a router that supports
 UPnP, you can simply ensure UPnP is enabled (Lighthouse will inform you in its
-initial logs if a route has been established). You can also manually [set up port mappings/port forwarding](./advanced_networking.md/#how-to-open-ports) in your router to your local Lighthouse instance. By default,
+initial logs if a route has been established). You can also manually [set up port mappings/port forwarding](./advanced_networking.md#how-to-open-ports) in your router to your local Lighthouse instance. By default,
 Lighthouse uses port 9000 for both TCP and UDP. Opening both these ports will
 make your Lighthouse node maximally contactable.
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -29,7 +29,7 @@
 - [How can I monitor my validators?](#net-monitor)
 - [My beacon node and validator client are on different servers. How can I point the validator client to the beacon node?](#net-bn-vc)
 - [Should I do anything to the beacon node or validator client settings if I have a relocation of the node / change of IP address?](#net-ip)
-- 
+- [How to change the TCP/UDP port 9000 that Lighthouse listens on?](#net-port)
 
 
 ## [Miscellaneous](#miscellaneous-1)

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -25,10 +25,11 @@
 ## [Network, Monitoring and Maintenance](#network-monitoring-and-maintenance-1)
 - [I have a low peer count and it is not increasing](#net-peer)
 - [How do I update lighthouse?](#net-update)
-- [Do I need to set up any port mappings (port forwarding)?](#net-port)
+- [Do I need to set up any port mappings (port forwarding)?](#net-port-forwarding)
 - [How can I monitor my validators?](#net-monitor)
 - [My beacon node and validator client are on different servers. How can I point the validator client to the beacon node?](#net-bn-vc)
 - [Should I do anything to the beacon node or validator client settings if I have a relocation of the node / change of IP address?](#net-ip)
+- 
 
 
 ## [Miscellaneous](#miscellaneous-1)
@@ -360,7 +361,7 @@ $ docker pull sigp/lighthouse:v1.0.0
 If you are building a docker image, the process will be similar to the one described [here.](./docker.md#building-the-docker-image)
 You just need to make sure the code you have checked out is up to date.
 
-### <a name="net-port"></a> Do I need to set up any port mappings (port forwarding)?
+### <a name="net-port-forwarding"></a> Do I need to set up any port mappings (port forwarding)?
 
 It is not strictly required to open any ports for Lighthouse to connect and
 participate in the network. Lighthouse should work out-of-the-box. However, if
@@ -420,6 +421,9 @@ The settings are as follows:
 
 ### <a name="net-ip"></a> Should I do anything to the beacon node or validator client settings if I have a relocation of the node / change of IP address?
 No. Lighthouse will auto-detect the change and update your Ethereum Node Record (ENR). You just need to make sure you are not manually setting the ENR with `--enr-address` (which, for common use cases, this flag is not used).
+
+### <a name="net-port"></a> How to change the TCP/UDP port 9000 that Lighthouse listens on?
+Use the flag ```--port <PORT>``` in the beacon node. This flag can be useful when you are running two beacon nodes at the same time. You can leave one beacon node as the default port 9000, and configure the second beacon node to listen on, e.g., ```--port 9001```.
 
 ## Miscellaneous
 

--- a/book/src/validator-doppelganger.md
+++ b/book/src/validator-doppelganger.md
@@ -43,13 +43,12 @@ DP works by staying silent on the network for 2-3 epochs before starting to sign
 Staying silent and refusing to sign messages will cause the following:
 
 - 2-3 missed attestations, incurring penalties and missed rewards.
-- 2-3 epochs of missed sync committee contributions (if the validator is in a sync committee, which is unlikely), incurring penalties and missed rewards.
 - Potentially missed rewards by missing a block proposal (if the validator is an elected block
     proposer, which is unlikely).
 
 The loss of rewards and penalties incurred due to the missed duties will be very small in
-dollar-values. Generally, they will equate to around one US dollar (at August 2021 figures) or about
-2% of the reward for one validator for one day. Since DP costs so little but can protect a user from
+dollar-values. Neglecting block proposals, generally they will equate to around 0.00002 ETH (equivalent to USD 0.04 assuming ETH is trading at USD 2000), or less than
+1% of the reward for one validator for one day. Since DP costs so little but can protect a user from
 slashing, many users will consider this a worthwhile trade-off.
 
 The 2-3 epochs of missed duties will be incurred whenever the VC is started (e.g., after an update


### PR DESCRIPTION
Revise the page by removing the info on sync committee delay. Also added an faq on changing the port.