### PR TITLE
[Merged by Bors] - Add `lint-fix` task to automatically fix some Clippy warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ test-full: cargo-fmt test-release test-debug test-ef test-exec-engine
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	cargo clippy --workspace --tests -- \
+	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D warnings \
 		-A clippy::derive_partial_eq_without_eq \
@@ -179,6 +179,10 @@ lint:
 		-A clippy::vec-init-then-push \
 		-A clippy::question-mark \
 		-A clippy::uninlined-format-args
+
+# Lints the code using Clippy and automatically fix some simple compiler warnings.
+lint-fix:
+	EXTRA_CLIPPY_OPTS="--fix --allow-staged --allow-dirty" $(MAKE) lint
 
 nightly-lint:
 	cp .github/custom/clippy.toml .


### PR DESCRIPTION
## Issue Addressed

This PR adds a new `lint-fix` task to automatically fix simple Clippy warnings using `cargo clippy --fix`.

Usage:

```
make lint-fix
```