### PR TITLE
Configurable diff buffer cache size

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -666,6 +666,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("diff-buffer-cache-size")
+                .long("diff-buffer-cache-size")
+                .value_name("SIZE")
+                .help("The maximum number of diff buffers to hold in memory. This cache is used \
+                       when fetching historic states [default: 16]")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("compression-level")
                 .long("compression-level")
                 .value_name("LEVEL")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -390,6 +390,11 @@ pub fn get_config<E: EthSpec>(
     if let Some(state_cache_size) = clap_utils::parse_optional(cli_args, "state-cache-size")? {
         client_config.store.state_cache_size = state_cache_size;
     }
+    if let Some(diff_buffer_cache_size) =
+        clap_utils::parse_optional(cli_args, "diff-buffer-cache-size")?
+    {
+        client_config.store.diff_buffer_cache_size = diff_buffer_cache_size;
+    }
     if let Some(compression_level) = clap_utils::parse_optional(cli_args, "compression-level")? {
         client_config.store.compression_level = compression_level;
     }

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -10,6 +10,7 @@ pub const DEFAULT_EPOCHS_PER_STATE_DIFF: u64 = 4;
 pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 64;
 pub const DEFAULT_STATE_CACHE_SIZE: usize = 128;
 pub const DEFAULT_COMPRESSION_LEVEL: i32 = 1;
+pub const DEFAULT_DIFF_BUFFER_CACHE_SIZE: usize = 16;
 const EST_COMPRESSION_FACTOR: usize = 2;
 pub const DEFAULT_HISTORIC_STATE_CACHE_SIZE: usize = 1;
 
@@ -22,8 +23,10 @@ pub struct StoreConfig {
     pub block_cache_size: usize,
     /// Maximum number of states to store in the in-memory state cache.
     pub state_cache_size: usize,
-    /// Compression level for `BeaconStateDiff`s.
+    /// Compression level for blocks, state diffs and other compressed values.
     pub compression_level: i32,
+    /// Maximum number of `HDiffBuffer`s to store in memory.
+    pub diff_buffer_cache_size: usize,
     /// Maximum number of states from freezer database to store in the in-memory state cache.
     pub historic_state_cache_size: usize,
     /// Whether to compact the database on initialization.
@@ -60,6 +63,7 @@ impl Default for StoreConfig {
             epochs_per_state_diff: DEFAULT_EPOCHS_PER_STATE_DIFF,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
             state_cache_size: DEFAULT_STATE_CACHE_SIZE,
+            diff_buffer_cache_size: DEFAULT_DIFF_BUFFER_CACHE_SIZE,
             compression_level: DEFAULT_COMPRESSION_LEVEL,
             historic_state_cache_size: DEFAULT_HISTORIC_STATE_CACHE_SIZE,
             compact_on_init: false,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -44,9 +44,6 @@ use types::EthSpec;
 use types::*;
 use zstd::{Decoder, Encoder};
 
-// FIXME(sproul): configurable
-const DIFF_BUFFER_CACHE_SIZE: usize = 16;
-
 pub const MAX_PARENT_STATES_TO_CACHE: u64 = 1;
 
 /// On-disk database that stores finalized states efficiently.
@@ -155,7 +152,7 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
         let historic_state_cache_size =
             NonZeroUsize::new(config.historic_state_cache_size).ok_or(Error::ZeroCacheSize)?;
         let diff_buffer_cache_size =
-            NonZeroUsize::new(DIFF_BUFFER_CACHE_SIZE).ok_or(Error::ZeroCacheSize)?;
+            NonZeroUsize::new(config.diff_buffer_cache_size).ok_or(Error::ZeroCacheSize)?;
 
         let db = HotColdDB {
             split: RwLock::new(Split::default()),
@@ -202,7 +199,7 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
         let historic_state_cache_size =
             NonZeroUsize::new(config.historic_state_cache_size).ok_or(Error::ZeroCacheSize)?;
         let diff_buffer_cache_size =
-            NonZeroUsize::new(DIFF_BUFFER_CACHE_SIZE).ok_or(Error::ZeroCacheSize)?;
+            NonZeroUsize::new(config.diff_buffer_cache_size).ok_or(Error::ZeroCacheSize)?;
 
         let db = HotColdDB {
             split: RwLock::new(Split::default()),


### PR DESCRIPTION
## Proposed Changes

Add a new `--diff-buffer-cache-size` flag for controlling the number of `HDiffBuffer`s held in memory.
