### PR TITLE
[Merged by Bors] - Update doppelganger note about sync committee contributions

### DIFF
--- a/book/src/validator-doppelganger.md
+++ b/book/src/validator-doppelganger.md
@@ -45,7 +45,8 @@ Staying silent and refusing to sign messages will cause the following:
 - 2-3 missed attestations, incurring penalties and missed rewards.
 - Potentially missed rewards by missing a block proposal (if the validator is an elected block
     proposer, which is unlikely).
-- Sync committee contributions are not delayed as those are not slashable
+
+Notably, sync committee contributions are not slashable and will continue to be produced even when DP is suppressing other messages.
 
 The loss of rewards and penalties incurred due to the missed duties will be very small in
 dollar-values. Generally, they will equate to around one US dollar (at August 2021 figures) or about

--- a/book/src/validator-doppelganger.md
+++ b/book/src/validator-doppelganger.md
@@ -43,9 +43,9 @@ DP works by staying silent on the network for 2-3 epochs before starting to sign
 Staying silent and refusing to sign messages will cause the following:
 
 - 2-3 missed attestations, incurring penalties and missed rewards.
-- 2-3 epochs of missed sync committee contributions (if the validator is in a sync committee, which is unlikely), incurring penalties and missed rewards.
 - Potentially missed rewards by missing a block proposal (if the validator is an elected block
     proposer, which is unlikely).
+- Sync committee contributions are not delayed as those are not slashable
 
 The loss of rewards and penalties incurred due to the missed duties will be very small in
 dollar-values. Generally, they will equate to around one US dollar (at August 2021 figures) or about


### PR DESCRIPTION
**Motivation**

As clarified [on discord](https://discord.com/channels/605577013327167508/605577013331361793/1121246688183603240), sync committee contributions are not delayed if DP is enabled.

**Description**

This PR updates doppelganger note about sync committee contributions. Based on the current docs, a user might assume that DP is not working as expected.
