### PR TITLE
update clang in cross docker

### DIFF
--- a/scripts/cross/Dockerfile
+++ b/scripts/cross/Dockerfile
@@ -9,6 +9,6 @@ RUN apt-get install -y unzip && \
     unzip protoc.zip -d /usr && \
     chmod +x /usr/bin/protoc
 
-RUN apt-get install -y cmake clang-3.9 && ln -s ../lib/llvm-3.9/bin/clang /usr/bin/clang
+RUN apt-get install -y cmake clang-5.0
 
 ENV PROTOC=/usr/bin/protoc


### PR DESCRIPTION
## Issue Addressed

Hopefully fixes this: https://github.com/sigp/lighthouse/issues/3929

I believe the issue here is the minimum version of clang we need for bindgen is 5.0

https://rust-lang.github.io/rust-bindgen/requirements.html

I'm also removing the symlink here because I'm not sure why it was originally required if I'm honest