### PR TITLE
Fix EpochCache handling in ef-tests

### DIFF
--- a/consensus/state_processing/src/epoch_cache.rs
+++ b/consensus/state_processing/src/epoch_cache.rs
@@ -23,6 +23,7 @@ pub fn initialize_epoch_cache<E: EthSpec>(
     }
 
     // Compute base rewards.
+    state.build_total_active_balance_cache_at(epoch, spec)?;
     let total_active_balance = state.get_total_active_balance_at_epoch(epoch)?;
     let sqrt_total_active_balance = SqrtTotalActiveBalance::new(total_active_balance);
     let base_reward_per_increment = BaseRewardPerIncrement::new(total_active_balance, spec)?;

--- a/consensus/state_processing/src/per_epoch_processing/altair.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair.rs
@@ -28,6 +28,8 @@ pub fn process_epoch<T: EthSpec>(
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
     state.build_committee_cache(RelativeEpoch::Next, spec)?;
+    state.build_total_active_balance_cache_at(state.current_epoch(), spec)?;
+    initialize_epoch_cache(state, state.current_epoch(), spec)?;
 
     // Pre-compute participating indices and total balances.
     let mut participation_cache = ParticipationCache::new(state, spec)?;

--- a/consensus/state_processing/src/per_epoch_processing/base.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base.rs
@@ -24,6 +24,8 @@ pub fn process_epoch<T: EthSpec>(
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
     state.build_committee_cache(RelativeEpoch::Next, spec)?;
+    state.build_total_active_balance_cache_at(state.current_epoch(), spec)?;
+    initialize_epoch_cache(state, state.current_epoch(), spec)?;
 
     // Load the struct we use to assign validators into sets based on their participation.
     //

--- a/consensus/state_processing/src/per_epoch_processing/capella.rs
+++ b/consensus/state_processing/src/per_epoch_processing/capella.rs
@@ -24,6 +24,8 @@ pub fn process_epoch<T: EthSpec>(
     state.build_committee_cache(RelativeEpoch::Previous, spec)?;
     state.build_committee_cache(RelativeEpoch::Current, spec)?;
     state.build_committee_cache(RelativeEpoch::Next, spec)?;
+    state.build_total_active_balance_cache_at(state.current_epoch(), spec)?;
+    initialize_epoch_cache(state, state.current_epoch(), spec)?;
 
     // Pre-compute participating indices and total balances.
     let mut participation_cache = ParticipationCache::new(state, spec)?;

--- a/testing/ef_tests/src/cases/epoch_processing.rs
+++ b/testing/ef_tests/src/cases/epoch_processing.rs
@@ -5,6 +5,7 @@ use crate::decode::{ssz_decode_state, yaml_decode_file};
 use crate::type_name;
 use crate::type_name::TypeName;
 use serde_derive::Deserialize;
+use state_processing::epoch_cache::initialize_epoch_cache;
 use state_processing::per_epoch_processing::capella::process_historical_summaries_update;
 use state_processing::per_epoch_processing::{
     altair, base,
@@ -135,6 +136,7 @@ impl<E: EthSpec> EpochTransition<E> for RewardsAndPenalties {
 
 impl<E: EthSpec> EpochTransition<E> for RegistryUpdates {
     fn run(state: &mut BeaconState<E>, spec: &ChainSpec) -> Result<(), EpochProcessingError> {
+        initialize_epoch_cache(state, state.current_epoch(), spec)?;
         process_registry_updates(state, spec)
     }
 }

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -4,6 +4,7 @@ use crate::case_result::{check_state_diff, compare_beacon_state_results_without_
 use crate::decode::{ssz_decode_file, ssz_decode_file_with, ssz_decode_state, yaml_decode_file};
 use crate::testing_spec;
 use serde_derive::Deserialize;
+use state_processing::epoch_cache::initialize_epoch_cache;
 use state_processing::{
     per_block_processing::{
         errors::BlockProcessingError,
@@ -86,6 +87,7 @@ impl<E: EthSpec> Operation<E> for Attestation<E> {
         spec: &ChainSpec,
         _: &Operations<E, Self>,
     ) -> Result<(), BlockProcessingError> {
+        initialize_epoch_cache(state, state.current_epoch(), spec)?;
         let mut ctxt = ConsensusContext::new(state.slot());
         match state {
             BeaconState::Base(_) => base::process_attestations(


### PR DESCRIPTION
## Proposed Changes

A few tweaks to get the EF tests passing after the `EpochCache` was added to the `BeaconState`.

In some sense it would be nice to error if a cache isn't built, as it ensures our cache priming is working as intended, however I think this should probably happen as an additional (informational) logging step prior to running e.g. block processing or epoch processing.

I'm also working on overhauling epoch processing (again) into a single pass to match the FV project, and will be rearranging the caches in the process of doing that.
