### PR TITLE
Remove // from mev-rs patch section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes//ethereum-consensus?rev=9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d#9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d"
+source = "git+https://www.github.com/ralexstokes/ethereum-consensus.git?rev=9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d#9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d"
 dependencies = [
  "async-stream",
  "blst",
@@ -5035,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "mev-rs"
 version = "0.2.1"
-source = "git+https://github.com/ralexstokes//mev-rs?rev=7813d4a4a564e0754e9aaab2d95520ba437c3889#7813d4a4a564e0754e9aaab2d95520ba437c3889"
+source = "git+https://www.github.com/ralexstokes/mev-rs.git?rev=7813d4a4a564e0754e9aaab2d95520ba437c3889#7813d4a4a564e0754e9aaab2d95520ba437c3889"
 dependencies = [
  "async-trait",
  "axum",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
+source = "git+https://www.github.com/ralexstokes/ssz-rs.git?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
 dependencies = [
  "bitvec 1.0.1",
  "hex",
@@ -7853,7 +7853,7 @@ dependencies = [
 [[package]]
 name = "ssz-rs-derive"
 version = "0.8.0"
-source = "git+https://github.com/ralexstokes//ssz-rs?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
+source = "git+https://www.github.com/ralexstokes/ssz-rs.git?rev=adf1a0b14cef90b9536f28ef89da1fab316465e1#adf1a0b14cef90b9536f28ef89da1fab316465e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,11 +92,11 @@ warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c
 arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="f002b99989b561ddce62e4cf2887b0f8860ae991" }
 
 [patch."https://github.com/ralexstokes/mev-rs"]
-mev-rs = { git = "https://github.com/ralexstokes//mev-rs", rev = "7813d4a4a564e0754e9aaab2d95520ba437c3889" }
+mev-rs = { git = "https://www.github.com/ralexstokes/mev-rs.git", rev = "7813d4a4a564e0754e9aaab2d95520ba437c3889" }
 [patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com/ralexstokes//ethereum-consensus", rev = "9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d" }
+ethereum-consensus = { git = "https://www.github.com/ralexstokes/ethereum-consensus.git", rev = "9b0ee0a8a45b968c8df5e7e64ea1c094e16f053d" }
 [patch."https://github.com/ralexstokes/ssz-rs"]
-ssz-rs = { git = "https://github.com/ralexstokes//ssz-rs", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
+ssz-rs = { git = "https://www.github.com/ralexstokes/ssz-rs.git", rev = "adf1a0b14cef90b9536f28ef89da1fab316465e1" }
 
 [profile.maxperf]
 inherits = "release"


### PR DESCRIPTION
## Issue Addressed

A user on Discord reported being unable to compile from source due to errors caused by the `//` in some of our Git dependency URLs.

```
$ make
cargo install --path lighthouse --force --locked \
        --features "jemalloc" \
        --profile "release" \

  Installing lighthouse v4.2.0 (/samsung_8tb_ssd/lighthouse/lighthouse)
    Updating git repository `https://github.com/ralexstokes//ethereum-consensus`
warning: spurious network error (3 tries remaining): remote error: 
 ralexstokes//ethereum-consensus is not a valid repository name
Visit https://support.github.com/ for help; class=Net (12)
warning: spurious network error (2 tries remaining): remote error: 
 ralexstokes//ethereum-consensus is not a valid repository name
Visit https://support.github.com/ for help; class=Net (12)
warning: spurious network error (1 tries remaining): remote error: 
 ralexstokes//ethereum-consensus is not a valid repository name
Visit https://support.github.com/ for help; class=Net (12)
error: failed to load source for dependency `ethereum-consensus`
```

I haven't been able to reproduce the error on my machine, but this may be due to hitting a different `github.com` server or some caching I'm unaware of (I tried deleting `~/.cargo/git/checkouts/<package>` without success).

## Proposed Changes

Use `www.github.com` to patch the deps instead of `//`. I'm not sure if we can remove the `[patch]` entirely until `mev-rs` does. I get weird circular errors about the package name being either `ssz-rs` or `ssz_rs` when I try to just pin the commits in the `Cargo.toml`.

## Additional Info

- `mev-rs` issue: https://github.com/ralexstokes/mev-rs/issues/91
- Cargo issue: https://github.com/rust-lang/cargo/issues/5478
