### PR TITLE
bump proc-macro2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6146,9 +6146,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
## Issue Addressed

Addresses issue:  #4459

## Proposed Changes

`cargo update -p proc-macro2`

proc-macro2 v1.0.58 -> v1.0.63

## Additional Info

See: #4459 / https://github.com/rust-lang/rust/issues/113152