### PR TITLE
Test for jack

### DIFF
--- a/beacon_node/network/src/beacon_processor/mod.rs
+++ b/beacon_node/network/src/beacon_processor/mod.rs
@@ -370,7 +370,7 @@ impl DuplicateCache {
 #[derivative(Debug(bound = "T: BeaconChainTypes"))]
 pub struct WorkEvent<T: BeaconChainTypes> {
     drop_during_sync: bool,
-    work: Work<T>,
+    pub work: Work<T>, // this test will never be merged, this is fine
 }
 
 impl<T: BeaconChainTypes> WorkEvent<T> {

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1433,8 +1433,5 @@ mod tests {
                 }
             }
         }
-        let network_msg = network_rx.try_recv().unwrap();
-
-        slog::info!(log, "network got"; "msg" => ?network_msg);
     }
 }


### PR DESCRIPTION
## Issue Addressed

This is a test that reproduces #4331 

I doubt it's meant to be merged at all, but per request of @jmcph4, a playground for him to solve this

The test goes like this:
- epochs are of 8 slots
- chain's oldest block at the beginning is slot 28
- chain needs to backfill to slot 17
- the test finishes when backfill reports a `Completed` outcome (never does)

To run the test
- first `cd beacon_node/network/src/sync`
- `cargo test jacks_hack`

These are the logs it produces
```log
running 1 test
Jul 04 03:05:19.540 DEBG Connection established, connection: Listener, peer_id: 1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh
Jul 04 03:05:19.540 DEBG Resuming backfill sync, processing_target: 3, awaiting_batches: 0, start_epoch: 3
Jul 04 03:05:19.540 TRCE Sending backfill BlocksByRange Request, peer: 1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, count: 16, method: BlocksByRange
Jul 04 03:05:19.541 DEBG Requesting batch, start_slot: 25, end_slot: 40, downloaded: 0, processed: 0, processed_no_penalty: 0, state: Downloading(1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, 0 blocks, 1), epoch: 3
Jul 04 03:05:19.541 INFO initial state, state: Syncing { completed: 0, remaining: 7 }
Jul 04 03:05:19.541 INFO got: request blocks
Jul 04 03:05:19.548 DEBG Completed batch received, awaiting_batches: 0, blocks: 2, epoch: 3
Jul 04 03:05:19.548 TRCE Sending backfill BlocksByRange Request, peer: 1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, count: 16, method: BlocksByRange
Jul 04 03:05:19.549 DEBG Requesting batch, start_slot: 9, end_slot: 24, downloaded: 0, processed: 0, processed_no_penalty: 0, state: Downloading(1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, 0 blocks, 2), epoch: 1
Jul 04 03:05:19.549 INFO got: process blocks
Jul 04 03:05:19.549 INFO Backfill moved the chain to 25
Jul 04 03:05:19.549 DEBG Backfill batch processed, client: Unknown, peer: 1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, batch_epoch: 3, start_slot: 25, end_slot: 40, downloaded: 0, processed: 0, processed_no_penalty: 0, state: Processing(1AfaK87Fe2RMZ5yxJ
VBfpZshXNLtBz1mhWG1DL3ZZCFyQh), result: Success { was_non_empty: true }
Jul 04 03:05:19.550 INFO got: request blocks
Jul 04 03:05:19.557 DEBG Completed batch received, awaiting_batches: 0, blocks: 2, epoch: 1
Jul 04 03:05:19.557 TRCE Sending backfill BlocksByRange Request, peer: 1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, count: 16, method: BlocksByRange
Jul 04 03:05:19.558 DEBG Requesting batch, start_slot: 1, end_slot: 16, downloaded: 0, processed: 0, processed_no_penalty: 0, state: Downloading(1AfaK87Fe2RMZ5yxJVBfpZshXNLtBz1mhWG1DL3ZZCFyQh, 0 blocks, 3), epoch: 0
Jul 04 03:05:19.558 INFO got: request blocks
Jul 04 03:05:19.564 DEBG Completed batch received, awaiting_batches: 0, blocks: 2, epoch: 0

thread 'sync::backfill_sync::tests::jacks_hack' has overflowed its stack
```
it needs to go to slot `17` but goes all the way to slot `1` why?
**hint**: solving this needs to update two lines of code

If you need help ping @AgeManning or me
