### PR TITLE
[Merged by Bors] - Correct checks for backfill completeness

### DIFF
--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1155,7 +1155,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         false
     }
 
-    /// Checks that if we were to backfill all the way to `start_epoch` that we'd be done
+    /// Checks if backfill would complete by syncing to `start_epoch`.
     fn would_complete(&self, start_epoch: Epoch) -> bool {
         start_epoch
             <= self

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1155,7 +1155,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         false
     }
 
-    /// Checks that if we were to backfill all the way to `epoch` that we'd be done
+    /// Checks that if we were to backfill all the way to `start_epoch` that we'd be done
     fn would_complete(&self, start_epoch: Epoch) -> bool {
         start_epoch <= self
             .beacon_chain

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1099,7 +1099,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
             Entry::Occupied(_) => {
                 // this batch doesn't need downloading, let this same function decide the next batch
                 if batch_id
-                    == self
+                    <= self
                         .beacon_chain
                         .genesis_backfill_slot
                         .epoch(T::EthSpec::slots_per_epoch())
@@ -1115,7 +1115,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
             Entry::Vacant(entry) => {
                 entry.insert(BatchInfo::new(&batch_id, BACKFILL_EPOCHS_PER_BATCH));
                 if batch_id
-                    == self
+                    <= self
                         .beacon_chain
                         .genesis_backfill_slot
                         .epoch(T::EthSpec::slots_per_epoch())
@@ -1152,7 +1152,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
     /// Checks with the beacon chain if backfill sync has completed.
     fn check_completed(&mut self) -> bool {
         if self.current_start
-            == self
+            <= self
                 .beacon_chain
                 .genesis_backfill_slot
                 .epoch(T::EthSpec::slots_per_epoch())

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1157,10 +1157,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
 
     /// Checks that if we were to backfill all the way to `start_epoch` that we'd be done
     fn would_complete(&self, start_epoch: Epoch) -> bool {
-        start_epoch <= self
-            .beacon_chain
-            .genesis_backfill_slot
-            .epoch(T::EthSpec::slots_per_epoch())
+        start_epoch
+            <= self
+                .beacon_chain
+                .genesis_backfill_slot
+                .epoch(T::EthSpec::slots_per_epoch())
     }
 
     /// Updates the global network state indicating the current state of a backfill sync.


### PR DESCRIPTION
## Issue Addressed

#4331 

## Proposed Changes

 - Use comparison rather than strict equality between the earliest epoch we know about and the backfill target (which will be the most recent WSP by default or genesis)
 - Add helper function `BackFillSync<T>::would_complete` to achieve this in one location

## Additional Info

 - There's an ad hoc test for this in #4461
