### PR TITLE
[Merged by Bors] - Bump default checkpoint sync timeout to 3 minutes

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -848,7 +848,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Set the timeout for checkpoint sync calls to remote beacon node HTTP endpoint.")
                 .value_name("SECONDS")
                 .takes_value(true)
-                .default_value("60")
+                .default_value("180")
         )
         .arg(
             Arg::with_name("reconstruct-historic-states")

--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -48,6 +48,17 @@ The Ethereum community provides various [public endpoints](https://eth-clients.g
 lighthouse bn --checkpoint-sync-url https://example.com/ ...
 ```
 
+### Adjusting the timeout
+
+If the beacon node fails to start due to a timeout from the checkpoint sync server, you can try
+running it again with a longer timeout by adding the flag `--checkpoint-sync-url-timeout`.
+
+```
+lighthouse bn --checkpoint-sync-url-timeout 300 --checkpoint-sync-url https://example.com/ ...
+```
+
+The flag takes a value in seconds. For more information see `lighthouse bn --help`.
+
 ## Backfilling Blocks
 
 Once forwards sync completes, Lighthouse will commence a "backfill sync" to download the blocks

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -177,7 +177,7 @@ fn checkpoint_sync_url_timeout_default() {
     CommandLineTest::new()
         .run_with_zero_port()
         .with_config(|config| {
-            assert_eq!(config.chain.checkpoint_sync_url_timeout, 60);
+            assert_eq!(config.chain.checkpoint_sync_url_timeout, 180);
         });
 }
 


### PR DESCRIPTION
## Issue Addressed

[Users on Twitter](https://twitter.com/ashekhirin/status/1676334843192397824) are getting checkpoint sync URL timeouts with the default of 60s, so this PR increases the default timeout to 3 minutes.

I've also added a short section to the book about adjusting the timeout with `--checkpoint-sync-url-timeout`.
