### PR TITLE
remove uninlined arg lint suppression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,6 @@ lint:
 	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D warnings \
-		-A clippy::uninlined-format-args \
 		-A clippy::derive_partial_eq_without_eq \
 		-A clippy::from-over-into \
 		-A clippy::upper-case-acronyms \


### PR DESCRIPTION
## Issue Addressed

This didn't require changes when I removed this locally, not sure why it was there. Maybe it was more useful when the branch was in a less stable state?
