### PR TITLE
remove patched dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,8 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.5.2"
-source = "git+https://github.com/jimmygchen/ethereum_ssz?rev=231aa8c840262da694e024235dbc638a2980c545#231aa8c840262da694e024235dbc638a2980c545"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6085d7fd3cf84bd2b8fec150d54c8467fb491d8db9c460607c5534f653a0ee38"
 dependencies = [
  "darling 0.13.4",
  "proc-macro2",
@@ -7997,8 +7998,9 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.5.3"
-source = "git+https://github.com/sigp/ssz_types?rev=63a80d04286c8561d5c211230a21bf1299d66059#63a80d04286c8561d5c211230a21bf1299d66059"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382939886cb24ee8ac885d09116a60f6262d827c7a9e36012b4f6d3d0116d0b3"
 dependencies = [
  "arbitrary",
  "derivative",
@@ -8907,8 +8909,9 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.5.1"
-source = "git+https://github.com/sigp/tree_hash?rev=a2471f3b240f407a0ec7436cff11f03e5ec8c706#a2471f3b240f407a0ec7436cff11f03e5ec8c706"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c998ac5fe2b07c025444bdd522e6258110b63861c6698eedc610c071980238d"
 dependencies = [
  "ethereum-types 0.14.1",
  "ethereum_hashing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,9 +91,6 @@ resolver = "2"
 [patch.crates-io]
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 arbitrary = { git = "https://github.com/michaelsproul/arbitrary", rev="f002b99989b561ddce62e4cf2887b0f8860ae991" }
-tree_hash = { git = "https://github.com/sigp/tree_hash", rev="a2471f3b240f407a0ec7436cff11f03e5ec8c706" }
-ssz_types = { git = "https://github.com/sigp/ssz_types", rev="63a80d04286c8561d5c211230a21bf1299d66059" }
-ethereum_ssz_derive = { git = "https://github.com/jimmygchen/ethereum_ssz", rev="231aa8c840262da694e024235dbc638a2980c545"}
 
 [patch."https://github.com/ralexstokes/mev-rs"]
 mev-rs = { git = "https://github.com/ralexstokes//mev-rs", rev = "7813d4a4a564e0754e9aaab2d95520ba437c3889" }

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -35,11 +35,11 @@ sloggers = { version = "2.1.1", features = ["json"] }
 slot_clock = { path = "../../common/slot_clock" }
 ethereum_hashing = "1.0.0-beta.2"
 ethereum_ssz = "0.5.0"
-ssz_types = "0.5.3"
-ethereum_ssz_derive = "0.5.0"
+ssz_types = "0.5.4"
+ethereum_ssz_derive = "0.5.3"
 state_processing = { path = "../../consensus/state_processing" }
 tree_hash_derive = "0.5.0"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 types = { path = "../../consensus/types" }
 tokio = "1.14.0"
 tokio-stream = "0.1.3"

--- a/beacon_node/eth1/Cargo.toml
+++ b/beacon_node/eth1/Cargo.toml
@@ -20,8 +20,8 @@ hex = "0.4.2"
 types = { path = "../../consensus/types"}
 merkle_proof = { path = "../../consensus/merkle_proof"}
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
-tree_hash = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
+tree_hash = "0.5.2"
 parking_lot = "0.12.0"
 slog = "2.5.2"
 superstruct = "0.5.0"

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -23,14 +23,14 @@ bytes = "1.1.0"
 task_executor = { path = "../../common/task_executor" }
 hex = "0.4.2"
 ethereum_ssz = "0.5.0"
-ssz_types = "0.5.3"
+ssz_types = "0.5.4"
 eth2 = { path = "../../common/eth2" }
 kzg = { path = "../../crypto/kzg" }
 state_processing = { path = "../../consensus/state_processing" }
 superstruct = "0.6.0"
 lru = "0.7.1"
 exit-future = "0.2.0"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 tree_hash_derive = "0.5.0"
 parking_lot = "0.12.0"
 slot_clock = { path = "../../common/slot_clock" }

--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -18,7 +18,7 @@ state_processing = { path = "../../consensus/state_processing" }
 merkle_proof = { path = "../../consensus/merkle_proof" }
 ethereum_ssz = "0.5.0"
 ethereum_hashing = "1.0.0-beta.2"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 tokio = { version = "1.14.0", features = ["full"] }
 slog = "2.5.2"
 int_to_bytes = { path = "../../consensus/int_to_bytes" }

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -32,7 +32,7 @@ parking_lot = "0.12.0"
 safe_arith = {path = "../../consensus/safe_arith"}
 task_executor = { path = "../../common/task_executor" }
 lru = "0.7.7"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 sysinfo = "0.26.5"
 system_health = { path = "../../common/system_health" }
 directory = { path = "../../common/directory" }

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2021"
 discv5 = { version = "0.3.0", features = ["libp2p"]}
 unsigned-varint = { version = "0.6.0", features = ["codec"] }
 types = { path =  "../../consensus/types" }
-ssz_types = "0.5.3"
+ssz_types = "0.5.4"
 serde = { version = "1.0.116", features = ["derive"] }
 serde_derive = "1.0.116"
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
-tree_hash = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
+tree_hash = "0.5.2"
 tree_hash_derive = "0.5.0"
 slog = { version = "2.5.2", features = ["max_level_trace"] }
 lighthouse_version = { path = "../../common/lighthouse_version" }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -22,7 +22,7 @@ slot_clock = { path = "../../common/slot_clock" }
 slog = { version = "2.5.2", features = ["max_level_trace", "nested-values"] }
 hex = "0.4.2"
 ethereum_ssz = "0.5.0"
-ssz_types = "0.5.3"
+ssz_types = "0.5.4"
 futures = "0.3.7"
 error-chain = "0.12.4"
 tokio = { version = "1.14.0", features = ["full"] }

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -13,7 +13,7 @@ parking_lot = "0.12.0"
 types = { path = "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 rayon = "1.5.0"
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -14,7 +14,7 @@ leveldb = { version = "0.8.6" }
 parking_lot = "0.12.0"
 itertools = "0.10.0"
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 types = { path =  "../../consensus/types" }
 state_processing = { path = "../../consensus/state_processing" }
 slog = "2.5.2"

--- a/common/deposit_contract/Cargo.toml
+++ b/common/deposit_contract/Cargo.toml
@@ -15,5 +15,5 @@ hex = "0.4.2"
 [dependencies]
 types = { path = "../../consensus/types"}
 ethereum_ssz = "0.5.0"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 ethabi = "16.0.0"

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -21,7 +21,7 @@ bytes = "1.0.1"
 account_utils = { path = "../../common/account_utils" }
 sensitive_url = { path = "../../common/sensitive_url" }
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 futures-util = "0.3.8"
 futures = "0.3.8"
 store = { path = "../../beacon_node/store", optional = true }

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -16,7 +16,7 @@ filesystem = { path = "../filesystem" }
 types = { path = "../../consensus/types" }
 rand = "0.8.5"
 deposit_contract = { path = "../deposit_contract" }
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 hex = "0.4.2"
 derivative = "2.1.1"
 lockfile = { path = "../lockfile" }

--- a/consensus/cached_tree_hash/Cargo.toml
+++ b/consensus/cached_tree_hash/Cargo.toml
@@ -6,11 +6,11 @@ edition = "2021"
 
 [dependencies]
 ethereum-types = "0.14.1"
-ssz_types = "0.5.3"
+ssz_types = "0.5.4"
 ethereum_hashing = "1.0.0-beta.2"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 ethereum_ssz = "0.5.0"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 smallvec = "1.6.1"
 
 [dev-dependencies]

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -11,7 +11,7 @@ types = { path = "../types" }
 state_processing = { path = "../state_processing" }
 proto_array = { path = "../proto_array" }
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 slog = { version = "2.5.2", features = ["max_level_trace", "release_max_level_trace"] }
 
 [dev-dependencies]

--- a/consensus/proto_array/Cargo.toml
+++ b/consensus/proto_array/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin.rs"
 [dependencies]
 types = { path = "../types" }
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 serde = "1.0.116"
 serde_derive = "1.0.116"
 serde_yaml = "0.8.13"

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -14,11 +14,11 @@ bls = { path = "../../crypto/bls" }
 integer-sqrt = "0.1.5"
 itertools = "0.10.0"
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
-ssz_types = "0.5.3"
+ethereum_ssz_derive = "0.5.3"
+ssz_types = "0.5.4"
 merkle_proof = { path = "../merkle_proof" }
 safe_arith = { path = "../safe_arith" }
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 types = { path = "../types", default-features = false }
 rayon = "1.4.1"
 ethereum_hashing = "1.0.0-beta.2"

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -27,11 +27,11 @@ serde = {version = "1.0.116" , features = ["rc"] }
 serde_derive = "1.0.116"
 slog = "2.5.2"
 ethereum_ssz = { version = "0.5.0", features = ["arbitrary"] }
-ethereum_ssz_derive = "0.5.0"
-ssz_types = { version = "0.5.3", features = ["arbitrary"] }
+ethereum_ssz_derive = "0.5.3"
+ssz_types = { version = "0.5.4", features = ["arbitrary"] }
 swap_or_not_shuffle = { path = "../swap_or_not_shuffle", features = ["arbitrary"] }
 test_random_derive = { path = "../../common/test_random_derive" }
-tree_hash = { version = "0.5.0", features = ["arbitrary"] }
+tree_hash = { version = "0.5.2", features = ["arbitrary"] }
 tree_hash_derive = "0.5.0"
 rand_xorshift = "0.3.0"
 cached_tree_hash = { path = "../cached_tree_hash" }

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 ethereum_ssz = "0.5.0"
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 milagro_bls = { git = "https://github.com/sigp/milagro_bls", tag = "v1.4.2", optional = true }
 rand = "0.7.3"
 serde = "1.0.116"

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
-tree_hash = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
+tree_hash = "0.5.2"
 derivative = "2.1.1"
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -28,7 +28,7 @@ environment = { path = "../lighthouse/environment" }
 eth2_network_config = { path = "../common/eth2_network_config" }
 genesis = { path = "../beacon_node/genesis" }
 deposit_contract = { path = "../common/deposit_contract" }
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 clap_utils = { path = "../common/clap_utils" }
 lighthouse_network = { path = "../beacon_node/lighthouse_network" }
 validator_dir = { path = "../common/validator_dir", features = ["insecure_keys"] }

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -13,7 +13,7 @@ lmdb = ["lmdb-rkv", "lmdb-rkv-sys"]
 bincode = "1.3.1"
 byteorder = "1.3.4"
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
 flate2 = { version = "1.0.14", features = ["zlib"], default-features = false }
 lazy_static = "1.4.0"
 lighthouse_metrics = { path = "../common/lighthouse_metrics" }
@@ -26,7 +26,7 @@ serde = "1.0"
 serde_derive = "1.0"
 slog = "2.5.2"
 sloggers = { version = "2.1.1", features = ["json"] }
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 tree_hash_derive = "0.5.0"
 types = { path = "../consensus/types" }
 strum = { version = "0.24.1", features = ["derive"] }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -27,8 +27,8 @@ serde_yaml = "0.8.13"
 eth2_network_config = { path = "../../common/eth2_network_config" }
 ethereum_serde_utils = "0.5.0"
 ethereum_ssz = "0.5.0"
-ethereum_ssz_derive = "0.5.0"
-tree_hash = "0.5.0"
+ethereum_ssz_derive = "0.5.3"
+tree_hash = "0.5.2"
 tree_hash_derive = "0.5.0"
 cached_tree_hash = { path = "../../consensus/cached_tree_hash" }
 state_processing = { path = "../../consensus/state_processing" }

--- a/validator_client/Cargo.toml
+++ b/validator_client/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.14.0", features = ["time", "rt-multi-thread", "macros"] }
 logging = { path = "../common/logging" }
 
 [dependencies]
-tree_hash = "0.5.0"
+tree_hash = "0.5.2"
 clap = "2.33.3"
 slashing_protection = { path = "./slashing_protection" }
 slot_clock = { path = "../common/slot_clock" }


### PR DESCRIPTION
## Issue Addressed

Removes patches for some crates where we have updated releases we can use instead

specifically these:

```
tree_hash = { git = "https://github.com/sigp/tree_hash", rev="a2471f3b240f407a0ec7436cff11f03e5ec8c706" }
ssz_types = { git = "https://github.com/sigp/ssz_types", rev="63a80d04286c8561d5c211230a21bf1299d66059" }
ethereum_ssz_derive = { git = "https://github.com/jimmygchen/ethereum_ssz", rev="231aa8c840262da694e024235dbc638a2980c545"}
```
