### PR TITLE
remove clang from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.68.2-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG FEATURES
 ARG PROFILE=release

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -2,7 +2,7 @@
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
 FROM rust:1.68.2-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 ARG PORTABLE
 ENV PORTABLE $PORTABLE

--- a/testing/antithesis/Dockerfile.libvoidstar
+++ b/testing/antithesis/Dockerfile.libvoidstar
@@ -1,5 +1,5 @@
 FROM rust:1.68.2-bullseye AS builder
-RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake clang libclang-dev protobuf-compiler
+RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev protobuf-compiler
 COPY . lighthouse
 
 # Build lighthouse directly with a cargo build command, bypassing the Makefile.


### PR DESCRIPTION
## Issue Addressed

We had to add `clang` to the `Dockerfile` and `lcli/Dockerfile` at some point, but I've tested without it on mac and linux and it still seems to work. So I wonder if updating the rust image we are building from fixed this issue.
