### PR TITLE
fix failing network tests

### DIFF
--- a/beacon_node/network/src/beacon_processor/tests.rs
+++ b/beacon_node/network/src/beacon_processor/tests.rs
@@ -707,8 +707,8 @@ async fn attestation_to_unknown_block_processed(import_method: BlockImportMethod
         BlockImportMethod::Rpc => {
             rig.enqueue_rpc_block();
             events.push(RPC_BLOCK);
-            rig.enqueue_single_lookup_rpc_blobs();
             if num_blobs > 0 {
+                rig.enqueue_single_lookup_rpc_blobs();
                 events.push(RPC_BLOB);
             }
         }
@@ -790,8 +790,8 @@ async fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod
         BlockImportMethod::Rpc => {
             rig.enqueue_rpc_block();
             events.push(RPC_BLOCK);
-            rig.enqueue_single_lookup_rpc_blobs();
             if num_blobs > 0 {
+                rig.enqueue_single_lookup_rpc_blobs();
                 events.push(RPC_BLOB);
             }
         }


### PR DESCRIPTION
## Issue Addressed

Some network tests would fail when the number of random blobs generated during the deneb fork was zero, because we queue a blob work request, without queueing the corresponding event, this no longer queues the work request.

Example failure: 

https://github.com/sigp/lighthouse/actions/runs/5465377673/jobs/9948751102?pr=4469

```
failures:

---- beacon_processor::tests::aggregate_attestation_to_unknown_block_processed_after_rpc_block stdout ----
thread 'beacon_processor::tests::aggregate_attestation_to_unknown_block_processed_after_rpc_block' panicked at 'assertion failed: `(left == right)`
  left: `["rpc_block", "rpc_blob"]`,
 right: `["rpc_block", "unknown_block_aggregate"]`', beacon_node/network/src/beacon_processor/tests.rs:462:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    beacon_processor::tests::aggregate_attestation_to_unknown_block_processed_after_rpc_block