### PR TITLE
Remove `IntoGossipVerifiedBlock`

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -632,40 +632,6 @@ pub struct ExecutionPendingBlock<T: BeaconChainTypes> {
     pub payload_verification_handle: PayloadVerificationHandle<T::EthSpec>,
 }
 
-pub trait IntoGossipVerifiedBlock<T: BeaconChainTypes>: Sized {
-    fn into_gossip_verified_block(
-        self,
-        chain: &BeaconChain<T>,
-    ) -> Result<GossipVerifiedBlock<T>, BlockError<T::EthSpec>>;
-    fn inner(&self) -> Arc<SignedBeaconBlock<T::EthSpec>>;
-}
-
-impl<T: BeaconChainTypes> IntoGossipVerifiedBlock<T> for GossipVerifiedBlock<T> {
-    fn into_gossip_verified_block(
-        self,
-        _chain: &BeaconChain<T>,
-    ) -> Result<GossipVerifiedBlock<T>, BlockError<T::EthSpec>> {
-        Ok(self)
-    }
-
-    fn inner(&self) -> Arc<SignedBeaconBlock<T::EthSpec>> {
-        self.block.clone()
-    }
-}
-
-impl<T: BeaconChainTypes> IntoGossipVerifiedBlock<T> for Arc<SignedBeaconBlock<T::EthSpec>> {
-    fn into_gossip_verified_block(
-        self,
-        chain: &BeaconChain<T>,
-    ) -> Result<GossipVerifiedBlock<T>, BlockError<T::EthSpec>> {
-        GossipVerifiedBlock::new(self, chain)
-    }
-
-    fn inner(&self) -> Arc<SignedBeaconBlock<T::EthSpec>> {
-        self.clone()
-    }
-}
-
 /// Implemented on types that can be converted into a `ExecutionPendingBlock`.
 ///
 /// Used to allow functions to accept blocks at various stages of verification.

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -64,7 +64,7 @@ pub use attestation_verification::Error as AttestationError;
 pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceStoreError};
 pub use block_verification::{
     get_block_root, BlockError, ExecutionPayloadError, GossipVerifiedBlock,
-    IntoExecutionPendingBlock, IntoGossipVerifiedBlock,
+    IntoExecutionPendingBlock,
 };
 pub use canonical_head::{CachedHead, CanonicalHead, CanonicalHeadRwLock};
 pub use eth1_chain::{Eth1Chain, Eth1ChainBackend};


### PR DESCRIPTION
## Issue Addressed

In merging `unstable` into `deneb-free-blobs`, I realized `IntoGossipVerifiedBlock` is implemented for `Arc<SignedBeaconBlock>` and `GossipVerifiedBlock`, but its methods are only ever invoked on `Arc<SignedBeaconBlock>`. Removing the trait also makes this a bit easier to work with during block + blob production