### PR TITLE
[Merged by Bors] - Add state-root command and network support to lcli

### DIFF
--- a/lcli/src/block_root.rs
+++ b/lcli/src/block_root.rs
@@ -31,14 +31,19 @@ use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::BlockId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
+use eth2_network_config::Eth2NetworkConfig;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use types::{EthSpec, FullPayload, SignedBeaconBlock};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(5);
 
-pub fn run<T: EthSpec>(env: Environment<T>, matches: &ArgMatches) -> Result<(), String> {
-    let spec = &T::default_spec();
+pub fn run<T: EthSpec>(
+    env: Environment<T>,
+    network_config: Eth2NetworkConfig,
+    matches: &ArgMatches,
+) -> Result<(), String> {
+    let spec = &network_config.chain_spec::<T>()?;
     let executor = env.core_context().executor;
 
     /*

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -49,6 +49,7 @@ use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
+use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
 use state_processing::state_advance::{complete_state_advance, partial_state_advance};
 use std::fs::File;
@@ -59,8 +60,12 @@ use types::{BeaconState, CloneConfig, EthSpec, Hash256};
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
 
-pub fn run<T: EthSpec>(env: Environment<T>, matches: &ArgMatches) -> Result<(), String> {
-    let spec = &T::default_spec();
+pub fn run<T: EthSpec>(
+    env: Environment<T>,
+    network_config: Eth2NetworkConfig,
+    matches: &ArgMatches,
+) -> Result<(), String> {
+    let spec = &network_config.chain_spec::<T>()?;
     let executor = env.core_context().executor;
 
     let output_path: Option<PathBuf> = parse_optional(matches, "output-path")?;

--- a/lcli/src/state_root.rs
+++ b/lcli/src/state_root.rs
@@ -1,0 +1,76 @@
+use crate::transition_blocks::load_from_ssz_with;
+use clap::ArgMatches;
+use clap_utils::{parse_optional, parse_required};
+use environment::Environment;
+use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
+use eth2_network_config::Eth2NetworkConfig;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use types::{BeaconState, EthSpec};
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub fn run<T: EthSpec>(
+    env: Environment<T>,
+    network_config: Eth2NetworkConfig,
+    matches: &ArgMatches,
+) -> Result<(), String> {
+    let executor = env.core_context().executor;
+
+    let spec = &network_config.chain_spec::<T>()?;
+
+    let state_path: Option<PathBuf> = parse_optional(matches, "state-path")?;
+    let beacon_url: Option<SensitiveUrl> = parse_optional(matches, "beacon-url")?;
+    let runs: usize = parse_required(matches, "runs")?;
+
+    info!(
+        "Using {} network ({} spec)",
+        spec.config_name.as_deref().unwrap_or("unknown"),
+        T::spec_name()
+    );
+    info!("Doing {} runs", runs);
+
+    let state = match (state_path, beacon_url) {
+        (Some(state_path), None) => {
+            info!("State path: {:?}", state_path);
+            load_from_ssz_with(&state_path, spec, BeaconState::from_ssz_bytes)?
+        }
+        (None, Some(beacon_url)) => {
+            let state_id: StateId = parse_required(matches, "state-id")?;
+            let client = BeaconNodeHttpClient::new(beacon_url, Timeouts::set_all(HTTP_TIMEOUT));
+            executor
+                .handle()
+                .ok_or("shutdown in progress")?
+                .block_on(async move {
+                    client
+                        .get_debug_beacon_states::<T>(state_id)
+                        .await
+                        .map_err(|e| format!("Failed to download state: {:?}", e))
+                })
+                .map_err(|e| format!("Failed to complete task: {:?}", e))?
+                .ok_or_else(|| format!("Unable to locate state at {:?}", state_id))?
+                .data
+        }
+        _ => return Err("must supply either --state-path or --beacon-url".into()),
+    };
+
+    /*
+     * Perform the core "runs".
+     */
+    let mut state_root = None;
+    for i in 0..runs {
+        let mut state = state.clone();
+        let timer = Instant::now();
+        state_root = Some(
+            state
+                .update_tree_hash_cache()
+                .map_err(|e| format!("error computing state root: {e:?}"))?,
+        );
+        info!("Run {}: {:?}", i, timer.elapsed());
+    }
+
+    if let Some(state_root) = state_root {
+        info!("State root is {:?}", state_root);
+    }
+    Ok(())
+}

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -71,6 +71,7 @@ use eth2::{
     types::{BlockId, StateId},
     BeaconNodeHttpClient, SensitiveUrl, Timeouts,
 };
+use eth2_network_config::Eth2NetworkConfig;
 use ssz::Encode;
 use state_processing::{
     block_signature_verifier::BlockSignatureVerifier, per_block_processing, per_slot_processing,
@@ -94,8 +95,12 @@ struct Config {
     exclude_post_block_thc: bool,
 }
 
-pub fn run<T: EthSpec>(env: Environment<T>, matches: &ArgMatches) -> Result<(), String> {
-    let spec = &T::default_spec();
+pub fn run<T: EthSpec>(
+    env: Environment<T>,
+    network_config: Eth2NetworkConfig,
+    matches: &ArgMatches,
+) -> Result<(), String> {
+    let spec = &network_config.chain_spec::<T>()?;
     let executor = env.core_context().executor;
 
     /*


### PR DESCRIPTION
## Proposed Changes

* Add `lcli state-root` command for computing the hash tree root of a `BeaconState`.
* Add a `--network` flag which can be used instead of `--testnet-dir` to set the network, e.g. Mainnet, Goerli, Gnosis.
* Use the new network flag in `transition-blocks`, `skip-slots`, and `block-root`, which previously only supported mainnet.
* **BREAKING CHANGE** Remove the default value of `~/.lighthouse/testnet` from `--testnet-dir`. This may have made sense in previous versions where `lcli` was more testnet focussed, but IMO it is an unnecessary complication and foot-gun today.
