### PR TITLE
Remove `Banned` connection state from peer database

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -23,7 +23,8 @@ pub struct PeerInfo<T: EthSpec> {
     /// The peers reputation
     score: Score,
     /// Time at which peer was banned
-    banned_since: Option<u64>,
+    #[serde(skip)]
+    banned_since: Option<Instant>,
     /// Client managing this peer
     client: Client,
     /// Connection status of this peer

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -290,6 +290,10 @@ impl<T: EthSpec> PeerInfo<T> {
         self.banned_since
     }
 
+    pub fn banned_since_mut(&mut self) -> &mut Option<u64> {
+        &mut self.banned_since
+    }
+
     /// Checks if the connection status is banned. This can lag behind the score state
     /// temporarily.
     pub fn is_banned(&self) -> bool {

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -22,6 +22,8 @@ use PeerConnectionStatus::*;
 pub struct PeerInfo<T: EthSpec> {
     /// The peers reputation
     score: Score,
+    /// Time at which peer was banned
+    banned_since: Option<u64>,
     /// Client managing this peer
     client: Client,
     /// Connection status of this peer
@@ -57,6 +59,7 @@ impl<TSpec: EthSpec> Default for PeerInfo<TSpec> {
     fn default() -> PeerInfo<TSpec> {
         PeerInfo {
             score: Score::default(),
+            banned_since: None,
             client: Client::default(),
             connection_status: Default::default(),
             listening_addresses: Vec::new(),
@@ -283,10 +286,14 @@ impl<T: EthSpec> PeerInfo<T> {
         self.is_connected() || self.is_dialing()
     }
 
+    pub fn banned_since(&self) -> Option<u64> {
+        self.banned_since
+    }
+
     /// Checks if the connection status is banned. This can lag behind the score state
     /// temporarily.
     pub fn is_banned(&self) -> bool {
-        matches!(self.connection_status, PeerConnectionStatus::Banned { .. })
+        self.score_is_banned()
     }
 
     /// Checks if the peer's score is banned.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -503,11 +503,6 @@ pub enum PeerConnectionStatus {
         /// last time the peer was connected or discovered.
         since: Instant,
     },
-    /// The peer has been banned and is disconnected.
-    Banned {
-        /// moment when the peer was banned.
-        since: Instant,
-    },
     /// We are currently dialing this peer.
     Dialing {
         /// time since we last communicated with the peer.

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -287,11 +287,11 @@ impl<T: EthSpec> PeerInfo<T> {
         self.is_connected() || self.is_dialing()
     }
 
-    pub fn banned_since(&self) -> Option<u64> {
+    pub fn banned_since(&self) -> Option<Instant> {
         self.banned_since
     }
 
-    pub fn banned_since_mut(&mut self) -> &mut Option<u64> {
+    pub fn banned_since_mut(&mut self) -> &mut Option<Instant> {
         &mut self.banned_since
     }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -780,9 +780,9 @@ impl PeerState {
             PeerConnectionStatus::Connected { .. } => PeerState::Connected,
             PeerConnectionStatus::Dialing { .. } => PeerState::Connecting,
             PeerConnectionStatus::Disconnecting { .. } => PeerState::Disconnecting,
-            PeerConnectionStatus::Disconnected { .. }
-            | PeerConnectionStatus::Banned { .. }
-            | PeerConnectionStatus::Unknown => PeerState::Disconnected,
+            PeerConnectionStatus::Disconnected { .. } | PeerConnectionStatus::Unknown => {
+                PeerState::Disconnected
+            }
         }
     }
 }


### PR DESCRIPTION
## Issue Addressed

#2772

## Proposed Changes

 - Add `banned_since` field to `PeerInfo` type, capturing the time at which a peer was banned
 - Add accessors for this field
   - `banned_since`
   - `banned_since_mut`
 - Remove references to the old `PeerConnectionStatus::Banned` state
 - Correct the definition of whether a peer is banned or not to rely solely on the `ScoreState::Banned` variant

## Additional Info

N/A
