### PR TITLE
[Merged by Bors] - Clean up local testnet files without prompting

### DIFF
--- a/scripts/local_testnet/clean.sh
+++ b/scripts/local_testnet/clean.sh
@@ -9,5 +9,5 @@ set -Eeuo pipefail
 source ./vars.env
 
 if [ -d $DATADIR ]; then
-  rm -r $DATADIR
+  rm -rf $DATADIR
 fi


### PR DESCRIPTION
## Issue Addressed

Addresses an issue where CI could fail due to an nonexisting file error:

```
Run ./clean.sh
rm: cannot remove '/home/runner/.lighthouse/local-testnet/geth_datadir4/geth/fastcache.tmp.1549331618': No such file or directory
Error: Process completed with exit code 1.
```

This seems to happen quite frequently now, I'm not sure exactly why but perhaps worth trying suppressing the prompt?

https://github.com/sigp/lighthouse/actions/runs/5455027574/jobs/9925916159?pr=4463
