### PR TITLE
[Merged by Bors] - Speed up CI by installing foundry with Github action

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -58,8 +58,10 @@ jobs:
       uses: arduino/setup-protoc@e52d9eb8f7b63115df1ac544a1376fdbf5a39612
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Run tests in release
       run: make test-release
   release-tests-windows:
@@ -78,9 +80,10 @@ jobs:
       run: |
         choco install python protoc visualstudio2019-workload-vctools -y
         npm config set msvs_version 2019
-    - name: Install anvil
-      # Extra feature to work around https://github.com/foundry-rs/foundry/issues/5115
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil --features ethers/ipc
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Install make
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
@@ -141,8 +144,10 @@ jobs:
       uses: arduino/setup-protoc@e52d9eb8f7b63115df1ac544a1376fdbf5a39612
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:
@@ -197,8 +202,10 @@ jobs:
       uses: arduino/setup-protoc@e52d9eb8f7b63115df1ac544a1376fdbf5a39612
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Run the beacon chain sim that starts from an eth1 contract
       run: cargo run --release --bin simulator eth1-sim
   merge-transition-ubuntu:
@@ -213,8 +220,10 @@ jobs:
       uses: arduino/setup-protoc@e52d9eb8f7b63115df1ac544a1376fdbf5a39612
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Run the beacon chain sim and go through the merge transition
       run: cargo run --release --bin simulator eth1-sim --post-merge
   no-eth1-simulator-ubuntu:
@@ -243,8 +252,10 @@ jobs:
       uses: arduino/setup-protoc@e52d9eb8f7b63115df1ac544a1376fdbf5a39612
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install anvil
-      run: cargo install --git https://github.com/foundry-rs/foundry --locked anvil
+    - name: Install Foundry (anvil)
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly
     - name: Run the syncing simulator
       run: cargo run --release --bin simulator syncing-sim
   doppelganger-protection-test:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -60,8 +60,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Run tests in release
       run: make test-release
   release-tests-windows:
@@ -82,8 +80,6 @@ jobs:
         npm config set msvs_version 2019
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Install make
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
@@ -146,8 +142,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:
@@ -204,8 +198,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Run the beacon chain sim that starts from an eth1 contract
       run: cargo run --release --bin simulator eth1-sim
   merge-transition-ubuntu:
@@ -222,8 +214,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Run the beacon chain sim and go through the merge transition
       run: cargo run --release --bin simulator eth1-sim --post-merge
   no-eth1-simulator-ubuntu:
@@ -254,8 +244,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
-      with:
-        version: nightly
     - name: Run the syncing simulator
       run: cargo run --release --bin simulator syncing-sim
   doppelganger-protection-test:


### PR DESCRIPTION
## Issue Addressed

Speed up CI by installing foundry with Github action instead of building Anvil from source.

Building anvil from source on GItHub hosted runners currently takes about 10 mins. Using the `foundry-toolchain` action to install only takes about 2 seconds.
