### PR TITLE
[Merged by Bors] - Fix bug in lcli transition-blocks and improve pretty-ssz

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -968,7 +968,9 @@ fn run<T: EthSpec>(
                 .map_err(|e| format!("Failed to skip slots: {}", e))
         }
         ("pretty-ssz", Some(matches)) => {
-            run_parse_ssz::<T>(matches).map_err(|e| format!("Failed to pretty print hex: {}", e))
+            let network_config = get_network_config()?;
+            run_parse_ssz::<T>(network_config, matches)
+                .map_err(|e| format!("Failed to pretty print hex: {}", e))
         }
         ("deploy-deposit-contract", Some(matches)) => {
             deploy_deposit_contract::run::<T>(env, matches)

--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -1,5 +1,6 @@
 use clap::ArgMatches;
 use clap_utils::parse_required;
+use eth2_network_config::Eth2NetworkConfig;
 use serde::Serialize;
 use snap::raw::Decoder;
 use ssz::Decode;
@@ -26,7 +27,10 @@ impl FromStr for OutputFormat {
     }
 }
 
-pub fn run_parse_ssz<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
+pub fn run_parse_ssz<T: EthSpec>(
+    network_config: Eth2NetworkConfig,
+    matches: &ArgMatches,
+) -> Result<(), String> {
     let type_str = matches.value_of("type").ok_or("No type supplied")?;
     let filename = matches.value_of("ssz-file").ok_or("No file supplied")?;
     let format = parse_required(matches, "format")?;
@@ -44,44 +48,79 @@ pub fn run_parse_ssz<T: EthSpec>(matches: &ArgMatches) -> Result<(), String> {
         bytes
     };
 
-    info!("Using {} spec", T::spec_name());
-    info!("Type: {:?}", type_str);
+    let spec = &network_config.chain_spec::<T>()?;
+    info!(
+        "Using {} network config ({} preset)",
+        spec.config_name.as_deref().unwrap_or("unknown"),
+        T::spec_name()
+    );
+    info!("Type: {type_str}");
 
+    // More fork-specific decoders may need to be added in future, but shouldn't be 100% necessary,
+    // as the fork-generic decoder will always be available (requires correct --network flag).
     match type_str {
-        "signed_block_base" => decode_and_print::<SignedBeaconBlockBase<T>>(&bytes, format)?,
-        "signed_block_altair" => decode_and_print::<SignedBeaconBlockAltair<T>>(&bytes, format)?,
-        "signed_block_merge" => decode_and_print::<SignedBeaconBlockMerge<T>>(&bytes, format)?,
-        "block_base" => decode_and_print::<BeaconBlockBase<T>>(&bytes, format)?,
-        "block_altair" => decode_and_print::<BeaconBlockAltair<T>>(&bytes, format)?,
-        "block_merge" => decode_and_print::<BeaconBlockMerge<T>>(&bytes, format)?,
-        "state_base" => decode_and_print::<BeaconStateBase<T>>(&bytes, format)?,
-        "state_altair" => decode_and_print::<BeaconStateAltair<T>>(&bytes, format)?,
-        "state_merge" => decode_and_print::<BeaconStateMerge<T>>(&bytes, format)?,
+        "SignedBeaconBlock" => decode_and_print::<SignedBeaconBlock<T>>(
+            &bytes,
+            |bytes| SignedBeaconBlock::from_ssz_bytes(bytes, spec),
+            format,
+        )?,
+        "SignedBeaconBlockBase" | "SignedBeaconBlockPhase0" => {
+            decode_and_print(&bytes, SignedBeaconBlockBase::<T>::from_ssz_bytes, format)?
+        }
+        "SignedBeaconBlockAltair" => {
+            decode_and_print(&bytes, SignedBeaconBlockAltair::<T>::from_ssz_bytes, format)?
+        }
+        "SignedBeaconBlockMerge" | "SignedBeaconBlockBellatrix" => {
+            decode_and_print(&bytes, SignedBeaconBlockMerge::<T>::from_ssz_bytes, format)?
+        }
+        "SignedBeaconBlockCapella" => decode_and_print(
+            &bytes,
+            SignedBeaconBlockCapella::<T>::from_ssz_bytes,
+            format,
+        )?,
+        "BeaconState" => decode_and_print::<BeaconState<T>>(
+            &bytes,
+            |bytes| BeaconState::from_ssz_bytes(bytes, spec),
+            format,
+        )?,
+        "BeaconStateBase" | "BeaconStatePhase0" => {
+            decode_and_print(&bytes, BeaconStateBase::<T>::from_ssz_bytes, format)?
+        }
+        "BeaconStateAltair" => {
+            decode_and_print(&bytes, BeaconStateAltair::<T>::from_ssz_bytes, format)?
+        }
+        "BeaconStateMerge" | "BeaconStateBellatrix" => {
+            decode_and_print(&bytes, BeaconStateMerge::<T>::from_ssz_bytes, format)?
+        }
+        "BeaconStateCapella" => {
+            decode_and_print(&bytes, BeaconStateCapella::<T>::from_ssz_bytes, format)?
+        }
         other => return Err(format!("Unknown type: {}", other)),
     };
 
     Ok(())
 }
 
-fn decode_and_print<T: Decode + Serialize>(
+fn decode_and_print<T: Serialize>(
     bytes: &[u8],
+    decoder: impl FnOnce(&[u8]) -> Result<T, ssz::DecodeError>,
     output_format: OutputFormat,
 ) -> Result<(), String> {
-    let item = T::from_ssz_bytes(bytes).map_err(|e| format!("SSZ decode failed: {:?}", e))?;
+    let item = decoder(bytes).map_err(|e| format!("SSZ decode failed: {e:?}"))?;
 
     match output_format {
         OutputFormat::Json => {
             println!(
                 "{}",
                 serde_json::to_string(&item)
-                    .map_err(|e| format!("Unable to write object to JSON: {:?}", e))?
+                    .map_err(|e| format!("Unable to write object to JSON: {e:?}"))?
             );
         }
         OutputFormat::Yaml => {
             println!(
                 "{}",
                 serde_yaml::to_string(&item)
-                    .map_err(|e| format!("Unable to write object to YAML: {:?}", e))?
+                    .map_err(|e| format!("Unable to write object to YAML: {e:?}"))?
             );
         }
     }

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -103,7 +103,7 @@ echo "executing: ./setup.sh >> $LOG_DIR/setup.log"
 ./setup.sh >> $LOG_DIR/setup.log 2>&1
 
 # Update future hardforks time in the EL genesis file based on the CL genesis time
-GENESIS_TIME=$(lcli pretty-ssz state_merge $TESTNET_DIR/genesis.ssz  | jq | grep -Po 'genesis_time": "\K.*\d')
+GENESIS_TIME=$(lcli pretty-ssz --testnet-dir $TESTNET_DIR BeaconState $TESTNET_DIR/genesis.ssz | jq | grep -Po 'genesis_time": "\K.*\d')
 echo $GENESIS_TIME
 CAPELLA_TIME=$((GENESIS_TIME + (CAPELLA_FORK_EPOCH * 32 * SECONDS_PER_SLOT)))
 echo $CAPELLA_TIME


### PR DESCRIPTION
## Proposed Changes

- Fix bad `state_root` reuse in `lcli transition-blocks` that resulted in invalid results at skipped slots.
- Modernise `lcli pretty-ssz` to include fork-generic decoders for `SignedBeaconBlock` and `BeaconState` which respect the `--network`/`--testnet-dir` flag.

## Additional Info

Breaking change: the underscore names like `signed_block_merge` are removed in favour of the fork-generic name `SignedBeaconBlock`, and fork-specific names which match the superstruct variants, e.g. `SignedBeaconBlockMerge`.
