### PR TITLE
[Merged by Bors] - Fix incorrect ideal rewards calculation

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_rewards.rs
+++ b/beacon_node/beacon_chain/src/attestation_rewards.rs
@@ -330,7 +330,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // compute ideal head rewards
             let head = get_attestation_component_delta(
                 true,
-                total_balances.previous_epoch_attesters(),
+                total_balances.previous_epoch_head_attesters(),
                 total_balances,
                 base_reward,
                 finality_delay,
@@ -352,7 +352,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             // compute ideal source rewards
             let source = get_attestation_component_delta(
                 true,
-                total_balances.previous_epoch_head_attesters(),
+                total_balances.previous_epoch_attesters(),
                 total_balances,
                 base_reward,
                 finality_delay,


### PR DESCRIPTION
## Issue Addressed

The PR fixes a bug where the the ideal rewards for source and head were incorrectly set.

Output from testing a validator that performed optimally in a Phase 0 epoch , note the `source` and `target` under ideal rewards is incorrect (compared to the actual `total_rewards` below):

```json
{ 
   "ideal_rewards": [
    ...
      {
        "effective_balance": "32000000000",
        "head": "18771",
        "target": "18770",
        "source": "18729",
        "inclusion_delay": "17083",
        "inactivity": "0"
      }
    ],
    "total_rewards": [
      {
        "validator_index": "0",
        "head": "18729",
        "target": "18770",
        "source": "18771",
        "inclusion_delay": "17083",
        "inactivity": "0"
      }
    ]
```