### PR TITLE
API - Handle blocks without blobs gracefully

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1102,10 +1102,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn get_blobs_checking_early_attester_cache(
         &self,
         block_root: &Hash256,
-    ) -> Result<Option<BlobSidecarList<T::EthSpec>>, Error> {
+    ) -> Result<BlobSidecarList<T::EthSpec>, Error> {
         self.early_attester_cache
             .get_blobs(*block_root)
-            .map_or_else(|| self.get_blobs(block_root), |blobs| Ok(Some(blobs)))
+            .map_or_else(|| self.get_blobs(block_root), |blobs| Ok(blobs))
     }
 
     /// Returns the block at the given root, if any.
@@ -1188,18 +1188,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn get_blobs(
         &self,
         block_root: &Hash256,
-    ) -> Result<Option<BlobSidecarList<T::EthSpec>>, Error> {
-
-        let blobs = self.store.get_blobs(block_root)?;
-        match Some(blobs) {
+    ) -> Result<BlobSidecarList<T::EthSpec>, Error> {
+        match self.store.get_blobs(block_root)? {
             Some(blobs) => Ok(blobs),
             None => {
-                // if there are no blobs, but a block exists return an empty list
-                if let Some(_) = self.store.try_get_full_block(block_root)? {
-                    return Ok(Some(BlobSidecarList::default()))
-                }
-                // if there is no blob and no block return none.
-                Ok(None)
+                Ok(BlobSidecarList::default())
             }
         }
     }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1105,7 +1105,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     ) -> Result<BlobSidecarList<T::EthSpec>, Error> {
         self.early_attester_cache
             .get_blobs(*block_root)
-            .map_or_else(|| self.get_blobs(block_root), |blobs| Ok(blobs))
+            .map_or_else(|| self.get_blobs(block_root), Ok)
     }
 
     /// Returns the block at the given root, if any.
@@ -1185,15 +1185,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// - block and blobs are inconsistent in the database
     /// - this method is called with a pre-deneb block root
     /// - this method is called for a blob that is beyond the prune depth
-    pub fn get_blobs(
-        &self,
-        block_root: &Hash256,
-    ) -> Result<BlobSidecarList<T::EthSpec>, Error> {
+    pub fn get_blobs(&self, block_root: &Hash256) -> Result<BlobSidecarList<T::EthSpec>, Error> {
         match self.store.get_blobs(block_root)? {
             Some(blobs) => Ok(blobs),
-            None => {
-                Ok(BlobSidecarList::default())
-            }
+            None => Ok(BlobSidecarList::default()),
         }
     }
 

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -698,14 +698,14 @@ where
         let block = self.chain.head_beacon_block();
         let block_root = block.canonical_root();
         let blobs = self.chain.get_blobs(&block_root).unwrap();
-        RpcBlock::new(block, blobs).unwrap()
+        RpcBlock::new(block, Some(blobs)).unwrap()
     }
 
     pub fn get_full_block(&self, block_root: &Hash256) -> RpcBlock<E> {
         let block = self.chain.get_blinded_block(block_root).unwrap().unwrap();
         let full_block = self.chain.store.make_full_block(block_root, block).unwrap();
         let blobs = self.chain.get_blobs(block_root).unwrap();
-        RpcBlock::new(Arc::new(full_block), blobs).unwrap()
+        RpcBlock::new(Arc::new(full_block), Some(blobs)).unwrap()
     }
 
     pub fn get_all_validators(&self) -> Vec<usize> {

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -134,7 +134,8 @@ async fn produces_attestations() {
             assert_eq!(data.target.root, target_root, "bad target root");
 
             let rpc_block =
-                RpcBlock::<MainnetEthSpec>::new(Arc::new(block.clone()), Some(blobs.clone())).unwrap();
+                RpcBlock::<MainnetEthSpec>::new(Arc::new(block.clone()), Some(blobs.clone()))
+                    .unwrap();
             let beacon_chain::data_availability_checker::MaybeAvailableBlock::Available(available_block) = chain
                 .data_availability_checker
                 .check_rpc_block_availability(rpc_block)
@@ -209,7 +210,8 @@ async fn early_attester_cache_old_request() {
         .get_blobs(&head.beacon_block_root)
         .expect("should get blobs");
 
-    let rpc_block = RpcBlock::<MainnetEthSpec>::new(head.beacon_block.clone(), Some(head_blobs)).unwrap();
+    let rpc_block =
+        RpcBlock::<MainnetEthSpec>::new(head.beacon_block.clone(), Some(head_blobs)).unwrap();
     let beacon_chain::data_availability_checker::MaybeAvailableBlock::Available(available_block) = harness.chain
         .data_availability_checker
         .check_rpc_block_availability(rpc_block)

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -134,7 +134,7 @@ async fn produces_attestations() {
             assert_eq!(data.target.root, target_root, "bad target root");
 
             let rpc_block =
-                RpcBlock::<MainnetEthSpec>::new(Arc::new(block.clone()), blobs.clone()).unwrap();
+                RpcBlock::<MainnetEthSpec>::new(Arc::new(block.clone()), Some(blobs.clone())).unwrap();
             let beacon_chain::data_availability_checker::MaybeAvailableBlock::Available(available_block) = chain
                 .data_availability_checker
                 .check_rpc_block_availability(rpc_block)
@@ -209,7 +209,7 @@ async fn early_attester_cache_old_request() {
         .get_blobs(&head.beacon_block_root)
         .expect("should get blobs");
 
-    let rpc_block = RpcBlock::<MainnetEthSpec>::new(head.beacon_block.clone(), head_blobs).unwrap();
+    let rpc_block = RpcBlock::<MainnetEthSpec>::new(head.beacon_block.clone(), Some(head_blobs)).unwrap();
     let beacon_chain::data_availability_checker::MaybeAvailableBlock::Available(available_block) = harness.chain
         .data_availability_checker
         .check_rpc_block_availability(rpc_block)

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -66,12 +66,12 @@ async fn get_chain_segment() -> (Vec<BeaconSnapshot<E>>, Vec<Option<BlobSidecarL
             beacon_block: Arc::new(full_block),
             beacon_state: snapshot.beacon_state,
         });
-        segment_blobs.push(
-            Some(harness
+        segment_blobs.push(Some(
+            harness
                 .chain
                 .get_blobs(&snapshot.beacon_block_root)
-                .unwrap()),
-        )
+                .unwrap(),
+        ))
     }
     (segment, segment_blobs)
 }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -67,10 +67,10 @@ async fn get_chain_segment() -> (Vec<BeaconSnapshot<E>>, Vec<Option<BlobSidecarL
             beacon_state: snapshot.beacon_state,
         });
         segment_blobs.push(
-            harness
+            Some(harness
                 .chain
                 .get_blobs(&snapshot.beacon_block_root)
-                .unwrap(),
+                .unwrap()),
         )
     }
     (segment, segment_blobs)
@@ -114,26 +114,22 @@ async fn get_chain_segment_with_signed_blobs() -> (
             .chain
             .get_blobs(&snapshot.beacon_block_root)
             .unwrap()
-            .map(|blobs| {
-                let blobs = blobs
-                    .into_iter()
-                    .map(|blob| {
-                        let block_root = blob.block_root;
-                        let blob_index = blob.index;
-                        SignedBlobSidecar {
-                            message: blob,
-                            signature: harness
-                                .blob_signature_cache
-                                .read()
-                                .get(&BlobSignatureKey::new(block_root, blob_index))
-                                .unwrap()
-                                .clone(),
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                VariableList::from(blobs)
-            });
-        segment_blobs.push(signed_blobs)
+            .into_iter()
+            .map(|blob| {
+                let block_root = blob.block_root;
+                let blob_index = blob.index;
+                SignedBlobSidecar {
+                    message: blob,
+                    signature: harness
+                        .blob_signature_cache
+                        .read()
+                        .get(&BlobSignatureKey::new(block_root, blob_index))
+                        .unwrap()
+                        .clone(),
+                }
+            })
+            .collect::<Vec<_>>();
+        segment_blobs.push(Some(VariableList::from(signed_blobs)))
     }
     (segment, segment_blobs)
 }

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2179,7 +2179,7 @@ async fn weak_subjectivity_sync() {
         beacon_chain
             .process_block(
                 full_block.canonical_root(),
-                RpcBlock::new(Arc::new(full_block), blobs).unwrap(),
+                RpcBlock::new(Arc::new(full_block), Some(blobs)).unwrap(),
                 NotifyExecutionLayer::Yes,
                 || Ok(()),
             )
@@ -2239,7 +2239,7 @@ async fn weak_subjectivity_sync() {
         if let MaybeAvailableBlock::Available(block) = harness
             .chain
             .data_availability_checker
-            .check_rpc_block_availability(RpcBlock::new(Arc::new(full_block), blobs).unwrap())
+            .check_rpc_block_availability(RpcBlock::new(Arc::new(full_block), Some(blobs)).unwrap())
             .expect("should check availability")
         {
             available_blocks.push(block);

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -258,9 +258,9 @@ impl BlockId {
         chain: &BeaconChain<T>,
     ) -> Result<BlobSidecarList<T::EthSpec>, warp::Rejection> {
         let root = self.root(chain)?.0;
-        chain.get_blobs(&root).map_err(
-            |e| warp_utils::reject::beacon_chain_error(e)
-        )
+        chain
+            .get_blobs(&root)
+            .map_err(warp_utils::reject::beacon_chain_error)
     }
 
     pub async fn blob_sidecar_list_filtered<T: BeaconChainTypes>(

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -261,7 +261,7 @@ impl BlockId {
         match chain.get_blobs(&root) {
             Ok(Some(blob_sidecar_list)) => Ok(blob_sidecar_list),
             Ok(None) => Err(warp_utils::reject::custom_not_found(format!(
-                "No blobs with block root {} found in the store",
+                "Block not found {} in the store",
                 root
             ))),
             Err(e) => Err(warp_utils::reject::beacon_chain_error(e)),

--- a/beacon_node/http_api/src/block_id.rs
+++ b/beacon_node/http_api/src/block_id.rs
@@ -258,14 +258,9 @@ impl BlockId {
         chain: &BeaconChain<T>,
     ) -> Result<BlobSidecarList<T::EthSpec>, warp::Rejection> {
         let root = self.root(chain)?.0;
-        match chain.get_blobs(&root) {
-            Ok(Some(blob_sidecar_list)) => Ok(blob_sidecar_list),
-            Ok(None) => Err(warp_utils::reject::custom_not_found(format!(
-                "Block not found {} in the store",
-                root
-            ))),
-            Err(e) => Err(warp_utils::reject::beacon_chain_error(e)),
-        }
+        chain.get_blobs(&root).map_err(
+            |e| warp_utils::reject::beacon_chain_error(e)
+        )
     }
 
     pub async fn blob_sidecar_list_filtered<T: BeaconChainTypes>(

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -1087,12 +1087,7 @@ async fn test_blobs_by_range() {
             .block_root_at_slot(Slot::new(slot), WhenSlotSkipped::None)
             .unwrap();
         blob_count += root
-            .and_then(|root| {
-                rig.chain
-                    .get_blobs(&root)
-                    .unwrap_or_default()
-                    .map(|blobs| blobs.len())
-            })
+            .map(|root| rig.chain.get_blobs(&root).unwrap_or_default().len())
             .unwrap_or(0);
     }
     let mut actual_count = 0;


### PR DESCRIPTION
## Issue Addressed

On my local testnet after the deneb fork my lighthouse node returns for a block that does exist.

```json
  {
    "code": 404,
    "message": "NOT_FOUND: No blobs with block root 0x3956…d78c found in the store",
    "stacktraces": []
  }
  ```
I would expect the endpoint to handle blocks without blobs gracefully and would return an empty array. The beaconchain API specification also defines the 404 error code as an error where the [block was not found](https://github.com/ethereum/beacon-APIs/blob/master/apis/beacon/blob_sidecars/blob_sidecars.yaml#L49).

## Proposed Changes

This PR proposes to handle requests gracefully if there are no blobs for a block.

## Additional Info

```bash
BLOCK_ROOT=0x3956e3e21be49b23abbfbb7c05c00aa078bc03be4f37dc1590b036bafd10d78c
$ curl localhost:5000/eth/v1/beacon/blob_sidecars/$BLOCK_ROOT
{
    "code": 404,
    "message": "NOT_FOUND: No blobs with block root 0x3956…d78c found in the store",
    "stacktraces": []
  }
$ curl localhost:5000/eth/v1/beacon/headers/$BLOCK_ROOT
  {
    "execution_optimistic": false,
    "finalized": false,
    "data": {
      "root": "0x3956e3e21be49b23abbfbb7c05c00aa078bc03be4f37dc1590b036bafd10d78c",
      "canonical": true,
      "header": {
        "message": {
          "slot": "130",
          "proposer_index": "45",
          "parent_root": "0xf550895fcd6b5d6a78c00b2c2fe0bd32d878031d5562b9b9ad8183c431fbe88d",
          "state_root": "0x249cc0a46ff183f990cd706d0167677b8fa2d99fad270e9d7361575c226846f6",
          "body_root": "0x76bc18d7cc0d0ac32219633b1f05d67c421bac15f59511a924c705c2e8cb128f"
        },
        "signature": "0x8d9e86ac47704f4dc6be13a79fbf99d4bab22506794d831b86ede1bebd1b23b92c7717442cb96e9fb698868d2c77521009fd469fd4445d87f6a0976a7187fe86ef6cf606c3d87461d8e45bb9943c7a3cae305973f24fe74d9b3945c5d8165a27"
      }
    }
  }
]```