### PR TITLE
[Merged by Bors] - Development feature flag - Disable backfill

### DIFF
--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -49,3 +49,7 @@ execution_layer =  { path = "../execution_layer" }
 beacon_processor =  { path = "../beacon_processor" }
 parking_lot = "0.12.0"
 environment = { path = "../../lighthouse/environment" }
+
+[features]
+# default = ["no-backfill"]
+no-backfill = []

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -51,5 +51,4 @@ parking_lot = "0.12.0"
 environment = { path = "../../lighthouse/environment" }
 
 [features]
-# default = ["disable-backfill"]
 disable-backfill = []

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -51,5 +51,5 @@ parking_lot = "0.12.0"
 environment = { path = "../../lighthouse/environment" }
 
 [features]
-# default = ["no-backfill"]
-no-backfill = []
+# default = ["disable-backfill"]
+disable-backfill = []

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -51,4 +51,5 @@ parking_lot = "0.12.0"
 environment = { path = "../../lighthouse/environment" }
 
 [features]
+# NOTE: This can be run via cargo build --bin lighthouse --features network/disable-backfill
 disable-backfill = []

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -232,6 +232,12 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         // build the channels for external comms
         let (network_senders, network_recievers) = NetworkSenders::new();
 
+        #[cfg(feature = "disable-backfill")]
+        warn!(
+            network_log,
+            "Backfill is disabled. DO NOT RUN IN PRODUCTION"
+        );
+
         // try and construct UPnP port mappings if required.
         if let Some(upnp_config) = crate::nat::UPnPConfig::from_config(config) {
             let upnp_log = network_log.new(o!("service" => "UPnP"));

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -395,7 +395,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
 
                     // If we would otherwise be synced, first check if we need to perform or
                     // complete a backfill sync.
-                    #[cfg(not(feature="disable_backfill"))]
+                    #[cfg(not(feature = "disable_backfill"))]
                     if matches!(sync_state, SyncState::Synced) {
                         // Determine if we need to start/resume/restart a backfill sync.
                         match self.backfill_sync.start(&mut self.network) {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -395,6 +395,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
 
                     // If we would otherwise be synced, first check if we need to perform or
                     // complete a backfill sync.
+                    #[cfg(not(feature="disable_backfill"))]
                     if matches!(sync_state, SyncState::Synced) {
                         // Determine if we need to start/resume/restart a backfill sync.
                         match self.backfill_sync.start(&mut self.network) {
@@ -419,6 +420,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 }
                 Some((RangeSyncType::Finalized, start_slot, target_slot)) => {
                     // If there is a backfill sync in progress pause it.
+                    #[cfg(not(feature = "disable_backfill"))]
                     self.backfill_sync.pause();
 
                     SyncState::SyncingFinalized {
@@ -428,6 +430,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 }
                 Some((RangeSyncType::Head, start_slot, target_slot)) => {
                     // If there is a backfill sync in progress pause it.
+                    #[cfg(not(feature = "disable_backfill"))]
                     self.backfill_sync.pause();
 
                     SyncState::SyncingHead {


### PR DESCRIPTION
Often when testing I have to create a hack which is annoying to maintain. 

I think it might be handy to add a custom compile-time flag that developers can use if they want to test things locally without having to backfill a bunch of blocks.

There is probably an argument to have a feature called "backfill" which is enabled by default and can be disabled. I didn't go this route because I think it's counter-intuitive to have a feature that enables a core and necessary behaviour.