### PR TITLE
Standard Liveness Endpoint 

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2988,19 +2988,20 @@ impl ApiTester {
             .collect::<Vec<_>>();
 
         // Construct the expected response
-        let expected: Vec<StandardLivenessResponseData> = head_state
+        let expected: Vec<LivenessResponseData> = head_state
             .validators()
             .iter()
             .enumerate()
-            .map(|(index, _)| StandardLivenessResponseData {
+            .map(|(index, _)| LivenessResponseData {
                 index: index as u64,
+                epoch,
                 is_live: false,
             })
             .collect();
 
         let result = self
             .client
-            .post_validator_liveness_epoch(epoch, indices.clone())
+            .post_validator_liveness_epoch(&indices.clone(), epoch)
             .await
             .unwrap()
             .data;
@@ -3015,7 +3016,7 @@ impl ApiTester {
 
         let result = self
             .client
-            .post_validator_liveness_epoch(epoch, indices.clone())
+            .post_validator_liveness_epoch(&indices.clone(), epoch)
             .await
             .unwrap()
             .data;

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1636,6 +1636,26 @@ impl BeaconNodeHttpClient {
         .await
     }
 
+     /// `POST validator/liveness/{epoch}`
+     pub fn post_validator_liveness(&self, ids: &[u64], epoch: Epoch) ->  Result<GenericResponse<Vec<LivenessResponseData>>, Error> {    
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("liveness");
+            .push(&epoch.to_string())
+        self.post_with_timeout_and_response(
+            path,
+            &LivenessRequestData {
+                indices: ids.to_vec(),
+                epoch,
+            },
+            self.timeouts.liveness,
+        )
+        .await
+    }
+
     /// `POST validator/duties/attester/{epoch}`
     pub async fn post_validator_duties_attester(
         &self,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1640,8 +1640,8 @@ impl BeaconNodeHttpClient {
     pub async fn post_validator_liveness_epoch(
         &self,
         epoch: Epoch,
-        indices: Vec<u64>,
-    ) -> Result<GenericResponse<Vec<StandardLivenessResponseData>>, Error> {
+        indices: &[u64],
+    ) -> Result<GenericResponse<Vec<LivenessResponseData>>, Error> {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -1636,15 +1636,20 @@ impl BeaconNodeHttpClient {
         .await
     }
 
-     /// `POST validator/liveness/{epoch}`
-     pub fn post_validator_liveness(&self, ids: &[u64], epoch: Epoch) ->  Result<GenericResponse<Vec<LivenessResponseData>>, Error> {    
+    /// `POST validator/liveness/{epoch}`
+    pub async fn post_validator_liveness(
+        &self,
+        ids: &[u64],
+        epoch: Epoch,
+    ) -> Result<GenericResponse<Vec<LivenessResponseData>>, Error> {
         let mut path = self.server.full.clone();
 
         path.path_segments_mut()
             .map_err(|()| Error::InvalidUrl(self.server.clone()))?
             .push("validator")
-            .push("liveness");
-            .push(&epoch.to_string())
+            .push("liveness")
+            .push(&epoch.to_string());
+
         self.post_with_timeout_and_response(
             path,
             &LivenessRequestData {

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -182,7 +182,7 @@ async fn beacon_node_liveness<'a, T: 'static + SlotClock, E: EthSpec>(
                 OfflineOnFailure::Yes,
                 |beacon_node| async move {
                     beacon_node
-                        .post_lighthouse_liveness(validator_indices, previous_epoch)
+                        .post_validator_liveness(validator_indices, previous_epoch)
                         .await
                         .map_err(|e| format!("Failed query for validator liveness: {:?}", e))
                         .map(|result| result.data)
@@ -209,7 +209,7 @@ async fn beacon_node_liveness<'a, T: 'static + SlotClock, E: EthSpec>(
             OfflineOnFailure::Yes,
             |beacon_node| async move {
                 beacon_node
-                    .post_lighthouse_liveness(validator_indices, current_epoch)
+                    .post_validator_liveness(validator_indices, current_epoch)
                     .await
                     .map_err(|e| format!("Failed query for validator liveness: {:?}", e))
                     .map(|result| result.data)

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -182,7 +182,7 @@ async fn beacon_node_liveness<'a, T: 'static + SlotClock, E: EthSpec>(
                 OfflineOnFailure::Yes,
                 |beacon_node| async move {
                     beacon_node
-                        .post_lighthouse_liveness(validator_indices, previous_epoch)
+                        .post_validator_liveness_epoch(previous_epoch, validator_indices)
                         .await
                         .map_err(|e| format!("Failed query for validator liveness: {:?}", e))
                         .map(|result| result.data)
@@ -209,7 +209,7 @@ async fn beacon_node_liveness<'a, T: 'static + SlotClock, E: EthSpec>(
             OfflineOnFailure::Yes,
             |beacon_node| async move {
                 beacon_node
-                    .post_lighthouse_liveness(validator_indices, current_epoch)
+                    .post_validator_liveness_epoch(current_epoch, validator_indices)
                     .await
                     .map_err(|e| format!("Failed query for validator liveness: {:?}", e))
                     .map(|result| result.data)


### PR DESCRIPTION
## Issue Addressed

Solves #4522 
## Proposed Changes

Validator Client now uses standard liveness endpoint  `/eth/v1/validator/liveness/{epoch}`  implemented here #4343 
