### PR TITLE
[WIP] Optimal Maximum Coverage using CBC MIP Solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ genesis.ssz
 # IntelliJ
 /*.iml
 .idea
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1232,6 +1232,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "coin_cbc"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f86c5252b7b745adc0bc8a724171018dd2fc1e63629f7f8ec2f28a66b0d6ed7"
+dependencies = [
+ "coin_cbc_sys",
+ "lazy_static",
+]
+
+[[package]]
+name = "coin_cbc_sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "085619f8bdc38e24e25c6336ecc3f2e6c0543d67566dff6daef0e32f7ac20f76"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "compare_fields"
 version = "0.2.0"
 dependencies = [
@@ -3250,6 +3269,16 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "good_lp"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0833c2bc3cee9906df9969ade12b0b3b8759faa7bc2682b428be767033cdcd4"
+dependencies = [
+ "coin_cbc",
+ "fnv",
+]
 
 [[package]]
 name = "group"
@@ -5798,6 +5827,7 @@ dependencies = [
  "derivative",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "good_lp",
  "itertools",
  "lazy_static",
  "lighthouse_metrics",

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -20,6 +20,7 @@ serde_derive = "1.0.116"
 store = { path = "../store" }
 bitvec = "1"
 rand = "0.8.5"
+good_lp = "1.4.1"
 
 [dev-dependencies]
 beacon_chain =  { path = "../beacon_chain" }

--- a/beacon_node/operation_pool/src/attestation.rs
+++ b/beacon_node/operation_pool/src/attestation.rs
@@ -1,5 +1,6 @@
 use crate::attestation_storage::AttestationRef;
 use crate::max_cover::MaxCover;
+use crate::mip_max_cover::MipMaxCover;
 use crate::reward_cache::RewardCache;
 use state_processing::common::{
     altair, base, get_attestation_participation_flag_indices, get_attesting_indices,
@@ -163,6 +164,20 @@ impl<'a, T: EthSpec> MaxCover for AttMaxCover<'a, T> {
 
     fn score(&self) -> usize {
         self.fresh_validators_rewards.values().sum::<u64>() as usize
+    }
+}
+
+impl<'a, T: EthSpec> MipMaxCover<'a> for AttMaxCover<'a, T> {
+    type Element = u64;
+
+    fn covering_set(&self) -> &'a Vec<Self::Element> {
+        &self.att.indexed.attesting_indices
+    }
+
+    fn element_weight(&self, element: &Self::Element) -> Option<f64> {
+        self.fresh_validators_rewards
+            .get(&element)
+            .map(|w| *w as f64)
     }
 }
 

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -5,6 +5,7 @@ mod attester_slashing;
 mod bls_to_execution_changes;
 mod max_cover;
 mod metrics;
+mod mip_max_cover;
 mod persistence;
 mod reward_cache;
 mod sync_aggregate_id;

--- a/beacon_node/operation_pool/src/mip_max_cover.rs
+++ b/beacon_node/operation_pool/src/mip_max_cover.rs
@@ -1,78 +1,157 @@
-use good_lp::{constraint, default_solver, variable, variables, Expression, Solution, SolverModel};
+use std::collections::HashMap;
 use std::iter::Sum;
 use std::ops::Mul;
 
-pub fn max_cover(
-    sets: Vec<Vec<usize>>,
-    weights: Vec<f64>,
-    k: usize,
-) -> Result<Vec<usize>, &'static str> {
-    // produce lists of sets containing a given element
-    let mut sets_with: Vec<Vec<usize>> = vec![];
-    sets_with.resize_with(weights.len(), Vec::new);
-    for i in 0..sets.len() {
-        for &j in &sets[i] {
-            sets_with[j].push(i);
+use good_lp::{constraint, default_solver, variable, variables, Expression, Solution, SolverModel};
+use itertools::Itertools;
+use state_processing::common::base;
+use types::{BeaconState, ChainSpec, EthSpec};
+
+use crate::AttestationRef;
+
+struct MaxCoverAttestation<'a, T: EthSpec> {
+    attn: AttestationRef<'a, T>,
+    mapped_attesting_indices: Vec<usize>,
+}
+
+pub struct MaxCoverProblemInstance<'a, T: EthSpec> {
+    attestations: Vec<MaxCoverAttestation<'a, T>>,
+    weights: Vec<u64>,
+    limit: usize,
+}
+
+// TODO: check if clones can be reduced
+
+impl<'a, T: EthSpec> MaxCoverProblemInstance<'a, T> {
+    pub fn new(
+        attestations: &Vec<AttestationRef<'a, T>>,
+        state: &BeaconState<T>,
+        total_active_balance: u64,
+        spec: &ChainSpec,
+        limit: usize,
+    ) -> MaxCoverProblemInstance<'a, T> {
+        let mapped_index_to_attestor_index: Vec<u64> = attestations
+            .iter()
+            .map(|attn| &(attn.indexed.attesting_indices))
+            .flatten()
+            .sorted_unstable()
+            .dedup()
+            .map(|attestor_index| attestor_index.clone())
+            .collect();
+
+        let attestor_index_to_mapped_index: HashMap<u64, usize> = mapped_index_to_attestor_index
+            .iter()
+            .enumerate()
+            .map(|(idx, attestor_index)| (*attestor_index, idx))
+            .collect();
+
+        let weights = mapped_index_to_attestor_index
+            .iter()
+            .flat_map(|validator_index| {
+                let reward = base::get_base_reward(
+                    state,
+                    *validator_index as usize,
+                    total_active_balance,
+                    spec,
+                )
+                .ok()?
+                .checked_div(spec.proposer_reward_quotient)?;
+                Some(reward)
+            })
+            .collect();
+
+        let attestations = attestations
+            .iter()
+            .map(|attn| MaxCoverAttestation {
+                attn: attn.clone(),
+                mapped_attesting_indices: attn
+                    .indexed
+                    .attesting_indices
+                    .iter()
+                    .flat_map(|validator_index| {
+                        let mapped_index =
+                            attestor_index_to_mapped_index.get(validator_index)?.clone();
+                        Some(mapped_index)
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        MaxCoverProblemInstance {
+            attestations,
+            weights,
+            limit,
         }
     }
 
-    let mut vars = variables!();
+    pub fn max_cover(&self) -> Result<Vec<AttestationRef<'a, T>>, &'static str> {
+        // produce lists of sets containing a given element
+        let mut sets_with: Vec<Vec<usize>> = vec![];
+        sets_with.resize_with(self.weights.len(), Vec::new);
+        for i in 0..self.attestations.len() {
+            for &j in &self.attestations[i].mapped_attesting_indices {
+                sets_with[j].push(i);
+            }
+        }
 
-    // initialise set variables
-    let xs = vars.add_vector(variable().binary(), sets.len());
+        let mut vars = variables!();
 
-    // initialise element variables
-    let ys = vars.add_vector(variable().min(0.0).max(1.0), weights.len());
+        // initialise set variables
+        let xs = vars.add_vector(variable().binary(), self.attestations.len());
 
-    // define objective function as linear combination of element variables and weights
-    let objective = Expression::sum((0..weights.len()).map(|yi| ys[yi].mul(weights[yi])));
-    let mut problem = vars.maximise(objective).using(default_solver);
+        // initialise element variables
+        let ys = vars.add_vector(variable().min(0.0).max(1.0), self.weights.len());
 
-    // limit solution size to k sets
-    problem = problem.with(Expression::sum(xs.iter()).leq(k as f64));
+        // define objective function as linear combination of element variables and weights
+        let objective =
+            Expression::sum((0..self.weights.len()).map(|yi| ys[yi].mul(self.weights[yi] as f64)));
+        let mut problem = vars.maximise(objective).using(default_solver);
 
-    // add constraint allowing to cover an element only if one of the sets containing it is included
-    for j in 0..weights.len() {
-        problem = problem.with(constraint! {
-            Expression::sum(sets_with[j].iter().map(|i| xs[*i])) >= ys[j]
-        });
+        // limit solution size to k sets
+        problem = problem.with(Expression::sum(xs.iter()).leq(self.limit as f64));
+
+        // add constraint allowing to cover an element only if one of the sets containing it is included
+        for j in 0..self.weights.len() {
+            problem = problem.with(constraint! {
+                Expression::sum(sets_with[j].iter().map(|i| xs[*i])) >= ys[j]
+            });
+        }
+
+        // tell CBC not to log
+        problem.set_parameter("log", "0");
+
+        // TODO: Verify this under the new assumptions
+        // should be safe to `unwrap` since the problem is under-constrained
+        let solution = problem.solve().unwrap();
+
+        // report solution
+        Ok(xs
+            .iter()
+            .enumerate()
+            .filter(|(_, &x)| solution.value(x) > 0.0)
+            .map(|(i, _)| self.attestations[i].attn.clone())
+            .collect())
     }
-
-    // tell CBC not to log
-    problem.set_parameter("log", "0");
-
-    // TODO: Verify this under the new assumptions
-    // should be safe to `unwrap` since the problem is underconstrained
-    let solution = problem.solve().unwrap();
-
-    // report solution
-    let mut coverage = Vec::with_capacity(weights.len());
-    xs.iter()
-        .enumerate()
-        .filter(|(_, &x)| solution.value(x) > 0.0)
-        .for_each(|(i, _)| coverage.push(i));
-
-    Ok(coverage)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::max_cover;
-
-    #[test]
-    fn small_coverage() {
-        let sets = vec![
-            vec![0, 1, 2],
-            vec![0, 3],
-            vec![1, 2],
-            vec![3, 2],
-            vec![0, 4],
-            vec![2, 3, 0],
-        ];
-        let weights = vec![12.1, 11.3, 3.9, 2.3, 8.2];
-        let k = 2;
-
-        let result = max_cover(sets, weights, k).unwrap();
-        assert_eq!(result, vec![0, 4]);
-    }
+    // use super::max_cover;
+    //
+    // #[test]
+    // fn small_coverage() {
+    //     let sets = vec![
+    //         vec![0, 1, 2],
+    //         vec![0, 3],
+    //         vec![1, 2],
+    //         vec![3, 2],
+    //         vec![0, 4],
+    //         vec![2, 3, 0],
+    //     ];
+    //     let weights = vec![12.1, 11.3, 3.9, 2.3, 8.2];
+    //     let k = 2;
+    //
+    //     let result = max_cover(sets, weights, k).unwrap();
+    //     assert_eq!(result, vec![0, 4]);
+    // }
 }

--- a/beacon_node/operation_pool/src/mip_max_cover.rs
+++ b/beacon_node/operation_pool/src/mip_max_cover.rs
@@ -35,6 +35,8 @@ impl<'b, RawSet> MipMaxCoverProblemInstance<'b, RawSet>
 where
     RawSet: for<'a> MipMaxCover<'a>,
 {
+    const SOLUTION_LENGTH_SCALING_FACTOR: f64 = 0.0001f64;
+
     pub fn new(raw_sets: &Vec<RawSet>, limit: usize) -> Option<MipMaxCoverProblemInstance<RawSet>> {
         let ordered_elements: Vec<&RawSet::Element> = raw_sets
             .iter()
@@ -102,7 +104,9 @@ where
 
         // define objective function as linear combination of element variables and weights
         let objective =
-            Expression::sum((0..self.weights.len()).map(|yi| ys[yi].mul(self.weights[yi])));
+            Expression::sum((0..self.weights.len()).map(|yi| ys[yi].mul(self.weights[yi])))
+                - Expression::sum((0..xs.len()).map(|xi| xs[xi]))
+                    * Self::SOLUTION_LENGTH_SCALING_FACTOR;
         let mut problem = vars.maximise(objective).using(default_solver);
 
         // limit solution size to k sets
@@ -272,6 +276,6 @@ mod tests {
         let instance = MipMaxCoverProblemInstance::new(&sets, 5).unwrap();
         let cover = instance.max_cover().unwrap();
         assert_eq!(total_quality(&cover), 19.0);
-        assert_eq!(cover.len(), 5);
+        assert_eq!(cover.len(), 4);
     }
 }

--- a/beacon_node/operation_pool/src/mip_max_cover.rs
+++ b/beacon_node/operation_pool/src/mip_max_cover.rs
@@ -1,0 +1,78 @@
+use good_lp::{constraint, default_solver, variable, variables, Expression, Solution, SolverModel};
+use std::iter::Sum;
+use std::ops::Mul;
+
+pub fn max_cover(
+    sets: Vec<Vec<usize>>,
+    weights: Vec<f64>,
+    k: usize,
+) -> Result<Vec<usize>, &'static str> {
+    // produce lists of sets containing a given element
+    let mut sets_with: Vec<Vec<usize>> = vec![];
+    sets_with.resize_with(weights.len(), Vec::new);
+    for i in 0..sets.len() {
+        for &j in &sets[i] {
+            sets_with[j].push(i);
+        }
+    }
+
+    let mut vars = variables!();
+
+    // initialise set variables
+    let xs = vars.add_vector(variable().binary(), sets.len());
+
+    // initialise element variables
+    let ys = vars.add_vector(variable().min(0.0).max(1.0), weights.len());
+
+    // define objective function as linear combination of element variables and weights
+    let objective = Expression::sum((0..weights.len()).map(|yi| ys[yi].mul(weights[yi])));
+    let mut problem = vars.maximise(objective).using(default_solver);
+
+    // limit solution size to k sets
+    problem = problem.with(Expression::sum(xs.iter()).leq(k as f64));
+
+    // add constraint allowing to cover an element only if one of the sets containing it is included
+    for j in 0..weights.len() {
+        problem = problem.with(constraint! {
+            Expression::sum(sets_with[j].iter().map(|i| xs[*i])) >= ys[j]
+        });
+    }
+
+    // tell CBC not to log
+    problem.set_parameter("log", "0");
+
+    // TODO: Verify this under the new assumptions
+    // should be safe to `unwrap` since the problem is underconstrained
+    let solution = problem.solve().unwrap();
+
+    // report solution
+    let mut coverage = Vec::with_capacity(weights.len());
+    xs.iter()
+        .enumerate()
+        .filter(|(_, &x)| solution.value(x) > 0.0)
+        .for_each(|(i, _)| coverage.push(i));
+
+    Ok(coverage)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::max_cover;
+
+    #[test]
+    fn small_coverage() {
+        let sets = vec![
+            vec![0, 1, 2],
+            vec![0, 3],
+            vec![1, 2],
+            vec![3, 2],
+            vec![0, 4],
+            vec![2, 3, 0],
+        ];
+        let weights = vec![12.1, 11.3, 3.9, 2.3, 8.2];
+        let k = 2;
+
+        let result = max_cover(sets, weights, k).unwrap();
+        assert_eq!(result, vec![0, 4]);
+    }
+}


### PR DESCRIPTION
## Issue Addressed

This PR addresses an extension to #4507 , introducing a MIP-based approach to calculate the Maximum Coverage over aggregated attestations optimally.

## Proposed Changes

Allow conditionally using the [Decomposition Approach](https://lighthouse-blog.sigmaprime.io/docs/satalia-02-exact-approaches.pdf) for selecting the aggregated attestations to be included in a block.

## Additional Info

Based on our discussions with @ michaelsproul  and @paulhauner , given that this approach is very expensive computationally, this should be opt-in and not enabled by default unless a highly optimised implementation is discovered.
