### PR TITLE
[Merged by Bors] - opt `maybe_update_best_child_and_descendant`: remove an impossible case

### DIFF
--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -884,7 +884,7 @@ impl ProtoArray {
                         }
                     } else {
                         // Choose the winner by weight.
-                        if child.weight >= best_child.weight {
+                        if child.weight > best_child.weight {
                             change_to_child
                         } else {
                             no_change


### PR DESCRIPTION
Here `child.weight == best_child.weight` is impossible since it's already checked [above](https://github.com/sigp/lighthouse/blob/dfcb3363c757671eb19d5f8e519b4b94ac74677a/consensus/proto_array/src/proto_array.rs#L878).