### PR TITLE
optimize `apply_score_changes`

### DIFF
--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -286,11 +286,15 @@ impl ProtoArray {
                     // Invalid nodes (or their ancestors) should not receive a proposer boost.
                     && !execution_status_is_invalid
                 {
-                    proposer_score = calculate_committee_fraction::<E>(
-                        new_justified_balances,
-                        proposer_score_boost,
-                    )
-                    .ok_or(Error::ProposerBoostOverflow(node_index))?;
+                    // only compute `proposer_score` once
+                    if proposer_score == 0 {
+                        proposer_score = calculate_committee_fraction::<E>(
+                            new_justified_balances,
+                            proposer_score_boost,
+                        )
+                        .ok_or(Error::ProposerBoostOverflow(node_index))?;
+                    }
+
                     node_delta = node_delta
                         .checked_add(proposer_score as i64)
                         .ok_or(Error::DeltaOverflow(node_index))?;

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -226,10 +226,10 @@ impl ProtoArray {
             });
         }
 
-        if justified_checkpoint != self.justified_checkpoint
-            || finalized_checkpoint != self.finalized_checkpoint
-        {
+        if justified_checkpoint != self.justified_checkpoint {
             self.justified_checkpoint = justified_checkpoint;
+        }
+        if finalized_checkpoint != self.finalized_checkpoint {
             self.finalized_checkpoint = finalized_checkpoint;
         }
 

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -286,15 +286,11 @@ impl ProtoArray {
                     // Invalid nodes (or their ancestors) should not receive a proposer boost.
                     && !execution_status_is_invalid
                 {
-                    // only compute `proposer_score` once
-                    if proposer_score == 0 {
-                        proposer_score = calculate_committee_fraction::<E>(
-                            new_justified_balances,
-                            proposer_score_boost,
-                        )
-                        .ok_or(Error::ProposerBoostOverflow(node_index))?;
-                    }
-
+                    proposer_score = calculate_committee_fraction::<E>(
+                        new_justified_balances,
+                        proposer_score_boost,
+                    )
+                    .ok_or(Error::ProposerBoostOverflow(node_index))?;
                     node_delta = node_delta
                         .checked_add(proposer_score as i64)
                         .ok_or(Error::DeltaOverflow(node_index))?;


### PR DESCRIPTION
Only compute `proposer_score` once, since both `new_justified_balances` and `proposer_score_boost` are immutable.

The other change is so that it's more aligned with [`ForkChoice.update_checkpoint`](https://github.com/sigp/lighthouse/blob/dfcb3363c757671eb19d5f8e519b4b94ac74677a/consensus/fork_choice/src/fork_choice.rs#L946-L956)