### PR TITLE
increase the max topic subscriptions #4581

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -15,7 +15,8 @@ use crate::service::behaviour::BehaviourEvent;
 pub use crate::service::behaviour::Gossipsub;
 use crate::types::{
     fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind, GossipTopic,
-    SnappyTransform, Subnet, SubnetDiscovery,
+    SnappyTransform, Subnet, SubnetDiscovery, BASE_CORE_TOPICS, ALTAIR_CORE_TOPICS, CAPELLA_CORE_TOPICS,
+    LIGHT_CLIENT_GOSSIP_TOPICS,
 };
 use crate::EnrExt;
 use crate::Eth2Enr;
@@ -41,7 +42,7 @@ use std::{
 use types::ForkName;
 use types::{
     consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, consts::deneb::BLOB_SIDECAR_SUBNET_COUNT,
-    EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
+    EnrForkId, EthSpec, ForkContext, Slot, SubnetId
 };
 use utils::{build_transport, strip_peer_id, Context as ServiceContext, MAX_CONNECTIONS_PER_PEER};
 
@@ -224,6 +225,15 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             // Set up a scoring update interval
             let update_gossipsub_scores = tokio::time::interval(params.decay_interval);
 
+            let max_subnets = ctx.chain_spec.attestation_subnet_count as usize
+                + SYNC_COMMITTEE_SUBNET_COUNT as usize
+                + BLOB_SIDECAR_SUBNET_COUNT as usize
+                + BASE_CORE_TOPICS.len() 
+                + ALTAIR_CORE_TOPICS.len() 
+                + CAPELLA_CORE_TOPICS.len() 
+                + LIGHT_CLIENT_GOSSIP_TOPICS.len();
+
+
             let possible_fork_digests = ctx.fork_context.all_fork_digests();
             let filter = gossipsub::MaxCountSubscriptionFilter {
                 filter: utils::create_whitelist_filter(
@@ -232,9 +242,12 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     SYNC_COMMITTEE_SUBNET_COUNT,
                     BLOB_SIDECAR_SUBNET_COUNT,
                 ),
-                max_subscribed_topics: 400,
+                // during a fork we subscribe to both the old and new fork subnets
+                // if there are two forks in quick succession, we may need 3x instead of 2x.
+                max_subscribed_topics: max_subnets * 3,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
-                max_subscriptions_per_request: 200,
+
+                max_subscriptions_per_request: max_subnets * 3,
             };
 
             let gossipsub_config_params = GossipsubConfigParams {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -232,9 +232,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     SYNC_COMMITTEE_SUBNET_COUNT,
                     BLOB_SIDECAR_SUBNET_COUNT,
                 ),
-                max_subscribed_topics: 200,
+                max_subscribed_topics: 400,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
-                max_subscriptions_per_request: 160,
+                max_subscriptions_per_request: 200,
             };
 
             let gossipsub_config_params = GossipsubConfigParams {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -16,7 +16,7 @@ pub use crate::service::behaviour::Gossipsub;
 use crate::types::{
     fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind, GossipTopic,
     SnappyTransform, Subnet, SubnetDiscovery, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS,
-    CAPELLA_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
+    CAPELLA_CORE_TOPICS, DENEB_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
 };
 use crate::EnrExt;
 use crate::Eth2Enr;
@@ -225,12 +225,13 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             // Set up a scoring update interval
             let update_gossipsub_scores = tokio::time::interval(params.decay_interval);
 
-            let max_subnets = ctx.chain_spec.attestation_subnet_count as usize
+            let max_topics = ctx.chain_spec.attestation_subnet_count as usize
                 + SYNC_COMMITTEE_SUBNET_COUNT as usize
                 + BLOB_SIDECAR_SUBNET_COUNT as usize
                 + BASE_CORE_TOPICS.len()
                 + ALTAIR_CORE_TOPICS.len()
                 + CAPELLA_CORE_TOPICS.len()
+                + DENEB_CORE_TOPICS.len()
                 + LIGHT_CLIENT_GOSSIP_TOPICS.len();
 
             let possible_fork_digests = ctx.fork_context.all_fork_digests();
@@ -242,10 +243,10 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     BLOB_SIDECAR_SUBNET_COUNT,
                 ),
                 // during a fork we subscribe to both the old and new fork subnets
-                // if there are two forks in quick succession, we may need 3x instead of 2x.
-                max_subscribed_topics: max_subnets * 3,
+                // if there are two forks in quick succession, we may need 4x instead of 2x.
+                max_subscribed_topics: max_topics * 4,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
-                max_subscriptions_per_request: max_subnets * 3,
+                max_subscriptions_per_request: max_topics * 4,
             };
 
             let gossipsub_config_params = GossipsubConfigParams {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -246,7 +246,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                 // if there are two forks in quick succession, we may need 4x instead of 2x.
                 max_subscribed_topics: max_topics * 4,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
-                max_subscriptions_per_request: max_topics * 4,
+                max_subscriptions_per_request: max_topics * 2,
             };
 
             let gossipsub_config_params = GossipsubConfigParams {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -15,8 +15,8 @@ use crate::service::behaviour::BehaviourEvent;
 pub use crate::service::behaviour::Gossipsub;
 use crate::types::{
     fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind, GossipTopic,
-    SnappyTransform, Subnet, SubnetDiscovery, BASE_CORE_TOPICS, ALTAIR_CORE_TOPICS, CAPELLA_CORE_TOPICS,
-    LIGHT_CLIENT_GOSSIP_TOPICS,
+    SnappyTransform, Subnet, SubnetDiscovery, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS,
+    CAPELLA_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
 };
 use crate::EnrExt;
 use crate::Eth2Enr;
@@ -42,7 +42,7 @@ use std::{
 use types::ForkName;
 use types::{
     consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, consts::deneb::BLOB_SIDECAR_SUBNET_COUNT,
-    EnrForkId, EthSpec, ForkContext, Slot, SubnetId
+    EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
 };
 use utils::{build_transport, strip_peer_id, Context as ServiceContext, MAX_CONNECTIONS_PER_PEER};
 
@@ -228,11 +228,10 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             let max_subnets = ctx.chain_spec.attestation_subnet_count as usize
                 + SYNC_COMMITTEE_SUBNET_COUNT as usize
                 + BLOB_SIDECAR_SUBNET_COUNT as usize
-                + BASE_CORE_TOPICS.len() 
-                + ALTAIR_CORE_TOPICS.len() 
-                + CAPELLA_CORE_TOPICS.len() 
+                + BASE_CORE_TOPICS.len()
+                + ALTAIR_CORE_TOPICS.len()
+                + CAPELLA_CORE_TOPICS.len()
                 + LIGHT_CLIENT_GOSSIP_TOPICS.len();
-
 
             let possible_fork_digests = ctx.fork_context.all_fork_digests();
             let filter = gossipsub::MaxCountSubscriptionFilter {
@@ -246,7 +245,6 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                 // if there are two forks in quick succession, we may need 3x instead of 2x.
                 max_subscribed_topics: max_subnets * 3,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
-
                 max_subscriptions_per_request: max_subnets * 3,
             };
 

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -242,8 +242,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                     SYNC_COMMITTEE_SUBNET_COUNT,
                     BLOB_SIDECAR_SUBNET_COUNT,
                 ),
-                // during a fork we subscribe to both the old and new fork subnets
-                // if there are two forks in quick succession, we may need 4x instead of 2x.
+                // during a fork we subscribe to both the old and new topics
                 max_subscribed_topics: max_topics * 4,
                 // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
                 max_subscriptions_per_request: max_topics * 2,

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -19,5 +19,5 @@ pub use sync_state::{BackFillState, SyncState};
 pub use topics::{
     core_topics_to_subscribe, fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind,
     GossipTopic, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS, CAPELLA_CORE_TOPICS,
-    LIGHT_CLIENT_GOSSIP_TOPICS,
+    DENEB_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
 };

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -18,6 +18,6 @@ pub use subnet::{Subnet, SubnetDiscovery};
 pub use sync_state::{BackFillState, SyncState};
 pub use topics::{
     core_topics_to_subscribe, fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind,
-    GossipTopic, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS, CAPELLA_CORE_TOPICS,
-    DENEB_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
+    GossipTopic, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS, CAPELLA_CORE_TOPICS, DENEB_CORE_TOPICS,
+    LIGHT_CLIENT_GOSSIP_TOPICS,
 };

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -18,9 +18,6 @@ pub use subnet::{Subnet, SubnetDiscovery};
 pub use sync_state::{BackFillState, SyncState};
 pub use topics::{
     core_topics_to_subscribe, fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind,
-    GossipTopic, 
+    GossipTopic, ALTAIR_CORE_TOPICS, BASE_CORE_TOPICS, CAPELLA_CORE_TOPICS,
     LIGHT_CLIENT_GOSSIP_TOPICS,
-    BASE_CORE_TOPICS,
-    ALTAIR_CORE_TOPICS,
-    CAPELLA_CORE_TOPICS,
 };

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -18,5 +18,9 @@ pub use subnet::{Subnet, SubnetDiscovery};
 pub use sync_state::{BackFillState, SyncState};
 pub use topics::{
     core_topics_to_subscribe, fork_core_topics, subnet_from_topic_hash, GossipEncoding, GossipKind,
-    GossipTopic, LIGHT_CLIENT_GOSSIP_TOPICS,
+    GossipTopic, 
+    LIGHT_CLIENT_GOSSIP_TOPICS,
+    BASE_CORE_TOPICS,
+    ALTAIR_CORE_TOPICS,
+    CAPELLA_CORE_TOPICS,
 };


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?

See: #4581

## Proposed Changes

Please list or describe the changes introduced by this PR.

I propose to increase the `max_subscribed_topics` to 400 from 200 to allow for nodes to be connected to all topics during a fork transition. I also propose to increase `max_subscriptions_per_request` to 200 from 160. 

Kudos to [antithesis](https://antithesis.com/).
