### PR TITLE
Fix genesis state storage for genesis sync

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -337,12 +337,13 @@ where
             .build_caches(&self.spec)
             .map_err(|e| format!("Failed to build genesis state caches: {:?}", e))?;
 
-        store
-            .update_finalized_state(beacon_state_root, beacon_block_root, beacon_state.clone())
-            .map_err(|e| format!("Failed to set genesis state as finalized state: {:?}", e))?;
+        info!(store.log, "Storing genesis state"; "state_root" => ?beacon_state_root);
         store
             .put_state(&beacon_state_root, &beacon_state)
             .map_err(|e| format!("Failed to store genesis state: {:?}", e))?;
+        store
+            .update_finalized_state(beacon_state_root, beacon_block_root, beacon_state.clone())
+            .map_err(|e| format!("Failed to set genesis state as finalized state: {:?}", e))?;
 
         // Store the genesis block's execution payload (if any) in the hot database.
         if let Some(execution_payload) = &payload {


### PR DESCRIPTION
## Issue Addressed

Fix the `tree-states` branch's ability to sync from genesis.

## Proposed Changes

Gracefully handle the case where the `split.state_root` is `0x0` but we still need to load/store the genesis state.
