### PR TITLE
Initial Attempt to Eliminate Blob Clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -985,7 +985,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum//c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d#f5f6f863d475847876a2bd5ee252058d37c3a15d"
+source = "git+https://github.com/ethDreamer//c-kzg-4844?rev=c4b0c9050a565f3ea64615f8fd7b917f1795e086#c4b0c9050a565f3ea64615f8fd7b917f1795e086"
 dependencies = [
  "bindgen 0.66.1",
  "blst",
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d#f5f6f863d475847876a2bd5ee252058d37c3a15d"
+source = "git+https://github.com/ethDreamer/c-kzg-4844?rev=c4b0c9050a565f3ea64615f8fd7b917f1795e086#c4b0c9050a565f3ea64615f8fd7b917f1795e086"
 dependencies = [
  "bindgen 0.66.1",
  "blst",
@@ -4050,8 +4050,8 @@ name = "kzg"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "c-kzg 0.1.0 (git+https://github.com/ethereum//c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
+ "c-kzg 0.1.0 (git+https://github.com/ethDreamer//c-kzg-4844?rev=c4b0c9050a565f3ea64615f8fd7b917f1795e086)",
+ "c-kzg 0.1.0 (git+https://github.com/ethDreamer/c-kzg-4844?rev=c4b0c9050a565f3ea64615f8fd7b917f1795e086)",
  "derivative",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -6165,7 +6165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -525,8 +525,7 @@ pub fn verify_kzg_for_blob<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
 ) -> Result<KzgVerifiedBlob<T>, AvailabilityCheckError> {
     let _timer = crate::metrics::start_timer(&crate::metrics::KZG_VERIFICATION_SINGLE_TIMES);
-    //TODO(sean) remove clone
-    if validate_blob::<T>(kzg, blob.blob.clone(), blob.kzg_commitment, blob.kzg_proof)
+    if validate_blob::<T>(kzg, &blob.blob, blob.kzg_commitment, blob.kzg_proof)
         .map_err(AvailabilityCheckError::Kzg)?
     {
         Ok(KzgVerifiedBlob { blob })

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,10 +1,10 @@
 use kzg::{Error as KzgError, Kzg};
-use types::{EthSpec, Hash256, KzgCommitment, KzgProof, SigpBlob};
+use types::{EthSpec, Hash256, KzgCommitment, KzgProof, WrappedBlob};
 
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.
 pub fn validate_blob<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &SigpBlob<T>,
+    blob: &WrappedBlob<T>,
     kzg_commitment: KzgCommitment,
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
@@ -15,7 +15,7 @@ pub fn validate_blob<T: EthSpec>(
 pub fn validate_blobs<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
     expected_kzg_commitments: &[KzgCommitment],
-    blobs: &[SigpBlob<T>],
+    blobs: &[WrappedBlob<T>],
     kzg_proofs: &[KzgProof],
 ) -> Result<bool, KzgError> {
     let blobs = blobs
@@ -30,7 +30,7 @@ pub fn validate_blobs<T: EthSpec>(
 /// Compute the kzg proof given an ssz blob and its kzg commitment.
 pub fn compute_blob_kzg_proof<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &SigpBlob<T>,
+    blob: &WrappedBlob<T>,
     kzg_commitment: KzgCommitment,
 ) -> Result<KzgProof, KzgError> {
     kzg.compute_blob_kzg_proof(blob.c_kzg_blob(), kzg_commitment)
@@ -39,7 +39,7 @@ pub fn compute_blob_kzg_proof<T: EthSpec>(
 /// Compute the kzg commitment for a given blob.
 pub fn blob_to_kzg_commitment<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &SigpBlob<T>,
+    blob: &WrappedBlob<T>,
 ) -> Result<KzgCommitment, KzgError> {
     kzg.blob_to_kzg_commitment(blob.c_kzg_blob())
 }
@@ -47,7 +47,7 @@ pub fn blob_to_kzg_commitment<T: EthSpec>(
 /// Compute the kzg proof for a given blob and an evaluation point z.
 pub fn compute_kzg_proof<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &SigpBlob<T>,
+    blob: &WrappedBlob<T>,
     z: Hash256,
 ) -> Result<(KzgProof, Hash256), KzgError> {
     let z = z.0.into();

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,39 +1,28 @@
-use kzg::{Error as KzgError, Kzg, KzgPreset};
-use types::{Blob, EthSpec, Hash256, KzgCommitment, KzgProof};
-
-/// Converts a blob ssz List object to an array to be used with the kzg
-/// crypto library.
-fn ssz_blob_to_crypto_blob<T: EthSpec>(
-    blob: &Blob<T>,
-) -> Result<<<T as EthSpec>::Kzg as KzgPreset>::Blob, KzgError> {
-    T::blob_from_bytes(blob.as_ref())
-}
+use kzg::{Error as KzgError, Kzg};
+use types::{EthSpec, Hash256, KzgCommitment, KzgProof, SigpBlob};
 
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.
 pub fn validate_blob<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: Blob<T>,
+    blob: &SigpBlob<T>,
     kzg_commitment: KzgCommitment,
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
-    kzg.verify_blob_kzg_proof(
-        &ssz_blob_to_crypto_blob::<T>(&blob)?,
-        kzg_commitment,
-        kzg_proof,
-    )
+    kzg.verify_blob_kzg_proof(blob.c_kzg_blob(), kzg_commitment, kzg_proof)
 }
 
 /// Validate a batch of blob-commitment-proof triplets from multiple `BlobSidecars`.
 pub fn validate_blobs<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
     expected_kzg_commitments: &[KzgCommitment],
-    blobs: &[Blob<T>],
+    blobs: &[SigpBlob<T>],
     kzg_proofs: &[KzgProof],
 ) -> Result<bool, KzgError> {
     let blobs = blobs
         .iter()
-        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob)) // Avoid this clone
-        .collect::<Result<Vec<_>, KzgError>>()?;
+        // unfortunately we can't avoid this clone unless the API changes to take an array of references
+        .map(|blob| blob.c_kzg_blob().clone())
+        .collect::<Vec<_>>();
 
     kzg.verify_blob_kzg_proof_batch(&blobs, expected_kzg_commitments, kzg_proofs)
 }
@@ -41,29 +30,28 @@ pub fn validate_blobs<T: EthSpec>(
 /// Compute the kzg proof given an ssz blob and its kzg commitment.
 pub fn compute_blob_kzg_proof<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &Blob<T>,
+    blob: &SigpBlob<T>,
     kzg_commitment: KzgCommitment,
 ) -> Result<KzgProof, KzgError> {
-    // Avoid this blob clone
-    kzg.compute_blob_kzg_proof(&ssz_blob_to_crypto_blob::<T>(blob)?, kzg_commitment)
+    kzg.compute_blob_kzg_proof(blob.c_kzg_blob(), kzg_commitment)
 }
 
 /// Compute the kzg commitment for a given blob.
 pub fn blob_to_kzg_commitment<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &Blob<T>,
+    blob: &SigpBlob<T>,
 ) -> Result<KzgCommitment, KzgError> {
-    kzg.blob_to_kzg_commitment(&ssz_blob_to_crypto_blob::<T>(blob)?)
+    kzg.blob_to_kzg_commitment(blob.c_kzg_blob())
 }
 
 /// Compute the kzg proof for a given blob and an evaluation point z.
 pub fn compute_kzg_proof<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: &Blob<T>,
+    blob: &SigpBlob<T>,
     z: Hash256,
 ) -> Result<(KzgProof, Hash256), KzgError> {
     let z = z.0.into();
-    kzg.compute_kzg_proof(&ssz_blob_to_crypto_blob::<T>(blob)?, &z)
+    kzg.compute_kzg_proof(blob.c_kzg_blob(), &z)
         .map(|(proof, z)| (proof, Hash256::from_slice(&z.to_vec())))
 }
 

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -440,7 +440,6 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
 pub struct JsonBlobsBundleV1<E: EthSpec> {
     pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
-    #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub blobs: BlobsList<E>,
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1850,7 +1850,6 @@ pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
 pub struct BlobsBundle<E: EthSpec> {
     pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
-    #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub blobs: BlobsList<E>,
 }
 

--- a/consensus/types/src/blob.rs
+++ b/consensus/types/src/blob.rs
@@ -1,0 +1,229 @@
+use crate::EthSpec;
+use arbitrary::{Arbitrary, Unstructured};
+use kzg::{BlobTrait, KzgPreset, BYTES_PER_FIELD_ELEMENT};
+use rand::Rng;
+use safe_arith::SafeArith;
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
+use ssz::{Decode, DecodeError, Encode};
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use tree_hash::{PackedEncoding, TreeHash};
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SigpBlob<E: EthSpec>(Arc<<E::Kzg as KzgPreset>::Blob>);
+
+impl<E: EthSpec> SigpBlob<E> {
+    pub fn random_valid<R: Rng>(rng: &mut R) -> Result<Self, String> {
+        let mut blob_bytes = vec![0u8; <E::Kzg as KzgPreset>::BYTES_PER_BLOB];
+        rng.fill_bytes(&mut blob_bytes);
+
+        // Ensure that the blob is canonical by ensuring that
+        // each field element contained in the blob is < BLS_MODULUS
+        for i in 0..<E::Kzg as KzgPreset>::FIELD_ELEMENTS_PER_BLOB {
+            let Some(byte) = blob_bytes.get_mut(
+                i.checked_mul(BYTES_PER_FIELD_ELEMENT)
+                    .ok_or("overflow".to_string())?,
+            ) else {
+                return Err(format!("blob byte index out of bounds: {:?}", i));
+            };
+            *byte = 0;
+        }
+        let kzg_blob = <E::Kzg as KzgPreset>::Blob::from_bytes(&blob_bytes)
+            .map_err(|e| format!("failed to create blob: {:?}", e))?;
+        Ok(Self(Arc::new(kzg_blob)))
+    }
+
+    pub fn c_kzg_blob(&self) -> &<E::Kzg as KzgPreset>::Blob {
+        self.0.as_ref()
+    }
+}
+
+impl<'a, E: EthSpec> Arbitrary<'a> for SigpBlob<E> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let mut blob_bytes = vec![0u8; <E::Kzg as KzgPreset>::BYTES_PER_BLOB];
+        u.fill_buffer(&mut blob_bytes)?;
+        // FIXME: what is the correct error condition here?
+        //        also.. this is a duplication of the code above..
+        let arbitrary_error = arbitrary::Error::NotEnoughData;
+        for i in 0..<E::Kzg as KzgPreset>::FIELD_ELEMENTS_PER_BLOB {
+            let Some(byte) = blob_bytes.get_mut(
+                i.checked_mul(BYTES_PER_FIELD_ELEMENT)
+                    .ok_or(arbitrary_error)?,
+            ) else {
+                return Err(arbitrary_error);
+            };
+            *byte = 0;
+        }
+        let kzg_blob =
+            <E::Kzg as KzgPreset>::Blob::from_bytes(&blob_bytes).map_err(|_| arbitrary_error)?;
+        Ok(Self(Arc::new(kzg_blob)))
+    }
+}
+
+impl<E: EthSpec> Hash for SigpBlob<E> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.as_ref().as_ref().hash(state)
+    }
+}
+
+impl<E: EthSpec> Serialize for SigpBlob<E> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let hex_string = format!("0x{}", hex::encode(self.0.as_ref().as_ref()));
+        serializer.serialize_str(&hex_string)
+    }
+}
+
+impl<'de, T: EthSpec> Deserialize<'de> for SigpBlob<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BlobVisitor<T: EthSpec> {
+            _marker: std::marker::PhantomData<T>,
+        }
+
+        impl<'de, T: EthSpec> Visitor<'de> for BlobVisitor<T> {
+            type Value = SigpBlob<T>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a hex-encoded string representing a blob")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let hex_value = value
+                    .strip_prefix("0x")
+                    .ok_or_else(|| de::Error::invalid_value(de::Unexpected::Str(value), &self))?;
+
+                let bytes = hex::decode(hex_value)
+                    .map_err(|_| de::Error::invalid_value(de::Unexpected::Str(value), &self))?;
+
+                let kzg_blob =
+                    <T::Kzg as KzgPreset>::Blob::from_bytes(bytes.as_slice()).map_err(|_| {
+                        de::Error::invalid_length(
+                            bytes.len(),
+                            &"a blob with the correct byte length",
+                        )
+                    })?;
+
+                Ok(SigpBlob(Arc::new(kzg_blob)))
+            }
+        }
+
+        deserializer.deserialize_str(BlobVisitor {
+            _marker: std::marker::PhantomData,
+        })
+    }
+}
+
+impl<E: EthSpec> Encode for SigpBlob<E> {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_append(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(self.0.as_ref().as_ref())
+    }
+
+    fn ssz_bytes_len(&self) -> usize {
+        <E::Kzg as KzgPreset>::BYTES_PER_BLOB
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <E::Kzg as KzgPreset>::BYTES_PER_BLOB
+    }
+}
+
+impl<E: EthSpec> Decode for SigpBlob<E> {
+    fn is_ssz_fixed_len() -> bool {
+        true
+    }
+
+    fn ssz_fixed_len() -> usize {
+        <E::Kzg as KzgPreset>::BYTES_PER_BLOB
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        let kzg_blob = <E::Kzg as KzgPreset>::Blob::from_bytes(bytes).map_err(|_| {
+            DecodeError::InvalidByteLength {
+                len: bytes.len(),
+                expected: <E::Kzg as KzgPreset>::BYTES_PER_BLOB,
+            }
+        })?;
+
+        Ok(Self(Arc::new(kzg_blob)))
+    }
+}
+
+impl<E: EthSpec> TryFrom<Vec<u8>> for SigpBlob<E> {
+    type Error = String;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let length = bytes.len();
+        let kzg_blob = <E::Kzg as KzgPreset>::Blob::from_bytes(bytes.as_slice()).map_err(|_| {
+            format!(
+                "Invalid blob length: {} bytes, expected {}",
+                length,
+                <E::Kzg as KzgPreset>::BYTES_PER_BLOB
+            )
+        })?;
+        Ok(Self(Arc::new(kzg_blob)))
+    }
+}
+
+impl<E: EthSpec> TreeHash for SigpBlob<E> {
+    fn tree_hash_type() -> tree_hash::TreeHashType {
+        tree_hash::TreeHashType::Vector
+    }
+
+    fn tree_hash_packed_encoding(&self) -> PackedEncoding {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_packing_factor() -> usize {
+        unreachable!("Vector should never be packed.")
+    }
+
+    fn tree_hash_root(&self) -> tree_hash::Hash256 {
+        let num_leaves = <E::Kzg as KzgPreset>::BYTES_PER_BLOB
+            .safe_add(u8::tree_hash_packing_factor())
+            .and_then(|n| n.safe_sub(1))
+            .and_then(|n| n.safe_div(u8::tree_hash_packing_factor()))
+            .expect("unsafe math in tree_hash_root of Blob");
+        let mut hasher = tree_hash::MerkleHasher::with_leaves(num_leaves);
+
+        for byte in self.0.as_ref().as_ref() {
+            hasher
+                .write(&byte.tree_hash_packed_encoding())
+                .expect("ssz_types variable vec should not contain more elements than max");
+        }
+
+        hasher
+            .finish()
+            .expect("ssz_types variable vec should not have a remaining buffer")
+    }
+}
+
+impl<E: EthSpec> Default for SigpBlob<E> {
+    fn default() -> Self {
+        let bytes = vec![0u8; <E::Kzg as KzgPreset>::BYTES_PER_BLOB];
+        SigpBlob(Arc::new(
+            <E::Kzg as KzgPreset>::Blob::from_bytes(bytes.as_slice())
+                .expect("default blob should be valid"),
+        ))
+    }
+}
+
+impl<E: EthSpec> std::fmt::Debug for SigpBlob<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", serde_utils::hex::encode(self.0.as_ref()))
+    }
+}

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -14,7 +14,7 @@ use kzg::{Kzg, KzgCommitment, KzgProof};
 use test_random_derive::TestRandom;
 
 use crate::test_utils::TestRandom;
-use crate::{EthSpec, Hash256, SignedRoot, SigpBlob, Slot};
+use crate::{EthSpec, Hash256, SignedRoot, Slot, WrappedBlob};
 
 /// Container of the data that identifies an individual blob.
 #[derive(
@@ -60,7 +60,7 @@ pub struct BlobSidecar<T: EthSpec> {
     pub block_parent_root: Hash256,
     #[serde(with = "serde_utils::quoted_u64")]
     pub proposer_index: u64,
-    pub blob: SigpBlob<T>,
+    pub blob: WrappedBlob<T>,
     pub kzg_commitment: KzgCommitment,
     pub kzg_proof: KzgProof,
 }
@@ -124,14 +124,14 @@ impl<T: EthSpec> BlobSidecar<T> {
             slot: Slot::new(0),
             block_parent_root: Hash256::zero(),
             proposer_index: 0,
-            blob: SigpBlob::<T>::default(),
+            blob: WrappedBlob::<T>::default(),
             kzg_commitment: KzgCommitment::empty_for_testing(),
             kzg_proof: KzgProof::empty(),
         }
     }
 
     pub fn random_valid<R: Rng>(rng: &mut R, kzg: &Kzg<T::Kzg>) -> Result<Self, String> {
-        let blob = SigpBlob::<T>::random_valid(rng)?;
+        let blob = WrappedBlob::<T>::random_valid(rng)?;
         let kzg_blob = blob.c_kzg_blob();
 
         let commitment = kzg
@@ -192,5 +192,5 @@ pub type BlindedBlobSidecarList<T> = SidecarList<T, BlindedBlobSidecar>;
 pub type FixedBlobSidecarList<T> =
     FixedVector<Option<Arc<BlobSidecar<T>>>, <T as EthSpec>::MaxBlobsPerBlock>;
 
-pub type BlobsList<T> = VariableList<SigpBlob<T>, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
+pub type BlobsList<T> = VariableList<WrappedBlob<T>, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
 pub type BlobRootsList<T> = VariableList<Hash256, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
-pub use crate::blob::SigpBlob;
+pub use crate::blob::WrappedBlob;
 pub use crate::blob_sidecar::{
     BlindedBlobSidecar, BlindedBlobSidecarList, BlobRootsList, BlobSidecar, BlobSidecarList,
     BlobsList, SidecarList,

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -98,6 +98,7 @@ pub mod slot_data;
 #[cfg(feature = "sqlite")]
 pub mod sqlite;
 
+pub mod blob;
 pub mod blob_sidecar;
 pub mod sidecar;
 pub mod signed_blob;
@@ -120,6 +121,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{BeaconTreeHashCache, Error as BeaconStateError, *};
+pub use crate::blob::SigpBlob;
 pub use crate::blob_sidecar::{
     BlindedBlobSidecar, BlindedBlobSidecarList, BlobRootsList, BlobSidecar, BlobSidecarList,
     BlobsList, SidecarList,
@@ -207,7 +209,6 @@ pub type Uint256 = ethereum_types::U256;
 pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 pub type BLSFieldElement = Uint256;
-pub type Blob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
 pub type KzgProofs<T> = VariableList<KzgProof, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
 pub type VersionedHash = Hash256;
 pub type Hash64 = ethereum_types::H64;

--- a/consensus/types/src/signed_blob.rs
+++ b/consensus/types/src/signed_blob.rs
@@ -1,7 +1,7 @@
 use crate::sidecar::Sidecar;
 use crate::{
     test_utils::TestRandom, BlindedBlobSidecar, BlobSidecar, ChainSpec, Domain, EthSpec, Fork,
-    Hash256, Signature, SignedRoot, SigningData, SigpBlob,
+    Hash256, Signature, SignedRoot, SigningData, WrappedBlob,
 };
 use bls::PublicKey;
 use derivative::Derivative;
@@ -41,7 +41,7 @@ pub struct SignedSidecar<T: EthSpec, S: Sidecar<T>> {
 }
 
 impl<T: EthSpec> SignedSidecar<T, BlindedBlobSidecar> {
-    pub fn into_full_blob_sidecars(self, blob: SigpBlob<T>) -> SignedSidecar<T, BlobSidecar<T>> {
+    pub fn into_full_blob_sidecars(self, blob: WrappedBlob<T>) -> SignedSidecar<T, BlobSidecar<T>> {
         let blinded_sidecar = self.message;
         SignedSidecar {
             message: Arc::new(BlobSidecar {

--- a/consensus/types/src/signed_blob.rs
+++ b/consensus/types/src/signed_blob.rs
@@ -1,7 +1,7 @@
 use crate::sidecar::Sidecar;
 use crate::{
-    test_utils::TestRandom, BlindedBlobSidecar, Blob, BlobSidecar, ChainSpec, Domain, EthSpec,
-    Fork, Hash256, Signature, SignedRoot, SigningData,
+    test_utils::TestRandom, BlindedBlobSidecar, BlobSidecar, ChainSpec, Domain, EthSpec, Fork,
+    Hash256, Signature, SignedRoot, SigningData, SigpBlob,
 };
 use bls::PublicKey;
 use derivative::Derivative;
@@ -41,7 +41,7 @@ pub struct SignedSidecar<T: EthSpec, S: Sidecar<T>> {
 }
 
 impl<T: EthSpec> SignedSidecar<T, BlindedBlobSidecar> {
-    pub fn into_full_blob_sidecars(self, blob: Blob<T>) -> SignedSidecar<T, BlobSidecar<T>> {
+    pub fn into_full_blob_sidecars(self, blob: SigpBlob<T>) -> SignedSidecar<T, BlobSidecar<T>> {
         let blinded_sidecar = self.message;
         SignedSidecar {
             message: Arc::new(BlobSidecar {

--- a/consensus/types/src/test_utils/test_random.rs
+++ b/consensus/types/src/test_utils/test_random.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 mod address;
 mod aggregate_signature;
 mod bitfield;
+mod blob;
 mod hash256;
 mod kzg_commitment;
 mod kzg_proof;

--- a/consensus/types/src/test_utils/test_random/blob.rs
+++ b/consensus/types/src/test_utils/test_random/blob.rs
@@ -1,0 +1,8 @@
+use super::*;
+use crate::SigpBlob;
+
+impl<E: EthSpec> TestRandom for SigpBlob<E> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        SigpBlob::random_valid(rng).expect("should create valid blob")
+    }
+}

--- a/consensus/types/src/test_utils/test_random/blob.rs
+++ b/consensus/types/src/test_utils/test_random/blob.rs
@@ -1,8 +1,8 @@
 use super::*;
-use crate::SigpBlob;
+use crate::WrappedBlob;
 
-impl<E: EthSpec> TestRandom for SigpBlob<E> {
+impl<E: EthSpec> TestRandom for WrappedBlob<E> {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
-        SigpBlob::random_valid(rng).expect("should create valid blob")
+        WrappedBlob::random_valid(rng).expect("should create valid blob")
     }
 }

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = "1.0.116"
 ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
-c-kzg = { git = "https://github.com/ethDreamer/c-kzg-4844", rev = "c4b0c9050a565f3ea64615f8fd7b917f1795e086" , features = ["mainnet-spec"]}
-c_kzg_min = { package = "c-kzg", git = "https://github.com/ethDreamer//c-kzg-4844", rev = "c4b0c9050a565f3ea64615f8fd7b917f1795e086", features = ["minimal-spec"], optional = true }
+c-kzg = { git = "https://github.com/ethDreamer/c-kzg-4844", rev = "25f35f07bf7093f897b75f7f68157390fead6774" , features = ["mainnet-spec"]}
+c_kzg_min = { package = "c-kzg", git = "https://github.com/ethDreamer//c-kzg-4844", rev = "25f35f07bf7093f897b75f7f68157390fead6774", features = ["minimal-spec"], optional = true }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = "1.0.116"
 ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "f5f6f863d475847876a2bd5ee252058d37c3a15d" , features = ["mainnet-spec", "serde"]}
-c_kzg_min = { package = "c-kzg", git = "https://github.com/ethereum//c-kzg-4844", rev = "f5f6f863d475847876a2bd5ee252058d37c3a15d", features = ["minimal-spec", "serde"], optional = true }
+c-kzg = { git = "https://github.com/ethDreamer/c-kzg-4844", rev = "c4b0c9050a565f3ea64615f8fd7b917f1795e086" , features = ["mainnet-spec"]}
+c_kzg_min = { package = "c-kzg", git = "https://github.com/ethDreamer//c-kzg-4844", rev = "c4b0c9050a565f3ea64615f8fd7b917f1795e086", features = ["minimal-spec"], optional = true }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -40,7 +40,7 @@ impl From<c_kzg_min::Error> for CryptoError {
     }
 }
 
-pub trait BlobTrait: Sized + Clone {
+pub trait BlobTrait: Sized + Clone + Debug + PartialEq + Eq + Send + Sync + AsRef<[u8]> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, Error>;
 }
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -6,7 +6,7 @@ use kzg::{Kzg, KzgCommitment, KzgPreset, KzgProof, TrustedSetup};
 use serde_derive::Deserialize;
 use std::convert::TryInto;
 use std::marker::PhantomData;
-use types::Blob;
+use types::SigpBlob;
 
 pub fn get_kzg<P: KzgPreset>() -> Result<Kzg<P>, Error> {
     let trusted_setup: TrustedSetup = serde_json::from_reader(get_trusted_setup::<P>())
@@ -37,11 +37,11 @@ pub fn parse_commitment(commitment: &str) -> Result<KzgCommitment, Error> {
         .map(KzgCommitment)
 }
 
-pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<Blob<E>, Error> {
+pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<SigpBlob<E>, Error> {
     hex::decode(strip_0x(blob)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         .and_then(|bytes| {
-            Blob::<E>::new(bytes)
+            SigpBlob::<E>::try_from(bytes)
                 .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         })
 }
@@ -82,7 +82,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
     }
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
-        let parse_input = |input: &KZGVerifyBlobKZGProofInput| -> Result<(Blob<E>, KzgCommitment, KzgProof), Error> {
+        let parse_input = |input: &KZGVerifyBlobKZGProofInput| -> Result<(SigpBlob<E>, KzgCommitment, KzgProof), Error> {
             let blob = parse_blob::<E>(&input.blob)?;
             let commitment = parse_commitment(&input.commitment)?;
             let proof = parse_proof(&input.proof)?;
@@ -91,7 +91,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
 
         let kzg = get_kzg::<E::Kzg>()?;
         let result = parse_input(&self.input).and_then(|(blob, commitment, proof)| {
-            validate_blob::<E>(&kzg, blob, commitment, proof)
+            validate_blob::<E>(&kzg, &blob, commitment, proof)
                 .map_err(|e| Error::InternalError(format!("Failed to validate blob: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -6,7 +6,7 @@ use kzg::{Kzg, KzgCommitment, KzgPreset, KzgProof, TrustedSetup};
 use serde_derive::Deserialize;
 use std::convert::TryInto;
 use std::marker::PhantomData;
-use types::SigpBlob;
+use types::WrappedBlob;
 
 pub fn get_kzg<P: KzgPreset>() -> Result<Kzg<P>, Error> {
     let trusted_setup: TrustedSetup = serde_json::from_reader(get_trusted_setup::<P>())
@@ -37,11 +37,11 @@ pub fn parse_commitment(commitment: &str) -> Result<KzgCommitment, Error> {
         .map(KzgCommitment)
 }
 
-pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<SigpBlob<E>, Error> {
+pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<WrappedBlob<E>, Error> {
     hex::decode(strip_0x(blob)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         .and_then(|bytes| {
-            SigpBlob::<E>::try_from(bytes)
+            WrappedBlob::<E>::try_from(bytes)
                 .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         })
 }
@@ -82,7 +82,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
     }
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
-        let parse_input = |input: &KZGVerifyBlobKZGProofInput| -> Result<(SigpBlob<E>, KzgCommitment, KzgProof), Error> {
+        let parse_input = |input: &KZGVerifyBlobKZGProofInput| -> Result<(WrappedBlob<E>, KzgCommitment, KzgProof), Error> {
             let blob = parse_blob::<E>(&input.blob)?;
             let commitment = parse_commitment(&input.commitment)?;
             let proof = parse_proof(&input.proof)?;


### PR DESCRIPTION
Bringing this back as it keeps blobs off the stack and should be faster because we eliminate clones. The only question is if the extra complexity (contained in `consensus/types/src/blob.rs`) is worth this efficiency gain. The whole point of this PR is to use the:

```rust
pub struct WrappedBlob<E: EthSpec>(Arc<<E::Kzg as KzgPreset>::Blob>);
```

A cheaply `clone`able, heap-allocated, `Blob` internally stored as a `c_kzg::Blob`:
```rust
#[repr(C)]
pub struct Blob {
    bytes: [u8; BYTES_PER_BLOB],
}
```
and thus easily provides a reference to this type (via `c_kzg_blob()`) without the need to `clone()` the bytes.