### PR TITLE
(fix): HTTP error handling in VC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "4.3.0"
+version = "4.2.0"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "4.3.0"
+version = "4.2.0"
 dependencies = [
  "beacon_node",
  "clap",
@@ -4022,7 +4022,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "4.3.0"
+version = "4.2.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "4.3.0"
+version = "4.2.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "4.3.0"
+version = "4.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com"]
 edition = "2021"
 

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "4.3.0"
+version = "4.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v4.3.0-",
-    fallback = "Lighthouse/v4.3.0"
+    prefix = "Lighthouse/v4.2.0-",
+    fallback = "Lighthouse/v4.2.0"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "4.3.0"
+version = "4.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "4.3.0"
+version = "4.2.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false

--- a/validator_client/src/http_api/api_secret.rs
+++ b/validator_client/src/http_api/api_secret.rs
@@ -89,11 +89,11 @@ impl ApiSecret {
 
         let sk = fs::read(&sk_path)
             .map_err(|e| format!("cannot read {}: {}", SK_FILENAME, e))
-            .and_then(|bytes| {
+            .then(|bytes| {
                 serde_utils::hex::decode(&String::from_utf8_lossy(&bytes))
                     .map_err(|_| format!("{} should be 0x-prefixed hex", PK_FILENAME))
             })
-            .and_then(|bytes| {
+            .then(|bytes| {
                 if bytes.len() == SK_LEN {
                     let mut array = [0; SK_LEN];
                     array.copy_from_slice(&bytes);
@@ -110,7 +110,7 @@ impl ApiSecret {
 
         let pk = fs::read(&pk_path)
             .map_err(|e| format!("cannot read {}: {}", PK_FILENAME, e))
-            .and_then(|bytes| {
+            .then(|bytes| {
                 let hex =
                     String::from_utf8(bytes).map_err(|_| format!("{} is not utf8", SK_FILENAME))?;
                 if let Some(stripped) = hex.strip_prefix(PK_PREFIX) {
@@ -120,7 +120,7 @@ impl ApiSecret {
                     Err(format!("unable to parse {}", SK_FILENAME))
                 }
             })
-            .and_then(|bytes| {
+            .then(|bytes| {
                 if bytes.len() == PK_LEN {
                     let mut array = [0; PK_LEN];
                     array.copy_from_slice(&bytes);
@@ -186,7 +186,7 @@ impl ApiSecret {
         warp::any()
             .map(move || expected.clone())
             .and(warp::filters::header::header("Authorization"))
-            .and_then(move |expected: Vec<String>, header: String| async move {
+            .then(move |expected: Vec<String>, header: String| async move {
                 if expected.contains(&header) {
                     Ok(())
                 } else {

--- a/validator_client/src/http_api/create_validator.rs
+++ b/validator_client/src/http_api/create_validator.rs
@@ -35,7 +35,7 @@ pub async fn create_validators_mnemonic<P: AsRef<Path>, T: 'static + SlotClock, 
     let wallet_password = random_password();
     let mut wallet =
         WalletBuilder::from_mnemonic(&mnemonic, wallet_password.as_bytes(), String::new())
-            .and_then(|builder| builder.build())
+            .then(|builder| builder.build())
             .map_err(|e| {
                 warp_utils::reject::custom_server_error(format!(
                     "unable to create EIP-2386 wallet: {:?}",


### PR DESCRIPTION
## Issue Addressed

Closes #4597 

## Proposed Changes

Eliminate all instances of Warp's "and_then" (which backtracks) and replace them with "then" (which doesn't perform backtracking).

## Additional Info

No
