### PR TITLE
[Merged by Bors] - align editorconfig with rustfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,4 +6,4 @@ end_of_line=lf
 charset=utf-8
 trim_trailing_whitespace=true
 max_line_length=100
-insert_final_newline=false
+insert_final_newline=true


### PR DESCRIPTION
## Issue Addressed
There seems to be a conflict between `editorconfig` and `rustfmt`. 
`editorconfig` is configured with [`insert_final_newline=false`](https://github.com/sigp/lighthouse/blob/stable/.editorconfig#L9C1-L9C21) which [removes the newline](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#insert_final_newline), whereas `rustfmt` [adds a newline](https://rust-lang.github.io/rustfmt/?version=v1.6.0&search=#newline_style). 

## Proposed Changes

Align `.editorconfig` with `rustfmt` 

