### PR TITLE
Bump clang for deneb cross builds

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-3.9"]
+pre-build = ["apt-get install -y cmake clang-5.0"]
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-3.9"]
+pre-build = ["apt-get install -y cmake clang-5.0"]


### PR DESCRIPTION
I think we moved where we install clang for cross at some point and missed this in a merge from unstable to deneb. But we had bumped this here previously https://github.com/sigp/lighthouse/pull/4451