### PR TITLE
Add Deneb builder test & update mock builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=56418ea#56418ea4c376470c7d75eb12f75bc882e1a92ca6"
+source = "git+https://github.com/jimmygchen/ethereum-consensus?rev=14cb3ce#14cb3ceb41ccb664aa25394f280f3a5b799d613c"
 dependencies = [
  "async-stream",
  "blst",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/jimmygchen/ethereum-consensus?rev=14cb3ce#14cb3ceb41ccb664aa25394f280f3a5b799d613c"
+source = "git+https://github.com/jimmygchen/ethereum-consensus?rev=2354493#2354493fd631b736c189868b7dc1b415a160f0f7"
 dependencies = [
  "async-stream",
  "blst",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.3.5"
 dependencies = [
  "account_utils",
  "bls",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "directory",
  "environment",
@@ -181,6 +181,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -479,8 +528,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/beacon-api-client?rev=93d7e8c#93d7e8c38fe9782c4862909663e7b57c44f805a9"
+source = "git+https://github.com/ralexstokes/beacon-api-client?rev=56a290c#56a290ca9d2c67086917a0929cdf2fe35e5f917f"
 dependencies = [
+ "clap 4.3.21",
  "ethereum-consensus",
  "http",
  "itertools",
@@ -562,7 +612,7 @@ name = "beacon_node"
 version = "4.3.0"
 dependencies = [
  "beacon_chain",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "client",
  "directory",
@@ -785,7 +835,7 @@ name = "boot_node"
 version = "4.3.0"
 dependencies = [
  "beacon_node",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "eth2_network_config",
  "ethereum_ssz",
@@ -1068,10 +1118,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.10.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+
+[[package]]
 name = "clap_utils"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "dirs",
  "eth2_network_config",
  "ethereum-types 0.14.1",
@@ -1134,6 +1225,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "compare_fields"
@@ -1222,7 +1319,7 @@ checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -1508,7 +1605,7 @@ version = "0.1.0"
 dependencies = [
  "beacon_chain",
  "beacon_node",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "environment",
  "logging",
@@ -1683,7 +1780,7 @@ dependencies = [
 name = "directory"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "eth2_network_config",
 ]
@@ -2317,7 +2414,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=e380108#e380108d15fcc40349927fdf3d11c71f9edb67c2"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=56418ea#56418ea4c376470c7d75eb12f75bc882e1a92ca6"
 dependencies = [
  "async-stream",
  "blst",
@@ -3725,6 +3822,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi 0.3.2",
+ "rustix 0.38.4",
+ "windows-sys",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,7 +3987,7 @@ dependencies = [
  "account_utils",
  "beacon_chain",
  "bls",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "deposit_contract",
  "directory",
@@ -4414,7 +4522,7 @@ dependencies = [
  "beacon_processor",
  "bls",
  "boot_node",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "database_manager",
  "directory",
@@ -4779,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "mev-rs"
 version = "0.3.0"
-source = "git+https://github.com/ralexstokes/mev-rs?rev=216657016d5c0889b505857c89ae42c7aa2764af#216657016d5c0889b505857c89ae42c7aa2764af"
+source = "git+https://github.com/ralexstokes/mev-rs?rev=9d88a2386b58c2948fa850f0dd4b3dfe18bd4962#9d88a2386b58c2948fa850f0dd4b3dfe18bd4962"
 dependencies = [
  "anvil-rpc",
  "async-trait",
@@ -7127,7 +7235,7 @@ dependencies = [
 name = "simulator"
 version = "0.2.0"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "env_logger 0.9.3",
  "eth1",
  "eth1_test_rig",
@@ -8640,6 +8748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8656,7 +8770,7 @@ dependencies = [
  "account_utils",
  "bincode",
  "bls",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "deposit_contract",
  "directory",
@@ -8729,7 +8843,7 @@ version = "0.1.0"
 dependencies = [
  "account_utils",
  "bls",
- "clap",
+ "clap 2.34.0",
  "clap_utils",
  "environment",
  "eth2",
@@ -8972,7 +9086,7 @@ dependencies = [
  "beacon_node",
  "bls",
  "byteorder",
- "clap",
+ "clap 2.34.0",
  "diesel",
  "diesel_migrations",
  "env_logger 0.9.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,10 @@ resolver = "2"
 [patch.crates-io]
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 
+# PR: https://github.com/ralexstokes/ethereum-consensus/pull/213
+[patch."https://github.com/ralexstokes/ethereum-consensus"]
+ethereum-consensus = { git = "https://github.com/jimmygchen/ethereum-consensus", rev = "14cb3ce" }
+
 [profile.maxperf]
 inherits = "release"
 lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c
 
 # PR: https://github.com/ralexstokes/ethereum-consensus/pull/213
 [patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com/jimmygchen/ethereum-consensus", rev = "14cb3ce" }
+ethereum-consensus = { git = "https://github.com/jimmygchen/ethereum-consensus", rev = "2354493" }
 
 [profile.maxperf]
 inherits = "release"

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -42,8 +42,8 @@ lazy_static = "1.4.0"
 ethers-core = "1.0.2"
 builder_client = { path = "../builder_client" }
 fork_choice = { path = "../../consensus/fork_choice" }
-mev-rs = { git = "https://github.com/ralexstokes/mev-rs", rev = "216657016d5c0889b505857c89ae42c7aa2764af" }
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "e380108" }
+mev-rs = { git = "https://github.com/ralexstokes/mev-rs", rev = "9d88a2386b58c2948fa850f0dd4b3dfe18bd4962" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "56418ea" }
 ssz_rs = "0.9.0"
 tokio-stream = { version = "0.1.9", features = [ "sync" ] }
 strum = "0.24.0"

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -18,6 +18,7 @@ use mev_rs::{
             BuilderBid as BuilderBidBellatrix, SignedBuilderBid as SignedBuilderBidBellatrix,
         },
         capella::{BuilderBid as BuilderBidCapella, SignedBuilderBid as SignedBuilderBidCapella},
+        deneb::{BuilderBid as BuilderBidDeneb, SignedBuilderBid as SignedBuilderBidDeneb},
         BidRequest, BuilderBid, ExecutionPayload as ServerPayload, SignedBlindedBeaconBlock,
         SignedBuilderBid, SignedValidatorRegistration,
     },
@@ -35,8 +36,9 @@ use std::time::Duration;
 use task_executor::TaskExecutor;
 use tempfile::NamedTempFile;
 use tree_hash::TreeHash;
+use types::builder_bid::BlindedBlobsBundle;
 use types::{
-    Address, BeaconState, ChainSpec, EthSpec, ExecPayload, ExecutionPayload,
+    Address, BeaconState, BlobsBundle, ChainSpec, EthSpec, ExecPayload, ExecutionPayload,
     ExecutionPayloadHeader, ForkName, Hash256, Slot, Uint256,
 };
 
@@ -90,60 +92,50 @@ pub trait BidStuff {
     fn to_signed_bid(self, signature: BlsSignature) -> SignedBuilderBid;
 }
 
+macro_rules! map_builder_bid {
+    ($self_ident:ident, |$var:ident| $expr:expr) => {
+        match $self_ident {
+            BuilderBid::Bellatrix($var) => $expr,
+            BuilderBid::Capella($var) => $expr,
+            BuilderBid::Deneb($var) => $expr,
+        }
+    };
+}
+
 impl BidStuff for BuilderBid {
     fn fee_recipient_mut(&mut self) -> &mut ExecutionAddress {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.fee_recipient,
-            Self::Capella(bid) => &mut bid.header.fee_recipient,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.fee_recipient)
     }
 
     fn gas_limit_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.gas_limit,
-            Self::Capella(bid) => &mut bid.header.gas_limit,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.gas_limit)
     }
 
     fn value_mut(&mut self) -> &mut U256 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.value,
-            Self::Capella(bid) => &mut bid.value,
-        }
+        map_builder_bid!(self, |bid| &mut bid.value)
     }
 
     fn parent_hash_mut(&mut self) -> &mut Hash32 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.parent_hash,
-            Self::Capella(bid) => &mut bid.header.parent_hash,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.parent_hash)
     }
 
     fn prev_randao_mut(&mut self) -> &mut Hash32 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.prev_randao,
-            Self::Capella(bid) => &mut bid.header.prev_randao,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.prev_randao)
     }
 
     fn block_number_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.block_number,
-            Self::Capella(bid) => &mut bid.header.block_number,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.block_number)
     }
 
     fn timestamp_mut(&mut self) -> &mut u64 {
-        match self {
-            Self::Bellatrix(bid) => &mut bid.header.timestamp,
-            Self::Capella(bid) => &mut bid.header.timestamp,
-        }
+        map_builder_bid!(self, |bid| &mut bid.header.timestamp)
     }
 
     fn withdrawals_root_mut(&mut self) -> Result<&mut Root, MevError> {
         match self {
             Self::Bellatrix(_) => Err(MevError::InvalidFork),
             Self::Capella(bid) => Ok(&mut bid.header.withdrawals_root),
+            Self::Deneb(bid) => Ok(&mut bid.header.withdrawals_root),
         }
     }
 
@@ -152,10 +144,11 @@ impl BidStuff for BuilderBid {
         signing_key: &SecretKey,
         context: &Context,
     ) -> Result<Signature, Error> {
-        match self {
-            Self::Bellatrix(message) => sign_builder_message(message, signing_key, context),
-            Self::Capella(message) => sign_builder_message(message, signing_key, context),
-        }
+        map_builder_bid!(self, |message| sign_builder_message(
+            message,
+            signing_key,
+            context
+        ))
     }
 
     fn to_signed_bid(self, signature: Signature) -> SignedBuilderBid {
@@ -165,6 +158,9 @@ impl BidStuff for BuilderBid {
             }
             Self::Capella(message) => {
                 SignedBuilderBid::Capella(SignedBuilderBidCapella { message, signature })
+            }
+            Self::Deneb(message) => {
+                SignedBuilderBid::Deneb(SignedBuilderBidDeneb { message, signature })
             }
         }
     }
@@ -284,6 +280,10 @@ impl<E: EthSpec> MockBuilder<E> {
             op.apply(bid)?;
         }
         Ok(())
+    }
+
+    pub fn pubkey(&self) -> ethereum_consensus::crypto::PublicKey {
+        self.builder_sk.public_key()
     }
 }
 
@@ -435,7 +435,11 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
             finalized_hash: Some(finalized_execution_hash),
         };
 
-        let payload: ExecutionPayload<E> = self
+        let (payload, _block_value, maybe_blobs_bundle): (
+            ExecutionPayload<E>,
+            Uint256,
+            Option<BlobsBundle<E>>,
+        ) = self
             .el
             .get_full_payload_caching(
                 head_execution_hash,
@@ -455,21 +459,28 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
             ExecutionPayload::Deneb(payload) => ExecutionPayloadHeader::Deneb((&payload).into()),
         };
 
-        let json_payload = serde_json::to_string(&header).map_err(convert_err)?;
         let mut message = match fork {
+            ForkName::Deneb => {
+                let blinded_blobs: BlindedBlobsBundle<E> =
+                    maybe_blobs_bundle.map(Into::into).unwrap_or_default();
+                BuilderBid::Deneb(BuilderBidDeneb {
+                    header: to_ssz_rs(&header)?,
+                    blinded_blobs_bundle: to_ssz_rs(&blinded_blobs)?,
+                    value: to_ssz_rs(&Uint256::from(DEFAULT_BUILDER_PAYLOAD_VALUE_WEI))?,
+                    public_key: self.builder_sk.public_key(),
+                })
+            }
             ForkName::Capella => BuilderBid::Capella(BuilderBidCapella {
-                header: serde_json::from_str(json_payload.as_str()).map_err(convert_err)?,
+                header: to_ssz_rs(&header)?,
                 value: to_ssz_rs(&Uint256::from(DEFAULT_BUILDER_PAYLOAD_VALUE_WEI))?,
                 public_key: self.builder_sk.public_key(),
             }),
             ForkName::Merge => BuilderBid::Bellatrix(BuilderBidBellatrix {
-                header: serde_json::from_str(json_payload.as_str()).map_err(convert_err)?,
+                header: to_ssz_rs(&header)?,
                 value: to_ssz_rs(&Uint256::from(DEFAULT_BUILDER_PAYLOAD_VALUE_WEI))?,
                 public_key: self.builder_sk.public_key(),
             }),
-            ForkName::Base | ForkName::Altair | ForkName::Deneb => {
-                return Err(MevError::InvalidFork)
-            }
+            ForkName::Base | ForkName::Altair => return Err(MevError::InvalidFork),
         };
         *message.gas_limit_mut() = cached_data.gas_limit;
 
@@ -495,6 +506,12 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
             SignedBlindedBeaconBlock::Capella(block) => {
                 block.message.body.execution_payload_header.hash_tree_root()
             }
+            SignedBlindedBeaconBlock::Deneb(block_and_blobs) => block_and_blobs
+                .signed_blinded_block
+                .message
+                .body
+                .execution_payload_header
+                .hash_tree_root(),
         }
         .map_err(convert_err)?;
 
@@ -521,12 +538,12 @@ pub fn to_ssz_rs<T: Encode, U: SimpleSerialize>(ssz_data: &T) -> Result<U, MevEr
     ssz_rs::deserialize::<U>(&ssz_data.as_ssz_bytes()).map_err(convert_err)
 }
 
-fn convert_err<E: Debug>(e: E) -> MevError {
+pub fn convert_err<E: Debug>(e: E) -> MevError {
     custom_err(format!("{e:?}"))
 }
 
 // This is a bit of a hack since the `Custom` variant was removed from `mev_rs::Error`.
-fn custom_err(s: String) -> MevError {
+pub fn custom_err(s: String) -> MevError {
     MevError::Consensus(ethereum_consensus::state_transition::Error::Io(
         std::io::Error::new(std::io::ErrorKind::Other, s),
     ))

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -29,7 +29,10 @@ pub use execution_block_generator::{
     Block, ExecutionBlockGenerator,
 };
 pub use hook::Hook;
-pub use mock_builder::{Context as MockBuilderContext, MockBuilder, Operation, TestingBuilder};
+pub use mock_builder::{
+    convert_err, custom_err, from_ssz_rs, to_ssz_rs, Context as MockBuilderContext, MockBuilder,
+    Operation, TestingBuilder,
+};
 pub use mock_execution_layer::MockExecutionLayer;
 
 pub const DEFAULT_TERMINAL_DIFFICULTY: u64 = 6400;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -4009,6 +4009,20 @@ impl ApiTester {
             )));
 
         let slot = self.chain.slot().unwrap();
+        let propose_state = self
+            .harness
+            .chain
+            .state_at_slot(slot, StateSkipConfig::WithoutStateRoots)
+            .unwrap();
+        let withdrawals = get_expected_withdrawals(&propose_state, &self.chain.spec).unwrap();
+        let withdrawals_root = withdrawals.tree_hash_root();
+        // Set withdrawals root for builder
+        self.mock_builder
+            .as_ref()
+            .unwrap()
+            .builder
+            .add_operation(Operation::WithdrawalsRoot(withdrawals_root));
+
         let epoch = self.chain.epoch().unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -17,6 +17,7 @@ use lighthouse_network::{NetworkGlobals, Request};
 use slot_clock::{ManualSlotClock, SlotClock, TestingSlotClock};
 use store::MemoryStore;
 use tokio::sync::mpsc;
+use types::beacon_block_body::to_block_kzg_commitments;
 use types::{
     map_fork_name, map_fork_name_with,
     test_utils::{SeedableRng, TestRandom, XorShiftRng},
@@ -123,7 +124,8 @@ impl TestRig {
             for tx in Vec::from(transactions) {
                 payload.execution_payload.transactions.push(tx).unwrap();
             }
-            message.body.blob_kzg_commitments = bundle.commitments.clone();
+            message.body.blob_kzg_commitments =
+                to_block_kzg_commitments::<E>(bundle.commitments.clone());
 
             let BlobsBundle {
                 commitments,

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -833,17 +833,16 @@ impl BeaconNodeHttpClient {
     }
 
     /// `POST v2/beacon/blinded_blocks`
-    //TODO(sean) update this along with builder updates
-    pub async fn post_beacon_blinded_blocks_v2<T: EthSpec>(
+    pub async fn post_beacon_blinded_blocks_v2<T: EthSpec, Payload: AbstractExecPayload<T>>(
         &self,
-        block: &SignedBlindedBeaconBlock<T>,
+        block_contents: &SignedBlockContents<T, Payload>,
         validation_level: Option<BroadcastValidation>,
     ) -> Result<(), Error> {
         self.post_generic_with_consensus_version(
             self.post_beacon_blinded_blocks_v2_path(validation_level)?,
-            block,
+            block_contents,
             Some(self.timeouts.proposal),
-            block.message().body().fork_name(),
+            block_contents.signed_block().message().body().fork_name(),
         )
         .await?;
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1415,9 +1415,21 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> ForkVersionDeserialize
                     D,
                 >(value, fork_name)?))
             }
-            ForkName::Deneb => Ok(BlockContents::BlockAndBlobSidecars(
-                BeaconBlockAndBlobSidecars::deserialize_by_fork::<'de, D>(value, fork_name)?,
-            )),
+            ForkName::Deneb => {
+                let block_contents = match Payload::block_type() {
+                    BlockType::Blinded => BlockContents::BlindedBlockAndBlobSidecars(
+                        BlindedBeaconBlockAndBlobSidecars::deserialize_by_fork::<'de, D>(
+                            value, fork_name,
+                        )?,
+                    ),
+                    BlockType::Full => BlockContents::BlockAndBlobSidecars(
+                        BeaconBlockAndBlobSidecars::deserialize_by_fork::<'de, D>(
+                            value, fork_name,
+                        )?,
+                    ),
+                };
+                Ok(block_contents)
+            }
         }
     }
 }

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -9,8 +9,21 @@ use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-pub type KzgCommitments<T> =
+pub type KzgCommitments<T> = VariableList<KzgCommitment, <T as EthSpec>::MaxBlobsPerBlock>;
+pub type BlockBodyKzgCommitments<T> =
     VariableList<KzgCommitment, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
+
+pub fn to_block_kzg_commitments<E: EthSpec>(
+    commitments: KzgCommitments<E>,
+) -> BlockBodyKzgCommitments<E> {
+    commitments.to_vec().into()
+}
+
+pub fn from_block_kzg_commitments<E: EthSpec>(
+    commitments: &BlockBodyKzgCommitments<E>,
+) -> KzgCommitments<E> {
+    commitments.to_vec().into()
+}
 
 /// The body of a `BeaconChain` block, containing operations.
 ///
@@ -72,7 +85,7 @@ pub struct BeaconBlockBody<T: EthSpec, Payload: AbstractExecPayload<T> = FullPay
     pub bls_to_execution_changes:
         VariableList<SignedBlsToExecutionChange, T::MaxBlsToExecutionChanges>,
     #[superstruct(only(Deneb))]
-    pub blob_kzg_commitments: KzgCommitments<T>,
+    pub blob_kzg_commitments: BlockBodyKzgCommitments<T>,
     #[superstruct(only(Base, Altair))]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -84,11 +84,14 @@ impl<T: EthSpec> BlobItems<T> for BlobRootsList<T> {
         Ok(roots)
     }
 
-    fn try_from_blobs(_blobs: BlobsList<T>) -> Result<Self, String> {
-        // It is possible to convert from blobs to blob roots, however this should be done using
-        // `From` or `Into` instead of this generic implementation; this function implementation
-        // should be unreachable, and attempt to use this indicates a bug somewhere.
-        Err("Unexpected conversion from blob to blob roots".to_string())
+    fn try_from_blobs(blobs: BlobsList<T>) -> Result<Self, String> {
+        VariableList::new(
+            blobs
+                .into_iter()
+                .map(|blob| blob.tree_hash_root())
+                .collect(),
+        )
+        .map_err(|e| format!("{e:?}"))
     }
 
     fn len(&self) -> usize {

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -216,6 +216,21 @@ impl<E: EthSpec> From<Arc<BlobSidecar<E>>> for BlindedBlobSidecar {
     }
 }
 
+impl<E: EthSpec> From<BlobSidecar<E>> for BlindedBlobSidecar {
+    fn from(blob_sidecar: BlobSidecar<E>) -> Self {
+        BlindedBlobSidecar {
+            block_root: blob_sidecar.block_root,
+            index: blob_sidecar.index,
+            slot: blob_sidecar.slot,
+            block_parent_root: blob_sidecar.block_parent_root,
+            proposer_index: blob_sidecar.proposer_index,
+            blob_root: blob_sidecar.blob.tree_hash_root(),
+            kzg_commitment: blob_sidecar.kzg_commitment,
+            kzg_proof: blob_sidecar.kzg_proof,
+        }
+    }
+}
+
 impl<T: EthSpec> PartialOrd for BlobSidecar<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.index.partial_cmp(&other.index)

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -1,22 +1,39 @@
 use crate::beacon_block_body::KzgCommitments;
 use crate::{
-    BlobRootsList, ChainSpec, EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
-    ExecutionPayloadHeaderMerge, ExecutionPayloadHeaderRef, ForkName, ForkVersionDeserialize,
-    KzgProofs, SignedRoot, Uint256,
+    BlobRootsList, BlobsBundle, ChainSpec, EthSpec, ExecutionPayloadHeaderCapella,
+    ExecutionPayloadHeaderDeneb, ExecutionPayloadHeaderMerge, ExecutionPayloadHeaderRef, ForkName,
+    ForkVersionDeserialize, KzgProofs, SignedRoot, Uint256,
 };
 use bls::PublicKeyBytes;
 use bls::Signature;
 use serde::Deserializer;
 use serde_derive::{Deserialize, Serialize};
+use ssz_derive::Encode;
 use superstruct::superstruct;
+use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 
-#[derive(PartialEq, Debug, Serialize, Deserialize, TreeHash, Clone)]
+#[derive(PartialEq, Debug, Default, Serialize, Deserialize, TreeHash, Clone, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlindedBlobsBundle<E: EthSpec> {
     pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
     pub blob_roots: BlobRootsList<E>,
+}
+
+impl<E: EthSpec> From<BlobsBundle<E>> for BlindedBlobsBundle<E> {
+    fn from(blobs_bundle: BlobsBundle<E>) -> Self {
+        BlindedBlobsBundle {
+            commitments: blobs_bundle.commitments,
+            proofs: blobs_bundle.proofs,
+            blob_roots: blobs_bundle
+                .blobs
+                .into_iter()
+                .map(|blob| blob.tree_hash_root())
+                .collect::<Vec<_>>()
+                .into(),
+        }
+    }
 }
 
 #[superstruct(

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -972,9 +972,10 @@ impl<T: EthSpec> From<BlindedPayload<T>> for ExecutionPayloadHeader<T> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(untagged)]
 #[serde(bound = "E: EthSpec")]
+#[ssz(enum_behaviour = "transparent")]
 pub enum FullPayloadContents<E: EthSpec> {
     Payload(ExecutionPayload<E>),
     PayloadAndBlobs(ExecutionPayloadAndBlobs<E>),
@@ -1037,14 +1038,14 @@ impl<E: EthSpec> ForkVersionDeserialize for FullPayloadContents<E> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
     pub execution_payload: ExecutionPayload<E>,
     pub blobs_bundle: BlobsBundle<E>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlobsBundle<E: EthSpec> {
     pub commitments: KzgCommitments<E>,

--- a/consensus/types/src/signed_blob.rs
+++ b/consensus/types/src/signed_blob.rs
@@ -59,13 +59,6 @@ impl<T: EthSpec> SignedSidecar<T, BlindedBlobSidecar> {
     }
 }
 
-/// List of Signed Sidecars that implements `Sidecar`.
-pub type SignedSidecarList<T, Sidecar> =
-    VariableList<SignedSidecar<T, Sidecar>, <T as EthSpec>::MaxBlobsPerBlock>;
-pub type SignedBlobSidecarList<T> = SignedSidecarList<T, BlobSidecar<T>>;
-
-pub type SignedBlobSidecar<T> = SignedSidecar<T, BlobSidecar<T>>;
-
 impl<T: EthSpec> SignedBlobSidecar<T> {
     /// Verify `self.signature`.
     ///
@@ -99,3 +92,21 @@ impl<T: EthSpec> SignedBlobSidecar<T> {
         self.signature.verify(pubkey, message)
     }
 }
+
+impl<T: EthSpec> From<SignedBlobSidecar<T>> for SignedBlindedBlobSidecar<T> {
+    fn from(signed: SignedBlobSidecar<T>) -> Self {
+        SignedBlindedBlobSidecar {
+            message: Arc::new(signed.message.into()),
+            signature: signed.signature,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub type SignedBlobSidecar<T> = SignedSidecar<T, BlobSidecar<T>>;
+pub type SignedBlindedBlobSidecar<T> = SignedSidecar<T, BlindedBlobSidecar>;
+
+/// List of Signed Sidecars that implements `Sidecar`.
+pub type SignedSidecarList<T, Sidecar> =
+    VariableList<SignedSidecar<T, Sidecar>, <T as EthSpec>::MaxBlobsPerBlock>;
+pub type SignedBlobSidecarList<T> = SignedSidecarList<T, BlobSidecar<T>>;

--- a/scripts/local_testnet/genesis.json
+++ b/scripts/local_testnet/genesis.json
@@ -13,7 +13,7 @@
     "londonBlock": 0,
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 0,
-    "shardingForkTime": 0,
+    "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true
   },

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -110,7 +110,7 @@ echo $CAPELLA_TIME
 sed -i 's/"shanghaiTime".*$/"shanghaiTime": '"$CAPELLA_TIME"',/g' $genesis_file
 CANCUN_TIME=$((GENESIS_TIME + (DENEB_FORK_EPOCH * 32 * SECONDS_PER_SLOT)))
 echo $CANCUN_TIME
-sed -i 's/"shardingForkTime".*$/"shardingForkTime": '"$CANCUN_TIME"',/g' $genesis_file
+sed -i 's/"cancunTime".*$/"cancunTime": '"$CANCUN_TIME"',/g' $genesis_file
 cat $genesis_file
 
 # Delay to let boot_enr.yaml to be created
@@ -141,7 +141,7 @@ sleeping 20
 
 # Reset the `genesis.json` config file fork times.
 sed -i 's/"shanghaiTime".*$/"shanghaiTime": 0,/g' $genesis_file
-sed -i 's/"shardingForkTime".*$/"shardingForkTime": 0,/g' $genesis_file
+sed -i 's/"cancunTime".*$/"cancunTime": 0,/g' $genesis_file
 
 for (( bn=1; bn<=$BN_COUNT; bn++ )); do
     secret=$DATADIR/geth_datadir$bn/geth/jwtsecret

--- a/scripts/tests/genesis.json
+++ b/scripts/tests/genesis.json
@@ -13,7 +13,7 @@
     "londonBlock": 0,
     "mergeForkBlock": 0,
     "shanghaiTime": 0,
-    "shardingForkTime": 0,
+    "cancunTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true
   },

--- a/scripts/tests/genesis.json
+++ b/scripts/tests/genesis.json
@@ -13,7 +13,7 @@
     "londonBlock": 0,
     "mergeForkBlock": 0,
     "shanghaiTime": 0,
-    "cancunTime": 0,
+    "shardingForkTime": 0,
     "terminalTotalDifficulty": 0,
     "terminalTotalDifficultyPassed": true
   },


### PR DESCRIPTION
## Changes

- Add a Deneb builder flow http test, which revealed a couple of issues (see below), now we have a working happy path \o/. I'll look into adding more testes. 
- Fix an issue with builder bid signature mismatch. It turned out that the tree hash changes based on the variable list max size. So I had to use a different type alias for `KzgCommitments` in BlobsBundle, as the `KzgCommitments` in `BlockBody` has a different max size:
https://github.com/sigp/lighthouse/blob/66be8c260ccef6eab5dd1ee63fd0b5b64404cc16/consensus/types/src/beacon_block_body.rs#L12-L14
- Add [missing deserialization logic](https://github.com/sigp/lighthouse/pull/4607/files#diff-d43db73dcaf47e9e087bdc0d1f9c6d8db76ac6843d47d1e555b386493b550a52R1418-R1432) for blinded block contents
- Update `mock-builder` to support Deneb types from updated `mev-rs` and `ethereum-consensus` libs
- Update `shardingForkTime` to `cancunTime` in local testnet scripts

## Additional Info

- I had to make some adjustments when running the deneb builder test in debug mode:
  - Use `RUST_MIN_STACK=8388608`: 4mb thread stack limit wasnt enough, looks like we really need to get @ethDreamer's [eliminate blob clone PR](https://github.com/sigp/lighthouse/pull/4593) in.
  - Increase `get_header` timeout: 1 second timeout wasn't enough when running in debug - I think we might even want to override this in tests via env vars, as it's likely that mock builder requires more time to return a response. 
- There is a [separate branch](https://github.com/jimmygchen/lighthouse/pull/8) I use for testing with `mock-relay` that contains expected withdrawals changes cherry-picked from #4390. I've excluded it from this PR as expected withdrawals endpoint change is still under review.