### PR TITLE
add `BeaconState.get_beacon_committee_length`

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1694,10 +1694,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // required to attest is available on the head state.
                 Some((
                     head_state.current_justified_checkpoint(),
-                    head_state
-                        .get_beacon_committee(request_slot, request_index)?
-                        .committee
-                        .len(),
+                    head_state.get_beacon_committee_size(request_slot, request_index)?,
                 ))
             } else {
                 // If the head state is in a *different* epoch to the request, more work is required

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -571,6 +571,23 @@ impl<T: EthSpec> BeaconState<T> {
         Ok(cache.shuffling())
     }
 
+    /// Get the Beacon committee size at the given slot and index.
+    ///
+    /// Utilises the committee cache.
+    pub fn get_beacon_committee_size(
+        &self,
+        slot: Slot,
+        index: CommitteeIndex,
+    ) -> Result<usize, Error> {
+        let epoch = slot.epoch(T::slots_per_epoch());
+        let relative_epoch = RelativeEpoch::from_epoch(self.current_epoch(), epoch)?;
+        let cache = self.committee_cache(relative_epoch)?;
+
+        cache
+            .get_beacon_committee_size(slot, index)
+            .ok_or(Error::NoCommittee { slot, index })
+    }
+
     /// Get the Beacon committee at the given slot and index.
     ///
     /// Utilises the committee cache.


### PR DESCRIPTION
For [`current_epoch_attesting_info`](https://github.com/sigp/lighthouse/blob/dfcb3363c757671eb19d5f8e519b4b94ac74677a/beacon_node/beacon_chain/src/beacon_chain.rs#L1666), only committee size is necessary.