### PR TITLE
[Merged by Bors] - remove `optional_eth2_network_config`

### DIFF
--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -344,18 +344,6 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
         Ok(self)
     }
 
-    /// Optionally adds a network configuration to the environment.
-    pub fn optional_eth2_network_config(
-        self,
-        optional_config: Option<Eth2NetworkConfig>,
-    ) -> Result<Self, String> {
-        if let Some(config) = optional_config {
-            self.eth2_network_config(config)
-        } else {
-            Ok(self)
-        }
-    }
-
     /// Consumes the builder, returning an `Environment`.
     pub fn build(self) -> Result<Environment<E>, String> {
         let (signal, exit) = exit_future::signal();

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -513,7 +513,7 @@ fn run<E: EthSpec>(
 
     let mut environment = builder
         .multi_threaded_tokio_runtime()?
-        .optional_eth2_network_config(Some(eth2_network_config))?
+        .eth2_network_config(eth2_network_config)?
         .build()?;
 
     let log = environment.core_context().log().clone();


### PR DESCRIPTION
It seems the passed [`optional_config`](https://github.com/sigp/lighthouse/blob/dfcb3363c757671eb19d5f8e519b4b94ac74677a/lighthouse/src/main.rs#L515) is always `Some` instead of `None`.