### PR TITLE
[Merged by Bors] - Revive mplex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,6 +4120,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-mplex"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93959ed08b6caf9810e067655e25f1362098797fef7c44d3103e63dcb6f0fabe"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.1",
+ "rand 0.8.5",
+ "smallvec 1.11.0",
+ "unsigned-varint 0.7.1",
+]
+
+[[package]]
 name = "libp2p-noise"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4384,6 +4403,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libp2p",
+ "libp2p-mplex",
  "lighthouse_metrics",
  "lighthouse_version",
  "lru 0.7.8",

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -44,6 +44,7 @@ prometheus-client = "0.21.0"
 unused_port = { path = "../../common/unused_port" }
 delay_map = "0.3.0"
 void = "1"
+libp2p-mplex = "0.40.0"
 
 [dependencies.libp2p]
 version = "0.52"

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -50,13 +50,21 @@ pub fn build_transport(
         transport.or_transport(libp2p::websocket::WsConfig::new(trans_clone))
     };
 
+    // mplex config
+    let mut mplex_config = libp2p_mplex::MplexConfig::new();
+    mplex_config.set_max_buffer_size(256);
+    mplex_config.set_max_buffer_behaviour(libp2p_mplex::MaxBufferBehaviour::Block);
+
     // yamux config
     let mut yamux_config = yamux::Config::default();
     yamux_config.set_window_update_mode(yamux::WindowUpdateMode::on_read());
     let (transport, bandwidth) = transport
         .upgrade(core::upgrade::Version::V1)
         .authenticate(generate_noise_config(&local_private_key))
-        .multiplex(yamux_config)
+        .multiplex(core::upgrade::SelectUpgrade::new(
+            yamux_config,
+            mplex_config,
+        ))
         .timeout(Duration::from_secs(10))
         .boxed()
         .with_bandwidth_logging();


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

In #4431 , we seem to have removed support for mplex as it is being deprecated in libp2p. See https://github.com/libp2p/specs/issues/553 . Related rust-libp2p PR https://github.com/libp2p/rust-libp2p/pull/3920
However, since this isn't part of the official [consensus specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/p2p-interface.md#multiplexing), we still need to support mplex. 

> Clients MUST support [mplex](https://github.com/libp2p/specs/tree/master/mplex) and MAY support [yamux](https://github.com/hashicorp/yamux/blob/master/spec.md).

This PR adds back mplex support as before.