### PR TITLE
Use kzg_rust library for minimal kzg requirements

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -327,15 +327,14 @@ jobs:
       run: rustup update stable
     - name: Run cargo audit to identify known security vulnerabilities reported to the RustSec Advisory Database
       run:  make audit
-# TODO(sean): re-enable this when we can figure it out with c-kzg
-#  cargo-vendor:
-#    name: cargo-vendor
-#    runs-on: ubuntu-latest
-#    needs: cargo-fmt
-#    steps:
-#    - uses: actions/checkout@v3
-#    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
-#      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
+ cargo-vendor:
+   name: cargo-vendor
+   runs-on: ubuntu-latest
+   needs: cargo-fmt
+   steps:
+   - uses: actions/checkout@v3
+   - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
+     run:  CARGO_HOME=$(readlink -f $HOME) make vendor
   cargo-udeps:
     name: cargo-udeps
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "8c6f84b74db2535ebae81eede2f39b947dcbf01d093ae5f791e5dd414a1bf289"
 
 [[package]]
 name = "arbitrary"
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener",
 ]
@@ -277,7 +277,7 @@ checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
 dependencies = [
  "async-stream-impl",
  "futures-core",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -323,7 +323,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -378,9 +378,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -395,7 +395,7 @@ dependencies = [
  "memchr",
  "mime",
  "percent-encoding",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "rustversion",
  "serde",
  "serde_json",
@@ -675,9 +675,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -742,7 +742,7 @@ name = "bls"
 version = "0.2.0"
 dependencies = [
  "arbitrary",
- "blst 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blst",
  "ethereum-types 0.14.1",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -761,17 +761,6 @@ name = "blst"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
-dependencies = [
- "cc",
- "glob",
- "threadpool",
- "zeroize",
-]
-
-[[package]]
-name = "blst"
-version = "0.3.11"
-source = "git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2#efe2990b3df511d182bf91c2164ccaff15b1e7a2"
 dependencies = [
  "cc",
  "glob",
@@ -969,9 +958,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -1117,7 +1109,7 @@ dependencies = [
  "state_processing",
  "store",
  "task_executor",
- "time 0.3.24",
+ "time 0.3.25",
  "timer",
  "tokio",
  "types",
@@ -1158,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
 
 [[package]]
 name = "convert_case"
@@ -1405,17 +1397,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.0.0-rc.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d4ba9852b42210c7538b75484f9daa0655e9a3ac04f693747bb0f02cf3cfe16"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
 dependencies = [
  "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "packed_simd_2",
  "platforms 3.0.2",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1559,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1570,9 +1575,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
 
 [[package]]
 name = "derivative"
@@ -1615,7 +1620,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7a532c1f99a0f596f6960a60d1e119e91582b24b39e2d83a190e61262c3ef0c"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "byteorder",
  "diesel_derives",
  "itoa",
@@ -1789,7 +1794,7 @@ version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "digest 0.10.7",
  "elliptic-curve 0.13.5",
  "rfc6979 0.4.0",
@@ -1808,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
 dependencies = [
  "pkcs8 0.10.2",
  "signature 2.1.0",
@@ -1832,12 +1837,12 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.0.0-pre.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd577ba9d4bcab443cac60003d8fd32c638e7024a3ec92c200d7af5d2c397ed"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
 dependencies = [
- "curve25519-dalek 4.0.0-rc.1",
- "ed25519 2.2.1",
+ "curve25519-dalek 4.0.0",
+ "ed25519 2.2.2",
  "rand_core 0.6.4",
  "serde",
  "sha2 0.10.7",
@@ -1961,7 +1966,7 @@ checksum = "0be7b2ac146c1f99fe245c02d16af0696450d8e06c135db75e10eeb9e642c20d"
 dependencies = [
  "base64 0.21.2",
  "bytes",
- "ed25519-dalek 2.0.0-pre.0",
+ "ed25519-dalek 2.0.0",
  "hex",
  "k256 0.13.1",
  "log",
@@ -2038,9 +2043,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94c0e13118e7d7533271f754a168ae8400e6a1cc043f2bfd53cc7290f1a1de3"
+checksum = "da96524cc884f6558f1769b6c46686af2fe8e8b4cd253bd5a3cdba8181b8e070"
 dependencies = [
  "serde",
 ]
@@ -2317,7 +2322,7 @@ version = "0.1.1"
 source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=e380108#e380108d15fcc40349927fdf3d11c71f9edb67c2"
 dependencies = [
  "async-stream",
- "blst 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blst",
  "bs58 0.4.0",
  "enr 0.6.2",
  "hex",
@@ -2743,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "libz-sys",
@@ -2879,7 +2884,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "waker-fn",
 ]
 
@@ -2947,7 +2952,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "pin-utils",
  "slab",
 ]
@@ -3326,7 +3331,7 @@ checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
 ]
 
 [[package]]
@@ -3406,9 +3411,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -3432,7 +3437,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "socket2 0.4.9",
  "tokio",
  "tower-service",
@@ -3449,7 +3454,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3857,9 +3862,9 @@ dependencies = [
 [[package]]
 name = "kzg_rust"
 version = "0.1.0"
-source = "git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2#efe2990b3df511d182bf91c2164ccaff15b1e7a2"
+source = "git+https://github.com/pawanjay176/kzg_rust?rev=0ba90fd6105c0429e611700ff218a6da7299370c#0ba90fd6105c0429e611700ff218a6da7299370c"
 dependencies = [
- "blst 0.3.11 (git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2)",
+ "blst",
  "hex",
  "serde",
  "serde_json",
@@ -3980,12 +3985,6 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
-
-[[package]]
-name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
@@ -4007,9 +4006,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.52.1"
+version = "0.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38039ba2df4f3255842050845daef4a004cc1f26da03dbc645535088b51910ef"
+checksum = "ca4894076bfa3051e4f1725747308861af1e6641213640aeeb784f583e40e7d9"
 dependencies = [
  "bytes",
  "futures",
@@ -4104,9 +4103,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e378da62e8c9251f6e885ed173a561663f29b251e745586cf6ae6150b295c37"
+checksum = "2d157562dba6017193e5285acf6b1054759e83540bfd79f75b69d6ce774c88da"
 dependencies = [
  "asynchronous-codec",
  "base64 0.21.2",
@@ -4201,9 +4200,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-metrics"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3787ea81798dcc5bf1d8b40a8e8245cf894b168d04dd70aa48cb3ff2fff141d2"
+checksum = "239ba7d28f8d0b5d77760dc6619c05c7e88e74ec8fbbe97f856f20a56745e620"
 dependencies = [
  "instant",
  "libp2p-core",
@@ -4258,9 +4257,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.43.2"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43106820057e0f65c77b01a3873593f66e676da4e40c70c3a809b239109f1d30"
+checksum = "28016944851bd73526d3c146aabf0fa9bbe27c558f080f9e5447da3a1772c01a"
 dependencies = [
  "either",
  "fnv",
@@ -4331,9 +4330,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.44.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a9b42ab6de15c6f076d8fb11dc5f48d899a10b55a2e16b12be9012a05287b0"
+checksum = "8eedcb62824c4300efb9cfd4e2a6edaf3ca097b9e68b36dabe45a44469fd6a85"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4583,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logging"
@@ -4689,9 +4688,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67827e6ea8ee8a7c4a72227ef4fc08957040acffdb5f122733b24fa12daff41b"
+checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
 
 [[package]]
 name = "maybe-uninit"
@@ -5274,7 +5273,7 @@ dependencies = [
  "autocfg 0.1.8",
  "byteorder",
  "lazy_static",
- "libm 0.2.7",
+ "libm",
  "num-integer",
  "num-iter",
  "num-traits",
@@ -5394,9 +5393,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -5426,18 +5425,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
@@ -5486,16 +5485,6 @@ dependencies = [
  "elliptic-curve 0.13.5",
  "primeorder",
  "sha2 0.10.7",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
-dependencies = [
- "cfg-if",
- "libm 0.1.4",
 ]
 
 [[package]]
@@ -5688,18 +5677,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5714,9 +5703,9 @@ checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -5740,7 +5729,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.7",
+ "der 0.7.8",
  "spki 0.7.2",
 ]
 
@@ -5802,7 +5791,7 @@ dependencies = [
  "concurrent-queue",
  "libc",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "windows-sys",
 ]
 
@@ -6018,13 +6007,13 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b6a5217beb0ad503ee7fa752d451c905113d70721b937126158f3106a48cc1"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -6303,13 +6292,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.4",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -6324,9 +6313,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6369,8 +6358,8 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding",
- "pin-project-lite 0.2.10",
- "rustls 0.21.5",
+ "pin-project-lite 0.2.12",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6553,11 +6542,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.5",
@@ -6591,13 +6580,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.2",
+ "rustls-webpki 0.101.3",
  "sct 0.7.0",
 ]
 
@@ -6622,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.2"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -6788,7 +6777,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.7",
+ "der 0.7.8",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -6858,9 +6847,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -6898,9 +6887,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6909,9 +6898,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -7128,7 +7117,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -7263,7 +7252,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -7308,7 +7297,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.24",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -7368,14 +7357,14 @@ checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
 name = "snow"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccba027ba85743e09d15c03296797cad56395089b832b48b5a5217880f57733"
+checksum = "0c9d1425eb528a21de2755c75af4c9b5d57f50a0d4c3b7f1828a4cd03f8ba155"
 dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek 4.0.0-rc.1",
+ "curve25519-dalek 4.0.0",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.0",
@@ -7441,7 +7430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.7",
+ "der 0.7.8",
 ]
 
 [[package]]
@@ -7773,14 +7762,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.8",
  "windows-sys",
 ]
 
@@ -7848,18 +7837,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7898,9 +7887,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa",
@@ -7992,20 +7981,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg 1.1.0",
  "backtrace",
  "bytes",
  "libc",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]
@@ -8016,7 +8004,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
 ]
 
@@ -8057,7 +8045,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "percent-encoding",
  "phf",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "postgres-protocol",
  "postgres-types",
  "socket2 0.5.3",
@@ -8093,7 +8081,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -8104,7 +8092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tokio-util 0.7.8",
 ]
@@ -8149,7 +8137,7 @@ dependencies = [
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "slab",
  "tokio",
 ]
@@ -8163,7 +8151,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "slab",
  "tokio",
  "tracing",
@@ -8221,7 +8209,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -8248,7 +8236,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
- "pin-project-lite 0.2.10",
+ "pin-project-lite 0.2.12",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -9185,24 +9173,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
+ "windows_aarch64_msvc 0.48.2",
+ "windows_i686_gnu 0.48.2",
+ "windows_i686_msvc 0.48.2",
+ "windows_x86_64_gnu 0.48.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.48.0",
+ "windows_x86_64_msvc 0.48.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9212,9 +9200,9 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9224,9 +9212,9 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9236,9 +9224,9 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9248,15 +9236,15 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9266,15 +9254,15 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "winnow"
-version = "0.5.3"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]
@@ -9369,14 +9357,15 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.10.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d9ba232399af1783a58d8eb26f6b5006fbefe2dc9ef36bd283324792d03ea5"
+checksum = "0329ef377816896f014435162bb3711ea7a07729c23d0960e6f8048b21b8fe91"
 dependencies = [
  "futures",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
+ "pin-project",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2223,7 +2223,6 @@ dependencies = [
  "discv5",
  "eth2_config",
  "ethereum_ssz",
- "kzg",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,14 +758,13 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a30d0edd9dd1c60ddb42b80341c7852f6f985279a5c1a83659dcb65899dec99"
+checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
 dependencies = [
  "cc",
  "glob",
  "threadpool",
- "which",
  "zeroize",
 ]
 
@@ -889,19 +888,6 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "c-kzg"
-version = "0.1.0"
-source = "git+https://github.com/ethereum//c-kzg-4844?rev=13cec820c08f45318f82ed4e0da0300042758b92#13cec820c08f45318f82ed4e0da0300042758b92"
-dependencies = [
- "bindgen 0.64.0",
- "cc",
- "glob",
- "hex",
- "libc",
- "serde",
 ]
 
 [[package]]
@@ -3844,17 +3830,28 @@ name = "kzg"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "c-kzg 0.1.0 (git+https://github.com/ethereum//c-kzg-4844?rev=13cec820c08f45318f82ed4e0da0300042758b92)",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=13cec820c08f45318f82ed4e0da0300042758b92)",
+ "c-kzg",
  "derivative",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
+ "kzg_rust",
  "serde",
  "serde_derive",
  "tree_hash",
+]
+
+[[package]]
+name = "kzg_rust"
+version = "0.1.0"
+source = "git+https://github.com/pawanjay176/kzg_rust?rev=5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c#5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c"
+dependencies = [
+ "blst",
+ "hex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ name = "bls"
 version = "0.2.0"
 dependencies = [
  "arbitrary",
- "blst",
+ "blst 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethereum-types 0.14.1",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -761,6 +761,17 @@ name = "blst"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c94087b935a822949d3291a9989ad2b2051ea141eda0fd4e478a75f6aa3e604b"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+ "zeroize",
+]
+
+[[package]]
+name = "blst"
+version = "0.3.11"
+source = "git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2#efe2990b3df511d182bf91c2164ccaff15b1e7a2"
 dependencies = [
  "cc",
  "glob",
@@ -2306,7 +2317,7 @@ version = "0.1.1"
 source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=e380108#e380108d15fcc40349927fdf3d11c71f9edb67c2"
 dependencies = [
  "async-stream",
- "blst",
+ "blst 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.4.0",
  "enr 0.6.2",
  "hex",
@@ -3846,9 +3857,9 @@ dependencies = [
 [[package]]
 name = "kzg_rust"
 version = "0.1.0"
-source = "git+https://github.com/pawanjay176/kzg_rust?rev=5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c#5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c"
+source = "git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2#efe2990b3df511d182bf91c2164ccaff15b1e7a2"
 dependencies = [
- "blst",
+ "blst 0.3.11 (git+https://github.com/pawanjay176/kzg_rust?rev=efe2990b3df511d182bf91c2164ccaff15b1e7a2)",
  "hex",
  "serde",
  "serde_json",

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -81,7 +81,7 @@ pub use events::ServerSentEventHandler;
 pub use execution_layer::EngineState;
 pub use execution_payload::NotifyExecutionLayer;
 pub use fork_choice::{ExecutionStatus, ForkchoiceUpdateParameters};
-pub use kzg::TrustedSetup;
+pub use kzg::{TrustedSetup, get_trusted_setup_from_id, KzgPresetId};
 pub use metrics::scrape_for_metrics;
 pub use migrate::MigratorConfig;
 pub use parking_lot;

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -522,7 +522,7 @@ where
             .expect("cannot build without validator keypairs");
         let chain_config = self.chain_config.unwrap_or_default();
         let trusted_setup: TrustedSetup =
-            serde_json::from_reader(eth2_network_config::get_trusted_setup::<E::Kzg>())
+            serde_json::from_reader(kzg::get_trusted_setup::<E::Kzg>())
                 .map_err(|e| format!("Unable to read trusted setup file: {}", e))
                 .unwrap();
 
@@ -602,7 +602,7 @@ pub fn mock_execution_layer_from_parts<T: EthSpec>(
     });
 
     let trusted_setup: TrustedSetup =
-        serde_json::from_reader(eth2_network_config::get_trusted_setup::<T::Kzg>())
+        serde_json::from_reader(kzg::get_trusted_setup::<T::Kzg>())
             .map_err(|e| format!("Unable to read trusted setup file: {}", e))
             .expect("should have trusted setup");
     let kzg = Kzg::new_from_trusted_setup(trusted_setup).expect("should create kzg");

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -377,10 +377,10 @@ pub fn get_config<E: EthSpec>(
     }
 
     // 4844 params
-    client_config.trusted_setup = context
-        .eth2_network_config
-        .as_ref()
-        .and_then(|config| config.kzg_trusted_setup.clone());
+    let trusted_setup_bytes = beacon_chain::get_trusted_setup_from_id(
+        beacon_chain::KzgPresetId::from_str(&E::spec_name().to_string())?,
+    );
+    client_config.trusted_setup = serde_json::from_reader(trusted_setup_bytes).unwrap();
 
     // Override default trusted setup file if required
     // TODO: consider removing this when we get closer to launch

--- a/common/eth2_network_config/Cargo.toml
+++ b/common/eth2_network_config/Cargo.toml
@@ -17,7 +17,6 @@ tempfile = "3.1.0"
 serde_yaml = "0.8.13"
 serde_json = "1.0.58"
 types = { path = "../../consensus/types"}
-kzg = { path = "../../crypto/kzg" }
 ethereum_ssz = "0.5.0"
 eth2_config = { path = "../eth2_config"}
 discv5 = "0.3.1"

--- a/common/eth2_network_config/src/lib.rs
+++ b/common/eth2_network_config/src/lib.rs
@@ -13,7 +13,7 @@
 
 use discv5::enr::{CombinedKey, Enr};
 use eth2_config::{instantiate_hardcoded_nets, HardcodedNet};
-use kzg::{KzgPreset, KzgPresetId, TrustedSetup};
+// use kzg::{KzgPreset, KzgPresetId, TrustedSetup};
 use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -39,25 +39,25 @@ pub const DEFAULT_HARDCODED_NETWORK: &str = "mainnet";
 ///
 /// This is done to ensure that testnets also inherit the high security and
 /// randomness of the mainnet kzg trusted setup ceremony.
-const TRUSTED_SETUP: &[u8] =
+pub const TRUSTED_SETUP: &[u8] =
     include_bytes!("../built_in_network_configs/testing_trusted_setups.json");
 
-const TRUSTED_SETUP_MINIMAL: &[u8] =
+pub const TRUSTED_SETUP_MINIMAL: &[u8] =
     include_bytes!("../built_in_network_configs/minimal_testing_trusted_setups.json");
 
-pub fn get_trusted_setup<P: KzgPreset>() -> &'static [u8] {
-    match P::spec_name() {
-        KzgPresetId::Mainnet => TRUSTED_SETUP,
-        KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
-    }
-}
+// pub fn get_trusted_setup<P: KzgPreset>() -> &'static [u8] {
+//     match P::spec_name() {
+//         KzgPresetId::Mainnet => TRUSTED_SETUP,
+//         KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
+//     }
+// }
 
-pub fn get_trusted_setup_from_id(id: KzgPresetId) -> &'static [u8] {
-    match id {
-        KzgPresetId::Mainnet => TRUSTED_SETUP,
-        KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
-    }
-}
+// pub fn get_trusted_setup_from_id(id: KzgPresetId) -> &'static [u8] {
+//     match id {
+//         KzgPresetId::Mainnet => TRUSTED_SETUP,
+//         KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
+//     }
+// }
 
 /// Specifies an Eth2 network.
 ///
@@ -70,7 +70,7 @@ pub struct Eth2NetworkConfig {
     pub boot_enr: Option<Vec<Enr<CombinedKey>>>,
     pub genesis_state_bytes: Option<Vec<u8>>,
     pub config: Config,
-    pub kzg_trusted_setup: Option<TrustedSetup>,
+    // pub kzg_trusted_setup: Option<TrustedSetup>,
 }
 
 impl Eth2NetworkConfig {
@@ -88,20 +88,20 @@ impl Eth2NetworkConfig {
     fn from_hardcoded_net(net: &HardcodedNet) -> Result<Self, String> {
         let config: Config = serde_yaml::from_reader(net.config)
             .map_err(|e| format!("Unable to parse yaml config: {:?}", e))?;
-        let kzg_trusted_setup = if let Some(epoch) = config.deneb_fork_epoch {
-            // Only load the trusted setup if the deneb fork epoch is set
-            if epoch.value != Epoch::max_value() {
-                let trusted_setup_bytes =
-                    get_trusted_setup_from_id(KzgPresetId::from_str(&config.preset_base)?);
-                let trusted_setup: TrustedSetup = serde_json::from_reader(trusted_setup_bytes)
-                    .map_err(|e| format!("Unable to read trusted setup file: {}", e))?;
-                Some(trusted_setup)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // let kzg_trusted_setup = if let Some(epoch) = config.deneb_fork_epoch {
+        //     // Only load the trusted setup if the deneb fork epoch is set
+        //     if epoch.value != Epoch::max_value() {
+        //         let trusted_setup_bytes =
+        //             get_trusted_setup_from_id(KzgPresetId::from_str(&config.preset_base)?);
+        //         let trusted_setup: TrustedSetup = serde_json::from_reader(trusted_setup_bytes)
+        //             .map_err(|e| format!("Unable to read trusted setup file: {}", e))?;
+        //         Some(trusted_setup)
+        //     } else {
+        //         None
+        //     }
+        // } else {
+        //     None
+        // };
         Ok(Self {
             deposit_contract_deploy_block: serde_yaml::from_reader(net.deploy_block)
                 .map_err(|e| format!("Unable to parse deploy block: {:?}", e))?,
@@ -112,7 +112,6 @@ impl Eth2NetworkConfig {
             genesis_state_bytes: Some(net.genesis_state_bytes.to_vec())
                 .filter(|bytes| !bytes.is_empty()),
             config,
-            kzg_trusted_setup,
         })
     }
 
@@ -256,27 +255,27 @@ impl Eth2NetworkConfig {
             None
         };
 
-        let kzg_trusted_setup = if let Some(epoch) = config.deneb_fork_epoch {
-            // Only load the trusted setup if the deneb fork epoch is set
-            if epoch.value != Epoch::max_value() {
-                let trusted_setup: TrustedSetup = serde_json::from_reader(
-                    get_trusted_setup_from_id(KzgPresetId::from_str(&config.preset_base)?),
-                )
-                .map_err(|e| format!("Unable to read trusted setup file: {}", e))?;
-                Some(trusted_setup)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // let kzg_trusted_setup = if let Some(epoch) = config.deneb_fork_epoch {
+        //     // Only load the trusted setup if the deneb fork epoch is set
+        //     if epoch.value != Epoch::max_value() {
+        //         let trusted_setup: TrustedSetup = serde_json::from_reader(
+        //             get_trusted_setup_from_id(KzgPresetId::from_str(&config.preset_base)?),
+        //         )
+        //         .map_err(|e| format!("Unable to read trusted setup file: {}", e))?;
+        //         Some(trusted_setup)
+        //     } else {
+        //         None
+        //     }
+        // } else {
+        //     None
+        // };
 
         Ok(Self {
             deposit_contract_deploy_block,
             boot_enr,
             genesis_state_bytes,
             config,
-            kzg_trusted_setup,
+            // kzg_trusted_setup,
         })
     }
 }

--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -17,7 +17,7 @@ ethereum_hashing = "1.0.0-beta.2"
 ethereum-types = "0.14.1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 zeroize = { version = "1.4.2", features = ["zeroize_derive"] }
-blst = { version = "0.3.3", optional = true }
+blst = { version = "0.3.11", optional = true }
 
 [features]
 default = ["supranational"]

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,10 +17,5 @@ ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "13cec820c08f45318f82ed4e0da0300042758b92" , features = ["mainnet-spec"]}
-c_kzg_min = { package = "c-kzg", git = "https://github.com/ethereum//c-kzg-4844", rev = "13cec820c08f45318f82ed4e0da0300042758b92", features = ["minimal-spec"], optional = true }
+kzg_rust = { git = "https://github.com/pawanjay176/kzg_rust", rev = "5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c", features = ["minimal"] }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
-
-[features]
-# TODO(deneb): enabled by default for convenience, would need more cfg magic to disable
-default = ["c_kzg_min"]
-minimal-spec = ["c_kzg_min"]

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,5 +17,5 @@ ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "13cec820c08f45318f82ed4e0da0300042758b92" , features = ["mainnet-spec"]}
-kzg_rust = { git = "https://github.com/pawanjay176/kzg_rust", rev = "efe2990b3df511d182bf91c2164ccaff15b1e7a2", features = ["minimal"] }
+kzg_rust = { git = "https://github.com/pawanjay176/kzg_rust", rev = "0ba90fd6105c0429e611700ff218a6da7299370c", features = ["minimal"] }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,5 +17,5 @@ ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "13cec820c08f45318f82ed4e0da0300042758b92" , features = ["mainnet-spec"]}
-kzg_rust = { git = "https://github.com/pawanjay176/kzg_rust", rev = "5affce6eb7a81c5d2fc3d0c9a9d9f5b3252bce8c", features = ["minimal"] }
+kzg_rust = { git = "https://github.com/pawanjay176/kzg_rust", rev = "efe2990b3df511d182bf91c2164ccaff15b1e7a2", features = ["minimal"] }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/crypto/kzg/src/kzg_commitment.rs
+++ b/crypto/kzg/src/kzg_commitment.rs
@@ -30,7 +30,13 @@ impl From<KzgCommitment> for c_kzg::Bytes48 {
     }
 }
 
-impl From<KzgCommitment> for c_kzg_min::Bytes48 {
+impl From<KzgCommitment> for kzg_rust::Bytes48 {
+    fn from(value: KzgCommitment) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<KzgCommitment> for kzg_rust::KzgCommitment {
     fn from(value: KzgCommitment) -> Self {
         value.0.into()
     }

--- a/crypto/kzg/src/kzg_proof.rs
+++ b/crypto/kzg/src/kzg_proof.rs
@@ -17,7 +17,13 @@ impl From<KzgProof> for c_kzg::Bytes48 {
     }
 }
 
-impl From<KzgProof> for c_kzg_min::Bytes48 {
+impl From<KzgProof> for kzg_rust::Bytes48 {
+    fn from(value: KzgProof) -> Self {
+        value.0.into()
+    }
+}
+
+impl From<KzgProof> for kzg_rust::KzgProof {
     fn from(value: KzgProof) -> Self {
         value.0.into()
     }

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -462,3 +462,29 @@ impl<P: KzgPreset> Kzg<P> {
         .map_err(Error::InvalidKzgProof)
     }
 }
+
+
+/// Contains the bytes from the trusted setup json.
+/// The mainnet trusted setup is also reused in testnets.
+///
+/// This is done to ensure that testnets also inherit the high security and
+/// randomness of the mainnet kzg trusted setup ceremony.
+const TRUSTED_SETUP: &[u8] =
+    include_bytes!("../../../common/eth2_network_config/built_in_network_configs/testing_trusted_setups.json");
+
+const TRUSTED_SETUP_MINIMAL: &[u8] =
+    include_bytes!("../../../common/eth2_network_config/built_in_network_configs/minimal_testing_trusted_setups.json");
+
+pub fn get_trusted_setup<P: KzgPreset>() -> &'static [u8] {
+    match P::spec_name() {
+        KzgPresetId::Mainnet => TRUSTED_SETUP,
+        KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
+    }
+}
+
+pub fn get_trusted_setup_from_id(id: KzgPresetId) -> &'static [u8] {
+    match id {
+        KzgPresetId::Mainnet => TRUSTED_SETUP,
+        KzgPresetId::Minimal => TRUSTED_SETUP_MINIMAL,
+    }
+}

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -23,7 +23,7 @@ pub enum Error {
 #[derive(Debug)]
 pub enum CryptoError {
     CKzg(c_kzg::Error),
-    CKzgMin(c_kzg_min::Error),
+    RustKzg(kzg_rust::Error),
 }
 
 impl From<c_kzg::Error> for CryptoError {
@@ -32,9 +32,9 @@ impl From<c_kzg::Error> for CryptoError {
     }
 }
 
-impl From<c_kzg_min::Error> for CryptoError {
-    fn from(e: c_kzg_min::Error) -> Self {
-        Self::CKzgMin(e)
+impl From<kzg_rust::Error> for CryptoError {
+    fn from(e: kzg_rust::Error) -> Self {
+        Self::RustKzg(e)
     }
 }
 
@@ -244,13 +244,120 @@ macro_rules! implement_kzg_preset {
     };
 }
 
+impl KzgPreset for MinimalKzgPreset {
+    type KzgSettings = kzg_rust::KzgSettings;
+    type Blob = kzg_rust::Blob;
+    type Bytes32 = kzg_rust::Bytes32;
+    type Bytes48 = kzg_rust::Bytes48;
+    type Error = kzg_rust::Error;
+
+    const BYTES_PER_BLOB: usize = kzg_rust::BYTES_PER_BLOB;
+    const BYTES_PER_FIELD_ELEMENT: usize = kzg_rust::BYTES_PER_FIELD_ELEMENT;
+    const FIELD_ELEMENTS_PER_BLOB: usize = kzg_rust::FIELD_ELEMENTS_PER_BLOB;
+
+    fn spec_name() -> KzgPresetId {
+        KzgPresetId::Minimal
+    }
+
+    fn load_trusted_setup(trusted_setup: TrustedSetup) -> Result<Self::KzgSettings, CryptoError> {
+        Self::KzgSettings::load_trusted_setup(trusted_setup.g1_points(), trusted_setup.g2_points())
+            .map_err(CryptoError::from)
+    }
+
+    fn compute_blob_kzg_proof(
+        blob: Self::Blob,
+        kzg_commitment: KzgCommitment,
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<KzgProof, CryptoError> {
+        kzg_rust::compute_blob_kzg_proof(&blob, &kzg_commitment.into(), trusted_setup)
+            .map(|proof| KzgProof(proof.to_bytes()))
+            .map_err(CryptoError::from)
+    }
+
+    fn verify_blob_kzg_proof(
+        blob: Self::Blob,
+        kzg_commitment: KzgCommitment,
+        kzg_proof: KzgProof,
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<bool, CryptoError> {
+        kzg_rust::verify_blob_kzg_proof(
+            &blob,
+            &kzg_commitment.into(),
+            &kzg_proof.into(),
+            trusted_setup,
+        )
+        .map_err(CryptoError::from)
+    }
+
+    fn verify_blob_kzg_proof_batch(
+        blobs: &[Self::Blob],
+        commitments_bytes: &[Self::Bytes48],
+        proofs_bytes: &[Self::Bytes48],
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<bool, CryptoError> {
+        let commitments: Vec<_> = commitments_bytes
+            .into_iter()
+            .map(|c| kzg_rust::KzgCommitment(*c))
+            .collect();
+        let proofs: Vec<_> = proofs_bytes
+            .into_iter()
+            .map(|p| kzg_rust::KzgProof(*p))
+            .collect();
+        kzg_rust::verify_blob_kzg_proof_batch(&blobs, &commitments, &proofs, trusted_setup)
+            .map_err(CryptoError::from)
+    }
+
+    fn blob_to_kzg_commitment(
+        blob: Self::Blob,
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<KzgCommitment, CryptoError> {
+        kzg_rust::blob_to_kzg_commitment(&blob, trusted_setup)
+            .map(|com| KzgCommitment(com.to_bytes()))
+            .map_err(CryptoError::from)
+    }
+
+    fn compute_kzg_proof(
+        blob: Self::Blob,
+        z: Self::Bytes32,
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<(KzgProof, Self::Bytes32), CryptoError> {
+        kzg_rust::compute_kzg_proof(&blob, &z, trusted_setup)
+            .map(|(proof, y)| (KzgProof(proof.to_bytes()), y))
+            .map_err(CryptoError::from)
+    }
+
+    fn verify_kzg_proof(
+        kzg_commitment: KzgCommitment,
+        z: Self::Bytes32,
+        y: Self::Bytes32,
+        kzg_proof: KzgProof,
+        trusted_setup: &Self::KzgSettings,
+    ) -> Result<bool, CryptoError> {
+        kzg_rust::verify_kzg_proof(
+            &kzg_commitment.into(),
+            &z,
+            &y,
+            &kzg_proof.into(),
+            trusted_setup,
+        )
+        .map_err(CryptoError::from)
+    }
+}
+
+impl BlobTrait for kzg_rust::Blob {
+    fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Self::from_bytes(bytes)
+            .map_err(CryptoError::from)
+            .map_err(Error::InvalidBlob)
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, arbitrary::Arbitrary)]
 pub struct MainnetKzgPreset;
 #[derive(Clone, PartialEq, Eq, Debug, Default, Serialize, Deserialize, arbitrary::Arbitrary)]
 pub struct MinimalKzgPreset;
 
 implement_kzg_preset!(MainnetKzgPreset, c_kzg, Mainnet);
-implement_kzg_preset!(MinimalKzgPreset, c_kzg_min, Minimal);
 
 /// A wrapper over a kzg library that holds the trusted setup parameters.
 #[derive(Debug)]

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -296,14 +296,14 @@ impl KzgPreset for MinimalKzgPreset {
         trusted_setup: &Self::KzgSettings,
     ) -> Result<bool, CryptoError> {
         let commitments: Vec<_> = commitments_bytes
-            .into_iter()
+            .iter()
             .map(|c| kzg_rust::KzgCommitment(*c))
             .collect();
         let proofs: Vec<_> = proofs_bytes
-            .into_iter()
+            .iter()
             .map(|p| kzg_rust::KzgProof(*p))
             .collect();
-        kzg_rust::verify_blob_kzg_proof_batch(&blobs, &commitments, &proofs, trusted_setup)
+        kzg_rust::verify_blob_kzg_proof_batch(blobs, &commitments, &proofs, trusted_setup)
             .map_err(CryptoError::from)
     }
 

--- a/lcli/src/new_testnet.rs
+++ b/lcli/src/new_testnet.rs
@@ -1,7 +1,7 @@
 use account_utils::eth2_keystore::keypair_from_secret;
 use clap::ArgMatches;
 use clap_utils::{parse_optional, parse_required, parse_ssz_optional};
-use eth2_network_config::{get_trusted_setup, Eth2NetworkConfig};
+use eth2_network_config::{Eth2NetworkConfig};
 use eth2_wallet::bip39::Seed;
 use eth2_wallet::bip39::{Language, Mnemonic};
 use eth2_wallet::{recover_validator_secret_from_mnemonic, KeyType};
@@ -196,25 +196,12 @@ pub fn run<T: EthSpec>(testnet_dir_path: PathBuf, matches: &ArgMatches) -> Resul
         None
     };
 
-    let kzg_trusted_setup = if let Some(epoch) = spec.deneb_fork_epoch {
-        // Only load the trusted setup if the deneb fork epoch is set
-        if epoch != Epoch::max_value() {
-            let trusted_setup: TrustedSetup =
-                serde_json::from_reader(get_trusted_setup::<T::Kzg>())
-                    .map_err(|e| format!("Unable to read trusted setup file: {}", e))?;
-            Some(trusted_setup)
-        } else {
-            None
-        }
-    } else {
-        None
-    };
+    
     let testnet = Eth2NetworkConfig {
         deposit_contract_deploy_block,
         boot_enr: Some(vec![]),
         genesis_state_bytes,
         config: Config::from_chain_spec::<T>(&spec),
-        kzg_trusted_setup,
     };
 
     testnet.write_to_file(testnet_dir_path, overwrite_files)

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::case_result::compare_result;
 use beacon_chain::kzg_utils::validate_blob;
-use eth2_network_config::get_trusted_setup;
+use kzg::get_trusted_setup;
 use kzg::{Kzg, KzgCommitment, KzgPreset, KzgProof, TrustedSetup};
 use serde_derive::Deserialize;
 use std::convert::TryInto;


### PR DESCRIPTION
## Issue Addressed

Resolves #4440 

## Proposed Changes

Use [kzg_rust](https://github.com/pawanjay176/kzg_rust) library only for minimal spec kzg tests to get away from all c-kzg headaches.
I think this should be safe to do as EF tests anyway run mainnet presets and none of the tests we run that require minimal kzg specs are super critical w.r.t the kzg functions. Please correct me if I'm wrong.