### PR TITLE
[Merged by Bors] - `ForkChoice`: remove an impossible case for `parent_checkpoints`

### DIFF
--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -756,7 +756,7 @@ where
             .unrealized_justified_checkpoint
             .zip(parent_block.unrealized_finalized_checkpoint)
             .filter(|(parent_justified, parent_finalized)| {
-                parent_justified.epoch == block_epoch && parent_finalized.epoch + 1 >= block_epoch
+                parent_justified.epoch == block_epoch && parent_finalized.epoch + 1 == block_epoch
             });
 
         let (unrealized_justified_checkpoint, unrealized_finalized_checkpoint) = if let Some((


### PR DESCRIPTION
`parent_finalized.epoch + 1 > block_epoch` will never be `true` since as the comment says:

```
 A block in epoch `N` cannot contain attestations which would finalize an epoch higher than `N - 1`.
```