### PR TITLE
Add git commit hash to Deneb docker image tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,7 +44,7 @@ jobs:
             - name: Extract version (if deneb)
               if: github.event.ref == 'refs/heads/deneb-free-blobs'
               run: |
-                    echo "VERSION=deneb" >> $GITHUB_ENV
+                    echo "VERSION=deneb-${GITHUB_SHA::7}" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')


### PR DESCRIPTION
## Issue Addressed

This PR adds a git commit short hash suffix to the docker image tag, e.g. `lighthouse:deneb-aaabbb3-modern` instead of `lighthouse:deneb-modern`, so we know what version is deployed to the devnet