### PR TITLE
fix comment of `weigh_justification_and_finalization`

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/weigh_justification_and_finalization.rs
+++ b/consensus/state_processing/src/per_epoch_processing/weigh_justification_and_finalization.rs
@@ -47,7 +47,7 @@ pub fn weigh_justification_and_finalization<T: EthSpec>(
         Ok(true)
     };
 
-    // The 2nd/3rd/4th most recent epochs are all justified, the 2nd using the 4th as source.
+    // The 2nd/3rd/4th most recent epochs are all justified, the 3nd using the 4th as source.
     if all_bits_set(1..4)? && old_previous_justified_checkpoint.epoch.safe_add(3)? == current_epoch
     {
         *state.finalized_checkpoint_mut() = old_previous_justified_checkpoint;
@@ -57,7 +57,7 @@ pub fn weigh_justification_and_finalization<T: EthSpec>(
     {
         *state.finalized_checkpoint_mut() = old_previous_justified_checkpoint;
     }
-    // The 1st/2nd/3rd most recent epochs are all justified, the 1st using the 3nd as source.
+    // The 1st/2nd/3rd most recent epochs are all justified, the 2st using the 3nd as source.
     if all_bits_set(0..3)? && old_current_justified_checkpoint.epoch.safe_add(2)? == current_epoch {
         *state.finalized_checkpoint_mut() = old_current_justified_checkpoint;
     }


### PR DESCRIPTION
Here's my reasoning: 

`old_previous_justified_checkpoint` is the current justified checkpoint of the `3rd` most recent epoch.

So `old_previous_justified_checkpoint.epoch.safe_add(3)? == current_epoch` means the current justified checkpoint of the 3rd most recent epoch is the `4th` most recent epoch.

By `all_bits_set(1..4)` we know the `2nd/3rd/4th` most recent epochs are all justified, so the `3rd` most recent epoch must be justified at the `2nd` most recent epoch(otherwise bit `2` has no other chance to be set, the bit for epoch N can **only** be set at epoch `N` or epoch `N+1`), and its source must be the `4th` most recent epoch(because the current justified checkpoint of the last epoch(the `3th` most recent epoch), is the `4th` most recent epoch), thus `the 3nd using the 4th as source`.

In fact the `2nd` most recent epoch isn't necessarily using `4th` as source, since it may be justified at the `1st` most recent epoch, in that case it'll be using `3rd` as source.

This is why the original comment for `all_bits_set(1..4)? && old_previous_justified_checkpoint.epoch.safe_add(3)? == current_epoch` is not correct IMO.

And similarly for the other one.

