### PR TITLE
[Merged by Bors] - Fix the link of anvil in lighthouse book

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -9,7 +9,7 @@ particularly useful for development but still a good way to ensure you have the
 base dependencies.
 
 The additional requirements for developers are:
-- [`anvil`](https://github.com/foundry-rs/foundry/tree/master/anvil). This is used to
+- [`anvil`](https://github.com/foundry-rs/foundry/tree/master/crates/anvil). This is used to
   simulate the execution chain during tests. You'll get failures during tests if you
   don't have `anvil` available on your `PATH`.
 - [`cmake`](https://cmake.org/cmake/help/latest/command/install.html). Used by


### PR DESCRIPTION
## Issue Addressed

Wrong link for anvil

## Proposed Changes

Fix the link to correct one. 
