### PR TITLE
Use reprocessing queue to send HTTP responses for duplicate blocks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2480,7 +2480,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 // If the block is relevant, add it to the filtered chain segment.
                 Ok(_) => filtered_chain_segment.push((block_root, block)),
                 // If the block is already known, simply ignore this block.
-                Err(BlockError::BlockIsAlreadyKnown) => continue,
+                // FIXME(sproul): double-check this
+                Err(BlockError::BlockIsAlreadyKnownValid) => continue,
                 // If the block is the genesis block, simply ignore this block.
                 Err(BlockError::GenesisBlock) => continue,
                 // If the block is is for a finalized slot, simply ignore this block.

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -495,7 +495,7 @@ where
                         chain: None,
                         network_senders: None,
                         network_globals: None,
-                        beacon_processor_send: None,
+                        beacon_processor_senders: None,
                         eth1_service: Some(genesis_service.eth1_service.clone()),
                         log: context.log().clone(),
                         sse_logging_components: runtime_context.sse_logging_components.clone(),
@@ -733,7 +733,7 @@ where
                 network_senders: self.network_senders.clone(),
                 network_globals: self.network_globals.clone(),
                 eth1_service: self.eth1_service.clone(),
-                beacon_processor_send: Some(beacon_processor_channels.beacon_processor_tx.clone()),
+                beacon_processor_senders: Some(beacon_processor_channels.senders()),
                 sse_logging_components: runtime_context.sse_logging_components.clone(),
                 log: log.clone(),
             });

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -3,7 +3,7 @@ use beacon_chain::{
     test_utils::{
         BeaconChainHarness, BoxedMutator, Builder as HarnessBuilder, EphemeralHarnessType,
     },
-    BeaconChain, BeaconChainTypes,
+    BeaconChain,
 };
 use beacon_processor::{BeaconProcessor, BeaconProcessorChannels, BeaconProcessorConfig};
 use directory::DEFAULT_ROOT_DIR;
@@ -38,6 +38,7 @@ pub const EXTERNAL_ADDR: &str = "/ip4/0.0.0.0/tcp/9000";
 /// HTTP API tester that allows interaction with the underlying beacon chain harness.
 pub struct InteractiveTester<E: EthSpec> {
     pub harness: BeaconChainHarness<EphemeralHarnessType<E>>,
+    pub ctx: Arc<Context<EphemeralHarnessType<E>>>,
     pub client: BeaconNodeHttpClient,
     pub network_rx: NetworkReceivers<E>,
 }
@@ -47,6 +48,7 @@ pub struct InteractiveTester<E: EthSpec> {
 /// Glue-type between `tests::ApiTester` and `InteractiveTester`.
 pub struct ApiServer<E: EthSpec, SFut: Future<Output = ()>> {
     pub server: SFut,
+    pub ctx: Arc<Context<EphemeralHarnessType<E>>>,
     pub listening_socket: SocketAddr,
     pub network_rx: NetworkReceivers<E>,
     pub local_enr: Enr,
@@ -94,6 +96,7 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         let ApiServer {
             server,
+            ctx,
             listening_socket,
             network_rx,
             ..
@@ -118,35 +121,36 @@ impl<E: EthSpec> InteractiveTester<E> {
 
         Self {
             harness,
+            ctx,
             client,
             network_rx,
         }
     }
 }
 
-pub async fn create_api_server<T: BeaconChainTypes>(
-    chain: Arc<BeaconChain<T>>,
+pub async fn create_api_server<E: EthSpec>(
+    chain: Arc<BeaconChain<EphemeralHarnessType<E>>>,
     test_runtime: &TestRuntime,
     log: Logger,
-) -> ApiServer<T::EthSpec, impl Future<Output = ()>> {
+) -> ApiServer<E, impl Future<Output = ()>> {
     // Get a random unused port.
     let port = unused_port::unused_tcp4_port().unwrap();
     create_api_server_on_port(chain, test_runtime, log, port).await
 }
 
-pub async fn create_api_server_on_port<T: BeaconChainTypes>(
-    chain: Arc<BeaconChain<T>>,
+pub async fn create_api_server_on_port<E: EthSpec>(
+    chain: Arc<BeaconChain<EphemeralHarnessType<E>>>,
     test_runtime: &TestRuntime,
     log: Logger,
     port: u16,
-) -> ApiServer<T::EthSpec, impl Future<Output = ()>> {
+) -> ApiServer<E, impl Future<Output = ()>> {
     let (network_senders, network_receivers) = NetworkSenders::new();
 
     // Default metadata
     let meta_data = MetaData::V2(MetaDataV2 {
         seq_number: SEQ_NUMBER,
-        attnets: EnrAttestationBitfield::<T::EthSpec>::default(),
-        syncnets: EnrSyncCommitteeBitfield::<T::EthSpec>::default(),
+        attnets: EnrAttestationBitfield::<E>::default(),
+        syncnets: EnrSyncCommitteeBitfield::<E>::default(),
     });
     let enr_key = CombinedKey::generate_secp256k1();
     let enr = EnrBuilder::new("v4").build(&enr_key).unwrap();
@@ -185,14 +189,15 @@ pub async fn create_api_server_on_port<T: BeaconChainTypes>(
         eth1::Service::new(eth1::Config::default(), log.clone(), chain.spec.clone()).unwrap();
 
     let beacon_processor_config = BeaconProcessorConfig::default();
+    let beacon_processor_channels = BeaconProcessorChannels::new(&beacon_processor_config);
+    let beacon_processor_senders = beacon_processor_channels.senders();
     let BeaconProcessorChannels {
-        beacon_processor_tx,
+        beacon_processor_tx: _,
         beacon_processor_rx,
         work_reprocessing_tx,
         work_reprocessing_rx,
-    } = BeaconProcessorChannels::new(&beacon_processor_config);
+    } = beacon_processor_channels;
 
-    let beacon_processor_send = beacon_processor_tx;
     BeaconProcessor {
         network_globals: network_globals.clone(),
         executor: test_runtime.task_executor.clone(),
@@ -231,16 +236,18 @@ pub async fn create_api_server_on_port<T: BeaconChainTypes>(
         chain: Some(chain),
         network_senders: Some(network_senders),
         network_globals: Some(network_globals),
-        beacon_processor_send: Some(beacon_processor_send),
+        beacon_processor_senders: Some(beacon_processor_senders),
         eth1_service: Some(eth1_service),
         sse_logging_components: None,
         log,
     });
 
-    let (listening_socket, server) = crate::serve(ctx, test_runtime.task_executor.exit()).unwrap();
+    let (listening_socket, server) =
+        crate::serve(ctx.clone(), test_runtime.task_executor.exit()).unwrap();
 
     ApiServer {
         server,
+        ctx,
         listening_socket,
         network_rx: network_receivers,
         local_enr: enr,

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -368,6 +368,7 @@ pub async fn consensus_partial_pass_only_consensus() {
         None,
         ProvenancedBlock::local(gossip_block_b.unwrap()),
         tester.harness.chain.clone(),
+        tester.ctx.beacon_processor_senders.clone().unwrap(),
         &channel.0,
         test_logger,
         validation_level.unwrap(),
@@ -645,6 +646,7 @@ pub async fn equivocation_consensus_late_equivocation() {
         None,
         ProvenancedBlock::local(gossip_block_b.unwrap()),
         tester.harness.chain,
+        tester.ctx.beacon_processor_senders.clone().unwrap(),
         &channel.0,
         test_logger,
         validation_level.unwrap(),
@@ -1297,6 +1299,7 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
     let publication_result: Result<(), Rejection> = publish_blinded_block(
         block_b,
         tester.harness.chain,
+        tester.ctx.beacon_processor_senders.clone().unwrap(),
         &channel.0,
         test_logger,
         validation_level.unwrap(),

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -231,6 +231,7 @@ impl ApiTester {
 
         let ApiServer {
             server,
+            ctx: _,
             listening_socket: _,
             network_rx,
             local_enr,
@@ -315,6 +316,7 @@ impl ApiTester {
 
         let ApiServer {
             server,
+            ctx: _,
             listening_socket,
             network_rx,
             local_enr,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -765,7 +765,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             }
             Err(e @ BlockError::FutureSlot { .. })
             | Err(e @ BlockError::WouldRevertFinalizedSlot { .. })
-            | Err(e @ BlockError::BlockIsAlreadyKnown)
+            | Err(e @ BlockError::BlockIsAlreadyKnownValid)
+            | Err(e @ BlockError::BlockIsAlreadyKnownProcessingOrInvalid)
             | Err(e @ BlockError::NotFinalizedDescendant { .. }) => {
                 debug!(self.log, "Could not verify block for gossip. Ignoring the block";
                             "error" => %e);
@@ -793,6 +794,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             | Err(e @ BlockError::PerBlockProcessingError(_))
             | Err(e @ BlockError::NonLinearParentRoots)
             | Err(e @ BlockError::BlockIsNotLaterThanParent { .. })
+            | Err(e @ BlockError::BlockIsAlreadyKnownInvalid)
             | Err(e @ BlockError::InvalidSignature)
             | Err(e @ BlockError::WeakSubjectivityConflict)
             | Err(e @ BlockError::InconsistentFork(_))

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -536,7 +536,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     peer_action: Some(PeerAction::LowToleranceError),
                 })
             }
-            BlockError::BlockIsAlreadyKnown => {
+            BlockError::BlockIsAlreadyKnownValid
+            | BlockError::BlockIsAlreadyKnownProcessingOrInvalid => {
                 // This can happen for many reasons. Head sync's can download multiples and parent
                 // lookups can download blocks before range sync
                 Ok(())

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -448,7 +448,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             BlockProcessResult::Err(e) => {
                 trace!(self.log, "Single block processing failed"; "block" => %root, "error" => %e);
                 match e {
-                    BlockError::BlockIsAlreadyKnown => {
+                    BlockError::BlockIsAlreadyKnownValid
+                    | BlockError::BlockIsAlreadyKnownProcessingOrInvalid => {
                         // No error here
                     }
                     BlockError::BeaconChainError(e) => {
@@ -540,7 +541,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 self.request_parent(parent_lookup, cx);
             }
             BlockProcessResult::Ok
-            | BlockProcessResult::Err(BlockError::BlockIsAlreadyKnown { .. }) => {
+            | BlockProcessResult::Err(BlockError::BlockIsAlreadyKnownValid) => {
                 // Check if the beacon processor is available
                 let beacon_processor = match cx.beacon_processor_if_enabled() {
                     Some(beacon_processor) => beacon_processor,

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -283,7 +283,11 @@ fn test_parent_lookup_happy_path() {
     rig.expect_empty_network();
 
     // Processing succeeds, now the rest of the chain should be sent for processing.
-    bl.parent_block_processed(chain_hash, BlockError::BlockIsAlreadyKnown.into(), &mut cx);
+    bl.parent_block_processed(
+        chain_hash,
+        BlockError::BlockIsAlreadyKnownValid.into(),
+        &mut cx,
+    );
     rig.expect_parent_chain_process();
     let process_result = BatchProcessResult::Success {
         was_non_empty: true,
@@ -654,7 +658,11 @@ fn test_same_chain_race_condition() {
         // the processing result
         if i + 2 == depth {
             // one block was removed
-            bl.parent_block_processed(chain_hash, BlockError::BlockIsAlreadyKnown.into(), &mut cx)
+            bl.parent_block_processed(
+                chain_hash,
+                BlockError::BlockIsAlreadyKnownValid.into(),
+                &mut cx,
+            )
         } else {
             bl.parent_block_processed(chain_hash, BlockError::ParentUnknown(block).into(), &mut cx)
         }


### PR DESCRIPTION
## Issue Addressed

Closes #4473

## Proposed Changes

In order to avoid returning HTTP 400s when valid duplicate blocks are posted to the API:

- Split the `BlockIsAlreadyKnown` error into three variants for "valid", "invalid" and "processing". If a block is valid (i.e. in fork choice with valid status) then we can return a 200 straight away. Conversely if it's invalid (i.e. in fork choice with invalid status) we can return a 400 straight away.
- Classify a block as "processing" if it is optimistically imported _or_ if it is present in the gossip filter but not (yet) present in fork choice.
- To handle "processing" blocks, use the reprocessing queue to wait for a block with the same block root to be imported. Send a 200 as soon as one is.
- Timeout on the reprocess queue after 2 seconds, at which point the status will be checked once more in fork choice, before a 400 is returned.

## Additional Info

There are still several ways in which this behaves sub-optimally

### Sub-optimal case 1: block is invalid

We don't usually add invalid blocks to fork choice (only if they are imported optimistically then invalidated), and we also don't _remember_ invalid blocks outside of the networking crate. Therefore if we receive an invalid block over HTTP which we've already processed and rejected, we will get a `BlockAlreadyKnownProcessingOrInvalid` from gossip verification. This will then be force us to wait the full 2 second timeout, at which point we'll return a 400. Other than the long wait, this is the correct behaviour (400 for an invalid block).

We initially talked about using the `DuplicateCache` from networking to guess whether a block is processing or invalid, but I _haven't made this change_ because it would require making the duplicate cache accessible from the `beacon_chain`. This seems like a delicate change that might require more careful thought and justification than this PR (which is already a large code change just to fix a slightly annoying corner case).

### Sub-optimal case 2: valid block race

1. Check fork choice: block is not there.
2. Check gossip cache: block is there (it is being processed).
3. Block finishes processing.
4. Wait 2 seconds for a notification that will never arrive.
5. Timeout, re-check fork choice, see the valid status, and return 200 OK.

This is also the correct behaviour, just with a sub-optimal 2 second wait. In practice I think block processing is unlikely to finish before step (4) _if it was started at a similar time_ to step (1), which is the case for block relays. This is because gossip validation is much faster than full block import. For home users connected to relays it will be more likely, but in this case there's no harm done, just a slower HTTP response to the VC.

### Sub-optimal case 3: slow-to-process valid blocks

If a block takes longer than 2s to process, then we'll hit the timeout and return a 400. This is the same as our behaviour today but hopefully reduced in frequency enough to not be too annoying.