### PR TITLE
Parallel gossip verification and block unblinding

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -338,11 +338,14 @@ pub async fn is_optimistic_candidate_block<T: BeaconChainTypes>(
 
 /// Validate the gossip block's execution_payload according to the checks described here:
 /// https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/p2p-interface.md#beacon_block
-pub fn validate_execution_payload_for_gossip<T: BeaconChainTypes>(
+pub fn validate_execution_payload_for_gossip<
+    T: BeaconChainTypes,
+    Payload: AbstractExecPayload<T::EthSpec>,
+>(
     parent_block: &ProtoBlock,
-    block: BeaconBlockRef<'_, T::EthSpec>,
+    block: BeaconBlockRef<'_, T::EthSpec, Payload>,
     chain: &BeaconChain<T>,
-) -> Result<(), BlockError<T::EthSpec>> {
+) -> Result<(), BlockError<T::EthSpec, Payload>> {
     // Only apply this validation if this is a merge beacon block.
     if let Ok(execution_payload) = block.body().execution_payload() {
         // This logic should match `is_execution_enabled`. We use only the execution block hash of

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1425,7 +1425,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .then(
-            |block: SignedBeaconBlock<T::EthSpec, BlindedPayload<_>>,
+            |block: SignedBlindedBeaconBlock<T::EthSpec>,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
@@ -1466,16 +1466,13 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner
                     .clone()
                     .spawn_async_with_rejection(Priority::P0, async move {
-                        let block =
-                            SignedBeaconBlock::<T::EthSpec, BlindedPayload<_>>::from_ssz_bytes(
-                                &block_bytes,
-                                &chain.spec,
-                            )
-                            .map_err(|e| {
-                                warp_utils::reject::custom_bad_request(format!(
-                                    "invalid SSZ: {e:?}"
-                                ))
-                            })?;
+                        let block = SignedBlindedBeaconBlock::<T::EthSpec>::from_ssz_bytes(
+                            &block_bytes,
+                            &chain.spec,
+                        )
+                        .map_err(|e| {
+                            warp_utils::reject::custom_bad_request(format!("invalid SSZ: {e:?}"))
+                        })?;
                         publish_blocks::publish_blinded_block(
                             block,
                             chain,
@@ -1502,7 +1499,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(log_filter.clone())
         .then(
             |validation_level: api_types::BroadcastValidationQuery,
-             block: SignedBeaconBlock<T::EthSpec, BlindedPayload<_>>,
+             block: SignedBlindedBeaconBlock<T::EthSpec>,
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -247,6 +247,8 @@ pub async fn publish_blinded_block<T: BeaconChainTypes>(
     let gossip_verified_blinded_block = gossip_result?;
     let full_block = reconstruction_result?;
 
+    // Pass the gossip-verified full block to `publish_block` so that it doesn't re-run
+    // gossip verification.
     let provenanced_gossip_verified_block = match full_block {
         ProvenancedBlock::Local(block, phantom) => {
             ProvenancedBlock::Local(gossip_verified_blinded_block.unblind(block), phantom)

--- a/beacon_node/http_api/src/task_spawner.rs
+++ b/beacon_node/http_api/src/task_spawner.rs
@@ -29,6 +29,7 @@ impl Priority {
 }
 
 /// Spawns tasks on the `BeaconProcessor` or directly on the tokio executor.
+#[derive(Clone)]
 pub struct TaskSpawner<E: EthSpec> {
     /// Used to send tasks to the `BeaconProcessor`. The tokio executor will be
     /// used if this is `None`.
@@ -122,11 +123,11 @@ impl<E: EthSpec> TaskSpawner<E> {
     ///
     /// If you call this function you MUST convert the rejection to a response and not let it
     /// propagate into Warp's filters. See `convert_rejection`.
-    pub async fn spawn_async_with_rejection_no_conversion(
+    pub async fn spawn_async_with_rejection_no_conversion<T: Send + Sync + 'static>(
         self,
         priority: Priority,
-        func: impl Future<Output = Result<Response, warp::Rejection>> + Send + Sync + 'static,
-    ) -> Result<Response, warp::Rejection> {
+        func: impl Future<Output = Result<T, warp::Rejection>> + Send + Sync + 'static,
+    ) -> Result<T, warp::Rejection> {
         if let Some(beacon_processor_send) = &self.beacon_processor_send {
             // Create a wrapper future that will execute `func` and send the
             // result to a channel held by this thread.

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -4,7 +4,10 @@ use beacon_chain::{
 };
 use eth2::types::{BroadcastValidation, SignedBeaconBlock, SignedBlindedBeaconBlock};
 use http_api::test_utils::InteractiveTester;
-use http_api::{publish_blinded_block, publish_block, reconstruct_block, ProvenancedBlock};
+use http_api::{
+    publish_blinded_block, publish_block, reconstruct_block, task_spawner::TaskSpawner,
+    ProvenancedBlock,
+};
 use tree_hash::TreeHash;
 use types::{Hash256, MainnetEthSpec, Slot};
 use warp::Rejection;
@@ -1294,9 +1297,11 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
 
     let channel = tokio::sync::mpsc::unbounded_channel();
 
+    let task_spawner = TaskSpawner::new(tester.ctx.beacon_processor_send.clone());
     let publication_result: Result<(), Rejection> = publish_blinded_block(
         block_b,
         tester.harness.chain,
+        task_spawner,
         &channel.0,
         test_logger,
         validation_level.unwrap(),

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -244,6 +244,7 @@ impl ApiTester {
 
         let ApiServer {
             server,
+            ctx: _,
             listening_socket: _,
             network_rx,
             local_enr,
@@ -328,6 +329,7 @@ impl ApiTester {
 
         let ApiServer {
             server,
+            ctx: _,
             listening_socket,
             network_rx,
             local_enr,


### PR DESCRIPTION
## Issue Addressed

Closes #4473
Replaces #4643

## Proposed Changes

- Check gossip validity of blinded blocks in parallel with the request to unblind. This should ensure that the gossip duplicate check almost always completes before we receive the block on gossip from the relay.
- Gossip verification is refactored to abstract over `Payload: AbstractExecPayload<E>` to enable the checking of blinded blocks.
- Updated the V2 SSZ endpoint to use the `task_spawner` (a small omission caused by conflicts between several recently merged PRs).
