### PR TITLE
Tree states to support per-slot state diffs

### DIFF
--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2489,7 +2489,7 @@ async fn revert_minority_fork_on_resume() {
 }
 
 #[tokio::test]
-// #[ignore]
+#[ignore]
 // FIXME(jimmy): Ignoring this now as the test is flaky :/ It intermittently fails with an IO error
 // "..cold_db/LOCK file held by another process".
 // There seems to be some race condition between dropping the lock file and and re-opening the db.

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2489,6 +2489,12 @@ async fn revert_minority_fork_on_resume() {
 }
 
 #[tokio::test]
+// #[ignore]
+// FIXME(jimmy): Ignoring this now as the test is flaky :/ It intermittently fails with an IO error
+// "..cold_db/LOCK file held by another process".
+// There seems to be some race condition between dropping the lock file and and re-opening the db.
+// There's a higher chance this test would fail when the entire test suite is run. Maybe it isn't
+// fast enough at dropping the cold_db LOCK file before the test attempts to open it again.
 async fn should_not_initialize_incompatible_store_config() {
     let validator_count = 16;
     let spec = MinimalEthSpec::default_spec();
@@ -2509,7 +2515,7 @@ async fn should_not_initialize_incompatible_store_config() {
         ..store_config
     };
     let maybe_err =
-        try_get_store_with_spec_and_config(&db_path, spec.clone(), different_store_config).err();
+        try_get_store_with_spec_and_config(&db_path, spec, different_store_config).err();
 
     assert!(matches!(
         maybe_err,

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -21,6 +21,7 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::time::Duration;
+use store::hdiff::HierarchyConfig;
 use store::{
     config::StoreConfigError,
     iter::{BlockRootsIterator, StateRootsIterator},
@@ -50,7 +51,13 @@ fn get_store_with_spec(
     db_path: &TempDir,
     spec: ChainSpec,
 ) -> Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>> {
-    let config = StoreConfig::default();
+    let config = StoreConfig {
+        // More frequent snapshots and hdiffs in tests for testing
+        hierarchy_config: HierarchyConfig {
+            exponents: vec![1, 3, 5],
+        },
+        ..Default::default()
+    };
     try_get_store_with_spec_and_config(db_path, spec, config).expect("disk store should initialize")
 }
 

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -534,6 +534,21 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
+            Arg::with_name("hierarchy-exponents")
+                .long("hierarchy-exponents")
+                .value_name("EXPONENTS")
+                .help("Specifies the frequency for storing full state snapshots and hierarchical \
+                        diffs in the freezer DB. Accepts a comma-separated list of ascending \
+                        exponents. Each exponent defines an interval for storing diffs to the layer \
+                        above. The last exponent defines the interval for full snapshots. \
+                        For example, a config of '4,8,12' would store a full snapshot every \
+                        4096 (2^12) slots, first-level diffs every 256 (2^8) slots, and second-level \
+                        diffs every 16 (2^4) slots. \
+                        Cannot be changed after initialization. \
+                        [default: 5,9,11,13,16,18,21]")
+                .takes_value(true)
+        )
+        .arg(
             Arg::with_name("epochs-per-migration")
                 .long("epochs-per-migration")
                 .value_name("N")

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -48,7 +48,7 @@ pub struct StoreConfig {
 // FIXME(sproul): schema migration, add hdiff
 pub struct OnDiskStoreConfig {
     pub linear_blocks: bool,
-    pub linear_restore_points: bool,
+    pub hierarchy_config: HierarchyConfig,
 }
 
 #[derive(Debug, Clone)]
@@ -80,7 +80,7 @@ impl StoreConfig {
     pub fn as_disk_config(&self) -> OnDiskStoreConfig {
         OnDiskStoreConfig {
             linear_blocks: self.linear_blocks,
-            linear_restore_points: self.linear_restore_points,
+            hierarchy_config: self.hierarchy_config.clone(),
         }
     }
 

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -41,7 +41,7 @@ pub enum Error {
     },
     MissingStateRoot(Slot),
     MissingState(Hash256),
-    MissingSnapshot(Epoch),
+    MissingSnapshot(Slot),
     MissingDiff(Epoch),
     NoBaseStateFound(Hash256),
     BlockReplayError(BlockReplayError),

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -301,6 +301,12 @@ mod tests {
             moduli.storage_strategy(first_layer * 2).unwrap(),
             StorageStrategy::DiffFrom(Slot::new(0))
         );
+
+        let replay_strategy_slot = first_layer + 1;
+        assert_eq!(
+            moduli.storage_strategy(replay_strategy_slot).unwrap(),
+            StorageStrategy::ReplayFrom(first_layer)
+        );
     }
 
     #[test]

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -19,7 +19,7 @@ pub enum Error {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Encode, Decode)]
 pub struct HierarchyConfig {
-    exponents: Vec<u8>,
+    pub exponents: Vec<u8>,
 }
 
 #[derive(Debug)]

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -198,7 +198,7 @@ impl CompressedU64Diff {
 impl Default for HierarchyConfig {
     fn default() -> Self {
         HierarchyConfig {
-            exponents: vec![4, 9, 11, 13, 16, 18, 21],
+            exponents: vec![5, 9, 11, 13, 16, 18, 21],
         }
     }
 }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1451,10 +1451,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         encoder.write_all(&bytes).map_err(Error::Compression)?;
         encoder.finish().map_err(Error::Compression)?;
 
-        let epoch = state.current_epoch();
         let key = get_key_for_col(
             DBColumn::BeaconStateSnapshot.into(),
-            &epoch.as_u64().to_be_bytes(),
+            &state.slot().as_u64().to_be_bytes(),
         );
         ops.push(KeyValueStoreOp::PutKeyValue(key, compressed_value));
         Ok(())
@@ -1565,7 +1564,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         // Load buffer for the previous state.
         // This amount of recursion (<10 levels) should be OK.
         let t = std::time::Instant::now();
-        let (slot, mut buffer) = match self.hierarchy.storage_strategy(slot)? {
+        let (_buffer_slot, mut buffer) = match self.hierarchy.storage_strategy(slot)? {
             // Base case.
             StorageStrategy::Snapshot => {
                 let state = self

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1403,10 +1403,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<(), Error> {
         self.store_cold_state_summary(state_root, state.slot(), ops)?;
 
-        if state.slot() % E::slots_per_epoch() != 0 {
-            return Ok(());
-        }
-
         let slot = state.slot();
         match self.hierarchy.storage_strategy(slot)? {
             StorageStrategy::Nothing => {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -79,7 +79,7 @@ pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
     #[allow(dead_code)]
     historic_state_cache: Mutex<LruCache<Slot, BeaconState<E>>>,
     /// Cache of hierarchical diff buffers.
-    diff_buffer_cache: Mutex<LruCache<Epoch, HDiffBuffer>>,
+    diff_buffer_cache: Mutex<LruCache<Slot, HDiffBuffer>>,
     // Cache of hierarchical diffs.
     // FIXME(sproul): see if this is necessary
     /// Chain spec.
@@ -113,7 +113,7 @@ pub enum HotColdDBError {
     MissingPrevState(Hash256),
     MissingSplitState(Hash256, Slot),
     MissingStateDiff(Hash256),
-    MissingHDiff(Epoch),
+    MissingHDiff(Slot),
     MissingExecutionPayload(Hash256),
     MissingFullBlockExecutionPayloadPruned(Hash256, Slot),
     MissingAnchorInfo,
@@ -1407,8 +1407,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             return Ok(());
         }
 
-        let epoch = state.current_epoch();
-        match self.hierarchy.storage_strategy(epoch)? {
+        let slot = state.slot();
+        match self.hierarchy.storage_strategy(slot)? {
             StorageStrategy::Nothing => {
                 debug!(
                     self.log,
@@ -1431,6 +1431,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     self.log,
                     "Storing cold state";
                     "strategy" => "diff",
+                    "from_slot" => from,
                     "slot" => state.slot(),
                 );
                 self.store_cold_state_as_diff(state, from, ops)?;
@@ -1462,13 +1463,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         Ok(())
     }
 
-    pub fn load_cold_state_bytes_as_snapshot(
-        &self,
-        epoch: Epoch,
-    ) -> Result<Option<Vec<u8>>, Error> {
+    pub fn load_cold_state_bytes_as_snapshot(&self, slot: Slot) -> Result<Option<Vec<u8>>, Error> {
         match self.cold_db.get_bytes(
             DBColumn::BeaconStateSnapshot.into(),
-            &epoch.as_u64().to_be_bytes(),
+            &slot.as_u64().to_be_bytes(),
         )? {
             Some(bytes) => {
                 let mut ssz_bytes =
@@ -1483,12 +1481,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
     }
 
-    pub fn load_cold_state_as_snapshot(
-        &self,
-        epoch: Epoch,
-    ) -> Result<Option<BeaconState<E>>, Error> {
+    pub fn load_cold_state_as_snapshot(&self, slot: Slot) -> Result<Option<BeaconState<E>>, Error> {
         Ok(self
-            .load_cold_state_bytes_as_snapshot(epoch)?
+            .load_cold_state_bytes_as_snapshot(slot)?
             .map(|bytes| BeaconState::from_ssz_bytes(&bytes, &self.spec))
             .transpose()?)
     }
@@ -1496,18 +1491,18 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     pub fn store_cold_state_as_diff(
         &self,
         state: &BeaconState<E>,
-        from_epoch: Epoch,
+        from_slot: Slot,
         ops: &mut Vec<KeyValueStoreOp>,
     ) -> Result<(), Error> {
         // Load diff base state bytes.
-        let base_buffer = self.load_hdiff_buffer_for_epoch(from_epoch)?;
+        let base_buffer = self.load_hdiff_buffer_for_slot(from_slot)?;
         let target_buffer = HDiffBuffer::from_state(state.clone());
         let diff = HDiff::compute(&base_buffer, &target_buffer)?;
         let diff_bytes = diff.as_ssz_bytes();
 
         let key = get_key_for_col(
             DBColumn::BeaconStateDiff.into(),
-            &state.current_epoch().as_u64().to_be_bytes(),
+            &state.slot().as_u64().to_be_bytes(),
         );
         ops.push(KeyValueStoreOp::PutKeyValue(key, diff_bytes));
         Ok(())
@@ -1527,9 +1522,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///
     /// Will reconstruct the state if it lies between restore points.
     pub fn load_cold_state_by_slot(&self, slot: Slot) -> Result<Option<BeaconState<E>>, Error> {
-        let epoch = slot.epoch(E::slots_per_epoch());
-
-        let hdiff_buffer = self.load_hdiff_buffer_for_epoch(epoch)?;
+        let hdiff_buffer = self.load_hdiff_buffer_for_slot(slot)?;
         let base_state = hdiff_buffer.into_state(&self.spec)?;
 
         if base_state.slot() == slot {
@@ -1548,23 +1541,23 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .map(Some)
     }
 
-    fn load_hdiff_for_epoch(&self, epoch: Epoch) -> Result<HDiff, Error> {
+    fn load_hdiff_for_slot(&self, slot: Slot) -> Result<HDiff, Error> {
         self.cold_db
             .get_bytes(
                 DBColumn::BeaconStateDiff.into(),
-                &epoch.as_u64().to_be_bytes(),
+                &slot.as_u64().to_be_bytes(),
             )?
             .map(|bytes| HDiff::from_ssz_bytes(&bytes))
-            .ok_or(HotColdDBError::MissingHDiff(epoch))?
+            .ok_or(HotColdDBError::MissingHDiff(slot))?
             .map_err(Into::into)
     }
 
-    fn load_hdiff_buffer_for_epoch(&self, epoch: Epoch) -> Result<HDiffBuffer, Error> {
-        if let Some(buffer) = self.diff_buffer_cache.lock().get(&epoch) {
+    fn load_hdiff_buffer_for_slot(&self, slot: Slot) -> Result<HDiffBuffer, Error> {
+        if let Some(buffer) = self.diff_buffer_cache.lock().get(&slot) {
             debug!(
                 self.log,
                 "Hit diff buffer cache";
-                "epoch" => epoch
+                "slot" => slot
             );
             return Ok(buffer.clone());
         }
@@ -1572,29 +1565,29 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         // Load buffer for the previous state.
         // This amount of recursion (<10 levels) should be OK.
         let t = std::time::Instant::now();
-        let mut buffer = match self.hierarchy.storage_strategy(epoch)? {
+        let mut buffer = match self.hierarchy.storage_strategy(slot)? {
             // Base case.
             StorageStrategy::Snapshot => {
                 let state = self
-                    .load_cold_state_as_snapshot(epoch)?
-                    .ok_or(Error::MissingSnapshot(epoch))?;
+                    .load_cold_state_as_snapshot(slot)?
+                    .ok_or(Error::MissingSnapshot(slot))?;
                 return Ok(HDiffBuffer::from_state(state));
             }
             // Recursive case.
-            StorageStrategy::DiffFrom(from) => self.load_hdiff_buffer_for_epoch(from)?,
+            StorageStrategy::DiffFrom(from) => self.load_hdiff_buffer_for_slot(from)?,
             StorageStrategy::Nothing => unreachable!("FIXME(sproul)"),
         };
 
         // Load diff and apply it to buffer.
-        let diff = self.load_hdiff_for_epoch(epoch)?;
+        let diff = self.load_hdiff_for_slot(slot)?;
         diff.apply(&mut buffer)?;
 
-        self.diff_buffer_cache.lock().put(epoch, buffer.clone());
+        self.diff_buffer_cache.lock().put(slot, buffer.clone());
         debug!(
             self.log,
             "Added diff buffer to cache";
             "load_time_ms" => t.elapsed().as_millis(),
-            "epoch" => epoch
+            "slot" => slot
         );
 
         Ok(buffer)
@@ -1741,14 +1734,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     /// Initialise the anchor info for checkpoint sync starting from `block`.
     pub fn init_anchor_info(&self, block: BeaconBlockRef<'_, E>) -> Result<KeyValueStoreOp, Error> {
         let anchor_slot = block.slot();
-        let anchor_epoch = anchor_slot.epoch(E::slots_per_epoch());
 
         // Set the `state_upper_limit` to the slot of the *next* checkpoint.
         // See `get_state_upper_limit` for rationale.
-        let next_snapshot_slot = self
-            .hierarchy
-            .next_snapshot_epoch(anchor_epoch)?
-            .start_slot(E::slots_per_epoch());
+        let next_snapshot_slot = self.hierarchy.next_snapshot_slot(anchor_slot)?;
         let anchor_info = AnchorInfo {
             anchor_slot,
             oldest_block_slot: anchor_slot,

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -15,6 +15,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::string::ToString;
 use std::time::Duration;
+use store::hdiff::HierarchyConfig;
 use tempfile::TempDir;
 use types::{
     Address, Checkpoint, Epoch, ExecutionBlockHash, ForkName, Hash256, MainnetEthSpec,
@@ -445,6 +446,35 @@ fn eth1_cache_follow_distance_manual() {
             assert_eq!(config.eth1.cache_follow_distance, Some(128));
             assert_eq!(config.eth1.cache_follow_distance(), 128);
         });
+}
+#[test]
+fn hierarchy_exponents_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.store.hierarchy_config, HierarchyConfig::default());
+        });
+}
+#[test]
+fn hierarchy_exponents_valid() {
+    CommandLineTest::new()
+        .flag("hierarchy-exponents", Some("3,6,9,12"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.store.hierarchy_config,
+                HierarchyConfig {
+                    exponents: vec![3, 6, 9, 12]
+                }
+            );
+        });
+}
+#[test]
+#[should_panic]
+fn hierarchy_exponents_invalid_order() {
+    CommandLineTest::new()
+        .flag("hierarchy-exponents", Some("7,6,9,12"))
+        .run_with_zero_port();
 }
 
 // Tests for Bellatrix flags.


### PR DESCRIPTION
## Issue Addressed

#4475 

## Changes

- Update `HDiff` to support storing snapshots/hdiffs at per-slot level. Snapshots and HDiffs are now keyed by slots in DB.
- Store `HierarchyConfig` on disk (`OnDiskStoreConfig`).
- Add validity check for the hierarchy config when opening the DB.
- Add `--hierarchy-exponents` cli flag to beacon node.
- Add `StorageStrategy::ReplayFrom` to fix a panic when a hdiff is not present at the requested slot.
- Fix incorrect `storage_strategy` calculation which caused diffs with respect to the previous diff in the same layer instead of the diff from the previous layer being stored, which resulted in loading and applying more diffs than required. 
- Add snapshot to `diff_buffer_cache` instead of loading it from db every time we need it.
- Rename `XorDiff` to `CompressedU64Diff`.
- Lower `hierarchy_config` in store tests for more frequent snapshot & hdiffs to cover more scenarios.
