### PR TITLE
rust 1.72 lints

### DIFF
--- a/beacon_node/beacon_chain/src/observed_attesters.rs
+++ b/beacon_node/beacon_chain/src/observed_attesters.rs
@@ -841,7 +841,7 @@ mod tests {
                     let mut store = $type::default();
                     let max_cap = store.max_capacity();
 
-                    let to_skip = vec![1_u64, 3, 4, 5];
+                    let to_skip = [1_u64, 3, 4, 5];
                     let periods = (0..max_cap * 3)
                         .into_iter()
                         .filter(|i| !to_skip.contains(i))
@@ -1012,7 +1012,7 @@ mod tests {
                     let mut store = $type::default();
                     let max_cap = store.max_capacity();
 
-                    let to_skip = vec![1_u64, 3, 4, 5];
+                    let to_skip = [1_u64, 3, 4, 5];
                     let periods = (0..max_cap * 3)
                         .into_iter()
                         .filter(|i| !to_skip.contains(i))
@@ -1121,7 +1121,7 @@ mod tests {
                     let mut store = $type::default();
                     let max_cap = store.max_capacity();
 
-                    let to_skip = vec![1_u64, 3, 4, 5];
+                    let to_skip = [1_u64, 3, 4, 5];
                     let periods = (0..max_cap * 3)
                         .into_iter()
                         .filter(|i| !to_skip.contains(i))

--- a/beacon_node/genesis/src/common.rs
+++ b/beacon_node/genesis/src/common.rs
@@ -39,7 +39,7 @@ pub fn genesis_deposits(
 
     Ok(deposit_data
         .into_iter()
-        .zip(proofs.into_iter())
+        .zip(proofs)
         .map(|(data, proof)| (data, proof.into()))
         .map(|(data, proof)| Deposit { proof, data })
         .collect())

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -647,7 +647,7 @@ impl<TSpec: EthSpec> Discovery<TSpec> {
                 if subnet_queries.len() == MAX_SUBNETS_IN_QUERY || self.queued_queries.is_empty() {
                     // This query is for searching for peers of a particular subnet
                     // Drain subnet_queries so we can re-use it as we continue to process the queue
-                    let grouped_queries: Vec<SubnetQuery> = subnet_queries.drain(..).collect();
+                    let grouped_queries: Vec<SubnetQuery> = std::mem::take(&mut subnet_queries);
                     self.start_subnet_query(grouped_queries);
                     processed = true;
                 }

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -969,6 +969,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
 
         macro_rules! prune_peers {
             ($filter: expr) => {
+                let filter = $filter;
                 for (peer_id, info) in self
                     .network_globals
                     .peers
@@ -976,7 +977,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                     .worst_connected_peers()
                     .iter()
                     .filter(|(_, info)| {
-                        !info.has_future_duty() && !info.is_trusted() && $filter(*info)
+                        !info.has_future_duty() && !info.is_trusted() && filter(*info)
                     })
                 {
                     if peers_to_prune.len()

--- a/beacon_node/store/src/chunked_vector.rs
+++ b/beacon_node/store/src/chunked_vector.rs
@@ -299,7 +299,8 @@ macro_rules! field {
             }
 
             fn update_pattern(spec: &ChainSpec) -> UpdatePattern {
-                $update_pattern(spec)
+                let update_pattern = $update_pattern;
+                update_pattern(spec)
             }
 
             fn get_value(
@@ -307,7 +308,8 @@ macro_rules! field {
                 vindex: u64,
                 spec: &ChainSpec,
             ) -> Result<Self::Value, ChunkError> {
-                $get_value(state, vindex, spec)
+                let get_value = $get_value;
+                get_value(state, vindex, spec)
             }
 
             fn is_fixed_length() -> bool {

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -167,7 +167,7 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
             )
         };
 
-        for (start_key, end_key) in vec![
+        for (start_key, end_key) in [
             endpoints(DBColumn::BeaconStateTemporary),
             endpoints(DBColumn::BeaconState),
         ] {

--- a/consensus/safe_arith/src/iter.rs
+++ b/consensus/safe_arith/src/iter.rs
@@ -28,10 +28,10 @@ mod test {
 
     #[test]
     fn unsigned_sum_small() {
-        let v = vec![400u64, 401, 402, 403, 404, 405, 406];
+        let arr = [400u64, 401, 402, 403, 404, 405, 406];
         assert_eq!(
-            v.iter().copied().safe_sum().unwrap(),
-            v.iter().copied().sum()
+            arr.iter().copied().safe_sum().unwrap(),
+            arr.iter().copied().sum()
         );
     }
 
@@ -61,10 +61,10 @@ mod test {
 
     #[test]
     fn signed_sum_almost_overflow() {
-        let v = vec![i64::MIN, 1, -1i64, i64::MAX, i64::MAX, 1];
+        let arr = [i64::MIN, 1, -1i64, i64::MAX, i64::MAX, 1];
         assert_eq!(
-            v.iter().copied().safe_sum().unwrap(),
-            v.iter().copied().sum()
+            arr.iter().copied().safe_sum().unwrap(),
+            arr.iter().copied().sum()
         );
     }
 }

--- a/crypto/bls/src/generic_public_key_bytes.rs
+++ b/crypto/bls/src/generic_public_key_bytes.rs
@@ -27,10 +27,7 @@ impl<Pub> Copy for GenericPublicKeyBytes<Pub> {}
 
 impl<Pub> Clone for GenericPublicKeyBytes<Pub> {
     fn clone(&self) -> Self {
-        Self {
-            bytes: self.bytes,
-            _phantom: PhantomData,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html

Changes:
- change some vecs to arrays
- binding closures to variables before invoking them
  - was getting this lint in macros: https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_closure_call
- couple other small changes