### PR TITLE
[Merged by Bors] - Show `--gui` flag in help text

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1125,7 +1125,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("gui")
                 .long("gui")
-                .hidden(true)
                 .help("Enable the graphical user interface and all its requirements. \
                       This enables --http and --validator-monitor-auto and enables SSE logging.")
                 .takes_value(false)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Remove the `hidden(true)` modifier on the `--gui` flag so it shows up when running `lighthouse bn --help`

## Additional Info

We need to include this now that Siren has had its first stable release.
