### PR TITLE
[Merged by Bors] - Increase `web3signer_tests` timeouts

### DIFF
--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
 
     /// If the we are unable to reach the Web3Signer HTTP API within this time out then we will
     /// assume it failed to start.
-    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(20);
+    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
     /// Set to `false` to send the Web3Signer logs to the console during tests. Logs are useful when
     /// debugging.

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -51,11 +51,11 @@ mod tests {
 
     /// If the we are unable to reach the Web3Signer HTTP API within this time out then we will
     /// assume it failed to start.
-    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(60);
+    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(120);
 
     /// Set to `false` to send the Web3Signer logs to the console during tests. Logs are useful when
     /// debugging.
-    const SUPPRESS_WEB3SIGNER_LOGS: bool = true;
+    const SUPPRESS_WEB3SIGNER_LOGS: bool = false;
 
     lazy_static! {
         static ref TEMP_DIR: Arc<Mutex<TempDir>> = Arc::new(Mutex::new(

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
 
     /// If the we are unable to reach the Web3Signer HTTP API within this time out then we will
     /// assume it failed to start.
-    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(30);
+    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(40);
 
     /// Set to `false` to send the Web3Signer logs to the console during tests. Logs are useful when
     /// debugging.

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -51,11 +51,11 @@ mod tests {
 
     /// If the we are unable to reach the Web3Signer HTTP API within this time out then we will
     /// assume it failed to start.
-    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(120);
+    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
     /// Set to `false` to send the Web3Signer logs to the console during tests. Logs are useful when
     /// debugging.
-    const SUPPRESS_WEB3SIGNER_LOGS: bool = false;
+    const SUPPRESS_WEB3SIGNER_LOGS: bool = true;
 
     lazy_static! {
         static ref TEMP_DIR: Arc<Mutex<TempDir>> = Arc::new(Mutex::new(

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
 
     /// If the we are unable to reach the Web3Signer HTTP API within this time out then we will
     /// assume it failed to start.
-    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(40);
+    const UPCHECK_TIMEOUT: Duration = Duration::from_secs(60);
 
     /// Set to `false` to send the Web3Signer logs to the console during tests. Logs are useful when
     /// debugging.


### PR DESCRIPTION
## Issue Addressed

`web3signer_tests` can sometimes timeout.

## Proposed Changes

Increase the `web3signer_tests` timeout from 20s to 30s

## Additional Info
Previously I believed the consistent CI failures were due to this, but it ended up being something different. See below:

---

The timing of this makes it very likely it is related to the [latest release of `web3-signer`](https://github.com/Consensys/web3signer/releases/tag/23.8.1).

I now believe this is due to an out of date Java runtime on our runners. A newer version of Java became a requirement with the new `web3-signer` release.

However, I was getting timeouts locally, which implies that the margin before timeout is quite small at 20s so bumping it up to 30s could be a good idea regardless.