### PR TITLE
[Merged by Bors] - require http and metrics for respective flags

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::{App, Arg};
+use clap::{App, Arg, ArgGroup};
 use strum::VariantNames;
 use types::ProgressiveBalancesMode;
 
@@ -316,7 +316,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-address")
                 .long("http-address")
-                .requires("http")
+                .requires("enable_http")
                 .value_name("ADDRESS")
                 .help("Set the listen address for the RESTful HTTP API server.")
                 .default_value_if("http", None, "127.0.0.1")
@@ -325,7 +325,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-port")
                 .long("http-port")
-                .requires("http")
+                .requires("enable_http")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the RESTful HTTP API server.")
                 .default_value_if("http", None, "5052")
@@ -334,7 +334,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-allow-origin")
                 .long("http-allow-origin")
-                .requires("http")
+                .requires("enable_http")
                 .value_name("ORIGIN")
                 .help("Set the value of the Access-Control-Allow-Origin response HTTP header. \
                     Use * to allow any origin (not recommended in production). \
@@ -345,13 +345,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-disable-legacy-spec")
                 .long("http-disable-legacy-spec")
-                .requires("http")
+                .requires("enable_http")
                 .hidden(true)
         )
         .arg(
             Arg::with_name("http-spec-fork")
                 .long("http-spec-fork")
-                .requires("http")
+                .requires("enable_http")
                 .value_name("FORK")
                 .help("Serve the spec for a specific hard fork on /eth/v1/config/spec. It should \
                        not be necessary to set this flag.")
@@ -369,7 +369,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-tls-cert")
                 .long("http-tls-cert")
-                .requires("http")
+                .requires("enable_http")
                 .help("The path of the certificate to be used when serving the HTTP API server \
                     over TLS.")
                 .takes_value(true)
@@ -377,7 +377,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-tls-key")
                 .long("http-tls-key")
-                .requires("http")
+                .requires("enable_http")
                 .help("The path of the private key to be used when serving the HTTP API server \
                     over TLS. Must not be password-protected.")
                 .takes_value(true)
@@ -385,7 +385,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-allow-sync-stalled")
                 .long("http-allow-sync-stalled")
-                .requires("http")
+                .requires("enable_http")
                 .help("Forces the HTTP to indicate that the node is synced when sync is actually \
                     stalled. This is useful for very small testnets. TESTING ONLY. DO NOT USE ON \
                     MAINNET.")
@@ -393,7 +393,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-sse-capacity-multiplier")
                 .long("http-sse-capacity-multiplier")
-                .requires("http")
+                .requires("enable_http")
                 .takes_value(true)
                 .default_value_if("http", None, "1")
                 .value_name("N")
@@ -403,7 +403,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-duplicate-block-status")
                 .long("http-duplicate-block-status")
-                .requires("http")
+                .requires("enable_http")
                 .takes_value(true)
                 .default_value_if("http", None, "202")
                 .value_name("STATUS_CODE")
@@ -413,7 +413,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-enable-beacon-processor")
                 .long("http-enable-beacon-processor")
-                .requires("http")
+                .requires("enable_http")
                 .value_name("BOOLEAN")
                 .help("The beacon processor is a scheduler which provides quality-of-service and \
                     DoS protection. When set to \"true\", HTTP API requests will be queued and scheduled \
@@ -1234,4 +1234,5 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("64")
                 .takes_value(true)
         )
+        .group(ArgGroup::with_name("enable_http").args(&["http", "gui", "staking"]))
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -319,7 +319,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .requires("enable_http")
                 .value_name("ADDRESS")
                 .help("Set the listen address for the RESTful HTTP API server.")
-                .default_value_if("http", None, "127.0.0.1")
+                .default_value_if("enable_http", None, "127.0.0.1")
                 .takes_value(true),
         )
         .arg(
@@ -328,7 +328,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .requires("enable_http")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the RESTful HTTP API server.")
-                .default_value_if("http", None, "5052")
+                .default_value_if("enable_http", None, "5052")
                 .takes_value(true),
         )
         .arg(
@@ -395,7 +395,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("http-sse-capacity-multiplier")
                 .requires("enable_http")
                 .takes_value(true)
-                .default_value_if("http", None, "1")
+                .default_value_if("enable_http", None, "1")
                 .value_name("N")
                 .help("Multiplier to apply to the length of HTTP server-sent-event (SSE) channels. \
                        Increasing this value can prevent messages from being dropped.")
@@ -405,7 +405,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("http-duplicate-block-status")
                 .requires("enable_http")
                 .takes_value(true)
-                .default_value_if("http", None, "202")
+                .default_value_if("enable_http", None, "202")
                 .value_name("STATUS_CODE")
                 .help("Status code to send when a block that is already known is POSTed to the \
                        HTTP API.")
@@ -420,7 +420,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     alongside other tasks. When set to \"false\", HTTP API responses will be executed \
                     immediately.")
                 .takes_value(true)
-                .default_value_if("http", None, "true")
+                .default_value_if("enable_http", None, "true")
         )
         /* Prometheus metrics HTTP server related arguments */
         .arg(

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -316,22 +316,25 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-address")
                 .long("http-address")
+                .requires("http")
                 .value_name("ADDRESS")
                 .help("Set the listen address for the RESTful HTTP API server.")
-                .default_value("127.0.0.1")
+                .default_value_if("http", None, "127.0.0.1")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("http-port")
                 .long("http-port")
+                .requires("http")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the RESTful HTTP API server.")
-                .default_value("5052")
+                .default_value_if("http", None, "5052")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("http-allow-origin")
                 .long("http-allow-origin")
+                .requires("http")
                 .value_name("ORIGIN")
                 .help("Set the value of the Access-Control-Allow-Origin response HTTP header. \
                     Use * to allow any origin (not recommended in production). \
@@ -342,11 +345,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-disable-legacy-spec")
                 .long("http-disable-legacy-spec")
+                .requires("http")
                 .hidden(true)
         )
         .arg(
             Arg::with_name("http-spec-fork")
                 .long("http-spec-fork")
+                .requires("http")
                 .value_name("FORK")
                 .help("Serve the spec for a specific hard fork on /eth/v1/config/spec. It should \
                        not be necessary to set this flag.")
@@ -364,6 +369,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-tls-cert")
                 .long("http-tls-cert")
+                .requires("http")
                 .help("The path of the certificate to be used when serving the HTTP API server \
                     over TLS.")
                 .takes_value(true)
@@ -371,6 +377,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-tls-key")
                 .long("http-tls-key")
+                .requires("http")
                 .help("The path of the private key to be used when serving the HTTP API server \
                     over TLS. Must not be password-protected.")
                 .takes_value(true)
@@ -378,6 +385,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-allow-sync-stalled")
                 .long("http-allow-sync-stalled")
+                .requires("http")
                 .help("Forces the HTTP to indicate that the node is synced when sync is actually \
                     stalled. This is useful for very small testnets. TESTING ONLY. DO NOT USE ON \
                     MAINNET.")
@@ -385,8 +393,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-sse-capacity-multiplier")
                 .long("http-sse-capacity-multiplier")
+                .requires("http")
                 .takes_value(true)
-                .default_value("1")
+                .default_value_if("http", None, "1")
                 .value_name("N")
                 .help("Multiplier to apply to the length of HTTP server-sent-event (SSE) channels. \
                        Increasing this value can prevent messages from being dropped.")
@@ -394,8 +403,9 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-duplicate-block-status")
                 .long("http-duplicate-block-status")
+                .requires("http")
                 .takes_value(true)
-                .default_value("202")
+                .default_value_if("http", None, "202")
                 .value_name("STATUS_CODE")
                 .help("Status code to send when a block that is already known is POSTed to the \
                        HTTP API.")
@@ -403,13 +413,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-enable-beacon-processor")
                 .long("http-enable-beacon-processor")
+                .requires("http")
                 .value_name("BOOLEAN")
                 .help("The beacon processor is a scheduler which provides quality-of-service and \
                     DoS protection. When set to \"true\", HTTP API requests will be queued and scheduled \
                     alongside other tasks. When set to \"false\", HTTP API responses will be executed \
                     immediately.")
                 .takes_value(true)
-                .default_value("true")
+                .default_value_if("http", None, "true")
         )
         /* Prometheus metrics HTTP server related arguments */
         .arg(
@@ -422,22 +433,25 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("metrics-address")
                 .long("metrics-address")
                 .value_name("ADDRESS")
+                .requires("metrics")
                 .help("Set the listen address for the Prometheus metrics HTTP server.")
-                .default_value("127.0.0.1")
+                .default_value_if("metrics", None, "127.0.0.1")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("metrics-port")
                 .long("metrics-port")
+                .requires("metrics")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the Prometheus metrics HTTP server.")
-                .default_value("5054")
+                .default_value_if("metrics", None, "5054")
                 .takes_value(true),
         )
         .arg(
             Arg::with_name("metrics-allow-origin")
                 .long("metrics-allow-origin")
                 .value_name("ORIGIN")
+                .requires("metrics")
                 .help("Set the value of the Access-Control-Allow-Origin response HTTP header. \
                     Use * to allow any origin (not recommended in production). \
                     If no value is supplied, the CORS allowed origin is set to the listen \

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -94,7 +94,7 @@ pub fn get_config<E: EthSpec>(
      * Http API server
      */
 
-    if cli_args.is_present("http") {
+    if cli_args.is_present("enable_http") {
         client_config.http_api.enabled = true;
 
         if let Some(address) = cli_args.value_of("http-address") {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1403,6 +1403,7 @@ fn http_flag() {
 fn http_address_flag() {
     let addr = "127.0.0.99".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
+        .flag("http", None)
         .flag("http-address", Some("127.0.0.99"))
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
@@ -1411,6 +1412,7 @@ fn http_address_flag() {
 fn http_address_ipv6_flag() {
     let addr = "::1".parse::<IpAddr>().unwrap();
     CommandLineTest::new()
+        .flag("http", None)
         .flag("http-address", Some("::1"))
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.http_api.listen_addr, addr));
@@ -1420,6 +1422,7 @@ fn http_port_flag() {
     let port1 = unused_tcp4_port().expect("Unable to find unused port.");
     let port2 = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
+        .flag("http", None)
         .flag("http-port", Some(port1.to_string().as_str()))
         .flag("port", Some(port2.to_string().as_str()))
         .run()
@@ -2383,6 +2386,7 @@ fn http_sse_capacity_multiplier_default() {
 #[test]
 fn http_sse_capacity_multiplier_override() {
     CommandLineTest::new()
+        .flag("http", None)
         .flag("http-sse-capacity-multiplier", Some("10"))
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.http_api.sse_capacity_multiplier, 10));
@@ -2400,6 +2404,7 @@ fn http_duplicate_block_status_default() {
 #[test]
 fn http_duplicate_block_status_override() {
     CommandLineTest::new()
+        .flag("http", None)
         .flag("http-duplicate-block-status", Some("301"))
         .run_with_zero_port()
         .with_config(|config| {

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -216,7 +216,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     consumers who have access to the API token. This method is useful for \
                     exporting validators, however it should be used with caution since it \
                     exposes private key data to authorized users.")
-                .required(false)
                 .takes_value(false),
         )
         .arg(
@@ -226,7 +225,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("If present, any validators created via the HTTP will have keystore \
                     passwords stored in the secrets-dir rather than the validator \
                     definitions file.")
-                .required(false)
                 .takes_value(false),
         )
         /* Prometheus metrics HTTP server related arguments */

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -170,6 +170,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
          .arg(
              Arg::with_name("http-address")
                  .long("http-address")
+                 .requires("http")
                  .value_name("ADDRESS")
                  .help("Set the address for the HTTP address. The HTTP server is not encrypted \
                         and therefore it is unsafe to publish on a public network. When this \
@@ -189,6 +190,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-port")
                 .long("http-port")
+                .requires("http")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the RESTful HTTP API server.")
                 .default_value("5062")
@@ -197,6 +199,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-allow-origin")
                 .long("http-allow-origin")
+                .requires("http")
                 .value_name("ORIGIN")
                 .help("Set the value of the Access-Control-Allow-Origin response HTTP header. \
                     Use * to allow any origin (not recommended in production). \
@@ -207,6 +210,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-allow-keystore-export")
                 .long("http-allow-keystore-export")
+                .requires("http")
                 .help("If present, allow access to the DELETE /lighthouse/keystores HTTP \
                     API method, which allows exporting keystores and passwords to HTTP API \
                     consumers who have access to the API token. This method is useful for \
@@ -218,6 +222,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("http-store-passwords-in-secrets-dir")
                 .long("http-store-passwords-in-secrets-dir")
+                .requires("http")
                 .help("If present, any validators created via the HTTP will have keystore \
                     passwords stored in the secrets-dir rather than the validator \
                     definitions file.")
@@ -234,6 +239,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("metrics-address")
                 .long("metrics-address")
+                .requires("metrics")
                 .value_name("ADDRESS")
                 .help("Set the listen address for the Prometheus metrics HTTP server.")
                 .default_value("127.0.0.1")
@@ -242,6 +248,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("metrics-port")
                 .long("metrics-port")
+                .requires("metrics")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the Prometheus metrics HTTP server.")
                 .default_value("5064")
@@ -250,6 +257,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("metrics-allow-origin")
                 .long("metrics-allow-origin")
+                .requires("metrics")
                 .value_name("ORIGIN")
                 .help("Set the value of the Access-Control-Allow-Origin response HTTP header. \
                     Use * to allow any origin (not recommended in production). \

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -193,7 +193,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .requires("http")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the RESTful HTTP API server.")
-                .default_value("5062")
+                .default_value_if("http", None, "5062")
                 .takes_value(true),
         )
         .arg(
@@ -242,7 +242,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .requires("metrics")
                 .value_name("ADDRESS")
                 .help("Set the listen address for the Prometheus metrics HTTP server.")
-                .default_value("127.0.0.1")
+                .default_value_if("metrics", None, "127.0.0.1")
                 .takes_value(true),
         )
         .arg(
@@ -251,7 +251,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .requires("metrics")
                 .value_name("PORT")
                 .help("Set the listen TCP port for the Prometheus metrics HTTP server.")
-                .default_value("5064")
+                .default_value_if("metrics", None, "5064")
                 .takes_value(true),
         )
         .arg(


### PR DESCRIPTION
## Issue Addressed

following discussion on https://github.com/sigp/lighthouse/pull/4639#discussion_r1305183750 this PR makes the `http` and `metrics` sub-flags to require those main flags enabled  


