### PR TITLE
Simplifications for ./crypto

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -723,7 +723,7 @@ mod tests {
         SignedBeaconBlock::from_block(full_block, Signature::empty())
     }
 
-    fn default_blob_sidecar() -> Arc<BlobSidecar<Spec>> {
+    fn empty_blob_sidecar() -> Arc<BlobSidecar<Spec>> {
         Arc::new(BlobSidecar::empty())
     }
 
@@ -1048,21 +1048,21 @@ mod tests {
         assert_eq!(
             encode_then_decode_response(
                 SupportedProtocol::BlobsByRangeV1,
-                RPCCodedResponse::Success(RPCResponse::BlobsByRange(default_blob_sidecar())),
+                RPCCodedResponse::Success(RPCResponse::BlobsByRange(empty_blob_sidecar())),
                 ForkName::Deneb,
                 &chain_spec
             ),
-            Ok(Some(RPCResponse::BlobsByRange(default_blob_sidecar()))),
+            Ok(Some(RPCResponse::BlobsByRange(empty_blob_sidecar()))),
         );
 
         assert_eq!(
             encode_then_decode_response(
                 SupportedProtocol::BlobsByRootV1,
-                RPCCodedResponse::Success(RPCResponse::BlobsByRoot(default_blob_sidecar())),
+                RPCCodedResponse::Success(RPCResponse::BlobsByRoot(empty_blob_sidecar())),
                 ForkName::Deneb,
                 &chain_spec
             ),
-            Ok(Some(RPCResponse::BlobsByRoot(default_blob_sidecar()))),
+            Ok(Some(RPCResponse::BlobsByRoot(empty_blob_sidecar()))),
         );
     }
 

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -292,7 +292,7 @@ fn test_blobs_by_range_chunked_rpc() {
         });
 
         // BlocksByRange Response
-        let blob = BlobSidecar::<E>::default();
+        let blob = BlobSidecar::<E>::empty();
 
         let rpc_response = Response::BlobsByRange(Some(Arc::new(blob)));
 

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -11,7 +11,7 @@ harness = false
 [dependencies]
 merkle_proof = { path = "../../consensus/merkle_proof" }
 bls = { path = "../../crypto/bls", features = ["arbitrary"] }
-kzg = { path = "../../crypto/kzg", features = ["arbitrary"] }
+kzg = { path = "../../crypto/kzg" }
 compare_fields = { path = "../../common/compare_fields" }
 compare_fields_derive = { path = "../../common/compare_fields_derive" }
 eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -45,7 +45,6 @@ impl Ord for BlobIdentifier {
     Encode,
     Decode,
     TreeHash,
-    Default,
     TestRandom,
     Derivative,
     arbitrary::Arbitrary,
@@ -120,7 +119,16 @@ impl<T: EthSpec> BlobSidecar<T> {
     }
 
     pub fn empty() -> Self {
-        Self::default()
+        Self {
+            block_root: Hash256::zero(),
+            index: 0,
+            slot: Slot::new(0),
+            block_parent_root: Hash256::zero(),
+            proposer_index: 0,
+            blob: Blob::<T>::default(),
+            kzg_commitment: KzgCommitment::empty_for_testing(),
+            kzg_proof: KzgProof::empty(),
+        }
     }
 
     pub fn random_valid<R: Rng>(rng: &mut R, kzg: &Kzg<T::Kzg>) -> Result<Self, String> {
@@ -154,7 +162,7 @@ impl<T: EthSpec> BlobSidecar<T> {
             blob,
             kzg_commitment: commitment,
             kzg_proof: proof,
-            ..Default::default()
+            ..Self::empty()
         })
     }
 
@@ -198,7 +206,6 @@ impl<T: EthSpec> BlobSidecar<T> {
     Encode,
     Decode,
     TreeHash,
-    Default,
     TestRandom,
     Derivative,
     arbitrary::Arbitrary,

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -18,7 +18,7 @@ hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
 c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "fa3c62989527073fdce8b2138bb27a52bb2407c5" , features = ["mainnet-spec"]}
 c_kzg_min = { package = "c-kzg", git = "https://github.com/ethereum//c-kzg-4844", rev = "fa3c62989527073fdce8b2138bb27a52bb2407c5", features = ["minimal-spec"], optional = true }
-arbitrary = { version = "1.0", features = ["derive"], optional = true }
+arbitrary = { version = "1.0", features = ["derive"] }
 
 [features]
 # TODO(deneb): enabled by default for convenience, would need more cfg magic to disable

--- a/crypto/kzg/src/kzg_proof.rs
+++ b/crypto/kzg/src/kzg_proof.rs
@@ -37,12 +37,6 @@ impl fmt::Display for KzgProof {
     }
 }
 
-impl Default for KzgProof {
-    fn default() -> Self {
-        KzgProof([0; BYTES_PER_PROOF])
-    }
-}
-
 impl From<[u8; BYTES_PER_PROOF]> for KzgProof {
     fn from(bytes: [u8; BYTES_PER_PROOF]) -> Self {
         Self(bytes)
@@ -87,25 +81,8 @@ impl<'de> Deserialize<'de> for KzgProof {
     where
         D: Deserializer<'de>,
     {
-        pub struct StringVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for StringVisitor {
-            type Value = String;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a hex string with 0x prefix")
-            }
-
-            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(value.to_string())
-            }
-        }
-
-        let string = deserializer.deserialize_str(StringVisitor)?;
-        <Self as std::str::FromStr>::from_str(&string).map_err(serde::de::Error::custom)
+        let string = String::deserialize(deserializer)?;
+        Self::from_str(&string).map_err(serde::de::Error::custom)
     }
 }
 
@@ -138,7 +115,6 @@ impl Debug for KzgProof {
     }
 }
 
-#[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for KzgProof {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let mut bytes = [0u8; BYTES_PER_PROOF];


### PR DESCRIPTION
## Proposed Changes

- Remove footgun `Default` implementations for `BlobSidecar`, `KzgCommitment`, `KzgProof`.
- Simplify `serde` deserialization of commitment & proof.
