### PR TITLE
[Merged by Bors] - Update the voluntary exit endpoint to comply with the key manager specification

### DIFF
--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -666,7 +666,7 @@ impl ValidatorClientHttpClient {
         &self,
         pubkey: &PublicKeyBytes,
         epoch: Option<Epoch>,
-    ) -> Result<SignedVoluntaryExit, Error> {
+    ) -> Result<GenericResponse<SignedVoluntaryExit>, Error> {
         let mut path = self.server.full.clone();
 
         path.path_segments_mut()

--- a/validator_client/src/http_api/create_signed_voluntary_exit.rs
+++ b/validator_client/src/http_api/create_signed_voluntary_exit.rs
@@ -1,5 +1,6 @@
 use crate::validator_store::ValidatorStore;
 use bls::{PublicKey, PublicKeyBytes};
+use eth2::types::GenericResponse;
 use slog::{info, Logger};
 use slot_clock::SlotClock;
 use std::sync::Arc;
@@ -11,7 +12,7 @@ pub async fn create_signed_voluntary_exit<T: 'static + SlotClock + Clone, E: Eth
     validator_store: Arc<ValidatorStore<T, E>>,
     slot_clock: T,
     log: Logger,
-) -> Result<SignedVoluntaryExit, warp::Rejection> {
+) -> Result<GenericResponse<SignedVoluntaryExit>, warp::Rejection> {
     let epoch = match maybe_epoch {
         Some(epoch) => epoch,
         None => get_current_epoch::<T, E>(slot_clock).ok_or_else(|| {
@@ -60,7 +61,7 @@ pub async fn create_signed_voluntary_exit<T: 'static + SlotClock + Clone, E: Eth
             ))
         })?;
 
-    Ok(signed_voluntary_exit)
+    Ok(GenericResponse::from(signed_voluntary_exit))
 }
 
 /// Calculates the current epoch from the genesis time and current time.

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -502,7 +502,7 @@ impl ApiTester {
             .await;
 
         assert!(resp.is_ok());
-        assert_eq!(resp.unwrap().message.epoch, expected_exit_epoch);
+        assert_eq!(resp.unwrap().data.message.epoch, expected_exit_epoch);
 
         self
     }


### PR DESCRIPTION
## Issue Addressed

#4635 

## Proposed Changes

Wrap the `SignedVoluntaryExit` object in a `GenericResponse` container, adding an additional `data` layer, to ensure compliance with the key manager API specification.

The new response would look like this:

```json
{"data":{"message":{"epoch":"196868","validator_index":"505597"},"signature":"0xhexsig"}}
```

This is a backward incompatible change and will affect Siren as well.

