### PR TITLE
Deneb review suggestions (2)

### DIFF
--- a/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
+++ b/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
@@ -6,12 +6,13 @@ use serde_derive::Deserialize;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGBlobToKZGCommitmentInput {
     pub blob: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGBlobToKZGCommitment<E: EthSpec> {
     pub input: KZGBlobToKZGCommitmentInput,
     pub output: Option<String>,

--- a/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
@@ -6,13 +6,14 @@ use serde_derive::Deserialize;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGComputeBlobKZGProofInput {
     pub blob: String,
     pub commitment: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGComputeBlobKZGProof<E: EthSpec> {
     pub input: KZGComputeBlobKZGProofInput,
     pub output: Option<String>,

--- a/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
@@ -13,13 +13,14 @@ pub fn parse_point(point: &str) -> Result<Hash256, Error> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGComputeKZGProofInput {
     pub blob: String,
     pub z: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGComputeKZGProof<E: EthSpec> {
     pub input: KZGComputeKZGProofInput,
     pub output: Option<(String, Hash256)>,

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -47,6 +47,7 @@ pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<Blob<E>, Error> {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGVerifyBlobKZGProofInput {
     pub blob: String,
     pub commitment: String,
@@ -54,7 +55,7 @@ pub struct KZGVerifyBlobKZGProofInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGVerifyBlobKZGProof<E: EthSpec> {
     pub input: KZGVerifyBlobKZGProofInput,
     pub output: Option<bool>,

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -16,7 +16,7 @@ pub fn get_kzg<P: KzgPreset>() -> Result<Kzg<P>, Error> {
 }
 
 pub fn parse_proof(proof: &str) -> Result<KzgProof, Error> {
-    hex::decode(&proof[2..])
+    hex::decode(strip_0x(proof)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse proof: {:?}", e)))
         .and_then(|bytes| {
             bytes
@@ -27,7 +27,7 @@ pub fn parse_proof(proof: &str) -> Result<KzgProof, Error> {
 }
 
 pub fn parse_commitment(commitment: &str) -> Result<KzgCommitment, Error> {
-    hex::decode(&commitment[2..])
+    hex::decode(strip_0x(commitment)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse commitment: {:?}", e)))
         .and_then(|bytes| {
             bytes.try_into().map_err(|e| {
@@ -38,12 +38,19 @@ pub fn parse_commitment(commitment: &str) -> Result<KzgCommitment, Error> {
 }
 
 pub fn parse_blob<E: EthSpec>(blob: &str) -> Result<Blob<E>, Error> {
-    hex::decode(&blob[2..])
+    hex::decode(strip_0x(blob)?)
         .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         .and_then(|bytes| {
             Blob::<E>::new(bytes)
                 .map_err(|e| Error::FailedToParseTest(format!("Failed to parse blob: {:?}", e)))
         })
+}
+
+fn strip_0x(s: &str) -> Result<&str, Error> {
+    s.strip_prefix("0x").ok_or(Error::FailedToParseTest(format!(
+        "Hex is missing 0x prefix: {}",
+        s
+    )))
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -5,6 +5,7 @@ use serde_derive::Deserialize;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGVerifyBlobKZGProofBatchInput {
     pub blobs: Vec<String>,
     pub commitments: Vec<String>,
@@ -12,7 +13,7 @@ pub struct KZGVerifyBlobKZGProofBatchInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGVerifyBlobKZGProofBatch<E: EthSpec> {
     pub input: KZGVerifyBlobKZGProofBatchInput,
     pub output: Option<bool>,

--- a/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
@@ -5,6 +5,7 @@ use serde_derive::Deserialize;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct KZGVerifyKZGProofInput {
     pub commitment: String,
     pub z: String,
@@ -13,7 +14,7 @@ pub struct KZGVerifyKZGProofInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(bound = "E: EthSpec")]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
 pub struct KZGVerifyKZGProof<E: EthSpec> {
     pub input: KZGVerifyKZGProofInput,
     pub output: Option<bool>,


### PR DESCRIPTION
## Issue Addressed

Related to #4676

## Proposed Changes

This includes my review suggestions from reviewing:

- `./account_manager`
- `./beacon_node/genesis`
- `./beacon_node/builder_client`
- `./beacon_node/eth1`
- `./testing`

I also made [this comment](https://github.com/sigp/lighthouse/pull/4054#discussion_r1309853394) on #4054.

## Additional Info

I set `deny_unknown_fields` for serde in the new KZG tests (see 55d75c9c4b4446464e1e510048f106215aa598dd). I was using this to check to see if we missed any fields and I figured we might as well leave it there.

In 04cd40af381bf81c2557cf7ff198d6351d5edd45 I made us *require* as 0x prefix for KGZ-y objects. It's not a big deal, but I thought it might help us from accidentally skipping a byte if the `0x` prefix disappears.

NA
