### PR TITLE
[Merged by Bors] - Update Java runtime requirement to 17 for Web3Signer tests

### DIFF
--- a/book/src/setup.md
+++ b/book/src/setup.md
@@ -14,7 +14,7 @@ The additional requirements for developers are:
   don't have `anvil` available on your `PATH`.
 - [`cmake`](https://cmake.org/cmake/help/latest/command/install.html). Used by
   some dependencies. See [`Installation Guide`](./installation.md) for more info.
-- [`java 11 runtime`](https://openjdk.java.net/projects/jdk/). 11 is the minimum,
+- [`java 17 runtime`](https://openjdk.java.net/projects/jdk/). 17 is the minimum,
   used by web3signer_tests.
 - [`libpq-dev`](https://www.postgresql.org/docs/devel/libpq.html). Also know as
   `libpq-devel` on some systems. 

--- a/testing/web3signer_tests/tls/README.md
+++ b/testing/web3signer_tests/tls/README.md
@@ -1,6 +1,6 @@
 ## TLS Testing Files
 
 The files in this directory are used for testing TLS with web3signer. We store them in this
-repository since the are not sensitive and it's simpler than regenerating them for each test.
+repository since they are not sensitive and it's simpler than regenerating them for each test.
 
 The files were generated using the `./generate.sh` script.


### PR DESCRIPTION
Web3Signer now requires Java runtime v17, see [v23.8.0 release](https://github.com/Consensys/web3signer/releases/tag/23.8.0).

We have some Web3Signer tests that requires a compatible Java runtime to be installed on dev machines. This PR updates `setup` documentation in Lighthouse book, and also fixes a small typo.
