### PR TITLE
Fix stuck CI on Deneb branch

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -67,6 +67,8 @@ jobs:
       run: rustup update stable
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in release
       run: make test-release
   release-tests-windows:
@@ -88,6 +90,8 @@ jobs:
         npm config set msvs_version 2019
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Install make
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
@@ -153,6 +157,8 @@ jobs:
       run: rustup update stable
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:
@@ -199,6 +205,8 @@ jobs:
       run: rustup update stable
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the beacon chain sim that starts from an eth1 contract
       run: cargo run --release --bin simulator eth1-sim
   merge-transition-ubuntu:
@@ -211,6 +219,8 @@ jobs:
       run: rustup update stable
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the beacon chain sim and go through the merge transition
       run: cargo run --release --bin simulator eth1-sim --post-merge
   no-eth1-simulator-ubuntu:
@@ -233,6 +243,8 @@ jobs:
       run: rustup update stable
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the syncing simulator
       run: cargo run --release --bin simulator syncing-sim
   doppelganger-protection-test:


### PR DESCRIPTION
## Issue Addressed

This PR contains a cherry-pick commit from `unstable` to fix some stuck CI jobs due to a bug in latest nightly version of Anvil.
