### PR TITLE
Fix stuck CI on Tree States branch

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -60,6 +60,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in release
       run: make test-release
   release-tests-windows:
@@ -80,6 +82,8 @@ jobs:
         npm config set msvs_version 2019
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Install make
       run: choco install -y make
     - uses: KyleMayes/install-llvm-action@v1
@@ -142,6 +146,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in debug
       run: make test-debug
   state-transition-vectors-ubuntu:
@@ -198,6 +204,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the beacon chain sim that starts from an eth1 contract
       run: cargo run --release --bin simulator eth1-sim
   merge-transition-ubuntu:
@@ -214,6 +222,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the beacon chain sim and go through the merge transition
       run: cargo run --release --bin simulator eth1-sim --post-merge
   no-eth1-simulator-ubuntu:
@@ -244,6 +254,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Foundry (anvil)
       uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run the syncing simulator
       run: cargo run --release --bin simulator syncing-sim
   doppelganger-protection-test:


### PR DESCRIPTION
## Issue Addressed

This PR contains a cherry-pick commit from `unstable` to fix some stuck CI jobs due to a bug in latest nightly version of Anvil.

We can probably do a merge from `unstable` soon, but would be good to unblock CI.