### PR TITLE
[Merged by Bors] - Release v4.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "beacon_node",
  "clap",
@@ -3880,7 +3880,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "4.4.0"
+version = "4.4.1"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "4.4.0"
+version = "4.4.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v4.4.0-",
-    fallback = "Lighthouse/v4.4.0"
+    prefix = "Lighthouse/v4.4.1-",
+    fallback = "Lighthouse/v4.4.1"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "4.4.0"
+version = "4.4.1"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = "2021"
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "4.4.0"
+version = "4.4.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = "2021"
 autotests = false


### PR DESCRIPTION
## Proposed Changes

New release to replace the cancelled v4.4.0 release.

This release includes the bugfix #4687 which avoids a deadlock that was present in v4.4.0.

## Additional Info

Awaiting testing over the weekend this will be merged Monday September 4th.
