### PR TITLE
Deneb review `common/eth2`

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1729,7 +1729,7 @@ pub fn serve<T: BeaconChainTypes>(
         );
 
     /*
-     * beacon/blobs
+     * beacon/blob_sidecars
      */
 
     // GET beacon/blob_sidecars/{block_id}

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -373,8 +373,8 @@ pub async fn reconstruct_block<T: BeaconChainTypes>(
             .try_into_full_block_and_blobs(Some(full_payload_contents))
             .map(ProvenancedBlock::builder),
     }
-    .ok_or_else(|| {
-        warp_utils::reject::custom_server_error("Unable to add payload to block".to_string())
+    .map_err(|e| {
+        warp_utils::reject::custom_server_error(format!("Unable to add payload to block: {e:?}"))
     })
 }
 

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -918,7 +918,7 @@ impl BeaconNodeHttpClient {
         Ok(Some(response.json().await?))
     }
 
-    /// `GET v1/beacon/blobs/{block_id}`
+    /// `GET v1/beacon/blob_sidecars/{block_id}`
     ///
     /// Returns `Ok(None)` on a 404 error.
     pub async fn get_blobs<T: EthSpec>(
@@ -931,8 +931,7 @@ impl BeaconNodeHttpClient {
             None => return Ok(None),
         };
 
-        let GenericResponse { data } = response.json().await?;
-        Ok(Some(GenericResponse { data }))
+        Ok(Some(response.json().await?))
     }
 
     /// `GET v1/beacon/blinded_blocks/{block_id}`

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1548,50 +1548,47 @@ impl<T: EthSpec> SignedBlockContents<T, BlindedPayload<T>> {
     pub fn try_into_full_block_and_blobs(
         self,
         maybe_full_payload_contents: Option<FullPayloadContents<T>>,
-    ) -> Option<SignedBlockContents<T, FullPayload<T>>> {
+    ) -> Result<SignedBlockContents<T, FullPayload<T>>, String> {
         match self {
             SignedBlockContents::BlindedBlockAndBlobSidecars(blinded_block_and_blob_sidecars) => {
-                maybe_full_payload_contents.and_then(|full_payload_contents| {
-                    match full_payload_contents.deconstruct() {
-                        (full_payload, Some(blobs_bundle)) => {
-                            let maybe_full_block = blinded_block_and_blob_sidecars
-                                .signed_blinded_block
-                                .try_into_full_block(Some(full_payload));
-                            let full_blob_sidecars: Vec<_> = blinded_block_and_blob_sidecars
+                match maybe_full_payload_contents {
+                    None | Some(FullPayloadContents::Payload(_)) => {
+                        Err("Can't build full block contents without payload and blobs".to_string())
+                    }
+                    Some(FullPayloadContents::PayloadAndBlobs(payload_and_blobs)) => {
+                        let signed_block = blinded_block_and_blob_sidecars
+                            .signed_blinded_block
+                            .try_into_full_block(Some(payload_and_blobs.execution_payload))
+                            .ok_or("Failed to build full block with payload".to_string())?;
+                        let signed_blob_sidecars: SignedBlobSidecarList<T> =
+                            blinded_block_and_blob_sidecars
                                 .signed_blinded_blob_sidecars
                                 .into_iter()
-                                .zip(blobs_bundle.blobs)
+                                .zip(payload_and_blobs.blobs_bundle.blobs)
                                 .map(|(blinded_blob_sidecar, blob)| {
                                     blinded_blob_sidecar.into_full_blob_sidecars(blob)
                                 })
-                                .collect();
+                                .collect::<Vec<_>>()
+                                .into();
 
-                            maybe_full_block.map(|signed_block| {
-                                SignedBlockContents::BlockAndBlobSidecars(
-                                    SignedBeaconBlockAndBlobSidecars {
-                                        signed_block,
-                                        signed_blob_sidecars: VariableList::from(
-                                            full_blob_sidecars,
-                                        ),
-                                    },
-                                )
-                            })
-                        }
-                        //FIXME: maybe this should return err
-                        // Can't build full block contents without full blobs
-                        _ => None,
+                        Ok(SignedBlockContents::new(
+                            signed_block,
+                            Some(signed_blob_sidecars),
+                        ))
                     }
-                })
+                }
             }
             SignedBlockContents::Block(blinded_block) => {
                 let full_payload_opt = maybe_full_payload_contents.map(|o| o.deconstruct().0);
                 blinded_block
                     .try_into_full_block(full_payload_opt)
                     .map(SignedBlockContents::Block)
+                    .ok_or("Can't build full block without payload".to_string())
             }
-            // Unexpected scenario for blinded block proposal
-            //FIXME: maybe this should return err
-            SignedBlockContents::BlockAndBlobSidecars(_) => None,
+            SignedBlockContents::BlockAndBlobSidecars(_) => Err(
+                "BlockAndBlobSidecars variant not expected when constructing full block"
+                    .to_string(),
+            ),
         }
     }
 }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -978,8 +978,11 @@ impl ForkVersionDeserialize for SsePayloadAttributes {
             ForkName::Merge => serde_json::from_value(value)
                 .map(Self::V1)
                 .map_err(serde::de::Error::custom),
-            ForkName::Capella | ForkName::Deneb => serde_json::from_value(value)
+            ForkName::Capella => serde_json::from_value(value)
                 .map(Self::V2)
+                .map_err(serde::de::Error::custom),
+            ForkName::Deneb => serde_json::from_value(value)
+                .map(Self::V3)
                 .map_err(serde::de::Error::custom),
             ForkName::Base | ForkName::Altair => Err(serde::de::Error::custom(format!(
                 "SsePayloadAttributes deserialization for {fork_name} not implemented"
@@ -1519,8 +1522,10 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> SignedBlockContents<T, Payload
             SignedBlockContents::BlockAndBlobSidecars(block_and_sidecars) => {
                 Some(block_and_sidecars.signed_blob_sidecars.clone())
             }
+            SignedBlockContents::BlindedBlockAndBlobSidecars(block_and_sidecars) => {
+                Some(block_and_sidecars.signed_blinded_blob_sidecars.clone())
+            }
             SignedBlockContents::Block(_block) => None,
-            SignedBlockContents::BlindedBlockAndBlobSidecars(_) => None,
         }
     }
 
@@ -1572,6 +1577,7 @@ impl<T: EthSpec> SignedBlockContents<T, BlindedPayload<T>> {
                                 )
                             })
                         }
+                        //FIXME: maybe this should return err
                         // Can't build full block contents without full blobs
                         _ => None,
                     }
@@ -1584,6 +1590,7 @@ impl<T: EthSpec> SignedBlockContents<T, BlindedPayload<T>> {
                     .map(SignedBlockContents::Block)
             }
             // Unexpected scenario for blinded block proposal
+            //FIXME: maybe this should return err
             SignedBlockContents::BlockAndBlobSidecars(_) => None,
         }
     }


### PR DESCRIPTION
## Issue Addressed

Related to https://github.com/sigp/lighthouse/issues/4676.

## Proposed Changes
- Deserialize deneb fork versioned `SsePayloadAttributes` into `SsePayloadAttributesV3`
- Convert `SignedBlockContents::try_into_full_block_and_blobs` to return `Result` instead of `Option` so an error message can be included during unexpected / error scenarios. Refactored the function a bit to reduce amount of nested `map`s for readability, and improved error handling.
- Update `SignedBlockContents::blobs_cloned` to include blobs for the blinded variant. The original intention to return None was to an attempt to indicate an unexpected scenario, but I've realized this pattern is quite misleading, and can lead to some hard to find bugs and misuse of the function. We're better off doing the assertions / checks outside of these functions.
- Some other minor cleanups: code comments, remove unnecessary code