### PR TITLE
[Merged by Bors] - Allow libp2p to determine listening addresses

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -16,6 +16,11 @@ use std::sync::Arc;
 use std::time::Duration;
 use types::{ForkContext, ForkName};
 
+pub const DEFAULT_IPV4_ADDRESS: Ipv4Addr = Ipv4Addr::UNSPECIFIED;
+pub const DEFAULT_TCP_PORT: u16 = 9000u16;
+pub const DEFAULT_DISC_PORT: u16 = 9000u16;
+pub const DEFAULT_QUIC_PORT: u16 = 9001u16;
+
 /// The cache time is set to accommodate the circulation time of an attestation.
 ///
 /// The p2p spec declares that we accept attestations within the following range:
@@ -304,10 +309,10 @@ impl Default for Config {
                 .expect("The total rate limit has been specified"),
         );
         let listen_addresses = ListenAddress::V4(ListenAddr {
-            addr: Ipv4Addr::UNSPECIFIED,
-            disc_port: 9000,
-            quic_port: 9001,
-            tcp_port: 9000,
+            addr: DEFAULT_IPV4_ADDRESS,
+            disc_port: DEFAULT_DISC_PORT,
+            quic_port: DEFAULT_QUIC_PORT,
+            tcp_port: DEFAULT_TCP_PORT,
         });
 
         let discv5_listen_config =

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1038,8 +1038,8 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                 self.on_dial_failure(peer_id, error)
             }
             FromSwarm::NewListenAddr(ev) => {
-                let addr: &Multiaddr = ev.addr;
-                let listener_id: ListenerId = ev.listener_id;
+                let addr = ev.addr;
+                let listener_id = ev.listener_id;
 
                 trace!(self.log, "Received NewListenAddr event from swarm"; "listener_id" => ?listener_id, "addr" => ?addr);
 
@@ -1051,11 +1051,8 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                 let mut addr_iter = addr.iter();
 
                 if let Err(e) = match addr_iter.next() {
-                    Some(Protocol::Ip4(ip)) => match (addr_iter.next(), addr_iter.next()) {
+                    Some(Protocol::Ip4(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => self.update_enr_tcp_port(port),
-                        (Some(Protocol::Udp(port)), None) => {
-                            self.update_enr_udp_socket(SocketAddr::new(IpAddr::V4(ip), port))
-                        }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             self.update_enr_quic_port(port)
                         }
@@ -1064,11 +1061,8 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                             return;
                         }
                     },
-                    Some(Protocol::Ip6(ip)) => match (addr_iter.next(), addr_iter.next()) {
+                    Some(Protocol::Ip6(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => self.update_enr_tcp_port(port),
-                        (Some(Protocol::Udp(port)), None) => {
-                            self.update_enr_udp_socket(SocketAddr::new(IpAddr::V6(ip), port))
-                        }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             self.update_enr_quic_port(port)
                         }

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1038,11 +1038,15 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                 self.on_dial_failure(peer_id, error)
             }
             FromSwarm::NewListenAddr(ev) => {
-                /* TODO(jmcph4): plumb user override status into config somehow */
                 let addr: &Multiaddr = ev.addr;
                 let listener_id: ListenerId = ev.listener_id;
 
                 trace!(self.log, "Received NewListenAddr event from swarm"; "listener_id" => ?listener_id, "addr" => ?addr);
+
+                if !self.update_tcp_port.0 {
+                    debug!(self.log, "Skipping ENR update");
+                    return;
+                }
 
                 let mut addr_iter = addr.iter();
 

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -85,7 +85,7 @@ pub struct UpdatePorts {
     pub tcp4: bool,
     /// TCP port associated wih IPv6 address (if present)
     pub tcp6: bool,
-    /// QUIC port associated wih IPv6 address (if present)
+    /// QUIC port associated wih IPv4 address (if present)
     pub quic4: bool,
     /// QUIC port associated wih IPv6 address (if present)
     pub quic6: bool,
@@ -1060,7 +1060,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                     Some(Protocol::Ip4(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => {
                             if !self.update_ports.tcp4 {
-                                debug!(self.log, "Skipping ENR (tcp4) update");
+                                debug!(self.log, "Skipping ENR update"; "multiaddr" => ?addr);
                                 return;
                             }
 
@@ -1068,7 +1068,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                         }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             if !self.update_ports.quic4 {
-                                debug!(self.log, "Skipping ENR (quic4) update");
+                                debug!(self.log, "Skipping ENR update"; "multiaddr" => ?addr);
                                 return;
                             }
 
@@ -1082,7 +1082,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                     Some(Protocol::Ip6(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => {
                             if !self.update_ports.tcp6 {
-                                debug!(self.log, "Skipping ENR (tcp6) update");
+                                debug!(self.log, "Skipping ENR update"; "multiaddr" => ?addr);
                                 return;
                             }
 
@@ -1090,7 +1090,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                         }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             if !self.update_ports.quic6 {
-                                debug!(self.log, "Skipping ENR (quic6) update");
+                                debug!(self.log, "Skipping ENR update"; "multiaddr" => ?addr);
                                 return;
                             }
 

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1122,6 +1122,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                     let local_enr: Enr = self.discv5.local_enr();
                     info!(self.log, "Updated local ENR"; "enr" => local_enr.to_base64(), "seq" => local_enr.seq(), "id"=> %local_enr.node_id(),
                         "ip4" => ?local_enr.ip4(), "udp4"=> ?local_enr.udp4(), "tcp4" => ?local_enr.tcp4(), "tcp6" => ?local_enr.tcp6(), "udp6" => ?local_enr.udp6());
+                    enr::save_enr_to_disk(Path::new(&self.enr_dir), &self.local_enr(), &self.log);
                 };
 
                 match addr.iter().nth(1) {

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1064,43 +1064,39 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                     }
                 };
 
-                let update_enr = |ip: IpAddr, transport: Protocol, port: u16| {
-                    let insert_into_enr = |key: &str, port: &u16| {
-                        if let Err(e) = self.discv5.enr_insert(key, port) {
-                            warn!(self.log, "Failed to write to ENR"; "error" => ?e);
-                        }
-                    };
-
-                    match ip {
-                        IpAddr::V4(_) => match proto {
-                            Protocol::Tcp(port) => insert_into_enr("tcp4", &port),
-                            Protocol::Udp(port) => insert_into_enr("udp4", &port),
-                            Protocol::QuicV1 => insert_into_enr("quic4", &port),
-                            _ => {
-                                crit!(self.log, "Attempt to update discovery with unsupported transport (this should never occur)"; "transport" => ?transport);
-                                return;
-                            }
-                        },
-                        IpAddr::V6(_) => match proto {
-                            Protocol::Tcp(port) => insert_into_enr("tcp6", &port),
-                            Protocol::Udp(port) => insert_into_enr("udp6", &port),
-                            Protocol::QuicV1 => insert_into_enr("quic6", &port),
-                            _ => {
-                                crit!(self.log, "Attempt to update discovery with unsupported transport (this should never occur)"; "transport" => ?transport);
-                                return;
-                            }
-                        },
+                let insert_into_enr = |key: &str, port: &u16| {
+                    if let Err(e) = self.discv5.enr_insert(key, port) {
+                        warn!(self.log, "Failed to write to ENR"; "error" => ?e);
                     }
-
-                    *self.network_globals.local_enr.write() = self.discv5.local_enr();
-
-                    let local_enr: Enr = self.discv5.local_enr();
-                    info!(self.log, "Updated local ENR"; "enr" => local_enr.to_base64(), "seq" => local_enr.seq(), "id"=> %local_enr.node_id(),
-                        "ip4" => ?local_enr.ip4(), "udp4"=> ?local_enr.udp4(), "tcp4" => ?local_enr.tcp4(), "tcp6" => ?local_enr.tcp6(), "udp6" => ?local_enr.udp6());
-                    enr::save_enr_to_disk(Path::new(&self.enr_dir), &self.local_enr(), &self.log);
                 };
 
-                update_enr(ip, proto.clone(), port);
+                match ip {
+                    IpAddr::V4(_) => match proto {
+                        Protocol::Tcp(port) => insert_into_enr("tcp4", &port),
+                        Protocol::Udp(port) => insert_into_enr("udp4", &port),
+                        Protocol::QuicV1 => insert_into_enr("quic4", &port),
+                        _ => {
+                            crit!(self.log, "Attempt to update discovery with unsupported transport (this should never occur)"; "transport" => ?proto);
+                            return;
+                        }
+                    },
+                    IpAddr::V6(_) => match proto {
+                        Protocol::Tcp(port) => insert_into_enr("tcp6", &port),
+                        Protocol::Udp(port) => insert_into_enr("udp6", &port),
+                        Protocol::QuicV1 => insert_into_enr("quic6", &port),
+                        _ => {
+                            crit!(self.log, "Attempt to update discovery with unsupported transport (this should never occur)"; "transport" => ?proto);
+                            return;
+                        }
+                    },
+                }
+
+                *self.network_globals.local_enr.write() = self.discv5.local_enr();
+
+                let local_enr: Enr = self.discv5.local_enr();
+                info!(self.log, "Updated local ENR"; "enr" => local_enr.to_base64(), "seq" => local_enr.seq(), "id"=> %local_enr.node_id(),
+                    "ip4" => ?local_enr.ip4(), "udp4"=> ?local_enr.udp4(), "tcp4" => ?local_enr.tcp4(), "tcp6" => ?local_enr.tcp6(), "udp6" => ?local_enr.udp6());
+                enr::save_enr_to_disk(Path::new(&self.enr_dir), &self.local_enr(), &self.log);
             }
             FromSwarm::ConnectionEstablished(_)
             | FromSwarm::ConnectionClosed(_)

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -186,6 +186,7 @@ pub struct Discovery<TSpec: EthSpec> {
     /// always false.
     pub started: bool,
 
+    /// Specifies whether various port numbers should be updated after the discovery service has been started
     update_ports: UpdatePorts,
 
     /// Logger for the discovery behaviour.

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1059,12 +1059,12 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                 if let Err(e) = match addr_iter.next() {
                     Some(Protocol::Ip4(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => {
-                            if self.update_ports.tcp4 {
-                            self.update_enr_tcp_port(port)
-                            } else {
+                            if !self.update_ports.tcp4 {
                                 debug!(self.log, "Skipping ENR (tcp4) update");
+                                return;
                             }
 
+                            self.update_enr_tcp_port(port)
                         }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             if !self.update_ports.quic4 {

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -78,11 +78,16 @@ pub struct DiscoveredPeers {
     pub peers: HashMap<Enr, Option<Instant>>,
 }
 
+/// Specifies which port numbers should be modified after start of the discovery service
 #[derive(Debug)]
 pub struct UpdatePorts {
+    /// TCP port associated wih IPv4 address (if present)
     pub tcp4: bool,
+    /// TCP port associated wih IPv6 address (if present)
     pub tcp6: bool,
+    /// QUIC port associated wih IPv6 address (if present)
     pub quic4: bool,
+    /// QUIC port associated wih IPv6 address (if present)
     pub quic6: bool,
 }
 
@@ -1054,12 +1059,12 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                 if let Err(e) = match addr_iter.next() {
                     Some(Protocol::Ip4(_)) => match (addr_iter.next(), addr_iter.next()) {
                         (Some(Protocol::Tcp(port)), None) => {
-                            if !self.update_ports.tcp4 {
+                            if self.update_ports.tcp4 {
+                            self.update_enr_tcp_port(port)
+                            } else {
                                 debug!(self.log, "Skipping ENR (tcp4) update");
-                                return;
                             }
 
-                            self.update_enr_tcp_port(port)
                         }
                         (Some(Protocol::Udp(port)), Some(Protocol::QuicV1)) => {
                             if !self.update_ports.quic4 {

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -615,21 +615,13 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                 self.upnp_mappings = mappings;
                 // If there is an external TCP port update, modify our local ENR.
                 if let Some(tcp_port) = self.upnp_mappings.tcp_port {
-                    if let Err(e) = self
-                        .libp2p
-                        .discovery_mut()
-                        .update_enr_tcp_port(false, tcp_port)
-                    {
+                    if let Err(e) = self.libp2p.discovery_mut().update_enr_tcp_port(tcp_port) {
                         warn!(self.log, "Failed to update ENR"; "error" => e);
                     }
                 }
                 // If there is an external QUIC port update, modify our local ENR.
                 if let Some(quic_port) = self.upnp_mappings.udp_quic_port {
-                    if let Err(e) = self
-                        .libp2p
-                        .discovery_mut()
-                        .update_enr_quic_port(false, quic_port)
-                    {
+                    if let Err(e) = self.libp2p.discovery_mut().update_enr_quic_port(quic_port) {
                         warn!(self.log, "Failed to update ENR"; "error" => e);
                     }
                 }

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -615,13 +615,21 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                 self.upnp_mappings = mappings;
                 // If there is an external TCP port update, modify our local ENR.
                 if let Some(tcp_port) = self.upnp_mappings.tcp_port {
-                    if let Err(e) = self.libp2p.discovery_mut().update_enr_tcp_port(tcp_port) {
+                    if let Err(e) = self
+                        .libp2p
+                        .discovery_mut()
+                        .update_enr_tcp_port(false, tcp_port)
+                    {
                         warn!(self.log, "Failed to update ENR"; "error" => e);
                     }
                 }
                 // If there is an external QUIC port update, modify our local ENR.
                 if let Some(quic_port) = self.upnp_mappings.udp_quic_port {
-                    if let Err(e) = self.libp2p.discovery_mut().update_enr_quic_port(quic_port) {
+                    if let Err(e) = self
+                        .libp2p
+                        .discovery_mut()
+                        .update_enr_quic_port(false, quic_port)
+                    {
                         warn!(self.log, "Failed to update ENR"; "error" => e);
                     }
                 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -29,6 +29,9 @@ const DUMMY_ENR_TCP_PORT: u16 = 7777;
 const DUMMY_ENR_UDP_PORT: u16 = 8888;
 const DUMMY_ENR_QUIC_PORT: u16 = 9999;
 
+const _: () =
+    assert!(DUMMY_ENR_QUIC_PORT != 0 && DUMMY_ENR_TCP_PORT != 0 && DUMMY_ENR_UDP_PORT != 0);
+
 /// Returns the `lighthouse beacon_node` command.
 fn base_cmd() -> Command {
     let lighthouse_bin = env!("CARGO_BIN_EXE_lighthouse");
@@ -1277,7 +1280,6 @@ fn enr_udp_port_flag() {
 #[test]
 fn enr_quic_port_flag() {
     let port = DUMMY_ENR_QUIC_PORT;
-    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-quic-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1286,7 +1288,6 @@ fn enr_quic_port_flag() {
 #[test]
 fn enr_tcp_port_flag() {
     let port = DUMMY_ENR_TCP_PORT;
-    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-tcp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1295,7 +1296,6 @@ fn enr_tcp_port_flag() {
 #[test]
 fn enr_udp6_port_flag() {
     let port = DUMMY_ENR_UDP_PORT;
-    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-udp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1304,7 +1304,6 @@ fn enr_udp6_port_flag() {
 #[test]
 fn enr_quic6_port_flag() {
     let port = DUMMY_ENR_QUIC_PORT;
-    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-quic6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1313,7 +1312,6 @@ fn enr_quic6_port_flag() {
 #[test]
 fn enr_tcp6_port_flag() {
     let port = DUMMY_ENR_TCP_PORT;
-    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-tcp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1322,8 +1320,11 @@ fn enr_tcp6_port_flag() {
 #[test]
 fn enr_match_flag_over_ipv4() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
-    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+
+    // the reason we use the ENR dummy values is because, due to the nature of the `--enr-match` flag, these will eventually become ENR ports (as well as listening ports).
+    let udp4_port = DUMMY_ENR_UDP_PORT;
+    let tcp4_port = DUMMY_ENR_TCP_PORT;
+
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some("127.0.0.2"))
@@ -1347,8 +1348,11 @@ fn enr_match_flag_over_ipv4() {
 fn enr_match_flag_over_ipv6() {
     const ADDR: &str = "::1";
     let addr = ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+
+    // the reason we use the ENR dummy values is because, due to the nature of the `--enr-match` flag, these will eventually become ENR ports (as well as listening ports).
+    let udp6_port = DUMMY_ENR_UDP_PORT;
+    let tcp6_port = DUMMY_ENR_TCP_PORT;
+
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(ADDR))
@@ -1371,13 +1375,18 @@ fn enr_match_flag_over_ipv6() {
 #[test]
 fn enr_match_flag_over_ipv4_and_ipv6() {
     const IPV6_ADDR: &str = "::1";
+
+    // the reason we use the ENR dummy values is because, due to the nature of the `--enr-match` flag, these will eventually become ENR ports (as well as listening ports).
+    let udp6_port = DUMMY_ENR_UDP_PORT;
+    let tcp6_port = DUMMY_ENR_TCP_PORT;
     let ipv6_addr = IPV6_ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+
     const IPV4_ADDR: &str = "127.0.0.1";
+    // the reason we use the ENR dummy values is because, due to the nature of the `--enr-match` flag, these will eventually become ENR ports (as well as listening ports).
+    let udp4_port = DUMMY_ENR_UDP_PORT;
+    let tcp4_port = DUMMY_ENR_TCP_PORT;
     let ipv4_addr = IPV4_ADDR.parse::<Ipv4Addr>().unwrap();
-    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(IPV4_ADDR))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -25,6 +25,9 @@ use types::{
 use unused_port::{unused_tcp4_port, unused_tcp6_port, unused_udp4_port, unused_udp6_port};
 
 const DEFAULT_ETH1_ENDPOINT: &str = "http://localhost:8545/";
+const DUMMY_ENR_TCP_PORT: u16 = 7777;
+const DUMMY_ENR_UDP_PORT: u16 = 8888;
+const DUMMY_ENR_QUIC_PORT: u16 = 9999;
 
 /// Returns the `lighthouse beacon_node` command.
 fn base_cmd() -> Command {
@@ -1264,7 +1267,8 @@ fn network_load_flag() {
 // Tests for ENR flags.
 #[test]
 fn enr_udp_port_flag() {
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_UDP_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-udp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1272,7 +1276,8 @@ fn enr_udp_port_flag() {
 }
 #[test]
 fn enr_quic_port_flag() {
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_QUIC_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-quic-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1280,7 +1285,8 @@ fn enr_quic_port_flag() {
 }
 #[test]
 fn enr_tcp_port_flag() {
-    let port = unused_tcp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_TCP_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-tcp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1288,7 +1294,8 @@ fn enr_tcp_port_flag() {
 }
 #[test]
 fn enr_udp6_port_flag() {
-    let port = unused_udp6_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_UDP_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-udp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1296,7 +1303,8 @@ fn enr_udp6_port_flag() {
 }
 #[test]
 fn enr_quic6_port_flag() {
-    let port = unused_udp6_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_QUIC_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-quic6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1304,7 +1312,8 @@ fn enr_quic6_port_flag() {
 }
 #[test]
 fn enr_tcp6_port_flag() {
-    let port = unused_tcp6_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_TCP_PORT;
+    assert!(port != 0);
     CommandLineTest::new()
         .flag("enr-tcp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1039,7 +1039,7 @@ fn network_port_flag_over_ipv6() {
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4() {
     let tcp4_port = 0;
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let disc4_port = 0;
     CommandLineTest::new()
         .flag("port", Some(tcp4_port.to_string().as_str()))
         .flag("discovery-port", Some(disc4_port.to_string().as_str()))
@@ -1078,7 +1078,7 @@ fn network_port_and_discovery_port_flags_over_ipv6() {
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
     let tcp4_port = 0;
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let disc4_port = 0;
     let tcp6_port = 0;
     let disc6_port = 0;
     CommandLineTest::new()
@@ -1113,8 +1113,8 @@ fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
 #[test]
 fn network_port_discovery_quic_port_flags_over_ipv4_and_ipv6() {
     let tcp4_port = 0;
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let quic4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let disc4_port = 0;
+    let quic4_port = 0;
     let tcp6_port = 0;
     let disc6_port = 0;
     let quic6_port = 0;
@@ -1263,7 +1263,7 @@ fn network_load_flag() {
 // Tests for ENR flags.
 #[test]
 fn enr_udp_port_flag() {
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-udp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1271,7 +1271,7 @@ fn enr_udp_port_flag() {
 }
 #[test]
 fn enr_quic_port_flag() {
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-quic-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1312,7 +1312,7 @@ fn enr_tcp6_port_flag() {
 #[test]
 fn enr_match_flag_over_ipv4() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
-    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let udp4_port = 0;
     let tcp4_port = 0;
     CommandLineTest::new()
         .flag("enr-match", None)
@@ -1366,7 +1366,7 @@ fn enr_match_flag_over_ipv4_and_ipv6() {
     let tcp6_port = 0;
     const IPV4_ADDR: &str = "127.0.0.1";
     let ipv4_addr = IPV4_ADDR.parse::<Ipv4Addr>().unwrap();
-    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let udp4_port = 0;
     let tcp4_port = 0;
     CommandLineTest::new()
         .flag("enr-match", None)
@@ -1405,7 +1405,7 @@ fn enr_match_flag_over_ipv4_and_ipv6() {
 #[test]
 fn enr_address_flag_with_ipv4() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1418,7 +1418,7 @@ fn enr_address_flag_with_ipv4() {
 #[test]
 fn enr_address_flag_with_ipv6() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1432,7 +1432,7 @@ fn enr_address_flag_with_ipv6() {
 fn enr_address_dns_flag() {
     let addr = Ipv4Addr::LOCALHOST;
     let ipv6addr = Ipv6Addr::LOCALHOST;
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-address", Some("localhost"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -22,6 +22,7 @@ use types::{
     Address, Checkpoint, Epoch, ExecutionBlockHash, ForkName, Hash256, MainnetEthSpec,
     ProgressiveBalancesMode,
 };
+use unused_port::{unused_tcp4_port, unused_tcp6_port, unused_udp4_port, unused_udp6_port};
 
 const DEFAULT_ETH1_ENDPOINT: &str = "http://localhost:8545/";
 
@@ -1003,7 +1004,7 @@ fn network_listen_address_flag_wrong_double_v6_value_config() {
 }
 #[test]
 fn network_port_flag_over_ipv4() {
-    let port = 0;
+    let port = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("port", Some(port.to_string().as_str()))
         .run()
@@ -1020,7 +1021,7 @@ fn network_port_flag_over_ipv4() {
 }
 #[test]
 fn network_port_flag_over_ipv6() {
-    let port = 0;
+    let port = unused_tcp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(port.to_string().as_str()))
@@ -1038,8 +1039,8 @@ fn network_port_flag_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4() {
-    let tcp4_port = 0;
-    let disc4_port = 0;
+    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("port", Some(tcp4_port.to_string().as_str()))
         .flag("discovery-port", Some(disc4_port.to_string().as_str()))
@@ -1057,8 +1058,8 @@ fn network_port_and_discovery_port_flags_over_ipv4() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv6() {
-    let tcp6_port = 0;
-    let disc6_port = 0;
+    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(tcp6_port.to_string().as_str()))
@@ -1077,10 +1078,10 @@ fn network_port_and_discovery_port_flags_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = 0;
-    let disc4_port = 0;
-    let tcp6_port = 0;
-    let disc6_port = 0;
+    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1112,12 +1113,12 @@ fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
 
 #[test]
 fn network_port_discovery_quic_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = 0;
-    let disc4_port = 0;
-    let quic4_port = 0;
-    let tcp6_port = 0;
-    let disc6_port = 0;
-    let quic6_port = 0;
+    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let quic4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let quic6_port = unused_udp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1263,7 +1264,7 @@ fn network_load_flag() {
 // Tests for ENR flags.
 #[test]
 fn enr_udp_port_flag() {
-    let port = 0;
+    let port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-udp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1271,7 +1272,7 @@ fn enr_udp_port_flag() {
 }
 #[test]
 fn enr_quic_port_flag() {
-    let port = 0;
+    let port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-quic-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1279,7 +1280,7 @@ fn enr_quic_port_flag() {
 }
 #[test]
 fn enr_tcp_port_flag() {
-    let port = 0;
+    let port = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-tcp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1287,7 +1288,7 @@ fn enr_tcp_port_flag() {
 }
 #[test]
 fn enr_udp6_port_flag() {
-    let port = 0;
+    let port = unused_udp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-udp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1295,7 +1296,7 @@ fn enr_udp6_port_flag() {
 }
 #[test]
 fn enr_quic6_port_flag() {
-    let port = 0;
+    let port = unused_udp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-quic6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1303,7 +1304,7 @@ fn enr_quic6_port_flag() {
 }
 #[test]
 fn enr_tcp6_port_flag() {
-    let port = 0;
+    let port = unused_tcp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-tcp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1312,8 +1313,8 @@ fn enr_tcp6_port_flag() {
 #[test]
 fn enr_match_flag_over_ipv4() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
-    let udp4_port = 0;
-    let tcp4_port = 0;
+    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some("127.0.0.2"))
@@ -1337,8 +1338,8 @@ fn enr_match_flag_over_ipv4() {
 fn enr_match_flag_over_ipv6() {
     const ADDR: &str = "::1";
     let addr = ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = 0;
-    let tcp6_port = 0;
+    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(ADDR))
@@ -1362,12 +1363,12 @@ fn enr_match_flag_over_ipv6() {
 fn enr_match_flag_over_ipv4_and_ipv6() {
     const IPV6_ADDR: &str = "::1";
     let ipv6_addr = IPV6_ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = 0;
-    let tcp6_port = 0;
+    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
     const IPV4_ADDR: &str = "127.0.0.1";
     let ipv4_addr = IPV4_ADDR.parse::<Ipv4Addr>().unwrap();
-    let udp4_port = 0;
-    let tcp4_port = 0;
+    let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(IPV4_ADDR))
@@ -1405,7 +1406,7 @@ fn enr_match_flag_over_ipv4_and_ipv6() {
 #[test]
 fn enr_address_flag_with_ipv4() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = 0;
+    let port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1418,7 +1419,7 @@ fn enr_address_flag_with_ipv4() {
 #[test]
 fn enr_address_flag_with_ipv6() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = 0;
+    let port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1432,7 +1433,7 @@ fn enr_address_flag_with_ipv6() {
 fn enr_address_dns_flag() {
     let addr = Ipv4Addr::LOCALHOST;
     let ipv6addr = Ipv6Addr::LOCALHOST;
-    let port = 0;
+    let port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("enr-address", Some("localhost"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1479,8 +1480,8 @@ fn http_address_ipv6_flag() {
 }
 #[test]
 fn http_port_flag() {
-    let port1 = 0;
-    let port2 = 0;
+    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("http-port", Some(port1.to_string().as_str()))
         .flag("port", Some(port2.to_string().as_str()))
@@ -1635,8 +1636,8 @@ fn metrics_address_ipv6_flag() {
 }
 #[test]
 fn metrics_port_flag() {
-    let port1 = 0;
-    let port2 = 0;
+    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("metrics", None)
         .flag("metrics-port", Some(port1.to_string().as_str()))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1010,7 +1010,7 @@ fn network_listen_address_flag_wrong_double_v6_value_config() {
 }
 #[test]
 fn network_port_flag_over_ipv4() {
-    let port = unused_tcp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("port", Some(port.to_string().as_str()))
         .run()
@@ -1027,7 +1027,7 @@ fn network_port_flag_over_ipv4() {
 }
 #[test]
 fn network_port_flag_over_ipv6() {
-    let port = unused_tcp6_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(port.to_string().as_str()))
@@ -1045,8 +1045,8 @@ fn network_port_flag_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
+    let disc4_port = 0;
     CommandLineTest::new()
         .flag("port", Some(tcp4_port.to_string().as_str()))
         .flag("discovery-port", Some(disc4_port.to_string().as_str()))
@@ -1064,8 +1064,8 @@ fn network_port_and_discovery_port_flags_over_ipv4() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv6() {
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = 0;
+    let disc6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(tcp6_port.to_string().as_str()))
@@ -1084,10 +1084,10 @@ fn network_port_and_discovery_port_flags_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
+    let disc4_port = 0;
+    let tcp6_port = 0;
+    let disc6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1119,12 +1119,12 @@ fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
 
 #[test]
 fn network_port_discovery_quic_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
-    let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let quic4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let quic6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
+    let disc4_port = 0;
+    let quic4_port = 0;
+    let tcp6_port = 0;
+    let disc6_port = 0;
+    let quic6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1498,8 +1498,8 @@ fn http_address_ipv6_flag() {
 }
 #[test]
 fn http_port_flag() {
-    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
-    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port1 = 0;
+    let port2 = 0;
     CommandLineTest::new()
         .flag("http-port", Some(port1.to_string().as_str()))
         .flag("port", Some(port2.to_string().as_str()))
@@ -1654,8 +1654,8 @@ fn metrics_address_ipv6_flag() {
 }
 #[test]
 fn metrics_port_flag() {
-    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
-    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port1 = 0;
+    let port2 = 0;
     CommandLineTest::new()
         .flag("metrics", None)
         .flag("metrics-port", Some(port1.to_string().as_str()))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -22,7 +22,6 @@ use types::{
     Address, Checkpoint, Epoch, ExecutionBlockHash, ForkName, Hash256, MainnetEthSpec,
     ProgressiveBalancesMode,
 };
-use unused_port::{unused_tcp4_port, unused_tcp6_port, unused_udp4_port, unused_udp6_port};
 
 const DEFAULT_ETH1_ENDPOINT: &str = "http://localhost:8545/";
 
@@ -1004,7 +1003,7 @@ fn network_listen_address_flag_wrong_double_v6_value_config() {
 }
 #[test]
 fn network_port_flag_over_ipv4() {
-    let port = unused_tcp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("port", Some(port.to_string().as_str()))
         .run()
@@ -1039,7 +1038,7 @@ fn network_port_flag_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
     let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
     CommandLineTest::new()
         .flag("port", Some(tcp4_port.to_string().as_str()))
@@ -1078,7 +1077,7 @@ fn network_port_and_discovery_port_flags_over_ipv6() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
     let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
     let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
     let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
@@ -1113,7 +1112,7 @@ fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
 
 #[test]
 fn network_port_discovery_quic_port_flags_over_ipv4_and_ipv6() {
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
     let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
     let quic4_port = unused_udp4_port().expect("Unable to find unused port.");
     let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
@@ -1280,7 +1279,7 @@ fn enr_quic_port_flag() {
 }
 #[test]
 fn enr_tcp_port_flag() {
-    let port = unused_tcp4_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-tcp-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1314,7 +1313,7 @@ fn enr_tcp6_port_flag() {
 fn enr_match_flag_over_ipv4() {
     let addr = "127.0.0.2".parse::<Ipv4Addr>().unwrap();
     let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some("127.0.0.2"))
@@ -1368,7 +1367,7 @@ fn enr_match_flag_over_ipv4_and_ipv6() {
     const IPV4_ADDR: &str = "127.0.0.1";
     let ipv4_addr = IPV4_ADDR.parse::<Ipv4Addr>().unwrap();
     let udp4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp4_port = unused_tcp4_port().expect("Unable to find unused port.");
+    let tcp4_port = 0;
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(IPV4_ADDR))
@@ -1480,8 +1479,8 @@ fn http_address_ipv6_flag() {
 }
 #[test]
 fn http_port_flag() {
-    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
-    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port1 = 0;
+    let port2 = 0;
     CommandLineTest::new()
         .flag("http-port", Some(port1.to_string().as_str()))
         .flag("port", Some(port2.to_string().as_str()))
@@ -1636,8 +1635,8 @@ fn metrics_address_ipv6_flag() {
 }
 #[test]
 fn metrics_port_flag() {
-    let port1 = unused_tcp4_port().expect("Unable to find unused port.");
-    let port2 = unused_tcp4_port().expect("Unable to find unused port.");
+    let port1 = 0;
+    let port2 = 0;
     CommandLineTest::new()
         .flag("metrics", None)
         .flag("metrics-port", Some(port1.to_string().as_str()))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1020,7 +1020,7 @@ fn network_port_flag_over_ipv4() {
 }
 #[test]
 fn network_port_flag_over_ipv6() {
-    let port = unused_tcp6_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(port.to_string().as_str()))
@@ -1057,8 +1057,8 @@ fn network_port_and_discovery_port_flags_over_ipv4() {
 }
 #[test]
 fn network_port_and_discovery_port_flags_over_ipv6() {
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = 0;
+    let disc6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("port", Some(tcp6_port.to_string().as_str()))
@@ -1079,8 +1079,8 @@ fn network_port_and_discovery_port_flags_over_ipv6() {
 fn network_port_and_discovery_port_flags_over_ipv4_and_ipv6() {
     let tcp4_port = 0;
     let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = 0;
+    let disc6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1115,9 +1115,9 @@ fn network_port_discovery_quic_port_flags_over_ipv4_and_ipv6() {
     let tcp4_port = 0;
     let disc4_port = unused_udp4_port().expect("Unable to find unused port.");
     let quic4_port = unused_udp4_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
-    let disc6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let quic6_port = unused_udp6_port().expect("Unable to find unused port.");
+    let tcp6_port = 0;
+    let disc6_port = 0;
+    let quic6_port = 0;
     CommandLineTest::new()
         .flag("listen-address", Some("::1"))
         .flag("listen-address", Some("127.0.0.1"))
@@ -1287,7 +1287,7 @@ fn enr_tcp_port_flag() {
 }
 #[test]
 fn enr_udp6_port_flag() {
-    let port = unused_udp6_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-udp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1295,7 +1295,7 @@ fn enr_udp6_port_flag() {
 }
 #[test]
 fn enr_quic6_port_flag() {
-    let port = unused_udp6_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-quic6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1303,7 +1303,7 @@ fn enr_quic6_port_flag() {
 }
 #[test]
 fn enr_tcp6_port_flag() {
-    let port = unused_tcp6_port().expect("Unable to find unused port.");
+    let port = 0;
     CommandLineTest::new()
         .flag("enr-tcp6-port", Some(port.to_string().as_str()))
         .run_with_zero_port()
@@ -1337,8 +1337,8 @@ fn enr_match_flag_over_ipv4() {
 fn enr_match_flag_over_ipv6() {
     const ADDR: &str = "::1";
     let addr = ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+    let udp6_port = 0;
+    let tcp6_port = 0;
     CommandLineTest::new()
         .flag("enr-match", None)
         .flag("listen-address", Some(ADDR))
@@ -1362,8 +1362,8 @@ fn enr_match_flag_over_ipv6() {
 fn enr_match_flag_over_ipv4_and_ipv6() {
     const IPV6_ADDR: &str = "::1";
     let ipv6_addr = IPV6_ADDR.parse::<Ipv6Addr>().unwrap();
-    let udp6_port = unused_udp6_port().expect("Unable to find unused port.");
-    let tcp6_port = unused_tcp6_port().expect("Unable to find unused port.");
+    let udp6_port = 0;
+    let tcp6_port = 0;
     const IPV4_ADDR: &str = "127.0.0.1";
     let ipv4_addr = IPV4_ADDR.parse::<Ipv4Addr>().unwrap();
     let udp4_port = unused_udp4_port().expect("Unable to find unused port.");

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1424,7 +1424,7 @@ fn enr_match_flag_over_ipv4_and_ipv6() {
 #[test]
 fn enr_address_flag_with_ipv4() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_UDP_PORT;
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1437,7 +1437,7 @@ fn enr_address_flag_with_ipv4() {
 #[test]
 fn enr_address_flag_with_ipv6() {
     let addr = "192.167.1.1".parse::<Ipv4Addr>().unwrap();
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_UDP_PORT;
     CommandLineTest::new()
         .flag("enr-address", Some("192.167.1.1"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))
@@ -1451,7 +1451,7 @@ fn enr_address_flag_with_ipv6() {
 fn enr_address_dns_flag() {
     let addr = Ipv4Addr::LOCALHOST;
     let ipv6addr = Ipv6Addr::LOCALHOST;
-    let port = unused_udp4_port().expect("Unable to find unused port.");
+    let port = DUMMY_ENR_UDP_PORT;
     CommandLineTest::new()
         .flag("enr-address", Some("localhost"))
         .flag("enr-udp-port", Some(port.to_string().as_str()))

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -22,7 +22,6 @@ use types::{
     Address, Checkpoint, Epoch, ExecutionBlockHash, ForkName, Hash256, MainnetEthSpec,
     ProgressiveBalancesMode,
 };
-use unused_port::{unused_tcp4_port, unused_tcp6_port, unused_udp4_port, unused_udp6_port};
 
 const DEFAULT_ETH1_ENDPOINT: &str = "http://localhost:8545/";
 const DUMMY_ENR_TCP_PORT: u16 = 7777;


### PR DESCRIPTION
## Issue Addressed

#4675 

## Proposed Changes

 - Update local ENR (**only port numbers**) with local addresses received from libp2p (via `SwarmEvent::NewListenAddr`)
 - Only use the zero port for CLI tests

## Additional Info

### See Also ###

 - #4705 
 - #4402 
 - #4745 