### PR TITLE
Fix `parent_beacon_block_root` during proposer prep

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4592,8 +4592,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let prepare_payload_handle = match &state {
             BeaconState::Base(_) | BeaconState::Altair(_) => None,
             BeaconState::Merge(_) | BeaconState::Capella(_) | BeaconState::Deneb(_) => {
-                let prepare_payload_handle =
-                    get_execution_payload(self.clone(), &state, proposer_index, builder_params)?;
+                let prepare_payload_handle = get_execution_payload(
+                    self.clone(),
+                    &state,
+                    parent_root,
+                    proposer_index,
+                    builder_params,
+                )?;
                 Some(prepare_payload_handle)
             }
         };

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -404,6 +404,7 @@ pub fn get_execution_payload<
 >(
     chain: Arc<BeaconChain<T>>,
     state: &BeaconState<T::EthSpec>,
+    parent_block_root: Hash256,
     proposer_index: u64,
     builder_params: BuilderParams,
 ) -> Result<PreparePayloadHandle<T::EthSpec, Payload>, BlockProductionError> {
@@ -426,10 +427,10 @@ pub fn get_execution_payload<
         &BeaconState::Base(_) | &BeaconState::Altair(_) => None,
     };
     let parent_beacon_block_root = match state {
-        &BeaconState::Deneb(_) => Some(state.latest_block_header().canonical_root()),
-        &BeaconState::Merge(_) | &BeaconState::Capella(_) => None,
+        BeaconState::Deneb(_) => Some(parent_block_root),
+        BeaconState::Merge(_) | BeaconState::Capella(_) => None,
         // These shouldn't happen but they're here to make the pattern irrefutable
-        &BeaconState::Base(_) | &BeaconState::Altair(_) => None,
+        BeaconState::Base(_) | BeaconState::Altair(_) => None,
     };
 
     // Spawn a task to obtain the execution payload from the EL via a series of async calls. The

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -402,22 +402,34 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
         let prev_randao = head_state
             .get_randao_mix(head_state.current_epoch())
             .map_err(convert_err)?;
-        let parent_root = head_state.latest_block_header().parent_root;
+        let expected_withdrawals = match fork {
+            ForkName::Base | ForkName::Altair | ForkName::Merge => None,
+            ForkName::Capella | ForkName::Deneb => Some(
+                self.beacon_client
+                    .get_expected_withdrawals(&StateId::Head)
+                    .await
+                    .unwrap()
+                    .data,
+            ),
+        };
 
         let payload_attributes = match fork {
-            ForkName::Merge => {
-                PayloadAttributes::new(timestamp, *prev_randao, fee_recipient, None, None)
-            }
-            // the withdrawals root is filled in by operations
-            ForkName::Capella => {
-                PayloadAttributes::new(timestamp, *prev_randao, fee_recipient, Some(vec![]), None)
-            }
+            // the withdrawals root is filled in by operations, but we supply the valid withdrawals
+            // first in order to avoid tripping the execution block generator's payload attributes
+            // check.
+            ForkName::Merge | ForkName::Capella => PayloadAttributes::new(
+                timestamp,
+                *prev_randao,
+                fee_recipient,
+                expected_withdrawals,
+                None,
+            ),
             ForkName::Deneb => PayloadAttributes::new(
                 timestamp,
                 *prev_randao,
                 fee_recipient,
-                Some(vec![]),
-                Some(parent_root),
+                expected_withdrawals,
+                Some(head_block_root),
             ),
             ForkName::Base | ForkName::Altair => {
                 return Err(MevError::InvalidFork);
@@ -451,7 +463,7 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
             .map_err(convert_err)?
             .into();
 
-        let header: ExecutionPayloadHeader<E> = match payload {
+        let header = match payload {
             ExecutionPayload::Merge(payload) => ExecutionPayloadHeader::Merge((&payload).into()),
             ExecutionPayload::Capella(payload) => {
                 ExecutionPayloadHeader::Capella((&payload).into())

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -415,8 +415,9 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
 
         let payload_attributes = match fork {
             // the withdrawals root is filled in by operations, but we supply the valid withdrawals
-            // first in order to avoid tripping the execution block generator's payload attributes
-            // check.
+            // first to avoid polluting the execution block generator with invalid payload attributes
+            // NOTE: this was part of an effort to add payload attribute uniqueness checks,
+            // which was abandoned because it broke too many tests in subtle ways.
             ForkName::Merge | ForkName::Capella => PayloadAttributes::new(
                 timestamp,
                 *prev_randao,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3973,20 +3973,6 @@ impl ApiTester {
             )));
 
         let slot = self.chain.slot().unwrap();
-        let propose_state = self
-            .harness
-            .chain
-            .state_at_slot(slot, StateSkipConfig::WithoutStateRoots)
-            .unwrap();
-        let withdrawals = get_expected_withdrawals(&propose_state, &self.chain.spec).unwrap();
-        let withdrawals_root = withdrawals.tree_hash_root();
-        // Set withdrawals root for builder
-        self.mock_builder
-            .as_ref()
-            .unwrap()
-            .builder
-            .add_operation(Operation::WithdrawalsRoot(withdrawals_root));
-
         let epoch = self.chain.epoch().unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
@@ -4024,20 +4010,6 @@ impl ApiTester {
             )));
 
         let slot = self.chain.slot().unwrap();
-        let propose_state = self
-            .harness
-            .chain
-            .state_at_slot(slot, StateSkipConfig::WithoutStateRoots)
-            .unwrap();
-        let withdrawals = get_expected_withdrawals(&propose_state, &self.chain.spec).unwrap();
-        let withdrawals_root = withdrawals.tree_hash_root();
-        // Set withdrawals root for builder
-        self.mock_builder
-            .as_ref()
-            .unwrap()
-            .builder
-            .add_operation(Operation::WithdrawalsRoot(withdrawals_root));
-
         let epoch = self.chain.epoch().unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 


### PR DESCRIPTION
## Issue Addressed

Fix a bug whereby Lighthouse would send the wrong `parent_beacon_block_root` in the payload attributes when preparing a payload.

We were sending the root of the _parent_ of the canonical head block in all cases, which is wrong most of the time when we want to build upon the canonical head. In this case, we should send the root _of the canonical head block itself_ (this is specced in [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788)). Using the parent root happened to be correct in the case of a single-slot re-org, although this was just a happy accident.

The bug only has low impact because when we actually request a payload we use the correct parent block root, here:

https://github.com/sigp/lighthouse/blob/13606533b58615af80058ee6570893731e6d0e7b/beacon_node/beacon_chain/src/execution_payload.rs#L428-L429

So we get a payload ID cache miss almost every slot, and force the EL to build a payload last-minute off the new (correct) payload attributes.

## Proposed changes

- [x] Fix the issue.
- [ ] Add a test (TODO).

## Additional Info

Thanks to @pinges for bringing this to our attention. Besu (correctly) assumed that the `headBlockHash` should determine the `parentBeaconBlockRoot`, and was failing to produce blocks with Lighthouse as a result. Besu merged a workaround (which is probably a good defensive measure) in https://github.com/hyperledger/besu/pull/5843.
