### PR TITLE
Update `BlindedBlobsBundle` SSZ list max length and update builder tests 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/beacon-api-client?rev=56a290c#56a290ca9d2c67086917a0929cdf2fe35e5f917f"
+source = "git+https://github.com/ralexstokes/beacon-api-client?rev=d838d93#d838d930f80fdfcadfe32147bcb2e805aec074bc"
 dependencies = [
  "clap 4.3.21",
  "ethereum-consensus",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/jimmygchen/ethereum-consensus?rev=2354493#2354493fd631b736c189868b7dc1b415a160f0f7"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=2bcb975#2bcb97563bb8dcb15802d1a280b58f21577ea3e2"
 dependencies = [
  "async-stream",
  "blst",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "mev-rs"
 version = "0.3.0"
-source = "git+https://github.com/ralexstokes/mev-rs?rev=9d88a2386b58c2948fa850f0dd4b3dfe18bd4962#9d88a2386b58c2948fa850f0dd4b3dfe18bd4962"
+source = "git+https://github.com/ralexstokes/mev-rs?rev=e01daed#e01daedd1706c3ec9d70d7e2baf301f0ad3645f8"
 dependencies = [
  "anvil-rpc",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,7 +528,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 [[package]]
 name = "beacon-api-client"
 version = "0.1.0"
-source = "git+https://github.com/ralexstokes/beacon-api-client?rev=d838d93#d838d930f80fdfcadfe32147bcb2e805aec074bc"
+source = "git+https://github.com/ralexstokes/beacon-api-client?rev=7f28993615fde52d563dd601a0511c34fe9b7c38#7f28993615fde52d563dd601a0511c34fe9b7c38"
 dependencies = [
  "clap 4.3.21",
  "ethereum-consensus",
@@ -2413,7 +2413,7 @@ dependencies = [
 [[package]]
 name = "ethereum-consensus"
 version = "0.1.1"
-source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=2bcb975#2bcb97563bb8dcb15802d1a280b58f21577ea3e2"
+source = "git+https://github.com/ralexstokes/ethereum-consensus?rev=12508c1f9b0c8f4bf4c5e9b6d441e840c1b37fd9#12508c1f9b0c8f4bf4c5e9b6d441e840c1b37fd9"
 dependencies = [
  "async-stream",
  "blst",
@@ -4906,7 +4906,7 @@ dependencies = [
 [[package]]
 name = "mev-rs"
 version = "0.3.0"
-source = "git+https://github.com/ralexstokes/mev-rs?rev=e01daed#e01daedd1706c3ec9d70d7e2baf301f0ad3645f8"
+source = "git+https://github.com/jimmygchen/mev-rs?rev=dedc77a#dedc77a796986603fb3376c5f353863d09e0dbf2"
 dependencies = [
  "anvil-rpc",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,6 @@ resolver = "2"
 [patch.crates-io]
 warp = { git = "https://github.com/macladson/warp", rev="7e75acc368229a46a236a8c991bf251fe7fe50ef" }
 
-# PR: https://github.com/ralexstokes/ethereum-consensus/pull/213
-[patch."https://github.com/ralexstokes/ethereum-consensus"]
-ethereum-consensus = { git = "https://github.com/jimmygchen/ethereum-consensus", rev = "2354493" }
-
 [profile.maxperf]
 inherits = "release"
 lto = "fat"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -118,7 +118,6 @@ use store::{
 use task_executor::{ShutdownReason, TaskExecutor};
 use tokio_stream::Stream;
 use tree_hash::TreeHash;
-use types::beacon_block_body::from_block_kzg_commitments;
 use types::beacon_state::CloneConfig;
 use types::blob_sidecar::{BlobSidecarList, FixedBlobSidecarList};
 use types::sidecar::BlobItems;
@@ -4994,11 +4993,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             metrics::start_timer(&metrics::BLOCK_PRODUCTION_BLOBS_VERIFICATION_TIMES);
         let maybe_sidecar_list = match (blobs_opt, proofs_opt) {
             (Some(blobs_or_blobs_roots), Some(proofs)) => {
-                let expected_kzg_commitments = block
-                    .body()
-                    .blob_kzg_commitments()
-                    .map(from_block_kzg_commitments::<T::EthSpec>)
-                    .map_err(|_| {
+                let expected_kzg_commitments =
+                    block.body().blob_kzg_commitments().map_err(|_| {
                         BlockProductionError::InvalidBlockVariant(
                             "deneb block does not contain kzg commitments".to_string(),
                         )

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5018,7 +5018,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         .ok_or(BlockProductionError::TrustedSetupNotInitialized)?;
                     kzg_utils::validate_blobs::<T::EthSpec>(
                         kzg,
-                        &expected_kzg_commitments,
+                        expected_kzg_commitments,
                         blobs,
                         &kzg_proofs,
                     )
@@ -5029,7 +5029,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     Sidecar::build_sidecar(
                         blobs_or_blobs_roots,
                         &block,
-                        &expected_kzg_commitments,
+                        expected_kzg_commitments,
                         kzg_proofs,
                     )
                     .map_err(BlockProductionError::FailedToBuildBlobSidecars)?,

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -42,8 +42,8 @@ lazy_static = "1.4.0"
 ethers-core = "1.0.2"
 builder_client = { path = "../builder_client" }
 fork_choice = { path = "../../consensus/fork_choice" }
-mev-rs = { git = "https://github.com/ralexstokes/mev-rs", rev = "9d88a2386b58c2948fa850f0dd4b3dfe18bd4962" }
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "56418ea" }
+mev-rs = { git = "https://github.com/ralexstokes/mev-rs", rev = "e01daed" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "2bcb975" }
 ssz_rs = "0.9.0"
 tokio-stream = { version = "0.1.9", features = [ "sync" ] }
 strum = "0.24.0"

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -42,8 +42,8 @@ lazy_static = "1.4.0"
 ethers-core = "1.0.2"
 builder_client = { path = "../builder_client" }
 fork_choice = { path = "../../consensus/fork_choice" }
-mev-rs = { git = "https://github.com/ralexstokes/mev-rs", rev = "e01daed" }
-ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "2bcb975" }
+mev-rs = { git = "https://github.com/jimmygchen/mev-rs", rev = "dedc77a" }
+ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "12508c1f9b0c8f4bf4c5e9b6d441e840c1b37fd9" }
 ssz_rs = "0.9.0"
 tokio-stream = { version = "0.1.9", features = [ "sync" ] }
 strum = "0.24.0"

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -42,6 +42,7 @@ lazy_static = "1.4.0"
 ethers-core = "1.0.2"
 builder_client = { path = "../builder_client" }
 fork_choice = { path = "../../consensus/fork_choice" }
+#PR: https://github.com/ralexstokes/mev-rs/pull/124
 mev-rs = { git = "https://github.com/jimmygchen/mev-rs", rev = "dedc77a" }
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "12508c1f9b0c8f4bf4c5e9b6d441e840c1b37fd9" }
 ssz_rs = "0.9.0"

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -2,7 +2,7 @@ use super::*;
 use serde::{Deserialize, Serialize};
 use strum::EnumString;
 use superstruct::superstruct;
-use types::beacon_block_body::BuilderKzgCommitments;
+use types::beacon_block_body::KzgCommitments;
 use types::blob_sidecar::BlobsList;
 use types::{
     EthSpec, ExecutionBlockHash, ExecutionPayload, ExecutionPayloadCapella, ExecutionPayloadDeneb,
@@ -438,7 +438,7 @@ impl From<JsonPayloadAttributes> for PayloadAttributes {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(bound = "E: EthSpec", rename_all = "camelCase")]
 pub struct JsonBlobsBundleV1<E: EthSpec> {
-    pub commitments: BuilderKzgCommitments<E>,
+    pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub blobs: BlobsList<E>,

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -39,7 +39,7 @@ use tree_hash::TreeHash;
 use types::builder_bid::BlindedBlobsBundle;
 use types::{
     Address, BeaconState, ChainSpec, EthSpec, ExecPayload, ExecutionPayload,
-    ExecutionPayloadHeader, ForkName, Hash256, Slot, Uint256,
+    ExecutionPayloadHeader, ForkName, ForkVersionedResponse, Hash256, Slot, Uint256,
 };
 
 #[derive(Clone)]
@@ -533,7 +533,13 @@ impl<E: EthSpec> mev_rs::BlindedBlockProvider for MockBuilder<E> {
             .get_payload_by_root(&from_ssz_rs(&node)?)
             .ok_or_else(|| convert_err("missing payload for tx root"))?;
 
-        let json_payload = serde_json::to_string(&payload).map_err(convert_err)?;
+        let fork = payload.payload_ref().fork_name();
+        let resp = ForkVersionedResponse {
+            version: Some(fork),
+            data: payload,
+        };
+
+        let json_payload = serde_json::to_string(&resp).map_err(convert_err)?;
         serde_json::from_str(json_payload.as_str()).map_err(convert_err)
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -17,7 +17,6 @@ use lighthouse_network::{NetworkGlobals, Request};
 use slot_clock::{ManualSlotClock, SlotClock, TestingSlotClock};
 use store::MemoryStore;
 use tokio::sync::mpsc;
-use types::beacon_block_body::to_block_kzg_commitments;
 use types::{
     map_fork_name, map_fork_name_with,
     test_utils::{SeedableRng, TestRandom, XorShiftRng},
@@ -124,8 +123,7 @@ impl TestRig {
             for tx in Vec::from(transactions) {
                 payload.execution_payload.transactions.push(tx).unwrap();
             }
-            message.body.blob_kzg_commitments =
-                to_block_kzg_commitments::<E>(bundle.commitments.clone());
+            message.body.blob_kzg_commitments = bundle.commitments.clone();
 
             let eth2::types::BlobsBundle {
                 commitments,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -12,7 +12,7 @@ use std::fmt::{self, Display};
 use std::str::{from_utf8, FromStr};
 use std::time::Duration;
 use tree_hash::TreeHash;
-use types::beacon_block_body::BuilderKzgCommitments;
+use types::beacon_block_body::KzgCommitments;
 use types::builder_bid::BlindedBlobsBundle;
 pub use types::*;
 
@@ -1793,7 +1793,7 @@ pub struct ExecutionPayloadAndBlobs<E: EthSpec> {
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlobsBundle<E: EthSpec> {
-    pub commitments: BuilderKzgCommitments<E>,
+    pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub blobs: BlobsList<E>,

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -9,23 +9,8 @@ use superstruct::superstruct;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-//TODO: Remove this type and use `BlockBodyKzgCommitments` everywhere when this PR is merged:
-// https://github.com/ethereum/builder-specs/pull/87
-pub type BuilderKzgCommitments<T> = VariableList<KzgCommitment, <T as EthSpec>::MaxBlobsPerBlock>;
-pub type BlockBodyKzgCommitments<T> =
+pub type KzgCommitments<T> =
     VariableList<KzgCommitment, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
-
-pub fn to_block_kzg_commitments<E: EthSpec>(
-    commitments: BuilderKzgCommitments<E>,
-) -> BlockBodyKzgCommitments<E> {
-    commitments.to_vec().into()
-}
-
-pub fn from_block_kzg_commitments<E: EthSpec>(
-    commitments: &BlockBodyKzgCommitments<E>,
-) -> BuilderKzgCommitments<E> {
-    commitments.to_vec().into()
-}
 
 /// The body of a `BeaconChain` block, containing operations.
 ///
@@ -87,7 +72,7 @@ pub struct BeaconBlockBody<T: EthSpec, Payload: AbstractExecPayload<T> = FullPay
     pub bls_to_execution_changes:
         VariableList<SignedBlsToExecutionChange, T::MaxBlsToExecutionChanges>,
     #[superstruct(only(Deneb))]
-    pub blob_kzg_commitments: BlockBodyKzgCommitments<T>,
+    pub blob_kzg_commitments: KzgCommitments<T>,
     #[superstruct(only(Base, Altair))]
     #[ssz(skip_serializing, skip_deserializing)]
     #[tree_hash(skip_hashing)]

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -233,5 +233,5 @@ pub type BlindedBlobSidecarList<T> = SidecarList<T, BlindedBlobSidecar>;
 pub type FixedBlobSidecarList<T> =
     FixedVector<Option<Arc<BlobSidecar<T>>>, <T as EthSpec>::MaxBlobsPerBlock>;
 
-pub type BlobsList<T> = VariableList<Blob<T>, <T as EthSpec>::MaxBlobsPerBlock>;
-pub type BlobRootsList<T> = VariableList<Hash256, <T as EthSpec>::MaxBlobsPerBlock>;
+pub type BlobsList<T> = VariableList<Blob<T>, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
+pub type BlobRootsList<T> = VariableList<Hash256, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -1,4 +1,4 @@
-use crate::beacon_block_body::BuilderKzgCommitments;
+use crate::beacon_block_body::KzgCommitments;
 use crate::{
     BlobRootsList, ChainSpec, EthSpec, ExecutionPayloadHeaderCapella, ExecutionPayloadHeaderDeneb,
     ExecutionPayloadHeaderMerge, ExecutionPayloadHeaderRef, ForkName, ForkVersionDeserialize,
@@ -15,7 +15,7 @@ use tree_hash_derive::TreeHash;
 #[derive(PartialEq, Debug, Default, Serialize, Deserialize, TreeHash, Clone, Encode)]
 #[serde(bound = "E: EthSpec")]
 pub struct BlindedBlobsBundle<E: EthSpec> {
-    pub commitments: BuilderKzgCommitments<E>,
+    pub commitments: KzgCommitments<E>,
     pub proofs: KzgProofs<E>,
     pub blob_roots: BlobRootsList<E>,
 }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -210,7 +210,7 @@ pub type Address = H160;
 pub type ForkVersion = [u8; 4];
 pub type BLSFieldElement = Uint256;
 pub type Blob<T> = FixedVector<u8, <T as EthSpec>::BytesPerBlob>;
-pub type KzgProofs<T> = VariableList<KzgProof, <T as EthSpec>::MaxBlobsPerBlock>;
+pub type KzgProofs<T> = VariableList<KzgProof, <T as EthSpec>::MaxBlobCommitmentsPerBlock>;
 pub type VersionedHash = Hash256;
 pub type Hash64 = ethereum_types::H64;
 

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -398,8 +398,13 @@ impl<T: EthSpec> AbstractExecPayload<T> for FullPayload<T> {
             ForkName::Deneb => Ok(FullPayloadDeneb::default().into()),
         }
     }
-    fn default_blobs_at_fork(_fork_name: ForkName) -> Result<BlobsList<T>, Error> {
-        Ok(VariableList::default())
+    fn default_blobs_at_fork(fork_name: ForkName) -> Result<BlobsList<T>, Error> {
+        match fork_name {
+            ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
+                Err(Error::IncorrectStateVariant)
+            }
+            ForkName::Deneb => Ok(VariableList::default()),
+        }
     }
 }
 
@@ -916,8 +921,13 @@ impl<T: EthSpec> AbstractExecPayload<T> for BlindedPayload<T> {
             ForkName::Deneb => Ok(BlindedPayloadDeneb::default().into()),
         }
     }
-    fn default_blobs_at_fork(_fork_name: ForkName) -> Result<BlobRootsList<T>, Error> {
-        Ok(VariableList::default())
+    fn default_blobs_at_fork(fork_name: ForkName) -> Result<BlobRootsList<T>, Error> {
+        match fork_name {
+            ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
+                Err(Error::IncorrectStateVariant)
+            }
+            ForkName::Deneb => Ok(VariableList::default()),
+        }
     }
 }
 

--- a/consensus/types/src/sidecar.rs
+++ b/consensus/types/src/sidecar.rs
@@ -1,4 +1,4 @@
-use crate::beacon_block_body::BuilderKzgCommitments;
+use crate::beacon_block_body::KzgCommitments;
 use crate::test_utils::TestRandom;
 use crate::{
     AbstractExecPayload, BeaconBlock, BlindedBlobSidecar, BlindedBlobSidecarList, BlobRootsList,
@@ -33,7 +33,7 @@ pub trait Sidecar<E: EthSpec>:
     fn build_sidecar<Payload: AbstractExecPayload<E>>(
         blob_items: Self::BlobItems,
         block: &BeaconBlock<E, Payload>,
-        expected_kzg_commitments: &BuilderKzgCommitments<E>,
+        expected_kzg_commitments: &KzgCommitments<E>,
         kzg_proofs: Vec<KzgProof>,
     ) -> Result<SidecarList<E, Self>, String>;
 }
@@ -106,7 +106,7 @@ impl<E: EthSpec> Sidecar<E> for BlobSidecar<E> {
     fn build_sidecar<Payload: AbstractExecPayload<E>>(
         blobs: BlobsList<E>,
         block: &BeaconBlock<E, Payload>,
-        expected_kzg_commitments: &BuilderKzgCommitments<E>,
+        expected_kzg_commitments: &KzgCommitments<E>,
         kzg_proofs: Vec<KzgProof>,
     ) -> Result<SidecarList<E, Self>, String> {
         let beacon_block_root = block.canonical_root();
@@ -152,7 +152,7 @@ impl<E: EthSpec> Sidecar<E> for BlindedBlobSidecar {
     fn build_sidecar<Payload: AbstractExecPayload<E>>(
         blob_roots: BlobRootsList<E>,
         block: &BeaconBlock<E, Payload>,
-        expected_kzg_commitments: &BuilderKzgCommitments<E>,
+        expected_kzg_commitments: &KzgCommitments<E>,
         kzg_proofs: Vec<KzgProof>,
     ) -> Result<SidecarList<E, BlindedBlobSidecar>, String> {
         let beacon_block_root = block.canonical_root();

--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -138,6 +138,6 @@ Update the genesis time to now using:
 3. The above mock builders do not support non mainnet presets as of now, and will require setting `SECONDS_PER_SLOT` and `SECONDS_PER_ETH1_BLOCK` to `12` in `./vars.env`. 
 4. Start the testnet with the following command (the `-p` flag enables the validator client `--builder-proposals` flag:
     ```bash
-    ./start_local_testnet -p genesis.json
+    ./start_local_testnet.sh -p genesis.json
     ```
 5. Block production using builder flow will start at epoch 4.

--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -135,7 +135,7 @@ Update the genesis time to now using:
     - [`mock-relay`](https://github.com/realbigsean/mock-relay)
     - [`dummy-builder`](https://github.com/michaelsproul/dummy_builder)
 2. (Optional) Add `--always-prefer-builder-payload` to `BN_ARGS`.
-3. The above mock builders do not support non mainnet presets as of now, and will require setting `SECONDS_PER_SLOT` and `SECONDS_PER_ETH1_BLOCK` to `12` in `./vars.env`. 
+3. The above mock builders do not support non-mainnet presets as of now, and will require setting `SECONDS_PER_SLOT` and `SECONDS_PER_ETH1_BLOCK` to `12` in `./vars.env`. 
 4. Start the testnet with the following command (the `-p` flag enables the validator client `--builder-proposals` flag:
     ```bash
     ./start_local_testnet.sh -p genesis.json

--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -128,3 +128,16 @@ Update the genesis time to now using:
 
 > Note: you probably want to just rerun `./start_local_testnet.sh` to start over
 > but this is another option.
+
+### Testing builder flow
+
+1. Add builder URL to `BN_ARGS` in `./var.env`, e.g. `--builder http://localhost:8650`. Some mock builder server options: 
+    - [`mock-relay`](https://github.com/realbigsean/mock-relay)
+    - [`dummy-builder`](https://github.com/michaelsproul/dummy_builder)
+2. (Optional) Add `--always-prefer-builder-payload` to `BN_ARGS`.
+3. The above mock builders do not support non mainnet presets as of now, and will require setting `SECONDS_PER_SLOT` and `SECONDS_PER_ETH1_BLOCK` to `12` in `./vars.env`. 
+4. Start the testnet with the following command (the `-p` flag enables the validator client `--builder-proposals` flag:
+    ```bash
+    ./start_local_testnet -p genesis.json
+    ```
+5. Block production using builder flow will start at epoch 4.

--- a/scripts/local_testnet/beacon_node.sh
+++ b/scripts/local_testnet/beacon_node.sh
@@ -63,4 +63,5 @@ exec $lighthouse_binary \
 	--disable-packet-filter \
 	--target-peers $((BN_COUNT - 1)) \
   --execution-endpoint $execution_endpoint \
-  --execution-jwt $execution_jwt
+  --execution-jwt $execution_jwt \
+  $BN_ARGS

--- a/scripts/local_testnet/setup.sh
+++ b/scripts/local_testnet/setup.sh
@@ -47,6 +47,6 @@ lcli \
 	insecure-validators \
 	--count $VALIDATOR_COUNT \
 	--base-dir $DATADIR \
-	--node-count $BN_COUNT
+	--node-count $VC_COUNT
 
 echo Validators generated with keystore passwords at $DATADIR.

--- a/scripts/local_testnet/vars.env
+++ b/scripts/local_testnet/vars.env
@@ -61,5 +61,8 @@ SECONDS_PER_ETH1_BLOCK=1
 # Proposer score boost percentage
 PROPOSER_SCORE_BOOST=40
 
+# Command line arguments for beacon node client
+BN_ARGS=""
+
 # Command line arguments for validator client
 VC_ARGS=""

--- a/scripts/tests/vars.env
+++ b/scripts/tests/vars.env
@@ -58,5 +58,8 @@ SECONDS_PER_ETH1_BLOCK=1
 # Proposer score boost percentage
 PROPOSER_SCORE_BOOST=70
 
+# Command line arguments for beacon node client
+BN_ARGS=""
+
 # Enable doppelganger detection
 VC_ARGS=" --enable-doppelganger-protection "


### PR DESCRIPTION
## Issue Addressed

Addresses #4665 

## Proposed Changes

- Use `MAX_BLOB_COMMITMENTS_PER_BLOCK` as max length for `BlindedBlobsBundle` SSZ lists. This removes the `BuilderKzgCommitments` type and replace its usage with `BlockBodyKzgCommitments` everywhere, and renaming `BlockBodyKzgCommitments` back to just `KzgCommitments`.  Builder spec PR:
  - https://github.com/ethereum/builder-specs/pull/87
- Testing:
  - Update `mev-rs` and `ethereum-consensus` dependencies to support latest deneb spec.
  - Update `mock_builder::open_bid` to convert response to `mev-rs` `ExecutionPayload` type correctly
  - Update local testnet scripts and README to support builder testing.

## Issues

There's an issue with proposer prep that's currently being fixed in #4703, and the fix is required before continuing with testing.