### PR TITLE
[Merged by Bors] - validator client: start http api before genesis

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -8,6 +8,7 @@ use env_logger::{Builder, Env};
 use environment::{EnvironmentBuilder, LoggerConfig};
 use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK, HARDCODED_NET_NAMES};
 use ethereum_hashing::have_sha_extensions;
+use futures::TryFutureExt;
 use lighthouse_version::VERSION;
 use malloc_utils::configure_memory_allocator;
 use slog::{crit, info, warn};
@@ -659,8 +660,8 @@ fn run<E: EthSpec>(
                 executor.clone().spawn(
                     async move {
                         if let Err(e) = ProductionValidatorClient::new(context, config)
+                            .and_then(|mut vc| async move { vc.start_service().await })
                             .await
-                            .and_then(|mut vc| vc.start_service())
                         {
                             crit!(log, "Failed to start validator client"; "reason" => e);
                             // Ignore the error since it always occurs during normal operation when

--- a/testing/node_test_rig/src/lib.rs
+++ b/testing/node_test_rig/src/lib.rs
@@ -220,14 +220,13 @@ impl<E: EthSpec> LocalValidatorClient<E> {
         config.validator_dir = files.validator_dir.path().into();
         config.secrets_dir = files.secrets_dir.path().into();
 
-        ProductionValidatorClient::new(context, config)
+        let mut client = ProductionValidatorClient::new(context, config).await?;
+
+        client
+            .start_service()
             .await
-            .map(move |mut client| {
-                client
-                    .start_service()
-                    .expect("should start validator services");
-                Self { client, files }
-            })
+            .expect("should start validator services");
+        Ok(Self { client, files })
     }
 }
 

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -528,6 +528,44 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
         let (block_service_tx, block_service_rx) = mpsc::channel(channel_capacity);
         let log = self.context.log();
 
+        let api_secret = ApiSecret::create_or_open(&self.config.validator_dir)?;
+
+        self.http_api_listen_addr = if self.config.http_api.enabled {
+            let ctx = Arc::new(http_api::Context {
+                task_executor: self.context.executor.clone(),
+                api_secret,
+                validator_store: Some(self.validator_store.clone()),
+                validator_dir: Some(self.config.validator_dir.clone()),
+                secrets_dir: Some(self.config.secrets_dir.clone()),
+                graffiti_file: self.config.graffiti_file.clone(),
+                graffiti_flag: self.config.graffiti,
+                spec: self.context.eth2_config.spec.clone(),
+                config: self.config.http_api.clone(),
+                sse_logging_components: self.context.sse_logging_components.clone(),
+                slot_clock: self.slot_clock.clone(),
+                log: log.clone(),
+                _phantom: PhantomData,
+            });
+
+            let exit = self.context.executor.exit();
+
+            let (listen_addr, server) = http_api::serve(ctx, exit)
+                .map_err(|e| format!("Unable to start HTTP API server: {:?}", e))?;
+
+            self.context
+                .clone()
+                .executor
+                .spawn_without_exit(server, "http-api");
+
+            Some(listen_addr)
+        } else {
+            info!(log, "HTTP API server is disabled");
+            None
+        };
+
+        // Wait until genesis has occurred.
+        wait_for_genesis(&self.beacon_nodes, self.genesis_time, &self.context).await?;
+
         duties_service::start_update_service(self.duties_service.clone(), block_service_tx);
 
         self.block_service
@@ -566,41 +604,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
 
         spawn_notifier(self).map_err(|e| format!("Failed to start notifier: {}", e))?;
 
-        let api_secret = ApiSecret::create_or_open(&self.config.validator_dir)?;
-
-        self.http_api_listen_addr = if self.config.http_api.enabled {
-            let ctx = Arc::new(http_api::Context {
-                task_executor: self.context.executor.clone(),
-                api_secret,
-                validator_store: Some(self.validator_store.clone()),
-                validator_dir: Some(self.config.validator_dir.clone()),
-                secrets_dir: Some(self.config.secrets_dir.clone()),
-                graffiti_file: self.config.graffiti_file.clone(),
-                graffiti_flag: self.config.graffiti,
-                spec: self.context.eth2_config.spec.clone(),
-                config: self.config.http_api.clone(),
-                sse_logging_components: self.context.sse_logging_components.clone(),
-                slot_clock: self.slot_clock.clone(),
-                log: log.clone(),
-                _phantom: PhantomData,
-            });
-
-            let exit = self.context.executor.exit();
-
-            let (listen_addr, server) = http_api::serve(ctx, exit)
-                .map_err(|e| format!("Unable to start HTTP API server: {:?}", e))?;
-
-            self.context
-                .clone()
-                .executor
-                .spawn_without_exit(server, "http-api");
-
-            Some(listen_addr)
-        } else {
-            info!(log, "HTTP API server is disabled");
-            None
-        };
-
         if self.config.enable_latency_measurement_service {
             latency::start_latency_service(
                 self.context.clone(),
@@ -608,9 +611,6 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                 self.duties_service.beacon_nodes.clone(),
             );
         }
-
-        // Wait until genesis has occurred.
-        wait_for_genesis(&self.beacon_nodes, self.genesis_time, &self.context).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Issue Addressed

On a new network a user might require importing validators before waiting until genesis has occurred.

## Proposed Changes

Starts the validator client http api before waiting for genesis 

## Additional Info

cc @antondlr 