### PR TITLE
Blob references in ckzg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,16 +698,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
-source = "git+https://github.com/rust-lang/rust-bindgen?rev=0de11f0a521611ac8738b7b01d19dddaf3899e66#0de11f0a521611ac8738b7b01d19dddaf3899e66"
+version = "0.66.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cexpr",
  "clang-sys",
  "lazy_static",
  "lazycell",
  "log",
  "peeking_take_while",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
@@ -943,9 +945,10 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum//c-kzg-4844?rev=fa3c62989527073fdce8b2138bb27a52bb2407c5#fa3c62989527073fdce8b2138bb27a52bb2407c5"
+source = "git+https://github.com/ethereum//c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d#f5f6f863d475847876a2bd5ee252058d37c3a15d"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen 0.66.1",
+ "blst",
  "cc",
  "glob",
  "hex",
@@ -956,9 +959,10 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=fa3c62989527073fdce8b2138bb27a52bb2407c5#fa3c62989527073fdce8b2138bb27a52bb2407c5"
+source = "git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d#f5f6f863d475847876a2bd5ee252058d37c3a15d"
 dependencies = [
- "bindgen 0.64.0",
+ "bindgen 0.66.1",
+ "blst",
  "cc",
  "glob",
  "hex",
@@ -3951,8 +3955,8 @@ name = "kzg"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "c-kzg 0.1.0 (git+https://github.com/ethereum//c-kzg-4844?rev=fa3c62989527073fdce8b2138bb27a52bb2407c5)",
- "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=fa3c62989527073fdce8b2138bb27a52bb2407c5)",
+ "c-kzg 0.1.0 (git+https://github.com/ethereum//c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
+ "c-kzg 0.1.0 (git+https://github.com/ethereum/c-kzg-4844?rev=f5f6f863d475847876a2bd5ee252058d37c3a15d)",
  "derivative",
  "ethereum_hashing",
  "ethereum_serde_utils",
@@ -5998,6 +6002,16 @@ version = "0.1.0"
 dependencies = [
  "reqwest",
  "sensitive_url",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -17,7 +17,7 @@ pub fn validate_blob<T: EthSpec>(
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
     kzg.verify_blob_kzg_proof(
-        ssz_blob_to_crypto_blob::<T>(&blob)?,
+        &ssz_blob_to_crypto_blob::<T>(&blob)?,
         kzg_commitment,
         kzg_proof,
     )
@@ -45,7 +45,7 @@ pub fn compute_blob_kzg_proof<T: EthSpec>(
     kzg_commitment: KzgCommitment,
 ) -> Result<KzgProof, KzgError> {
     // Avoid this blob clone
-    kzg.compute_blob_kzg_proof(ssz_blob_to_crypto_blob::<T>(blob)?, kzg_commitment)
+    kzg.compute_blob_kzg_proof(&ssz_blob_to_crypto_blob::<T>(blob)?, kzg_commitment)
 }
 
 /// Compute the kzg commitment for a given blob.
@@ -53,7 +53,7 @@ pub fn blob_to_kzg_commitment<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
     blob: &Blob<T>,
 ) -> Result<KzgCommitment, KzgError> {
-    kzg.blob_to_kzg_commitment(ssz_blob_to_crypto_blob::<T>(blob)?)
+    kzg.blob_to_kzg_commitment(&ssz_blob_to_crypto_blob::<T>(blob)?)
 }
 
 /// Compute the kzg proof for a given blob and an evaluation point z.
@@ -63,7 +63,7 @@ pub fn compute_kzg_proof<T: EthSpec>(
     z: Hash256,
 ) -> Result<(KzgProof, Hash256), KzgError> {
     let z = z.0.into();
-    kzg.compute_kzg_proof(ssz_blob_to_crypto_blob::<T>(blob)?, z)
+    kzg.compute_kzg_proof(&ssz_blob_to_crypto_blob::<T>(blob)?, &z)
         .map(|(proof, z)| (proof, Hash256::from_slice(&z.to_vec())))
 }
 
@@ -75,5 +75,5 @@ pub fn verify_kzg_proof<T: EthSpec>(
     z: Hash256,
     y: Hash256,
 ) -> Result<bool, KzgError> {
-    kzg.verify_kzg_proof(kzg_commitment, z.0.into(), y.0.into(), kzg_proof)
+    kzg.verify_kzg_proof(kzg_commitment, &z.0.into(), &y.0.into(), kzg_proof)
 }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -151,11 +151,11 @@ impl<T: EthSpec> BlobSidecar<T> {
         let kzg_blob = T::blob_from_bytes(&blob).unwrap();
 
         let commitment = kzg
-            .blob_to_kzg_commitment(kzg_blob.clone())
+            .blob_to_kzg_commitment(&kzg_blob)
             .map_err(|e| format!("error computing kzg commitment: {:?}", e))?;
 
         let proof = kzg
-            .compute_blob_kzg_proof(kzg_blob, commitment)
+            .compute_blob_kzg_proof(&kzg_blob, commitment)
             .map_err(|e| format!("error computing kzg proof: {:?}", e))?;
 
         Ok(Self {

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -2,7 +2,7 @@ use crate::test_utils::TestRandom;
 use crate::{Blob, ChainSpec, Domain, EthSpec, Fork, Hash256, SignedBlobSidecar, SignedRoot, Slot};
 use bls::SecretKey;
 use derivative::Derivative;
-use kzg::{Kzg, KzgCommitment, KzgPreset, KzgProof};
+use kzg::{Kzg, KzgCommitment, KzgPreset, KzgProof, BYTES_PER_FIELD_ELEMENT};
 use rand::Rng;
 use serde_derive::{Deserialize, Serialize};
 use ssz::Encode;
@@ -138,7 +138,7 @@ impl<T: EthSpec> BlobSidecar<T> {
         // each field element contained in the blob is < BLS_MODULUS
         for i in 0..T::Kzg::FIELD_ELEMENTS_PER_BLOB {
             let Some(byte) = blob_bytes.get_mut(
-                i.checked_mul(T::Kzg::BYTES_PER_FIELD_ELEMENT)
+                i.checked_mul(BYTES_PER_FIELD_ELEMENT)
                     .ok_or("overflow".to_string())?,
             ) else {
                 return Err(format!("blob byte index out of bounds: {:?}", i));

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -16,8 +16,8 @@ serde_derive = "1.0.116"
 ethereum_serde_utils = "0.5.0"
 hex = "0.4.2"
 ethereum_hashing = "1.0.0-beta.2"
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "fa3c62989527073fdce8b2138bb27a52bb2407c5" , features = ["mainnet-spec"]}
-c_kzg_min = { package = "c-kzg", git = "https://github.com/ethereum//c-kzg-4844", rev = "fa3c62989527073fdce8b2138bb27a52bb2407c5", features = ["minimal-spec"], optional = true }
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "f5f6f863d475847876a2bd5ee252058d37c3a15d" , features = ["mainnet-spec", "serde"]}
+c_kzg_min = { package = "c-kzg", git = "https://github.com/ethereum//c-kzg-4844", rev = "f5f6f863d475847876a2bd5ee252058d37c3a15d", features = ["minimal-spec", "serde"], optional = true }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -24,6 +24,8 @@ pub enum Error {
 pub enum CryptoError {
     CKzg(c_kzg::Error),
     CKzgMin(c_kzg_min::Error),
+    /// Trusted setup is for the incorrect kzg preset.
+    InconsistentTrustedSetup,
 }
 
 impl From<c_kzg::Error> for CryptoError {
@@ -146,6 +148,9 @@ macro_rules! implement_kzg_preset {
             fn load_trusted_setup(
                 trusted_setup: TrustedSetup,
             ) -> Result<Self::KzgSettings, CryptoError> {
+                if trusted_setup.g1_len() != Self::FIELD_ELEMENTS_PER_BLOB {
+                    return Err(CryptoError::InconsistentTrustedSetup);
+                }
                 $module_name::KzgSettings::load_trusted_setup(
                     &trusted_setup.g1_points(),
                     &trusted_setup.g2_points(),

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -87,13 +87,13 @@ pub trait KzgPreset:
     fn load_trusted_setup(trusted_setup: TrustedSetup) -> Result<Self::KzgSettings, CryptoError>;
 
     fn compute_blob_kzg_proof(
-        blob: Self::Blob,
+        blob: &Self::Blob,
         kzg_commitment: KzgCommitment,
         trusted_setup: &Self::KzgSettings,
     ) -> Result<KzgProof, CryptoError>;
 
     fn verify_blob_kzg_proof(
-        blob: Self::Blob,
+        blob: &Self::Blob,
         kzg_commitment: KzgCommitment,
         kzg_proof: KzgProof,
         trusted_setup: &Self::KzgSettings,
@@ -107,20 +107,20 @@ pub trait KzgPreset:
     ) -> Result<bool, CryptoError>;
 
     fn blob_to_kzg_commitment(
-        blob: Self::Blob,
+        blob: &Self::Blob,
         trusted_setup: &Self::KzgSettings,
     ) -> Result<KzgCommitment, CryptoError>;
 
     fn compute_kzg_proof(
-        blob: Self::Blob,
-        z: Self::Bytes32,
+        blob: &Self::Blob,
+        z: &Self::Bytes32,
         trusted_setup: &Self::KzgSettings,
     ) -> Result<(KzgProof, Self::Bytes32), CryptoError>;
 
     fn verify_kzg_proof(
         kzg_commitment: KzgCommitment,
-        z: Self::Bytes32,
-        y: Self::Bytes32,
+        z: &Self::Bytes32,
+        y: &Self::Bytes32,
         kzg_proof: KzgProof,
         trusted_setup: &Self::KzgSettings,
     ) -> Result<bool, CryptoError>;
@@ -147,20 +147,20 @@ macro_rules! implement_kzg_preset {
                 trusted_setup: TrustedSetup,
             ) -> Result<Self::KzgSettings, CryptoError> {
                 $module_name::KzgSettings::load_trusted_setup(
-                    trusted_setup.g1_points(),
-                    trusted_setup.g2_points(),
+                    &trusted_setup.g1_points(),
+                    &trusted_setup.g2_points(),
                 )
                 .map_err(CryptoError::from)
             }
 
             fn compute_blob_kzg_proof(
-                blob: Self::Blob,
+                blob: &Self::Blob,
                 kzg_commitment: KzgCommitment,
                 trusted_setup: &Self::KzgSettings,
             ) -> Result<KzgProof, CryptoError> {
                 $module_name::KzgProof::compute_blob_kzg_proof(
                     blob,
-                    kzg_commitment.into(),
+                    &kzg_commitment.into(),
                     trusted_setup,
                 )
                 .map(|proof| KzgProof(proof.to_bytes().into_inner()))
@@ -168,15 +168,15 @@ macro_rules! implement_kzg_preset {
             }
 
             fn verify_blob_kzg_proof(
-                blob: Self::Blob,
+                blob: &Self::Blob,
                 kzg_commitment: KzgCommitment,
                 kzg_proof: KzgProof,
                 trusted_setup: &Self::KzgSettings,
             ) -> Result<bool, CryptoError> {
                 $module_name::KzgProof::verify_blob_kzg_proof(
                     blob,
-                    kzg_commitment.into(),
-                    kzg_proof.into(),
+                    &kzg_commitment.into(),
+                    &kzg_proof.into(),
                     trusted_setup,
                 )
                 .map_err(CryptoError::from)
@@ -198,7 +198,7 @@ macro_rules! implement_kzg_preset {
             }
 
             fn blob_to_kzg_commitment(
-                blob: Self::Blob,
+                blob: &Self::Blob,
                 trusted_setup: &Self::KzgSettings,
             ) -> Result<KzgCommitment, CryptoError> {
                 $module_name::KzgCommitment::blob_to_kzg_commitment(blob, trusted_setup)
@@ -207,8 +207,8 @@ macro_rules! implement_kzg_preset {
             }
 
             fn compute_kzg_proof(
-                blob: Self::Blob,
-                z: Self::Bytes32,
+                blob: &Self::Blob,
+                z: &Self::Bytes32,
                 trusted_setup: &Self::KzgSettings,
             ) -> Result<(KzgProof, Self::Bytes32), CryptoError> {
                 $module_name::KzgProof::compute_kzg_proof(blob, z, trusted_setup)
@@ -218,16 +218,16 @@ macro_rules! implement_kzg_preset {
 
             fn verify_kzg_proof(
                 kzg_commitment: KzgCommitment,
-                z: Self::Bytes32,
-                y: Self::Bytes32,
+                z: &Self::Bytes32,
+                y: &Self::Bytes32,
                 kzg_proof: KzgProof,
                 trusted_setup: &Self::KzgSettings,
             ) -> Result<bool, CryptoError> {
                 $module_name::KzgProof::verify_kzg_proof(
-                    kzg_commitment.into(),
+                    &kzg_commitment.into(),
                     z,
                     y,
-                    kzg_proof.into(),
+                    &kzg_proof.into(),
                     trusted_setup,
                 )
                 .map_err(CryptoError::from)
@@ -274,7 +274,7 @@ impl<P: KzgPreset> Kzg<P> {
     /// Compute the kzg proof given a blob and its kzg commitment.
     pub fn compute_blob_kzg_proof(
         &self,
-        blob: P::Blob,
+        blob: &P::Blob,
         kzg_commitment: KzgCommitment,
     ) -> Result<KzgProof, Error> {
         P::compute_blob_kzg_proof(blob, kzg_commitment, &self.trusted_setup)
@@ -284,7 +284,7 @@ impl<P: KzgPreset> Kzg<P> {
     /// Verify a kzg proof given the blob, kzg commitment and kzg proof.
     pub fn verify_blob_kzg_proof(
         &self,
-        blob: P::Blob,
+        blob: &P::Blob,
         kzg_commitment: KzgCommitment,
         kzg_proof: KzgProof,
     ) -> Result<bool, Error> {
@@ -322,17 +322,17 @@ impl<P: KzgPreset> Kzg<P> {
     }
 
     /// Converts a blob to a kzg commitment.
-    pub fn blob_to_kzg_commitment(&self, blob: P::Blob) -> Result<KzgCommitment, Error> {
+    pub fn blob_to_kzg_commitment(&self, blob: &P::Blob) -> Result<KzgCommitment, Error> {
         P::blob_to_kzg_commitment(blob, &self.trusted_setup).map_err(Error::InvalidBlob)
     }
 
     /// Computes the kzg proof for a given `blob` and an evaluation point `z`
     pub fn compute_kzg_proof(
         &self,
-        blob: P::Blob,
-        z: Bytes32,
+        blob: &P::Blob,
+        z: &Bytes32,
     ) -> Result<(KzgProof, Bytes32), Error> {
-        P::compute_kzg_proof(blob, P::bytes32_in(z), &self.trusted_setup)
+        P::compute_kzg_proof(blob, &P::bytes32_in(*z), &self.trusted_setup)
             .map_err(Error::KzgProofComputationFailed)
             .map(|(proof, y)| (proof, P::bytes32_out(y)))
     }
@@ -341,14 +341,14 @@ impl<P: KzgPreset> Kzg<P> {
     pub fn verify_kzg_proof(
         &self,
         kzg_commitment: KzgCommitment,
-        z: Bytes32,
-        y: Bytes32,
+        z: &Bytes32,
+        y: &Bytes32,
         kzg_proof: KzgProof,
     ) -> Result<bool, Error> {
         P::verify_kzg_proof(
             kzg_commitment,
-            P::bytes32_in(z),
-            P::bytes32_in(y),
+            &P::bytes32_in(*z),
+            &P::bytes32_in(*y),
             kzg_proof,
             &self.trusted_setup,
         )

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 use std::str::FromStr;
 
 pub use crate::{kzg_commitment::KzgCommitment, kzg_proof::KzgProof, trusted_setup::TrustedSetup};
-pub use c_kzg::{Bytes32, Bytes48, BYTES_PER_COMMITMENT, BYTES_PER_PROOF};
+pub use c_kzg::{Bytes32, Bytes48, BYTES_PER_COMMITMENT, BYTES_PER_FIELD_ELEMENT, BYTES_PER_PROOF};
 
 #[derive(Debug)]
 pub enum Error {
@@ -71,7 +71,6 @@ pub trait KzgPreset:
     type Error: Into<CryptoError>;
 
     const BYTES_PER_BLOB: usize;
-    const BYTES_PER_FIELD_ELEMENT: usize;
     const FIELD_ELEMENTS_PER_BLOB: usize;
 
     fn spec_name() -> KzgPresetId;
@@ -138,7 +137,6 @@ macro_rules! implement_kzg_preset {
             type Error = $module_name::Error;
 
             const BYTES_PER_BLOB: usize = $module_name::BYTES_PER_BLOB;
-            const BYTES_PER_FIELD_ELEMENT: usize = $module_name::BYTES_PER_FIELD_ELEMENT;
             const FIELD_ELEMENTS_PER_BLOB: usize = $module_name::FIELD_ELEMENTS_PER_BLOB;
 
             fn spec_name() -> KzgPresetId {

--- a/crypto/kzg/src/trusted_setup.rs
+++ b/crypto/kzg/src/trusted_setup.rs
@@ -1,4 +1,4 @@
-use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT, FIELD_ELEMENTS_PER_BLOB};
+use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT};
 use serde::{
     de::{self, Deserializer, Visitor},
     Deserialize, Serialize,
@@ -22,7 +22,6 @@ struct G2Point([u8; BYTES_PER_G2_POINT]);
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TrustedSetup {
     #[serde(rename = "setup_G1_lagrange")]
-    #[serde(deserialize_with = "deserialize_g1_points")]
     g1_points: Vec<G1Point>,
     #[serde(rename = "setup_G2")]
     g2_points: Vec<G2Point>,
@@ -132,23 +131,6 @@ impl<'de> Deserialize<'de> for G2Point {
 
         deserializer.deserialize_str(G2PointVisitor)
     }
-}
-
-fn deserialize_g1_points<'de, D>(deserializer: D) -> Result<Vec<G1Point>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let mut decoded: Vec<G1Point> = serde::de::Deserialize::deserialize(deserializer)?;
-    // FIELD_ELEMENTS_PER_BLOB is a compile time parameter that
-    // depends on whether lighthouse is compiled with minimal or mainnet features.
-    // Minimal and mainnet trusted setup parameters differ only by the
-    // number of G1 points they contain.
-    //
-    // Hence, we truncate the number of G1 points after deserialisation
-    // to ensure that we have the right number of g1 points in the
-    // trusted setup.
-    decoded.truncate(FIELD_ELEMENTS_PER_BLOB);
-    Ok(decoded)
 }
 
 fn strip_prefix(s: &str) -> &str {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

After fixing the windows crashes in ckzg and the interface change to take references in the bindings interface with https://github.com/ethereum/c-kzg-4844/pull/356 , this PR just adopts to the new references interface.


