### PR TITLE
Implement SSZ decoding for `SignedBlockContents`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,7 +753,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -6165,7 +6165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1397,7 +1397,7 @@ mod tests {
     #[test]
     fn ssz_signed_block_contents_pre_deneb() {
         type E = MainnetEthSpec;
-        let spec = ForkName::Capella.make_genesis_spec(E::default_spec())
+        let spec = ForkName::Capella.make_genesis_spec(E::default_spec());
 
         let block: SignedBlockContents<E, FullPayload<E>> = SignedBeaconBlock::from_block(
             BeaconBlock::<E>::Capella(BeaconBlockCapella::empty(&spec)),
@@ -1415,7 +1415,7 @@ mod tests {
     #[test]
     fn ssz_signed_block_contents_with_blobs() {
         type E = MainnetEthSpec;
-        let spec = ForkName::Deneb.make_genesis_spec(E::default_spec())
+        let spec = ForkName::Deneb.make_genesis_spec(E::default_spec());
 
         let block = SignedBeaconBlock::from_block(
             BeaconBlock::<E>::Deneb(BeaconBlockDeneb::empty(&spec)),

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1397,10 +1397,7 @@ mod tests {
     #[test]
     fn ssz_signed_block_contents_pre_deneb() {
         type E = MainnetEthSpec;
-        let mut spec = E::default_spec();
-        spec.altair_fork_epoch = Some(Epoch::new(0));
-        spec.bellatrix_fork_epoch = Some(Epoch::new(0));
-        spec.capella_fork_epoch = Some(Epoch::new(0));
+        let spec = ForkName::Capella.make_genesis_spec(E::default_spec())
 
         let block: SignedBlockContents<E, FullPayload<E>> = SignedBeaconBlock::from_block(
             BeaconBlock::<E>::Capella(BeaconBlockCapella::empty(&spec)),
@@ -1418,11 +1415,7 @@ mod tests {
     #[test]
     fn ssz_signed_block_contents_with_blobs() {
         type E = MainnetEthSpec;
-        let mut spec = E::default_spec();
-        spec.altair_fork_epoch = Some(Epoch::new(0));
-        spec.bellatrix_fork_epoch = Some(Epoch::new(0));
-        spec.capella_fork_epoch = Some(Epoch::new(0));
-        spec.deneb_fork_epoch = Some(Epoch::new(0));
+        let spec = ForkName::Deneb.make_genesis_spec(E::default_spec())
 
         let block = SignedBeaconBlock::from_block(
             BeaconBlock::<E>::Deneb(BeaconBlockDeneb::empty(&spec)),

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -197,6 +197,21 @@ pub struct BlindedBlobSidecar {
     pub kzg_proof: KzgProof,
 }
 
+impl BlindedBlobSidecar {
+    pub fn empty() -> Self {
+        Self {
+            block_root: Hash256::zero(),
+            index: 0,
+            slot: Slot::new(0),
+            block_parent_root: Hash256::zero(),
+            proposer_index: 0,
+            blob_root: Hash256::zero(),
+            kzg_commitment: KzgCommitment::empty_for_testing(),
+            kzg_proof: KzgProof::empty(),
+        }
+    }
+}
+
 impl SignedRoot for BlindedBlobSidecar {}
 
 pub type SidecarList<T, Sidecar> = VariableList<Arc<Sidecar>, <T as EthSpec>::MaxBlobsPerBlock>;


### PR DESCRIPTION
## Issue Addressed

Addresses #4580.

## Proposed Changes

Implement SSZ decoding for `SignedBlockContents` with blobs. Also fixed a bug in `SignedBlockContents` matching the incorrect block types.
