### PR TITLE
[Merged by Bors] - Fix local testnet to generate keys in the correct folders 

### DIFF
--- a/scripts/local_testnet/setup.sh
+++ b/scripts/local_testnet/setup.sh
@@ -46,6 +46,6 @@ lcli \
 	insecure-validators \
 	--count $VALIDATOR_COUNT \
 	--base-dir $DATADIR \
-	--node-count $BN_COUNT
+	--node-count $VC_COUNT
 
 echo Validators generated with keystore passwords at $DATADIR.


### PR DESCRIPTION
Fix local testnet to generate keys in the correct folders when `BN_COUNT` and `VC_COUNT` don't match.

The current script place the generated validator keys in validator folders based on the `BN_COUNT` config, e.g. `node_1/validators`, `node_2/validators`..etc. We should be using `VC_COUNT` here instead, otherwise the number of validator clients may not match the number of directories generated, and would result in either:
1. a VC not having any keys  (when `BN_COUNT` < `VC_COUNT`)
2. a validator key directory not being used (when `BN_COUNT` > `VC_COUNT`).