### PR TITLE
[Merged by Bors] - fix docs about `--builder`

### DIFF
--- a/book/src/builders.md
+++ b/book/src/builders.md
@@ -21,7 +21,7 @@ The beacon node and validator client each require a new flag for lighthouse to b
 ```
 lighthouse bn --builder https://mainnet-builder.test
 ```
-The `--builder` flag will cause the beacon node to simultaneously query the provided URL and the local execution engine during block production for a block payload with stubbed-out transactions.
+The `--builder` flag will cause the beacon node to simultaneously query the provided URL and the local execution engine during block production for a block payload with stubbed-out transactions. If either fails, the successful result will be used;If both succeed, the more profitable result will be used.
 
 The beacon node will *only* query for this type of block (a "blinded" block) when a validator specifically requests it.
 Otherwise, it will continue to serve full blocks as normal. In order to configure the validator client to query for

--- a/book/src/builders.md
+++ b/book/src/builders.md
@@ -21,9 +21,7 @@ The beacon node and validator client each require a new flag for lighthouse to b
 ```
 lighthouse bn --builder https://mainnet-builder.test
 ```
-The `--builder` flag will cause the beacon node to query the provided URL during block production for a block
-payload with stubbed-out transactions. If this request fails, Lighthouse will fall back to the local
-execution engine and produce a block using transactions gathered and verified locally.
+The `--builder` flag will cause the beacon node to simultaneously query the provided URL and the local execution engine during block production for a block payload with stubbed-out transactions.
 
 The beacon node will *only* query for this type of block (a "blinded" block) when a validator specifically requests it.
 Otherwise, it will continue to serve full blocks as normal. In order to configure the validator client to query for

--- a/book/src/builders.md
+++ b/book/src/builders.md
@@ -21,7 +21,7 @@ The beacon node and validator client each require a new flag for lighthouse to b
 ```
 lighthouse bn --builder https://mainnet-builder.test
 ```
-The `--builder` flag will cause the beacon node to simultaneously query the provided URL and the local execution engine during block production for a block payload with stubbed-out transactions. If either fails, the successful result will be used;If both succeed, the more profitable result will be used.
+The `--builder` flag will cause the beacon node to simultaneously query the provided URL and the local execution engine during block production for a block payload with stubbed-out transactions. If either fails, the successful result will be used; If both succeed, the more profitable result will be used.
 
 The beacon node will *only* query for this type of block (a "blinded" block) when a validator specifically requests it.
 Otherwise, it will continue to serve full blocks as normal. In order to configure the validator client to query for


### PR DESCRIPTION
Align the document with the [implementation](https://github.com/sigp/lighthouse/blob/2841f60686d642fcc0785c884d43e34e47a800dc/beacon_node/execution_layer/src/lib.rs#L740) regarding the `--builder` flag.


The `tokio::join!` macro takes a list of async expressions and evaluates them concurrently on the same task.