### PR TITLE
Improve state cache eviction and reduce mem usage

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -142,7 +142,7 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
         spec: ChainSpec,
         log: Logger,
     ) -> Result<HotColdDB<E, MemoryStore<E>, MemoryStore<E>>, Error> {
-        config.verify_compression_level()?;
+        config.verify::<E>()?;
 
         let hierarchy = config.hierarchy_config.to_moduli()?;
 
@@ -189,7 +189,7 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
         spec: ChainSpec,
         log: Logger,
     ) -> Result<Arc<Self>, Error> {
-        config.verify_compression_level()?;
+        config.verify::<E>()?;
 
         let hierarchy = config.hierarchy_config.to_moduli()?;
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1795,12 +1795,7 @@ fn epochs_per_migration_override() {
 fn epochs_per_state_diff_default() {
     CommandLineTest::new()
         .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(
-                config.store.epochs_per_state_diff,
-                beacon_node::beacon_chain::store::config::DEFAULT_EPOCHS_PER_STATE_DIFF
-            )
-        });
+        .with_config(|config| assert_eq!(config.store.epochs_per_state_diff, 16));
 }
 #[test]
 fn epochs_per_state_diff_override() {


### PR DESCRIPTION
## Proposed Changes

Reduce the occurrence of `WARN State cache missed` on tree-states. Quite often we would end up in a situation where the new finalized state had been pruned from the cache, and so the finalization migration would need to rebuild it. On top of being a bit slow, this was bad because it meant the new finalized state in the cache didn't share nodes (memory) with the more recent states in the cache.

To fix this, the cache now uses a custom cache eviction algorithm on top of LRU, that tries to avoid evicting states that could become finalized. Since making this change I haven't seen any cache misses on my local node. I think we should even be able to run with a really small number of states (like 4) without cache misses. I'm yet to test this though.