### PR TITLE
[Merged by Bors] - Bump `quinn-proto` to address rustsec vuln

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6192,9 +6192,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13f81c9a9d574310b8351f8666f5a93ac3b0069c45c28ad52c10291389a7cf9"
+checksum = "2c78e758510582acc40acb90458401172d41f1016f8c9dde89e49677afb7eec1"
 dependencies = [
  "bytes",
  "rand 0.8.5",


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Bumps `quinn-proto` to address a QUIC-related vulnerability: https://rustsec.org/advisories/RUSTSEC-2023-0063

Fixes a `cargo audit` failure.

## Additional Info

NA
