### PR TITLE
[Merged by Bors] - Fix cli options

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1273,5 +1273,5 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("64")
                 .takes_value(true)
         )
-        .group(ArgGroup::with_name("enable_http").args(&["http", "gui", "staking"]))
+        .group(ArgGroup::with_name("enable_http").args(&["http", "gui", "staking"]).multiple(true))
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2338,6 +2338,18 @@ fn gui_flag() {
 }
 
 #[test]
+fn multiple_http_enabled_flags() {
+    CommandLineTest::new()
+        .flag("gui", None)
+        .flag("http", None)
+        .flag("staking", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(config.http_api.enabled);
+        });
+}
+
+#[test]
 fn optimistic_finalized_sync_default() {
     CommandLineTest::new()
         .run_with_zero_port()


### PR DESCRIPTION
## Issue Addressed

Fixes breaking change introduced on https://github.com/sigp/lighthouse/pull/4674/  that doesn't allow multiple `http_enabled` `ArgGroup` flags