### PR TITLE
[Merged by Bors] - Exit aggregation step early if no validator is aggregator

### DIFF
--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -491,6 +491,14 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
     ) -> Result<(), String> {
         let log = self.context.log();
 
+        if !validator_duties
+            .iter()
+            .any(|duty_and_proof| duty_and_proof.selection_proof.is_some())
+        {
+            // Exit early if no validator is aggregator
+            return Ok(());
+        }
+
         let aggregated_attestation = &self
             .beacon_nodes
             .first_success(


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/4712

## Proposed Changes

Exit aggregation step early if no validator is aggregator. This avoids an unnecessary request to the beacon node and more importantly fixes noisy errors if Lighthouse VC is used with other clients such as Lodestar and Prysm.

## Additional Info

Related issue https://github.com/ChainSafe/lodestar/issues/5553
