### PR TITLE
reduce blob prune logging in forward sync

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2210,11 +2210,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         ops.push(StoreOp::KeyValueOp(update_blob_info));
 
         self.do_atomically_with_block_and_blobs_cache(ops)?;
-        info!(
-            self.log,
-            "Blob pruning complete";
-            "blob_lists_pruned" => blob_lists_pruned,
-        );
+        if blob_lists_pruned != 0 {
+            info!(
+                self.log,
+                "Blob pruning complete";
+                "blob_lists_pruned" => blob_lists_pruned,
+            );
+        }
 
         Ok(())
     }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2210,13 +2210,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         ops.push(StoreOp::KeyValueOp(update_blob_info));
 
         self.do_atomically_with_block_and_blobs_cache(ops)?;
-        if blob_lists_pruned != 0 {
-            info!(
-                self.log,
-                "Blob pruning complete";
-                "blob_lists_pruned" => blob_lists_pruned,
-            );
-        }
+        debug!(
+            self.log,
+            "Blob pruning complete";
+            "blob_lists_pruned" => blob_lists_pruned,
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Issue Addressed

The `INFO` log `Blob pruning complete` occurs every time we finalize a new epoch, so in forwards sync we see it a lot. During forwards sync, we don't download any blobs prior to the data availability boundary, so `blob_lists_pruned` is always `0` until we are within 4096 epochs. This change just suppresses the log if the `blob_lists_pruned` value is zero.

