### PR TITLE
insert cached child at the front of a chain of parent lookups

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -1193,7 +1193,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             };
             match child_lookup.get_cached_child_block() {
                 CachedChild::Ok(rpc_block) => {
-                    blocks.push(rpc_block);
+                    // Insert this block at the front. This order is important because we later check
+                    // for linear roots in `filter_chain_segment`
+                    blocks.insert(0, rpc_block);
                 }
                 CachedChild::DownloadIncomplete => {
                     trace!(self.log, "Parent lookup chain complete, awaiting child response"; "chain_hash" => ?chain_hash);

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -27,7 +27,7 @@ pub use single_block_lookup::CachedChildComponents;
 pub use single_block_lookup::{BlobRequestState, BlockRequestState};
 use slog::{debug, error, trace, warn, Logger};
 use smallvec::SmallVec;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -1122,7 +1122,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 let (chain_hash, blocks, hashes, block_request) =
                     parent_lookup.parts_for_processing();
 
-                let blocks = self.add_child_block_to_chain(chain_hash, blocks, cx);
+                let blocks = self.add_child_block_to_chain(chain_hash, blocks, cx).into();
 
                 let process_id = ChainSegmentProcessId::ParentLookup(chain_hash);
 
@@ -1177,9 +1177,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn add_child_block_to_chain(
         &mut self,
         chain_hash: Hash256,
-        mut blocks: Vec<RpcBlock<T::EthSpec>>,
+        mut blocks: VecDeque<RpcBlock<T::EthSpec>>,
         cx: &SyncNetworkContext<T>,
-    ) -> Vec<RpcBlock<T::EthSpec>> {
+    ) -> VecDeque<RpcBlock<T::EthSpec>> {
         // Find the child block that spawned the parent lookup request and add it to the chain
         // to send for processing.
         if let Some(child_lookup_id) = self
@@ -1195,7 +1195,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 CachedChild::Ok(rpc_block) => {
                     // Insert this block at the front. This order is important because we later check
                     // for linear roots in `filter_chain_segment`
-                    blocks.insert(0, rpc_block);
+                    blocks.push_front(rpc_block);
                 }
                 CachedChild::DownloadIncomplete => {
                     trace!(self.log, "Parent lookup chain complete, awaiting child response"; "chain_hash" => ?chain_hash);

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -9,6 +9,7 @@ use beacon_chain::data_availability_checker::DataAvailabilityChecker;
 use beacon_chain::BeaconChainTypes;
 use itertools::Itertools;
 use lighthouse_network::PeerId;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use store::Hash256;
 use strum::IntoStaticStr;
@@ -145,7 +146,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         self,
     ) -> (
         Hash256,
-        Vec<RpcBlock<T::EthSpec>>,
+        VecDeque<RpcBlock<T::EthSpec>>,
         Vec<Hash256>,
         SingleBlockLookup<Parent, T>,
     ) {
@@ -155,10 +156,10 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             current_parent_request,
         } = self;
         let block_count = downloaded_blocks.len();
-        let mut blocks = Vec::with_capacity(block_count);
+        let mut blocks = VecDeque::with_capacity(block_count);
         let mut hashes = Vec::with_capacity(block_count);
         for (hash, block) in downloaded_blocks.into_iter() {
-            blocks.push(block);
+            blocks.push_back(block);
             hashes.push(hash);
         }
         (chain_hash, blocks, hashes, current_parent_request)


### PR DESCRIPTION
## Issue Addressed

I induced some parent lookups on devnet 8 and I observed this log on almost every response:

`Sep 25 19:41:18.582 DEBG Invalid block received                  outcome: NonLinearParentRoots, msg: peer sent invalid block`

I'm pretty sure this is happening because we append the "cached child" block (the block that triggers the chain of parent requests) to the end of the chain of blocks here:  https://github.com/sigp/lighthouse/blob/deneb-free-blobs/beacon_node/network/src/sync/block_lookups/mod.rs#L1196

This comment seems to suggest blocks here should be ordered from highest slot to lowest slot (assuming "highest" and "lowest" here refer to slot). The fact that blocks are reversed here, and later used in order of ascending slot in `filter_chain_segment` also backs this up.

https://github.com/sigp/lighthouse/blob/42b34dbbe4515be73e7354a43a427d3c6ea66b78/beacon_node/network/src/network_beacon_processor/sync_methods.rs#L403