### PR TITLE
Make deneb-enabled VCs compatible with pre-deneb beacon nodes

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1019,6 +1019,7 @@ pub struct Config {
     ejection_balance: u64,
     #[serde(with = "serde_utils::quoted_u64")]
     min_per_epoch_churn_limit: u64,
+    #[serde(default)]
     #[serde(with = "serde_utils::quoted_u64")]
     max_per_epoch_activation_churn_limit: u64,
     #[serde(with = "serde_utils::quoted_u64")]


### PR DESCRIPTION
Add `serde(default)` to `max_per_epoch_activation_churn_limit` in spec config so that Deneb VC is compatible to older BN versions without the field.

This is required before we merge `deneb-free-blobs` into `unstable`, so users don't run into compatibility issues with BNs running on older versions without this Deneb config.

## Issue addressed

I've deployed a deneb branch to a BN and VC, and noticed that the VC isn't able to use other pre-deneb BNs as fallback due to this error: `Unable to read spec from beacon node`

Our VCs requires the config json to be parsable using [`Config`](https://github.com/sigp/lighthouse/blob/e0bf605316e3ee330d70eb18f95e4503d5044266/consensus/types/src/chain_spec.rs#L942), so all fields must match. In this case the fallback BNs config doesn't contain the `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT` field so the VC fails to use them as a fallback node.

This PR adds `serde(default)` to `max_per_epoch_activation_churn_limit` in spec config so that a Deneb-enabled VC is compatible to older BN versions without the field.