### PR TITLE
feat(consensus): add the `max_request_blocks` field in `ChainSpec`

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1248,7 +1248,7 @@ impl Config {
             deposit_network_id,
             deposit_contract_address,
             gossip_max_size,
-            max_request_blocks,
+            max_request_blocks: _,
             min_epochs_for_block_requests,
             max_chunk_size,
             ttfb_timeout,

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -172,6 +172,7 @@ pub struct ChainSpec {
     pub subnets_per_node: u8,
     pub epochs_per_subnet_subscription: u64,
     pub gossip_max_size: u64,
+    pub max_request_blocks: u64,
     pub min_epochs_for_block_requests: u64,
     pub max_chunk_size: u64,
     pub ttfb_timeout: u64,
@@ -633,6 +634,7 @@ impl ChainSpec {
             target_aggregators_per_committee: 16,
             epochs_per_subnet_subscription: 256,
             gossip_max_size: default_gossip_max_size(),
+            max_request_blocks: default_max_request_blocks(),
             min_epochs_for_block_requests: default_min_epochs_for_block_requests(),
             max_chunk_size: default_max_chunk_size(),
             ttfb_timeout: default_ttfb_timeout(),
@@ -865,6 +867,7 @@ impl ChainSpec {
             target_aggregators_per_committee: 16,
             epochs_per_subnet_subscription: 256,
             gossip_max_size: default_gossip_max_size(),
+            max_request_blocks: default_max_request_blocks(),
             min_epochs_for_block_requests: default_min_epochs_for_block_requests(),
             max_chunk_size: default_max_chunk_size(),
             ttfb_timeout: default_ttfb_timeout(),
@@ -987,6 +990,9 @@ pub struct Config {
     #[serde(default = "default_gossip_max_size")]
     #[serde(with = "serde_utils::quoted_u64")]
     gossip_max_size: u64,
+    #[serde(default = "default_max_request_blocks")]
+    #[serde(with = "serde_utils::quoted_u64")]
+    max_request_blocks: u64,
     #[serde(default = "default_min_epochs_for_block_requests")]
     #[serde(with = "serde_utils::quoted_u64")]
     min_epochs_for_block_requests: u64,
@@ -1053,6 +1059,10 @@ fn default_subnets_per_node() -> u8 {
 
 const fn default_gossip_max_size() -> u64 {
     10485760
+}
+
+const fn default_max_request_blocks() -> u64 {
+    1024
 }
 
 const fn default_min_epochs_for_block_requests() -> u64 {
@@ -1184,6 +1194,7 @@ impl Config {
             deposit_contract_address: spec.deposit_contract_address,
 
             gossip_max_size: spec.gossip_max_size,
+            max_request_blocks: spec.max_request_blocks,
             min_epochs_for_block_requests: spec.min_epochs_for_block_requests,
             max_chunk_size: spec.max_chunk_size,
             ttfb_timeout: spec.ttfb_timeout,
@@ -1237,6 +1248,7 @@ impl Config {
             deposit_network_id,
             deposit_contract_address,
             gossip_max_size,
+            max_request_blocks,
             min_epochs_for_block_requests,
             max_chunk_size,
             ttfb_timeout,


### PR DESCRIPTION
## Issue Addressed
- Close #4711 

## Proposed Changes
- Update the `ChainSpec` struct of `consensus` crate
   Add the `max_request_blocks` field

## Additional Info
Originally, this PR is for addressing the issue of missing the `MAX_REQUEST_BLOCKS` info from lighthouse beacon API `/eth/v1/config/spec`.
While resolving the issue, I found that we don't need to update anything from BN crate code, but update the `ChainSpec` from `consensus` crate.
Hence, the PR is for updating the `consensus` crate, adding one more field to `ChainSpec` struct and related codes.