### PR TITLE
[Merged by Bors] - collect bandwidth metrics per transport

### DIFF
--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -190,21 +190,21 @@ pub fn scrape_discovery_metrics() {
 
 /// Agregated `BandwidthSinks` of tcp and quic transports
 /// used in libp2p.
-pub struct AgregatedBandwithSinks {
+pub struct AggregatedBandwidthSinks {
     tcp_sinks: Arc<BandwidthSinks>,
     quic_sinks: Option<Arc<BandwidthSinks>>,
 }
 
-impl AgregatedBandwithSinks {
-    /// Create a new `AgregatedBandwithSinks`.
+impl AggregatedBandwidthSinks {
+    /// Create a new `AggregatedBandwidthSinks`.
     pub fn new(tcp_sinks: Arc<BandwidthSinks>, quic_sinks: Option<Arc<BandwidthSinks>>) -> Self {
-        AgregatedBandwithSinks {
+        AggregatedBandwidthSinks {
             tcp_sinks,
             quic_sinks,
         }
     }
 
-    /// Total quic inbound bandwith.
+    /// Total QUIC inbound bandwidth.
     pub fn total_quic_inbound(&self) -> u64 {
         self.quic_sinks
             .as_ref()
@@ -212,12 +212,12 @@ impl AgregatedBandwithSinks {
             .unwrap_or_default()
     }
 
-    /// Total tcp inbound bandwith.
+    /// Total TCP inbound bandwidth.
     pub fn total_tcp_inbound(&self) -> u64 {
         self.tcp_sinks.total_inbound()
     }
 
-    /// Total quic outbound bandwith.
+    /// Total QUIC outbound bandwidth.
     pub fn total_quic_outbound(&self) -> u64 {
         self.quic_sinks
             .as_ref()
@@ -225,22 +225,22 @@ impl AgregatedBandwithSinks {
             .unwrap_or_default()
     }
 
-    /// Total tcp outbound bandwith.
+    /// Total TCP outbound bandwidth.
     pub fn total_tcp_outbound(&self) -> u64 {
         self.tcp_sinks.total_outbound()
     }
 
-    /// Total agregated inbound bandwith.
+    /// Total aggregated inbound bandwidth.
     pub fn total_inbound(&self) -> u64 {
         self.total_tcp_inbound() + self.total_quic_inbound()
     }
 
-    /// Total agregated outbound bandwith.
+    /// Total aggregated outbound bandwidth.
     pub fn total_outbound(&self) -> u64 {
         self.total_tcp_outbound() + self.total_quic_outbound()
     }
 
-    /// Total agregated inbound and outbound bandwidth.
+    /// Total bandwidth.
     pub fn total(&self) -> u64 {
         self.total_inbound() + self.total_outbound()
     }

--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -229,19 +229,4 @@ impl AggregatedBandwidthSinks {
     pub fn total_tcp_outbound(&self) -> u64 {
         self.tcp_sinks.total_outbound()
     }
-
-    /// Total aggregated inbound bandwidth.
-    pub fn total_inbound(&self) -> u64 {
-        self.total_tcp_inbound() + self.total_quic_inbound()
-    }
-
-    /// Total aggregated outbound bandwidth.
-    pub fn total_outbound(&self) -> u64 {
-        self.total_tcp_outbound() + self.total_quic_outbound()
-    }
-
-    /// Total bandwidth.
-    pub fn total(&self) -> u64 {
-        self.total_inbound() + self.total_outbound()
-    }
 }

--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -188,7 +188,7 @@ pub fn scrape_discovery_metrics() {
     set_gauge(&DISCOVERY_RECV_BYTES, metrics.bytes_recv as i64);
 }
 
-/// Agregated `BandwidthSinks` of tcp and quic transports
+/// Aggregated `BandwidthSinks` of tcp and quic transports
 /// used in libp2p.
 pub struct AggregatedBandwidthSinks {
     tcp_sinks: Arc<BandwidthSinks>,

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -4,7 +4,7 @@ use crate::config::{gossipsub_config, GossipsubConfigParams, NetworkLoad};
 use crate::discovery::{
     subnet_predicate, DiscoveredPeers, Discovery, FIND_NODE_QUERY_CLOSEST_PEERS,
 };
-use crate::metrics::AgregatedBandwithSinks;
+use crate::metrics::AggregatedBandwidthSinks;
 use crate::peer_manager::{
     config::Config as PeerManagerCfg, peerdb::score::PeerAction, peerdb::score::ReportSource,
     ConnectionDirection, PeerManager, PeerManagerEvent,
@@ -124,7 +124,7 @@ pub struct Network<AppReqId: ReqId, TSpec: EthSpec> {
     update_gossipsub_scores: tokio::time::Interval,
     gossip_cache: GossipCache,
     /// The bandwidth logger for the underlying libp2p transport.
-    pub bandwidth: AgregatedBandwithSinks,
+    pub bandwidth: AggregatedBandwidthSinks,
     /// This node's PeerId.
     pub local_peer_id: PeerId,
     /// Logger for behaviour actions.

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -4,6 +4,7 @@ use crate::config::{gossipsub_config, GossipsubConfigParams, NetworkLoad};
 use crate::discovery::{
     subnet_predicate, DiscoveredPeers, Discovery, FIND_NODE_QUERY_CLOSEST_PEERS,
 };
+use crate::metrics::AgregatedBandwithSinks;
 use crate::peer_manager::{
     config::Config as PeerManagerCfg, peerdb::score::PeerAction, peerdb::score::ReportSource,
     ConnectionDirection, PeerManager, PeerManagerEvent,
@@ -23,7 +24,6 @@ use crate::{error, metrics, Enr, NetworkGlobals, PubsubMessage, TopicHash};
 use api_types::{PeerRequestId, Request, RequestId, Response};
 use futures::stream::StreamExt;
 use gossipsub_scoring_parameters::{lighthouse_gossip_thresholds, PeerScoreSettings};
-use libp2p::bandwidth::BandwidthSinks;
 use libp2p::gossipsub::{
     self, IdentTopic as Topic, MessageAcceptance, MessageAuthenticity, MessageId, PublishError,
     TopicScoreParams,
@@ -124,7 +124,7 @@ pub struct Network<AppReqId: ReqId, TSpec: EthSpec> {
     update_gossipsub_scores: tokio::time::Interval,
     gossip_cache: GossipCache,
     /// The bandwidth logger for the underlying libp2p transport.
-    pub bandwidth: Arc<BandwidthSinks>,
+    pub bandwidth: AgregatedBandwithSinks,
     /// This node's PeerId.
     pub local_peer_id: PeerId,
     /// Logger for behaviour actions.

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -1,4 +1,4 @@
-use crate::metrics::AgregatedBandwithSinks;
+use crate::metrics::AggregatedBandwidthSinks;
 use crate::multiaddr::Protocol;
 use crate::rpc::{MetaData, MetaDataV1, MetaDataV2};
 use crate::types::{
@@ -44,7 +44,7 @@ type BoxedTransport = Boxed<(PeerId, StreamMuxerBox)>;
 pub fn build_transport(
     local_private_key: Keypair,
     quic_support: bool,
-) -> std::io::Result<(BoxedTransport, AgregatedBandwithSinks)> {
+) -> std::io::Result<(BoxedTransport, AggregatedBandwidthSinks)> {
     // mplex config
     let mut mplex_config = libp2p_mplex::MplexConfig::new();
     mplex_config.set_max_buffer_size(256);
@@ -84,7 +84,7 @@ pub fn build_transport(
             AgregatedBandwithSinks::new(tcp_bandwidth, Some(quic_bandwidth)),
         )
     } else {
-        (tcp, AgregatedBandwithSinks::new(tcp_bandwidth, None))
+        (tcp, AggregatedBandwidthSinks::new(tcp_bandwidth, None))
     };
 
     // Enables DNS over the transport.

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -81,7 +81,7 @@ pub fn build_transport(
             .boxed();
         (
             transport,
-            AgregatedBandwithSinks::new(tcp_bandwidth, Some(quic_bandwidth)),
+            AggregatedBandwidthSinks::new(tcp_bandwidth, Some(quic_bandwidth)),
         )
     } else {
         (tcp, AggregatedBandwidthSinks::new(tcp_bandwidth, None))

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -1,3 +1,4 @@
+use crate::metrics::AgregatedBandwithSinks;
 use crate::multiaddr::Protocol;
 use crate::rpc::{MetaData, MetaDataV1, MetaDataV2};
 use crate::types::{
@@ -5,7 +6,6 @@ use crate::types::{
 };
 use crate::{GossipTopic, NetworkConfig};
 use futures::future::Either;
-use libp2p::bandwidth::BandwidthSinks;
 use libp2p::core::{multiaddr::Multiaddr, muxing::StreamMuxerBox, transport::Boxed};
 use libp2p::gossipsub;
 use libp2p::identity::{secp256k1, Keypair};
@@ -44,7 +44,7 @@ type BoxedTransport = Boxed<(PeerId, StreamMuxerBox)>;
 pub fn build_transport(
     local_private_key: Keypair,
     quic_support: bool,
-) -> std::io::Result<(BoxedTransport, Arc<BandwidthSinks>)> {
+) -> std::io::Result<(BoxedTransport, AgregatedBandwithSinks)> {
     // mplex config
     let mut mplex_config = libp2p_mplex::MplexConfig::new();
     mplex_config.set_max_buffer_size(256);
@@ -55,30 +55,39 @@ pub fn build_transport(
     yamux_config.set_window_update_mode(yamux::WindowUpdateMode::on_read());
 
     // Creates the TCP transport layer
-    let tcp = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default().nodelay(true))
-        .upgrade(core::upgrade::Version::V1)
-        .authenticate(generate_noise_config(&local_private_key))
-        .multiplex(core::upgrade::SelectUpgrade::new(
-            yamux_config,
-            mplex_config,
-        ))
-        .timeout(Duration::from_secs(10));
+    let (tcp, tcp_bandwidth) =
+        libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default().nodelay(true))
+            .upgrade(core::upgrade::Version::V1)
+            .authenticate(generate_noise_config(&local_private_key))
+            .multiplex(core::upgrade::SelectUpgrade::new(
+                yamux_config,
+                mplex_config,
+            ))
+            .timeout(Duration::from_secs(10))
+            .with_bandwidth_logging();
 
     let (transport, bandwidth) = if quic_support {
         // Enables Quic
         // The default quic configuration suits us for now.
         let quic_config = libp2p_quic::Config::new(&local_private_key);
-        tcp.or_transport(libp2p_quic::tokio::Transport::new(quic_config))
+        let (quic, quic_bandwidth) =
+            libp2p_quic::tokio::Transport::new(quic_config).with_bandwidth_logging();
+        let transport = tcp
+            .or_transport(quic)
             .map(|either_output, _| match either_output {
                 Either::Left((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
                 Either::Right((peer_id, muxer)) => (peer_id, StreamMuxerBox::new(muxer)),
             })
-            .with_bandwidth_logging()
+            .boxed();
+        (
+            transport,
+            AgregatedBandwithSinks::new(tcp_bandwidth, Some(quic_bandwidth)),
+        )
     } else {
-        tcp.with_bandwidth_logging()
+        (tcp, AgregatedBandwithSinks::new(tcp_bandwidth, None))
     };
 
-    // // Enables DNS over the transport.
+    // Enables DNS over the transport.
     let transport = libp2p::dns::TokioDnsConfig::system(transport)?.boxed();
 
     Ok((transport, bandwidth))

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -218,35 +218,8 @@ lazy_static! {
     /*
      * Bandwidth metrics
      */
-    pub static ref INBOUND_LIBP2P_QUIC_BYTES: Result<IntGauge> =
-        try_create_int_gauge("libp2p_inbound_quic_bytes", "The inbound quic bandwidth over libp2p");
-
-    pub static ref INBOUND_LIBP2P_TCP_BYTES: Result<IntGauge> =
-        try_create_int_gauge("libp2p_inbound_tcp_bytes", "The inbound tcp bandwidth over libp2p");
-
-    pub static ref INBOUND_LIBP2P_BYTES: Result<IntGauge> =
-        try_create_int_gauge("libp2p_inbound_bytes", "The inbound bandwidth over libp2p");
-
-    pub static ref OUTBOUND_LIBP2P_BYTES: Result<IntGauge> = try_create_int_gauge(
-        "libp2p_outbound_bytes",
-        "The outbound bandwidth over libp2p"
-    );
-
-    pub static ref OUTBOUND_LIBP2P_QUIC_BYTES: Result<IntGauge> = try_create_int_gauge(
-        "libp2p_quic_outbound_bytes",
-        "The outbound quic bandwidth over libp2p"
-    );
-
-    pub static ref OUTBOUND_LIBP2P_TCP_BYTES: Result<IntGauge> = try_create_int_gauge(
-        "libp2p_tcp_outbound_bytes",
-        "The outbound tcp bandwidth over libp2p"
-    );
-
-    pub static ref TOTAL_LIBP2P_BANDWIDTH: Result<IntGauge> = try_create_int_gauge(
-        "libp2p_total_bandwidth",
-        "The total inbound/outbound bandwidth over libp2p"
-    );
-
+    pub static ref LIBP2P_BYTES: Result<IntCounterVec> =
+        try_create_int_counter_vec("libp2p_inbound_bytes", "The bandwidth over libp2p", &["direction", "transport"]);
 
     /*
      * Sync related metrics
@@ -309,27 +282,22 @@ lazy_static! {
 }
 
 pub fn update_bandwidth_metrics(bandwidth: &AggregatedBandwidthSinks) {
-    set_gauge(&INBOUND_LIBP2P_BYTES, bandwidth.total_inbound() as i64);
-    set_gauge(
-        &INBOUND_LIBP2P_TCP_BYTES,
-        bandwidth.total_tcp_inbound() as i64,
-    );
-    set_gauge(
-        &INBOUND_LIBP2P_QUIC_BYTES,
-        bandwidth.total_quic_inbound() as i64,
-    );
-    set_gauge(&TOTAL_LIBP2P_BANDWIDTH, bandwidth.total() as i64);
-    set_gauge(&OUTBOUND_LIBP2P_BYTES, bandwidth.total_outbound() as i64);
-    set_gauge(
-        &OUTBOUND_LIBP2P_TCP_BYTES,
-        bandwidth.total_tcp_outbound() as i64,
-    );
-    set_gauge(
-        &OUTBOUND_LIBP2P_QUIC_BYTES,
-        bandwidth.total_quic_outbound() as i64,
-    );
-    set_gauge(&INBOUND_LIBP2P_BYTES, bandwidth.total_inbound() as i64);
-    set_gauge(&OUTBOUND_LIBP2P_BYTES, bandwidth.total_outbound() as i64);
+    if let Some(tcp_in_bandwidth) = get_int_counter(&LIBP2P_BYTES, &["inbound", "tcp"]) {
+        tcp_in_bandwidth.reset();
+        tcp_in_bandwidth.inc_by(bandwidth.total_tcp_inbound());
+    }
+    if let Some(tcp_out_bandwidth) = get_int_counter(&LIBP2P_BYTES, &["outbound", "tcp"]) {
+        tcp_out_bandwidth.reset();
+        tcp_out_bandwidth.inc_by(bandwidth.total_tcp_outbound());
+    }
+    if let Some(quic_in_bandwidth) = get_int_counter(&LIBP2P_BYTES, &["inbound", "quic"]) {
+        quic_in_bandwidth.reset();
+        quic_in_bandwidth.inc_by(bandwidth.total_quic_inbound());
+    }
+    if let Some(quic_out_bandwidth) = get_int_counter(&LIBP2P_BYTES, &["outbound", "quic"]) {
+        quic_out_bandwidth.reset();
+        quic_out_bandwidth.inc_by(bandwidth.total_quic_outbound());
+    }
 }
 
 pub fn register_finality_update_error(error: &LightClientFinalityUpdateError) {

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -7,7 +7,7 @@ use beacon_chain::{
 use fnv::FnvHashMap;
 pub use lighthouse_metrics::*;
 use lighthouse_network::{
-    metrics::AgregatedBandwithSinks, peer_manager::peerdb::client::ClientKind, types::GossipKind,
+    metrics::AggregatedBandwidthSinks, peer_manager::peerdb::client::ClientKind, types::GossipKind,
     GossipTopic, Gossipsub, NetworkGlobals,
 };
 use std::sync::Arc;
@@ -308,7 +308,7 @@ lazy_static! {
     );
 }
 
-pub fn update_bandwidth_metrics(bandwidth: &AgregatedBandwithSinks) {
+pub fn update_bandwidth_metrics(bandwidth: &AggregatedBandwidthSinks) {
     set_gauge(&INBOUND_LIBP2P_BYTES, bandwidth.total_inbound() as i64);
     set_gauge(
         &INBOUND_LIBP2P_TCP_BYTES,

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -497,7 +497,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                         }
                     }
                 }
-                metrics::update_bandwidth_metrics(self.libp2p.bandwidth.clone());
+                metrics::update_bandwidth_metrics(&self.libp2p.bandwidth);
             }
         };
         executor.spawn(service_fut, "network");


### PR DESCRIPTION
## Issue Addressed

Following the conversation on https://github.com/libp2p/rust-libp2p/pull/3666 the changes introduced in this PR will allow us to give more insights if the bandwidth limitations happen at the transport level, namely if quic helps vs yamux and it's [window size limitation](https://github.com/libp2p/rust-yamux/issues/162) or if the bottleneck is at the gossipsub level.
## Proposed Changes

introduce new quic and tcp bandwidth metric gauges.

cc @mxinden (turned out to be easier, Thomas gave me a hint)
