### PR TITLE
[Merged by Bors] - Address Clippy 1.73 lints

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
@@ -66,7 +66,7 @@ impl CheckpointMap {
     pub fn insert(&mut self, checkpoint: Checkpoint, eth1_finalization_data: Eth1FinalizationData) {
         self.store
             .entry(checkpoint.epoch)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push((checkpoint.root, eth1_finalization_data));
 
         // faster to reduce size after the fact than do pre-checking to see

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -343,7 +343,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
         let block_hash = block.block_hash();
         self.block_hashes
             .entry(block.block_number())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(block_hash);
         self.blocks.insert(block_hash, block);
 

--- a/beacon_node/http_api/src/standard_block_rewards.rs
+++ b/beacon_node/http_api/src/standard_block_rewards.rs
@@ -5,8 +5,8 @@ use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2::lighthouse::StandardBlockReward;
 use std::sync::Arc;
 use warp_utils::reject::beacon_chain_error;
-//// The difference between block_rewards and beacon_block_rewards is the later returns block
-//// reward format that satisfies beacon-api specs
+/// The difference between block_rewards and beacon_block_rewards is the later returns block
+/// reward format that satisfies beacon-api specs
 pub fn compute_beacon_block_rewards<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_id: BlockId,

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -1043,7 +1043,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                         Subnet::Attestation(_) => {
                             subnet_to_peer
                                 .entry(subnet)
-                                .or_insert_with(Vec::new)
+                                .or_default()
                                 .push((*peer_id, info.clone()));
                         }
                         Subnet::SyncCommittee(id) => {

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -330,13 +330,15 @@ impl Eq for Score {}
 
 impl PartialOrd for Score {
     fn partial_cmp(&self, other: &Score) -> Option<std::cmp::Ordering> {
-        self.score().partial_cmp(&other.score())
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Score {
     fn cmp(&self, other: &Score) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal)
+        self.score()
+            .partial_cmp(&other.score())
+            .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
 

--- a/beacon_node/operation_pool/src/attestation_storage.rs
+++ b/beacon_node/operation_pool/src/attestation_storage.rs
@@ -151,14 +151,8 @@ impl<T: EthSpec> AttestationMap<T> {
             indexed,
         } = SplitAttestation::new(attestation, attesting_indices);
 
-        let attestation_map = self
-            .checkpoint_map
-            .entry(checkpoint)
-            .or_insert_with(AttestationDataMap::default);
-        let attestations = attestation_map
-            .attestations
-            .entry(data)
-            .or_insert_with(Vec::new);
+        let attestation_map = self.checkpoint_map.entry(checkpoint).or_default();
+        let attestations = attestation_map.attestations.entry(data).or_default();
 
         // Greedily aggregate the attestation with all existing attestations.
         // NOTE: this is sub-optimal and in future we will remove this in favour of max-clique

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -48,7 +48,7 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
         self.col_keys
             .write()
             .entry(col.as_bytes().to_vec())
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(key.to_vec());
         Ok(())
     }

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -193,7 +193,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .into_iter()
             .fold(HashMap::new(), |mut map, duty_and_proof| {
                 map.entry(duty_and_proof.duty.committee_index)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(duty_and_proof);
                 map
             });

--- a/validator_client/src/duties_service/sync.rs
+++ b/validator_client/src/duties_service/sync.rs
@@ -163,7 +163,7 @@ impl SyncDutiesMap {
 
         committees_writer
             .entry(committee_period)
-            .or_insert_with(CommitteeDuties::default)
+            .or_default()
             .init(validator_indices);
 
         // Return shared reference


### PR DESCRIPTION
## Proposed Changes

Fix Clippy lints enabled by default in Rust 1.73.0, released today.
