### PR TITLE
Address Clippy 1.73 lints on Deneb branch

### DIFF
--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -451,7 +451,7 @@ pub struct KzgVerifiedBlob<T: EthSpec> {
 
 impl<T: EthSpec> PartialOrd for KzgVerifiedBlob<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.blob.partial_cmp(&other.blob)
+        Some(self.cmp(other))
     }
 }
 

--- a/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/eth1_finalization_cache.rs
@@ -66,7 +66,7 @@ impl CheckpointMap {
     pub fn insert(&mut self, checkpoint: Checkpoint, eth1_finalization_data: Eth1FinalizationData) {
         self.store
             .entry(checkpoint.epoch)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push((checkpoint.root, eth1_finalization_data));
 
         // faster to reduce size after the fact than do pre-checking to see

--- a/beacon_node/beacon_chain/src/historical_blocks.rs
+++ b/beacon_node/beacon_chain/src/historical_blocks.rs
@@ -172,20 +172,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let signature_set = signed_blocks
             .iter()
             .zip_eq(block_roots)
-            .filter_map(|(block, block_root)| {
-                (block_root != self.genesis_block_root).then(|| {
-                    block_proposal_signature_set_from_parts(
-                        block,
-                        Some(block_root),
-                        block.message().proposer_index(),
-                        &self.spec.fork_at_epoch(block.message().epoch()),
-                        self.genesis_validators_root,
-                        |validator_index| {
-                            pubkey_cache.get(validator_index).cloned().map(Cow::Owned)
-                        },
-                        &self.spec,
-                    )
-                })
+            .filter(|&(_block, block_root)| (block_root != self.genesis_block_root))
+            .map(|(block, block_root)| {
+                block_proposal_signature_set_from_parts(
+                    block,
+                    Some(block_root),
+                    block.message().proposer_index(),
+                    &self.spec.fork_at_epoch(block.message().epoch()),
+                    self.genesis_validators_root,
+                    |validator_index| pubkey_cache.get(validator_index).cloned().map(Cow::Owned),
+                    &self.spec,
+                )
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(HistoricalBlockError::SignatureSet)

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -343,7 +343,7 @@ impl<T: EthSpec> ExecutionBlockGenerator<T> {
         let block_hash = block.block_hash();
         self.block_hashes
             .entry(block.block_number())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(block_hash);
         self.blocks.insert(block_hash, block);
 

--- a/beacon_node/http_api/src/standard_block_rewards.rs
+++ b/beacon_node/http_api/src/standard_block_rewards.rs
@@ -5,8 +5,8 @@ use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2::lighthouse::StandardBlockReward;
 use std::sync::Arc;
 use warp_utils::reject::beacon_chain_error;
-//// The difference between block_rewards and beacon_block_rewards is the later returns block
-//// reward format that satisfies beacon-api specs
+/// The difference between block_rewards and beacon_block_rewards is the later returns block
+/// reward format that satisfies beacon-api specs
 pub fn compute_beacon_block_rewards<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_id: BlockId,

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -1043,7 +1043,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                         Subnet::Attestation(_) => {
                             subnet_to_peer
                                 .entry(subnet)
-                                .or_insert_with(Vec::new)
+                                .or_default()
                                 .push((*peer_id, info.clone()));
                         }
                         Subnet::SyncCommittee(id) => {

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -330,13 +330,15 @@ impl Eq for Score {}
 
 impl PartialOrd for Score {
     fn partial_cmp(&self, other: &Score) -> Option<std::cmp::Ordering> {
-        self.score().partial_cmp(&other.score())
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Score {
     fn cmp(&self, other: &Score) -> std::cmp::Ordering {
-        self.partial_cmp(other).unwrap_or(std::cmp::Ordering::Equal)
+        self.score()
+            .partial_cmp(&other.score())
+            .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
 

--- a/beacon_node/operation_pool/src/attestation_storage.rs
+++ b/beacon_node/operation_pool/src/attestation_storage.rs
@@ -151,14 +151,8 @@ impl<T: EthSpec> AttestationMap<T> {
             indexed,
         } = SplitAttestation::new(attestation, attesting_indices);
 
-        let attestation_map = self
-            .checkpoint_map
-            .entry(checkpoint)
-            .or_insert_with(AttestationDataMap::default);
-        let attestations = attestation_map
-            .attestations
-            .entry(data)
-            .or_insert_with(Vec::new);
+        let attestation_map = self.checkpoint_map.entry(checkpoint).or_default();
+        let attestations = attestation_map.attestations.entry(data).or_default();
 
         // Greedily aggregate the attestation with all existing attestations.
         // NOTE: this is sub-optimal and in future we will remove this in favour of max-clique

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -48,7 +48,7 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
         self.col_keys
             .write()
             .entry(col.as_bytes().to_vec())
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(key.to_vec());
         Ok(())
     }

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -38,7 +38,7 @@ impl BlobIdentifier {
 
 impl PartialOrd for BlobIdentifier {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.index.partial_cmp(&other.index)
+        Some(self.cmp(other))
     }
 }
 
@@ -109,7 +109,7 @@ impl<E: EthSpec> From<BlobSidecar<E>> for BlindedBlobSidecar {
 
 impl<T: EthSpec> PartialOrd for BlobSidecar<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.index.partial_cmp(&other.index)
+        Some(self.cmp(other))
     }
 }
 

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -193,7 +193,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .into_iter()
             .fold(HashMap::new(), |mut map, duty_and_proof| {
                 map.entry(duty_and_proof.duty.committee_index)
-                    .or_insert_with(Vec::new)
+                    .or_default()
                     .push(duty_and_proof);
                 map
             });

--- a/validator_client/src/duties_service/sync.rs
+++ b/validator_client/src/duties_service/sync.rs
@@ -163,7 +163,7 @@ impl SyncDutiesMap {
 
         committees_writer
             .entry(committee_period)
-            .or_insert_with(CommitteeDuties::default)
+            .or_default()
             .init(validator_indices);
 
         // Return shared reference


### PR DESCRIPTION
## Issue Addressed

Merging latest `unstable` again to get some clippy fixes for Rust 1.73 and some additional fixes for Deneb branch.