### PR TITLE
[Merged by Bors] - Add `vendor` directory to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+vendor/
 **/*.rs.bk
 *.pk
 *.sk


### PR DESCRIPTION
## Issue Addressed

The vendor directory gets populated after running `cargo vendor`. This directory should be ignored by VCS.