### PR TITLE
[Merged by Bors] - remove crit! logging from ListenerClosed event on Ok()

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -32,7 +32,7 @@ use libp2p::identify;
 use libp2p::multiaddr::{Multiaddr, Protocol as MProtocol};
 use libp2p::swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use libp2p::PeerId;
-use slog::{crit, debug, error, info, o, trace, warn};
+use slog::{crit, debug, info, o, trace, warn};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::{
@@ -1564,7 +1564,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                             debug!(self.log, "Listener gracefuly closed"; "addresses" => ?addresses)
                         }
                         Err(reason) => {
-                            error!(self.log, "Listener abruptly closed"; "addresses" => ?addresses, "reason" => ?reason)
+                            crit!(self.log, "Listener abruptly closed"; "addresses" => ?addresses, "reason" => ?reason)
                         }
                     };
                     if Swarm::listeners(&self.swarm).count() == 0 {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -32,7 +32,7 @@ use libp2p::identify;
 use libp2p::multiaddr::{Multiaddr, Protocol as MProtocol};
 use libp2p::swarm::{Swarm, SwarmBuilder, SwarmEvent};
 use libp2p::PeerId;
-use slog::{crit, debug, info, o, trace, warn};
+use slog::{crit, debug, error, info, o, trace, warn};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::{
@@ -1559,7 +1559,14 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                 SwarmEvent::ListenerClosed {
                     addresses, reason, ..
                 } => {
-                    crit!(self.log, "Listener closed"; "addresses" => ?addresses, "reason" => ?reason);
+                    match reason {
+                        Ok(_) => {
+                            debug!(self.log, "Listener gracefuly closed"; "addresses" => ?addresses)
+                        }
+                        Err(reason) => {
+                            error!(self.log, "Listener abruptly closed"; "addresses" => ?addresses, "reason" => ?reason)
+                        }
+                    };
                     if Swarm::listeners(&self.swarm).count() == 0 {
                         Some(NetworkEvent::ZeroListeners)
                     } else {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -803,7 +803,7 @@ fn run_jwt_optional_flags_test(jwt_flag: &str, jwt_id_flag: &str, jwt_version_fl
     let id = "bn-1";
     let version = "Lighthouse-v2.1.3";
     CommandLineTest::new()
-        .flag("execution-endpoint", Some(execution_endpoint.clone()))
+        .flag("execution-endpoint", Some(execution_endpoint))
         .flag(jwt_flag, dir.path().join(jwt_file).as_os_str().to_str())
         .flag(jwt_id_flag, Some(id))
         .flag(jwt_version_flag, Some(version))


### PR DESCRIPTION
## Issue Addressed

Since adding Quic support on https://github.com/sigp/lighthouse/pull/4577, and due to `quinn`s api nature LH now triggers the [`ListenerClosed`](https://docs.rs/libp2p/0.52.3/libp2p/swarm/struct.ListenerClosed.html) event.. @michaelsproul noticed we are logging this event as `crit!` independently of the reason. This PR matches the reason, logging with `debug!` and `error!` (instead of `crit!`) according to its `Result`  
## Additional Info
LH will still log `crit!` until https://github.com/libp2p/rust-libp2p/pull/4621 has been merged
