### PR TITLE
[Merged by Bors] - Generalise compare_fields to work with iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ name = "compare_fields"
 version = "0.2.0"
 dependencies = [
  "compare_fields_derive",
+ "itertools",
 ]
 
 [[package]]

--- a/common/compare_fields/Cargo.toml
+++ b/common/compare_fields/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.2.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 
+[dependencies]
+itertools = { workspace = true }
+
 [dev-dependencies]
 compare_fields_derive = { workspace = true }
 

--- a/common/compare_fields_derive/src/lib.rs
+++ b/common/compare_fields_derive/src/lib.rs
@@ -4,10 +4,11 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
-fn is_slice(field: &syn::Field) -> bool {
+fn is_iter(field: &syn::Field) -> bool {
     field.attrs.iter().any(|attr| {
         attr.path.is_ident("compare_fields")
-            && attr.tokens.to_string().replace(' ', "") == "(as_slice)"
+            && (attr.tokens.to_string().replace(' ', "") == "(as_slice)"
+                || attr.tokens.to_string().replace(' ', "") == "(as_iter)")
     })
 }
 
@@ -34,13 +35,13 @@ pub fn compare_fields_derive(input: TokenStream) -> TokenStream {
         let field_name = ident_a.to_string();
         let ident_b = ident_a.clone();
 
-        let quote = if is_slice(field) {
+        let quote = if is_iter(field) {
             quote! {
-                comparisons.push(compare_fields::Comparison::from_slice(
+                comparisons.push(compare_fields::Comparison::from_into_iter(
                         #field_name.to_string(),
                         &self.#ident_a,
-                        &b.#ident_b)
-                );
+                        &b.#ident_b
+                ));
             }
         } else {
             quote! {


### PR DESCRIPTION
## Proposed Changes

Add `compare_fields(as_iter)` as a field attribute to `compare_fields_derive`. This allows any iterable type to be compared in the same as a slice (by index). 

This is forwards-compatible with tree-states types like `List` and `Vector` which can not be cast to slices.
