### PR TITLE
Verify Versioned Hashes During Optimistic Sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+dependencies = [
+ "alloy-eips",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rlp",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+dependencies = [
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-rlp",
+ "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b6fb2b432ff223d513db7f908937f63c252bee0af9b82bfd25b0a5dd1eb0d8"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "k256 0.13.3",
+ "keccak-asm",
+ "proptest",
+ "rand",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
+dependencies = [
+ "alloy-rlp-derive",
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "amcl"
 version = "0.3.0"
 source = "git+https://github.com/sigp/milagro_bls?tag=v1.5.1#d3fc0a40cfe8b72ccda46ba050ee6786a59ce753"
@@ -228,6 +317,130 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand",
+]
 
 [[package]]
 name = "arrayref"
@@ -485,7 +698,7 @@ checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
 dependencies = [
  "futures",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -839,6 +1052,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1347,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver",
+ "semver 1.0.21",
  "serde",
  "serde_json",
  "thiserror",
@@ -1311,7 +1539,7 @@ name = "compare_fields"
 version = "0.2.0"
 dependencies = [
  "compare_fields_derive",
- "itertools 0.10.5",
+ "itertools",
 ]
 
 [[package]]
@@ -1329,6 +1557,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5104de16b218eddf8e34ffe2f86f74bfa4e61e95a1b89732fccf6325efd0557"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -1593,7 +1834,7 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "platforms 3.3.0",
- "rustc_version",
+ "rustc_version 0.4.0",
  "subtle",
  "zeroize",
 ]
@@ -1820,7 +2061,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -2755,6 +2996,8 @@ dependencies = [
 name = "execution_layer"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-rlp",
  "arc-swap",
  "async-trait",
  "builder_client",
@@ -2849,6 +3092,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,7 +3141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -3454,6 +3708,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hex_fmt"
@@ -4186,6 +4449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -5618,6 +5891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5987,13 +6261,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
 dependencies = [
  "futures",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -6371,6 +6656,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "proptest"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.4.2",
+ "lazy_static",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.8.2",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
 ]
 
 [[package]]
@@ -6866,6 +7171,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruint"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec 3.6.9",
+ "primitive-types 0.12.2",
+ "proptest",
+ "rand",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
+
+[[package]]
 name = "rusqlite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6899,11 +7234,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.21",
 ]
 
 [[package]]
@@ -7033,6 +7377,18 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rw-stream-sink"
@@ -7202,11 +7558,29 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -7406,6 +7780,16 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -7700,7 +8084,7 @@ dependencies = [
  "curve25519-dalek",
  "rand_core",
  "ring 0.17.7",
- "rustc_version",
+ "rustc_version 0.4.0",
  "sha2 0.10.8",
  "subtle",
 ]
@@ -8674,6 +9058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
 name = "uint"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8685,6 +9075,12 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unescape"
@@ -8962,6 +9358,15 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "waker-fn"
@@ -9546,7 +9951,7 @@ dependencies = [
  "js-sys",
  "log",
  "pharos",
- "rustc_version",
+ "rustc_version 0.4.0",
  "send_wrapper",
  "thiserror",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=974d488bab5e21e9f17452a39a4bfa56677367b2#974d488bab5e21e9f17452a39a4bfa56677367b2"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=974d488bab5e21e9f17452a39a4bfa56677367b2#974d488bab5e21e9f17452a39a4bfa56677367b2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=974d488bab5e21e9f17452a39a4bfa56677367b2#974d488bab5e21e9f17452a39a4bfa56677367b2"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#32618e9243a761858a0843e7e55575e48fdbf500"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=974d488bab5e21e9f17452a39a4bfa56677367b2#974d488bab5e21e9f17452a39a4bfa56677367b2"
 dependencies = [
  "alloy-eips",
  "alloy-json-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ name = "compare_fields"
 version = "0.2.0"
 dependencies = [
  "compare_fields_derive",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.73.0-bullseye AS builder
+FROM rust:1.75.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG FEATURES

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -51,5 +51,5 @@ hash-db = "0.15.2"
 pretty_reqwest_error = { workspace = true }
 arc-swap = "1.6.0"
 eth2_network_config = { workspace = true }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1b16d804ef01f4ec3c25e7986381c22739c105b9" }
-reth-rlp = { git = "https://github.com/paradigmxyz/reth", rev = "1b16d804ef01f4ec3c25e7986381c22739c105b9" }
+alloy-rlp = "0.3"
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git" }

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -51,3 +51,5 @@ hash-db = "0.15.2"
 pretty_reqwest_error = { workspace = true }
 arc-swap = "1.6.0"
 eth2_network_config = { workspace = true }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1b16d804ef01f4ec3c25e7986381c22739c105b9" }
+reth-rlp = { git = "https://github.com/paradigmxyz/reth", rev = "1b16d804ef01f4ec3c25e7986381c22739c105b9" }

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -52,4 +52,4 @@ pretty_reqwest_error = { workspace = true }
 arc-swap = "1.6.0"
 eth2_network_config = { workspace = true }
 alloy-rlp = "0.3"
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "974d488bab5e21e9f17452a39a4bfa56677367b2" }

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -17,7 +17,6 @@ pub use json_structures::{JsonWithdrawal, TransitionConfigurationV1};
 use pretty_reqwest_error::PrettyReqwestError;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
-use state_processing::per_block_processing::deneb::kzg_commitment_to_versioned_hash;
 use std::convert::TryFrom;
 use strum::IntoStaticStr;
 use superstruct::superstruct;
@@ -26,14 +25,16 @@ pub use types::{
     ExecutionPayloadRef, FixedVector, ForkName, Hash256, Transactions, Uint256, VariableList,
     Withdrawal, Withdrawals,
 };
-use types::{
-    BeaconStateError, ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge,
-    KzgProofs, VersionedHash,
-};
+use types::{ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge, KzgProofs};
 
 pub mod auth;
 pub mod http;
 pub mod json_structures;
+mod new_payload_request;
+
+pub use new_payload_request::{
+    NewPayloadRequest, NewPayloadRequestCapella, NewPayloadRequestDeneb, NewPayloadRequestMerge,
+};
 
 pub const LATEST_TAG: &str = "latest";
 
@@ -567,120 +568,6 @@ impl<E: EthSpec> ExecutionPayloadBodyV1<E> {
                     ))
                 }
             }
-        }
-    }
-}
-
-#[superstruct(
-    variants(Merge, Capella, Deneb),
-    variant_attributes(derive(Clone, Debug, PartialEq),),
-    map_into(ExecutionPayload),
-    map_ref_into(ExecutionPayloadRef),
-    cast_error(
-        ty = "BeaconStateError",
-        expr = "BeaconStateError::IncorrectStateVariant"
-    ),
-    partial_getter_error(
-        ty = "BeaconStateError",
-        expr = "BeaconStateError::IncorrectStateVariant"
-    )
-)]
-#[derive(Clone, Debug, PartialEq)]
-pub struct NewPayloadRequest<'block, E: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
-    pub execution_payload: &'block ExecutionPayloadMerge<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
-    pub execution_payload: &'block ExecutionPayloadCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
-    pub execution_payload: &'block ExecutionPayloadDeneb<E>,
-    #[superstruct(only(Deneb))]
-    pub versioned_hashes: Vec<VersionedHash>,
-    #[superstruct(only(Deneb))]
-    pub parent_beacon_block_root: Hash256,
-}
-
-impl<'block, E: EthSpec> NewPayloadRequest<'block, E> {
-    pub fn parent_hash(&self) -> ExecutionBlockHash {
-        match self {
-            Self::Merge(payload) => payload.execution_payload.parent_hash,
-            Self::Capella(payload) => payload.execution_payload.parent_hash,
-            Self::Deneb(payload) => payload.execution_payload.parent_hash,
-        }
-    }
-
-    pub fn block_hash(&self) -> ExecutionBlockHash {
-        match self {
-            Self::Merge(payload) => payload.execution_payload.block_hash,
-            Self::Capella(payload) => payload.execution_payload.block_hash,
-            Self::Deneb(payload) => payload.execution_payload.block_hash,
-        }
-    }
-
-    pub fn block_number(&self) -> u64 {
-        match self {
-            Self::Merge(payload) => payload.execution_payload.block_number,
-            Self::Capella(payload) => payload.execution_payload.block_number,
-            Self::Deneb(payload) => payload.execution_payload.block_number,
-        }
-    }
-
-    pub fn execution_payload_ref(&self) -> ExecutionPayloadRef<'block, E> {
-        match self {
-            Self::Merge(request) => ExecutionPayloadRef::Merge(request.execution_payload),
-            Self::Capella(request) => ExecutionPayloadRef::Capella(request.execution_payload),
-            Self::Deneb(request) => ExecutionPayloadRef::Deneb(request.execution_payload),
-        }
-    }
-
-    pub fn into_execution_payload(self) -> ExecutionPayload<E> {
-        match self {
-            Self::Merge(request) => ExecutionPayload::Merge(request.execution_payload.clone()),
-            Self::Capella(request) => ExecutionPayload::Capella(request.execution_payload.clone()),
-            Self::Deneb(request) => ExecutionPayload::Deneb(request.execution_payload.clone()),
-        }
-    }
-}
-
-impl<'a, E: EthSpec> TryFrom<BeaconBlockRef<'a, E>> for NewPayloadRequest<'a, E> {
-    type Error = BeaconStateError;
-
-    fn try_from(block: BeaconBlockRef<'a, E>) -> Result<Self, Self::Error> {
-        match block {
-            BeaconBlockRef::Base(_) | BeaconBlockRef::Altair(_) => {
-                Err(Self::Error::IncorrectStateVariant)
-            }
-            BeaconBlockRef::Merge(block_ref) => Ok(Self::Merge(NewPayloadRequestMerge {
-                execution_payload: &block_ref.body.execution_payload.execution_payload,
-            })),
-            BeaconBlockRef::Capella(block_ref) => Ok(Self::Capella(NewPayloadRequestCapella {
-                execution_payload: &block_ref.body.execution_payload.execution_payload,
-            })),
-            BeaconBlockRef::Deneb(block_ref) => Ok(Self::Deneb(NewPayloadRequestDeneb {
-                execution_payload: &block_ref.body.execution_payload.execution_payload,
-                versioned_hashes: block_ref
-                    .body
-                    .blob_kzg_commitments
-                    .iter()
-                    .map(kzg_commitment_to_versioned_hash)
-                    .collect(),
-                parent_beacon_block_root: block_ref.parent_root,
-            })),
-        }
-    }
-}
-
-impl<'a, E: EthSpec> TryFrom<ExecutionPayloadRef<'a, E>> for NewPayloadRequest<'a, E> {
-    type Error = BeaconStateError;
-
-    fn try_from(payload: ExecutionPayloadRef<'a, E>) -> Result<Self, Self::Error> {
-        match payload {
-            ExecutionPayloadRef::Merge(payload) => Ok(Self::Merge(NewPayloadRequestMerge {
-                execution_payload: payload,
-            })),
-            ExecutionPayloadRef::Capella(payload) => Ok(Self::Capella(NewPayloadRequestCapella {
-                execution_payload: payload,
-            })),
-            ExecutionPayloadRef::Deneb(_) => Err(Self::Error::IncorrectStateVariant),
         }
     }
 }

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -803,10 +803,10 @@ impl HttpJsonRpc {
 
     pub async fn new_payload_v3<T: EthSpec>(
         &self,
-        new_payload_request_deneb: NewPayloadRequestDeneb<T>,
+        new_payload_request_deneb: NewPayloadRequestDeneb<'_, T>,
     ) -> Result<PayloadStatusV1, Error> {
         let params = json!([
-            JsonExecutionPayload::V3(new_payload_request_deneb.execution_payload.into()),
+            JsonExecutionPayload::V3(new_payload_request_deneb.execution_payload.clone().into()),
             new_payload_request_deneb.versioned_hashes,
             new_payload_request_deneb.parent_beacon_block_root,
         ]);
@@ -1079,7 +1079,7 @@ impl HttpJsonRpc {
     // new_payload that the execution engine supports
     pub async fn new_payload<T: EthSpec>(
         &self,
-        new_payload_request: NewPayloadRequest<T>,
+        new_payload_request: NewPayloadRequest<'_, T>,
     ) -> Result<PayloadStatusV1, Error> {
         let engine_capabilities = self.get_engine_capabilities(None).await?;
         match new_payload_request {

--- a/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
+++ b/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
@@ -118,7 +118,7 @@ impl<'block, E: EthSpec> NewPayloadRequest<'block, E> {
         Ok(())
     }
 
-    /// Verify the version hashes computed by the blob transactions match the version hashes computed from the commitments
+    /// Verify the versioned hashes computed by the blob transactions match the versioned hashes computed from the commitments.
     ///
     /// ## Specification
     ///

--- a/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
+++ b/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
@@ -176,3 +176,75 @@ impl<'a, E: EthSpec> TryFrom<ExecutionPayloadRef<'a, E>> for NewPayloadRequest<'
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::NewPayloadRequest;
+    use types::{BeaconBlock, MainnetEthSpec};
+
+    #[test]
+    fn test_optimistic_sync_verifications() {
+        let beacon_block = get_valid_beacon_block();
+        let new_payload_request = NewPayloadRequest::try_from(beacon_block.to_ref())
+            .expect("should create new payload request");
+
+        assert!(new_payload_request
+            .perform_optimistic_sync_verifications()
+            .is_ok());
+    }
+
+    fn get_valid_beacon_block() -> BeaconBlock<MainnetEthSpec> {
+        BeaconBlock::Deneb(serde_json::from_str(r#"{
+          "slot": "88160",
+          "proposer_index": "583",
+          "parent_root": "0x60770cd86a497ca3aa2e91f1687aa3ebafac87af52c30a920b5f40bd9e930eb6",
+          "state_root": "0x4a0e0abbcbcf576f2cb7387c4289ab13b8a128e32127642f056143d6164941a6",
+          "body": {
+            "randao_reveal": "0xb5253d5739496abc4f67c7c92e39e46cca452c2fdfc5275e3e0426a012aa62df82f47f7dece348e28db4bb212f0e793d187120bbd47b8031ed79344116eb4128f0ce0b05ba18cd615bb13966c1bd7d89e23cc769c8e4d8e4a63755f623ac3bed",
+            "eth1_data": {
+              "deposit_root": "0xe4785ac914d8673797f886e3151ce2647f81ae070c7ddb6845e65fd1c47d1222",
+              "deposit_count": "1181",
+              "block_hash": "0x010671bdfbfce6b0071984a06a7ded6deef13b4f8fdbae402c606a7a0c8780d1"
+            },
+            "graffiti": "0x6c6f6465737461722f6765746800000000000000000000000000000000000000",
+            "proposer_slashings": [],
+            "attester_slashings": [],
+            "attestations": [],
+            "deposits": [],
+            "voluntary_exits": [],
+            "sync_aggregate": {
+              "sync_committee_bits": "0xfebffffffebfff7fff7f7fffbbefffff6affffffffbfffffefffebfffdbf77fff7fd77ffffefffdff7ffffeffffffe7e5ffffffdefffff7ffbffff7fffffffff",
+              "sync_committee_signature": "0x91939b5baf2a6f52d405b6dd396f5346ec435eca7d25912c91cc6a2f7030d870d68bebe4f2b21872a06929ff4cf3e5e9191053cb43eb24ebe34b9a75fb88a3acd06baf329c87f68bd664b49891260c698d7bca0f5365870b5b2b3a76f582156c"
+            },
+            "execution_payload": {
+              "parent_hash": "0xa6f3ed782a992f79ad38da2af91b3e8923c71b801c50bc9033bb35a2e1da885f",
+              "fee_recipient": "0xf97e180c050e5ab072211ad2c213eb5aee4df134",
+              "state_root": "0x3bfd1a7f309ed35048c349a8daf01815bdc09a6d5df86ea77d1056f248ba2017",
+              "receipts_root": "0xcb5b8ffea57cd0fa87194d49bc8bb7fad08c93c9934b886489503c328d15fd36",
+              "logs_bloom": "0x002000000000000000000000800000000000000000001040000000000000000000000001000000000000000000000000000000000000100000000020000c0800000000000000008000000008000000200000800000000000000000000000000000000000000000008000000000008000000000000000000002000010000000000000000000000000000000000000000000000000000000080000004000000000800000000000000000000100000000000000000000000000000000000800000000000102000000000000000000000000000000080000001000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+              "prev_randao": "0xb2693020177d99ffbd4c267023be172d759e7306ff51b0e7d677d3148fbd7f1d",
+              "block_number": "74807",
+              "gas_limit": "30000000",
+              "gas_used": "128393",
+              "timestamp": "1697039520",
+              "extra_data": "0xd883010d03846765746888676f312e32312e31856c696e7578",
+              "base_fee_per_gas": "7",
+              "block_hash": "0xc64f3a43c64aeb98518a237f6279fa03095b9f95ca673c860ad7f16fb9340062",
+              "transactions": [
+                "0x02f9017a8501a1f0ff4382317585012a05f2008512a05f2000830249f094c1b0bc605e2c808aa0867bfc98e51a1fe3e9867f80b901040cc7326300000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000036e534e16b8920d000000000000000000000000fb3e9c7cb92443931ee6b5b9728598d4eb9618c1000000000000000000000000fc7360b3b28cf4204268a8354dbec60720d155d2000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000009a054a063f0fe7b9c68de8df91aaa5e96c15ab540000000000000000000000000c8d41b8fcc066cdabaf074d78e5153e8ce018a9c080a07dd9be0d014ffcd5b6883d0917c66b74ba51f0d976c8fc5674af192af6fa9450a02dad2c660974c125f5f22b1e6e8862a292e08cc2b4cafda35af650ee62868a43",
+                "0x03f8db8501a1f0ff430d84773594008504a817c8008252089454e594b6de0aa4b0188cd1549dd7ba715a455d078080c08504a817c800f863a001253ce00f525e3495cffa0b865eadb90a4c5ee812185cc796af74b6ec0a5dd7a0010720372a4d7dcab84413ed0cfc164fb91fb6ef1562ec2f7a82e912a1d9e129a0015a73e97950397896ed2c47dcab7c0360220bcfb413a8f210a7b6e6264e698880a04402cb0f13c17ef41dca106b1e1520c7aadcbe62984d81171e29914f587d67c1a02db62a8edb581917958e4a3884e7eececbaec114c5ee496e238033e896f997ac"
+              ],
+              "withdrawals": [],
+              "blob_gas_used": "393216",
+              "excess_blob_gas": "58720256"
+            },
+            "bls_to_execution_changes": [],
+            "blob_kzg_commitments": [
+              "0xa7accb7a25224a8c2e0cee9cd569fc1798665bfbfe780e08945fa9098ec61da4061f5b04e750a88d3340a801850a54fa",
+              "0xac7b47f99836510ae9076dc5f5da1f370679dea1d47073307a14cbb125cdc7822ae619637135777cb40e13d897fd00a7",
+              "0x997794110b9655833a88ad5a4ec40a3dc7964877bfbeb04ca1abe1d51bdc43e20e4c5757028896d298d7da954a6f14a1"
+            ]
+          }
+        }"#).expect("should decode"))
+    }
+}

--- a/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
+++ b/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
@@ -1,0 +1,176 @@
+use crate::{block_hash::calculate_execution_block_hash, metrics, Error};
+
+use state_processing::per_block_processing::deneb::kzg_commitment_to_versioned_hash;
+use superstruct::superstruct;
+use types::{
+    BeaconBlockRef, BeaconStateError, EthSpec, ExecutionBlockHash, ExecutionPayload,
+    ExecutionPayloadRef, Hash256, VersionedHash,
+};
+use types::{ExecutionPayloadCapella, ExecutionPayloadDeneb, ExecutionPayloadMerge};
+
+#[superstruct(
+    variants(Merge, Capella, Deneb),
+    variant_attributes(derive(Clone, Debug, PartialEq),),
+    map_into(ExecutionPayload),
+    map_ref_into(ExecutionPayloadRef),
+    cast_error(
+        ty = "BeaconStateError",
+        expr = "BeaconStateError::IncorrectStateVariant"
+    ),
+    partial_getter_error(
+        ty = "BeaconStateError",
+        expr = "BeaconStateError::IncorrectStateVariant"
+    )
+)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct NewPayloadRequest<'block, E: EthSpec> {
+    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
+    pub execution_payload: &'block ExecutionPayloadMerge<E>,
+    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
+    pub execution_payload: &'block ExecutionPayloadCapella<E>,
+    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
+    pub execution_payload: &'block ExecutionPayloadDeneb<E>,
+    #[superstruct(only(Deneb))]
+    pub versioned_hashes: Vec<VersionedHash>,
+    #[superstruct(only(Deneb))]
+    pub parent_beacon_block_root: Hash256,
+}
+
+impl<'block, E: EthSpec> NewPayloadRequest<'block, E> {
+    pub fn parent_hash(&self) -> ExecutionBlockHash {
+        match self {
+            Self::Merge(payload) => payload.execution_payload.parent_hash,
+            Self::Capella(payload) => payload.execution_payload.parent_hash,
+            Self::Deneb(payload) => payload.execution_payload.parent_hash,
+        }
+    }
+
+    pub fn block_hash(&self) -> ExecutionBlockHash {
+        match self {
+            Self::Merge(payload) => payload.execution_payload.block_hash,
+            Self::Capella(payload) => payload.execution_payload.block_hash,
+            Self::Deneb(payload) => payload.execution_payload.block_hash,
+        }
+    }
+
+    pub fn block_number(&self) -> u64 {
+        match self {
+            Self::Merge(payload) => payload.execution_payload.block_number,
+            Self::Capella(payload) => payload.execution_payload.block_number,
+            Self::Deneb(payload) => payload.execution_payload.block_number,
+        }
+    }
+
+    pub fn execution_payload_ref(&self) -> ExecutionPayloadRef<'block, E> {
+        match self {
+            Self::Merge(request) => ExecutionPayloadRef::Merge(request.execution_payload),
+            Self::Capella(request) => ExecutionPayloadRef::Capella(request.execution_payload),
+            Self::Deneb(request) => ExecutionPayloadRef::Deneb(request.execution_payload),
+        }
+    }
+
+    pub fn into_execution_payload(self) -> ExecutionPayload<E> {
+        match self {
+            Self::Merge(request) => ExecutionPayload::Merge(request.execution_payload.clone()),
+            Self::Capella(request) => ExecutionPayload::Capella(request.execution_payload.clone()),
+            Self::Deneb(request) => ExecutionPayload::Deneb(request.execution_payload.clone()),
+        }
+    }
+
+    /// Performs the required verifications of the payload when the chain is optimistically syncing.
+    ///
+    /// ## Specification
+    ///
+    /// Performs the verifications in the `verify_and_notify_new_payload` function:
+    ///
+    /// https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#modified-verify_and_notify_new_payload
+    pub fn perform_optimistic_sync_verifications(&self) -> Result<(), Error> {
+        self.verfiy_payload_block_hash()?;
+        self.verify_versioned_hashes()?;
+
+        Ok(())
+    }
+
+    /// Verify the block hash is consistent locally within Lighthouse.
+    ///
+    /// ## Specification
+    ///
+    /// Equivalent to `is_valid_block_hash` in the spec:
+    /// https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#is_valid_block_hash
+    pub fn verfiy_payload_block_hash(&self) -> Result<(), Error> {
+        let payload = self.execution_payload_ref();
+        let parent_beacon_block_root = self.parent_beacon_block_root().ok().cloned();
+
+        let _timer = metrics::start_timer(&metrics::EXECUTION_LAYER_VERIFY_BLOCK_HASH);
+
+        let (header_hash, rlp_transactions_root) =
+            calculate_execution_block_hash(payload, parent_beacon_block_root);
+
+        if header_hash != self.block_hash() {
+            return Err(Error::BlockHashMismatch {
+                computed: header_hash,
+                payload: payload.block_hash(),
+                transactions_root: rlp_transactions_root,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Verify the version hashes computed by the blob transactions match the version hashes computed from the commitments
+    ///
+    /// ## Specification
+    ///
+    /// Equivalent to `is_valid_versioned_hashes` in the spec:
+    /// https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#is_valid_versioned_hashes
+    pub fn verify_versioned_hashes(&self) -> Result<(), Error> {
+        match self {
+            Self::Merge(_) | Self::Capella(_) => Ok(()),
+            Self::Deneb(request) => Ok(()),
+        }
+    }
+}
+
+impl<'a, E: EthSpec> TryFrom<BeaconBlockRef<'a, E>> for NewPayloadRequest<'a, E> {
+    type Error = BeaconStateError;
+
+    fn try_from(block: BeaconBlockRef<'a, E>) -> Result<Self, Self::Error> {
+        match block {
+            BeaconBlockRef::Base(_) | BeaconBlockRef::Altair(_) => {
+                Err(Self::Error::IncorrectStateVariant)
+            }
+            BeaconBlockRef::Merge(block_ref) => Ok(Self::Merge(NewPayloadRequestMerge {
+                execution_payload: &block_ref.body.execution_payload.execution_payload,
+            })),
+            BeaconBlockRef::Capella(block_ref) => Ok(Self::Capella(NewPayloadRequestCapella {
+                execution_payload: &block_ref.body.execution_payload.execution_payload,
+            })),
+            BeaconBlockRef::Deneb(block_ref) => Ok(Self::Deneb(NewPayloadRequestDeneb {
+                execution_payload: &block_ref.body.execution_payload.execution_payload,
+                versioned_hashes: block_ref
+                    .body
+                    .blob_kzg_commitments
+                    .iter()
+                    .map(kzg_commitment_to_versioned_hash)
+                    .collect(),
+                parent_beacon_block_root: block_ref.parent_root,
+            })),
+        }
+    }
+}
+
+impl<'a, E: EthSpec> TryFrom<ExecutionPayloadRef<'a, E>> for NewPayloadRequest<'a, E> {
+    type Error = BeaconStateError;
+
+    fn try_from(payload: ExecutionPayloadRef<'a, E>) -> Result<Self, Self::Error> {
+        match payload {
+            ExecutionPayloadRef::Merge(payload) => Ok(Self::Merge(NewPayloadRequestMerge {
+                execution_payload: payload,
+            })),
+            ExecutionPayloadRef::Capella(payload) => Ok(Self::Capella(NewPayloadRequestCapella {
+                execution_payload: payload,
+            })),
+            ExecutionPayloadRef::Deneb(_) => Err(Self::Error::IncorrectStateVariant),
+        }
+    }
+}

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -61,6 +61,7 @@ mod metrics;
 pub mod payload_cache;
 mod payload_status;
 pub mod test_utils;
+mod versioned_hashes;
 
 /// Indicates the default jwt authenticated execution endpoint.
 pub const DEFAULT_EXECUTION_ENDPOINT: &str = "http://localhost:8551/";
@@ -141,6 +142,7 @@ pub enum Error {
     InvalidBlobConversion(String),
     BeaconStateError(BeaconStateError),
     PayloadTypeMismatch,
+    VerifyingVersionedHashes(versioned_hashes::Error),
 }
 
 impl From<BeaconStateError> for Error {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1321,7 +1321,7 @@ impl<T: EthSpec> ExecutionLayer<T> {
     /// Maps to the `engine_newPayload` JSON-RPC call.
     pub async fn notify_new_payload(
         &self,
-        new_payload_request: NewPayloadRequest<T>,
+        new_payload_request: NewPayloadRequest<'_, T>,
     ) -> Result<PayloadStatus, Error> {
         let _timer = metrics::start_timer_vec(
             &metrics::EXECUTION_LAYER_REQUEST_TIMES,

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -699,7 +699,7 @@ pub fn generate_blobs<E: EthSpec>(
     Ok((bundle, transactions.into()))
 }
 
-fn static_valid_tx<T: EthSpec>() -> Result<Transaction<T::MaxBytesPerTransaction>, String> {
+pub fn static_valid_tx<T: EthSpec>() -> Result<Transaction<T::MaxBytesPerTransaction>, String> {
     // This is a real transaction hex encoded, but we don't care about the contents of the transaction.
     let transaction: EthersTransaction = serde_json::from_str(
         r#"{

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -244,7 +244,7 @@ impl<T: EthSpec> MockExecutionLayer<T> {
         // TODO: again consider forks
         let status = self
             .el
-            .notify_new_payload(payload.try_into().unwrap())
+            .notify_new_payload(payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -25,8 +25,8 @@ use warp::{http::StatusCode, Filter, Rejection};
 
 use crate::EngineCapabilities;
 pub use execution_block_generator::{
-    generate_blobs, generate_genesis_block, generate_genesis_header, generate_pow_block, Block,
-    ExecutionBlockGenerator,
+    generate_blobs, generate_genesis_block, generate_genesis_header, generate_pow_block,
+    static_valid_tx, Block, ExecutionBlockGenerator,
 };
 pub use hook::Hook;
 pub use mock_builder::{MockBuilder, Operation};

--- a/beacon_node/execution_layer/src/versioned_hashes.rs
+++ b/beacon_node/execution_layer/src/versioned_hashes.rs
@@ -1,0 +1,89 @@
+extern crate reth_primitives;
+extern crate reth_rlp;
+
+use reth_primitives::{Transaction, TransactionSigned};
+use reth_rlp::Decodable;
+use std::collections::HashSet;
+use types::{EthSpec, ExecutionPayloadRef, Hash256, Unsigned, VersionedHash};
+
+#[derive(Debug)]
+pub enum Error {
+    DecodingTransaction(String),
+    LengthMismatch { expected: usize, found: usize },
+    MissingHash(VersionedHash),
+}
+
+pub fn verify_versioned_hashes<E: EthSpec>(
+    execution_payload: ExecutionPayloadRef<E>,
+    expected_versioned_hashes: &Vec<VersionedHash>,
+) -> Result<(), Error> {
+    match execution_payload {
+        ExecutionPayloadRef::Merge(_) | ExecutionPayloadRef::Capella(_) => Ok(()),
+        ExecutionPayloadRef::Deneb(payload) => {
+            let versioned_hashes = get_versioned_hashes::<E>(&payload.transactions)?;
+            // ensure that all expected hashes are present
+            for expected_hash in expected_versioned_hashes {
+                if !versioned_hashes.contains(expected_hash) {
+                    return Err(Error::MissingHash(*expected_hash));
+                }
+            }
+            // ensure that there are no extra hashes
+            if versioned_hashes.len() != expected_versioned_hashes.len() {
+                return Err(Error::LengthMismatch {
+                    expected: expected_versioned_hashes.len(),
+                    found: versioned_hashes.len(),
+                });
+            }
+            Ok(())
+        }
+    }
+}
+
+pub fn get_versioned_hashes<E: EthSpec>(
+    transactions: &types::Transactions<E>,
+) -> Result<HashSet<VersionedHash>, Error> {
+    Ok(transactions
+        .into_iter()
+        .map(beacon_tx_to_reth_signed_tx)
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter_map(|tx| match tx.transaction {
+            Transaction::Eip4844(blob_tx) => Some(blob_tx.blob_versioned_hashes),
+            _ => None,
+        })
+        .flatten()
+        .map(Hash256::from)
+        .collect())
+}
+
+pub fn beacon_tx_to_reth_signed_tx<N: Unsigned>(
+    tx: &types::Transaction<N>,
+) -> Result<TransactionSigned, Error> {
+    let tx_bytes = Vec::from(tx.clone());
+    TransactionSigned::decode(&mut tx_bytes.as_slice())
+        .map_err(|e| Error::DecodingTransaction(e.to_string()))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::static_valid_tx;
+    use reth_primitives::Transaction;
+
+    #[test]
+    fn test_decode_reth_transaction() {
+        type E = types::MainnetEthSpec;
+        let valid_tx = static_valid_tx::<E>().expect("should give me known valid transaction");
+        let tx = beacon_tx_to_reth_signed_tx(&valid_tx).expect("should decode tx");
+        assert!(matches!(
+            tx.transaction,
+            Transaction::Legacy(reth_primitives::TxLegacy {
+                chain_id: Some(0x01),
+                nonce: 0x15,
+                gas_price: 0x4a817c800,
+                to: reth_primitives::TransactionKind::Call(..),
+                ..
+            })
+        ));
+    }
+}

--- a/beacon_node/execution_layer/src/versioned_hashes.rs
+++ b/beacon_node/execution_layer/src/versioned_hashes.rs
@@ -68,7 +68,7 @@ pub fn beacon_tx_to_reth_signed_tx<N: Unsigned>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::static_valid_tx;
+    use crate::test_utils::static_valid_tx;
     use reth_primitives::Transaction;
 
     type E = types::MainnetEthSpec;

--- a/beacon_node/execution_layer/src/versioned_hashes.rs
+++ b/beacon_node/execution_layer/src/versioned_hashes.rs
@@ -3,45 +3,45 @@ extern crate reth_rlp;
 
 use reth_primitives::{Transaction, TransactionSigned};
 use reth_rlp::Decodable;
-use std::collections::HashSet;
 use types::{EthSpec, ExecutionPayloadRef, Hash256, Unsigned, VersionedHash};
 
 #[derive(Debug)]
 pub enum Error {
     DecodingTransaction(String),
     LengthMismatch { expected: usize, found: usize },
-    MissingHash(VersionedHash),
+    VersionHashMismatch { expected: Hash256, found: Hash256 },
 }
 
 pub fn verify_versioned_hashes<E: EthSpec>(
     execution_payload: ExecutionPayloadRef<E>,
-    expected_versioned_hashes: &Vec<VersionedHash>,
+    expected_versioned_hashes: &[VersionedHash],
 ) -> Result<(), Error> {
-    match execution_payload {
-        ExecutionPayloadRef::Merge(_) | ExecutionPayloadRef::Capella(_) => Ok(()),
-        ExecutionPayloadRef::Deneb(payload) => {
-            let versioned_hashes = get_versioned_hashes::<E>(&payload.transactions)?;
-            // ensure that all expected hashes are present
-            for expected_hash in expected_versioned_hashes {
-                if !versioned_hashes.contains(expected_hash) {
-                    return Err(Error::MissingHash(*expected_hash));
-                }
-            }
-            // ensure that there are no extra hashes
-            if versioned_hashes.len() != expected_versioned_hashes.len() {
-                return Err(Error::LengthMismatch {
-                    expected: expected_versioned_hashes.len(),
-                    found: versioned_hashes.len(),
-                });
-            }
-            Ok(())
+    let versioned_hashes =
+        extract_versioned_hashes_from_transactions::<E>(execution_payload.transactions())?;
+    if versioned_hashes.len() != expected_versioned_hashes.len() {
+        return Err(Error::LengthMismatch {
+            expected: expected_versioned_hashes.len(),
+            found: versioned_hashes.len(),
+        });
+    }
+    for (found, expected) in versioned_hashes
+        .iter()
+        .zip(expected_versioned_hashes.iter())
+    {
+        if found != expected {
+            return Err(Error::VersionHashMismatch {
+                expected: *expected,
+                found: *found,
+            });
         }
     }
+
+    Ok(())
 }
 
-pub fn get_versioned_hashes<E: EthSpec>(
+pub fn extract_versioned_hashes_from_transactions<E: EthSpec>(
     transactions: &types::Transactions<E>,
-) -> Result<HashSet<VersionedHash>, Error> {
+) -> Result<Vec<VersionedHash>, Error> {
     Ok(transactions
         .into_iter()
         .map(beacon_tx_to_reth_signed_tx)
@@ -49,7 +49,8 @@ pub fn get_versioned_hashes<E: EthSpec>(
         .into_iter()
         .filter_map(|tx| match tx.transaction {
             Transaction::Eip4844(blob_tx) => Some(blob_tx.blob_versioned_hashes),
-            _ => None,
+            // enumerating all variants explicitly to make pattern irrefutable in case new types are added
+            Transaction::Eip1559(_) | Transaction::Eip2930(_) | Transaction::Legacy(_) => None,
         })
         .flatten()
         .map(Hash256::from)
@@ -70,9 +71,10 @@ mod test {
     use crate::static_valid_tx;
     use reth_primitives::Transaction;
 
+    type E = types::MainnetEthSpec;
+
     #[test]
     fn test_decode_reth_transaction() {
-        type E = types::MainnetEthSpec;
         let valid_tx = static_valid_tx::<E>().expect("should give me known valid transaction");
         let tx = beacon_tx_to_reth_signed_tx(&valid_tx).expect("should decode tx");
         assert!(matches!(
@@ -85,5 +87,36 @@ mod test {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn test_extract_versioned_hashes() {
+        use serde::Deserialize;
+
+        #[derive(Deserialize)]
+        #[serde(transparent)]
+        struct TestTransactions<E: EthSpec>(
+            #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")] types::Transactions<E>,
+        );
+
+        let TestTransactions(raw_transactions): TestTransactions<E> = serde_json::from_str(r#"[
+            "0x03f901388501a1f0ff430f843b9aca00843b9aca0082520894e7249813d8ccf6fa95a2203f46a64166073d58878080c002f8c6a0012e98362c814f1724262c0d211a1463418a5f6382a8d457b37a2698afbe7b5ea00100ef985761395dfa8ed5ce91f3f2180b612401909e4cb8f33b90c8a454d9baa0013d45411623b90d90f916e4025ada74b453dd4ca093c017c838367c9de0f801a001753e2af0b1e70e7ef80541355b2a035cc9b2c177418bb2a4402a9b346cf84da0011789b520a8068094a92aa0b04db8d8ef1c6c9818947c5210821732b8744049a0011c4c4f95597305daa5f62bf5f690e37fa11f5de05a95d05cac4e2119e394db80a0ccd86a742af0e042d08cbb35d910ddc24bbc6538f9e53be6620d4b6e1bb77662a01a8bacbc614940ac2f5c23ffc00a122c9f085046883de65c88ab0edb859acb99",
+            "0x02f9017a8501a1f0ff4382363485012a05f2008512a05f2000830249f094c1b0bc605e2c808aa0867bfc98e51a1fe3e9867f80b901040cc7326300000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000009445a285baa43e00000000000000000000000000c500931f24edb821cef6e28f7adb33b38578c82000000000000000000000000fc7360b3b28cf4204268a8354dbec60720d155d2000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000009a054a063f0fe7b9c68de8df91aaa5e96c15ab540000000000000000000000000c8d41b8fcc066cdabaf074d78e5153e8ce018a9c080a008e14475c1173cd9f5740c24c08b793f9e16c36c08fa73769db95050e31e3396a019767dcdda26c4a774ca28c9df15d0c20e43bd07bd33ee0f84d6096cb5a1ebed"
+        ]"#).expect("should get raw transactions");
+        let expected_versioned_hashes = vec![
+            "0x012e98362c814f1724262c0d211a1463418a5f6382a8d457b37a2698afbe7b5e",
+            "0x0100ef985761395dfa8ed5ce91f3f2180b612401909e4cb8f33b90c8a454d9ba",
+            "0x013d45411623b90d90f916e4025ada74b453dd4ca093c017c838367c9de0f801",
+            "0x01753e2af0b1e70e7ef80541355b2a035cc9b2c177418bb2a4402a9b346cf84d",
+            "0x011789b520a8068094a92aa0b04db8d8ef1c6c9818947c5210821732b8744049",
+            "0x011c4c4f95597305daa5f62bf5f690e37fa11f5de05a95d05cac4e2119e394db",
+        ]
+        .into_iter()
+        .map(|tx| Hash256::from_slice(&hex::decode(&tx[2..]).expect("should decode hex")))
+        .collect::<Vec<_>>();
+
+        let versioned_hashes = extract_versioned_hashes_from_transactions::<E>(&raw_transactions)
+            .expect("should get versioned hashes");
+        assert_eq!(versioned_hashes, expected_versioned_hashes);
     }
 }

--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.73.0-bullseye AS builder
+FROM rust:1.75.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG FEATURES

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -4,7 +4,7 @@ version = "4.6.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 
 [features]
 default = ["slasher-lmdb"]

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -381,7 +381,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_a
             .execution_layer
-            .notify_new_payload(valid_payload.clone().try_into().unwrap())
+            .notify_new_payload(valid_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
@@ -435,7 +435,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_a
             .execution_layer
-            .notify_new_payload(invalid_payload.try_into().unwrap())
+            .notify_new_payload(invalid_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert!(matches!(
@@ -507,7 +507,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_a
             .execution_layer
-            .notify_new_payload(second_payload.clone().try_into().unwrap())
+            .notify_new_payload(second_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
@@ -559,7 +559,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_b
             .execution_layer
-            .notify_new_payload(second_payload.clone().try_into().unwrap())
+            .notify_new_payload(second_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert!(matches!(status, PayloadStatus::Syncing));
@@ -597,7 +597,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_b
             .execution_layer
-            .notify_new_payload(valid_payload.clone().try_into().unwrap())
+            .notify_new_payload(valid_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);
@@ -611,7 +611,7 @@ impl<E: GenericExecutionEngine> TestRig<E> {
         let status = self
             .ee_b
             .execution_layer
-            .notify_new_payload(second_payload.clone().try_into().unwrap())
+            .notify_new_payload(second_payload.to_ref().try_into().unwrap())
             .await
             .unwrap();
         assert_eq!(status, PayloadStatus::Valid);


### PR DESCRIPTION
## Issue Addressed

* #4831

## Proposed Changes

I've done a bit of refactoring which I think makes the code a bit cleaner and eliminates some cloning of the execution payload.

## Additional Info

I used `alloy-consensus` to pull the versioned hashes from the raw transactions. Perhaps we should replace other functions that rely on `ethers_core` with `alloy` crates as well? An easy place to start (that could potentially fit in this PR) is calculating the block hash.