### PR TITLE
[Merged by Bors] - chore: replace deprecated hub with gh for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,9 +282,6 @@ jobs:
                   | <img src="https://simpleicons.org/icons/docker.svg" style="width: 32px;"/> | Docker | [${{ env.VERSION }}](https://hub.docker.com/r/${{ env.IMAGE_NAME }}/tags?page=1&ordering=last_updated&name=${{ env.VERSION }}) | [${{ env.IMAGE_NAME }}](https://hub.docker.com/r/${{ env.IMAGE_NAME }}) |
                   ENDBODY
                   )
-                  assets=()
-                  for asset in ./lighthouse-*.tar.gz*; do
-                      assets+=("-a" "$asset/$asset")
-                  done
+                  assets=(./lighthouse-*.tar.gz*)
                   tag_name="${{ env.VERSION }}"
-                  echo "$body" | gh release create --draft "${assets[@]}" -F "-" "$tag_name"
+                  echo "$body" | gh release create --draft -F "-" "$tag_name" "${assets[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,4 +287,4 @@ jobs:
                       assets+=("-a" "$asset/$asset")
                   done
                   tag_name="${{ env.VERSION }}"
-                  echo "$body" | hub release create --draft "${assets[@]}" -F "-" "$tag_name"
+                  echo "$body" | gh release create --draft "${assets[@]}" -F "-" "$tag_name"


### PR DESCRIPTION
## Issue Addressed

- The tool hub that is used to create draft releases has been removed as of October 2. See: https://github.com/actions/runner-images/issues/8362
- This change replaces `hub` usage in favour of [`gh`](https://cli.github.com/manual/gh_release_create) 

## Proposed Changes

- This change replaces `hub` usage in favour of [`gh`](https://cli.github.com/manual/gh_release_create) 

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
