### PR TITLE
Try disabling nextest

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in release
-      run: make nextest-release
+      run: make test-release
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats
@@ -89,7 +89,7 @@ jobs:
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - name: Run tests in release
-      run: make nextest-release
+      run: make test-release
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats
@@ -163,7 +163,7 @@ jobs:
       with:
         version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in debug
-      run: make nextest-debug
+      run: make test-debug
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats
@@ -195,7 +195,7 @@ jobs:
           cache-target: release
           bins: cargo-nextest
     - name: Run consensus-spec-tests with blst, milagro and fake_crypto
-      run: make nextest-ef
+      run: make test-ef
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats

--- a/Makefile
+++ b/Makefile
@@ -151,21 +151,21 @@ nextest-run-ef-tests:
 test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 
 test-beacon-chain-%:
-	env FORK_NAME=$* cargo nextest run --release --features fork_from_env,slasher/lmdb -p beacon_chain
+	env FORK_NAME=$* cargo test run --release --features fork_from_env,slasher/lmdb -p beacon_chain
 
 # Run the tests in the `operation_pool` crate for all known forks.
 test-op-pool: $(patsubst %,test-op-pool-%,$(FORKS))
 
 test-op-pool-%:
-	env FORK_NAME=$* cargo nextest run --release \
+	env FORK_NAME=$* cargo test run --release \
 		--features 'beacon_chain/fork_from_env'\
 		-p operation_pool
 
 # Run the tests in the `slasher` crate for all supported database backends.
 test-slasher:
-	cargo nextest run --release -p slasher --features lmdb
-	cargo nextest run --release -p slasher --no-default-features --features mdbx
-	cargo nextest run --release -p slasher --features lmdb,mdbx # both backends enabled
+	cargo test run --release -p slasher --features lmdb
+	cargo test run --release -p slasher --no-default-features --features mdbx
+	cargo test run --release -p slasher --features lmdb,mdbx # both backends enabled
 
 # Runs only the tests/state_transition_vectors tests.
 run-state-transition-tests:


### PR DESCRIPTION
## Issue Addressed

Experiment to see if avoiding nextest prevents an OOM on the self-hosted runner.

## Proposed Changes

I suspect that nextest is giving us a little too much parallelism. If the runner runs K jobs in parallel, and each job runs N tests, we end up with `K * N` tests. I'm not sure what `K` is currently (maybe 8?), `N` is probably 16-32. Each test might use 200-300MB of RAM, so this is potentially `8 * 32 * 300MB = 77GB` of RAM.
