### PR TITLE
[Merged by Bors] - Remove blob clones in KZG verification

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5123,7 +5123,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     kzg_utils::validate_blobs::<T::EthSpec>(
                         kzg,
                         expected_kzg_commitments,
-                        blobs,
+                        blobs.iter().collect(),
                         &kzg_proofs,
                     )
                     .map_err(BlockProductionError::KzgError)?;

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -12,7 +12,7 @@ fn ssz_blob_to_crypto_blob<T: EthSpec>(
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.
 pub fn validate_blob<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
-    blob: Blob<T>,
+    blob: &Blob<T>,
     kzg_commitment: KzgCommitment,
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
@@ -27,11 +27,11 @@ pub fn validate_blob<T: EthSpec>(
 pub fn validate_blobs<T: EthSpec>(
     kzg: &Kzg<T::Kzg>,
     expected_kzg_commitments: &[KzgCommitment],
-    blobs: &[Blob<T>],
+    blobs: Vec<&Blob<T>>,
     kzg_proofs: &[KzgProof],
 ) -> Result<bool, KzgError> {
     let blobs = blobs
-        .iter()
+        .into_iter()
         .map(|blob| ssz_blob_to_crypto_blob::<T>(blob)) // Avoid this clone
         .collect::<Result<Vec<_>, KzgError>>()?;
 

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -17,7 +17,7 @@ pub fn validate_blob<T: EthSpec>(
     kzg_proof: KzgProof,
 ) -> Result<bool, KzgError> {
     kzg.verify_blob_kzg_proof(
-        &ssz_blob_to_crypto_blob::<T>(&blob)?,
+        &ssz_blob_to_crypto_blob::<T>(blob)?,
         kzg_commitment,
         kzg_proof,
     )
@@ -32,7 +32,7 @@ pub fn validate_blobs<T: EthSpec>(
 ) -> Result<bool, KzgError> {
     let blobs = blobs
         .into_iter()
-        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob)) // Avoid this clone
+        .map(|blob| ssz_blob_to_crypto_blob::<T>(blob))
         .collect::<Result<Vec<_>, KzgError>>()?;
 
     kzg.verify_blob_kzg_proof_batch(&blobs, expected_kzg_commitments, kzg_proofs)

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -91,7 +91,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
 
         let kzg = get_kzg::<E::Kzg>()?;
         let result = parse_input(&self.input).and_then(|(blob, commitment, proof)| {
-            validate_blob::<E>(&kzg, blob, commitment, proof)
+            validate_blob::<E>(&kzg, &blob, commitment, proof)
                 .map_err(|e| Error::InternalError(format!("Failed to validate blob: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -54,7 +54,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
 
         let kzg = get_kzg::<E::Kzg>()?;
         let result = parse_input(&self.input).and_then(|(commitments, blobs, proofs)| {
-            validate_blobs::<E>(&kzg, &commitments, &blobs, &proofs)
+            validate_blobs::<E>(&kzg, &commitments, blobs.iter().collect(), &proofs)
                 .map_err(|e| Error::InternalError(format!("Failed to validate blobs: {:?}", e)))
         });
 


### PR DESCRIPTION
## Issue Addressed

This PR removes two instances of blob clones during blob verification that may not be necessary.