### PR TITLE
Global ENR

### DIFF
--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -144,6 +144,7 @@ pub async fn create_api_server<T: BeaconChainTypes>(
     let enr = EnrBuilder::new("v4").build(&enr_key).unwrap();
     let network_globals = Arc::new(NetworkGlobals::new(
         enr.clone(),
+        enr_key,
         meta_data,
         vec![],
         false,

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -248,7 +248,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         }
 
         // Check NAT if metrics are enabled
-        if self.network_globals.local_enr.read().udp4().is_some() {
+        if self.network_globals.local_enr.enr().udp4().is_some() {
             metrics::check_nat();
         }
 

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -291,6 +291,9 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
             discovery
         };
 
+        /* write back the ENR that discovery has built */
+        *network_globals.local_enr.write() = discovery.local_enr();
+
         let identify = {
             let local_public_key = local_keypair.public();
             let identify_config = if config.private {

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -282,13 +282,7 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
 
         let discovery = {
             // Build and start the discovery sub-behaviour
-            let mut discovery = Discovery::new(
-                local_keypair.clone(),
-                &config,
-                network_globals.clone(),
-                &log,
-            )
-            .await?;
+            let mut discovery = Discovery::new(&config, network_globals.clone(), &log).await?;
             // start searching for peers
             discovery.discover_peers(FIND_NODE_QUERY_CLOSEST_PEERS);
             discovery

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -1,4 +1,5 @@
 //! A collection of variables that are accessible outside of the network thread itself.
+use super::mutable_enr::MutableEnr;
 use crate::peer_manager::peerdb::PeerDB;
 use crate::rpc::{MetaData, MetaDataV2};
 use crate::types::{BackFillState, SyncState};
@@ -9,7 +10,6 @@ use discv5::enr::CombinedKey;
 use parking_lot::RwLock;
 use std::collections::HashSet;
 use types::EthSpec;
-use super::mutable_enr::MutableEnr;
 
 pub struct NetworkGlobals<TSpec: EthSpec> {
     /// The current local ENR.

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -40,7 +40,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         log: &slog::Logger,
     ) -> Self {
         NetworkGlobals {
-            local_enr: MutableEnr::new(enr, enr_key),
+            local_enr: MutableEnr::new(enr.clone(), enr_key),
             peer_id: RwLock::new(enr.peer_id()),
             listen_multiaddrs: RwLock::new(Vec::new()),
             local_metadata: RwLock::new(local_metadata),

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -4,6 +4,7 @@ mod pubsub;
 mod subnet;
 mod sync_state;
 mod topics;
+mod mutable_enr;
 
 use types::{BitVector, EthSpec};
 

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -1,10 +1,10 @@
 pub mod error;
 mod globals;
+pub mod mutable_enr;
 mod pubsub;
 mod subnet;
 mod sync_state;
 mod topics;
-mod mutable_enr;
 
 use types::{BitVector, EthSpec};
 

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
-use parking_lot::RwLock;
-use libp2p::bytes::Bytes;
 use discv5::enr::{Enr, EnrError};
+use libp2p::bytes::Bytes;
+use parking_lot::RwLock;
 
 use crate::discovery::enr::CombinedKey;
 
 /// Represents a port advertised via an ENR
-/// 
+///
 /// The ENR specification allows extension of the keys stored in any given ENR
 /// as well as specific keys for TCP and UDP ports over both IPv4 and IPv6. This
 /// type extends these to add the QUIC transport.
@@ -21,7 +21,7 @@ pub enum EnrPort {
 }
 
 /// Represents a mutable instance of an ENR
-/// 
+///
 /// Any mutation of an ENR necessitates re-signing the new ENR, so this type
 /// contains both the ENR itself as well as its corresponding signing key.
 #[derive(Clone)]
@@ -54,7 +54,7 @@ impl MutableEnr {
     }
 
     /// Update the specified port being advertised via this ENR
-    /// 
+    ///
     /// If the port is already being advertised in this ENR, it is overwritten. Otherwise, it is added as a new key-value pair.
     pub fn update_port(&self, port: EnrPort) -> Result<Option<Bytes>, EnrError> {
         match port {

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -24,6 +24,7 @@ pub enum EnrPort {
 /// 
 /// Any mutation of an ENR necessitates re-signing the new ENR, so this type
 /// contains both the ENR itself as well as its corresponding signing key.
+#[derive(Clone)]
 pub struct MutableEnr {
     /// Shared ENR
     pub enr: Arc<RwLock<Enr<CombinedKey>>>,

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -40,12 +40,12 @@ impl MutableEnr {
         }
     }
 
-    pub fn enr(&self) -> &Enr<CombinedKey> {
-        &self.enr.read()
+    pub fn enr(&self) -> Enr<CombinedKey> {
+        self.enr.read().clone()
     }
 
-    pub fn enr_key(&self) -> &CombinedKey {
-        self.enr_key.as_ref()
+    pub fn enr_key(&self) -> CombinedKey {
+        Arc::into_inner(self.enr_key.clone()).unwrap()
     }
 
     /// Insert an arbitrary key-value pair into the ENR

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -40,7 +40,7 @@ impl MutableEnr {
     }
 
     pub fn enr(&self) -> &Enr<CombinedKey> {
-        self.enr.as_ref()
+        &self.enr.read()
     }
 
     pub fn enr_key(&self) -> &CombinedKey {

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -26,7 +26,7 @@ pub enum EnrPort {
 /// contains both the ENR itself as well as its corresponding signing key.
 pub struct MutableEnr {
     /// Shared ENR
-    enr: Arc<RwLock<Enr<CombinedKey>>>,
+    pub enr: Arc<RwLock<Enr<CombinedKey>>>,
     /// Signing key for ENR modifications
     enr_key: Arc<CombinedKey>,
 }

--- a/beacon_node/lighthouse_network/src/types/mutable_enr.rs
+++ b/beacon_node/lighthouse_network/src/types/mutable_enr.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use libp2p::bytes::Bytes;
+use discv5::enr::{Enr, EnrError};
+
+use crate::discovery::enr::CombinedKey;
+
+/// Represents a port advertised via an ENR
+/// 
+/// The ENR specification allows extension of the keys stored in any given ENR
+/// as well as specific keys for TCP and UDP ports over both IPv4 and IPv6. This
+/// type extends these to add the QUIC transport.
+pub enum EnrPort {
+    Tcp4(u16),
+    Tcp6(u16),
+    Udp4(u16),
+    Udp6(u16),
+    Quic4(u16),
+    Quic6(u16),
+}
+
+/// Represents a mutable instance of an ENR
+/// 
+/// Any mutation of an ENR necessitates re-signing the new ENR, so this type
+/// contains both the ENR itself as well as its corresponding signing key.
+pub struct MutableEnr {
+    /// Shared ENR
+    enr: Arc<RwLock<Enr<CombinedKey>>>,
+    /// Signing key for ENR modifications
+    enr_key: Arc<CombinedKey>,
+}
+
+impl MutableEnr {
+    pub fn new(enr: Enr<CombinedKey>, enr_key: CombinedKey) -> Self {
+        Self {
+            enr: Arc::new(RwLock::new(enr)),
+            enr_key: Arc::new(enr_key),
+        }
+    }
+
+    pub fn enr(&self) -> &Enr<CombinedKey> {
+        self.enr.as_ref()
+    }
+
+    pub fn enr_key(&self) -> &CombinedKey {
+        self.enr_key.as_ref()
+    }
+
+    /// Insert an arbitrary key-value pair into the ENR
+    pub fn insert(&self, key: impl AsRef<[u8]>, value: &[u8]) -> Result<Option<Bytes>, EnrError> {
+        self.enr.write().insert(key, &value, &self.enr_key)
+    }
+
+    /// Update the specified port being advertised via this ENR
+    /// 
+    /// If the port is already being advertised in this ENR, it is overwritten. Otherwise, it is added as a new key-value pair.
+    pub fn update_port(&self, port: EnrPort) -> Result<Option<Bytes>, EnrError> {
+        match port {
+            EnrPort::Tcp4(p) => self.insert("tcp4", p.to_be_bytes().as_ref()),
+            EnrPort::Tcp6(p) => self.insert("tcp6", p.to_be_bytes().as_ref()),
+            EnrPort::Udp4(p) => self.insert("udp4", p.to_be_bytes().as_ref()),
+            EnrPort::Udp6(p) => self.insert("udp6", p.to_be_bytes().as_ref()),
+            EnrPort::Quic4(p) => self.insert("quic4", p.to_be_bytes().as_ref()),
+            EnrPort::Quic6(p) => self.insert("quic6", p.to_be_bytes().as_ref()),
+        }
+    }
+}

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -16,6 +16,7 @@ use futures::future::OptionFuture;
 use futures::prelude::*;
 use futures::StreamExt;
 use lighthouse_network::service::Network;
+use lighthouse_network::types::mutable_enr::EnrPort;
 use lighthouse_network::types::GossipKind;
 use lighthouse_network::{prometheus_client::registry::Registry, MessageAcceptance};
 use lighthouse_network::{
@@ -640,14 +641,26 @@ impl<T: BeaconChainTypes> NetworkService<T> {
                 self.upnp_mappings = mappings;
                 // If there is an external TCP port update, modify our local ENR.
                 if let Some(tcp_port) = self.upnp_mappings.tcp_port {
-                    if let Err(e) = self.libp2p.discovery_mut().update_enr_tcp_port(tcp_port) {
-                        warn!(self.log, "Failed to update ENR"; "error" => e);
+                    if let Err(e) = self
+                        .libp2p
+                        .discovery_mut()
+                        .network_globals
+                        .local_enr
+                        .update_port(EnrPort::Tcp4(tcp_port))
+                    {
+                        warn!(self.log, "Failed to update ENR"; "error" => ?e);
                     }
                 }
                 // If there is an external QUIC port update, modify our local ENR.
                 if let Some(quic_port) = self.upnp_mappings.udp_quic_port {
-                    if let Err(e) = self.libp2p.discovery_mut().update_enr_quic_port(quic_port) {
-                        warn!(self.log, "Failed to update ENR"; "error" => e);
+                    if let Err(e) = self
+                        .libp2p
+                        .discovery_mut()
+                        .network_globals
+                        .local_enr
+                        .update_port(EnrPort::Quic4(quic_port))
+                    {
+                        warn!(self.log, "Failed to update ENR"; "error" => ?e);
                     }
                 }
             }


### PR DESCRIPTION
## Issue Addressed

Closes #4706 

## Proposed Changes

 - Add an `EnrPort` type, representing ports we advertise in our ENR
 - Add a `MutableEnr` type, representing a single handle to a writeable ENR
 - Remove ad-hoc ENR port update helpers (`update_enr_tcp_port`, `update_enr_udp_port`, etc.)

## Additional Info

TBA
