### PR TITLE
[Merged by Bors] - Enable BLS portable feature on all CI tests

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -20,6 +20,9 @@ jobs:
           - ubuntu-22.04
           - macos-12
     runs-on: ${{ matrix.os }}
+    env:
+      # Enable portable to prevent issues with caching `blst` for the wrong CPU type
+      FEATURES: portable,jemalloc
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -26,6 +26,8 @@ env:
   WATCH_HOST: ${{ github.repository == 'sigp/lighthouse' && 'host.docker.internal' || 'localhost' }}
   # Disable incremental compilation
   CARGO_INCREMENTAL: 0
+  # Enable portable to prevent issues with caching `blst` for the wrong CPU type
+  TEST_FEATURES: portable
 jobs:
   target-branch-check:
     name: target-branch-check
@@ -286,6 +288,9 @@ jobs:
   doppelganger-protection-test:
     name: doppelganger-protection-test
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
+    env:
+      # Enable portable to prevent issues with caching `blst` for the wrong CPU type
+      FEATURES: jemalloc,portable
     steps:
     - uses: actions/checkout@v3
     - name: Get latest version of stable Rust

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ CROSS_PROFILE ?= release
 # List of features to use when running EF tests.
 EF_TEST_FEATURES ?=
 
+# List of features to use when running CI tests.
+TEST_FEATURES ?=
+
 # Cargo profile for regular builds.
 PROFILE ?= release
 
@@ -106,22 +109,26 @@ build-release-tarballs:
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors.
 test-release:
-	cargo test --workspace --release --exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network
+	cargo test --workspace --release --features "$(TEST_FEATURES)" \
+ 		--exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network
 
 # Runs the full workspace tests in **release**, without downloading any additional
 # test vectors, using nextest.
 nextest-release:
-	cargo nextest run --workspace --release --exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network
+	cargo nextest run --workspace --release --features "$(TEST_FEATURES)" \
+		--exclude ef_tests --exclude beacon_chain --exclude slasher --exclude network
 
 # Runs the full workspace tests in **debug**, without downloading any additional test
 # vectors.
 test-debug:
-	cargo test --workspace --exclude ef_tests --exclude beacon_chain --exclude network
+	cargo test --workspace --features "$(TEST_FEATURES)" \
+		--exclude ef_tests --exclude beacon_chain --exclude network
 
 # Runs the full workspace tests in **debug**, without downloading any additional test
 # vectors, using nextest.
 nextest-debug:
-	cargo nextest run --workspace --exclude ef_tests --exclude beacon_chain --exclude network
+	cargo nextest run --workspace --features "$(TEST_FEATURES)" \
+		--exclude ef_tests --exclude beacon_chain --exclude network
 
 # Runs cargo-fmt (linter).
 cargo-fmt:
@@ -129,7 +136,7 @@ cargo-fmt:
 
 # Typechecks benchmark code
 check-benches:
-	cargo check --workspace --benches
+	cargo check --workspace --benches --features "$(TEST_FEATURES)"
 
 # Runs only the ef-test vectors.
 run-ef-tests:
@@ -151,14 +158,14 @@ nextest-run-ef-tests:
 test-beacon-chain: $(patsubst %,test-beacon-chain-%,$(FORKS))
 
 test-beacon-chain-%:
-	env FORK_NAME=$* cargo nextest run --release --features fork_from_env,slasher/lmdb -p beacon_chain
+	env FORK_NAME=$* cargo nextest run --release --features "fork_from_env,slasher/lmdb,$(TEST_FEATURES)" -p beacon_chain
 
 # Run the tests in the `operation_pool` crate for all known forks.
 test-op-pool: $(patsubst %,test-op-pool-%,$(FORKS))
 
 test-op-pool-%:
 	env FORK_NAME=$* cargo nextest run --release \
-		--features 'beacon_chain/fork_from_env'\
+		--features "beacon_chain/fork_from_env,$(TEST_FEATURES)"\
 		-p operation_pool
 
 # Run the tests in the `network` crate for all known forks.
@@ -166,14 +173,14 @@ test-network: $(patsubst %,test-network-%,$(FORKS))
 
 test-network-%:
 	env FORK_NAME=$* cargo nextest run --release \
-		--features 'fork_from_env' \
+		--features "fork_from_env,$(TEST_FEATURES)" \
 		-p network
 		
 # Run the tests in the `slasher` crate for all supported database backends.
 test-slasher:
-	cargo nextest run --release -p slasher --features lmdb
-	cargo nextest run --release -p slasher --no-default-features --features mdbx
-	cargo nextest run --release -p slasher --features lmdb,mdbx # both backends enabled
+	cargo nextest run --release -p slasher --features "lmdb,$(TEST_FEATURES)"
+	cargo nextest run --release -p slasher --no-default-features --features "mdbx,$(TEST_FEATURES)"
+	cargo nextest run --release -p slasher --features "lmdb,mdbx,$(TEST_FEATURES)" # both backends enabled
 
 # Runs only the tests/state_transition_vectors tests.
 run-state-transition-tests:
@@ -199,7 +206,7 @@ test-full: cargo-fmt test-release test-debug test-ef test-exec-engine
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) -- \
+	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D warnings \
 		-A clippy::derive_partial_eq_without_eq \
@@ -230,8 +237,8 @@ make-ef-tests:
 
 # Verifies that crates compile with fuzzing features enabled
 arbitrary-fuzz:
-	cargo check -p state_processing --features arbitrary-fuzz
-	cargo check -p slashing_protection --features arbitrary-fuzz
+	cargo check -p state_processing --features arbitrary-fuzz,$(TEST_FEATURES)
+	cargo check -p slashing_protection --features arbitrary-fuzz,$(TEST_FEATURES)
 
 # Runs cargo audit (Audit Cargo.lock files for crates with security vulnerabilities reported to the RustSec Advisory Database)
 audit: install-audit audit-CI
@@ -248,7 +255,7 @@ vendor:
 
 # Runs `cargo udeps` to check for unused dependencies
 udeps:
-	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release
+	cargo +$(PINNED_NIGHTLY) udeps --tests --all-targets --release --features "$(TEST_FEATURES)"
 
 # Performs a `cargo` clean and cleans the `ef_tests` directory.
 clean:

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -10,6 +10,7 @@ default = ["participation_metrics"]
 write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
 participation_metrics = []  # Exposes validator participation metrics to Prometheus.
 fork_from_env = [] # Initialise the harness chain spec from the FORK_NAME env variable
+portable = ["bls/supranational-portable"]
 
 [dev-dependencies]
 maplit = { workspace = true }

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -56,3 +56,4 @@ environment = { workspace = true }
 # NOTE: This can be run via cargo build --bin lighthouse --features network/disable-backfill
 disable-backfill = []
 fork_from_env = ["beacon_chain/fork_from_env"]
+portable = ["beacon_chain/portable"]

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -24,3 +24,6 @@ rand = { workspace = true }
 beacon_chain = { workspace = true }
 tokio = { workspace = true }
 maplit = { workspace = true }
+
+[features]
+portable = ["beacon_chain/portable"]

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -40,3 +40,4 @@ arbitrary-fuzz = [
   "ssz_types/arbitrary",
   "tree_hash/arbitrary",
 ]
+portable = ["bls/supranational-portable"]

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -68,3 +68,4 @@ sqlite = []
 # The `arbitrary-fuzz` feature is a no-op provided for backwards compatibility.
 # For simplicity `Arbitrary` is now derived regardless of the feature's presence.
 arbitrary-fuzz = []
+portable = ["bls/supranational-portable"]

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 default = ["lmdb"]
 mdbx = ["dep:mdbx"]
 lmdb = ["lmdb-rkv", "lmdb-rkv-sys"]
+portable = ["types/portable"]
 
 [dependencies]
 bincode = { workspace = true }

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -9,6 +9,7 @@ edition = { workspace = true }
 ef_tests = []
 milagro = ["bls/milagro"]
 fake_crypto = ["bls/fake_crypto"]
+portable = ["beacon_chain/portable"]
 
 [dependencies]
 bls = { workspace = true }

--- a/testing/execution_engine_integration/Cargo.toml
+++ b/testing/execution_engine_integration/Cargo.toml
@@ -22,3 +22,6 @@ reqwest = { workspace = true }
 hex = { workspace = true }
 fork_choice = { workspace = true }
 logging = { workspace = true }
+
+[features]
+portable = ["types/portable"]

--- a/testing/execution_engine_integration/Makefile
+++ b/testing/execution_engine_integration/Makefile
@@ -1,5 +1,5 @@
 test:
-	cargo run --release --locked
+	cargo run --release --locked --features "$(TEST_FEATURES)"
 
 clean:
 	rm -rf execution_clients

--- a/testing/state_transition_vectors/Cargo.toml
+++ b/testing/state_transition_vectors/Cargo.toml
@@ -13,3 +13,6 @@ ethereum_ssz = { workspace = true }
 beacon_chain = { workspace = true }
 lazy_static = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+portable = ["beacon_chain/portable"]

--- a/testing/state_transition_vectors/Makefile
+++ b/testing/state_transition_vectors/Makefile
@@ -2,7 +2,7 @@ produce-vectors:
 	cargo run --release
 
 test:
-	cargo test --release
+	cargo test --release --features "$(TEST_FEATURES)"
 
 clean:
 	rm -r vectors/

--- a/validator_client/slashing_protection/Cargo.toml
+++ b/validator_client/slashing_protection/Cargo.toml
@@ -27,3 +27,4 @@ rayon = { workspace = true }
 
 [features]
 arbitrary-fuzz = ["types/arbitrary-fuzz"]
+portable = ["types/portable"]


### PR DESCRIPTION
## Issue Addressed

Addresses the recent CI failures caused by caching `blst` for the wrong CPU type. 

## Proposed Changes

- Use `FEATURES: jemalloc,portable` when building Lighthouse & `lcli` in tests
- Add a new `TEST_FEATURES` and set to `portable` for all CI test jobs.
- Updated Makefiles to read the `TEST_FEATURES` environment variable, and default to none.