### PR TITLE
[Merged by Bors] - fix deneb sync bug

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1052,7 +1052,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         PeerAction::MidToleranceError,
                         "block_blob_faulty_batch",
                     );
-                    self.inject_error(peer_id, id, RPCError::InvalidData(e))
+                    self.inject_error(peer_id, id, RPCError::InvalidData(e.into()))
                 }
             }
         }
@@ -1115,7 +1115,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         PeerAction::MidToleranceError,
                         "block_blob_faulty_backfill_batch",
                     );
-                    self.inject_error(peer_id, id, RPCError::InvalidData(e))
+                    self.inject_error(peer_id, id, RPCError::InvalidData(e.into()))
                 }
             }
         }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -564,4 +564,22 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             ByRangeRequestType::Blocks
         }
     }
+
+    pub fn insert_range_blocks_and_blobs_request(
+        &mut self,
+        id: Id,
+        request: BlocksAndBlobsByRangeRequest<T::EthSpec>,
+    ) {
+        self.range_blocks_and_blobs_requests.insert(id, request);
+    }
+
+    pub fn insert_backfill_blocks_and_blobs_requests(
+        &mut self,
+        id: Id,
+        batch_id: BatchId,
+        request: BlocksAndBlobsRequestInfo<T::EthSpec>,
+    ) {
+        self.backfill_blocks_and_blobs_requests
+            .insert(id, (batch_id, request));
+    }
 }


### PR DESCRIPTION
## Issue Addressed

I observed our forward sync on devnet 9 would stall when we would hit this log:
```
250425:Oct 19 00:54:17.133 WARN Blocks and blobs request for range received invalid data, error: KzgCommitmentMismatch, batch_id: 4338, peer_id: 16Uiu2HAmHbmkEQFDrJfNuy1aYyAfHkNUwSD9FN7EVAqGJ8YTF9Mh, service: sync, module: network::sync::manager:1036
```

## Proposed Changes

`range_sync_block_and_blob_response` [here](https://github.com/sigp/lighthouse/blob/1cb02a13a53d0e603ad5920c03832e5779c3df61/beacon_node/network/src/sync/manager.rs#L1013) removes the request from the sync manager. later, however if there's an error, `inject_error` [here](https://github.com/sigp/lighthouse/blob/1cb02a13a53d0e603ad5920c03832e5779c3df61/beacon_node/network/src/sync/manager.rs#L1055) expects the request to exist so we can handle retry logic. So this PR just re-inserts the request (withthout any accumulated blobs or blocks) when we hit an error here.

The issue is unique to block+blob sync because the error here is only possible from mismatches between blocks + blobs after we've downloaded both, there's no equivalent error in block sync

