### PR TITLE
Harden against old consensus message (attestation & sync) spam

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -49,7 +49,7 @@ use beacon_processor::{
 
 /// Set to `true` to introduce stricter penalties for peers who send some types of late consensus
 /// messages.
-const STRICT_LATE_MESSAGE_PENALTIES: bool = false;
+const STRICT_LATE_MESSAGE_PENALTIES: bool = true;
 
 /// An attestation that has been validated by the `BeaconChain`.
 ///
@@ -1921,7 +1921,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 if STRICT_LATE_MESSAGE_PENALTIES && hindsight_verification.is_err() {
                     self.gossip_penalize_peer(
                         peer_id,
-                        PeerAction::LowToleranceError,
+                        PeerAction::HighToleranceError,
                         "attn_past_slot",
                     );
                 }


### PR DESCRIPTION
## Proposed Changes

- This PR reintroduces strict late message penalties for peers that send attestation and sync committee messages from a slot that is prior to the earliest permissible slot, after taking `MAXIMUM_GOSSIP_CLOCK_DISPARITY` into account.
- Invalid attestation messages due to `PastSlot` used to be a low-tolerance error (before `STRICT_LATE_MESSAGE_PENALTIES` was disabled) , however due to the likelihood of racing, this is now set to high-tolerance, allowing the node to be protected against spam without being excessively strict.

## Additional Info

- There is a related PR to harden against finalized block spam (#4277) which we should probably revisit.