### PR TITLE
[Merged by Bors] - don't make `lcli` on self-hosted runners

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -309,8 +309,7 @@ jobs:
       run: |
           make
     - name: Install lcli
-# TODO(jimmy): re-enable this once we merge deneb into unstable
-#      if: env.SELF_HOSTED_RUNNERS == 'false'
+      if: env.SELF_HOSTED_RUNNERS == 'false'
       run: make install-lcli
     - name: Run the doppelganger protection failure test script
       run: |


### PR DESCRIPTION
## Issue Addressed

Our self-hosted runners now have a modern (Deneb-ready) version of `lcli` preinstalled so we no longer need to compile it. 
