### PR TITLE
[Merged by Bors] - Add block roots heal logic in v18 schema migration.

### DIFF
--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v18.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v18.rs
@@ -51,6 +51,9 @@ pub fn upgrade_to_v18<T: BeaconChainTypes>(
     db: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
     log: Logger,
 ) -> Result<Vec<KeyValueStoreOp>, Error> {
+    db.heal_freezer_block_roots()?;
+    info!(log, "Healed freezer block roots");
+
     // No-op, even if Deneb has already occurred. The database is probably borked in this case, but
     // *maybe* the fork recovery will revert the minority fork and succeed.
     if let Some(deneb_fork_epoch) = db.get_chain_spec().deneb_fork_epoch {


### PR DESCRIPTION
## Issue Addressed

Fixes #4697. 

This also unblocks the state pruning PR (#4835). Because self healing breaks if state pruning is applied to a database with missing block roots.

## Proposed Changes

- Fill in the missing block roots between last restore point slot and split slot when upgrading to latest database version.

