### PR TITLE
[Merged by Bors] - more logging improvements

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -343,7 +343,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 );
             }
             Ok(AvailabilityProcessingStatus::MissingComponents(_, _)) => {
-                warn!(
+                debug!(
                     self.log,
                     "Missing components over rpc";
                     "block_hash" => %block_root,

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -791,7 +791,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         match result {
             BlockProcessingResult::Ok(status) => match status {
                 AvailabilityProcessingStatus::Imported(root) => {
-                    debug!(self.log, "Single block processing succeeded"; "block" => %root);
+                    trace!(self.log, "Single block processing succeeded"; "block" => %root);
                 }
                 AvailabilityProcessingStatus::MissingComponents(_, _block_root) => {
                     match self.handle_missing_components::<R>(cx, &mut lookup) {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -786,13 +786,12 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             self.log,
             "Block component processed for lookup";
             "response_type" => ?R::response_type(),
-            "result" => ?result,
         );
 
         match result {
             BlockProcessingResult::Ok(status) => match status {
                 AvailabilityProcessingStatus::Imported(root) => {
-                    trace!(self.log, "Single block processing succeeded"; "block" => %root);
+                    debug!(self.log, "Single block processing succeeded"; "block" => %root);
                 }
                 AvailabilityProcessingStatus::MissingComponents(_, _block_root) => {
                     match self.handle_missing_components::<R>(cx, &mut lookup) {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -786,6 +786,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             self.log,
             "Block component processed for lookup";
             "response_type" => ?R::response_type(),
+            "block_root" => ?root,
         );
 
         match result {


### PR DESCRIPTION
## Issue Addressed

-downgrades `Missing components over rpc` to debug because this isn't unusual and just results in a re-try
-removes the result from  `Block component processed for lookup` because this prints the full block on an unknown parent error