### PR TITLE
[Merged by Bors] - restore cargo vendor in test suite

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -364,10 +364,8 @@ jobs:
       run:  make arbitrary-fuzz
     - name: Run cargo audit
       run: make audit-CI
-# TODO(sean): re-enable this when we can figure it out with c-kzg
-# Issue: https://github.com/sigp/lighthouse/issues/4440
-#    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
-#      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
+    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
+      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
   check-msrv:
     name: check-msrv
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Issue Addressed

resolves https://github.com/sigp/lighthouse/issues/4440

## Proposed Changes

restore our `cargo vendor` test in CI

changes to `c-kzg` here mean we no longer have to compile it twice and get duplicate source errors: https://github.com/sigp/lighthouse/pull/4862