### PR TITLE
Align proposer re-orgs with latest spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,6 +1856,7 @@ dependencies = [
  "fs2",
  "hex",
  "kzg",
+ "proto_array",
  "rayon",
  "serde",
  "serde_json",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4395,7 +4395,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// This function uses heuristics that align quite closely but not exactly with the re-org
     /// conditions set out in `get_state_for_re_org` and `get_proposer_head`. The differences are
     /// documented below.
-    fn overridden_forkchoice_update_params(
+    pub fn overridden_forkchoice_update_params(
         &self,
         canonical_forkchoice_params: ForkchoiceUpdateParameters,
     ) -> Result<ForkchoiceUpdateParameters, Error> {

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -716,6 +716,12 @@ impl<T: EthSpec> ExecutionLayer<T> {
         }
     }
 
+    pub async fn clear_proposer_preparation(&self, proposer_index: u64) {
+        self.proposer_preparation_data()
+            .await
+            .remove(&proposer_index);
+    }
+
     /// Removes expired entries from proposer_preparation_data and proposers caches
     async fn clean_proposer_caches(&self, current_epoch: Epoch) -> Result<(), Error> {
         let mut proposer_preparation_data = self.proposer_preparation_data().await;

--- a/consensus/fork_choice/src/fork_choice.rs
+++ b/consensus/fork_choice/src/fork_choice.rs
@@ -291,7 +291,7 @@ pub enum AttestationFromBlock {
 }
 
 /// Parameters which are cached between calls to `ForkChoice::get_head`.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ForkchoiceUpdateParameters {
     /// The most recent result of running `ForkChoice::get_head`.
     pub head_root: Hash256,

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -28,6 +28,7 @@ eth2_network_config = { workspace = true }
 ethereum_serde_utils = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
+proto_array = { workspace = true }
 tree_hash = { workspace = true }
 tree_hash_derive = { workspace = true }
 cached_tree_hash = { workspace = true }

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -547,6 +547,12 @@ fn fork_choice_withholding() {
 }
 
 #[test]
+fn fork_choice_get_proposer_head() {
+    ForkChoiceHandler::<MinimalEthSpec>::new("get_proposer_head").run();
+    ForkChoiceHandler::<MainnetEthSpec>::new("get_proposer_head").run();
+}
+
+#[test]
 fn optimistic_sync() {
     OptimisticSyncHandler::<MinimalEthSpec>::default().run();
     OptimisticSyncHandler::<MainnetEthSpec>::default().run();


### PR DESCRIPTION
## Proposed Changes

Update the proposer re-orgs feature for the latest spec, and add new spec test runners.

## Additional Info

- [ ] Add `REORG_PARENT_WEIGHT_THRESHOLD`.
- [ ] Rename `REORG_WEIGHT_THRESHOLD` to `REORG_HEAD_WEIGHT_THRESHOLD`.
- [ ] Add reorg parameters to ChainSpec/Config. We should use these as defaults while continuing to allow overrides via the CLI.