### PR TITLE
[Merged by Bors] - Fix comment for blob sidecar observation pruning

### DIFF
--- a/beacon_node/beacon_chain/src/observed_blob_sidecars.rs
+++ b/beacon_node/beacon_chain/src/observed_blob_sidecars.rs
@@ -87,7 +87,7 @@ impl<T: EthSpec> ObservedBlobSidecars<T> {
         Ok(())
     }
 
-    /// Prune all values earlier than the given slot.
+    /// Prune `blob_sidecar` observations for slots less than or equal to the given slot.
     pub fn prune(&mut self, finalized_slot: Slot) {
         if finalized_slot == 0 {
             return;


### PR DESCRIPTION
## Issue Addressed

The comment implies that observations for the given slot would be retained but they are not.

## Proposed Changes

I'm pretty sure the functionality is correct and the comment is slightly incorrect, so just update the comment. The comment needs to say something along the lines of "less than or equal to" rather than just "less than."

## Additional Info

It doesn't make sense to keep finalized observations since those are no longer accepted.
