### PR TITLE
add get light client bootstrap endpoint

### DIFF
--- a/beacon_node/http_api/src/light_client.rs
+++ b/beacon_node/http_api/src/light_client.rs
@@ -1,24 +1,77 @@
-use std::sync::Arc;
-
 use beacon_chain::{BeaconChain, BeaconChainTypes};
+use bytes::Bytes;
+use eth2::types;
+use eth2::types::{self as api_types};
+use slot_clock::SlotClock;
+use ssz::Encode;
+use std::sync::Arc;
 use types::{light_client_bootstrap::LightClientBootstrap, EthSpec, Hash256};
+use warp::{
+    hyper::{Body, Response},
+    Reply,
+};
 
-use crate::Error;
+use crate::version::add_consensus_version_header;
 
 pub async fn get_light_client_bootstrap<T: BeaconChainTypes, E: EthSpec>(
     chain: Arc<BeaconChain<T>>,
     block_root: Hash256,
-) -> Result<LightClientBootstrap<T::EthSpec>, Error> {
-    let Some(block) = chain.get_block(&block_root).await.unwrap() else {
-        panic!();
-    };
+    accept_header: Option<api_types::Accept>,
+) -> Result<Response<Body>, warp::Rejection> {
+    let is_altair_or_greater = chain
+        .spec
+        .altair_fork_epoch
+        .and_then(|fork_epoch| {
+            let current_epoch = chain.slot_clock.now()?.epoch(E::slots_per_epoch());
+            Some(current_epoch >= fork_epoch)
+        })
+        .unwrap_or(false);
 
-    let Some(mut state) = chain
+    if !is_altair_or_greater {
+        return Err(warp_utils::reject::custom_bad_request(format!(
+            "cannot fetch pre altair"
+        )));
+    }
+
+    let block = chain
+        .get_block(&block_root)
+        .await
+        .map_err(|e| {
+            warp_utils::reject::custom_bad_request(format!("failed to fetch beacon block: {:?}", e))
+        })?
+        .ok_or_else(|| warp_utils::reject::custom_bad_request(format!("no beacon block found")))?;
+
+    let mut state = chain
         .get_state(&block.state_root(), Some(block.slot()))
-        .unwrap()
-    else {
-        panic!();
-    };
+        .map_err(|e| {
+            warp_utils::reject::custom_bad_request(format!("failed to fetch beacon state: {:?}", e))
+        })?
+        .ok_or_else(|| warp_utils::reject::custom_bad_request(format!("no beacon state found")))?;
 
-    Ok(LightClientBootstrap::create_light_client_bootstrap(&mut state, block).unwrap())
+    let fork_name = state.fork_name(&chain.spec).map_err(|e| {
+        warp_utils::reject::custom_bad_request(format!("failed to fetch fork name: {:?}", e))
+    })?;
+
+    let light_client_bootstrap =
+        LightClientBootstrap::create_light_client_bootstrap(&mut state, block).map_err(|e| {
+            warp_utils::reject::custom_bad_request(format!(
+                "failed to create light client bootstrap: {:?}",
+                e
+            ))
+        })?;
+
+    match accept_header {
+        Some(_) => Response::builder()
+            .status(200)
+            .header("Content-Type", "application/octet-stream")
+            .body(light_client_bootstrap.as_ssz_bytes().into())
+            .map(|res: Response<Bytes>| add_consensus_version_header(res, fork_name))
+            .map_err(|e| {
+                warp_utils::reject::custom_server_error(format!("failed to create response: {}", e))
+            }),
+        None => Ok(add_consensus_version_header(
+            warp::reply::json(&light_client_bootstrap).into_response(),
+            fork_name,
+        )),
+    }
 }

--- a/beacon_node/http_api/src/light_client.rs
+++ b/beacon_node/http_api/src/light_client.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use types::{light_client_bootstrap::LightClientBootstrap, EthSpec, Hash256};
+
+use crate::Error;
+
+pub async fn get_light_client_bootstrap<T: BeaconChainTypes, E: EthSpec>(
+    chain: Arc<BeaconChain<T>>,
+    block_root: Hash256,
+) -> Result<LightClientBootstrap<T::EthSpec>, Error> {
+    let Some(block) = chain.get_block(&block_root).await.unwrap() else {
+        panic!();
+    };
+
+    let Some(mut state) = chain
+        .get_state(&block.state_root(), Some(block.slot()))
+        .unwrap()
+    else {
+        panic!();
+    };
+
+    Ok(LightClientBootstrap::create_light_client_bootstrap(&mut state, block).unwrap())
+}

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,7 +1,6 @@
 use super::{BeaconBlockHeader, BeaconState, EthSpec, FixedVector, Hash256, SyncCommittee};
 use crate::{
-    light_client_update::*, test_utils::TestRandom, AbstractExecPayload, BlindedBeaconBlock,
-    SignedBeaconBlock,
+    light_client_update::*, test_utils::TestRandom, AbstractExecPayload, Epoch, SignedBeaconBlock,
 };
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
@@ -50,11 +49,8 @@ impl<T: EthSpec> LightClientBootstrap<T> {
         beacon_state: &mut BeaconState<T>,
         signed_beacon_block: SignedBeaconBlock<T, Payload>,
     ) -> Result<Self, Error> {
-        // TODO check that we're altair or greater
-
         if beacon_state.slot() != beacon_state.latest_block_header().slot {
-            // TODO return error related to slot
-            return Err(Error::AltairForkNotActive);
+            return Err(Error::CreateBootstrapError);
         }
 
         let mut header = beacon_state.latest_block_header().clone();
@@ -62,8 +58,7 @@ impl<T: EthSpec> LightClientBootstrap<T> {
         header.state_root = beacon_state.tree_hash_root();
 
         if header.tree_hash_root() != signed_beacon_block.message().tree_hash_root() {
-            // TODO return error related to tree hash root
-            return Err(Error::AltairForkNotActive);
+            return Err(Error::CreateBootstrapError);
         }
 
         let current_sync_committee_branch =

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,5 +1,8 @@
 use super::{BeaconBlockHeader, BeaconState, EthSpec, FixedVector, Hash256, SyncCommittee};
-use crate::{light_client_update::*, test_utils::TestRandom};
+use crate::{
+    light_client_update::*, test_utils::TestRandom, AbstractExecPayload, BlindedBeaconBlock,
+    SignedBeaconBlock,
+};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use std::sync::Arc;
@@ -36,6 +39,36 @@ impl<T: EthSpec> LightClientBootstrap<T> {
         header.state_root = beacon_state.tree_hash_root();
         let current_sync_committee_branch =
             beacon_state.compute_merkle_proof(CURRENT_SYNC_COMMITTEE_INDEX)?;
+        Ok(LightClientBootstrap {
+            header,
+            current_sync_committee: beacon_state.current_sync_committee()?.clone(),
+            current_sync_committee_branch: FixedVector::new(current_sync_committee_branch)?,
+        })
+    }
+
+    pub fn create_light_client_bootstrap<Payload: AbstractExecPayload<T>>(
+        beacon_state: &mut BeaconState<T>,
+        signed_beacon_block: SignedBeaconBlock<T, Payload>,
+    ) -> Result<Self, Error> {
+        // TODO check that we're altair or greater
+
+        if beacon_state.slot() != beacon_state.latest_block_header().slot {
+            // TODO return error related to slot
+            return Err(Error::AltairForkNotActive);
+        }
+
+        let mut header = beacon_state.latest_block_header().clone();
+
+        header.state_root = beacon_state.tree_hash_root();
+
+        if header.tree_hash_root() != signed_beacon_block.message().tree_hash_root() {
+            // TODO return error related to tree hash root
+            return Err(Error::AltairForkNotActive);
+        }
+
+        let current_sync_committee_branch =
+            beacon_state.compute_merkle_proof(CURRENT_SYNC_COMMITTEE_INDEX)?;
+
         Ok(LightClientBootstrap {
             header,
             current_sync_committee: beacon_state.current_sync_committee()?.clone(),

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -29,6 +29,7 @@ pub enum Error {
     NotEnoughSyncCommitteeParticipants,
     MismatchingPeriods,
     InvalidFinalizedBlock,
+    CreateBootstrapError,
 }
 
 impl From<ssz_types::Error> for Error {


### PR DESCRIPTION
## Issue Addressed

#4894

## Proposed Changes

Add support for the `GET light_client/bootstrap` endpoint in the beacon api

https://ethereum.github.io/beacon-APIs/#/Beacon/getLightClientBootstrap

## Additional Info

