### PR TITLE
Add block-v3 SSZ tests

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2604,6 +2604,98 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_block_production_v3_ssz(self) -> Self {
+        let fork = self.chain.canonical_head.cached_head().head_fork();
+        let genesis_validators_root = self.chain.genesis_validators_root;
+
+        for _ in 0..E::slots_per_epoch() * 3 {
+            let slot = self.chain.slot().unwrap();
+            let epoch = self.chain.epoch().unwrap();
+
+            let proposer_pubkey_bytes = self
+                .client
+                .get_validator_duties_proposer(epoch)
+                .await
+                .unwrap()
+                .data
+                .into_iter()
+                .find(|duty| duty.slot == slot)
+                .map(|duty| duty.pubkey)
+                .unwrap();
+            let proposer_pubkey = (&proposer_pubkey_bytes).try_into().unwrap();
+
+            let sk = self
+                .validator_keypairs()
+                .iter()
+                .find(|kp| kp.pk == proposer_pubkey)
+                .map(|kp| kp.sk.clone())
+                .unwrap();
+
+            let randao_reveal = {
+                let domain = self.chain.spec.get_domain(
+                    epoch,
+                    Domain::Randao,
+                    &fork,
+                    genesis_validators_root,
+                );
+                let message = epoch.signing_root(domain);
+                sk.sign(message).into()
+            };
+
+            let (fork_version_response_bytes, is_blinded_payload) = self
+                .client
+                .get_validator_blocks_v3_ssz::<E>(slot, &randao_reveal, None)
+                .await
+                .unwrap();
+
+            if is_blinded_payload {
+                let block_contents = <BlockContents<E, BlindedPayload<E>>>::from_ssz_bytes(
+                    &fork_version_response_bytes.unwrap(),
+                    &self.chain.spec,
+                )
+                .expect("block contents bytes can be decoded");
+
+                let signed_block_contents =
+                    block_contents.sign(&sk, &fork, genesis_validators_root, &self.chain.spec);
+
+                self.client
+                    .post_beacon_blocks_ssz(&signed_block_contents)
+                    .await
+                    .unwrap();
+                
+                // This converts the generic `Payload` to a concrete type for comparison.
+                let signed_block = signed_block_contents.deconstruct().0;
+                let head_block = SignedBeaconBlock::from(signed_block.clone());
+                assert_eq!(head_block, signed_block);
+
+                self.chain.slot_clock.set_slot(slot.as_u64() + 1);
+            } else {
+                let block_contents = <BlockContents<E, FullPayload<E>>>::from_ssz_bytes(
+                    &fork_version_response_bytes.unwrap(),
+                    &self.chain.spec,
+                )
+                .expect("block contents bytes can be decoded");
+
+                let signed_block_contents =
+                    block_contents.sign(&sk, &fork, genesis_validators_root, &self.chain.spec);
+
+                self.client
+                    .post_beacon_blocks_ssz(&signed_block_contents)
+                    .await
+                    .unwrap();
+
+                assert_eq!(
+                    self.chain.head_beacon_block().as_ref(),
+                    signed_block_contents.signed_block()
+                );
+
+                self.chain.slot_clock.set_slot(slot.as_u64() + 1);
+            }
+        }
+
+        self
+    }
+
     pub async fn test_block_production_no_verify_randao(self) -> Self {
         for _ in 0..E::slots_per_epoch() {
             let slot = self.chain.slot().unwrap();
@@ -5050,6 +5142,20 @@ async fn block_production_ssz_with_skip_slots() {
         .await
         .skip_slots(E::slots_per_epoch() * 2)
         .test_block_production_ssz()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_production_ssz_v3() {
+    ApiTester::new().await.test_block_production_v3_ssz().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_production_v3_ssz_with_skip_slots() {
+    ApiTester::new()
+        .await
+        .skip_slots(E::slots_per_epoch() * 2)
+        .test_block_production_v3_ssz()
         .await;
 }
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2662,7 +2662,7 @@ impl ApiTester {
                     .post_beacon_blocks_ssz(&signed_block_contents)
                     .await
                     .unwrap();
-                
+
                 // This converts the generic `Payload` to a concrete type for comparison.
                 let signed_block = signed_block_contents.deconstruct().0;
                 let head_block = SignedBeaconBlock::from(signed_block.clone());

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -272,6 +272,31 @@ impl BeaconNodeHttpClient {
         }
     }
 
+    /// Perform a HTTP GET request using an 'accept' header, returning `None` on a 404 error.
+    pub async fn get_bytes_response_with_response_headers<U: IntoUrl>(
+        &self,
+        url: U,
+        accept_header: Accept,
+        timeout: Duration,
+    ) -> Result<(Option<Vec<u8>>, Option<HeaderMap>), Error> {
+        let opt_response = self
+            .get_response(url, |b| b.accept(accept_header).timeout(timeout))
+            .await
+            .optional()?;
+
+        // let headers = opt_response.headers();
+        match opt_response {
+            Some(resp) => {
+                let response_headers = resp.headers().clone();
+                Ok((
+                    Some(resp.bytes().await?.into_iter().collect::<Vec<_>>()),
+                    Some(response_headers),
+                ))
+            }
+            None => Ok((None, None)),
+        }
+    }
+
     /// Perform a HTTP POST request.
     async fn post<T: Serialize, U: IntoUrl>(&self, url: U, body: &T) -> Result<(), Error> {
         self.post_generic(url, body, None).await?;
@@ -1684,6 +1709,38 @@ impl BeaconNodeHttpClient {
         Ok(path)
     }
 
+    /// returns `GET v3/validator/blocks/{slot}` URL path
+    pub async fn get_validator_blocks_v3_path<T: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+    ) -> Result<Url, Error> {
+        let mut path = self.eth_path(V3)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("validator")
+            .push("blocks")
+            .push(&slot.to_string());
+
+        path.query_pairs_mut()
+            .append_pair("randao_reveal", &randao_reveal.to_string());
+
+        if let Some(graffiti) = graffiti {
+            path.query_pairs_mut()
+                .append_pair("graffiti", &graffiti.to_string());
+        }
+
+        if skip_randao_verification == SkipRandaoVerification::Yes {
+            path.query_pairs_mut()
+                .append_pair("skip_randao_verification", "");
+        }
+
+        Ok(path)
+    }
+
     /// `GET v3/validator/blocks/{slot}`
     pub async fn get_validator_blocks_v3<T: EthSpec>(
         &self,
@@ -1708,26 +1765,14 @@ impl BeaconNodeHttpClient {
         graffiti: Option<&Graffiti>,
         skip_randao_verification: SkipRandaoVerification,
     ) -> Result<ForkVersionedBeaconBlockType<T>, Error> {
-        let mut path = self.eth_path(V3)?;
-
-        path.path_segments_mut()
-            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
-            .push("validator")
-            .push("blocks")
-            .push(&slot.to_string());
-
-        path.query_pairs_mut()
-            .append_pair("randao_reveal", &randao_reveal.to_string());
-
-        if let Some(graffiti) = graffiti {
-            path.query_pairs_mut()
-                .append_pair("graffiti", &graffiti.to_string());
-        }
-
-        if skip_randao_verification == SkipRandaoVerification::Yes {
-            path.query_pairs_mut()
-                .append_pair("skip_randao_verification", "");
-        }
+        let path = self
+            .get_validator_blocks_v3_path::<T>(
+                slot,
+                randao_reveal,
+                graffiti,
+                skip_randao_verification,
+            )
+            .await?;
 
         let response = self.get_response(path, |b| b).await?;
 
@@ -1748,6 +1793,58 @@ impl BeaconNodeHttpClient {
                 .await?;
             Ok(ForkVersionedBeaconBlockType::Full(full_payload))
         }
+    }
+
+    /// `GET v3/validator/blocks/{slot}` in ssz format
+    pub async fn get_validator_blocks_v3_ssz<T: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+    ) -> Result<(Option<Vec<u8>>, bool), Error> {
+        self.get_validator_blocks_v3_modular_ssz::<T>(
+            slot,
+            randao_reveal,
+            graffiti,
+            SkipRandaoVerification::No,
+        )
+        .await
+    }
+
+    /// `GET v3/validator/blocks/{slot}` in ssz format
+    pub async fn get_validator_blocks_v3_modular_ssz<T: EthSpec>(
+        &self,
+        slot: Slot,
+        randao_reveal: &SignatureBytes,
+        graffiti: Option<&Graffiti>,
+        skip_randao_verification: SkipRandaoVerification,
+    ) -> Result<(Option<Vec<u8>>, bool), Error> {
+        let path = self
+            .get_validator_blocks_v3_path::<T>(
+                slot,
+                randao_reveal,
+                graffiti,
+                skip_randao_verification,
+            )
+            .await?;
+
+        let (response_content, response_headers) = self
+            .get_bytes_response_with_response_headers(
+                path,
+                Accept::Ssz,
+                self.timeouts.get_validator_block_ssz,
+            )
+            .await?;
+
+        let is_blinded_payload = match response_headers {
+            Some(headers) => headers
+                .get(EXECUTION_PAYLOAD_BLINDED_HEADER)
+                .map(|value| value.to_str().unwrap_or_default().to_lowercase() == "true")
+                .unwrap_or(false),
+            None => false,
+        };
+
+        Ok((response_content, is_blinded_payload))
     }
 
     /// `GET v2/validator/blocks/{slot}` in ssz format


### PR DESCRIPTION
## Proposed Changes

Add ssz tests for the block v3 endpoint. These tests were missed in the original block v3 PR. Also, these changes are required in this PR https://github.com/blockprint-collective/blockdreamer/pull/5 to test the block v3 ssz flow in blockdreamer

