### PR TITLE
Fix missed block logs

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -621,19 +621,19 @@ impl<T: EthSpec> ValidatorMonitor<T> {
                                             "parent block root" => ?prev_block_root,
                                         );
                                     }
-                                } else {
-                                    warn!(
-                                        self.log,
-                                        "Missing validator index";
-                                        "info" => "potentially inconsistency in the validator manager",
-                                        "index" => i,
-                                    )
                                 }
+                            } else {
+                                warn!(
+                                    self.log,
+                                    "Missing validator index";
+                                    "info" => "potentially inconsistency in the validator manager",
+                                    "index" => i,
+                                )
                             }
                         } else {
                             debug!(
                                 self.log,
-                                "Could not get proposers for from cache";
+                                "Could not get proposers from cache";
                                 "epoch" => ?slot_epoch
                             );
                         }


### PR DESCRIPTION
## Proposed Changes

Without this patch Lighthouse frequently logs:

> Nov 12 14:16:53.206 WARN Missing validator index                 index: 313814, info: potentially inconsistency in the validator manager, service: val_mon, service: beacon

The reason is that `self.indices` contains indices for _all_ validators, while `self.pubkeys` only contains pubkeys for monitored validators. The log occurs when a non-monitored validator misses a block.

Bug was introduced in https://github.com/sigp/lighthouse/pull/4731
