### PR TITLE
Modify `max_messages_per_rpc` from 500 to 5000

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -506,7 +506,7 @@ pub fn gossipsub_config(
         .gossip_lazy(load.gossip_lazy)
         .fanout_ttl(Duration::from_secs(60))
         .history_length(12)
-        .max_messages_per_rpc(Some(500)) // Responses to IWANT can be quite large
+        .max_messages_per_rpc(Some(5000)) // Responses to IWANT can be quite large
         .history_gossip(load.history_gossip)
         .validate_messages() // require validation before propagation
         .validation_mode(gossipsub::ValidationMode::Anonymous)


### PR DESCRIPTION


## Proposed Changes

The parameter `max_ihave_length` of libp2p gossipsub is set to 5000 by default. After another peer sends an IHAVE message containing 5000 message IDs, our peer will send it an IWANT message containing 5000 message IDs, and then it will send us 5000 messages in a rpc.

Since the parameter `max_messages_per_rpc` is set to 500, the remaining 4500 messages will be ignored, resulting in a decrease in the other peer's score and no longer receiving messages from it.

Therefore, this PR modifies the parameter `max_messages_per_rpc` from 500 to 5000.
