### PR TITLE
Fix Rust 1.74. clippy and `rustfmt` errors

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -569,9 +569,7 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (root, execution_optimistic, finalized) = state_id.root(&chain)?;
-                    Ok(root)
-                        .map(api_types::RootData::from)
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::GenericResponse::from(api_types::RootData::from(root)))
                         .map(|resp| {
                             resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
                         })
@@ -1939,9 +1937,7 @@ pub fn serve<T: BeaconChainTypes>(
                         chain
                             .naive_aggregation_pool
                             .read()
-                            .iter()
-                            .cloned()
-                            .filter(|att| query_filter(&att.data)),
+                            .iter().filter(|&att| query_filter(&att.data)).cloned(),
                     );
                     Ok(api_types::GenericResponse::from(attestations))
                 })
@@ -2318,8 +2314,7 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (rewards, execution_optimistic, finalized) =
                         standard_block_rewards::compute_beacon_block_rewards(chain, block_id)?;
-                    Ok(rewards)
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::GenericResponse::from(rewards))
                         .map(|resp| {
                             resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
                         })
@@ -2435,8 +2430,7 @@ pub fn serve<T: BeaconChainTypes>(
                     let execution_optimistic =
                         chain.is_optimistic_or_invalid_head().unwrap_or_default();
 
-                    Ok(attestation_rewards)
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::GenericResponse::from(attestation_rewards))
                         .map(|resp| resp.add_execution_optimistic(execution_optimistic))
                 })
             },
@@ -2462,8 +2456,7 @@ pub fn serve<T: BeaconChainTypes>(
                             chain, block_id, validators, log,
                         )?;
 
-                    Ok(rewards)
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::GenericResponse::from(rewards))
                         .map(|resp| {
                             resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
                         })

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -569,10 +569,12 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (root, execution_optimistic, finalized) = state_id.root(&chain)?;
-                    Ok(api_types::GenericResponse::from(api_types::RootData::from(root)))
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(api_types::RootData::from(
+                        root,
+                    )))
+                    .map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );
@@ -1937,7 +1939,9 @@ pub fn serve<T: BeaconChainTypes>(
                         chain
                             .naive_aggregation_pool
                             .read()
-                            .iter().filter(|&att| query_filter(&att.data)).cloned(),
+                            .iter()
+                            .filter(|&att| query_filter(&att.data))
+                            .cloned(),
                     );
                     Ok(api_types::GenericResponse::from(attestations))
                 })
@@ -2314,10 +2318,9 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (rewards, execution_optimistic, finalized) =
                         standard_block_rewards::compute_beacon_block_rewards(chain, block_id)?;
-                    Ok(api_types::GenericResponse::from(rewards))
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(rewards)).map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );
@@ -2456,10 +2459,9 @@ pub fn serve<T: BeaconChainTypes>(
                             chain, block_id, validators, log,
                         )?;
 
-                    Ok(api_types::GenericResponse::from(rewards))
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(rewards)).map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -378,7 +378,7 @@ fn handle_error<T>(
                 Ok(None)
             }
         }
-        _ => Err(err).map_err(RPCError::from),
+        _ => Err(RPCError::from(err)),
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Fix lint error here: 
https://github.com/sigp/lighthouse/actions/runs/6899736366/job/18771804765?pr=3954

Formatting error here:
https://github.com/sigp/lighthouse/actions/runs/6899976078/job/18772421594?pr=4931

There's a separate PR to fix new beta compiler warnings here: https://github.com/sigp/lighthouse/pull/4932