### PR TITLE
Fix Rust beta compiler warnings (rustc 1.75.0-beta.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,8 @@ lint:
 		-A clippy::upper-case-acronyms \
 		-A clippy::vec-init-then-push \
 		-A clippy::question-mark \
-		-A clippy::uninlined-format-args
+		-A clippy::uninlined-format-args \
+		-A clippy::enum_variant_names
 
 # Lints the code using Clippy and automatically fix some simple compiler warnings.
 lint-fix:

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -18,7 +18,7 @@ use crate::block_verification::{
 use crate::block_verification_types::{
     AsBlock, AvailableExecutedBlock, BlockImportData, ExecutedBlock, RpcBlock,
 };
-pub use crate::canonical_head::{CanonicalHead, CanonicalHeadRwLock};
+pub use crate::canonical_head::CanonicalHead;
 use crate::chain_config::ChainConfig;
 use crate::data_availability_checker::{
     Availability, AvailabilityCheckError, AvailableBlock, DataAvailabilityChecker,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -93,21 +93,15 @@ impl<E: EthSpec> TryFrom<BuilderBid<E>> for ProvenancedPayload<BlockProposalCont
     fn try_from(value: BuilderBid<E>) -> Result<Self, Error> {
         let block_proposal_contents = match value {
             BuilderBid::Merge(builder_bid) => BlockProposalContents::Payload {
-                payload: ExecutionPayloadHeader::Merge(builder_bid.header)
-                    .try_into()
-                    .map_err(|_| Error::InvalidPayloadConversion)?,
+                payload: ExecutionPayloadHeader::Merge(builder_bid.header).into(),
                 block_value: builder_bid.value,
             },
             BuilderBid::Capella(builder_bid) => BlockProposalContents::Payload {
-                payload: ExecutionPayloadHeader::Capella(builder_bid.header)
-                    .try_into()
-                    .map_err(|_| Error::InvalidPayloadConversion)?,
+                payload: ExecutionPayloadHeader::Capella(builder_bid.header).into(),
                 block_value: builder_bid.value,
             },
             BuilderBid::Deneb(builder_bid) => BlockProposalContents::PayloadAndBlobs {
-                payload: ExecutionPayloadHeader::Deneb(builder_bid.header)
-                    .try_into()
-                    .map_err(|_| Error::InvalidPayloadConversion)?,
+                payload: ExecutionPayloadHeader::Deneb(builder_bid.header).into(),
                 block_value: builder_bid.value,
                 kzg_commitments: builder_bid.blinded_blobs_bundle.commitments,
                 blobs: BlobItems::<E>::try_from_blob_roots(

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -655,14 +655,17 @@ pub fn load_test_blobs_bundle<E: EthSpec>() -> Result<(KzgCommitment, KzgProof, 
 
     Ok((
         commitments
-            .get(0)
+            .first()
             .cloned()
             .ok_or("commitment missing in test bundle")?,
         proofs
-            .get(0)
+            .first()
             .cloned()
             .ok_or("proof missing in test bundle")?,
-        blobs.get(0).cloned().ok_or("blob missing in test bundle")?,
+        blobs
+            .first()
+            .cloned()
+            .ok_or("blob missing in test bundle")?,
     ))
 }
 

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -1,4 +1,4 @@
-pub use crate::{common::genesis_deposits, interop::interop_genesis_state};
+pub use crate::common::genesis_deposits;
 pub use eth1::Config as Eth1Config;
 
 use eth1::{DepositLog, Eth1Block, Service as Eth1Service};

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -569,12 +569,12 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (root, execution_optimistic, finalized) = state_id.root(&chain)?;
-                    Ok(root)
-                        .map(api_types::RootData::from)
-                        .map(api_types::GenericResponse::from)
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(api_types::RootData::from(
+                        root,
+                    )))
+                    .map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );
@@ -1940,8 +1940,8 @@ pub fn serve<T: BeaconChainTypes>(
                             .naive_aggregation_pool
                             .read()
                             .iter()
-                            .cloned()
-                            .filter(|att| query_filter(&att.data)),
+                            .filter(|&att| query_filter(&att.data))
+                            .cloned(),
                     );
                     Ok(api_types::GenericResponse::from(attestations))
                 })
@@ -2318,11 +2318,9 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_json_task(Priority::P1, move || {
                     let (rewards, execution_optimistic, finalized) =
                         standard_block_rewards::compute_beacon_block_rewards(chain, block_id)?;
-                    Ok(rewards)
-                        .map(api_types::GenericResponse::from)
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(rewards)).map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );
@@ -2435,8 +2433,7 @@ pub fn serve<T: BeaconChainTypes>(
                     let execution_optimistic =
                         chain.is_optimistic_or_invalid_head().unwrap_or_default();
 
-                    Ok(attestation_rewards)
-                        .map(api_types::GenericResponse::from)
+                    Ok(api_types::GenericResponse::from(attestation_rewards))
                         .map(|resp| resp.add_execution_optimistic(execution_optimistic))
                 })
             },
@@ -2462,11 +2459,9 @@ pub fn serve<T: BeaconChainTypes>(
                             chain, block_id, validators, log,
                         )?;
 
-                    Ok(rewards)
-                        .map(api_types::GenericResponse::from)
-                        .map(|resp| {
-                            resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
-                        })
+                    Ok(api_types::GenericResponse::from(rewards)).map(|resp| {
+                        resp.add_execution_optimistic_finalized(execution_optimistic, finalized)
+                    })
                 })
             },
         );

--- a/beacon_node/http_metrics/src/metrics.rs
+++ b/beacon_node/http_metrics/src/metrics.rs
@@ -4,8 +4,6 @@ use lighthouse_metrics::TextEncoder;
 use lighthouse_network::prometheus_client::encoding::text::encode;
 use malloc_utils::scrape_allocator_metrics;
 
-pub use lighthouse_metrics::*;
-
 pub fn gather_prometheus_metrics<T: BeaconChainTypes>(
     ctx: &Context<T>,
 ) -> std::result::Result<String, String> {

--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -1,6 +1,6 @@
 //! Helper functions and an extension trait for Ethereum 2 ENRs.
 
-pub use discv5::enr::{self, CombinedKey, EnrBuilder};
+pub use discv5::enr::{CombinedKey, EnrBuilder};
 
 use super::enr_ext::CombinedKeyExt;
 use super::ENR_FILENAME;

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1489,7 +1489,7 @@ mod tests {
         assert!(the_best.is_some());
         // Consistency check
         let best_peers = pdb.best_peers_by_status(PeerInfo::is_connected);
-        assert_eq!(the_best.unwrap(), best_peers.get(0).unwrap().0);
+        assert_eq!(the_best.unwrap(), best_peers.first().unwrap().0);
     }
 
     #[test]

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -378,7 +378,7 @@ fn handle_error<T>(
                 Ok(None)
             }
         }
-        _ => Err(err).map_err(RPCError::from),
+        _ => Err(RPCError::from(err)),
     }
 }
 

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -224,7 +224,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         request_id: PeerRequestId,
         request: BlobsByRootRequest,
     ) {
-        let Some(requested_root) = request.blob_ids.get(0).map(|id| id.block_root) else {
+        let Some(requested_root) = request.blob_ids.first().map(|id| id.block_root) else {
             // No blob ids requested.
             return;
         };

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -929,7 +929,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 .collect::<Vec<_>>();
             // Sort peers prioritizing unrelated peers with less active requests.
             priorized_peers.sort_unstable();
-            priorized_peers.get(0).map(|&(_, _, peer)| peer)
+            priorized_peers.first().map(|&(_, _, peer)| peer)
         };
 
         if let Some(peer) = new_peer {

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1635,7 +1635,7 @@ mod deneb_only {
             self
         }
         fn invalidate_blobs_too_many(mut self) -> Self {
-            let first_blob = self.blobs.get(0).expect("blob").clone();
+            let first_blob = self.blobs.first().expect("blob").clone();
             self.blobs.push(first_blob);
             self
         }

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -885,7 +885,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
                 .collect::<Vec<_>>();
             // Sort peers prioritizing unrelated peers with less active requests.
             priorized_peers.sort_unstable();
-            priorized_peers.get(0).map(|&(_, _, peer)| peer)
+            priorized_peers.first().map(|&(_, _, peer)| peer)
         };
 
         if let Some(peer) = new_peer {

--- a/common/slot_clock/src/system_time_slot_clock.rs
+++ b/common/slot_clock/src/system_time_slot_clock.rs
@@ -2,8 +2,6 @@ use super::{ManualSlotClock, SlotClock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use types::Slot;
 
-pub use std::time::SystemTimeError;
-
 /// Determines the present slot based upon the present system time.
 #[derive(Clone)]
 pub struct SystemTimeSlotClock {

--- a/consensus/merkle_proof/src/lib.rs
+++ b/consensus/merkle_proof/src/lib.rs
@@ -250,7 +250,7 @@ impl MerkleTree {
         if deposit_count == (0x1 << level) {
             return Ok(MerkleTree::Finalized(
                 *finalized_branch
-                    .get(0)
+                    .first()
                     .ok_or(MerkleTreeError::PleaseNotifyTheDevs)?,
             ));
         }

--- a/consensus/types/src/sync_aggregator_selection_data.rs
+++ b/consensus/types/src/sync_aggregator_selection_data.rs
@@ -25,11 +25,11 @@ pub struct SyncAggregatorSelectionData {
     pub subcommittee_index: u64,
 }
 
+impl SignedRoot for SyncAggregatorSelectionData {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     ssz_and_tree_hash_tests!(SyncAggregatorSelectionData);
 }
-
-impl SignedRoot for SyncAggregatorSelectionData {}

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -127,7 +127,7 @@ vectors_and_tests!(
     ExitTest {
         block_modifier: Box::new(|_, block| {
             // Duplicate the exit
-            let exit = block.body().voluntary_exits().get(0).unwrap().clone();
+            let exit = block.body().voluntary_exits().first().unwrap().clone();
             block.body_mut().voluntary_exits_mut().push(exit).unwrap();
         }),
         expected: Err(BlockProcessingError::ExitInvalid {

--- a/watch/src/blockprint/mod.rs
+++ b/watch/src/blockprint/mod.rs
@@ -17,7 +17,7 @@ pub use config::Config;
 pub use database::{
     get_blockprint_by_root, get_blockprint_by_slot, get_highest_blockprint, get_lowest_blockprint,
     get_unknown_blockprint, get_validators_clients_at_slot, insert_batch_blockprint,
-    list_consensus_clients, WatchBlockprint,
+    WatchBlockprint,
 };
 pub use server::blockprint_routes;
 

--- a/watch/src/database/mod.rs
+++ b/watch/src/database/mod.rs
@@ -26,24 +26,29 @@ pub use self::error::Error;
 pub use self::models::{WatchBeaconBlock, WatchCanonicalSlot, WatchProposerInfo, WatchValidator};
 pub use self::watch_types::{WatchHash, WatchPK, WatchSlot};
 
+// Clippy has false positives on these re-exports from Rust 1.75.0-beta.1.
+#[allow(unused_imports)]
 pub use crate::block_rewards::{
     get_block_rewards_by_root, get_block_rewards_by_slot, get_highest_block_rewards,
     get_lowest_block_rewards, get_unknown_block_rewards, insert_batch_block_rewards,
     WatchBlockRewards,
 };
 
+#[allow(unused_imports)]
 pub use crate::block_packing::{
     get_block_packing_by_root, get_block_packing_by_slot, get_highest_block_packing,
     get_lowest_block_packing, get_unknown_block_packing, insert_batch_block_packing,
     WatchBlockPacking,
 };
 
+#[allow(unused_imports)]
 pub use crate::suboptimal_attestations::{
     get_all_suboptimal_attestations_for_epoch, get_attestation_by_index, get_attestation_by_pubkey,
     get_highest_attestation, get_lowest_attestation, insert_batch_suboptimal_attestations,
     WatchAttestation, WatchSuboptimalAttestation,
 };
 
+#[allow(unused_imports)]
 pub use crate::blockprint::{
     get_blockprint_by_root, get_blockprint_by_slot, get_highest_blockprint, get_lowest_blockprint,
     get_unknown_blockprint, get_validators_clients_at_slot, insert_batch_blockprint,


### PR DESCRIPTION
## Issue Addressed

Fix new warnings from new Rust beta compiler (rustc 1.75.0-beta.1).

Also:
- Add `clippy::enum_variant_names` to allowed list. We prefer `Error::BeaconStateError`  over `Error::BeaconState`.
- Ignore some `unused_imports` in `watch::database` as they seem to be false positives. We could probably change the way we do imports within `watch` as it isn't used elsewhere, but it won't allow us to arrange it the way it currently is, i.e. re-exporting database related functions via the `watch::database` module.