### PR TITLE
Implement graffiti management API

### DIFF
--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -737,17 +737,15 @@ impl ValidatorClientHttpClient {
     ) -> Result<(), Error> {
         let url = self.make_graffiti_url(pubkey)?;
         let set_graffiti_request = SetGraffitiRequest {
-            graffiti: Some(graffiti),
+            graffiti,
         };
-        self.post(url, &set_graffiti_request).await?;
-        Ok(())
+        self.post(url, &set_graffiti_request).await
     }
 
     /// `DELETE /eth/v1/validator/{pubkey}/graffiti`
     pub async fn delete_graffiti(&self, pubkey: &PublicKeyBytes) -> Result<(), Error> {
         let url = self.make_graffiti_url(pubkey)?;
-        self.delete(url).await?;
-        Ok(())
+        self.delete(url).await
     }
 }
 

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -729,10 +729,13 @@ impl ValidatorClientHttpClient {
     pub async fn set_graffiti(
         &self,
         pubkey: &PublicKeyBytes,
-        graffiti: Graffiti,
+        graffiti: GraffitiString,
     ) -> Result<(), Error> {
         let url = self.make_graffiti_url(pubkey)?;
-        self.post(url, &graffiti).await?;
+        let set_graffiti_request = SetGraffitiRequest {
+            graffiti: Some(graffiti),
+        };
+        self.post(url, &set_graffiti_request).await?;
         Ok(())
     }
 

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -537,6 +537,18 @@ impl ValidatorClientHttpClient {
         Ok(url)
     }
 
+    fn make_get_graffiti_url(&self, pubkey: &PublicKeyBytes) -> Result<Url, Error> {
+        let mut url = self.server.full.clone();
+        url.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("eth")
+            .push("v1")
+            .push("validator")
+            .push(&pubkey.to_string())
+            .push("graffiti");
+        Ok(url)
+    }
+
     fn make_gas_limit_url(&self, pubkey: &PublicKeyBytes) -> Result<Url, Error> {
         let mut url = self.server.full.clone();
         url.path_segments_mut()
@@ -683,6 +695,17 @@ impl ValidatorClientHttpClient {
         }
 
         self.post(path, &()).await
+    }
+
+    /// `GET /eth/v1/validator/{pubkey}/graffiti`
+    pub async fn get_graffiti(
+        &self,
+        pubkey: &PublicKeyBytes,
+    ) -> Result<GetGraffitiResponse, Error> {
+        let url = self.make_get_graffiti_url(pubkey)?;
+        self.get(url)
+            .await
+            .map(|generic: GenericResponse<GetGraffitiResponse>| generic.data)
     }
 }
 

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -243,9 +243,13 @@ impl ValidatorClientHttpClient {
         self.signed_json(response).await
     }
 
-    async fn delete<T: DeserializeOwned, U: IntoUrl>(&self, url: U) -> Result<T, Error> {
+    async fn delete<U: IntoUrl>(&self, url: U) -> Result<(), Error> {
         let response = self.delete_response(url).await?;
-        self.signed_json(response).await
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            Err(Error::StatusCode(response.status()))
+        }
     }
 
     async fn get_unsigned<T: DeserializeOwned, U: IntoUrl>(&self, url: U) -> Result<T, Error> {

--- a/common/eth2/src/lighthouse_vc/http_client.rs
+++ b/common/eth2/src/lighthouse_vc/http_client.rs
@@ -736,9 +736,7 @@ impl ValidatorClientHttpClient {
         graffiti: GraffitiString,
     ) -> Result<(), Error> {
         let url = self.make_graffiti_url(pubkey)?;
-        let set_graffiti_request = SetGraffitiRequest {
-            graffiti,
-        };
+        let set_graffiti_request = SetGraffitiRequest { graffiti };
         self.post(url, &set_graffiti_request).await
     }
 

--- a/common/eth2/src/lighthouse_vc/std_types.rs
+++ b/common/eth2/src/lighthouse_vc/std_types.rs
@@ -1,7 +1,7 @@
 use account_utils::ZeroizeString;
 use eth2_keystore::Keystore;
 use serde::{Deserialize, Serialize};
-use types::{Address, PublicKeyBytes};
+use types::{Address, Graffiti, PublicKeyBytes};
 
 pub use slashing_protection::interchange::Interchange;
 
@@ -171,4 +171,10 @@ pub enum DeleteRemotekeyStatus {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct DeleteRemotekeysResponse {
     pub data: Vec<Status<DeleteRemotekeyStatus>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetGraffitiResponse {
+    pub pubkey: PublicKeyBytes,
+    pub graffiti: Graffiti,
 }

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -171,5 +171,5 @@ pub struct SingleExportKeystoresResponse {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SetGraffitiRequest {
-    pub graffiti: Option<GraffitiString>,
+    pub graffiti: GraffitiString,
 }

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -168,3 +168,8 @@ pub struct SingleExportKeystoresResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validating_keystore_password: Option<ZeroizeString>,
 }
+
+#[derive(Deserialize)]
+pub struct SetGraffitiQuery {
+    pub graffiti: Option<Graffiti>,
+}

--- a/common/eth2/src/lighthouse_vc/types.rs
+++ b/common/eth2/src/lighthouse_vc/types.rs
@@ -169,7 +169,7 @@ pub struct SingleExportKeystoresResponse {
     pub validating_keystore_password: Option<ZeroizeString>,
 }
 
-#[derive(Deserialize)]
-pub struct SetGraffitiQuery {
-    pub graffiti: Option<Graffiti>,
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SetGraffitiRequest {
+    pub graffiti: Option<GraffitiString>,
 }

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -4,7 +4,7 @@ use slot_clock::SlotClock;
 use std::sync::Arc;
 use types::{graffiti::GraffitiString, EthSpec, Graffiti};
 
-pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+pub fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     validator_pubkey: PublicKey,
     validator_store: Arc<ValidatorStore<T, E>>,
     graffiti_flag: Option<Graffiti>,
@@ -26,7 +26,7 @@ pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     }
 }
 
-pub async fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+pub fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     validator_pubkey: PublicKey,
     graffiti: GraffitiString,
     validator_store: Arc<ValidatorStore<T, E>>,
@@ -53,7 +53,7 @@ pub async fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     }
 }
 
-pub async fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+pub fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     validator_pubkey: PublicKey,
     validator_store: Arc<ValidatorStore<T, E>>,
 ) -> Result<(), warp::Rejection> {

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -1,0 +1,20 @@
+use crate::validator_store::ValidatorStore;
+use bls::{PublicKey, PublicKeyBytes};
+use eth2::types::GenericResponse;
+use slog::{info, Logger};
+use slot_clock::SlotClock;
+use std::sync::Arc;
+use types::{EthSpec, Graffiti};
+
+pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+    pubkey: PublicKey,
+    validator_store: Arc<ValidatorStore<T, E>>,
+    log: Logger,
+) -> Result<Graffiti, warp::Rejection> {
+    let Some(graffiti) = validator_store.graffiti(&pubkey.into()) else {
+        return Err(warp_utils::reject::custom_server_error(
+            "Lighthouse shutting down".into(),
+        ));
+    };
+    Ok(graffiti)
+}

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -1,12 +1,9 @@
 use crate::validator_store::ValidatorStore;
-use bls::{PublicKey, PublicKeyBytes};
-use eth2::types::GenericResponse;
-use futures::TryFutureExt;
-use serde_json::from_str;
-use slog::{info, Logger};
+use bls::PublicKey;
+use slog::Logger;
 use slot_clock::SlotClock;
-use std::{str::FromStr, sync::Arc};
-use types::{graffiti::GraffitiString, EthSpec, Graffiti};
+use std::sync::Arc;
+use types::{EthSpec, Graffiti};
 
 pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     pubkey: PublicKey,
@@ -26,35 +23,20 @@ pub async fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     graffiti: Graffiti,
     validator_store: Arc<ValidatorStore<T, E>>,
     log: Logger,
-) -> Result<Graffiti, warp::Rejection> {
+) -> Result<(), warp::Rejection> {
     let validators_rw_lock = validator_store.initialized_validators();
-    let mut write_validators = validators_rw_lock.write();
-    let read_validators = validators_rw_lock.read();
+    let mut validators = validators_rw_lock.write();
+    validators.set_graffiti(&pubkey, graffiti).unwrap();
+    Ok(())
+}
 
-    match (
-        read_validators.is_enabled(&pubkey),
-        read_validators.validator(&pubkey.compress()),
-    ) {
-        (None, _) | (Some(_), None) => {
-            return Err(warp_utils::reject::custom_not_found(format!(
-                "no validator for {:?}",
-                pubkey
-            )))
-        }
-        (Some(is_enabled), Some(initialized_validator)) => {
-            // TODO unwrap
-            write_validators
-                .set_validator_definition_fields(
-                    initialized_validator.voting_public_key(),
-                    Some(is_enabled),
-                    initialized_validator.get_gas_limit(),
-                    initialized_validator.get_builder_proposals(),
-                    Some(GraffitiString::from_str(&graffiti.to_string()).unwrap()),
-                )
-                .await
-                .unwrap();
-
-            return Ok(graffiti);
-        }
-    };
+pub async fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+    pubkey: PublicKey,
+    validator_store: Arc<ValidatorStore<T, E>>,
+    log: Logger,
+) -> Result<(), warp::Rejection> {
+    let validators_rw_lock = validator_store.initialized_validators();
+    let mut validators = validators_rw_lock.write();
+    validators.delete_graffiti(&pubkey).unwrap();
+    Ok(())
 }

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -1,10 +1,12 @@
 use crate::validator_store::ValidatorStore;
 use bls::{PublicKey, PublicKeyBytes};
 use eth2::types::GenericResponse;
+use futures::TryFutureExt;
+use serde_json::from_str;
 use slog::{info, Logger};
 use slot_clock::SlotClock;
-use std::sync::Arc;
-use types::{EthSpec, Graffiti};
+use std::{sync::Arc, str::FromStr};
+use types::{EthSpec, Graffiti, graffiti::GraffitiString};
 
 pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
     pubkey: PublicKey,
@@ -17,4 +19,38 @@ pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
         ));
     };
     Ok(graffiti)
+}
+
+pub async fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
+    pubkey: PublicKey,
+    graffiti: Graffiti,
+    validator_store: Arc<ValidatorStore<T, E>>,
+    log: Logger,
+) -> Result<Graffiti, warp::Rejection> {
+
+    let validators_rw_lock = validator_store.initialized_validators();
+    let mut write_validators = validators_rw_lock.write();
+    let read_validators = validators_rw_lock.read();
+
+    match (
+        read_validators.is_enabled(&pubkey),
+        read_validators.validator(&pubkey.compress()),
+    ) {
+        (None, _) | (Some(_), None) => return Err(warp_utils::reject::custom_not_found(format!(
+            "no validator for {:?}",
+            pubkey
+        ))),
+        (Some(is_enabled), Some(initialized_validator)) => {
+            // TODO unwrap
+            write_validators.set_validator_definition_fields(
+                initialized_validator.voting_public_key(), 
+                Some(is_enabled), 
+                initialized_validator.get_gas_limit(), 
+                initialized_validator.get_builder_proposals(), 
+                Some(GraffitiString::from_str(&graffiti.to_string()).unwrap())
+            ).await.unwrap();
+
+            return Ok(graffiti)
+        }
+    };
 }

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -64,7 +64,7 @@ pub async fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
             "The key was not found on the server, nothing to delete".to_string(),
         )),
         Some(initialized_validator) => {
-            if initialized_validator.get_graffiti() == None {
+            if initialized_validator.get_graffiti().is_none() {
                 Ok(())
             } else {
                 initialized_validators

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -32,8 +32,8 @@ pub async fn set_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
                 initialized_validators
                     .set_graffiti(&validator_pubkey, graffiti)
                     .map_err(|_| {
-                        warp_utils::reject::custom_server_error(
-                            "failed to update graffiti".to_string(),
+                        warp_utils::reject::invalid_auth(
+                            "A graffiti was found, but cannot be updated. This may be because the graffiti was in configuration files that cannot be updated.".to_string(),
                         )
                     })?;
 
@@ -60,7 +60,7 @@ pub async fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
                 initialized_validators
                     .delete_graffiti(&validator_pubkey)
                     .map_err(|_| {
-                        warp_utils::reject::InvalidAuthorization(
+                        warp_utils::reject::invalid_auth(
                             "A graffiti was found, but cannot be removed. This may be because the graffiti was in configuration files that cannot be updated.".to_string()
                         )
                     })?;

--- a/validator_client/src/http_api/graffiti.rs
+++ b/validator_client/src/http_api/graffiti.rs
@@ -19,7 +19,7 @@ pub async fn get_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
                 return Ok(Graffiti::default());
             };
             Ok(graffiti)
-        },
+        }
     }
 }
 
@@ -70,7 +70,7 @@ pub async fn delete_graffiti<T: 'static + SlotClock + Clone, E: EthSpec>(
                     .delete_graffiti(&validator_pubkey)
                     .map_err(|_| {
                         warp_utils::reject::custom_server_error(
-                            "A graffiti was found, but failed to be removed.".to_string()
+                            "A graffiti was found, but failed to be removed.".to_string(),
                         )
                     })?;
 

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -659,7 +659,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::path::end())
         .and(warp::body::json())
         .and(validator_store_filter.clone())
-        .and(graffiti_file_filter)
+        .and(graffiti_file_filter.clone())
         .and(signer.clone())
         .and(task_executor_filter.clone())
         .and_then(
@@ -1073,15 +1073,23 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::body::json())
         .and(warp::path::end())
         .and(validator_store_filter.clone())
+        .and(graffiti_file_filter.clone())
         .and(signer.clone())
         .and(task_executor_filter.clone())
         .and_then(
             |pubkey: PublicKey,
              query: SetGraffitiRequest,
              validator_store: Arc<ValidatorStore<T, E>>,
+             graffiti_file: Option<GraffitiFile>,
              signer,
              task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
+                    if graffiti_file.is_some() {
+                        return Err(warp_utils::reject::invalid_auth(
+                            "Unable to update graffiti as the \"--graffiti-file\" flag is set"
+                                .to_string(),
+                        ));
+                    }
                     if let Some(handle) = task_executor.handle() {
                         let Some(graffiti) = query.graffiti else {
                             return Err(warp_utils::reject::custom_bad_request(
@@ -1107,14 +1115,22 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
         .and(warp::path("graffiti"))
         .and(warp::path::end())
         .and(validator_store_filter.clone())
+        .and(graffiti_file_filter.clone())
         .and(signer.clone())
         .and(task_executor_filter.clone())
         .and_then(
             |pubkey: PublicKey,
              validator_store: Arc<ValidatorStore<T, E>>,
+             graffiti_file: Option<GraffitiFile>,
              signer,
              task_executor: TaskExecutor| {
                 blocking_signed_json_task(signer, move || {
+                    if graffiti_file.is_some() {
+                        return Err(warp_utils::reject::invalid_auth(
+                            "Unable to update graffiti as the \"--graffiti-file\" flag is set"
+                                .to_string(),
+                        ));
+                    }
                     if let Some(handle) = task_executor.handle() {
                         handle.block_on(delete_graffiti(pubkey.clone(), validator_store))?;
                         Ok(())

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -1096,7 +1096,11 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         ));
                     }
                     if let Some(handle) = task_executor.handle() {
-                        handle.block_on(set_graffiti(pubkey.clone(), query.graffiti, validator_store))
+                        handle.block_on(set_graffiti(
+                            pubkey.clone(),
+                            query.graffiti,
+                            validator_store,
+                        ))
                     } else {
                         Err(warp_utils::reject::custom_server_error(
                             "An error occurred while attempting to set graffiti".into(),

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 
 pub mod test_utils;
 
-use crate::http_api::graffiti::{get_graffiti, set_graffiti, delete_graffiti};
+use crate::http_api::graffiti::{delete_graffiti, get_graffiti, set_graffiti};
 
 use crate::http_api::create_signed_voluntary_exit::create_signed_voluntary_exit;
 use crate::{determine_graffiti, GraffitiFile, ValidatorStore};
@@ -24,7 +24,7 @@ use eth2::lighthouse_vc::{
     std_types::{AuthResponse, GetFeeRecipientResponse, GetGasLimitResponse},
     types::{
         self as api_types, GenericResponse, GetGraffitiResponse, Graffiti, PublicKey,
-        PublicKeyBytes, SetGraffitiQuery
+        PublicKeyBytes, SetGraffitiQuery,
     },
 };
 use lighthouse_version::version_with_platform;
@@ -1090,9 +1090,14 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                         let Some(graffiti) = query.graffiti else {
                             return Err(warp_utils::reject::custom_server_error(
                                 "Lighthouse shutting down".into(),
-                            ))
+                            ));
                         };
-                        handle.block_on(set_graffiti(pubkey.clone(), graffiti, validator_store, log))?;
+                        handle.block_on(set_graffiti(
+                            pubkey.clone(),
+                            graffiti,
+                            validator_store,
+                            log,
+                        ))?;
                         Ok(())
                     } else {
                         Err(warp_utils::reject::custom_server_error(
@@ -1101,8 +1106,9 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     }
                 })
             },
-        ).map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
-    
+        )
+        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
+
     // DELETE /eth/v1/validator/{pubkey}/graffiti
     let delete_graffiti = eth_v1
         .and(warp::path("validator"))
@@ -1130,8 +1136,8 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                     }
                 })
             },
-        ).map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
-
+        )
+        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
 
     // GET /eth/v1/validator/{pubkey}/feerecipient
     let get_fee_recipient = eth_v1

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -1142,7 +1142,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                 })
             },
         )
-        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::NO_CONTENT));
+        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
 
     // GET /eth/v1/keystores
     let get_std_keystores = std_keystores

--- a/validator_client/src/http_api/mod.rs
+++ b/validator_client/src/http_api/mod.rs
@@ -1142,7 +1142,7 @@ pub fn serve<T: 'static + SlotClock + Clone, E: EthSpec>(
                 })
             },
         )
-        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::ACCEPTED));
+        .map(|reply| warp::reply::with_status(reply, warp::http::StatusCode::NO_CONTENT));
 
     // GET /eth/v1/keystores
     let get_std_keystores = std_keystores

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -814,6 +814,31 @@ async fn routes_with_invalid_auth() {
                 })
                 .await
         })
+        .await
+        .test_with_invalid_auth(|client| async move {
+            client
+                .delete_graffiti(
+                    &PublicKeyBytes::empty()
+                )
+                .await
+        })
+        .await
+        .test_with_invalid_auth(|client| async move {
+            client
+                .get_graffiti(
+                    &PublicKeyBytes::empty()
+                )
+                .await
+        })
+        .await
+        .test_with_invalid_auth(|client| async move {
+            client
+                .set_graffiti(
+                    &PublicKeyBytes::empty(),
+                    GraffitiString::default()
+                )
+                .await
+        })
         .await;
 }
 

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -663,6 +663,8 @@ impl ApiTester {
 
         let resp = self.client.delete_graffiti(&validator.voting_pubkey).await;
 
+        println!("{:?}", resp);
+
         assert!(resp.is_ok());
 
         let resp = self.client.get_graffiti(&validator.voting_pubkey).await;

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -663,8 +663,6 @@ impl ApiTester {
 
         let resp = self.client.delete_graffiti(&validator.voting_pubkey).await;
 
-        println!("{:?}", resp);
-
         assert!(resp.is_ok());
 
         let resp = self.client.get_graffiti(&validator.voting_pubkey).await;

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -816,27 +816,16 @@ async fn routes_with_invalid_auth() {
         })
         .await
         .test_with_invalid_auth(|client| async move {
-            client
-                .delete_graffiti(
-                    &PublicKeyBytes::empty()
-                )
-                .await
+            client.delete_graffiti(&PublicKeyBytes::empty()).await
+        })
+        .await
+        .test_with_invalid_auth(|client| async move {
+            client.get_graffiti(&PublicKeyBytes::empty()).await
         })
         .await
         .test_with_invalid_auth(|client| async move {
             client
-                .get_graffiti(
-                    &PublicKeyBytes::empty()
-                )
-                .await
-        })
-        .await
-        .test_with_invalid_auth(|client| async move {
-            client
-                .set_graffiti(
-                    &PublicKeyBytes::empty(),
-                    GraffitiString::default()
-                )
+                .set_graffiti(&PublicKeyBytes::empty(), GraffitiString::default())
                 .await
         })
         .await;

--- a/validator_client/src/initialized_validators.rs
+++ b/validator_client/src/initialized_validators.rs
@@ -116,8 +116,6 @@ pub enum Error {
     UnableToSaveKeyCache(key_cache::Error),
     UnableToDecryptKeyCache(key_cache::Error),
     UnableToDeletePasswordFile(PathBuf, io::Error),
-    /// Invalid graffiti, could not be converted to GraffitiString
-    InvalidGraffiti,
 }
 
 impl From<LockfileError> for Error {

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -18,7 +18,6 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
-use types::{sidecar::Sidecar, typenum::Gr};
 use types::{
     attestation::Error as AttestationError, graffiti::GraffitiString, AbstractExecPayload, Address,
     AggregateAndProof, Attestation, BeaconBlock, BlindedPayload, ChainSpec, ContributionAndProof,
@@ -29,6 +28,7 @@ use types::{
     SyncCommitteeContribution, SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId,
     ValidatorRegistrationData, VoluntaryExit,
 };
+use types::{sidecar::Sidecar, typenum::Gr};
 use validator_dir::ValidatorDir;
 
 pub use crate::doppelganger_service::DoppelgangerStatus;

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -18,7 +18,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
-use types::sidecar::Sidecar;
+use types::{sidecar::Sidecar, typenum::Gr};
 use types::{
     attestation::Error as AttestationError, graffiti::GraffitiString, AbstractExecPayload, Address,
     AggregateAndProof, Attestation, BeaconBlock, BlindedPayload, ChainSpec, ContributionAndProof,

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
+use types::sidecar::Sidecar;
 use types::{
     attestation::Error as AttestationError, graffiti::GraffitiString, AbstractExecPayload, Address,
     AggregateAndProof, Attestation, BeaconBlock, BlindedPayload, ChainSpec, ContributionAndProof,
@@ -28,7 +29,6 @@ use types::{
     SyncCommitteeContribution, SyncCommitteeMessage, SyncSelectionProof, SyncSubnetId,
     ValidatorRegistrationData, VoluntaryExit,
 };
-use types::{sidecar::Sidecar, typenum::Gr};
 use validator_dir::ValidatorDir;
 
 pub use crate::doppelganger_service::DoppelgangerStatus;


### PR DESCRIPTION
## Issue Addressed

#4947

## Proposed Changes

add standardized graffiti management APIs

https://github.com/ethereum/keymanager-APIs/pull/63

## Additional Notes

I made the decision of creating a separate function for `set_graffiti` instead of using `set_validator_definition_fields`. I may be missing context here, but I felt `set_validator_definition_fields` usage to be a bit dangerous here as it technically updates 4 fields (`enabled`, `gas_limit`, `builder_proposals` and `graffiti`)


