### PR TITLE
Remove block-delay-ms

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -422,24 +422,6 @@ fn no_doppelganger_protection_flag() {
         .with_config(|config| assert!(!config.enable_doppelganger_protection));
 }
 #[test]
-fn block_delay_ms() {
-    CommandLineTest::new()
-        .flag("block-delay-ms", Some("2000"))
-        .run()
-        .with_config(|config| {
-            assert_eq!(
-                config.block_delay,
-                Some(std::time::Duration::from_millis(2000))
-            )
-        });
-}
-#[test]
-fn no_block_delay_ms() {
-    CommandLineTest::new()
-        .run()
-        .with_config(|config| assert_eq!(config.block_delay, None));
-}
-#[test]
 fn no_gas_limit_flag() {
     CommandLineTest::new()
         .run()

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -21,7 +21,6 @@ use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::time::sleep;
 use types::{
     AbstractExecPayload, BlindedPayload, BlockType, EthSpec, FullPayload, Graffiti, PublicKeyBytes,
     Slot,
@@ -57,7 +56,6 @@ pub struct BlockServiceBuilder<T, E: EthSpec> {
     context: Option<RuntimeContext<E>>,
     graffiti: Option<Graffiti>,
     graffiti_file: Option<GraffitiFile>,
-    block_delay: Option<Duration>,
 }
 
 impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
@@ -70,7 +68,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
             context: None,
             graffiti: None,
             graffiti_file: None,
-            block_delay: None,
         }
     }
 
@@ -109,11 +106,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
         self
     }
 
-    pub fn block_delay(mut self, block_delay: Option<Duration>) -> Self {
-        self.block_delay = block_delay;
-        self
-    }
-
     pub fn build(self) -> Result<BlockService<T, E>, String> {
         Ok(BlockService {
             inner: Arc::new(Inner {
@@ -132,7 +124,6 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockServiceBuilder<T, E> {
                 proposer_nodes: self.proposer_nodes,
                 graffiti: self.graffiti,
                 graffiti_file: self.graffiti_file,
-                block_delay: self.block_delay,
             }),
         })
     }
@@ -222,7 +213,6 @@ pub struct Inner<T, E: EthSpec> {
     context: RuntimeContext<E>,
     graffiti: Option<Graffiti>,
     graffiti_file: Option<GraffitiFile>,
-    block_delay: Option<Duration>,
 }
 
 /// Attempts to produce attestations for any block producer(s) at the start of the epoch.
@@ -266,18 +256,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
         executor.spawn(
             async move {
                 while let Some(notif) = notification_rx.recv().await {
-                    let service = self.clone();
-
-                    if let Some(delay) = service.block_delay {
-                        debug!(
-                            service.context.log(),
-                            "Delaying block production by {}ms",
-                            delay.as_millis()
-                        );
-                        sleep(delay).await;
-                    }
-
-                    service.do_update(notif).await.ok();
+                    self.do_update(notif).await.ok();
                 }
                 debug!(log, "Block service shutting down");
             },

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -340,16 +340,4 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("500")
                 .takes_value(true),
         )
-        /*
-         * Experimental/development options.
-         */
-        .arg(
-            Arg::with_name("block-delay-ms")
-                .long("block-delay-ms")
-                .value_name("MILLIS")
-                .hidden(true)
-                .help("Time to delay block production from the start of the slot. Should only be \
-                       used for testing.")
-                .takes_value(true),
-        )
 }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -14,7 +14,6 @@ use slog::{info, warn, Logger};
 use std::fs;
 use std::net::IpAddr;
 use std::path::PathBuf;
-use std::time::Duration;
 use types::{Address, GRAFFITI_BYTES_LEN};
 
 pub const DEFAULT_BEACON_NODE: &str = "http://localhost:5052/";
@@ -70,10 +69,6 @@ pub struct Config {
     /// A list of custom certificates that the validator client will additionally use when
     /// connecting to a beacon node over SSL/TLS.
     pub beacon_nodes_tls_certs: Option<Vec<PathBuf>>,
-    /// Delay from the start of the slot to wait before publishing a block.
-    ///
-    /// This is *not* recommended in prod and should only be used for testing.
-    pub block_delay: Option<Duration>,
     /// Enables broadcasting of various requests (by topic) to all beacon nodes.
     pub broadcast_topics: Vec<ApiTopic>,
     /// Enables a service which attempts to measure latency between the VC and BNs.
@@ -114,7 +109,6 @@ impl Default for Config {
             enable_doppelganger_protection: false,
             enable_high_validator_count_metrics: false,
             beacon_nodes_tls_certs: None,
-            block_delay: None,
             builder_proposals: false,
             builder_registration_timestamp_override: None,
             gas_limit: None,
@@ -371,13 +365,6 @@ impl Config {
             parse_required(cli_args, "validator-registration-batch-size")?;
         if config.validator_registration_batch_size == 0 {
             return Err("validator-registration-batch-size cannot be 0".to_string());
-        }
-
-        /*
-         * Experimental
-         */
-        if let Some(delay_ms) = parse_optional::<u64>(cli_args, "block-delay-ms")? {
-            config.block_delay = Some(Duration::from_millis(delay_ms));
         }
 
         Ok(config)

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -472,8 +472,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
             .beacon_nodes(beacon_nodes.clone())
             .runtime_context(context.service_context("block".into()))
             .graffiti(config.graffiti)
-            .graffiti_file(config.graffiti_file.clone())
-            .block_delay(config.block_delay);
+            .graffiti_file(config.graffiti_file.clone());
 
         // If we have proposer nodes, add them to the block service builder.
         if proposer_nodes_num > 0 {


### PR DESCRIPTION
## Proposed Changes

Delete the experimental `block-delay-ms` flag which was used for testing late block re-orgs, which is now a liability. I believe there is no need for a deprecation notice or backwards-compatibility measures because this is a hidden flag that nobody should have been using.
