### PR TITLE
Clean-up re-org tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,6 +1857,7 @@ dependencies = [
  "fs2",
  "hex",
  "kzg",
+ "logging",
  "rayon",
  "serde",
  "serde_json",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -11,7 +11,6 @@ write_ssz_files = []  # Writes debugging .ssz files to /tmp during block process
 participation_metrics = []  # Exposes validator participation metrics to Prometheus.
 fork_from_env = [] # Initialise the harness chain spec from the FORK_NAME env variable
 portable = ["bls/supranational-portable"]
-ef_tests = []
 
 [dev-dependencies]
 maplit = { workspace = true }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -726,6 +726,13 @@ impl<T: EthSpec> ExecutionLayer<T> {
         }
     }
 
+    /// Delete proposer preparation data for `proposer_index`. This is only useful in tests.
+    pub async fn clear_proposer_preparation(&self, proposer_index: u64) {
+        self.proposer_preparation_data()
+            .await
+            .remove(&proposer_index);
+    }
+
     /// Removes expired entries from proposer_preparation_data and proposers caches
     async fn clean_proposer_caches(&self, current_epoch: Epoch) -> Result<(), Error> {
         let mut proposer_preparation_data = self.proposer_preparation_data().await;

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [features]
 # `ef_tests` feature must be enabled to actually run the tests
-ef_tests = ["beacon_chain/ef_tests"]
+ef_tests = []
 milagro = ["bls/milagro"]
 fake_crypto = ["bls/fake_crypto"]
 portable = ["beacon_chain/portable"]
@@ -40,3 +40,4 @@ beacon_chain = { workspace = true }
 store = { workspace = true }
 fork_choice = { workspace = true }
 execution_layer = { workspace = true }
+logging = { workspace = true }


### PR DESCRIPTION
Clean up our runner for the new EF re-org tests. In the process of doing this I also found an insignificant bug in our definition of `head_is_late`.

I also made some tweaks to the block delay cache to facilitate slightly easier usage during tests. It will now keep the minimum observed timestamp, which allows us to call `set_observed` at multiple points without causing problems. 