### PR TITLE
Fix cache initialization in block rewards API

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -672,10 +672,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
             // Regardless of where we got the state from, attempt to build all the
             // caches except the tree hash cache.
-            new_snapshot
-                .beacon_state
-                .build_all_caches(&self.spec)
-                .map_err(Error::HeadCacheError)?;
+            new_snapshot.beacon_state.build_all_caches(&self.spec)?;
 
             let new_cached_head = CachedHead {
                 snapshot: Arc::new(new_snapshot),

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -55,7 +55,7 @@ pub enum BeaconChainError {
     SlotClockDidNotStart,
     NoStateForSlot(Slot),
     BeaconStateError(BeaconStateError),
-    HeadCacheError(EpochCacheError),
+    EpochCacheError(EpochCacheError),
     DBInconsistent(String),
     DBError(store::Error),
     ForkChoiceError(ForkChoiceError),
@@ -246,6 +246,7 @@ easy_from_to!(StateAdvanceError, BeaconChainError);
 easy_from_to!(BlockReplayError, BeaconChainError);
 easy_from_to!(InconsistentFork, BeaconChainError);
 easy_from_to!(AvailabilityCheckError, BeaconChainError);
+easy_from_to!(EpochCacheError, BeaconChainError);
 
 #[derive(Debug)]
 pub enum BlockProductionError {


### PR DESCRIPTION
## Issue Addressed

Fix a bug in the block rewards API that caused the epoch cache to be initialized at slots `== 1 (mod 32)`. The cache is initialized by block replay, but when no block replay is required then an error would be triggered:

```bash
> curl "http://localhost:5052/eth/v1/beacon/rewards/blocks/33" | jq
```

```json
{
  "code": 500,
  "message": "UNHANDLED_ERROR: BlockRewardAttestationError",
  "stacktraces": []
}
```

## Proposed Changes

Call `initialize_epoch_cache` to ensure that the cache is initialized in all cases. This will be a very cheap check at most slots (where the cache is already built), and only marginally more expensive at slot 1 offsets.
