### PR TITLE
Enable progressive balances fast mode by default

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -112,7 +112,7 @@ impl Default for ChainConfig {
             shuffling_cache_size: crate::shuffling_cache::DEFAULT_CACHE_SIZE,
             genesis_backfill: false,
             always_prepare_payload: false,
-            progressive_balances_mode: ProgressiveBalancesMode::Checked,
+            progressive_balances_mode: ProgressiveBalancesMode::Fast,
             epochs_per_migration: crate::migrate::DEFAULT_EPOCHS_PER_MIGRATION,
         }
     }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1228,12 +1228,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("progressive-balances")
                 .long("progressive-balances")
                 .value_name("MODE")
-                .help("Options to enable or disable the progressive balances cache for \
-                        unrealized FFG progression calculation. The default `checked` mode compares \
-                        the progressive balances from the cache against results from the existing \
-                        method. If there is a mismatch, it falls back to the existing method. The \
-                        optimized mode (`fast`) is faster but is still experimental, and is \
-                        not recommended for mainnet usage at this time.")
+                .help("Control the progressive balances cache mode. The default `fast` mode uses \
+                        the cache to speed up fork choice. A more conservative `checked` mode \
+                        compares the cache's results against results without the cache. If \
+                        there is a mismatch, it falls back to the cache-free result. Using the \
+                        default `fast` mode is recommended unless advised otherwise by the \
+                        Lighthouse team.")
                 .takes_value(true)
                 .possible_values(ProgressiveBalancesMode::VARIANTS)
         )

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2443,20 +2443,20 @@ fn progressive_balances_default() {
         .with_config(|config| {
             assert_eq!(
                 config.chain.progressive_balances_mode,
-                ProgressiveBalancesMode::Checked
+                ProgressiveBalancesMode::Fast
             )
         });
 }
 
 #[test]
-fn progressive_balances_fast() {
+fn progressive_balances_checked() {
     CommandLineTest::new()
-        .flag("progressive-balances", Some("fast"))
+        .flag("progressive-balances", Some("checked"))
         .run_with_zero_port()
         .with_config(|config| {
             assert_eq!(
                 config.chain.progressive_balances_mode,
-                ProgressiveBalancesMode::Fast
+                ProgressiveBalancesMode::Checked
             )
         });
 }


### PR DESCRIPTION
## Proposed Changes

Since we added the progressive balances cache in #4362 there haven't been any issues on our infra or reported by users. I think it's time we take advantage of the cache and actually bring its benefits to users.

## Additional Info

In `tree-states` the cache is used by default with no option to turn it off. Enabling `fast` by default on stable paves the way for that.

There _was_ a bug in the progressive-balances cache on `tree-states` (#4834), but it was related to changes I'd made and not to the inherent implementation. The fuzzing of the `tree-states` branch is also exercising the cache and is yet to unearth any issues. 
