### PR TITLE
Rename the block and blob wrapper types used in the beacon API interfaces

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -70,7 +70,7 @@ use crate::{
     metrics, BeaconChain, BeaconChainError, BeaconChainTypes,
 };
 use derivative::Derivative;
-use eth2::types::{EventKind, FullSignedBlockContents};
+use eth2::types::{EventKind, PublishBlockRequest};
 use execution_layer::PayloadStatus;
 pub use fork_choice::{AttestationFromBlock, PayloadVerificationStatus};
 use parking_lot::RwLockReadGuard;
@@ -698,9 +698,7 @@ impl<T: BeaconChainTypes> IntoGossipVerifiedBlockContents<T> for GossipVerifiedB
     }
 }
 
-impl<T: BeaconChainTypes> IntoGossipVerifiedBlockContents<T>
-    for FullSignedBlockContents<T::EthSpec>
-{
+impl<T: BeaconChainTypes> IntoGossipVerifiedBlockContents<T> for PublishBlockRequest<T::EthSpec> {
     fn into_gossip_verified_block(
         self,
         chain: &BeaconChain<T>,

--- a/beacon_node/http_api/src/build_block_contents.rs
+++ b/beacon_node/http_api/src/build_block_contents.rs
@@ -1,19 +1,19 @@
 use beacon_chain::{BeaconBlockResponse, BeaconBlockResponseWrapper, BlockProductionError};
-use eth2::types::{BlockContents, BlockContentsWrapper, FullBlockContents};
+use eth2::types::{BlockContents, FullBlockContents, ProduceBlockV3Response};
 use types::{EthSpec, ForkName};
 type Error = warp::reject::Rejection;
 
 pub fn build_block_contents<E: EthSpec>(
     fork_name: ForkName,
     block_response: BeaconBlockResponseWrapper<E>,
-) -> Result<BlockContentsWrapper<E>, Error> {
+) -> Result<ProduceBlockV3Response<E>, Error> {
     match block_response {
         BeaconBlockResponseWrapper::Blinded(block) => {
-            Ok(BlockContentsWrapper::Blinded(block.block))
+            Ok(ProduceBlockV3Response::Blinded(block.block))
         }
         BeaconBlockResponseWrapper::Full(block) => match fork_name {
             ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => Ok(
-                BlockContentsWrapper::Full(FullBlockContents::Block(block.block)),
+                ProduceBlockV3Response::Full(FullBlockContents::Block(block.block)),
             ),
             ForkName::Deneb => {
                 let BeaconBlockResponse {
@@ -30,7 +30,7 @@ pub fn build_block_contents<E: EthSpec>(
                     ));
                 };
 
-                Ok(BlockContentsWrapper::Full(
+                Ok(ProduceBlockV3Response::Full(
                     FullBlockContents::BlockContents(BlockContents {
                         block,
                         kzg_proofs,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -41,7 +41,7 @@ use bytes::Bytes;
 use directory::DEFAULT_ROOT_DIR;
 use eth2::types::{
     self as api_types, BroadcastValidation, EndpointVersion, ForkChoice, ForkChoiceNode,
-    FullSignedBlockContents, ValidatorId, ValidatorStatus,
+    PublishBlockRequest, ValidatorId, ValidatorStatus,
 };
 use lighthouse_network::{types::SyncState, EnrExt, NetworkGlobals, PeerId, PubsubMessage};
 use lighthouse_version::version_with_platform;
@@ -1306,7 +1306,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .then(
-            move |block_contents: FullSignedBlockContents<T::EthSpec>,
+            move |block_contents: PublishBlockRequest<T::EthSpec>,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
@@ -1342,7 +1342,7 @@ pub fn serve<T: BeaconChainTypes>(
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   log: Logger| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
-                    let block_contents = FullSignedBlockContents::<T::EthSpec>::from_ssz_bytes(
+                    let block_contents = PublishBlockRequest::<T::EthSpec>::from_ssz_bytes(
                         &block_bytes,
                         &chain.spec,
                     )
@@ -1375,7 +1375,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(log_filter.clone())
         .then(
             move |validation_level: api_types::BroadcastValidationQuery,
-                  block_contents: FullSignedBlockContents<T::EthSpec>,
+                  block_contents: PublishBlockRequest<T::EthSpec>,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
@@ -1413,7 +1413,7 @@ pub fn serve<T: BeaconChainTypes>(
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
                   log: Logger| {
                 task_spawner.spawn_async_with_rejection(Priority::P0, async move {
-                    let block_contents = FullSignedBlockContents::<T::EthSpec>::from_ssz_bytes(
+                    let block_contents = PublishBlockRequest::<T::EthSpec>::from_ssz_bytes(
                         &block_bytes,
                         &chain.spec,
                     )

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -7,7 +7,7 @@ use beacon_chain::{
     IntoGossipVerifiedBlockContents, NotifyExecutionLayer,
 };
 use eth2::types::{into_full_block_and_blobs, BroadcastValidation, ErrorMessage};
-use eth2::types::{FullPayloadContents, FullSignedBlockContents};
+use eth2::types::{FullPayloadContents, PublishBlockRequest};
 use execution_layer::ProvenancedPayload;
 use lighthouse_network::PubsubMessage;
 use network::NetworkMessage;
@@ -304,7 +304,7 @@ pub async fn publish_blinded_block<T: BeaconChainTypes>(
     duplicate_status_code: StatusCode,
 ) -> Result<Response, Rejection> {
     let block_root = blinded_block.canonical_root();
-    let full_block: ProvenancedBlock<T, FullSignedBlockContents<T::EthSpec>> =
+    let full_block: ProvenancedBlock<T, PublishBlockRequest<T::EthSpec>> =
         reconstruct_block(chain.clone(), block_root, blinded_block, log.clone()).await?;
     publish_block::<T, _>(
         Some(block_root),
@@ -326,7 +326,7 @@ pub async fn reconstruct_block<T: BeaconChainTypes>(
     block_root: Hash256,
     block: SignedBlindedBeaconBlock<T::EthSpec>,
     log: Logger,
-) -> Result<ProvenancedBlock<T, FullSignedBlockContents<T::EthSpec>>, Rejection> {
+) -> Result<ProvenancedBlock<T, PublishBlockRequest<T::EthSpec>>, Rejection> {
     let full_payload_opt = if let Ok(payload_header) = block.message().body().execution_payload() {
         let el = chain.execution_layer.as_ref().ok_or_else(|| {
             warp_utils::reject::custom_server_error("Missing execution layer".to_string())

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -2,7 +2,7 @@ use beacon_chain::{
     test_utils::{AttestationStrategy, BlockStrategy},
     GossipVerifiedBlock, IntoGossipVerifiedBlockContents,
 };
-use eth2::types::{BroadcastValidation, FullSignedBlockContents, SignedBeaconBlock};
+use eth2::types::{BroadcastValidation, PublishBlockRequest, SignedBeaconBlock};
 use http_api::test_utils::InteractiveTester;
 use http_api::{publish_blinded_block, publish_block, reconstruct_block, ProvenancedBlock};
 use std::sync::Arc;
@@ -74,10 +74,7 @@ pub async fn gossip_invalid() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -128,10 +125,7 @@ pub async fn gossip_partial_pass() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -174,7 +168,7 @@ pub async fn gossip_full_pass() {
     let response: Result<(), eth2::Error> = tester
         .client
         .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block.clone(), blobs),
+            &PublishBlockRequest::new(block.clone(), blobs),
             validation_level,
         )
         .await;
@@ -266,10 +260,7 @@ pub async fn consensus_invalid() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -318,10 +309,7 @@ pub async fn consensus_gossip() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -373,7 +361,7 @@ pub async fn consensus_partial_pass_only_consensus() {
     assert_eq!(block_b.state_root(), state_after_b.tree_hash_root());
     assert_ne!(block_a.state_root(), block_b.state_root());
 
-    let gossip_block_contents_b = FullSignedBlockContents::new(block_b, blobs_b)
+    let gossip_block_contents_b = PublishBlockRequest::new(block_b, blobs_b)
         .into_gossip_verified_block(&tester.harness.chain);
     assert!(gossip_block_contents_b.is_ok());
     let gossip_block_a = GossipVerifiedBlock::new(block_a.clone().into(), &tester.harness.chain);
@@ -434,7 +422,7 @@ pub async fn consensus_full_pass() {
     let response: Result<(), eth2::Error> = tester
         .client
         .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block.clone(), blobs),
+            &PublishBlockRequest::new(block.clone(), blobs),
             validation_level,
         )
         .await;
@@ -485,10 +473,7 @@ pub async fn equivocation_invalid() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -545,7 +530,7 @@ pub async fn equivocation_consensus_early_equivocation() {
     assert!(tester
         .client
         .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block_a.clone(), blobs_a),
+            &PublishBlockRequest::new(block_a.clone(), blobs_a),
             validation_level
         )
         .await
@@ -559,7 +544,7 @@ pub async fn equivocation_consensus_early_equivocation() {
     let response: Result<(), eth2::Error> = tester
         .client
         .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block_b.clone(), blobs_b),
+            &PublishBlockRequest::new(block_b.clone(), blobs_b),
             validation_level,
         )
         .await;
@@ -610,10 +595,7 @@ pub async fn equivocation_gossip() {
 
     let response: Result<(), eth2::Error> = tester
         .client
-        .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block, blobs),
-            validation_level,
-        )
+        .post_beacon_blocks_v2(&PublishBlockRequest::new(block, blobs), validation_level)
         .await;
     assert!(response.is_err());
 
@@ -671,10 +653,10 @@ pub async fn equivocation_consensus_late_equivocation() {
     assert_eq!(block_b.state_root(), state_after_b.tree_hash_root());
     assert_ne!(block_a.state_root(), block_b.state_root());
 
-    let gossip_block_contents_b = FullSignedBlockContents::new(block_b, blobs_b)
+    let gossip_block_contents_b = PublishBlockRequest::new(block_b, blobs_b)
         .into_gossip_verified_block(&tester.harness.chain);
     assert!(gossip_block_contents_b.is_ok());
-    let gossip_block_contents_a = FullSignedBlockContents::new(block_a, blobs_a)
+    let gossip_block_contents_a = PublishBlockRequest::new(block_a, blobs_a)
         .into_gossip_verified_block(&tester.harness.chain);
     assert!(gossip_block_contents_a.is_err());
 
@@ -738,7 +720,7 @@ pub async fn equivocation_full_pass() {
     let response: Result<(), eth2::Error> = tester
         .client
         .post_beacon_blocks_v2(
-            &FullSignedBlockContents::new(block.clone(), blobs),
+            &PublishBlockRequest::new(block.clone(), blobs),
             validation_level,
         )
         .await;

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -64,8 +64,8 @@ struct ApiTester {
     harness: Arc<BeaconChainHarness<EphemeralHarnessType<E>>>,
     chain: Arc<BeaconChain<EphemeralHarnessType<E>>>,
     client: BeaconNodeHttpClient,
-    next_block: FullSignedBlockContents<E>,
-    reorg_block: FullSignedBlockContents<E>,
+    next_block: PublishBlockRequest<E>,
+    reorg_block: PublishBlockRequest<E>,
     attestations: Vec<Attestation<E>>,
     contribution_and_proofs: Vec<SignedContributionAndProof<E>>,
     attester_slashing: AttesterSlashing<E>,
@@ -173,13 +173,13 @@ impl ApiTester {
         let (next_block, _next_state) = harness
             .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
             .await;
-        let next_block = FullSignedBlockContents::from(next_block);
+        let next_block = PublishBlockRequest::from(next_block);
 
         // `make_block` adds random graffiti, so this will produce an alternate block
         let (reorg_block, _reorg_state) = harness
             .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap() + 1)
             .await;
-        let reorg_block = FullSignedBlockContents::from(reorg_block);
+        let reorg_block = PublishBlockRequest::from(reorg_block);
 
         let head_state_root = head.beacon_state_root();
         let attestations = harness
@@ -314,13 +314,13 @@ impl ApiTester {
         let (next_block, _next_state) = harness
             .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
             .await;
-        let next_block = FullSignedBlockContents::from(next_block);
+        let next_block = PublishBlockRequest::from(next_block);
 
         // `make_block` adds random graffiti, so this will produce an alternate block
         let (reorg_block, _reorg_state) = harness
             .make_block(head.beacon_state.clone(), harness.chain.slot().unwrap())
             .await;
-        let reorg_block = FullSignedBlockContents::from(reorg_block);
+        let reorg_block = PublishBlockRequest::from(reorg_block);
 
         let head_state_root = head.beacon_state_root();
         let attestations = harness
@@ -1301,7 +1301,7 @@ impl ApiTester {
 
         assert!(self
             .client
-            .post_beacon_blocks(&FullSignedBlockContents::from(block))
+            .post_beacon_blocks(&PublishBlockRequest::from(block))
             .await
             .is_err());
 
@@ -1328,7 +1328,7 @@ impl ApiTester {
 
         assert!(self
             .client
-            .post_beacon_blocks_ssz(&FullSignedBlockContents::from(block))
+            .post_beacon_blocks_ssz(&PublishBlockRequest::from(block))
             .await
             .is_err());
 
@@ -2577,7 +2577,7 @@ impl ApiTester {
 
             let signed_block = block.sign(&sk, &fork, genesis_validators_root, &self.chain.spec);
             let signed_block_contents =
-                FullSignedBlockContents::try_from(signed_block.clone()).unwrap();
+                PublishBlockRequest::try_from(signed_block.clone()).unwrap();
 
             self.client
                 .post_beacon_blocks(&signed_block_contents)

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -771,7 +771,7 @@ impl BeaconNodeHttpClient {
     /// Returns `Ok(None)` on a 404 error.
     pub async fn post_beacon_blocks<T: EthSpec>(
         &self,
-        block_contents: &FullSignedBlockContents<T>,
+        block_contents: &PublishBlockRequest<T>,
     ) -> Result<(), Error> {
         let mut path = self.eth_path(V1)?;
 
@@ -791,7 +791,7 @@ impl BeaconNodeHttpClient {
     /// Returns `Ok(None)` on a 404 error.
     pub async fn post_beacon_blocks_ssz<T: EthSpec>(
         &self,
-        block_contents: &FullSignedBlockContents<T>,
+        block_contents: &PublishBlockRequest<T>,
     ) -> Result<(), Error> {
         let mut path = self.eth_path(V1)?;
 
@@ -889,7 +889,7 @@ impl BeaconNodeHttpClient {
     /// `POST v2/beacon/blocks`
     pub async fn post_beacon_blocks_v2<T: EthSpec>(
         &self,
-        block_contents: &FullSignedBlockContents<T>,
+        block_contents: &PublishBlockRequest<T>,
         validation_level: Option<BroadcastValidation>,
     ) -> Result<(), Error> {
         self.post_generic_with_consensus_version(
@@ -906,7 +906,7 @@ impl BeaconNodeHttpClient {
     /// `POST v2/beacon/blocks`
     pub async fn post_beacon_blocks_v2_ssz<T: EthSpec>(
         &self,
-        block_contents: &FullSignedBlockContents<T>,
+        block_contents: &PublishBlockRequest<T>,
         validation_level: Option<BroadcastValidation>,
     ) -> Result<(), Error> {
         self.post_generic_with_consensus_version_and_ssz_body(

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use bls::SignatureBytes;
 use environment::RuntimeContext;
-use eth2::types::{FullBlockContents, FullSignedBlockContents};
+use eth2::types::{FullBlockContents, PublishBlockRequest};
 use eth2::{BeaconNodeHttpClient, StatusCode};
 use slog::{crit, debug, error, info, trace, warn, Logger};
 use slot_clock::SlotClock;
@@ -483,7 +483,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                     .validator_store
                     .sign_block(*validator_pubkey_ref, block, current_slot)
                     .await
-                    .map(|b| SignedBlock::Full(FullSignedBlockContents::new(b, maybe_blobs)))
+                    .map(|b| SignedBlock::Full(PublishBlockRequest::new(b, maybe_blobs)))
             }
             UnsignedBlock::Blinded(block) => self_ref
                 .validator_store
@@ -660,7 +660,7 @@ impl<E: EthSpec> UnsignedBlock<E> {
 }
 
 pub enum SignedBlock<E: EthSpec> {
-    Full(FullSignedBlockContents<E>),
+    Full(PublishBlockRequest<E>),
     Blinded(SignedBlindedBeaconBlock<E>),
 }
 


### PR DESCRIPTION
## Issue Addressed

Suggestion to rename these two Beacon API types, as I'm still feeling a bit confused and need to look at the code to understand what these types are for:
- `BlockContentsWrapper` -> `ProduceBlockV3Response`: response from `GET v3/validator/blocks`
- `FullSignedBlockContents` -> `PublishBlockRequest`: request body for `POST beacon/blocks`