### PR TITLE
Restore crash safety for database pruning

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -34,7 +34,7 @@ use std::time::Duration;
 use store::{Error as StoreError, HotColdDB, ItemStore, KeyValueStoreOp};
 use task_executor::{ShutdownReason, TaskExecutor};
 use types::{
-    BeaconBlock, BeaconState, ChainSpec, Checkpoint, Epoch, EthSpec, Graffiti, Hash256, Signature,
+    BeaconBlock, BeaconState, ChainSpec, Epoch, EthSpec, Graffiti, Hash256, Signature,
     SignedBeaconBlock, Slot,
 };
 
@@ -557,16 +557,6 @@ where
             store
                 .init_blob_info(weak_subj_block.slot())
                 .map_err(|e| format!("Failed to initialize blob info: {:?}", e))?,
-        );
-
-        // Store pruning checkpoint to prevent attempting to prune before the anchor state.
-        self.pending_io_batch.push(
-            store
-                .pruning_checkpoint_store_op(Checkpoint {
-                    root: weak_subj_block_root,
-                    epoch: weak_subj_state.slot().epoch(TEthSpec::slots_per_epoch()),
-                })
-                .map_err(|e| format!("{:?}", e))?,
         );
 
         let snapshot = BeaconSnapshot {

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -512,13 +512,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         genesis_block_root: Hash256,
         log: &Logger,
     ) -> Result<PruningOutcome, BeaconChainError> {
-        let old_finalized_checkpoint =
-            store
-                .load_pruning_checkpoint()?
-                .unwrap_or_else(|| Checkpoint {
-                    epoch: Epoch::new(0),
-                    root: Hash256::zero(),
-                });
+        let old_finalized_checkpoint = store.get_pruning_checkpoint();
 
         let old_finalized_slot = old_finalized_checkpoint
             .epoch
@@ -750,11 +744,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
             persisted_head.as_kv_store_op(BEACON_CHAIN_DB_KEY)?,
         ));
 
-        // Persist the new finalized checkpoint as the pruning checkpoint.
-        batch.push(StoreOp::KeyValueOp(
-            store.pruning_checkpoint_store_op(new_finalized_checkpoint)?,
-        ));
-
         store.do_atomically_with_block_and_blobs_cache(batch)?;
         debug!(
             log,
@@ -768,19 +757,26 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
             let (state_root, summary) = res?;
 
             if summary.slot <= new_finalized_slot {
-                // If state root doesn't match state root from canonical chain, or this slot
-                // is not part of the recently finalized chain, then delete.
+                // If state root doesn't match state root from canonical chain, then delete.
+                // We may also find older states here that should have been deleted by `migrate_db`
+                // but weren't due to wonky I/O atomicity.
                 if newly_finalized_chain
                     .get(&summary.slot)
                     .map_or(true, |(_, canonical_state_root)| {
                         state_root != Hash256::from(*canonical_state_root)
                     })
                 {
+                    let reason = if summary.slot < old_finalized_slot {
+                        "old dangling state"
+                    } else {
+                        "non-canonical"
+                    };
                     debug!(
                         log,
                         "Deleting state";
                         "state_root" => ?state_root,
                         "slot" => summary.slot,
+                        "reason" => reason,
                     );
                     state_delete_batch.push(StoreOp::DeleteState(state_root, Some(summary.slot)));
                 }


### PR DESCRIPTION
## Proposed Changes

* Fix atomicity issue between database pruning & migration (more detail below)
* Update `lighthouse db inspect` so that it works with more kinds of corrupt DBs, i.e. ones where the split state has been deleted.
* Add some extra comments & sanity checks.

## Additional Info

The main bug fixed here is one that's caused by the more aggressive state pruning that tree-states does. Previously, there was a "pruning checkpoint" which was updated by the database pruning function each time it ran successfully. The problem occurred when:

1. Pruning runs successfully updating the pruning checkpoint from `N` to `M`.
2. Lighthouse is shutdown (doesn't matter how) before `migrate_db` runs, meaning that the pruning checkpoint (updated to `M`) is now _ahead_ of the `split` (still at `N`).
3. After restarting, pruning runs again but with `M` as the starting checkpoint for pruning and `O` as the end checkpoint. The state pruning logic which _deletes all states that do not lie between `M` and `O`_, mistakenly deletes everything that lies between our original checkpoints `N` and `M`.
4. Now `migrate_db` tries to run and finds that the database is missing most of the hot states that it expected would exist, including the split state! At this point the database is irreparably damaged and the node will fail to start the next time it is restarted.

The fix is to never let the pruning checkpoint get out of sync with the split. This is achieved by abolishing the concept of a separate pruning checkpoint and deriving it from the split.

This bug doesn't exist on `stable` because there's no analogous state pruning logic. I looked for ways that a crash between pruning and migration could cause corruption (like #4773) but didn't spot any.
