### PR TITLE
Fix slasher conditions

### DIFF
--- a/slasher/src/block_queue.rs
+++ b/slasher/src/block_queue.rs
@@ -1,6 +1,6 @@
 use parking_lot::Mutex;
-use types::SignedBeaconBlockHeader;
 use std::collections::HashSet;
+use types::SignedBeaconBlockHeader;
 
 #[derive(Debug, Default)]
 pub struct BlockQueue {

--- a/slasher/src/block_queue.rs
+++ b/slasher/src/block_queue.rs
@@ -1,17 +1,18 @@
 use parking_lot::Mutex;
 use types::SignedBeaconBlockHeader;
+use std::collections::HashSet;
 
 #[derive(Debug, Default)]
 pub struct BlockQueue {
-    blocks: Mutex<Vec<SignedBeaconBlockHeader>>,
+    blocks: Mutex<HashSet<SignedBeaconBlockHeader>>,
 }
 
 impl BlockQueue {
     pub fn queue(&self, block_header: SignedBeaconBlockHeader) {
-        self.blocks.lock().push(block_header)
+        self.blocks.lock().insert(block_header);
     }
 
-    pub fn dequeue(&self) -> Vec<SignedBeaconBlockHeader> {
+    pub fn dequeue(&self) -> HashSet<SignedBeaconBlockHeader> {
         let mut blocks = self.blocks.lock();
         std::mem::take(&mut *blocks)
     }


### PR DESCRIPTION
## Issue Addressed

Addresses https://github.com/sigp/lighthouse/pull/4900#discussion_r1413266562

Thanks @jimmygchen 

## Proposed Changes

Previously, we were adding a `BlobSidecar`'s header to the slasher under the following conditions:
1. Gossip verification fails and the signature is valid
2. Just before importing a fully available block

These conditions do not cover all cases since a valid gossip blob with an equivocating header that gets into the `observed_blob_cache` will not fail gossip verification **and** will never be fully available since the proposer need not propagate the full signed equivocating block. Such a `BlobSidecar` with a slashable block header will just go sit in the DA cache and eventually get pruned.

Hence, this PR adds the signed header before adding the blobs to the DA cache.
I have also changed the `BlockQueue` data structure to be a `HashSet` instead of a `Vec` since we are adding potentially many duplicate headers per slot. Looking at the slasher code, I don't think changing the data structure is an issue, please correct me if that's wrong or unnecessary @michaelsproul 