### PR TITLE
Fix stuck linkcheck on CI

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - unstable
-      - debug
   pull_request:
     paths:
       - 'book/**'
@@ -24,7 +23,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run mdbook server
-        run: docker run -v ${{ github.workspace }}/book:/book --name book -p 3000:3000 -d peaceiris/mdbook:latest serve --hostname 0.0.0.0
+        run: |
+          docker run -v ${{ github.workspace }}/book:/book --name book -p 3000:3000 -d peaceiris/mdbook:latest serve --hostname 0.0.0.0
+          sleep 5
 
       - name: Print logs
         run: docker logs book

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - unstable
+      - debug
   pull_request:
     paths:
       - 'book/**'
@@ -22,14 +23,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Create docker network
-        run: docker network create book
-
       - name: Run mdbook server
-        run: docker run -v ${{ github.workspace }}/book:/book --network book --name book -p 3000:3000 -d peaceiris/mdbook:v0.4.20-rust serve --hostname 0.0.0.0
+        run: docker run -v ${{ github.workspace }}/book:/book --name book -p 3000:3000 -d peaceiris/mdbook:latest serve --hostname 0.0.0.0
 
       - name: Print logs
         run: docker logs book
 
       - name: Run linkcheck
-        run: docker run  --network book tennox/linkcheck:latest book:3000
+        run: |
+          curl -sL https://github.com/filiph/linkcheck/releases/download/3.0.0/linkcheck-3.0.0-linux-x64.tar.gz | tar xvzf - linkcheck/linkcheck --strip 1
+          ./linkcheck localhost:3000 -d


### PR DESCRIPTION
## Issue Addressed

The linkcheck job has been failing quite consistently on our CI for a long time, and I am not able to reproduce it using the exact commands - it works locally but not on GitHub.

With the following changes it seems to work:
1. Upgrade `linkcheck` to latest version `3.0.0`. There isn't a docker image available, so I've updated the step to download the release binary instead.
2. There's also a race condition (crawling starts before server started), so I've added a little 5s wait. 

I've also added `-d` to make the logs more verbose in case it gets stuck again.
