### PR TITLE
Update discv5 to enable concurrent requests to a single peer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,8 +1747,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c05fa26996c6141f78ac4fafbe297a7fa69690565ba4e0d1f2e60bde5ce501"
+source = "git+https://github.com/sigp/discv5?rev=546e19c4d6692b0ed538b57d2e963bbb1080722b#546e19c4d6692b0ed538b57d2e963bbb1080722b"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm",
@@ -1757,13 +1756,12 @@ dependencies = [
  "enr",
  "fnv",
  "futures",
- "hashlink 0.7.0",
+ "hashlink",
  "hex",
  "hkdf",
  "lazy_static",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "lru 0.7.8",
+ "libp2p 0.52.4",
+ "lru 0.12.0",
  "more-asserts",
  "parking_lot 0.11.2",
  "rand",
@@ -1941,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe81b5c06ecfdbc71dd845216f225f53b62a10cb8a16c946836a3467f701d05b"
+checksum = "2a3d8dc56e02f954cac8eb489772c552c473346fc34f67412bb6244fd647f7e4"
 dependencies = [
  "base64 0.21.5",
  "bytes",
@@ -3083,15 +3081,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.6",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
@@ -3116,15 +3105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
 dependencies = [
  "fxhash",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7249a3129cbc1ffccd74857f81464a323a152173cdb134e0fd81bc803b29facf"
-dependencies = [
- "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -4015,6 +3995,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94495eb319a85b70a68b85e2389a95bb3555c71c49025b78c691a854a7e6464"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom",
+ "instant",
+ "libp2p-allow-block-list 0.2.0",
+ "libp2p-connection-limits 0.2.1",
+ "libp2p-core 0.40.1",
+ "libp2p-identity",
+ "libp2p-swarm 0.43.7",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror",
+]
+
+[[package]]
+name = "libp2p"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1252a34c693386829c34d44ccfbce86679d2a9a2c61f582863649bbf57f26260"
@@ -4025,8 +4028,8 @@ dependencies = [
  "futures-timer",
  "getrandom",
  "instant",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
+ "libp2p-allow-block-list 0.3.0",
+ "libp2p-connection-limits 0.3.0",
  "libp2p-core 0.41.1",
  "libp2p-dns",
  "libp2p-gossipsub",
@@ -4037,7 +4040,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-plaintext",
  "libp2p-quic",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "libp2p-tcp",
  "libp2p-upnp",
  "libp2p-yamux",
@@ -4049,13 +4052,37 @@ dependencies = [
 
 [[package]]
 name = "libp2p-allow-block-list"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b46558c5c0bf99d3e2a1a38fd54ff5476ca66dd1737b12466a1824dd219311"
+dependencies = [
+ "libp2p-core 0.40.1",
+ "libp2p-identity",
+ "libp2p-swarm 0.43.7",
+ "void",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "107b238b794cb83ab53b74ad5dcf7cca3200899b72fe662840cfb52f5b0a32e6"
 dependencies = [
  "libp2p-core 0.41.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
+ "void",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f5107ad45cb20b2f6c3628c7b6014b996fcb13a88053f4569c872c6e30abf58"
+dependencies = [
+ "libp2p-core 0.40.1",
+ "libp2p-identity",
+ "libp2p-swarm 0.43.7",
  "void",
 ]
 
@@ -4067,7 +4094,7 @@ checksum = "f2af4b1e1a1d6c5005a59b42287c0a526bcce94d8d688e2e9233b18eb843ceb4"
 dependencies = [
  "libp2p-core 0.41.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "void",
 ]
 
@@ -4162,7 +4189,7 @@ dependencies = [
  "instant",
  "libp2p-core 0.41.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "prometheus-client",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4188,7 +4215,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.41.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "lru 0.12.0",
  "quick-protobuf",
  "quick-protobuf-codec",
@@ -4233,7 +4260,7 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.41.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "rand",
  "smallvec",
  "socket2 0.5.5",
@@ -4254,7 +4281,7 @@ dependencies = [
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "pin-project",
  "prometheus-client",
 ]
@@ -4346,6 +4373,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
+version = "0.43.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "580189e0074af847df90e75ef54f3f30059aedda37ea5a1659e8b9fca05c0141"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core 0.40.1",
+ "libp2p-identity",
+ "log",
+ "multistream-select",
+ "once_cell",
+ "rand",
+ "smallvec",
+ "void",
+]
+
+[[package]]
+name = "libp2p-swarm"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643ce11d87db56387631c9757b61b83435b434f94dc52ec267c1666e560e78b0"
@@ -4425,7 +4473,7 @@ dependencies = [
  "futures-timer",
  "igd-next",
  "libp2p-core 0.41.1",
- "libp2p-swarm",
+ "libp2p-swarm 0.44.0",
  "tokio",
  "tracing",
  "void",
@@ -4581,7 +4629,7 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
- "libp2p",
+ "libp2p 0.53.1",
  "libp2p-mplex",
  "lighthouse_metrics",
  "lighthouse_version",
@@ -4990,9 +5038,9 @@ dependencies = [
 
 [[package]]
 name = "more-asserts"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multiaddr"
@@ -6561,7 +6609,7 @@ dependencies = [
  "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.8.4",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ criterion = "0.3"
 delay_map = "0.3"
 derivative = "2"
 dirs = "3"
-discv5 = { version = "0.3", features = ["libp2p"] }
+discv5 = { git = "https://github.com/sigp/discv5", rev = "546e19c4d6692b0ed538b57d2e963bbb1080722b" ,features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"
 ethereum-types = "0.14"

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -5,7 +5,6 @@ use crate::{Enr, PeerIdSerialized};
 use directory::{
     DEFAULT_BEACON_NODE_DIR, DEFAULT_HARDCODED_NETWORK, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR,
 };
-use discv5::{Discv5Config, Discv5ConfigBuilder};
 use libp2p::gossipsub;
 use libp2p::Multiaddr;
 use serde::{Deserialize, Serialize};
@@ -91,7 +90,7 @@ pub struct Config {
 
     /// Discv5 configuration parameters.
     #[serde(skip)]
-    pub discv5_config: Discv5Config,
+    pub discv5_config: discv5::Config,
 
     /// List of nodes to initially connect to.
     pub boot_nodes_enr: Vec<Enr>,
@@ -320,7 +319,7 @@ impl Default for Config {
             discv5::ListenConfig::from_ip(Ipv4Addr::UNSPECIFIED.into(), 9000);
 
         // discv5 configuration
-        let discv5_config = Discv5ConfigBuilder::new(discv5_listen_config)
+        let discv5_config = discv5::ConfigBuilder::new(discv5_listen_config)
             .enable_packet_filter()
             .session_cache_capacity(5000)
             .request_timeout(Duration::from_secs(1))

--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -1,6 +1,6 @@
 //! Helper functions and an extension trait for Ethereum 2 ENRs.
 
-pub use discv5::enr::{CombinedKey, EnrBuilder};
+pub use discv5::enr::CombinedKey;
 
 use super::enr_ext::CombinedKeyExt;
 use super::ENR_FILENAME;
@@ -145,8 +145,8 @@ pub fn build_or_load_enr<T: EthSpec>(
 pub fn create_enr_builder_from_config<T: EnrKey>(
     config: &NetworkConfig,
     enable_libp2p: bool,
-) -> EnrBuilder<T> {
-    let mut builder = EnrBuilder::new("v4");
+) -> discv5::enr::Builder<T> {
+    let mut builder = Enr::builder();
     let (maybe_ipv4_address, maybe_ipv6_address) = &config.enr_address;
 
     if let Some(ip) = maybe_ipv4_address {

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -10,7 +10,7 @@ pub mod enr_ext;
 use crate::service::TARGET_SUBNET_PEERS;
 use crate::{error, Enr, NetworkConfig, NetworkGlobals, Subnet, SubnetDiscovery};
 use crate::{metrics, ClearDialError};
-use discv5::{enr::NodeId, Discv5, Discv5Event};
+use discv5::{enr::NodeId, Discv5};
 pub use enr::{
     build_enr, create_enr_builder_from_config, load_enr_from_disk, use_or_load_enr, CombinedKey,
     Eth2Enr,
@@ -143,15 +143,10 @@ enum EventStream {
     /// Awaiting an event stream to be generated. This is required due to the poll nature of
     /// `Discovery`
     Awaiting(
-        Pin<
-            Box<
-                dyn Future<Output = Result<mpsc::Receiver<Discv5Event>, discv5::Discv5Error>>
-                    + Send,
-            >,
-        >,
+        Pin<Box<dyn Future<Output = Result<mpsc::Receiver<discv5::Event>, discv5::Error>> + Send>>,
     ),
     /// The future has completed.
-    Present(mpsc::Receiver<Discv5Event>),
+    Present(mpsc::Receiver<discv5::Event>),
     // The future has failed or discv5 has been disabled. There are no events from discv5.
     InActive,
 }
@@ -992,7 +987,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                     match event {
                         // We filter out unwanted discv5 events here and only propagate useful results to
                         // the peer manager.
-                        Discv5Event::Discovered(_enr) => {
+                        discv5::Event::Discovered(_enr) => {
                             // Peers that get discovered during a query but are not contactable or
                             // don't match a predicate can end up here. For debugging purposes we
                             // log these to see if we are unnecessarily dropping discovered peers
@@ -1005,7 +1000,7 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                             }
                             */
                         }
-                        Discv5Event::SocketUpdated(socket_addr) => {
+                        discv5::Event::SocketUpdated(socket_addr) => {
                             info!(self.log, "Address updated"; "ip" => %socket_addr.ip(), "udp_port" => %socket_addr.port());
                             metrics::inc_counter(&metrics::ADDRESS_UPDATE_COUNT);
                             metrics::check_nat();
@@ -1026,10 +1021,10 @@ impl<TSpec: EthSpec> NetworkBehaviour for Discovery<TSpec> {
                             // NOTE: We assume libp2p itself can keep track of IP changes and we do
                             // not inform it about IP changes found via discovery.
                         }
-                        Discv5Event::EnrAdded { .. }
-                        | Discv5Event::TalkRequest(_)
-                        | Discv5Event::NodeInserted { .. }
-                        | Discv5Event::SessionEstablished { .. } => {} // Ignore all other discv5 server events
+                        discv5::Event::EnrAdded { .. }
+                        | discv5::Event::TalkRequest(_)
+                        | discv5::Event::NodeInserted { .. }
+                        | discv5::Event::SessionEstablished { .. } => {} // Ignore all other discv5 server events
                     }
                 }
             }

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -118,7 +118,7 @@ impl<TSpec: EthSpec> NetworkGlobals<TSpec> {
         use crate::CombinedKeyExt;
         let keypair = libp2p::identity::secp256k1::Keypair::generate();
         let enr_key: discv5::enr::CombinedKey = discv5::enr::CombinedKey::from_secp256k1(&keypair);
-        let enr = discv5::enr::EnrBuilder::new("v4").build(&enr_key).unwrap();
+        let enr = discv5::enr::Enr::empty(&enr_key).unwrap();
         NetworkGlobals::new(
             enr,
             MetaData::V2(MetaDataV2 {


### PR DESCRIPTION
## Issue Addressed

updates discv5 (pending a release) to enable concurrent requests to a single peer. I'm curious to see if we will get gains from this

## Proposed Changes

update discv5 

## Additional Info

This is pending https://github.com/sigp/enr/pull/66 + an Enr release

<!-- 
As with most networking PRs, this should be run for a couple of days and check everything is in order. I can't reasonably do this on my own. **Please deploy this in your infra**
--!>
