### PR TITLE
Update Rust version in lcli `Dockerfile`.

### DIFF
--- a/lcli/Dockerfile
+++ b/lcli/Dockerfile
@@ -1,7 +1,7 @@
 # `lcli` requires the full project to be in scope, so this should be built either:
 #  - from the `lighthouse` dir with the command: `docker build -f ./lcli/Dockerflie .`
 #  - from the current directory with the command: `docker build -f ./Dockerfile ../`
-FROM rust:1.69.0-bullseye AS builder
+FROM rust:1.73.0-bullseye AS builder
 RUN apt-get update && apt-get -y upgrade && apt-get install -y cmake libclang-dev
 COPY . lighthouse
 ARG PORTABLE


### PR DESCRIPTION
## Issue Addressed

This PR updates Rust version in lcli `Dockerfile` to 1.73.0. Minimum Rust version was updated to 1.73.0 in #4935.

Failing docker build:
https://github.com/sigp/lighthouse/actions/runs/7177492144/job/19544059658