### PR TITLE
Optimise block_root computation in gossip verification

### DIFF
--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -40,6 +40,10 @@ lazy_static! {
         "beacon_block_processing_block_root_seconds",
         "Time spent calculating the block root when processing a block."
     );
+    pub static ref BLOCK_HEADER_PROCESSING_BLOCK_ROOT: Result<Histogram> = try_create_histogram(
+        "beacon_block_header_processing_block_root_seconds",
+        "Time spent calculating the block root for a beacon block header."
+    );
     pub static ref BLOCK_PROCESSING_BLOB_ROOT: Result<Histogram> = try_create_histogram(
         "beacon_block_processing_blob_root_seconds",
         "Time spent calculating the blob root when processing a block."


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Before doing gossip verification, we get the header corresponding to a block to pass to a slasher.
The `SignedBeaconBlock` and its corresponding`SignedBeaconBlockHeader` have the same canonical root for the message, however, computing the root for the header is way faster since the root for the tree rooted at `BeaconBlockBody` is already calculated in the header.

In this PR, we reuse the header to compute the `block_root` instead of using the full block. 
The root computation in mainnet seems to take 10ms on average looking at the `beacon_block_processing_block_root_seconds` metric.
Using the header to compute the root should take micro seconds so this seems like a low hanging fruit optimisation.

