### PR TITLE
Fix the blinded v2 flow for local payloads

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5165,8 +5165,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                                 .try_into()
                                 .map_err(|_| BlockProductionError::InvalidPayloadFork)?,
                             bls_to_execution_changes: bls_to_execution_changes.into(),
-                            blob_kzg_commitments: kzg_commitments
-                                .ok_or(BlockProductionError::InvalidPayloadFork)?,
+                            blob_kzg_commitments: kzg_commitments.ok_or(
+                                BlockProductionError::MissingKzgCommitment(
+                                    "Kzg commitments missing from block contents".to_string(),
+                                ),
+                            )?,
                         },
                     }),
                     maybe_blobs_and_proofs,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -176,15 +176,26 @@ impl<T: EthSpec> From<BlockProposalContents<T, FullPayload<T>>>
     for BlockProposalContents<T, BlindedPayload<T>>
 {
     fn from(item: BlockProposalContents<T, FullPayload<T>>) -> Self {
-        let block_value = item.block_value().to_owned();
-
-        let blinded_payload: BlockProposalContents<T, BlindedPayload<T>> =
+        match item {
             BlockProposalContents::Payload {
-                payload: item.to_payload().execution_payload().into(),
+                payload,
                 block_value,
-            };
-
-        blinded_payload
+            } => BlockProposalContents::Payload {
+                payload: payload.execution_payload().into(),
+                block_value,
+            },
+            BlockProposalContents::PayloadAndBlobs {
+                payload,
+                block_value,
+                kzg_commitments,
+                blobs_and_proofs: _,
+            } => BlockProposalContents::PayloadAndBlobs {
+                payload: payload.execution_payload().into(),
+                block_value,
+                kzg_commitments,
+                blobs_and_proofs: None,
+            },
+        }
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The full to blinded conversion here https://github.com/sigp/lighthouse/blob/a3fb27c99b6696b7b9ccf69d5a43977f44440687/beacon_node/execution_layer/src/lib.rs#L175-L189 was always returning a pre-deneb payload.

This caused the `v1/validator/blinded_blocks/` endpoint to fail when returning a block from the local EL as the kzg commitment ended up being `None` here
https://github.com/sigp/lighthouse/blob/a3fb27c99b6696b7b9ccf69d5a43977f44440687/beacon_node/beacon_chain/src/beacon_chain.rs#L5168-L5169

