### PR TITLE
Investigate `UnknownTargetRoot` slasher errors

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -381,6 +381,11 @@ fn process_slash_info<T: BeaconChainTypes>(
     if let Some(slasher) = chain.slasher.as_ref() {
         let (indexed_attestation, check_signature, err) = match slash_info {
             SignatureNotChecked(attestation, err) => {
+                if let Error::UnknownHeadBlock { .. } = err {
+                    if attestation.data.beacon_block_root == attestation.data.target.root {
+                        return err;
+                    }
+                }
                 match obtain_indexed_attestation_and_committees_per_slot(chain, attestation) {
                     Ok((indexed, _)) => (indexed, true, err),
                     Err(e) => {


### PR DESCRIPTION
## Issue Addressed
https://github.com/sigp/lighthouse/issues/4972

## Proposed Changes
This PR addresses the issue where attestations failing with `UnknownHeadBlock` are incorrectly processed through the slasher, leading to subsequent failures in signature verification (`SignatureNotChecked`) The subsequent failure occurs when attempting to load the state for the target block. This is expected when the target is identical to the head, leading to an unknown state. The proposed solution involves requeuing attestations without involving the slasher when encountering `UnknownHeadBlock`.

Some `UnknownTargetRoot` errors could still occur particularly during startup. It happens when the `beacon_block_root` slot is later than `target_root` slot. However they are harmless because the requeueing will usually take care of processing them later.

## Additional Info


