### PR TITLE
Clean up blockv3 metadata and client

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -501,14 +501,14 @@ impl<E: EthSpec> BeaconBlockResponseWrapper<E> {
         })
     }
 
-    pub fn execution_payload_value(&self) -> Option<Uint256> {
+    pub fn execution_payload_value(&self) -> Uint256 {
         match self {
             BeaconBlockResponseWrapper::Full(resp) => resp.execution_payload_value,
             BeaconBlockResponseWrapper::Blinded(resp) => resp.execution_payload_value,
         }
     }
 
-    pub fn consensus_block_value(&self) -> Option<u64> {
+    pub fn consensus_block_value(&self) -> u64 {
         match self {
             BeaconBlockResponseWrapper::Full(resp) => resp.consensus_block_value,
             BeaconBlockResponseWrapper::Blinded(resp) => resp.consensus_block_value,
@@ -529,9 +529,9 @@ pub struct BeaconBlockResponse<T: EthSpec, Payload: AbstractExecPayload<T>> {
     /// The Blobs / Proofs associated with the new block
     pub blob_items: Option<(KzgProofs<T>, BlobsList<T>)>,
     /// The execution layer reward for the block
-    pub execution_payload_value: Option<Uint256>,
+    pub execution_payload_value: Uint256,
     /// The consensus layer reward to the proposer
-    pub consensus_block_value: Option<u64>,
+    pub consensus_block_value: u64,
 }
 
 impl FinalizationAndCanonicity {
@@ -5286,8 +5286,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             block,
             state,
             blob_items,
-            execution_payload_value: Some(execution_payload_value),
-            consensus_block_value: Some(consensus_block_value),
+            execution_payload_value,
+            consensus_block_value,
         })
     }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -5563,6 +5563,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                         parent_block_hash: forkchoice_update_params.head_hash.unwrap_or_default(),
                         payload_attributes: payload_attributes.into(),
                     },
+                    metadata: Default::default(),
                     version: Some(self.spec.fork_name_at_slot::<T::EthSpec>(prepare_slot)),
                 }));
             }

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -335,8 +335,9 @@ pub fn serve<E: EthSpec>(
                     .el
                     .get_payload_by_root(&root)
                     .ok_or_else(|| reject("missing payload for tx root"))?;
-                let resp = ForkVersionedResponse {
+                let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
                     version: Some(fork_name),
+                    metadata: Default::default(),
                     data: payload,
                 };
 
@@ -616,8 +617,9 @@ pub fn serve<E: EthSpec>(
                     .spec
                     .fork_name_at_epoch(slot.epoch(E::slots_per_epoch()));
                 let signed_bid = SignedBuilderBid { message, signature };
-                let resp = ForkVersionedResponse {
+                let resp: ForkVersionedResponse<_> = ForkVersionedResponse {
                     version: Some(fork_name),
+                    metadata: Default::default(),
                     data: signed_bid,
                 };
                 let json_bid = serde_json::to_string(&resp)

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2399,7 +2399,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
-                            metadata: EmptyMetadata,
+                            metadata: EmptyMetadata {},
                             data: bootstrap,
                         })
                         .into_response()),
@@ -2447,7 +2447,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
-                            metadata: EmptyMetadata,
+                            metadata: EmptyMetadata {},
                             data: update,
                         })
                         .into_response()),
@@ -2495,7 +2495,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
-                            metadata: EmptyMetadata,
+                            metadata: EmptyMetadata {},
                             data: update,
                         })
                         .into_response()),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -77,12 +77,12 @@ use tokio_stream::{
     StreamExt,
 };
 use types::{
-    Attestation, AttestationData, AttestationShufflingId, AttesterSlashing, BeaconStateError,
-    CommitteeCache, ConfigAndPreset, Epoch, EthSpec, ForkName, ForkVersionedResponse, Hash256,
-    ProposerPreparationData, ProposerSlashing, RelativeEpoch, SignedAggregateAndProof,
-    SignedBlindedBeaconBlock, SignedBlsToExecutionChange, SignedContributionAndProof,
-    SignedValidatorRegistrationData, SignedVoluntaryExit, Slot, SyncCommitteeMessage,
-    SyncContributionData,
+    fork_versioned_response::EmptyMetadata, Attestation, AttestationData, AttestationShufflingId,
+    AttesterSlashing, BeaconStateError, CommitteeCache, ConfigAndPreset, Epoch, EthSpec, ForkName,
+    ForkVersionedResponse, Hash256, ProposerPreparationData, ProposerSlashing, RelativeEpoch,
+    SignedAggregateAndProof, SignedBlindedBeaconBlock, SignedBlsToExecutionChange,
+    SignedContributionAndProof, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot,
+    SyncCommitteeMessage, SyncContributionData,
 };
 use validator::pubkey_to_validator_index;
 use version::{
@@ -2399,6 +2399,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
+                            metadata: EmptyMetadata,
                             data: bootstrap,
                         })
                         .into_response()),
@@ -2446,6 +2447,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
+                            metadata: EmptyMetadata,
                             data: update,
                         })
                         .into_response()),
@@ -2493,6 +2495,7 @@ pub fn serve<T: BeaconChainTypes>(
                             }),
                         _ => Ok(warp::reply::json(&ForkVersionedResponse {
                             version: Some(fork_name),
+                            metadata: EmptyMetadata,
                             data: update,
                         })
                         .into_response()),
@@ -3193,7 +3196,7 @@ pub fn serve<T: BeaconChainTypes>(
                     );
 
                     if endpoint_version == V3 {
-                        produce_block_v3(endpoint_version, accept_header, chain, slot, query).await
+                        produce_block_v3(accept_header, chain, slot, query).await
                     } else {
                         produce_block_v2(endpoint_version, accept_header, chain, slot, query).await
                     }

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -82,12 +82,11 @@ pub fn build_response_v3<T: BeaconChainTypes>(
     let consensus_block_value = block_response.consensus_block_value();
     let execution_payload_blinded = block_response.is_blinded();
 
-    // FIXME(sproul): block values shouldn't be optional
     let metadata = ProduceBlockV3Metadata {
         consensus_version: fork_name,
         execution_payload_blinded,
-        execution_payload_value: execution_payload_value.unwrap_or_default(),
-        consensus_block_value: consensus_block_value.unwrap_or_default(),
+        execution_payload_value,
+        consensus_block_value,
     };
 
     let block_contents = build_block_contents::build_block_contents(fork_name, block_response)?;

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -1,17 +1,3 @@
-use bytes::Bytes;
-use std::sync::Arc;
-use types::{payload::BlockProductionVersion, *};
-
-use beacon_chain::{
-    BeaconBlockResponseWrapper, BeaconChain, BeaconChainTypes, ProduceBlockVerification,
-};
-use eth2::types::{self as api_types, EndpointVersion, SkipRandaoVerification};
-use ssz::Encode;
-use warp::{
-    hyper::{Body, Response},
-    Reply,
-};
-
 use crate::{
     build_block_contents,
     version::{
@@ -19,6 +5,20 @@ use crate::{
         add_execution_payload_blinded_header, add_execution_payload_value_header,
         fork_versioned_response, inconsistent_fork_rejection,
     },
+};
+use beacon_chain::{
+    BeaconBlockResponseWrapper, BeaconChain, BeaconChainTypes, ProduceBlockVerification,
+};
+use bytes::Bytes;
+use eth2::types::{
+    self as api_types, EndpointVersion, ProduceBlockV3Metadata, SkipRandaoVerification,
+};
+use ssz::Encode;
+use std::sync::Arc;
+use types::{payload::BlockProductionVersion, *};
+use warp::{
+    hyper::{Body, Response},
+    Reply,
 };
 
 pub fn get_randao_verification(
@@ -40,7 +40,6 @@ pub fn get_randao_verification(
 }
 
 pub async fn produce_block_v3<T: BeaconChainTypes>(
-    endpoint_version: EndpointVersion,
     accept_header: Option<api_types::Accept>,
     chain: Arc<BeaconChain<T>>,
     slot: Slot,
@@ -68,13 +67,12 @@ pub async fn produce_block_v3<T: BeaconChainTypes>(
             warp_utils::reject::custom_bad_request(format!("failed to fetch a block: {:?}", e))
         })?;
 
-    build_response_v3(chain, block_response_type, endpoint_version, accept_header)
+    build_response_v3(chain, block_response_type, accept_header)
 }
 
 pub fn build_response_v3<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
     block_response: BeaconBlockResponseWrapper<T::EthSpec>,
-    endpoint_version: EndpointVersion,
     accept_header: Option<api_types::Accept>,
 ) -> Result<Response<Body>, warp::Rejection> {
     let fork_name = block_response
@@ -83,6 +81,14 @@ pub fn build_response_v3<T: BeaconChainTypes>(
     let execution_payload_value = block_response.execution_payload_value();
     let consensus_block_value = block_response.consensus_block_value();
     let execution_payload_blinded = block_response.is_blinded();
+
+    // FIXME(sproul): block values shouldn't be optional
+    let metadata = ProduceBlockV3Metadata {
+        consensus_version: fork_name,
+        execution_payload_blinded,
+        execution_payload_value: execution_payload_value.unwrap_or_default(),
+        consensus_block_value: consensus_block_value.unwrap_or_default(),
+    };
 
     let block_contents = build_block_contents::build_block_contents(fork_name, block_response)?;
 
@@ -100,12 +106,17 @@ pub fn build_response_v3<T: BeaconChainTypes>(
             .map_err(|e| -> warp::Rejection {
                 warp_utils::reject::custom_server_error(format!("failed to create response: {}", e))
             }),
-        _ => fork_versioned_response(endpoint_version, fork_name, block_contents)
-            .map(|response| warp::reply::json(&response).into_response())
-            .map(|res| add_consensus_version_header(res, fork_name))
-            .map(|res| add_execution_payload_blinded_header(res, execution_payload_blinded))
-            .map(|res| add_execution_payload_value_header(res, execution_payload_value))
-            .map(|res| add_consensus_block_value_header(res, consensus_block_value)),
+        _ => Ok(warp::reply::json(&ForkVersionedResponse {
+            version: Some(fork_name),
+            metadata,
+            data: block_contents,
+        })
+        .into_response())
+        .map(|res| res.into_response())
+        .map(|res| add_consensus_version_header(res, fork_name))
+        .map(|res| add_execution_payload_blinded_header(res, execution_payload_blinded))
+        .map(|res| add_execution_payload_value_header(res, execution_payload_value))
+        .map(|res| add_consensus_block_value_header(res, consensus_block_value)),
     }
 }
 

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -80,12 +80,12 @@ pub fn add_execution_payload_blinded_header<T: Reply>(
 /// Add the `Eth-Execution-Payload-Value` header to a response.
 pub fn add_execution_payload_value_header<T: Reply>(
     reply: T,
-    execution_payload_value: Option<Uint256>,
+    execution_payload_value: Uint256,
 ) -> Response {
     reply::with_header(
         reply,
         EXECUTION_PAYLOAD_VALUE_HEADER,
-        execution_payload_value.unwrap_or_default().to_string(),
+        execution_payload_value.to_string(),
     )
     .into_response()
 }
@@ -93,12 +93,12 @@ pub fn add_execution_payload_value_header<T: Reply>(
 /// Add the `Eth-Consensus-Block-Value` header to a response.
 pub fn add_consensus_block_value_header<T: Reply>(
     reply: T,
-    consensus_payload_value: Option<u64>,
+    consensus_payload_value: u64,
 ) -> Response {
     reply::with_header(
         reply,
         CONSENSUS_BLOCK_VALUE_HEADER,
-        consensus_payload_value.unwrap_or_default().to_string(),
+        consensus_payload_value.to_string(),
     )
     .into_response()
 }

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -1,11 +1,15 @@
-use crate::api_types::fork_versioned_response::ExecutionOptimisticFinalizedForkVersionedResponse;
 use crate::api_types::EndpointVersion;
 use eth2::{
     CONSENSUS_BLOCK_VALUE_HEADER, CONSENSUS_VERSION_HEADER, EXECUTION_PAYLOAD_BLINDED_HEADER,
     EXECUTION_PAYLOAD_VALUE_HEADER,
 };
 use serde::Serialize;
-use types::{ForkName, ForkVersionedResponse, InconsistentFork, Uint256};
+use types::{
+    fork_versioned_response::{
+        ExecutionOptimisticFinalizedForkVersionedResponse, ExecutionOptimisticFinalizedMetadata,
+    },
+    ForkName, ForkVersionedResponse, InconsistentFork, Uint256,
+};
 use warp::reply::{self, Reply, Response};
 
 pub const V1: EndpointVersion = EndpointVersion(1);
@@ -26,6 +30,7 @@ pub fn fork_versioned_response<T: Serialize>(
     };
     Ok(ForkVersionedResponse {
         version: fork_name,
+        metadata: Default::default(),
         data,
     })
 }
@@ -46,8 +51,10 @@ pub fn execution_optimistic_finalized_fork_versioned_response<T: Serialize>(
     };
     Ok(ExecutionOptimisticFinalizedForkVersionedResponse {
         version: fork_name,
-        execution_optimistic: Some(execution_optimistic),
-        finalized: Some(finalized),
+        metadata: ExecutionOptimisticFinalizedMetadata {
+            execution_optimistic: Some(execution_optimistic),
+            finalized: Some(finalized),
+        },
         data,
     })
 }

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -4,6 +4,7 @@ use beacon_chain::{
     test_utils::{AttestationStrategy, BlockStrategy, SyncCommitteeStrategy},
     ChainConfig,
 };
+use eth2::types::ProduceBlockV3Response;
 use eth2::types::{DepositContractData, StateId};
 use execution_layer::{ForkchoiceState, PayloadAttributes};
 use http_api::test_utils::InteractiveTester;
@@ -20,8 +21,6 @@ use types::{
     Address, Epoch, EthSpec, ExecPayload, ExecutionBlockHash, ForkName, MainnetEthSpec,
     MinimalEthSpec, ProposerPreparationData, Slot,
 };
-
-use eth2::types::ForkVersionedBeaconBlockType::{Blinded, Full};
 
 type E = MainnetEthSpec;
 
@@ -619,15 +618,17 @@ pub async fn proposer_boost_re_org_test(
     let randao_reveal = harness
         .sign_randao_reveal(&state_b, proposer_index, slot_c)
         .into();
-    let unsigned_block_type = tester
+    let (unsigned_block_type, _) = tester
         .client
         .get_validator_blocks_v3::<E>(slot_c, &randao_reveal, None)
         .await
         .unwrap();
 
     let (unsigned_block_c, block_c_blobs) = match unsigned_block_type {
-        Full(unsigned_block_contents_c) => unsigned_block_contents_c.data.deconstruct(),
-        Blinded(_) => {
+        ProduceBlockV3Response::Full(unsigned_block_contents_c) => {
+            unsigned_block_contents_c.deconstruct()
+        }
+        ProduceBlockV3Response::Blinded(_) => {
             panic!("Should not be a blinded block");
         }
     };

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -112,8 +112,8 @@ async fn state_by_root_pruned_from_fork_choice() {
             .unwrap()
             .unwrap();
 
-        assert!(response.finalized.unwrap());
-        assert!(!response.execution_optimistic.unwrap());
+        assert!(response.metadata.finalized.unwrap());
+        assert!(!response.metadata.execution_optimistic.unwrap());
 
         let mut state = response.data;
         assert_eq!(state.update_tree_hash_cache().unwrap(), state_root);
@@ -624,7 +624,7 @@ pub async fn proposer_boost_re_org_test(
         .await
         .unwrap();
 
-    let (unsigned_block_c, block_c_blobs) = match unsigned_block_type {
+    let (unsigned_block_c, block_c_blobs) = match unsigned_block_type.data {
         ProduceBlockV3Response::Full(unsigned_block_contents_c) => {
             unsigned_block_contents_c.deconstruct()
         }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -655,6 +655,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
+                .metadata
                 .finalized
                 .unwrap();
 
@@ -691,6 +692,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
+                .metadata
                 .finalized
                 .unwrap();
 
@@ -728,6 +730,7 @@ impl ApiTester {
                 .await
                 .unwrap()
                 .unwrap()
+                .metadata
                 .finalized
                 .unwrap();
 
@@ -3554,7 +3557,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: BlindedPayload<E> = match payload_type {
+        let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
                 payload.body().execution_payload().unwrap().into()
             }
@@ -3658,7 +3661,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: BlindedPayload<E> = match payload_type {
+        let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
                 payload.body().execution_payload().unwrap().into()
             }
@@ -3734,7 +3737,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: BlindedPayload<E> = match payload_type {
+        let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
                 payload.body().execution_payload().unwrap().into()
             }
@@ -3824,7 +3827,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: FullPayload<E> = match payload_type {
+        let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
                 payload.block().body().execution_payload().unwrap().into()
             }
@@ -3910,7 +3913,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: FullPayload<E> = match payload_type {
+        let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
                 payload.block().body().execution_payload().unwrap().into()
             }
@@ -3996,7 +3999,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: FullPayload<E> = match payload_type {
+        let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
                 payload.block().body().execution_payload().unwrap().into()
             }
@@ -4080,7 +4083,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: FullPayload<E> = match payload_type {
+        let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
                 payload.block().body().execution_payload().unwrap().into()
             }
@@ -4136,7 +4139,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4202,7 +4205,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4310,7 +4313,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
@@ -4330,7 +4333,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4458,7 +4461,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4488,7 +4491,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
@@ -4568,7 +4571,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let payload: FullPayload<E> = match payload_type {
+        let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
                 payload.block().body().execution_payload().unwrap().into()
             }
@@ -4637,7 +4640,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4701,7 +4704,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
@@ -4765,7 +4768,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4829,7 +4832,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
@@ -4891,7 +4894,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        let _block_contents = match payload_type {
+        let _block_contents = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => payload,
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
@@ -4963,7 +4966,7 @@ impl ApiTester {
             .await
             .unwrap();
 
-        match payload_type {
+        match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -287,7 +287,6 @@ impl BeaconNodeHttpClient {
             .await
             .optional()?;
 
-        // let headers = opt_response.headers();
         match opt_response {
             Some(resp) => {
                 let response_headers = resp.headers().clone();

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -128,8 +128,7 @@ pub struct Timeouts {
     pub get_beacon_blocks_ssz: Duration,
     pub get_debug_beacon_states: Duration,
     pub get_deposit_snapshot: Duration,
-    // FIXME(sproul): rename to get_validator_block
-    pub get_validator_block_ssz: Duration,
+    pub get_validator_block: Duration,
 }
 
 impl Timeouts {
@@ -145,7 +144,7 @@ impl Timeouts {
             get_beacon_blocks_ssz: timeout,
             get_debug_beacon_states: timeout,
             get_deposit_snapshot: timeout,
-            get_validator_block_ssz: timeout,
+            get_validator_block: timeout,
         }
     }
 }
@@ -1885,7 +1884,7 @@ impl BeaconNodeHttpClient {
             .get_response_with_response_headers(
                 path,
                 Accept::Json,
-                self.timeouts.get_validator_block_ssz,
+                self.timeouts.get_validator_block,
                 |response, headers| async move {
                     let metadata = ProduceBlockV3Metadata::try_from(&headers)
                         .map_err(Error::InvalidHeaders)?;
@@ -1943,7 +1942,7 @@ impl BeaconNodeHttpClient {
             .get_response_with_response_headers(
                 path,
                 Accept::Ssz,
-                self.timeouts.get_validator_block_ssz,
+                self.timeouts.get_validator_block,
                 |response, headers| async move {
                     let metadata = ProduceBlockV3Metadata::try_from(&headers)
                         .map_err(Error::InvalidHeaders)?;
@@ -2006,7 +2005,7 @@ impl BeaconNodeHttpClient {
             .get_validator_blocks_path::<T>(slot, randao_reveal, graffiti, skip_randao_verification)
             .await?;
 
-        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_validator_block_ssz)
+        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_validator_block)
             .await
     }
 
@@ -2110,7 +2109,7 @@ impl BeaconNodeHttpClient {
             )
             .await?;
 
-        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_validator_block_ssz)
+        self.get_bytes_opt_accept_header(path, Accept::Ssz, self.timeouts.get_validator_block)
             .await
     }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1520,6 +1520,9 @@ pub enum ProduceBlockV3Response<E: EthSpec> {
     Blinded(BlindedBeaconBlock<E>),
 }
 
+pub type JsonProduceBlockV3Response<E> =
+    ForkVersionedResponse<ProduceBlockV3Response<E>, ProduceBlockV3Metadata>;
+
 /// A wrapper over a [`BeaconBlock`] or a [`BlockContents`].
 #[derive(Debug, Encode, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -1534,12 +1537,24 @@ pub enum FullBlockContents<T: EthSpec> {
 
 pub type BlockContentsTuple<T> = (BeaconBlock<T>, Option<(KzgProofs<T>, BlobsList<T>)>);
 
-/// Metadata about a `ProduceBlockV3Response` which is returned in headers.
-#[derive(Debug)]
+// This value should never be used
+fn dummy_consensus_version() -> ForkName {
+    ForkName::Base
+}
+
+/// Metadata about a `ProduceBlockV3Response` which is returned in the body & headers.
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ProduceBlockV3Metadata {
+    // The consensus version is serialized & deserialized by `ForkVersionedResponse`.
+    #[serde(
+        skip_serializing,
+        skip_deserializing,
+        default = "dummy_consensus_version"
+    )]
     pub consensus_version: ForkName,
     pub execution_payload_blinded: bool,
     pub execution_payload_value: Uint256,
+    #[serde(with = "serde_utils::quoted_u64")]
     pub consensus_block_value: u64,
 }
 

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1434,12 +1434,6 @@ pub mod serde_status_code {
     }
 }
 
-// FIXME(sproul): replace by ForkVersionedResponse<ProduceBlockV3Response>?
-pub enum ForkVersionedBeaconBlockType<T: EthSpec> {
-    Full(ForkVersionedResponse<FullBlockContents<T>>),
-    Blinded(ForkVersionedResponse<BlindedBeaconBlock<T>>),
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1,9 +1,13 @@
 //! This module exposes a superset of the `types` crate. It adds additional types that are only
 //! required for the HTTP API.
 
-use crate::Error as ServerError;
+use crate::{
+    Error as ServerError, CONSENSUS_BLOCK_VALUE_HEADER, CONSENSUS_VERSION_HEADER,
+    EXECUTION_PAYLOAD_BLINDED_HEADER, EXECUTION_PAYLOAD_VALUE_HEADER,
+};
 use lighthouse_network::{ConnectionDirection, Enr, Multiaddr, PeerConnectionStatus};
 use mediatype::{names, MediaType, MediaTypeList};
+use reqwest::header::HeaderMap;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use ssz::{Decode, DecodeError};
@@ -1430,6 +1434,7 @@ pub mod serde_status_code {
     }
 }
 
+// FIXME(sproul): replace by ForkVersionedResponse<ProduceBlockV3Response>?
 pub enum ForkVersionedBeaconBlockType<T: EthSpec> {
     Full(ForkVersionedResponse<FullBlockContents<T>>),
     Blinded(ForkVersionedResponse<BlindedBeaconBlock<T>>),
@@ -1535,6 +1540,15 @@ pub enum FullBlockContents<T: EthSpec> {
 
 pub type BlockContentsTuple<T> = (BeaconBlock<T>, Option<(KzgProofs<T>, BlobsList<T>)>);
 
+/// Metadata about a `ProduceBlockV3Response` which is returned in headers.
+#[derive(Debug)]
+pub struct ProduceBlockV3Metadata {
+    pub consensus_version: ForkName,
+    pub execution_payload_blinded: bool,
+    pub execution_payload_value: Uint256,
+    pub consensus_block_value: u64,
+}
+
 impl<T: EthSpec> FullBlockContents<T> {
     pub fn new(block: BeaconBlock<T>, blob_data: Option<(KzgProofs<T>, BlobsList<T>)>) -> Self {
         match blob_data {
@@ -1556,13 +1570,19 @@ impl<T: EthSpec> FullBlockContents<T> {
                 len: bytes.len(),
                 expected: slot_len,
             })?;
-
         let slot = Slot::from_ssz_bytes(slot_bytes)?;
         let fork_at_slot = spec.fork_name_at_slot::<T>(slot);
+        Self::from_ssz_bytes_for_fork(bytes, fork_at_slot)
+    }
 
-        match fork_at_slot {
+    /// SSZ decode with fork variant passed in explicitly.
+    pub fn from_ssz_bytes_for_fork(
+        bytes: &[u8],
+        fork_name: ForkName,
+    ) -> Result<Self, ssz::DecodeError> {
+        match fork_name {
             ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
-                BeaconBlock::from_ssz_bytes(bytes, spec)
+                BeaconBlock::from_ssz_bytes_for_fork(bytes, fork_name)
                     .map(|block| FullBlockContents::Block(block))
             }
             ForkName::Deneb => {
@@ -1573,8 +1593,9 @@ impl<T: EthSpec> FullBlockContents<T> {
                 builder.register_type::<BlobsList<T>>()?;
 
                 let mut decoder = builder.build()?;
-                let block =
-                    decoder.decode_next_with(|bytes| BeaconBlock::from_ssz_bytes(bytes, spec))?;
+                let block = decoder.decode_next_with(|bytes| {
+                    BeaconBlock::from_ssz_bytes_for_fork(bytes, fork_name)
+                })?;
                 let kzg_proofs = decoder.decode_next()?;
                 let blobs = decoder.decode_next()?;
 
@@ -1642,6 +1663,52 @@ impl<T: EthSpec> Into<BeaconBlock<T>> for FullBlockContents<T> {
 }
 
 pub type SignedBlockContentsTuple<T> = (SignedBeaconBlock<T>, Option<(KzgProofs<T>, BlobsList<T>)>);
+
+fn parse_required_header<T>(
+    headers: &HeaderMap,
+    header_name: &str,
+    parse: impl FnOnce(&str) -> Result<T, String>,
+) -> Result<T, String> {
+    let str_value = headers
+        .get(header_name)
+        .ok_or_else(|| format!("missing required header {header_name}"))?
+        .to_str()
+        .map_err(|e| format!("invalid value in {header_name}: {e}"))?;
+    parse(str_value)
+}
+
+impl TryFrom<&HeaderMap> for ProduceBlockV3Metadata {
+    type Error = String;
+
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        let consensus_version = parse_required_header(headers, CONSENSUS_VERSION_HEADER, |s| {
+            s.parse::<ForkName>()
+                .map_err(|e| format!("invalid {CONSENSUS_VERSION_HEADER}: {e:?}"))
+        })?;
+        let execution_payload_blinded =
+            parse_required_header(headers, EXECUTION_PAYLOAD_BLINDED_HEADER, |s| {
+                s.parse::<bool>()
+                    .map_err(|e| format!("invalid {EXECUTION_PAYLOAD_BLINDED_HEADER}: {e:?}"))
+            })?;
+        let execution_payload_value =
+            parse_required_header(headers, EXECUTION_PAYLOAD_VALUE_HEADER, |s| {
+                s.parse::<Uint256>()
+                    .map_err(|e| format!("invalid {EXECUTION_PAYLOAD_VALUE_HEADER}: {e:?}"))
+            })?;
+        let consensus_block_value =
+            parse_required_header(headers, CONSENSUS_BLOCK_VALUE_HEADER, |s| {
+                s.parse::<u64>()
+                    .map_err(|e| format!("invalid {CONSENSUS_BLOCK_VALUE_HEADER}: {e:?}"))
+            })?;
+
+        Ok(ProduceBlockV3Metadata {
+            consensus_version,
+            execution_payload_blinded,
+            execution_payload_value,
+            consensus_block_value,
+        })
+    }
+}
 
 /// A wrapper over a [`SignedBeaconBlock`] or a [`SignedBlockContents`].
 #[derive(Clone, Debug, Encode, Serialize, Deserialize)]

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -112,12 +112,15 @@ impl<T: EthSpec, Payload: AbstractExecPayload<T>> BeaconBlock<T, Payload> {
 
         let slot = Slot::from_ssz_bytes(slot_bytes)?;
         let fork_at_slot = spec.fork_name_at_slot::<T>(slot);
+        Self::from_ssz_bytes_for_fork(bytes, fork_at_slot)
+    }
 
-        Ok(map_fork_name!(
-            fork_at_slot,
-            Self,
-            <_>::from_ssz_bytes(bytes)?
-        ))
+    /// Custom SSZ decoder that takes a `ForkName` as context.
+    pub fn from_ssz_bytes_for_fork(
+        bytes: &[u8],
+        fork_name: ForkName,
+    ) -> Result<Self, ssz::DecodeError> {
+        Ok(map_fork_name!(fork_name, Self, <_>::from_ssz_bytes(bytes)?))
     }
 
     /// Try decoding each beacon block variant in sequence.

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -4,47 +4,6 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::value::Value;
 use std::sync::Arc;
 
-// Deserialize is only implemented for types that implement ForkVersionDeserialize
-#[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct ExecutionOptimisticFinalizedForkVersionedResponse<T> {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<ForkName>,
-    pub execution_optimistic: Option<bool>,
-    pub finalized: Option<bool>,
-    pub data: T,
-}
-
-impl<'de, F> serde::Deserialize<'de> for ExecutionOptimisticFinalizedForkVersionedResponse<F>
-where
-    F: ForkVersionDeserialize,
-{
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            version: Option<ForkName>,
-            execution_optimistic: Option<bool>,
-            finalized: Option<bool>,
-            data: serde_json::Value,
-        }
-
-        let helper = Helper::deserialize(deserializer)?;
-        let data = match helper.version {
-            Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
-            None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
-        };
-
-        Ok(ExecutionOptimisticFinalizedForkVersionedResponse {
-            version: helper.version,
-            execution_optimistic: helper.execution_optimistic,
-            finalized: helper.finalized,
-            data,
-        })
-    }
-}
-
 pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
     fn deserialize_by_fork<'de, D: Deserializer<'de>>(
         value: Value,
@@ -52,17 +11,38 @@ pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
     ) -> Result<Self, D::Error>;
 }
 
-// Deserialize is only implemented for types that implement ForkVersionDeserialize
+/// Deserialize is only implemented for types that implement ForkVersionDeserialize.
+///
+/// The metadata of type M should be set to `()` if you don't care about adding fields other than
+/// version. If you *do* care about adding other fields you can mix in any type that implements
+/// `Deserialize`.
 #[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct ForkVersionedResponse<T> {
+pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ForkName>,
+    #[serde(flatten)]
+    pub metadata: M,
     pub data: T,
 }
 
-impl<'de, F> serde::Deserialize<'de> for ForkVersionedResponse<F>
+/// Metadata type similar to unit (i.e. `()`) but deserializes from a map (`serde_json::Value`).
+#[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
+pub struct EmptyMetadata;
+
+/// Fork versioned response with extra information about finalization & optimistic execution.
+pub type ExecutionOptimisticFinalizedForkVersionedResponse<T> =
+    ForkVersionedResponse<T, ExecutionOptimisticFinalizedMetadata>;
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct ExecutionOptimisticFinalizedMetadata {
+    pub execution_optimistic: Option<bool>,
+    pub finalized: Option<bool>,
+}
+
+impl<'de, F, M> serde::Deserialize<'de> for ForkVersionedResponse<F, M>
 where
     F: ForkVersionDeserialize,
+    M: DeserializeOwned,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -71,6 +51,8 @@ where
         #[derive(Deserialize)]
         struct Helper {
             version: Option<ForkName>,
+            #[serde(flatten)]
+            metadata: serde_json::Value,
             data: serde_json::Value,
         }
 
@@ -79,9 +61,11 @@ where
             Some(fork_name) => F::deserialize_by_fork::<'de, D>(helper.data, fork_name)?,
             None => serde_json::from_value(helper.data).map_err(serde::de::Error::custom)?,
         };
+        let metadata = serde_json::from_value(helper.metadata).map_err(serde::de::Error::custom)?;
 
         Ok(ForkVersionedResponse {
             version: helper.version,
+            metadata,
             data,
         })
     }
@@ -95,6 +79,22 @@ impl<F: ForkVersionDeserialize> ForkVersionDeserialize for Arc<F> {
         Ok(Arc::new(F::deserialize_by_fork::<'de, D>(
             value, fork_name,
         )?))
+    }
+}
+
+impl<T, M> ForkVersionedResponse<T, M> {
+    /// Apply a function to the inner `data`, potentially changing its type.
+    pub fn map_data<U>(self, f: impl FnOnce(T) -> U) -> ForkVersionedResponse<U, M> {
+        let ForkVersionedResponse {
+            version,
+            metadata,
+            data,
+        } = self;
+        ForkVersionedResponse {
+            version,
+            metadata,
+            data: f(data),
+        }
     }
 }
 
@@ -112,6 +112,7 @@ mod fork_version_response_tests {
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
                 version: Some(ForkName::Merge),
+                metadata: Default::default(),
                 data: ExecutionPayload::Merge(ExecutionPayloadMerge::default()),
             }))
             .unwrap();
@@ -129,6 +130,7 @@ mod fork_version_response_tests {
         let response_json =
             serde_json::to_string(&json!(ForkVersionedResponse::<ExecutionPayload<E>> {
                 version: Some(ForkName::Capella),
+                metadata: Default::default(),
                 data: ExecutionPayload::Merge(ExecutionPayloadMerge::default()),
             }))
             .unwrap();

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -13,7 +13,7 @@ pub trait ForkVersionDeserialize: Sized + DeserializeOwned {
 
 /// Deserialize is only implemented for types that implement ForkVersionDeserialize.
 ///
-/// The metadata of type M should be set to `()` if you don't care about adding fields other than
+/// The metadata of type M should be set to `EmptyMetadata` if you don't care about adding fields other than
 /// version. If you *do* care about adding other fields you can mix in any type that implements
 /// `Deserialize`.
 #[derive(Debug, PartialEq, Clone, Serialize)]

--- a/consensus/types/src/fork_versioned_response.rs
+++ b/consensus/types/src/fork_versioned_response.rs
@@ -26,8 +26,11 @@ pub struct ForkVersionedResponse<T, M = EmptyMetadata> {
 }
 
 /// Metadata type similar to unit (i.e. `()`) but deserializes from a map (`serde_json::Value`).
+///
+/// Unfortunately the braces are semantically significant, i.e. `struct EmptyMetadata;` does not
+/// work.
 #[derive(Debug, PartialEq, Clone, Default, Deserialize, Serialize)]
-pub struct EmptyMetadata;
+pub struct EmptyMetadata {}
 
 /// Fork versioned response with extra information about finalization & optimistic execution.
 pub type ExecutionOptimisticFinalizedForkVersionedResponse<T> =

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -83,7 +83,7 @@ const HTTP_SYNC_DUTIES_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
 const HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT: u32 = 4;
 const HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT: u32 = 4;
-const HTTP_GET_VALIDATOR_BLOCK_SSZ_TIMEOUT_QUOTIENT: u32 = 4;
+const HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT: u32 = 4;
 
 const DOPPELGANGER_SERVICE_NAME: &str = "doppelganger";
 
@@ -311,8 +311,7 @@ impl<T: EthSpec> ProductionValidatorClient<T> {
                         / HTTP_GET_BEACON_BLOCK_SSZ_TIMEOUT_QUOTIENT,
                     get_debug_beacon_states: slot_duration / HTTP_GET_DEBUG_BEACON_STATE_QUOTIENT,
                     get_deposit_snapshot: slot_duration / HTTP_GET_DEPOSIT_SNAPSHOT_QUOTIENT,
-                    get_validator_block_ssz: slot_duration
-                        / HTTP_GET_VALIDATOR_BLOCK_SSZ_TIMEOUT_QUOTIENT,
+                    get_validator_block: slot_duration / HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT,
                 }
             } else {
                 Timeouts::set_all(slot_duration)


### PR DESCRIPTION
## Proposed Changes

- Add the metadata fields like `execution_payload_value` to the JSON response for blocks/v3. Previously we were not following the spec.
- Overhaul (simplify?) `ForkVersionedResponse` so that it can carry arbitrary `metadata`. This is used to smuggle the metadata without adding a new variant of `ForkVersionedResponse`. This required some refactoring elsewhere, but on the whole I think it's an improvement.
- Parse and use the HTTP headers in the client code for the `produce_block` v3 API. This ensures the headers are checked in the tests, and enables blockdreamer to make use of the header metadata (see: https://github.com/blockprint-collective/blockdreamer/pull/5).


## Additional Info

This PR conflicts slightly with #4813. I was thinking we could merge this PR first.

This PR **does not** include the `builder_comparison_factor` change (https://github.com/ethereum/beacon-APIs/pull/386). That needs to happen in another PR.
