### PR TITLE
Track shared memory in metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.9.0",
+ "memoffset",
  "scopeguard",
 ]
 
@@ -2663,7 +2663,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset 0.9.0",
+ "memoffset",
  "rustc_version",
 ]
 
@@ -4846,10 +4846,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach"
-version = "0.3.2"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
 ]
@@ -4931,15 +4931,6 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "memoffset"
@@ -5277,19 +5268,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util 0.6.10",
  "types",
-]
-
-[[package]]
-name = "nix"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
 ]
 
 [[package]]
@@ -6182,16 +6160,16 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psutil"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f866af2b0f8e4b0d2d00aad8a9c5fc48fad33466cd99a64cbb3a4c1505f1a62d"
+checksum = "5e617cc9058daa5e1fe5a0d23ed745773a5ee354111dad1ec0235b0cc16b6730"
 dependencies = [
  "cfg-if",
  "darwin-libproc",
  "derive_more",
  "glob",
- "mach",
- "nix 0.23.2",
+ "mach2",
+ "nix 0.24.3",
  "num_cpus",
  "once_cell",
  "platforms 2.0.0",

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -36,7 +36,7 @@ pretty_reqwest_error = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-psutil = { version = "3.2.2", optional = true }
+psutil = { version = "3.3.0", optional = true }
 procfs = { version = "0.15.1", optional = true }
 
 [features]

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -243,6 +243,8 @@ pub struct ProcessHealth {
     pub pid_mem_resident_set_size: u64,
     /// The total virtual memory used by this pid.
     pub pid_mem_virtual_memory_size: u64,
+    /// The total shared memory used by this pid.
+    pub pid_mem_shared_memory_size: u64,
     /// Number of cpu seconds consumed by this pid.
     pub pid_process_seconds_total: u64,
 }
@@ -277,6 +279,7 @@ impl ProcessHealth {
             pid_num_threads: stat.num_threads,
             pid_mem_resident_set_size: process_mem.rss(),
             pid_mem_virtual_memory_size: process_mem.vms(),
+            pid_mem_shared_memory_size: process_mem.shared(),
             pid_process_seconds_total: process_times.busy().as_secs()
                 + process_times.children_system().as_secs()
                 + process_times.children_system().as_secs(),

--- a/common/warp_utils/src/metrics.rs
+++ b/common/warp_utils/src/metrics.rs
@@ -14,6 +14,10 @@ lazy_static::lazy_static! {
         "process_virtual_memory_bytes",
         "Virtual memory used by the current process"
     );
+    pub static ref PROCESS_SHR_MEM: Result<IntGauge> = try_create_int_gauge(
+        "process_shared_memory_bytes",
+        "Shared memory used by the current process"
+    );
     pub static ref PROCESS_SECONDS: Result<IntGauge> = try_create_int_gauge(
         "process_cpu_seconds_total",
         "Total cpu time taken by the current process"
@@ -90,6 +94,7 @@ pub fn scrape_process_health_metrics() {
         set_gauge(&PROCESS_NUM_THREADS, health.pid_num_threads);
         set_gauge(&PROCESS_RES_MEM, health.pid_mem_resident_set_size as i64);
         set_gauge(&PROCESS_VIRT_MEM, health.pid_mem_virtual_memory_size as i64);
+        set_gauge(&PROCESS_SHR_MEM, health.pid_mem_shared_memory_size as i64);
         set_gauge(&PROCESS_SECONDS, health.pid_process_seconds_total as i64);
     }
 }


### PR DESCRIPTION
## Issue Addressed

The metrics endpoint currently expose `process_resident_memory_bytes`, which includes shared memory. This usually gets pretty big when running a slasher, and it would be useful to exclude this memory so we don't get false positives on leaks.

This PR exposes an additional `process_shared_memory_bytes` which tracks the shared memory.