### PR TITLE
Bump `zerocopy` to address rustsec vuln

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9265,18 +9265,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.29"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d075cf85bbb114e933343e087b92f2146bac0d55b534cbb8188becf0039948e"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.29"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd5ca076997b97ef09d3ad65efe811fa68c9e874cb636ccb211223a813b0c2"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->
N/A

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Bumped `zerocopy` to address rustsec vuln: https://rustsec.org/advisories/RUSTSEC-2023-0075

## Additional Info
<!--
Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->
N/A