### PR TITLE
Disallow Syncing From Genesis By Default

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -956,6 +956,14 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("180")
         )
         .arg(
+            Arg::with_name("allow-insecure-genesis-sync")
+                .long("allow-insecure-genesis-sync")
+                .help("Enable syncing from genesis. This is insecure after Capella due to long-range attacks. This should only be used for testing. DO NOT use on mainnet!")
+                .conflicts_with("checkpoint-sync-url")
+                .conflicts_with("checkpoint-state")
+                .takes_value(false)
+        )
+        .arg(
             Arg::with_name("reconstruct-historic-states")
                 .long("reconstruct-historic-states")
                 .help("After a checkpoint sync, reconstruct historic states in the database. This requires syncing all the way back to genesis.")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -518,8 +518,15 @@ pub fn get_config<E: EthSpec>(
                 .map_err(|e| format!("Invalid checkpoint sync URL: {:?}", e))?;
 
             ClientGenesis::CheckpointSyncUrl { url }
-        } else {
+        } else if cli_args.is_present("allow-insecure-genesis-sync") {
             ClientGenesis::GenesisState
+        } else {
+            return Err(
+                    "Syncing from genesis is not secure post-Capella! \
+                    You should instead perform a checkpoint sync from a trusted node using the --checkpoint-sync-url option. \
+                    For a list of public endpoints, see:\nhttps://eth-clients.github.io/checkpoint-sync-endpoints/"
+                        .to_string(),
+                );
         }
     } else {
         if cli_args.is_present("checkpoint-state") || cli_args.is_present("checkpoint-sync-url") {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -50,6 +50,12 @@ struct CommandLineTest {
 }
 impl CommandLineTest {
     fn new() -> CommandLineTest {
+        let mut base_cmd = base_cmd();
+        base_cmd.arg("--allow-insecure-genesis-sync");
+        CommandLineTest { cmd: base_cmd }
+    }
+
+    fn without_allow_genesis_sync() -> CommandLineTest {
         let base_cmd = base_cmd();
         CommandLineTest { cmd: base_cmd }
     }
@@ -90,6 +96,12 @@ fn staking_flag() {
                 DEFAULT_ETH1_ENDPOINT
             );
         });
+}
+
+#[test]
+#[should_panic]
+fn run_without_allow_genesis_sync() {
+    CommandLineTest::without_allow_genesis_sync().run_with_zero_port();
 }
 
 #[test]


### PR DESCRIPTION
## Issue Addressed

* #4377 

This is WIP. Still needs:

 * When povided the gensis sync flag, consider blocks that are from outside the prune window available if they are finalized
 * During checkpoint sync backfill, always consider blobs from prior to the provided checkpoint available regardless of whether the flag is provided