### PR TITLE
create unified slashing cache

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3161,9 +3161,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         blobs: FixedBlobSidecarList<T::EthSpec>,
     ) -> Result<AvailabilityProcessingStatus, BlockError<T::EthSpec>> {
         if let Some(slasher) = self.slasher.as_ref() {
+            let mut slashable_cache = self.observed_slashable.write();
             for blob_sidecar in blobs.iter().filter_map(|blob| blob.clone()) {
-                self.observed_slashable
-                    .write()
+                slashable_cache
                     .observe_slashable(
                         blob_sidecar.slot(),
                         blob_sidecar.block_proposer_index(),

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3169,17 +3169,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .filter_map(|b| b.as_ref().map(|b| b.signed_block_header.clone()))
                 .unique()
             {
-                verify_header_signature::<T, BlockError<T::EthSpec>>(self, &header)?;
-
-                slashable_cache
-                    .observe_slashable(
-                        header.message.slot,
-                        header.message.proposer_index,
-                        block_root,
-                    )
-                    .map_err(|e| BlockError::BeaconChainError(e.into()))?;
-                if let Some(slasher) = self.slasher.as_ref() {
-                    slasher.accept_block_header(header);
+                if verify_header_signature::<T, BlockError<T::EthSpec>>(self, &header).is_ok() {
+                    slashable_cache
+                        .observe_slashable(
+                            header.message.slot,
+                            header.message.proposer_index,
+                            block_root,
+                        )
+                        .map_err(|e| BlockError::BeaconChainError(e.into()))?;
+                    if let Some(slasher) = self.slasher.as_ref() {
+                        slasher.accept_block_header(header);
+                    }
                 }
             }
         }

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -599,6 +599,16 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes>(
         });
     }
 
+    chain
+        .observed_slashable
+        .write()
+        .observe_slashable(
+            blob_sidecar.slot(),
+            blob_sidecar.block_proposer_index(),
+            block_root,
+        )
+        .map_err(|e| GossipBlobError::BeaconChainError(e.into()))?;
+
     // Now the signature is valid, store the proposal so we don't accept another blob sidecar
     // with the same `BlobIdentifier`.
     // It's important to double-check that the proposer still hasn't been observed so we don't
@@ -622,16 +632,6 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes>(
             index: blob_index,
         });
     }
-
-    chain
-        .observed_slashable
-        .write()
-        .observe_slashable(
-            blob_sidecar.slot(),
-            blob_sidecar.block_proposer_index(),
-            block_root,
-        )
-        .map_err(|e| GossipBlobError::BeaconChainError(e.into()))?;
 
     // Kzg verification for gossip blob sidecar
     let kzg = chain

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -623,6 +623,16 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes>(
         });
     }
 
+    chain
+        .observed_slashable
+        .write()
+        .observe_slashable(
+            blob_sidecar.slot(),
+            blob_sidecar.block_proposer_index(),
+            block_root,
+        )
+        .map_err(|e| GossipBlobError::BeaconChainError(e.into()))?;
+
     // Kzg verification for gossip blob sidecar
     let kzg = chain
         .kzg

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -2077,7 +2077,7 @@ fn get_signature_verifier<'a, T: BeaconChainTypes>(
 /// Verify that `header` was signed with a valid signature from its proposer.
 ///
 /// Return `Ok(())` if the signature is valid, and an `Err` otherwise.
-fn verify_header_signature<T: BeaconChainTypes, Err: BlockBlobError>(
+pub fn verify_header_signature<T: BeaconChainTypes, Err: BlockBlobError>(
     chain: &BeaconChain<T>,
     header: &SignedBeaconBlockHeader,
 ) -> Result<(), Err> {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -945,6 +945,11 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             return Err(BlockError::ProposalSignatureInvalid);
         }
 
+        chain
+            .observed_slashable
+            .write()
+            .observe_slashable(block.slot(), block.message().proposer_index(), block_root)
+            .map_err(|e| BlockError::BeaconChainError(e.into()))?;
         // Now the signature is valid, store the proposal so we don't accept another from this
         // validator and slot.
         //
@@ -958,12 +963,6 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         {
             return Err(BlockError::BlockIsAlreadyKnown);
         };
-
-        chain
-            .observed_slashable
-            .write()
-            .observe_slashable(block.slot(), block.message().proposer_index(), block_root)
-            .map_err(|e| BlockError::BeaconChainError(e.into()))?;
 
         if block.message().proposer_index() != expected_proposer as u64 {
             return Err(BlockError::IncorrectBlockProposer {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -58,6 +58,7 @@ use crate::execution_payload::{
     is_optimistic_candidate_block, validate_execution_payload_for_gossip, validate_merge_block,
     AllowOptimisticImport, NotifyExecutionLayer, PayloadNotifier,
 };
+use crate::observed_block_producers::SeenBlock;
 use crate::snapshot_cache::PreProcessingSnapshot;
 use crate::validator_monitor::HISTORIC_EPOCHS as VALIDATOR_MONITOR_HISTORIC_EPOCHS;
 use crate::validator_pubkey_cache::ValidatorPubkeyCache;
@@ -955,13 +956,17 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
         //
         // It's important to double-check that the proposer still hasn't been observed so we don't
         // have a race-condition when verifying two blocks simultaneously.
-        if chain
+        match chain
             .observed_block_producers
             .write()
-            .observe_proposal(block.message())
+            .observe_proposal(block_root, block.message())
             .map_err(|e| BlockError::BeaconChainError(e.into()))?
         {
-            return Err(BlockError::BlockIsAlreadyKnown);
+            SeenBlock::Slashable => {
+                return Err(BlockError::Slashable);
+            }
+            SeenBlock::Duplicate => return Err(BlockError::BlockIsAlreadyKnown),
+            SeenBlock::UniqueNonSlashable => {}
         };
 
         if block.message().proposer_index() != expected_proposer as u64 {
@@ -1242,14 +1247,15 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         notify_execution_layer: NotifyExecutionLayer,
     ) -> Result<Self, BlockError<T::EthSpec>> {
         chain
-            .observed_block_producers
-            .write()
-            .observe_proposal(block.message())
-            .map_err(|e| BlockError::BeaconChainError(e.into()))?;
-        chain
             .observed_slashable
             .write()
             .observe_slashable(block.slot(), block.message().proposer_index(), block_root)
+            .map_err(|e| BlockError::BeaconChainError(e.into()))?;
+
+        chain
+            .observed_block_producers
+            .write()
+            .observe_proposal(block_root, block.message())
             .map_err(|e| BlockError::BeaconChainError(e.into()))?;
 
         if let Some(parent) = chain

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -880,6 +880,7 @@ where
             // TODO: allow for persisting and loading the pool from disk.
             observed_block_producers: <_>::default(),
             observed_blob_sidecars: <_>::default(),
+            observed_slashable: <_>::default(),
             observed_voluntary_exits: <_>::default(),
             observed_proposer_slashings: <_>::default(),
             observed_attester_slashings: <_>::default(),

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -991,6 +991,13 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .start_slot(T::EthSpec::slots_per_epoch()),
         );
 
+        self.observed_slashable.write().prune(
+            new_view
+                .finalized_checkpoint
+                .epoch
+                .start_slot(T::EthSpec::slots_per_epoch()),
+        );
+
         self.snapshot_cache
             .try_write_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
             .map(|mut snapshot_cache| {

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -40,6 +40,7 @@ mod observed_attesters;
 mod observed_blob_sidecars;
 pub mod observed_block_producers;
 pub mod observed_operations;
+mod observed_slashable;
 pub mod otb_verification_service;
 mod persisted_beacon_chain;
 mod persisted_fork_choice;

--- a/beacon_node/beacon_chain/src/observed_block_producers.rs
+++ b/beacon_node/beacon_chain/src/observed_block_producers.rs
@@ -1,9 +1,10 @@
 //! Provides the `ObservedBlockProducers` struct which allows for rejecting gossip blocks from
 //! validators that have already produced a block.
 
-use std::collections::HashSet;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
-use types::{BeaconBlockRef, Epoch, EthSpec, Slot, Unsigned};
+use types::{BeaconBlockRef, Epoch, EthSpec, Hash256, Slot, Unsigned};
 
 #[derive(Debug, PartialEq)]
 pub enum Error {
@@ -39,7 +40,7 @@ impl ProposalKey {
 /// known_distinct_shufflings` which is much smaller.
 pub struct ObservedBlockProducers<E: EthSpec> {
     finalized_slot: Slot,
-    items: HashSet<ProposalKey>,
+    items: HashMap<ProposalKey, HashSet<Hash256>>,
     _phantom: PhantomData<E>,
 }
 
@@ -48,9 +49,27 @@ impl<E: EthSpec> Default for ObservedBlockProducers<E> {
     fn default() -> Self {
         Self {
             finalized_slot: Slot::new(0),
-            items: HashSet::new(),
+            items: HashMap::new(),
             _phantom: PhantomData,
         }
+    }
+}
+
+pub enum SeenBlock {
+    Duplicate,
+    Slashable,
+    UniqueNonSlashable,
+}
+
+impl SeenBlock {
+    pub fn proposer_previously_observed(self) -> bool {
+        match self {
+            Self::Duplicate | Self::Slashable => true,
+            Self::UniqueNonSlashable => false,
+        }
+    }
+    pub fn is_slashable(&self) -> bool {
+        matches!(self, Self::Slashable)
     }
 }
 
@@ -64,7 +83,11 @@ impl<E: EthSpec> ObservedBlockProducers<E> {
     ///
     /// - `block.proposer_index` is greater than `VALIDATOR_REGISTRY_LIMIT`.
     /// - `block.slot` is equal to or less than the latest pruned `finalized_slot`.
-    pub fn observe_proposal(&mut self, block: BeaconBlockRef<'_, E>) -> Result<bool, Error> {
+    pub fn observe_proposal(
+        &mut self,
+        block_root: Hash256,
+        block: BeaconBlockRef<'_, E>,
+    ) -> Result<SeenBlock, Error> {
         self.sanitize_block(block)?;
 
         let key = ProposalKey {
@@ -72,9 +95,69 @@ impl<E: EthSpec> ObservedBlockProducers<E> {
             proposer: block.proposer_index(),
         };
 
-        let already_exists = self.items.insert(key);
+        let entry = self.items.entry(key);
 
-        Ok(!already_exists)
+        let slashable_proposal = match entry {
+            Entry::Occupied(mut occupied_entry) => {
+                let block_roots = occupied_entry.get_mut();
+                let newly_inserted = block_roots.insert(block_root);
+
+                let is_equivocation = block_roots.len() > 1;
+
+                if is_equivocation {
+                    SeenBlock::Slashable
+                } else if !newly_inserted {
+                    SeenBlock::Duplicate
+                } else {
+                    SeenBlock::UniqueNonSlashable
+                }
+            }
+            Entry::Vacant(vacant_entry) => {
+                let block_roots = HashSet::from([block_root]);
+                vacant_entry.insert(block_roots);
+
+                SeenBlock::UniqueNonSlashable
+            }
+        };
+
+        Ok(slashable_proposal)
+    }
+
+    /// Returns `Ok(true)` if the `block` has been observed before, `Ok(false)` if not. Does not
+    /// update the cache, so calling this function multiple times will continue to return
+    /// `Ok(false)`, until `Self::observe_proposer` is called.
+    ///
+    /// ## Errors
+    ///
+    /// - `block.proposer_index` is greater than `VALIDATOR_REGISTRY_LIMIT`.
+    /// - `block.slot` is equal to or less than the latest pruned `finalized_slot`.
+    pub fn proposer_has_been_observed(
+        &self,
+        block: BeaconBlockRef<'_, E>,
+        block_root: Hash256,
+    ) -> Result<SeenBlock, Error> {
+        self.sanitize_block(block)?;
+
+        let key = ProposalKey {
+            slot: block.slot(),
+            proposer: block.proposer_index(),
+        };
+
+        if let Some(block_roots) = self.items.get(&key) {
+            let block_already_known = block_roots.contains(&block_root);
+            let no_prev_known_blocks =
+                block_roots.difference(&HashSet::from([block_root])).count() == 0;
+
+            if !no_prev_known_blocks {
+                Ok(SeenBlock::Slashable)
+            } else if block_already_known {
+                Ok(SeenBlock::Duplicate)
+            } else {
+                Ok(SeenBlock::UniqueNonSlashable)
+            }
+        } else {
+            Ok(SeenBlock::UniqueNonSlashable)
+        }
     }
 
     /// Returns `Ok(())` if the given `block` is sane.
@@ -106,14 +189,14 @@ impl<E: EthSpec> ObservedBlockProducers<E> {
         }
 
         self.finalized_slot = finalized_slot;
-        self.items.retain(|key| key.slot > finalized_slot);
+        self.items.retain(|key, _| key.slot > finalized_slot);
     }
 
     /// Returns `true` if the given `validator_index` has been stored in `self` at `epoch`.
     ///
     /// This is useful for doppelganger detection.
     pub fn index_seen_at_epoch(&self, validator_index: u64, epoch: Epoch) -> bool {
-        self.items.iter().any(|key| {
+        self.items.iter().any(|(key, _)| {
             key.slot.epoch(E::slots_per_epoch()) == epoch && key.proposer == validator_index
         })
     }
@@ -142,9 +225,12 @@ mod tests {
 
         // Slot 0, proposer 0
         let block_a = get_block(0, 0);
+        let block_root = block_a.canonical_root();
 
         assert_eq!(
-            cache.observe_proposal(block_a.to_ref()),
+            cache
+                .observe_proposal(block_root, block_a.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(false),
             "can observe proposer, indicates proposer unobserved"
         );
@@ -155,14 +241,16 @@ mod tests {
 
         assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
         assert_eq!(cache.items.len(), 1, "only one slot should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(0),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("slot zero should be present")
+                .len(),
+            1,
             "only one proposer should be present"
         );
 
@@ -174,14 +262,16 @@ mod tests {
 
         assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
         assert_eq!(cache.items.len(), 1, "only one slot should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(0),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("slot zero should be present")
+                .len(),
+            1,
             "only one proposer should be present"
         );
 
@@ -203,9 +293,12 @@ mod tests {
 
         // First slot of finalized epoch, proposer 0
         let block_b = get_block(E::slots_per_epoch(), 0);
+        let block_root_b = block_b.canonical_root();
 
         assert_eq!(
-            cache.observe_proposal(block_b.to_ref()),
+            cache
+                .observe_proposal(block_root_b, block_b.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Err(Error::FinalizedBlock {
                 slot: E::slots_per_epoch().into(),
                 finalized_slot: E::slots_per_epoch().into(),
@@ -225,20 +318,24 @@ mod tests {
         let block_b = get_block(three_epochs, 0);
 
         assert_eq!(
-            cache.observe_proposal(block_b.to_ref()),
+            cache
+                .observe_proposal(block_root_b, block_b.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(false),
             "can insert non-finalized block"
         );
 
         assert_eq!(cache.items.len(), 1, "only one slot should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(three_epochs),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("the three epochs slot should be present")
+                .len(),
+            1,
             "only one proposer should be present"
         );
 
@@ -256,14 +353,16 @@ mod tests {
         );
 
         assert_eq!(cache.items.len(), 1, "only one slot should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(three_epochs),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("the three epochs slot should be present")
+                .len(),
+            1,
             "only one proposer should be present"
         );
     }
@@ -274,78 +373,141 @@ mod tests {
 
         // Slot 0, proposer 0
         let block_a = get_block(0, 0);
+        let block_root_a = block_a.canonical_root();
 
         assert_eq!(
-            cache.observe_proposal(block_a.to_ref()),
+            cache
+                .proposer_has_been_observed(block_a.to_ref(), block_a.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(false),
+            "no observation in empty cache"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_a, block_a.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(false),
             "can observe proposer, indicates proposer unobserved"
         );
         assert_eq!(
-            cache.observe_proposal(block_a.to_ref()),
+            cache
+                .proposer_has_been_observed(block_a.to_ref(), block_a.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(true),
+            "observed block is indicated as true"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_a, block_a.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(true),
             "observing again indicates true"
         );
 
         assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
         assert_eq!(cache.items.len(), 1, "only one slot should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(0),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("slot zero should be present")
+                .len(),
+            1,
             "only one proposer should be present"
         );
 
         // Slot 1, proposer 0
         let block_b = get_block(1, 0);
+        let block_root_b = block_b.canonical_root();
 
         assert_eq!(
-            cache.observe_proposal(block_b.to_ref()),
+            cache
+                .proposer_has_been_observed(block_b.to_ref(), block_b.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(false),
+            "no observation for new slot"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_b, block_b.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(false),
             "can observe proposer for new slot, indicates proposer unobserved"
         );
         assert_eq!(
-            cache.observe_proposal(block_b.to_ref()),
+            cache
+                .proposer_has_been_observed(block_b.to_ref(), block_b.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(true),
+            "observed block in slot 1 is indicated as true"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_b, block_b.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(true),
             "observing slot 1 again indicates true"
         );
 
         assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
         assert_eq!(cache.items.len(), 2, "two slots should be present");
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(0),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("slot zero should be present")
+                .len(),
+            1,
             "only one proposer should be present in slot 0"
         );
-        assert!(
+        assert_eq!(
             cache
                 .items
                 .get(&ProposalKey {
                     slot: Slot::new(1),
                     proposer: 0
                 })
-                .is_some(),
+                .expect("slot zero should be present")
+                .len(),
+            1,
             "only one proposer should be present in slot 1"
         );
 
         // Slot 0, proposer 1
         let block_c = get_block(0, 1);
+        let block_root_c = block_c.canonical_root();
 
         assert_eq!(
-            cache.observe_proposal(block_c.to_ref()),
+            cache
+                .proposer_has_been_observed(block_c.to_ref(), block_c.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(false),
+            "no observation for new proposer"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_c, block_c.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(false),
             "can observe new proposer, indicates proposer unobserved"
         );
         assert_eq!(
-            cache.observe_proposal(block_c.to_ref()),
+            cache
+                .proposer_has_been_observed(block_c.to_ref(), block_c.canonical_root())
+                .map(|x| x.proposer_previously_observed()),
+            Ok(true),
+            "observed new proposer block is indicated as true"
+        );
+        assert_eq!(
+            cache
+                .observe_proposal(block_root_c, block_c.to_ref())
+                .map(SeenBlock::proposer_previously_observed),
             Ok(true),
             "observing new proposer again indicates true"
         );
@@ -356,7 +518,7 @@ mod tests {
             cache
                 .items
                 .iter()
-                .filter(|k| k.slot == cache.finalized_slot)
+                .filter(|(k, _)| k.slot == cache.finalized_slot)
                 .count(),
             2,
             "two proposers should be present in slot 0"
@@ -365,7 +527,7 @@ mod tests {
             cache
                 .items
                 .iter()
-                .filter(|k| k.slot == Slot::new(1))
+                .filter(|(k, _)| k.slot == Slot::new(1))
                 .count(),
             1,
             "only one proposer should be present in slot 1"

--- a/beacon_node/beacon_chain/src/observed_slashable.rs
+++ b/beacon_node/beacon_chain/src/observed_slashable.rs
@@ -1,0 +1,466 @@
+//! Provides the `ObservedSlashable` struct which tracks slashable messages seen in
+//! gossip or via RPC. Useful in supporting `broadcast_validation` in the Beacon API.
+
+use crate::observed_block_producers::Error;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::marker::PhantomData;
+use types::{EthSpec, Hash256, Slot, Unsigned};
+
+#[derive(Eq, Hash, PartialEq, Debug, Default)]
+pub struct ProposalKey {
+    pub slot: Slot,
+    pub proposer: u64,
+}
+
+/// Maintains a cache of observed `(block.slot, block.proposer)`.
+///
+/// The cache supports pruning based upon the finalized epoch. It does not automatically prune, you
+/// must call `Self::prune` manually.
+///
+/// The maximum size of the cache is determined by `slots_since_finality *
+/// VALIDATOR_REGISTRY_LIMIT`. This is quite a large size, so it's important that upstream
+/// functions only use this cache for blocks with a valid signature. Only allowing valid signed
+/// blocks reduces the theoretical maximum size of this cache to `slots_since_finality *
+/// active_validator_count`, however in reality that is more like `slots_since_finality *
+/// known_distinct_shufflings` which is much smaller.
+pub struct ObservedSlashable<E: EthSpec> {
+    finalized_slot: Slot,
+    items: HashMap<ProposalKey, HashSet<Hash256>>,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> Default for ObservedSlashable<E> {
+    /// Instantiates `Self` with `finalized_slot == 0`.
+    fn default() -> Self {
+        Self {
+            finalized_slot: Slot::new(0),
+            items: HashMap::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E: EthSpec> ObservedSlashable<E> {
+    /// Observe that the `header` was produced by `header.proposer_index` at `header.slot`. This will
+    /// update `self` so future calls to it indicate that this block is known.
+    ///
+    /// The supplied `block` **MUST** be signature verified (see struct-level documentation).
+    ///
+    /// ## Errors
+    ///
+    /// - `header.proposer_index` is greater than `VALIDATOR_REGISTRY_LIMIT`.
+    /// - `header.slot` is equal to or less than the latest pruned `finalized_slot`.
+    pub fn observe_slashable(
+        &mut self,
+        slot: Slot,
+        proposer_index: u64,
+        block_root: Hash256,
+    ) -> Result<(), Error> {
+        self.sanitize_header(slot, proposer_index)?;
+
+        let key = ProposalKey {
+            slot,
+            proposer: proposer_index,
+        };
+
+        let entry = self.items.entry(key);
+
+        match entry {
+            Entry::Occupied(mut occupied_entry) => {
+                let block_roots = occupied_entry.get_mut();
+                block_roots.insert(block_root);
+            }
+            Entry::Vacant(vacant_entry) => {
+                let block_roots = HashSet::from([block_root]);
+                vacant_entry.insert(block_roots);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns `Ok(true)` if the `block_root` is slashable, `Ok(false)` if not. Does not
+    /// update the cache, so calling this function multiple times will continue to return
+    /// `Ok(false)`, until `Self::observe_proposer` is called.
+    ///
+    /// ## Errors
+    ///
+    /// - `proposer_index` is greater than `VALIDATOR_REGISTRY_LIMIT`.
+    /// - `slot` is equal to or less than the latest pruned `finalized_slot`.
+    pub fn is_slashable(
+        &self,
+        slot: Slot,
+        proposer_index: u64,
+        block_root: Hash256,
+    ) -> Result<bool, Error> {
+        self.sanitize_header(slot, proposer_index)?;
+
+        let key = ProposalKey {
+            slot,
+            proposer: proposer_index,
+        };
+
+        if let Some(block_roots) = self.items.get(&key) {
+            let no_prev_known_blocks =
+                block_roots.difference(&HashSet::from([block_root])).count() == 0;
+
+            Ok(!no_prev_known_blocks)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Returns `Ok(())` if the given `header` is sane.
+    fn sanitize_header(&self, slot: Slot, proposer_index: u64) -> Result<(), Error> {
+        if proposer_index >= E::ValidatorRegistryLimit::to_u64() {
+            return Err(Error::ValidatorIndexTooHigh(proposer_index));
+        }
+
+        let finalized_slot = self.finalized_slot;
+        if finalized_slot > 0 && slot <= finalized_slot {
+            return Err(Error::FinalizedBlock {
+                slot,
+                finalized_slot,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Removes all observations of blocks equal to or earlier than `finalized_slot`.
+    ///
+    /// Stores `finalized_slot` in `self`, so that `self` will reject any block that has a slot
+    /// equal to or less than `finalized_slot`.
+    ///
+    /// No-op if `finalized_slot == 0`.
+    pub fn prune(&mut self, finalized_slot: Slot) {
+        if finalized_slot == 0 {
+            return;
+        }
+
+        self.finalized_slot = finalized_slot;
+        self.items.retain(|key, _| key.slot > finalized_slot);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{BeaconBlock, MainnetEthSpec};
+
+    type E = MainnetEthSpec;
+
+    fn get_block(slot: u64, proposer: u64) -> BeaconBlock<E> {
+        let mut block = BeaconBlock::empty(&E::default_spec());
+        *block.slot_mut() = slot.into();
+        *block.proposer_index_mut() = proposer;
+        block
+    }
+
+    #[test]
+    fn pruning() {
+        let mut cache = ObservedSlashable::<E>::default();
+
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 0, "no slots should be present");
+
+        // Slot 0, proposer 0
+        let block_a = get_block(0, 0);
+        let block_root = block_a.canonical_root();
+
+        assert_eq!(
+            cache.observe_slashable(block_a.slot(), block_a.proposer_index(), block_root),
+            Ok(()),
+            "can observe proposer, indicates proposer unobserved"
+        );
+
+        /*
+         * Preconditions.
+         */
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 1, "only one slot should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(0),
+                    proposer: 0
+                })
+                .expect("slot zero should be present")
+                .len(),
+            1,
+            "only one proposer should be present"
+        );
+
+        /*
+         * Check that a prune at the genesis slot does nothing.
+         */
+        cache.prune(Slot::new(0));
+
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 1, "only one slot should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(0),
+                    proposer: 0
+                })
+                .expect("slot zero should be present")
+                .len(),
+            1,
+            "only one proposer should be present"
+        );
+
+        /*
+         * Check that a prune empties the cache
+         */
+        cache.prune(E::slots_per_epoch().into());
+        assert_eq!(
+            cache.finalized_slot,
+            Slot::from(E::slots_per_epoch()),
+            "finalized slot is updated"
+        );
+        assert_eq!(cache.items.len(), 0, "no items left");
+
+        /*
+         * Check that we can't insert a finalized block
+         */
+        // First slot of finalized epoch, proposer 0
+        let block_b = get_block(E::slots_per_epoch(), 0);
+        let block_root_b = block_b.canonical_root();
+
+        assert_eq!(
+            cache.observe_slashable(block_b.slot(), block_b.proposer_index(), block_root_b),
+            Err(Error::FinalizedBlock {
+                slot: E::slots_per_epoch().into(),
+                finalized_slot: E::slots_per_epoch().into(),
+            }),
+            "cant insert finalized block"
+        );
+
+        assert_eq!(cache.items.len(), 0, "block was not added");
+
+        /*
+         * Check that we _can_ insert a non-finalized block
+         */
+        let three_epochs = E::slots_per_epoch() * 3;
+
+        // First slot of finalized epoch, proposer 0
+        let block_b = get_block(three_epochs, 0);
+
+        assert_eq!(
+            cache.observe_slashable(block_b.slot(), block_b.proposer_index(), block_root_b),
+            Ok(()),
+            "can insert non-finalized block"
+        );
+
+        assert_eq!(cache.items.len(), 1, "only one slot should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(three_epochs),
+                    proposer: 0
+                })
+                .expect("the three epochs slot should be present")
+                .len(),
+            1,
+            "only one proposer should be present"
+        );
+
+        /*
+         * Check that a prune doesnt wipe later blocks
+         */
+        let two_epochs = E::slots_per_epoch() * 2;
+        cache.prune(two_epochs.into());
+
+        assert_eq!(
+            cache.finalized_slot,
+            Slot::from(two_epochs),
+            "finalized slot is updated"
+        );
+
+        assert_eq!(cache.items.len(), 1, "only one slot should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(three_epochs),
+                    proposer: 0
+                })
+                .expect("the three epochs slot should be present")
+                .len(),
+            1,
+            "only one proposer should be present"
+        );
+    }
+
+    #[test]
+    fn simple_observations() {
+        let mut cache = ObservedSlashable::<E>::default();
+
+        // Slot 0, proposer 0
+        let block_a = get_block(0, 0);
+        let block_root_a = block_a.canonical_root();
+
+        assert_eq!(
+            cache.is_slashable(
+                block_a.slot(),
+                block_a.proposer_index(),
+                block_a.canonical_root()
+            ),
+            Ok(false),
+            "no observation in empty cache"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_a.slot(), block_a.proposer_index(), block_root_a),
+            Ok(()),
+            "can observe proposer, indicates proposer unobserved"
+        );
+        assert_eq!(
+            cache.is_slashable(
+                block_a.slot(),
+                block_a.proposer_index(),
+                block_a.canonical_root()
+            ),
+            Ok(false),
+            "observed block is indicated as true"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_a.slot(), block_a.proposer_index(), block_root_a),
+            Ok(()),
+            "observing again indicates true"
+        );
+
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 1, "only one slot should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(0),
+                    proposer: 0
+                })
+                .expect("slot zero should be present")
+                .len(),
+            1,
+            "only one proposer should be present"
+        );
+
+        // Slot 1, proposer 0
+        let block_b = get_block(1, 0);
+        let block_root_b = block_b.canonical_root();
+
+        assert_eq!(
+            cache.is_slashable(
+                block_b.slot(),
+                block_b.proposer_index(),
+                block_b.canonical_root()
+            ),
+            Ok(false),
+            "no observation for new slot"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_b.slot(), block_b.proposer_index(), block_root_b),
+            Ok(()),
+            "can observe proposer for new slot, indicates proposer unobserved"
+        );
+        assert_eq!(
+            cache.is_slashable(
+                block_b.slot(),
+                block_b.proposer_index(),
+                block_b.canonical_root()
+            ),
+            Ok(false),
+            "observed block in slot 1 is indicated as true"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_b.slot(), block_b.proposer_index(), block_root_b),
+            Ok(()),
+            "observing slot 1 again indicates true"
+        );
+
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 2, "two slots should be present");
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(0),
+                    proposer: 0
+                })
+                .expect("slot zero should be present")
+                .len(),
+            1,
+            "only one proposer should be present in slot 0"
+        );
+        assert_eq!(
+            cache
+                .items
+                .get(&ProposalKey {
+                    slot: Slot::new(1),
+                    proposer: 0
+                })
+                .expect("slot zero should be present")
+                .len(),
+            1,
+            "only one proposer should be present in slot 1"
+        );
+
+        // Slot 0, proposer 1
+        let block_c = get_block(0, 1);
+        let block_root_c = block_c.canonical_root();
+
+        assert_eq!(
+            cache.is_slashable(
+                block_c.slot(),
+                block_c.proposer_index(),
+                block_c.canonical_root()
+            ),
+            Ok(false),
+            "no observation for new proposer"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_c.slot(), block_c.proposer_index(), block_root_c),
+            Ok(()),
+            "can observe new proposer, indicates proposer unobserved"
+        );
+        assert_eq!(
+            cache.is_slashable(
+                block_c.slot(),
+                block_c.proposer_index(),
+                block_c.canonical_root()
+            ),
+            Ok(false),
+            "observed new proposer block is indicated as true"
+        );
+        assert_eq!(
+            cache.observe_slashable(block_c.slot(), block_c.proposer_index(), block_root_c),
+            Ok(()),
+            "observing new proposer again indicates true"
+        );
+
+        assert_eq!(cache.finalized_slot, 0, "finalized slot is zero");
+        assert_eq!(cache.items.len(), 3, "three slots should be present");
+        assert_eq!(
+            cache
+                .items
+                .iter()
+                .filter(|(k, _)| k.slot == cache.finalized_slot)
+                .count(),
+            2,
+            "two proposers should be present in slot 0"
+        );
+        assert_eq!(
+            cache
+                .items
+                .iter()
+                .filter(|(k, _)| k.slot == Slot::new(1))
+                .count(),
+            1,
+            "only one proposer should be present in slot 1"
+        );
+    }
+}

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -1226,9 +1226,13 @@ pub async fn blinded_equivocation_gossip() {
     );
 }
 
-/// This test checks that a block that is valid from both a gossip and consensus perspective but that equivocates **late** is rejected when using `broadcast_validation=consensus_and_equivocation`.
+/// This test checks that a block that is valid from both a gossip and
+/// consensus perspective but that equivocates **late** is rejected when using
+/// `broadcast_validation=consensus_and_equivocation`.
 ///
-/// This test is unique in that we can't actually test the HTTP API directly, but instead have to hook into the `publish_blocks` code manually. This is in order to handle the late equivocation case.
+/// This test is unique in that we can't actually test the HTTP API directly,
+/// but instead have to hook into the `publish_blocks` code manually. This is
+/// in order to handle the late equivocation case.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn blinded_equivocation_consensus_late_equivocation() {
     /* this test targets gossip-level validation */

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -155,13 +155,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         // Checks if a block from this proposer is already known.
         let block_equivocates = || {
-            match self
-                .chain
-                .observed_block_producers
-                .read()
-                .proposer_has_been_observed(block.message(), block.canonical_root())
-            {
-                Ok(seen_status) => seen_status.is_slashable(),
+            match self.chain.observed_slashable.read().is_slashable(
+                block.slot(),
+                block.message().proposer_index(),
+                block.canonical_root(),
+            ) {
+                Ok(is_slashable) => is_slashable,
                 //Both of these blocks will be rejected, so reject them now rather
                 // than re-queuing them.
                 Err(ObserveError::FinalizedBlock { .. })


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/5017

## Changes
- added a new slashing cache, to track slashing across all messages
- simplified the blob gossip cache, so it no longer tracks block roots
- I initially simplified the block gossip cache as well, but it turns out we still need to distinguish between "blocks failing gossip that are slashable" and "blocks failing gossip that are duplicates" so that we can correctly suppress the duplicate error code 
- Additionally, this makes sure we add slashable headers from blob sidecars received via RPC. And checks the signatures. (I don't think we were checking the signature before sending it to the slasher before).
  - I've also opted not to throw error  when the signature is invalid here (which would result in not importing the blobs even if the data is correct, and would lead us to downscore the peer), because on an RPC request we only really care whether the data is available or not

