### PR TITLE
Fix block v3 reward encodings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,9 +2341,9 @@ dependencies = [
 
 [[package]]
 name = "ethereum_serde_utils"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8cb04ea380a33e9c269fa5f8df6f2d63dee19728235f3e639e7674e038686a"
+checksum = "de4d5951468846963c24e8744c133d44f39dff2cd3a233f6be22b370d08a524f"
 dependencies = [
  "ethereum-types 0.14.1",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,7 @@ env_logger = "0.9"
 error-chain = "0.12"
 ethereum-types = "0.14"
 ethereum_hashing = "1.0.0-beta.2"
-# ethereum_serde_utils = "0.5"
-# FIXME(sproul): restore crates.io version
-ethereum_serde_utils = { git = "https://github.com/sigp/ethereum_serde_utils", branch = "decimal-u256" }
+ethereum_serde_utils = "0.5"
 ethereum_ssz = "0.5"
 ethereum_ssz_derive = "0.5"
 ethers-core = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,9 @@ env_logger = "0.9"
 error-chain = "0.12"
 ethereum-types = "0.14"
 ethereum_hashing = "1.0.0-beta.2"
-ethereum_serde_utils = "0.5"
+# ethereum_serde_utils = "0.5"
+# FIXME(sproul): restore crates.io version
+ethereum_serde_utils = { git = "https://github.com/sigp/ethereum_serde_utils", branch = "decimal-u256" }
 ethereum_ssz = "0.5"
 ethereum_ssz_derive = "0.5"
 ethers-core = "1"

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -511,11 +511,15 @@ impl<E: EthSpec> BeaconBlockResponseWrapper<E> {
         }
     }
 
-    pub fn consensus_block_value(&self) -> u64 {
+    pub fn consensus_block_value_gwei(&self) -> u64 {
         match self {
             BeaconBlockResponseWrapper::Full(resp) => resp.consensus_block_value,
             BeaconBlockResponseWrapper::Blinded(resp) => resp.consensus_block_value,
         }
+    }
+
+    pub fn consensus_block_value_wei(&self) -> Uint256 {
+        Uint256::from(self.consensus_block_value_gwei()) * 1_000_000_000
     }
 
     pub fn is_blinded(&self) -> bool {

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -80,7 +80,7 @@ pub fn build_response_v3<T: BeaconChainTypes>(
         .fork_name(&chain.spec)
         .map_err(inconsistent_fork_rejection)?;
     let execution_payload_value = block_response.execution_payload_value();
-    let consensus_block_value = block_response.consensus_block_value();
+    let consensus_block_value = block_response.consensus_block_value_wei();
     let execution_payload_blinded = block_response.is_blinded();
 
     let metadata = ProduceBlockV3Metadata {

--- a/beacon_node/http_api/src/version.rs
+++ b/beacon_node/http_api/src/version.rs
@@ -93,7 +93,7 @@ pub fn add_execution_payload_value_header<T: Reply>(
 /// Add the `Eth-Consensus-Block-Value` header to a response.
 pub fn add_consensus_block_value_header<T: Reply>(
     reply: T,
-    consensus_payload_value: u64,
+    consensus_payload_value: Uint256,
 ) -> Response {
     reply::with_header(
         reply,

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1554,9 +1554,10 @@ pub struct ProduceBlockV3Metadata {
     )]
     pub consensus_version: ForkName,
     pub execution_payload_blinded: bool,
+    #[serde(with = "serde_utils::u256_dec")]
     pub execution_payload_value: Uint256,
-    #[serde(with = "serde_utils::quoted_u64")]
-    pub consensus_block_value: u64,
+    #[serde(with = "serde_utils::u256_dec")]
+    pub consensus_block_value: Uint256,
 }
 
 impl<T: EthSpec> FullBlockContents<T> {
@@ -1707,7 +1708,7 @@ impl TryFrom<&HeaderMap> for ProduceBlockV3Metadata {
             })?;
         let consensus_block_value =
             parse_required_header(headers, CONSENSUS_BLOCK_VALUE_HEADER, |s| {
-                s.parse::<u64>()
+                s.parse::<Uint256>()
                     .map_err(|e| format!("invalid {CONSENSUS_BLOCK_VALUE_HEADER}: {e:?}"))
             })?;
 


### PR DESCRIPTION
## Proposed Changes

* Encode `consensus_block_value` in wei units rather than gwei (see: https://github.com/ethereum/beacon-APIs/pull/400).
* Encode both values as _decimal_ U256 rather than hex in the JSON response body (the headers were already using decimal).

## Additional Info

Needs a new release of `ethereum_serde_utils`. The PR to that repo that needs reviewing alongside this is https://github.com/sigp/ethereum_serde_utils/pull/5.
