### PR TITLE
Fix asset paths in release CI upload job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,6 @@ jobs:
                   | <img src="https://simpleicons.org/icons/docker.svg" style="width: 32px;"/> | Docker | [${{ env.VERSION }}](https://hub.docker.com/r/${{ env.IMAGE_NAME }}/tags?page=1&ordering=last_updated&name=${{ env.VERSION }}) | [${{ env.IMAGE_NAME }}](https://hub.docker.com/r/${{ env.IMAGE_NAME }}) |
                   ENDBODY
                   )
-                  assets=(./lighthouse-*.tar.gz*)
+                  assets=(./lighthouse-*.tar.gz*/lighthouse-*.tar.gz*)
                   tag_name="${{ env.VERSION }}"
                   echo "$body" | gh release create --draft -F "-" "$tag_name" "${assets[@]}"


### PR DESCRIPTION
## Issue Addressed

Fix the failure of the release CI job due to incorrect paths. The `v4.6.0-rc.0` release failed for this reason: https://github.com/sigp/lighthouse/actions/runs/7482170659/job/20366908168

## Proposed Changes

The release artifacts are downloaded into directories with the same names as the files. This PR updates the paths to include the containing directories.

I tested this fix already for the `v4.5.444-exp` release but forgot to backport it to `unstable`: https://github.com/sigp/lighthouse/actions/runs/6582951657

I'm about to run a `v4.6.111-exp` release for tree-states which will provide more up-to-date testing.
