### PR TITLE
Tree states release v4.6.111-exp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 dependencies = [
  "beacon_node",
  "clap",
@@ -4051,7 +4051,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -4639,7 +4639,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v4.5.444-exp-",
-    fallback = "Lighthouse/v4.5.444-exp"
+    prefix = "Lighthouse/v4.6.111-exp-",
+    fallback = "Lighthouse/v4.6.111-exp"
 );
 
 /// Returns `VERSION`, but with platform information appended to the end.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "4.5.444-exp"
+version = "4.6.111-exp"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Proposed Changes

New tree-states release with all the goodies from `v4.6.0-rc.0` including the OOM fix and Deneb on Goerli.
