### PR TITLE
Optimise blob sidecar proof generation

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -714,7 +714,10 @@ impl<T: BeaconChainTypes> IntoGossipVerifiedBlockContents<T> for PublishBlockReq
 
                 let gossip_verified_blobs = blob_sidecars
                     .into_iter()
-                    .map(|blob_sidecar| GossipVerifiedBlob::new(blob_sidecar, chain))
+                    .map(|blob_sidecar| {
+                        let index = blob_sidecar.index;
+                        GossipVerifiedBlob::new(blob_sidecar, index, chain)
+                    })
                     .collect::<Result<Vec<_>, GossipBlobError<T::EthSpec>>>()?
                     .into();
                 Ok::<_, BlockContentsError<T::EthSpec>>(gossip_verified_blobs)

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2497,49 +2497,32 @@ pub fn generate_rand_block_and_blobs<E: EthSpec>(
 ) -> (SignedBeaconBlock<E, FullPayload<E>>, Vec<BlobSidecar<E>>) {
     let inner = map_fork_name!(fork_name, BeaconBlock, <_>::random_for_test(rng));
     let mut block = SignedBeaconBlock::from_block(inner, types::Signature::random_for_test(rng));
-    let mut blob_sidecars = vec![];
-    if let Ok(message) = block.message_deneb_mut() {
-        // Get either zero blobs or a random number of blobs between 1 and Max Blobs.
-        let payload: &mut FullPayloadDeneb<E> = &mut message.body.execution_payload;
-        let num_blobs = match num_blobs {
-            NumBlobs::Random => rng.gen_range(1..=E::max_blobs_per_block()),
-            NumBlobs::None => 0,
-        };
-        let (bundle, transactions) =
-            execution_layer::test_utils::generate_blobs::<E>(num_blobs).unwrap();
+    let message = block.message_deneb_mut().unwrap();
+    // Get either zero blobs or a random number of blobs between 1 and Max Blobs.
+    let payload: &mut FullPayloadDeneb<E> = &mut message.body.execution_payload;
+    let num_blobs = match num_blobs {
+        NumBlobs::Random => rng.gen_range(1..=E::max_blobs_per_block()),
+        NumBlobs::None => 0,
+    };
+    let (bundle, transactions) =
+        execution_layer::test_utils::generate_blobs::<E>(num_blobs).unwrap();
 
-        payload.execution_payload.transactions = <_>::default();
-        for tx in Vec::from(transactions) {
-            payload.execution_payload.transactions.push(tx).unwrap();
-        }
-        message.body.blob_kzg_commitments = bundle.commitments.clone();
-
-        let eth2::types::BlobsBundle {
-            commitments,
-            proofs,
-            blobs,
-        } = bundle;
-
-        for (index, ((blob, kzg_commitment), kzg_proof)) in blobs
-            .into_iter()
-            .zip(commitments.into_iter())
-            .zip(proofs.into_iter())
-            .enumerate()
-        {
-            blob_sidecars.push(BlobSidecar {
-                index: index as u64,
-                blob: blob.clone(),
-                kzg_commitment,
-                kzg_proof,
-                signed_block_header: block.signed_block_header(),
-                kzg_commitment_inclusion_proof: block
-                    .message()
-                    .body()
-                    .kzg_commitment_merkle_proof(index)
-                    .unwrap(),
-            });
-        }
+    payload.execution_payload.transactions = <_>::default();
+    for tx in Vec::from(transactions) {
+        payload.execution_payload.transactions.push(tx).unwrap();
     }
+    message.body.blob_kzg_commitments = bundle.commitments.clone();
 
+    let eth2::types::BlobsBundle {
+        commitments: _,
+        proofs,
+        blobs,
+    } = bundle;
+
+    let blob_sidecars = BlobSidecar::build_sidecars(blobs, &block, proofs)
+        .unwrap()
+        .into_iter()
+        .map(|blob| Arc::into_inner(blob).unwrap())
+        .collect();
     (block, blob_sidecars)
 }

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2497,32 +2497,32 @@ pub fn generate_rand_block_and_blobs<E: EthSpec>(
 ) -> (SignedBeaconBlock<E, FullPayload<E>>, Vec<BlobSidecar<E>>) {
     let inner = map_fork_name!(fork_name, BeaconBlock, <_>::random_for_test(rng));
     let mut block = SignedBeaconBlock::from_block(inner, types::Signature::random_for_test(rng));
-    let message = block.message_deneb_mut().unwrap();
-    // Get either zero blobs or a random number of blobs between 1 and Max Blobs.
-    let payload: &mut FullPayloadDeneb<E> = &mut message.body.execution_payload;
-    let num_blobs = match num_blobs {
-        NumBlobs::Random => rng.gen_range(1..=E::max_blobs_per_block()),
-        NumBlobs::None => 0,
-    };
-    let (bundle, transactions) =
-        execution_layer::test_utils::generate_blobs::<E>(num_blobs).unwrap();
+    let mut blob_sidecars = vec![];
+    if let Ok(message) = block.message_deneb_mut() {
+        // Get either zero blobs or a random number of blobs between 1 and Max Blobs.
+        let payload: &mut FullPayloadDeneb<E> = &mut message.body.execution_payload;
+        let num_blobs = match num_blobs {
+            NumBlobs::Random => rng.gen_range(1..=E::max_blobs_per_block()),
+            NumBlobs::None => 0,
+        };
+        let (bundle, transactions) =
+            execution_layer::test_utils::generate_blobs::<E>(num_blobs).unwrap();
 
-    payload.execution_payload.transactions = <_>::default();
-    for tx in Vec::from(transactions) {
-        payload.execution_payload.transactions.push(tx).unwrap();
+        payload.execution_payload.transactions = <_>::default();
+        for tx in Vec::from(transactions) {
+            payload.execution_payload.transactions.push(tx).unwrap();
+        }
+        message.body.blob_kzg_commitments = bundle.commitments.clone();
+
+        let eth2::types::BlobsBundle {
+            commitments: _,
+            proofs,
+            blobs,
+        } = bundle;
+
+        for blob_sidecar in BlobSidecar::build_sidecars(blobs, &block, proofs).unwrap() {
+            blob_sidecars.push(Arc::try_unwrap(blob_sidecar).unwrap());
+        }
     }
-    message.body.blob_kzg_commitments = bundle.commitments.clone();
-
-    let eth2::types::BlobsBundle {
-        commitments: _,
-        proofs,
-        blobs,
-    } = bundle;
-
-    let blob_sidecars = BlobSidecar::build_sidecars(blobs, &block, proofs)
-        .unwrap()
-        .into_iter()
-        .map(|blob| Arc::into_inner(blob).unwrap())
-        .collect();
     (block, blob_sidecars)
 }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -196,7 +196,9 @@ fn update_parent_roots(
             *block.parent_root_mut() = root;
             let new_child = Arc::new(SignedBeaconBlock::from_block(block, signature));
             if let Some(blobs) = child_blobs {
-                update_blob_signed_header(&new_child, blobs);
+                if !blobs.is_empty() {
+                    update_blob_signed_header(&new_child, blobs);
+                }
             }
             child.beacon_block = new_child;
         }

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -207,6 +207,11 @@ fn update_blob_signed_header<E: EthSpec>(
     signed_block: &SignedBeaconBlock<E>,
     blobs: &mut BlobSidecarList<E>,
 ) {
+    let new_inclusion_proofs = signed_block
+        .message()
+        .body()
+        .kzg_commitment_inclusion_proofs()
+        .unwrap();
     for old_blob_sidecar in blobs.iter_mut() {
         let new_blob = Arc::new(BlobSidecar::<E> {
             index: old_blob_sidecar.index,
@@ -214,11 +219,10 @@ fn update_blob_signed_header<E: EthSpec>(
             kzg_commitment: old_blob_sidecar.kzg_commitment,
             kzg_proof: old_blob_sidecar.kzg_proof,
             signed_block_header: signed_block.signed_block_header(),
-            kzg_commitment_inclusion_proof: signed_block
-                .message()
-                .body()
-                .kzg_commitment_merkle_proof(old_blob_sidecar.index as usize)
-                .unwrap(),
+            kzg_commitment_inclusion_proof: new_inclusion_proofs
+                .get(old_blob_sidecar.index as usize)
+                .unwrap()
+                .clone(),
         });
         *old_blob_sidecar = new_blob;
     }

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -160,6 +160,7 @@ impl<'a, T: EthSpec, Payload: AbstractExecPayload<T>> BeaconBlockBodyRef<'a, T, 
                 // Part 1: Branches for the `BeaconBlockBody` container
                 let proof_body = self.kzg_commitments_body_proof()?;
 
+                // Part 2: Branches for the subtree rooted at `blob_kzg_commitments`
                 let depth = T::max_blob_commitments_per_block()
                     .next_power_of_two()
                     .ilog2();
@@ -180,7 +181,6 @@ impl<'a, T: EthSpec, Payload: AbstractExecPayload<T>> BeaconBlockBodyRef<'a, T, 
                 let length_root = Hash256::from_slice(length_bytes.as_slice());
 
                 for index in 0..body.blob_kzg_commitments.len() {
-                    // Part 2: Branches for the subtree rooted at `blob_kzg_commitments`
                     let (_, mut proof) = tree
                         .generate_proof(index, depth as usize)
                         .map_err(Error::MerkleTreeError)?;

--- a/testing/ef_tests/src/cases/merkle_proof_validity.rs
+++ b/testing/ef_tests/src/cases/merkle_proof_validity.rs
@@ -123,11 +123,12 @@ impl<E: EthSpec> LoadCase for KzgInclusionMerkleProofValidity<E> {
 
 impl<E: EthSpec> Case for KzgInclusionMerkleProofValidity<E> {
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
-        let Ok(proof) = self.block.to_ref().kzg_commitment_merkle_proof(0) else {
+        let Ok(proofs) = self.block.to_ref().kzg_commitment_inclusion_proofs() else {
             return Err(Error::FailedToParseTest(
                 "Could not retrieve merkle proof".to_string(),
             ));
         };
+        let proof = &proofs[0];
         let proof_len = proof.len();
         let branch_len = self.merkle_proof.branch.len();
         if proof_len != branch_len {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Avoid duplicating merkle proof generation for blob sidecars by reusing the body branches.

Testing performance locally.