### PR TITLE
Move from igd to igd-next

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,18 +364,6 @@ dependencies = [
 
 [[package]]
 name = "attohttpc"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb8867f378f33f78a811a8eb9bf108ad99430d7aad43315dd9319c827ef6247"
-dependencies = [
- "http 0.2.11",
- "log",
- "url",
- "wildmatch",
-]
-
-[[package]]
-name = "attohttpc"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d9a9bf8b79a749ee0b911b91b671cc2b6c670bdbc7e3dfd537576ddc94bb2a2"
@@ -3677,26 +3665,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "igd"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556b5a75cd4adb7c4ea21c64af1c48cefb2ce7d43dc4352c720a1fe47c21f355"
-dependencies = [
- "attohttpc 0.16.3",
- "log",
- "rand",
- "url",
- "xmltree",
-]
-
-[[package]]
 name = "igd-next"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e065e90a518ab5fedf79aa1e4b784e10f8e484a834f6bda85c42633a2cb7af"
+checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
 dependencies = [
  "async-trait",
- "attohttpc 0.24.1",
+ "attohttpc",
  "bytes",
  "futures",
  "http 0.2.11",
@@ -5205,7 +5180,7 @@ dependencies = [
  "genesis",
  "hex",
  "if-addrs 0.6.7",
- "igd",
+ "igd-next",
  "itertools",
  "lazy_static",
  "lighthouse_metrics",
@@ -8859,12 +8834,6 @@ name = "widestring"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
-
-[[package]]
-name = "wildmatch"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f44b95f62d34113cf558c93511ac93027e03e9c29a60dd0fd70e6e025c7270a"
 
 [[package]]
 name = "winapi"

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = { workspace = true }
 lighthouse_metrics = { workspace = true }
 logging = { workspace = true }
 task_executor = { workspace = true }
-igd = "0.12.1"
+igd-next = "0.14.3"
 itertools = { workspace = true }
 num_cpus = { workspace = true }
 lru_cache = { workspace = true }

--- a/beacon_node/network/src/nat.rs
+++ b/beacon_node/network/src/nat.rs
@@ -66,7 +66,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
     log: slog::Logger,
 ) {
     info!(log, "UPnP Attempting to initialise routes");
-    match igd::search_gateway(Default::default()) {
+    match igd_next::search_gateway(Default::default()) {
         Err(e) => info!(log, "UPnP not available"; "error" => %e),
         Ok(gateway) => {
             // Need to find the local listening address matched with the router subnet
@@ -109,7 +109,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                     // router, they should ideally try to set different port numbers.
                     mappings.tcp_port = add_port_mapping(
                         &gateway,
-                        igd::PortMappingProtocol::TCP,
+                        igd_next::PortMappingProtocol::TCP,
                         libp2p_socket,
                         "tcp",
                         &log,
@@ -123,7 +123,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                         let udp_socket = SocketAddrV4::new(address, udp_port);
                         add_port_mapping(
                             &gateway,
-                            igd::PortMappingProtocol::UDP,
+                            igd_next::PortMappingProtocol::UDP,
                             udp_socket,
                             "udp",
                             &log,
@@ -156,8 +156,8 @@ pub fn construct_upnp_mappings<T: EthSpec>(
 
 /// Sets up a port mapping for a protocol returning the mapped port if successful.
 fn add_port_mapping(
-    gateway: &igd::Gateway,
-    protocol: igd::PortMappingProtocol,
+    gateway: &igd_next::Gateway,
+    protocol: igd_next::PortMappingProtocol,
     socket: SocketAddrV4,
     protocol_string: &'static str,
     log: &slog::Logger,
@@ -168,10 +168,16 @@ fn add_port_mapping(
     // router, they should ideally try to set different port numbers.
     let mapping_string = &format!("lighthouse-{}", protocol_string);
     for _ in 0..2 {
-        match gateway.add_port(protocol, socket.port(), socket, 0, mapping_string) {
+        match gateway.add_port(
+            protocol,
+            socket.port(),
+            SocketAddr::V4(socket),
+            0,
+            mapping_string,
+        ) {
             Err(e) => {
                 match e {
-                    igd::AddPortError::PortInUse => {
+                    igd_next::AddPortError::PortInUse => {
                         // Try and remove and re-create
                         debug!(log, "UPnP port in use, attempting to remap"; "protocol" => protocol_string, "port" => socket.port());
                         match gateway.remove_port(protocol, socket.port()) {
@@ -202,10 +208,10 @@ fn add_port_mapping(
 pub fn remove_mappings(mappings: &EstablishedUPnPMappings, log: &slog::Logger) {
     if mappings.is_some() {
         debug!(log, "Removing UPnP port mappings");
-        match igd::search_gateway(Default::default()) {
+        match igd_next::search_gateway(Default::default()) {
             Ok(gateway) => {
                 if let Some(tcp_port) = mappings.tcp_port {
-                    match gateway.remove_port(igd::PortMappingProtocol::TCP, tcp_port) {
+                    match gateway.remove_port(igd_next::PortMappingProtocol::TCP, tcp_port) {
                         Ok(()) => debug!(log, "UPnP Removed TCP port mapping"; "port" => tcp_port),
                         Err(e) => {
                             debug!(log, "UPnP Failed to remove TCP port mapping"; "port" => tcp_port, "error" => %e)
@@ -213,7 +219,7 @@ pub fn remove_mappings(mappings: &EstablishedUPnPMappings, log: &slog::Logger) {
                     }
                 }
                 for udp_port in mappings.udp_ports() {
-                    match gateway.remove_port(igd::PortMappingProtocol::UDP, *udp_port) {
+                    match gateway.remove_port(igd_next::PortMappingProtocol::UDP, *udp_port) {
                         Ok(()) => debug!(log, "UPnP Removed UDP port mapping"; "port" => udp_port),
                         Err(e) => {
                             debug!(log, "UPnP Failed to remove UDP port mapping"; "port" => udp_port, "error" => %e)

--- a/beacon_node/network/src/nat.rs
+++ b/beacon_node/network/src/nat.rs
@@ -114,7 +114,7 @@ pub fn construct_upnp_mappings<T: EthSpec>(
                         "tcp",
                         &log,
                     ).map(|_| {
-                        let external_socket = external_ip.as_ref().map(|ip| SocketAddr::new((*ip).into(), config.tcp_port)).map_err(|_| ());
+                        let external_socket = external_ip.as_ref().map(|ip| SocketAddr::new(*ip, config.tcp_port)).map_err(|_| ());
                         info!(log, "UPnP TCP route established"; "external_socket" => format!("{}:{}", external_socket.as_ref().map(|ip| ip.to_string()).unwrap_or_else(|_| "".into()), config.tcp_port));
                         config.tcp_port
                     }).ok();


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/5020

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Move from igd to igd-next v0.14.3, which contains fix for the panic issue.

## Additional Info

<!-- Please provide any additional information. For example, future considerations
or information useful for reviewers. -->

- igd is no longer maintained and igd-next is a fork
- the [patch](https://github.com/dariusc93/rust-igd/pull/5) for the panic issue has been merged and released as igd-next v0.14.3
