### PR TITLE
[DO NOT MERGE] Head tracker bug repro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,6 +541,7 @@ dependencies = [
  "futures",
  "genesis",
  "hex",
+ "hiatus",
  "int_to_bytes",
  "itertools",
  "kzg",
@@ -3231,6 +3232,16 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hiatus"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0adf730fb1c95c8163f05a4f5805a5b35d00bf87f1ee7004923e43a68aac9b8"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.11.2",
+]
 
 [[package]]
 name = "hickory-proto"

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -71,6 +71,7 @@ exit-future = { workspace = true }
 oneshot_broadcast = { path = "../../common/oneshot_broadcast/" }
 slog-term = { workspace = true }
 slog-async = { workspace = true }
+hiatus = "*"
 
 [[test]]
 name = "beacon_chain_tests"

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -724,7 +724,7 @@ where
             };
 
         let (_head_state_root, head_state) = store
-            .get_advanced_hot_state(head_block_root, current_slot, head_block.state_root())
+            .get_advanced_hot_state(head_block_root, head_block.slot(), head_block.state_root())
             .map_err(|e| descriptive_db_error("head state", &e))?
             .ok_or("Head state not found in store")?;
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -805,10 +805,11 @@ where
         //
         // This *must* be stored before constructing the `BeaconChain`, so that its `Drop` instance
         // doesn't write a `PersistedBeaconChain` without the rest of the batch.
+        let head_tracker_reader = head_tracker.data.read();
         self.pending_io_batch.push(BeaconChain::<
             Witness<TSlotClock, TEth1Backend, TEthSpec, THotStore, TColdStore>,
         >::persist_head_in_batch_standalone(
-            genesis_block_root, &head_tracker
+            genesis_block_root, &head_tracker_reader
         ));
         self.pending_io_batch.push(BeaconChain::<
             Witness<TSlotClock, TEth1Backend, TEthSpec, THotStore, TColdStore>,
@@ -819,6 +820,7 @@ where
             .hot_db
             .do_atomically(self.pending_io_batch)
             .map_err(|e| format!("Error writing chain & metadata to disk: {:?}", e))?;
+        drop(head_tracker_reader);
 
         let genesis_validators_root = head_snapshot.beacon_state.genesis_validators_root();
         let genesis_time = head_snapshot.beacon_state.genesis_time();

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -26,7 +26,7 @@ pub mod events;
 pub mod execution_payload;
 pub mod fork_choice_signal;
 pub mod fork_revert;
-mod head_tracker;
+pub mod head_tracker;
 pub mod historical_blocks;
 pub mod kzg_utils;
 pub mod light_client_finality_update_verification;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1128,6 +1128,11 @@ lazy_static! {
         // Create a custom bucket list for greater granularity in block delay
         Ok(vec![0.1, 0.2, 0.3,0.4,0.5,0.75,1.0,1.25,1.5,1.75,2.0,2.5,3.0,3.5,4.0,5.0,6.0,7.0,8.0,9.0,10.0,15.0,20.0])
     );
+
+    pub static ref PRUNING_NUM_FORGOTTEN_BLOCKS: Result<IntCounter> = try_create_int_counter(
+        "beacon_chain_pruning_num_forgotten_blocks",
+        "Count of blocks submitted for processing"
+    );
 }
 
 /// Scrape the `beacon_chain` for metrics that are not constantly updated (e.g., the present slot,

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -653,10 +653,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         // Update the head tracker before the database, so that we maintain the invariant
         // that a block present in the head tracker is present in the database.
         // See https://github.com/sigp/lighthouse/issues/1557
-        hiatus::enable();
         println!("waiting to prune (step 2)");
         let s2 = hiatus::step(2);
-        let mut head_tracker_lock = head_tracker.0.write();
+        let mut head_tracker_lock = head_tracker.data.write();
 
         // Check that all the heads to be deleted are still present. The absence of any
         // head indicates a race, that will likely resolve itself, so we defer pruning until

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -514,9 +514,7 @@ where
             .custom_spec(spec)
             .store(self.store.expect("cannot build without store"))
             .store_migrator_config(
-                MigratorConfig::default()
-                    .blocking()
-                    .epochs_per_migration(chain_config.epochs_per_migration),
+                MigratorConfig::default().epochs_per_migration(chain_config.epochs_per_migration),
             )
             .task_executor(self.runtime.task_executor.clone())
             .execution_layer(self.execution_layer)

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -386,7 +386,7 @@ async fn bug_repro() {
     let store = get_store(&db_path);
     let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
 
-    hiatus::enable();
+    // hiatus::enable();
 
     let genesis_state = harness.get_current_state();
     let (fork_block, _) = harness.make_block(genesis_state, Slot::new(1)).await;
@@ -435,8 +435,8 @@ async fn bug_repro() {
         .unwrap()
         .unwrap();
     let head_tracker = HeadTracker::from_ssz_container(&pbc.ssz_head_tracker).unwrap();
-    // IS in the head tracker.
-    assert!(head_tracker.0.read().contains_key(&block_root));
+    // IS NOT in the head tracker.
+    assert!(!head_tracker.data.read().contains_key(&block_root));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Issue Addressed

Bug repro (and prelim fix) for #4773

## Proposed Changes

Data race is:

1. Beacon chain drop serializes the head tracker, and then releases the read lock.
2. Database pruning obtains the head tracker lock, writes the updated version of the head tracker _without_ the deleted blocks.
3. Beacon chain drop _writes_ its head tracker from 1, _restoring_ the block to the head tracker for next startup

Result: block is in head tracker but _not_ on disk, leading to `MissingBeaconBlock` errors and the indefinite stalling of database pruning (massive disk usage blowup).

The proposed fix is to _hold the head tracker read lock_ while doing the database write in `BeaconChain::drop`.

See commit fac3f97b699f3cb0d7018c7575c686703dc687ea for bug reproduction using Hiatus:

> cargo test -p beacon_chain --release --features logging/test_logger -- bug_repro --nocapture

## Additional Info

Credit to @dapplion for pair programming the fix & helping find the root cause.
