### PR TITLE
SSZ block V2 stack overflow

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4652,7 +4652,8 @@ pub fn serve<T: BeaconChainTypes>(
                         post_beacon_blocks_ssz
                             .uor(post_beacon_blocks_v2_ssz)
                             .uor(post_beacon_blinded_blocks_ssz)
-                            .uor(post_beacon_blinded_blocks_v2_ssz),
+                            .uor(post_beacon_blinded_blocks_v2_ssz)
+                            .boxed(),
                     )
                     .boxed()
                     .uor(post_beacon_blocks)
@@ -4686,6 +4687,7 @@ pub fn serve<T: BeaconChainTypes>(
                     .recover(warp_utils::reject::handle_rejection),
             ),
         )
+        .boxed()
         .recover(warp_utils::reject::handle_rejection)
         .with(slog_logging(log.clone()))
         .with(prometheus_metrics())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4652,8 +4652,7 @@ pub fn serve<T: BeaconChainTypes>(
                         post_beacon_blocks_ssz
                             .uor(post_beacon_blocks_v2_ssz)
                             .uor(post_beacon_blinded_blocks_ssz)
-                            .uor(post_beacon_blinded_blocks_v2_ssz)
-                            .boxed(),
+                            .uor(post_beacon_blinded_blocks_v2_ssz),
                     )
                     .boxed()
                     .uor(post_beacon_blocks)
@@ -4687,7 +4686,6 @@ pub fn serve<T: BeaconChainTypes>(
                     .recover(warp_utils::reject::handle_rejection),
             ),
         )
-        .boxed()
         .recover(warp_utils::reject::handle_rejection)
         .with(slog_logging(log.clone()))
         .with(prometheus_metrics())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4652,8 +4652,10 @@ pub fn serve<T: BeaconChainTypes>(
                         post_beacon_blocks_ssz
                             .uor(post_beacon_blocks_v2_ssz)
                             .uor(post_beacon_blinded_blocks_ssz)
-                            .uor(post_beacon_blinded_blocks_v2_ssz),
+                            .uor(post_beacon_blinded_blocks_v2_ssz)
+                            .boxed(),
                     )
+                    .boxed()
                     .uor(post_beacon_blocks)
                     .uor(post_beacon_blinded_blocks)
                     .uor(post_beacon_blocks_v2)
@@ -4685,6 +4687,7 @@ pub fn serve<T: BeaconChainTypes>(
                     .recover(warp_utils::reject::handle_rejection),
             ),
         )
+        .boxed()
         .recover(warp_utils::reject::handle_rejection)
         .with(slog_logging(log.clone()))
         .with(prometheus_metrics())


### PR DESCRIPTION
## Issue Addressed

When publishing a full block via the SSZ V2 endpoint, we get a stack overflow, it seems to be caused by this: https://github.com/seanmonstar/warp/issues/811

Added `.boxed()` has fixed it for me testing on kurtosis. I've probably added more than necessary, but being a bit conservative.