### PR TITLE
Remove the `blobs_db` directory when `--purge-db` flag is present. 

### DIFF
--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -62,6 +62,13 @@ pub fn get_config<E: EthSpec>(
             fs::remove_dir_all(freezer_db)
                 .map_err(|err| format!("Failed to remove freezer_db: {}", err))?;
         }
+
+        // Remove the blobs db.
+        let blobs_db = client_config.get_blobs_db_path();
+        if blobs_db.exists() {
+            fs::remove_dir_all(blobs_db)
+                .map_err(|err| format!("Failed to remove blobs_db: {}", err))?;
+        }
     }
 
     // Create `datadir` and any non-existing parent directories.


### PR DESCRIPTION
## Issue Addressed

The `blobs_db` is not correctly removed when the `--purge-db` flag is present.

## Proposed Changes

Removes the `blobs_db` the same way `chain_db` and `freezer_db` are removed when `--purge-db` flag is present.