### PR TITLE
Add `purge-db-safe` flag which requires manual confirmation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
 name = "beacon_node"
 version = "4.6.0"
 dependencies = [
+ "account_utils",
  "beacon_chain",
  "clap",
  "clap_utils",

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -103,13 +103,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .conflicts_with("count")
                 .takes_value(true),
         )
-        .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
 }
 
 pub fn cli_run<T: EthSpec>(

--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -64,13 +64,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long(NO_CONFIRMATION)
                 .help("Exits without prompting for confirmation that you understand the implications of a voluntary exit. This should be used with caution")
         )
-        .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
 }
 
 pub fn cli_run<E: EthSpec>(matches: &ArgMatches, env: Environment<E>) -> Result<(), String> {

--- a/account_manager/src/validator/import.rs
+++ b/account_manager/src/validator/import.rs
@@ -57,13 +57,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
-        .arg(
             Arg::with_name(REUSE_PASSWORD_FLAG)
                 .long(REUSE_PASSWORD_FLAG)
                 .help("If present, the same password will be used for all imported keystores."),

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -68,13 +68,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     instead generate them from the wallet seed when required.",
                 ),
         )
-        .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
 }
 
 pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), String> {

--- a/account_manager/src/wallet/create.rs
+++ b/account_manager/src/wallet/create.rs
@@ -80,13 +80,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true)
         )
         .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
-        .arg(
             Arg::with_name(MNEMONIC_LENGTH_FLAG)
                 .long(MNEMONIC_LENGTH_FLAG)
                 .value_name("MNEMONIC_LENGTH")

--- a/account_manager/src/wallet/recover.rs
+++ b/account_manager/src/wallet/recover.rs
@@ -52,13 +52,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .possible_values(&[HD_TYPE])
                 .default_value(HD_TYPE),
         )
-        .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
 }
 
 pub fn cli_run(matches: &ArgMatches, wallet_base_dir: PathBuf) -> Result<(), String> {

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -48,3 +48,4 @@ sensitive_url = { workspace = true }
 http_api = { workspace = true }
 unused_port = { workspace = true }
 strum = { workspace = true }
+account_utils = { workspace = true }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -724,6 +724,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("If present, the chain database will be deleted. Use with caution.")
         )
         .arg(
+            Arg::with_name("purge-db-safe")
+                .long("purge-db-safe")
+                .help("The same as --purge-db but requires manual confirmation before the database \
+                       is purged.")
+        )
+        .arg(
             Arg::with_name("compact-db")
                 .long("compact-db")
                 .help("If present, apply compaction to the database on start-up. Use with caution. \

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -101,6 +101,8 @@ FLAGS:
                                                referenced by validator client using the --proposer-node flag. This
                                                configuration is for enabling more secure setups.
         --purge-db                             If present, the chain database will be deleted. Use with caution.
+        --purge-db-safe                        The same as --purge-db but requires manual confirmation before the
+                                               database is purged.
         --reconstruct-historic-states          After a checkpoint sync, reconstruct historic states in the database.
                                                This requires syncing all the way back to genesis.
         --reset-payload-statuses               When present, Lighthouse will forget the payload statuses of any already-
@@ -115,6 +117,7 @@ FLAGS:
                                                server on localhost:5052 and import deposit logs from the execution node.
                                                This is equivalent to `--http` on merge-ready networks, or `--http
                                                --eth1` pre-merge
+        --stdin-inputs                         If present, read all user inputs from stdin instead of tty.
         --subscribe-all-subnets                Subscribe to all subnets regardless of validator count. This will also
                                                advertise the beacon node as being long-lived subscribed to all subnets.
         --validator-monitor-auto               Enables the automatic detection and monitoring of validators connected to

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -24,6 +24,7 @@ FLAGS:
                                          information about your validator and so this flag should be used with caution.
                                          For Windows users, the log file permissions will be inherited from the parent
                                          folder.
+        --stdin-inputs                   If present, read all user inputs from stdin instead of tty.
     -V, --version                        Prints version information
 
 OPTIONS:

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -63,6 +63,7 @@ FLAGS:
             Enable block production via the block v3 endpoint for this validator client. This should only be enabled
             when paired with a beacon node that has this endpoint implemented. This flag will be enabled by default in
             future.
+        --stdin-inputs                           If present, read all user inputs from stdin instead of tty.
         --unencrypted-http-transport
             This is a safety flag to ensure that the user is aware that the http transport is unencrypted and using a
             custom HTTP address is unsafe.

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -20,6 +20,7 @@ FLAGS:
                                          information about your validator and so this flag should be used with caution.
                                          For Windows users, the log file permissions will be inherited from the parent
                                          folder.
+        --stdin-inputs                   If present, read all user inputs from stdin instead of tty.
     -V, --version                        Prints version information
 
 OPTIONS:

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -27,6 +27,7 @@ FLAGS:
                                          information about your validator and so this flag should be used with caution.
                                          For Windows users, the log file permissions will be inherited from the parent
                                          folder.
+        --stdin-inputs                   If present, read all user inputs from stdin instead of tty.
     -V, --version                        Prints version information
 
 OPTIONS:

--- a/common/account_utils/src/lib.rs
+++ b/common/account_utils/src/lib.rs
@@ -35,6 +35,8 @@ const DEFAULT_PASSWORD_LEN: usize = 48;
 
 pub const MNEMONIC_PROMPT: &str = "Enter the mnemonic phrase:";
 
+pub const STDIN_INPUTS_FLAG: &str = "stdin-inputs";
+
 /// Returns the "default" path where a wallet should store its password file.
 pub fn default_wallet_password_path<P: AsRef<Path>>(wallet_name: &str, secrets_dir: P) -> PathBuf {
     secrets_dir.as_ref().join(format!("{}.pass", wallet_name))

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -1,5 +1,6 @@
 mod metrics;
 
+use account_utils::STDIN_INPUTS_FLAG;
 use beacon_node::ProductionBeaconNode;
 use clap::{App, Arg, ArgMatches};
 use clap_utils::{flags::DISABLE_MALLOC_TUNING_FLAG, get_eth2_network_config};
@@ -79,6 +80,14 @@ fn main() {
                  cfg!(feature = "spec-minimal"),
                  cfg!(feature = "gnosis"),
             ).as_str()
+        )
+        .arg(
+            Arg::with_name(STDIN_INPUTS_FLAG)
+                .takes_value(false)
+                .hidden(cfg!(windows))
+                .global(true)
+                .long(STDIN_INPUTS_FLAG)
+                .help("If present, read all user inputs from stdin instead of tty."),
         )
         .arg(
             Arg::with_name("env_log")

--- a/validator_manager/src/common.rs
+++ b/validator_manager/src/common.rs
@@ -1,3 +1,4 @@
+pub use account_utils::STDIN_INPUTS_FLAG;
 use account_utils::{strip_off_newlines, ZeroizeString};
 use eth2::lighthouse_vc::std_types::{InterchangeJsonStr, KeystoreJsonStr};
 use eth2::{
@@ -15,7 +16,6 @@ use tree_hash::TreeHash;
 use types::*;
 
 pub const IGNORE_DUPLICATES_FLAG: &str = "ignore-duplicates";
-pub const STDIN_INPUTS_FLAG: &str = "stdin-inputs";
 pub const COUNT_FLAG: &str = "count";
 
 /// When the `ethereum/staking-deposit-cli` tool generates deposit data JSON, it adds a

--- a/validator_manager/src/create_validators.rs
+++ b/validator_manager/src/create_validators.rs
@@ -91,13 +91,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
-        .arg(
             Arg::with_name(DISABLE_DEPOSITS_FLAG)
                 .long(DISABLE_DEPOSITS_FLAG)
                 .help(

--- a/validator_manager/src/move_validators.rs
+++ b/validator_manager/src/move_validators.rs
@@ -166,13 +166,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name(STDIN_INPUTS_FLAG)
-                .takes_value(false)
-                .hidden(cfg!(windows))
-                .long(STDIN_INPUTS_FLAG)
-                .help("If present, read all user inputs from stdin instead of tty."),
-        )
-        .arg(
             Arg::with_name(BUILDER_BOOST_FACTOR_FLAG)
                 .long(BUILDER_BOOST_FACTOR_FLAG)
                 .takes_value(true)


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/5028

## Proposed Changes

Add a new flag called `--purge-db-safe` which functions like `--purge-db` but requires manual confirmation. As such it is not suitable for environments that are designed to be automated.

## Additional Info

I moved the `stdin-inputs` flag to be a global flag under the `lighthouse` command, as I felt this is a cleaner solution than currently, even if not every subcommand will use it. Happy to change it back if someone has a different opinion.
