### PR TITLE
Stop Penalizing Peers in Parent SingleBlobLookup

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -92,6 +92,10 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         self.block_request_state.requested_block_root = block_root;
         self.block_request_state.state.state = State::AwaitingDownload;
         self.blob_request_state.state.state = State::AwaitingDownload;
+        self.block_request_state.state.component_downloaded = false;
+        self.blob_request_state.state.component_downloaded = false;
+        self.block_request_state.state.component_processed = false;
+        self.blob_request_state.state.component_processed = false;
         self.child_components = Some(ChildComponents::empty(block_root));
     }
 


### PR DESCRIPTION
## Issue Addressed

* #5095

## Proposed Changes

`update_request_parent_block()` needs to reset `component_downloaded` & `component_processed`

## Additional Info

Post-deneb, every [`SingleBlockLookup`](https://github.com/sigp/lighthouse/blob/185646acb2ddcab08d0c2896e675e9bf49be1314/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs#L51) downloads both blocks and blobs. When *either* the block or blobs response is received, the [`handle_verified_response()`](https://github.com/sigp/lighthouse/blob/185646acb2ddcab08d0c2896e675e9bf49be1314/beacon_node/network/src/sync/block_lookups/mod.rs#L367) handler is called:
```rust
    fn handle_verified_response<L: Lookup, R: RequestState<L, T>>(
        &self,
        seen_timestamp: Duration,
        cx: &SyncNetworkContext<T>,
        process_type: BlockProcessType,
        verified_response: R::VerifiedResponseType,
        lookup: &mut SingleBlockLookup<L, T>,
    ) -> Result<(), LookupRequestError> {
        ...
        R::request_state_mut(lookup)
            .get_state_mut()
            .component_downloaded = true;
        ...
        let cached_child = lookup.add_response::<R>(verified_response.clone());
        match cached_child {
            ...
            CachedChild::DownloadIncomplete => {
                // If this was the result of a block request, we can't determine if the block peer
                // did anything wrong. If we already had both a block and blobs response processed,
                // we should penalize the blobs peer because they did not provide all blobs on the
                // initial request.
                if lookup.both_components_downloaded() {
                    lookup.penalize_blob_peer(cx);
                    lookup
                        .blob_request_state
                        .state
                        .register_failure_downloading();
                }
                lookup.request_block_and_blobs(cx)?;
            }
        }
    }
```

The problem is with [`both_components_downloaded()`](https://github.com/sigp/lighthouse/blob/185646acb2ddcab08d0c2896e675e9bf49be1314/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs#L203):
```rust
    /// Returns true if the block has already been downloaded.
    pub fn both_components_downloaded(&self) -> bool {
        self.block_request_state.state.component_downloaded
            && self.blob_request_state.state.component_downloaded
    }
```

Without resetting `component_downloaded` each time we alter the request to a new parent block, the `both_components_downloaded()` condition will always trigger and cause us to penalize the peer and re-request the blobs every time the `SingleBlobLookup` response arrives before the `SingleBlockLookup` response (which is frequent if there are no blobs).

I also reset `component_processed` because that's probably also the right thing to do?