### PR TITLE
Reduce size of futures in HTTP API to prevent stack overflows

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -722,7 +722,7 @@ impl<T: BeaconChainTypes> IntoGossipVerifiedBlockContents<T> for PublishBlockReq
                 Ok::<_, BlockContentsError<T::EthSpec>>(gossip_verified_blobs)
             })
             .transpose()?;
-        let gossip_verified_block = GossipVerifiedBlock::new(Arc::new(block), chain)?;
+        let gossip_verified_block = GossipVerifiedBlock::new(block, chain)?;
 
         Ok((gossip_verified_block, gossip_verified_blobs))
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -952,7 +952,7 @@ mod test {
         };
 
         let availability_pending_block = AvailabilityPendingExecutedBlock {
-            block: Arc::new(block),
+            block,
             import_data,
             payload_verification_outcome,
         };

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1142,11 +1142,7 @@ async fn verify_block_for_gossip_slashing_detection() {
     let ((block1, blobs1), _) = harness.make_block(state.clone(), Slot::new(1)).await;
     let ((block2, _blobs2), _) = harness.make_block(state, Slot::new(1)).await;
 
-    let verified_block = harness
-        .chain
-        .verify_block_for_gossip(Arc::new(block1))
-        .await
-        .unwrap();
+    let verified_block = harness.chain.verify_block_for_gossip(block1).await.unwrap();
 
     if let Some((kzg_proofs, blobs)) = blobs1 {
         let sidecars =
@@ -1174,12 +1170,7 @@ async fn verify_block_for_gossip_slashing_detection() {
         )
         .await
         .unwrap();
-    unwrap_err(
-        harness
-            .chain
-            .verify_block_for_gossip(Arc::new(block2))
-            .await,
-    );
+    unwrap_err(harness.chain.verify_block_for_gossip(block2).await);
 
     // Slasher should have been handed the two conflicting blocks and crafted a slashing.
     slasher.process_queued(Epoch::new(0)).unwrap();
@@ -1198,11 +1189,7 @@ async fn verify_block_for_gossip_doppelganger_detection() {
     let state = harness.get_current_state();
     let ((block, _), _) = harness.make_block(state.clone(), Slot::new(1)).await;
 
-    let verified_block = harness
-        .chain
-        .verify_block_for_gossip(Arc::new(block))
-        .await
-        .unwrap();
+    let verified_block = harness.chain.verify_block_for_gossip(block).await.unwrap();
     let attestations = verified_block.block.message().body().attestations().clone();
     harness
         .chain
@@ -1564,7 +1551,6 @@ async fn import_duplicate_block_unrealized_justification() {
     let slot = harness.get_current_slot();
     let (block_contents, _) = harness.make_block(state.clone(), slot).await;
     let (block, _) = block_contents;
-    let block = Arc::new(block);
     let block_root = block.canonical_root();
 
     // Create two verified variants of the block, representing the same block being processed in

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -319,7 +319,7 @@ impl InvalidPayloadRig {
                         .get_full_block(&block_root)
                         .unwrap()
                         .unwrap(),
-                    block,
+                    *block,
                     "block from db must match block imported"
                 );
             }
@@ -700,7 +700,7 @@ async fn invalidates_all_descendants() {
         .chain
         .process_block(
             fork_block.canonical_root(),
-            Arc::new(fork_block),
+            fork_block,
             NotifyExecutionLayer::Yes,
             || Ok(()),
         )
@@ -800,7 +800,7 @@ async fn switches_heads() {
         .chain
         .process_block(
             fork_block.canonical_root(),
-            Arc::new(fork_block),
+            fork_block,
             NotifyExecutionLayer::Yes,
             || Ok(()),
         )
@@ -1044,8 +1044,7 @@ async fn invalid_parent() {
     // Produce another block atop the parent, but don't import yet.
     let slot = parent_block.slot() + 1;
     rig.harness.set_current_slot(slot);
-    let (block_tuple, state) = rig.harness.make_block(parent_state, slot).await;
-    let block = Arc::new(block_tuple.0);
+    let ((block, _), state) = rig.harness.make_block(parent_state, slot).await;
     let block_root = block.canonical_root();
     assert_eq!(block.parent_root(), parent_root);
 
@@ -1865,7 +1864,7 @@ impl InvalidHeadSetup {
                     .state_at_slot(slot - 1, StateSkipConfig::WithStateRoots)
                     .unwrap();
                 let (fork_block_tuple, _) = rig.harness.make_block(parent_state, slot).await;
-                opt_fork_block = Some(Arc::new(fork_block_tuple.0));
+                opt_fork_block = Some(fork_block_tuple.0);
             } else {
                 // Skipped slot.
             };

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1410,7 +1410,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(network_tx_filter.clone())
         .and(log_filter.clone())
         .then(
-            move |block_contents: SignedBlindedBeaconBlock<T::EthSpec>,
+            move |block_contents: Arc<SignedBlindedBeaconBlock<T::EthSpec>>,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
@@ -1450,6 +1450,7 @@ pub fn serve<T: BeaconChainTypes>(
                         &block_bytes,
                         &chain.spec,
                     )
+                    .map(Arc::new)
                     .map_err(|e| {
                         warp_utils::reject::custom_bad_request(format!("invalid SSZ: {e:?}"))
                     })?;
@@ -1478,7 +1479,7 @@ pub fn serve<T: BeaconChainTypes>(
         .and(log_filter.clone())
         .then(
             move |validation_level: api_types::BroadcastValidationQuery,
-                  blinded_block: SignedBlindedBeaconBlock<T::EthSpec>,
+                  blinded_block: Arc<SignedBlindedBeaconBlock<T::EthSpec>>,
                   task_spawner: TaskSpawner<T::EthSpec>,
                   chain: Arc<BeaconChain<T>>,
                   network_tx: UnboundedSender<NetworkMessage<T::EthSpec>>,
@@ -1519,6 +1520,7 @@ pub fn serve<T: BeaconChainTypes>(
                         &block_bytes,
                         &chain.spec,
                     )
+                    .map(Arc::new)
                     .map_err(|e| {
                         warp_utils::reject::custom_bad_request(format!("invalid SSZ: {e:?}"))
                     })?;

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -194,7 +194,7 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
 
     if let Some(gossip_verified_blobs) = gossip_verified_blobs {
         for blob in gossip_verified_blobs {
-            if let Err(e) = chain.process_gossip_blob(blob).await {
+            if let Err(e) = Box::pin(chain.process_gossip_blob(blob)).await {
                 let msg = format!("Invalid blob: {e}");
                 return if let BroadcastValidation::Gossip = validation_level {
                     Err(warp_utils::reject::broadcast_without_import(msg))
@@ -210,14 +210,13 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
         }
     }
 
-    match chain
-        .process_block(
-            block_root,
-            gossip_verified_block,
-            NotifyExecutionLayer::Yes,
-            publish_fn,
-        )
-        .await
+    match Box::pin(chain.process_block(
+        block_root,
+        gossip_verified_block,
+        NotifyExecutionLayer::Yes,
+        publish_fn,
+    ))
+    .await
     {
         Ok(AvailabilityProcessingStatus::Imported(root)) => {
             info!(

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -3,7 +3,7 @@ use beacon_chain::{
     GossipVerifiedBlock, IntoGossipVerifiedBlockContents,
 };
 use eth2::reqwest::StatusCode;
-use eth2::types::{BroadcastValidation, PublishBlockRequest, SignedBeaconBlock};
+use eth2::types::{BroadcastValidation, PublishBlockRequest};
 use http_api::test_utils::InteractiveTester;
 use http_api::{publish_blinded_block, publish_block, reconstruct_block, ProvenancedBlock};
 use std::sync::Arc;
@@ -63,7 +63,7 @@ pub async fn gossip_invalid() {
 
     tester.harness.advance_slot();
 
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
@@ -115,7 +115,7 @@ pub async fn gossip_partial_pass() {
 
     tester.harness.advance_slot();
 
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::random()
@@ -161,8 +161,7 @@ pub async fn gossip_full_pass() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) =
-        tester.harness.make_block(state_a, slot_b).await;
+    let ((block, blobs), _) = tester.harness.make_block(state_a, slot_b).await;
 
     let response: Result<(), eth2::Error> = tester
         .client
@@ -252,7 +251,7 @@ pub async fn consensus_invalid() {
 
     tester.harness.advance_slot();
 
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
@@ -304,7 +303,7 @@ pub async fn consensus_gossip() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
         .await;
@@ -418,8 +417,7 @@ pub async fn consensus_full_pass() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) =
-        tester.harness.make_block(state_a, slot_b).await;
+    let ((block, blobs), _) = tester.harness.make_block(state_a, slot_b).await;
 
     let response: Result<(), eth2::Error> = tester
         .client
@@ -465,7 +463,7 @@ pub async fn equivocation_invalid() {
 
     tester.harness.advance_slot();
 
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(chain_state_before, slot, |b| {
             *b.state_root_mut() = Hash256::zero();
@@ -518,10 +516,9 @@ pub async fn equivocation_consensus_early_equivocation() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block_a, blobs_a), state_after_a): ((SignedBeaconBlock<E>, _), _) =
+    let ((block_a, blobs_a), state_after_a) =
         tester.harness.make_block(state_a.clone(), slot_b).await;
-    let ((block_b, blobs_b), state_after_b): ((SignedBeaconBlock<E>, _), _) =
-        tester.harness.make_block(state_a, slot_b).await;
+    let ((block_b, blobs_b), state_after_b) = tester.harness.make_block(state_a, slot_b).await;
 
     /* check for `make_block` curios */
     assert_eq!(block_a.state_root(), state_after_a.tree_hash_root());
@@ -590,7 +587,7 @@ pub async fn equivocation_gossip() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) = tester
+    let ((block, blobs), _) = tester
         .harness
         .make_block_with_modifier(state_a, slot_b, |b| *b.state_root_mut() = Hash256::zero())
         .await;
@@ -645,10 +642,9 @@ pub async fn equivocation_consensus_late_equivocation() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block_a, blobs_a), state_after_a): ((SignedBeaconBlock<E>, _), _) =
+    let ((block_a, blobs_a), state_after_a) =
         tester.harness.make_block(state_a.clone(), slot_b).await;
-    let ((block_b, blobs_b), state_after_b): ((SignedBeaconBlock<E>, _), _) =
-        tester.harness.make_block(state_a, slot_b).await;
+    let ((block_b, blobs_b), state_after_b) = tester.harness.make_block(state_a, slot_b).await;
 
     /* check for `make_block` curios */
     assert_eq!(block_a.state_root(), state_after_a.tree_hash_root());
@@ -716,8 +712,7 @@ pub async fn equivocation_full_pass() {
     let slot_b = slot_a + 1;
 
     let state_a = tester.harness.get_current_state();
-    let ((block, blobs), _): ((SignedBeaconBlock<E>, _), _) =
-        tester.harness.make_block(state_a, slot_b).await;
+    let ((block, blobs), _) = tester.harness.make_block(state_a, slot_b).await;
 
     let response: Result<(), eth2::Error> = tester
         .client
@@ -1269,6 +1264,7 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
         .make_blinded_block(state_a.clone(), slot_b)
         .await;
     let (block_b, state_after_b) = tester.harness.make_blinded_block(state_a, slot_b).await;
+    let block_b = Arc::new(block_b);
 
     /* check for `make_blinded_block` curios */
     assert_eq!(block_a.state_root(), state_after_a.tree_hash_root());
@@ -1278,7 +1274,7 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
     let unblinded_block_a = reconstruct_block(
         tester.harness.chain.clone(),
         block_a.canonical_root(),
-        block_a,
+        Arc::new(block_a),
         test_logger.clone(),
     )
     .await
@@ -1301,15 +1297,11 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
         ProvenancedBlock::Builder(b, _) => b,
     };
 
-    let gossip_block_b = GossipVerifiedBlock::new(
-        Arc::new(inner_block_b.clone().deconstruct().0),
-        &tester.harness.chain,
-    );
+    let gossip_block_b =
+        GossipVerifiedBlock::new(inner_block_b.clone().deconstruct().0, &tester.harness.chain);
     assert!(gossip_block_b.is_ok());
-    let gossip_block_a = GossipVerifiedBlock::new(
-        Arc::new(inner_block_a.clone().deconstruct().0),
-        &tester.harness.chain,
-    );
+    let gossip_block_a =
+        GossipVerifiedBlock::new(inner_block_a.clone().deconstruct().0, &tester.harness.chain);
     assert!(gossip_block_a.is_err());
 
     let channel = tokio::sync::mpsc::unbounded_channel();

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -632,7 +632,7 @@ pub async fn proposer_boost_re_org_test(
             panic!("Should not be a blinded block");
         }
     };
-    let block_c = harness.sign_beacon_block(unsigned_block_c, &state_b);
+    let block_c = Arc::new(harness.sign_beacon_block(unsigned_block_c, &state_b));
 
     if should_re_org {
         // Block C should build on A.

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2597,7 +2597,7 @@ impl ApiTester {
 
             let signed_block = block.sign(&sk, &fork, genesis_validators_root, &self.chain.spec);
             let signed_block_contents =
-                PublishBlockRequest::try_from(signed_block.clone()).unwrap();
+                PublishBlockRequest::try_from(Arc::new(signed_block.clone())).unwrap();
 
             self.client
                 .post_beacon_blocks(&signed_block_contents)
@@ -2670,8 +2670,8 @@ impl ApiTester {
                 .unwrap();
 
             assert_eq!(
-                self.chain.head_beacon_block().as_ref(),
-                signed_block_contents.signed_block()
+                self.chain.head_beacon_block(),
+                *signed_block_contents.signed_block()
             );
 
             self.chain.slot_clock.set_slot(slot.as_u64() + 1);
@@ -2763,8 +2763,8 @@ impl ApiTester {
                         .unwrap();
 
                     assert_eq!(
-                        self.chain.head_beacon_block().as_ref(),
-                        signed_block_contents.signed_block()
+                        self.chain.head_beacon_block(),
+                        *signed_block_contents.signed_block()
                     );
 
                     self.chain.slot_clock.set_slot(slot.as_u64() + 1);
@@ -2994,7 +2994,7 @@ impl ApiTester {
                 .data;
 
             let signed_block = signed_block_contents.signed_block();
-            assert_eq!(&head_block, signed_block);
+            assert_eq!(head_block, **signed_block);
 
             self.chain.slot_clock.set_slot(slot.as_u64() + 1);
         }

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -250,7 +250,7 @@ impl TestRig {
         };
         Self {
             chain,
-            next_block: Arc::new(block),
+            next_block: block,
             next_blobs: blob_sidecars,
             attestations,
             next_block_attestations,

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -323,8 +323,9 @@ impl ForkChoiceTest {
             )
             .unwrap();
         let slot = self.harness.get_current_slot();
-        let (mut block_tuple, mut state) = self.harness.make_block(state, slot).await;
-        func(&mut block_tuple.0, &mut state);
+        let ((block_arc, _block_blobs), mut state) = self.harness.make_block(state, slot).await;
+        let mut block = (*block_arc).clone();
+        func(&mut block, &mut state);
         let current_slot = self.harness.get_current_slot();
         self.harness
             .chain
@@ -332,8 +333,8 @@ impl ForkChoiceTest {
             .fork_choice_write_lock()
             .on_block(
                 current_slot,
-                block_tuple.0.message(),
-                block_tuple.0.canonical_root(),
+                block.message(),
+                block.canonical_root(),
                 Duration::from_secs(0),
                 &state,
                 PayloadVerificationStatus::Verified,
@@ -366,8 +367,9 @@ impl ForkChoiceTest {
             )
             .unwrap();
         let slot = self.harness.get_current_slot();
-        let (mut block_tuple, mut state) = self.harness.make_block(state, slot).await;
-        mutation_func(&mut block_tuple.0, &mut state);
+        let ((block_arc, _block_blobs), mut state) = self.harness.make_block(state, slot).await;
+        let mut block = (*block_arc).clone();
+        mutation_func(&mut block, &mut state);
         let current_slot = self.harness.get_current_slot();
         let err = self
             .harness
@@ -376,8 +378,8 @@ impl ForkChoiceTest {
             .fork_choice_write_lock()
             .on_block(
                 current_slot,
-                block_tuple.0.message(),
-                block_tuple.0.canonical_root(),
+                block.message(),
+                block.canonical_root(),
                 Duration::from_secs(0),
                 &state,
                 PayloadVerificationStatus::Verified,

--- a/consensus/state_processing/src/per_block_processing/tests.rs
+++ b/consensus/state_processing/src/per_block_processing/tests.rs
@@ -90,7 +90,7 @@ async fn invalid_block_header_state_slot() {
     let slot = state.slot() + Slot::new(1);
 
     let ((signed_block, _), mut state) = harness.make_block_return_pre_state(state, slot).await;
-    let (mut block, signature) = signed_block.deconstruct();
+    let (mut block, signature) = (*signed_block).clone().deconstruct();
     *block.slot_mut() = slot + Slot::new(1);
 
     let mut ctxt = ConsensusContext::new(block.slot());
@@ -123,7 +123,7 @@ async fn invalid_parent_block_root() {
     let ((signed_block, _), mut state) = harness
         .make_block_return_pre_state(state, slot + Slot::new(1))
         .await;
-    let (mut block, signature) = signed_block.deconstruct();
+    let (mut block, signature) = (*signed_block).clone().deconstruct();
     *block.parent_root_mut() = Hash256::from([0xAA; 32]);
 
     let mut ctxt = ConsensusContext::new(block.slot());
@@ -158,7 +158,7 @@ async fn invalid_block_signature() {
     let ((signed_block, _), mut state) = harness
         .make_block_return_pre_state(state, slot + Slot::new(1))
         .await;
-    let (block, _) = signed_block.deconstruct();
+    let (block, _) = (*signed_block).clone().deconstruct();
 
     let mut ctxt = ConsensusContext::new(block.slot());
     let result = per_block_processing(

--- a/testing/state_transition_vectors/src/exit.rs
+++ b/testing/state_transition_vectors/src/exit.rs
@@ -57,7 +57,7 @@ impl ExitTest {
                 block_modifier(&harness, block);
             })
             .await;
-        (signed_block.0, state)
+        ((*signed_block.0).clone(), state)
     }
 
     fn process(

--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -450,12 +450,13 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                 self.validator_store
                     .sign_block(*validator_pubkey, block, slot)
                     .await
-                    .map(|b| SignedBlock::Full(PublishBlockRequest::new(b, maybe_blobs)))
+                    .map(|b| SignedBlock::Full(PublishBlockRequest::new(Arc::new(b), maybe_blobs)))
             }
             UnsignedBlock::Blinded(block) => self
                 .validator_store
                 .sign_block(*validator_pubkey, block, slot)
                 .await
+                .map(Arc::new)
                 .map(SignedBlock::Blinded),
         };
 
@@ -870,7 +871,7 @@ impl<E: EthSpec> UnsignedBlock<E> {
 
 pub enum SignedBlock<E: EthSpec> {
     Full(PublishBlockRequest<E>),
-    Blinded(SignedBlindedBeaconBlock<E>),
+    Blinded(Arc<SignedBlindedBeaconBlock<E>>),
 }
 
 impl<E: EthSpec> SignedBlock<E> {


### PR DESCRIPTION
## Issue Addressed

Closes #5080.

## Proposed Changes

- Use `Box::pin` on a few futures in `publish_block`. This reduces the size of related futures from 100KB to ~33KB.
- Use `Arc`s to reduce the amount of data on the stack in `publish_block` and related functions. This reduces the size of the publish block futures from ~33KB to ~16KB.

One of the reasons for the stack size blowup in futures is described in this blog post: https://swatinem.de/blog/future-size/.

Even with that knowledge, I still found it quite hard to determine interventions that would be effective, and did a lot of trial and error changing things and re-running the type-size analysis.

The commands I used for testing were:

```bash
RUSTFLAGS='-Zprint-type-sizes' cargo +nightly build --release > type_sizes.txt
```

Followed by post-processing:

```bash
cat type_sizes.txt | grep 'print-type-size type:' | sed 's/print-type-size type: `\(.*\)`: \([0-9]*\) bytes, alignment.*/"\1",\2/' | rg "warp" > output.csv
```

## Additional Info

There's still more we could do here. Some types like the `PreProcessingSnapshot` end up on the stack during block publishing, and are quite large due to containing unarced blocks and states.

There's also an outstanding mystery as to how 100KB futures can cause an 8MB stack to overflow, when only they should only be nested ~1 at a time. Either I've misunderstood what happens when futures poll sub-futures recursively, or there's something in `warp` that creates the amplification.

**NOTE**: I have yet to measure whether the boxing and arcing has an impact on performance. It would be good to monitor metrics for block publication time after deploying this branch.

A backtrace implicating `warp` can be found here: https://gist.github.com/michaelsproul/d0a4b93bb9d21a5be1103acf4c0a3753.

Thanks to @dapplion for pairing on this and helping with some of the early progress.
