### PR TITLE
Correct a bug that would cause unnecessary discovery requests

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -916,7 +916,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             {
                 self.max_outbound_dialing_peers()
                     .saturating_sub(dialing_peers)
-                    - peer_count
+                    .saturating_sub(peer_count)
             } else {
                 0
             };


### PR DESCRIPTION
## Issue Addressed

@antondlr found a bug where we would create unnecessary discovery queries. This occurs when we are close to our limit but are already dialing enough peers to reach over the limit. In this case, we would perform an additional unnecessary discovery request and report an underflow'd number.