### PR TITLE
Correct multiple dial bug

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -405,7 +405,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     /* Notifications from the Swarm */
 
     /// A peer is being dialed.
-    /// Returns true, if this peer should be dialed.
+    /// Returns true, if this peer will be dialed.
     pub fn dial_peer(&mut self, peer: Enr) -> bool {
         if self
             .network_globals

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -339,9 +339,11 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                         .write()
                         .update_min_ttl(&enr.peer_id(), min_ttl);
                 }
-                debug!(self.log, "Dialing discovered peer"; "peer_id" => %enr.peer_id());
-                self.dial_peer(enr);
-                to_dial_peers += 1;
+                let peer_id = enr.peer_id();
+                if self.dial_peer(enr) {
+                    debug!(self.log, "Dialing discovered peer"; "peer_id" => %peer_id);
+                    to_dial_peers += 1;
+                }
             }
         }
 
@@ -403,7 +405,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     /* Notifications from the Swarm */
 
     /// A peer is being dialed.
-    pub fn dial_peer(&mut self, peer: Enr) {
+    /// Returns true, if this peer should be dialed.
+    pub fn dial_peer(&mut self, peer: Enr) -> bool {
         if self
             .network_globals
             .peers
@@ -411,6 +414,9 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             .should_dial(&peer.peer_id())
         {
             self.peers_to_dial.push(peer);
+            true
+        } else {
+            false
         }
     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -326,8 +326,10 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             //    considered a priority. We have pre-allocated some extra priority slots for these
             //    peers as specified by PRIORITY_PEER_EXCESS. Therefore we dial these peers, even
             //    if we are already at our max_peer limit.
-            if min_ttl.is_some() && connected_or_dialing + to_dial_peers < self.max_priority_peers()
-                || connected_or_dialing + to_dial_peers < self.max_peers()
+            if !self.peers_to_dial.contains(&enr)
+                && ((min_ttl.is_some()
+                    && connected_or_dialing + to_dial_peers < self.max_priority_peers())
+                    || connected_or_dialing + to_dial_peers < self.max_peers())
             {
                 // This should be updated with the peer dialing. In fact created once the peer is
                 // dialed

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1161,9 +1161,11 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
 
         // Remove the ENR from the cache to prevent continual re-dialing on disconnects
         for enr in peers_to_dial {
-            debug!(self.log, "Dialing cached ENR peer"; "peer_id" => %enr.peer_id());
             self.discovery_mut().remove_cached_enr(&enr.peer_id());
-            self.peer_manager_mut().dial_peer(enr);
+            let peer_id = enr.peer_id();
+            if self.peer_manager_mut().dial_peer(enr) {
+                debug!(self.log, "Dialing cached ENR peer"; "peer_id" => %peer_id);
+            }
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

There is a race-condition where discovery queries pile up and return the same peer. Before the peer manager has a chance to dial peers, the queue can build up multiple peers to attempt to dial. 

This removes the chance of duplication of a peer in the dial queue and will therefore prevent the error that can result when we attempt to dial a peer twice. 
