### PR TITLE
Remove erroneous bash evaluation from `scripts/cli.sh`

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -90,7 +90,7 @@ rm -f help_general.md help_bn.md help_vc.md help_am.md help_vm.md help_vm_create
 
 # only exit at the very end
 if [[ $changes == true ]]; then
-    echo "Exiting with error to indicate changes occurred. To fix, run `make cli-local` or `make cli` and commit the changes."
+    echo "Exiting with error to indicate changes occurred. To fix, run 'make cli-local' or 'make cli' and commit the changes."
     exit 1
 else
     echo "CLI help texts are up to date."


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/pull/5041 introduced some hints for how to solve CI errors relating to the CLI help text files added in https://github.com/sigp/lighthouse/pull/4571

This had an unfortunate side effect. Since `make cli` and `make cli-local` were encased in back-ticks and echoed to the user, it caused Bash to evaluate them in the terminal.

We saw a case of this occurring [on CI here.](https://github.com/sigp/lighthouse/actions/runs/7619782000/job/20757610293?pr=5086)
The log line:
```
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
```
indicates that the CI job attempted to spin up a nested docker container which failed.

There were also effects seen locally. Running `make cli-local` would actually end up triggering `make cli` in the event that changes were required so you would end up seeing Docker logs. Luckily, we did not echo the offending line in the event that no changes were made, which prevented a infinite recursion situation.

## Proposed Changes

Replace the back-ticks with single quotes which do not get evaluated.
