### PR TITLE
Update Mergify commit message template to use PR title instead of commit message

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -4,6 +4,12 @@ queue_rules:
     batch_max_wait_time: 60 s
     checks_timeout: 10800 s
     merge_method: squash
+    commit_message_template: |
+      {{ title }} (#{{ number }})
+      
+      {% for commit in commits %}
+      * {{ commit.commit_message }}
+      {% endfor %}
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"


### PR DESCRIPTION
## Issue Addressed

Update Mergify commit message template to use **PR title** (instead of commit message) as the commit message **title**, and have commits in the **description**, like below:

```
commit 337aec07bd39bc3c478d94b92de2a0bc2a1496a3 (HEAD -> unstable, jimmygchen/unstable)
Author: Jimmy Chen <jchen.tc@gmail.com>
Date:   Thu Jan 25 15:53:49 2024 +1100

    My PR title (#47)
    
    * bello
    
    * Banana
    
    * Make CI instant again
        
    * Merge remote-tracking branch 'jimmygchen/unstable' into bello
```