### PR TITLE
Improve database compaction and `prune-states`

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2376,6 +2376,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             self.cold_db.do_atomically(cold_ops)?;
         }
 
+        // In order to reclaim space, we need to compact the freezer DB as well.
+        self.cold_db.compact()?;
+
         Ok(())
     }
 }

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -160,7 +160,7 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
         let start_key = BytesKey::from_vec(get_key_for_col(column.as_str(), &[]));
         let end_key = BytesKey::from_vec(get_key_for_col(
             column.as_str(),
-            &vec![0; std::cmp::max(column.key_size(), 32)],
+            &vec![0xff; std::cmp::max(column.key_size(), 32)],
         ));
         self.db.compact(&start_key, &end_key);
         Ok(())

--- a/beacon_node/store/src/leveldb_store.rs
+++ b/beacon_node/store/src/leveldb_store.rs
@@ -155,12 +155,12 @@ impl<E: EthSpec> KeyValueStore<E> for LevelDB<E> {
     }
 
     fn compact_column(&self, column: DBColumn) -> Result<(), Error> {
-        // Use key-size-agnostic keys [] and 0xff..ff (Hash256) to account for columns that may
-        // change size between databases or schema versions.
+        // Use key-size-agnostic keys [] and 0xff..ff with a minimum of 32 bytes to account for
+        // columns that may change size between sub-databases or schema versions.
         let start_key = BytesKey::from_vec(get_key_for_col(column.as_str(), &[]));
         let end_key = BytesKey::from_vec(get_key_for_col(
             column.as_str(),
-            Hash256::repeat_byte(0xff).as_bytes(),
+            &vec![0; std::cmp::max(column.key_size(), 32)],
         ));
         self.db.compact(&start_key, &end_key);
         Ok(())

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -108,7 +108,7 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
         self.transaction_mutex.lock()
     }
 
-    fn compact(&self) -> Result<(), Error> {
+    fn compact_column(&self, _column: DBColumn) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -537,7 +537,10 @@ pub fn prune_states<E: EthSpec>(
     // Check that the user has confirmed they want to proceed.
     if !prune_config.confirm {
         match db.get_anchor_info() {
-            Some(anchor_info) if anchor_info.state_upper_limit == STATE_UPPER_LIMIT_NO_RETAIN => {
+            Some(anchor_info)
+                if anchor_info.state_lower_limit == 0
+                    && anchor_info.state_upper_limit == STATE_UPPER_LIMIT_NO_RETAIN =>
+            {
                 info!(log, "States have already been pruned");
                 return Ok(());
             }

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -77,7 +77,15 @@ pub fn inspect_cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("freezer")
                 .long("freezer")
                 .help("Inspect the freezer DB rather than the hot DB")
-                .takes_value(false),
+                .takes_value(false)
+                .conflicts_with("blobs-db"),
+        )
+        .arg(
+            Arg::with_name("blobs-db")
+                .long("blobs-db")
+                .help("Inspect the blobs DB rather than the hot DB")
+                .takes_value(false)
+                .conflicts_with("freezer"),
         )
         .arg(
             Arg::with_name("output-dir")
@@ -103,8 +111,16 @@ pub fn compact_cli_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("freezer")
                 .long("freezer")
-                .help("Compact the freezer DB rather than the hot DB")
-                .takes_value(false),
+                .help("Inspect the freezer DB rather than the hot DB")
+                .takes_value(false)
+                .conflicts_with("blobs-db"),
+        )
+        .arg(
+            Arg::with_name("blobs-db")
+                .long("blobs-db")
+                .help("Inspect the blobs DB rather than the hot DB")
+                .takes_value(false)
+                .conflicts_with("freezer"),
         )
 }
 
@@ -272,6 +288,7 @@ pub struct InspectConfig {
     skip: Option<usize>,
     limit: Option<usize>,
     freezer: bool,
+    blobs_db: bool,
     /// Configures where the inspect output should be stored.
     output_dir: PathBuf,
 }
@@ -282,6 +299,7 @@ fn parse_inspect_config(cli_args: &ArgMatches) -> Result<InspectConfig, String> 
     let skip = clap_utils::parse_optional(cli_args, "skip")?;
     let limit = clap_utils::parse_optional(cli_args, "limit")?;
     let freezer = cli_args.is_present("freezer");
+    let blobs_db = cli_args.is_present("blobs-db");
 
     let output_dir: PathBuf =
         clap_utils::parse_optional(cli_args, "output-dir")?.unwrap_or_else(PathBuf::new);
@@ -291,6 +309,7 @@ fn parse_inspect_config(cli_args: &ArgMatches) -> Result<InspectConfig, String> 
         skip,
         limit,
         freezer,
+        blobs_db,
         output_dir,
     })
 }
@@ -298,32 +317,20 @@ fn parse_inspect_config(cli_args: &ArgMatches) -> Result<InspectConfig, String> 
 pub fn inspect_db<E: EthSpec>(
     inspect_config: InspectConfig,
     client_config: ClientConfig,
-    runtime_context: &RuntimeContext<E>,
-    log: Logger,
 ) -> Result<(), String> {
-    let spec = runtime_context.eth2_config.spec.clone();
     let hot_path = client_config.get_db_path();
     let cold_path = client_config.get_freezer_db_path();
     let blobs_path = client_config.get_blobs_db_path();
-
-    let db = HotColdDB::<E, LevelDB<E>, LevelDB<E>>::open(
-        &hot_path,
-        &cold_path,
-        &blobs_path,
-        |_, _, _| Ok(()),
-        client_config.store,
-        spec,
-        log,
-    )
-    .map_err(|e| format!("{:?}", e))?;
 
     let mut total = 0;
     let mut num_keys = 0;
 
     let sub_db = if inspect_config.freezer {
-        &db.cold_db
+        LevelDB::<E>::open(&cold_path).map_err(|e| format!("Unable to open freezer DB: {e:?}"))?
+    } else if inspect_config.blobs_db {
+        LevelDB::<E>::open(&blobs_path).map_err(|e| format!("Unable to open blobs DB: {e:?}"))?
     } else {
-        &db.hot_db
+        LevelDB::<E>::open(&hot_path).map_err(|e| format!("Unable to open hot DB: {e:?}"))?
     };
 
     let skip = inspect_config.skip.unwrap_or(0);
@@ -408,12 +415,18 @@ pub fn inspect_db<E: EthSpec>(
 pub struct CompactConfig {
     column: DBColumn,
     freezer: bool,
+    blobs_db: bool,
 }
 
 fn parse_compact_config(cli_args: &ArgMatches) -> Result<CompactConfig, String> {
     let column = clap_utils::parse_required(cli_args, "column")?;
     let freezer = cli_args.is_present("freezer");
-    Ok(CompactConfig { column, freezer })
+    let blobs_db = cli_args.is_present("blobs-db");
+    Ok(CompactConfig {
+        column,
+        freezer,
+        blobs_db,
+    })
 }
 
 pub fn compact_db<E: EthSpec>(
@@ -423,10 +436,13 @@ pub fn compact_db<E: EthSpec>(
 ) -> Result<(), Error> {
     let hot_path = client_config.get_db_path();
     let cold_path = client_config.get_freezer_db_path();
+    let blobs_path = client_config.get_blobs_db_path();
     let column = compact_config.column;
 
     let (sub_db, db_name) = if compact_config.freezer {
         (LevelDB::<E>::open(&cold_path)?, "freezer_db")
+    } else if compact_config.blobs_db {
+        (LevelDB::<E>::open(&blobs_path)?, "blobs_db")
     } else {
         (LevelDB::<E>::open(&hot_path)?, "hot_db")
     };
@@ -644,7 +660,7 @@ pub fn run<T: EthSpec>(cli_args: &ArgMatches<'_>, env: Environment<T>) -> Result
         }
         ("inspect", Some(cli_args)) => {
             let inspect_config = parse_inspect_config(cli_args)?;
-            inspect_db(inspect_config, client_config, &context, log)
+            inspect_db::<T>(inspect_config, client_config)
         }
         ("compact", Some(cli_args)) => {
             let compact_config = parse_compact_config(cli_args)?;

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -88,6 +88,26 @@ pub fn inspect_cli_app<'a, 'b>() -> App<'a, 'b> {
         )
 }
 
+pub fn compact_cli_app<'a, 'b>() -> App<'a, 'b> {
+    App::new("compact")
+        .setting(clap::AppSettings::ColoredHelp)
+        .about("Compact database manually")
+        .arg(
+            Arg::with_name("column")
+                .long("column")
+                .value_name("TAG")
+                .help("3-byte column ID (see `DBColumn`)")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("freezer")
+                .long("freezer")
+                .help("Compact the freezer DB rather than the hot DB")
+                .takes_value(false),
+        )
+}
+
 pub fn prune_payloads_app<'a, 'b>() -> App<'a, 'b> {
     App::new("prune-payloads")
         .alias("prune_payloads")
@@ -162,6 +182,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
         .subcommand(migrate_cli_app())
         .subcommand(version_cli_app())
         .subcommand(inspect_cli_app())
+        .subcommand(compact_cli_app())
         .subcommand(prune_payloads_app())
         .subcommand(prune_blobs_app())
         .subcommand(prune_states_app())
@@ -384,6 +405,41 @@ pub fn inspect_db<E: EthSpec>(
     Ok(())
 }
 
+pub struct CompactConfig {
+    column: DBColumn,
+    freezer: bool,
+}
+
+fn parse_compact_config(cli_args: &ArgMatches) -> Result<CompactConfig, String> {
+    let column = clap_utils::parse_required(cli_args, "column")?;
+    let freezer = cli_args.is_present("freezer");
+    Ok(CompactConfig { column, freezer })
+}
+
+pub fn compact_db<E: EthSpec>(
+    compact_config: CompactConfig,
+    client_config: ClientConfig,
+    log: Logger,
+) -> Result<(), Error> {
+    let hot_path = client_config.get_db_path();
+    let cold_path = client_config.get_freezer_db_path();
+    let column = compact_config.column;
+
+    let (sub_db, db_name) = if compact_config.freezer {
+        (LevelDB::<E>::open(&cold_path)?, "freezer_db")
+    } else {
+        (LevelDB::<E>::open(&hot_path)?, "hot_db")
+    };
+    info!(
+        log,
+        "Compacting database";
+        "db" => db_name,
+        "column" => ?column
+    );
+    sub_db.compact_column(column)?;
+    Ok(())
+}
+
 pub struct MigrateConfig {
     to: SchemaVersion,
 }
@@ -589,6 +645,10 @@ pub fn run<T: EthSpec>(cli_args: &ArgMatches<'_>, env: Environment<T>) -> Result
         ("inspect", Some(cli_args)) => {
             let inspect_config = parse_inspect_config(cli_args)?;
             inspect_db(inspect_config, client_config, &context, log)
+        }
+        ("compact", Some(cli_args)) => {
+            let compact_config = parse_compact_config(cli_args)?;
+            compact_db::<T>(compact_config, client_config, log).map_err(format_err)
         }
         ("prune-payloads", Some(_)) => {
             prune_payloads(client_config, &context, log).map_err(format_err)


### PR DESCRIPTION
## Issue Addressed

I noticed that `prune-states` doesn't actually clear any space on disk because we don't compact the freezer database after running it.

## Proposed Changes

- Compact the relevant columns of the freezer database after pruning states.
- Add a new `lighthouse db compact` command for manually compacting specific columns in a specific DB (hot, freezer or blobs).
- Add a `--blobs-db` option to `lighthouse db inspect` (and `compact`) so we can inspect the blobs DB as well as the freezer.

## Additional Info

I've manually tested the tree-states version of these changes (https://github.com/sigp/lighthouse/pull/5097) and the compaction works correctly.
