### PR TITLE
Fix bug in `--builder-proposals`

### DIFF
--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1191,6 +1191,19 @@ async fn validator_builder_boost_factor_global_builder_proposals_true() {
 }
 
 #[tokio::test]
+async fn validator_builder_boost_factor_global_builder_proposals_false() {
+    let config = Config {
+        builder_proposals: false,
+        prefer_builder_proposals: false,
+        builder_boost_factor: None,
+        ..Config::default()
+    };
+    ApiTester::new_with_config(config)
+        .await
+        .assert_default_builder_boost_factor(Some(0));
+}
+
+#[tokio::test]
 async fn validator_builder_boost_factor_global_prefer_builder_proposals_true() {
     let config = Config {
         builder_proposals: true,
@@ -1214,19 +1227,6 @@ async fn validator_builder_boost_factor_global_prefer_builder_proposals_false() 
     ApiTester::new_with_config(config)
         .await
         .assert_default_builder_boost_factor(None);
-}
-
-#[tokio::test]
-async fn validator_builder_boost_factor_global_builder_proposals_false() {
-    let config = Config {
-        builder_proposals: false,
-        prefer_builder_proposals: false,
-        builder_boost_factor: None,
-        ..Config::default()
-    };
-    ApiTester::new_with_config(config)
-        .await
-        .assert_default_builder_boost_factor(Some(0));
 }
 
 #[tokio::test]

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1217,16 +1217,16 @@ async fn validator_builder_boost_factor_global_prefer_builder_proposals_true() {
 }
 
 #[tokio::test]
-async fn validator_builder_boost_factor_global_prefer_builder_proposals_false() {
+async fn validator_builder_boost_factor_global_prefer_builder_proposals_true_overrides_builder_proposals() {
     let config = Config {
-        builder_proposals: true,
-        prefer_builder_proposals: false,
+        builder_proposals: false,
+        prefer_builder_proposals: true,
         builder_boost_factor: None,
         ..Config::default()
     };
     ApiTester::new_with_config(config)
         .await
-        .assert_default_builder_boost_factor(None);
+        .assert_default_builder_boost_factor(Some(u64::MAX));
 }
 
 #[tokio::test]

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1178,6 +1178,58 @@ async fn validator_derived_builder_boost_factor_with_process_defaults() {
 }
 
 #[tokio::test]
+async fn validator_builder_boost_factor_global_builder_proposals_true() {
+    let config = Config {
+        builder_proposals: true,
+        prefer_builder_proposals: false,
+        builder_boost_factor: None,
+        ..Config::default()
+    };
+    ApiTester::new_with_config(config)
+        .await
+        .assert_default_builder_boost_factor(None);
+}
+
+#[tokio::test]
+async fn validator_builder_boost_factor_global_prefer_builder_proposals_true() {
+    let config = Config {
+        builder_proposals: true,
+        prefer_builder_proposals: true,
+        builder_boost_factor: None,
+        ..Config::default()
+    };
+    ApiTester::new_with_config(config)
+        .await
+        .assert_default_builder_boost_factor(Some(u64::MAX));
+}
+
+#[tokio::test]
+async fn validator_builder_boost_factor_global_prefer_builder_proposals_false() {
+    let config = Config {
+        builder_proposals: true,
+        prefer_builder_proposals: false,
+        builder_boost_factor: None,
+        ..Config::default()
+    };
+    ApiTester::new_with_config(config)
+        .await
+        .assert_default_builder_boost_factor(None);
+}
+
+#[tokio::test]
+async fn validator_builder_boost_factor_global_builder_proposals_false() {
+    let config = Config {
+        builder_proposals: false,
+        prefer_builder_proposals: false,
+        builder_boost_factor: None,
+        ..Config::default()
+    };
+    ApiTester::new_with_config(config)
+        .await
+        .assert_default_builder_boost_factor(Some(0));
+}
+
+#[tokio::test]
 async fn prefer_builder_proposals_validator() {
     ApiTester::new()
         .await

--- a/validator_client/src/http_api/tests.rs
+++ b/validator_client/src/http_api/tests.rs
@@ -1217,7 +1217,7 @@ async fn validator_builder_boost_factor_global_prefer_builder_proposals_true() {
 }
 
 #[tokio::test]
-async fn validator_builder_boost_factor_global_prefer_builder_proposals_true_overrides_builder_proposals() {
+async fn validator_builder_boost_factor_global_prefer_builder_proposals_true_override() {
     let config = Config {
         builder_proposals: false,
         prefer_builder_proposals: true,

--- a/validator_client/src/validator_store.rs
+++ b/validator_client/src/validator_store.rs
@@ -572,7 +572,7 @@ impl<T: SlotClock + 'static, E: EthSpec> ValidatorStore<T, E> {
             return Some(u64::MAX);
         }
         self.builder_boost_factor.or({
-            if self.builder_proposals {
+            if !self.builder_proposals {
                 Some(0)
             } else {
                 None


### PR DESCRIPTION
## Issue Addressed

The validator client was using the wrong logic for the default `builder_boost_factor` when the `--builder-proposals` flag was provided. Rather than setting the boost to 0 when `builder-propsals` was _false_, it was setting it to 0 when `builder-proposals` was _true_.

## Proposed Changes

- [x] Fix the condition
- [x] Add another test case to cover this specifically
