### PR TITLE
Re-disable block verification tests in debug

### DIFF
--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1,4 +1,4 @@
-// #![cfg(not(debug_assertions))]
+#![cfg(not(debug_assertions))]
 
 use beacon_chain::block_verification_types::{AsBlock, ExecutedBlock, RpcBlock};
 use beacon_chain::{


### PR DESCRIPTION
## Issue Addressed

Run some tests in release that had accidentally been enabled in debug.