### PR TITLE
add superstruct flatten to structs where posisble

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7627,9 +7627,8 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "superstruct"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b9e5728aa1a87141cefd4e7509903fc01fa0dcb108022b1e841a67c5159fc5"
+version = "0.7.0"
+source = "git+https://github.com/realbigsean/superstruct?rev=748e0a5dbb824db48beacb2471aec1c62eaa1311#748e0a5dbb824db48beacb2471aec1c62eaa1311"
 dependencies = [
  "darling",
  "itertools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7628,7 +7628,7 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 [[package]]
 name = "superstruct"
 version = "0.7.0"
-source = "git+https://github.com/realbigsean/superstruct?rev=748e0a5dbb824db48beacb2471aec1c62eaa1311#748e0a5dbb824db48beacb2471aec1c62eaa1311"
+source = "git+https://github.com/realbigsean/superstruct?rev=76b67a19fdea613b5f7050e43644544f115aa517#76b67a19fdea613b5f7050e43644544f115aa517"
 dependencies = [
  "darling",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ smallvec = "1.11.2"
 snap = "1"
 ssz_types = "0.5"
 strum = { version = "0.24", features = ["derive"] }
-superstruct = {git = "https://github.com/realbigsean/superstruct", rev = "748e0a5dbb824db48beacb2471aec1c62eaa1311"}
+superstruct = {git = "https://github.com/realbigsean/superstruct", rev = "76b67a19fdea613b5f7050e43644544f115aa517"}
 syn = "1"
 sysinfo = "0.26"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ smallvec = "1.11.2"
 snap = "1"
 ssz_types = "0.5"
 strum = { version = "0.24", features = ["derive"] }
-superstruct = "0.6"
+superstruct = {git = "https://github.com/realbigsean/superstruct", rev = "748e0a5dbb824db48beacb2471aec1c62eaa1311"}
 syn = "1"
 sysinfo = "0.26"
 tempfile = "3"

--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -399,12 +399,8 @@ pub struct ProposeBlindedBlockResponse {
 )]
 #[derive(Clone, Debug, PartialEq)]
 pub struct GetPayloadResponse<T: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
-    pub execution_payload: ExecutionPayloadMerge<T>,
-    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
-    pub execution_payload: ExecutionPayloadCapella<T>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
-    pub execution_payload: ExecutionPayloadDeneb<T>,
+    #[superstruct(flatten)]
+    pub execution_payload: ExecutionPayload<T>,
     pub block_value: Uint256,
     #[superstruct(only(Deneb))]
     pub blobs_bundle: BlobsBundle<T>,
@@ -587,12 +583,8 @@ impl<E: EthSpec> ExecutionPayloadBodyV1<E> {
 )]
 #[derive(Clone, Debug, PartialEq)]
 pub struct NewPayloadRequest<E: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
-    pub execution_payload: ExecutionPayloadMerge<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
-    pub execution_payload: ExecutionPayloadCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
-    pub execution_payload: ExecutionPayloadDeneb<E>,
+    #[superstruct(flatten)]
+    pub execution_payload: ExecutionPayload<E>,
     #[superstruct(only(Deneb))]
     pub versioned_hashes: Vec<VersionedHash>,
     #[superstruct(only(Deneb))]

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -288,12 +288,8 @@ impl<T: EthSpec> From<JsonExecutionPayload<T>> for ExecutionPayload<T> {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub struct JsonGetPayloadResponse<T: EthSpec> {
-    #[superstruct(only(V1), partial_getter(rename = "execution_payload_v1"))]
-    pub execution_payload: JsonExecutionPayloadV1<T>,
-    #[superstruct(only(V2), partial_getter(rename = "execution_payload_v2"))]
-    pub execution_payload: JsonExecutionPayloadV2<T>,
-    #[superstruct(only(V3), partial_getter(rename = "execution_payload_v3"))]
-    pub execution_payload: JsonExecutionPayloadV3<T>,
+    #[superstruct(flatten)]
+    pub execution_payload: JsonExecutionPayload<T>,
     #[serde(with = "serde_utils::u256_hex_be")]
     pub block_value: Uint256,
     #[superstruct(only(V3))]

--- a/consensus/types/src/beacon_block.rs
+++ b/consensus/types/src/beacon_block.rs
@@ -64,16 +64,8 @@ pub struct BeaconBlock<T: EthSpec, Payload: AbstractExecPayload<T> = FullPayload
     pub parent_root: Hash256,
     #[superstruct(getter(copy))]
     pub state_root: Hash256,
-    #[superstruct(only(Base), partial_getter(rename = "body_base"))]
-    pub body: BeaconBlockBodyBase<T, Payload>,
-    #[superstruct(only(Altair), partial_getter(rename = "body_altair"))]
-    pub body: BeaconBlockBodyAltair<T, Payload>,
-    #[superstruct(only(Merge), partial_getter(rename = "body_merge"))]
-    pub body: BeaconBlockBodyMerge<T, Payload>,
-    #[superstruct(only(Capella), partial_getter(rename = "body_capella"))]
-    pub body: BeaconBlockBodyCapella<T, Payload>,
-    #[superstruct(only(Deneb), partial_getter(rename = "body_deneb"))]
-    pub body: BeaconBlockBodyDeneb<T, Payload>,
+    #[superstruct(flatten)]
+    pub body: BeaconBlockBody<T, Payload>,
 }
 
 pub type BlindedBeaconBlock<E> = BeaconBlock<E, BlindedPayload<E>>;

--- a/consensus/types/src/builder_bid.rs
+++ b/consensus/types/src/builder_bid.rs
@@ -23,12 +23,8 @@ use tree_hash_derive::TreeHash;
 #[serde(bound = "E: EthSpec", deny_unknown_fields, untagged)]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct BuilderBid<E: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "header_merge"))]
-    pub header: ExecutionPayloadHeaderMerge<E>,
-    #[superstruct(only(Capella), partial_getter(rename = "header_capella"))]
-    pub header: ExecutionPayloadHeaderCapella<E>,
-    #[superstruct(only(Deneb), partial_getter(rename = "header_deneb"))]
-    pub header: ExecutionPayloadHeaderDeneb<E>,
+    #[superstruct(flatten)]
+    pub header: ExecutionPayloadHeader<E>,
     #[superstruct(only(Deneb))]
     pub blob_kzg_commitments: KzgCommitments<E>,
     #[serde(with = "serde_utils::quoted_u256")]

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -140,12 +140,8 @@ pub trait AbstractExecPayload<T: EthSpec>:
 #[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct FullPayload<T: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
-    pub execution_payload: ExecutionPayloadMerge<T>,
-    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
-    pub execution_payload: ExecutionPayloadCapella<T>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
-    pub execution_payload: ExecutionPayloadDeneb<T>,
+    #[superstruct(flatten)]
+    pub execution_payload: ExecutionPayload<T>,
 }
 
 impl<T: EthSpec> From<FullPayload<T>> for ExecutionPayload<T> {
@@ -459,12 +455,8 @@ impl<T: EthSpec> TryFrom<ExecutionPayloadHeader<T>> for FullPayload<T> {
 #[arbitrary(bound = "T: EthSpec")]
 #[tree_hash(enum_behaviour = "transparent")]
 pub struct BlindedPayload<T: EthSpec> {
-    #[superstruct(only(Merge), partial_getter(rename = "execution_payload_merge"))]
-    pub execution_payload_header: ExecutionPayloadHeaderMerge<T>,
-    #[superstruct(only(Capella), partial_getter(rename = "execution_payload_capella"))]
-    pub execution_payload_header: ExecutionPayloadHeaderCapella<T>,
-    #[superstruct(only(Deneb), partial_getter(rename = "execution_payload_deneb"))]
-    pub execution_payload_header: ExecutionPayloadHeaderDeneb<T>,
+    #[superstruct(flatten)]
+    pub execution_payload_header: ExecutionPayloadHeader<T>,
 }
 
 impl<'a, T: EthSpec> From<BlindedPayloadRef<'a, T>> for BlindedPayload<T> {

--- a/consensus/types/src/signed_beacon_block.rs
+++ b/consensus/types/src/signed_beacon_block.rs
@@ -69,16 +69,8 @@ impl From<SignedBeaconBlockHash> for Hash256 {
 #[tree_hash(enum_behaviour = "transparent")]
 #[ssz(enum_behaviour = "transparent")]
 pub struct SignedBeaconBlock<E: EthSpec, Payload: AbstractExecPayload<E> = FullPayload<E>> {
-    #[superstruct(only(Base), partial_getter(rename = "message_base"))]
-    pub message: BeaconBlockBase<E, Payload>,
-    #[superstruct(only(Altair), partial_getter(rename = "message_altair"))]
-    pub message: BeaconBlockAltair<E, Payload>,
-    #[superstruct(only(Merge), partial_getter(rename = "message_merge"))]
-    pub message: BeaconBlockMerge<E, Payload>,
-    #[superstruct(only(Capella), partial_getter(rename = "message_capella"))]
-    pub message: BeaconBlockCapella<E, Payload>,
-    #[superstruct(only(Deneb), partial_getter(rename = "message_deneb"))]
-    pub message: BeaconBlockDeneb<E, Payload>,
+    #[superstruct(flatten)]
+    pub message: BeaconBlock<E, Payload>,
     pub signature: Signature,
 }
 


### PR DESCRIPTION
## Issue Addressed

Testing out `#[superstruct(flatten)]` on some lighthouse structs. Should probably wait till this is released in superstruct before merging.