### PR TITLE
Downgrade gossipsub duplicate logs

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -157,10 +157,6 @@ pub struct Config {
 
     /// Configuration for the inbound rate limiter (requests received by this node).
     pub inbound_rate_limiter_config: Option<InboundRateLimiterConfig>,
-
-    /// Whether to disable logging duplicate gossip messages as WARN. If set to true, duplicate
-    /// errors will be logged at DEBUG level.
-    pub disable_duplicate_warn_logs: bool,
 }
 
 impl Config {
@@ -378,7 +374,6 @@ impl Default for Config {
             outbound_rate_limiter_config: None,
             invalid_block_storage: None,
             inbound_rate_limiter_config: None,
-            disable_duplicate_warn_logs: false,
         }
     }
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1268,15 +1268,5 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("64")
                 .takes_value(true)
         )
-        .arg(
-            Arg::with_name("disable-duplicate-warn-logs")
-                .long("disable-duplicate-warn-logs")
-                .help("Disable warning logs for duplicate gossip messages. The WARN level log is \
-                    useful for detecting a duplicate validator key running elsewhere. However, this may \
-                    result in excessive warning logs if the validator is broadcasting messages to \
-                    multiple beacon nodes via the validator client --broadcast flag. In this case, \
-                    disabling these warn logs may be useful.")
-                .takes_value(false)
-        )
         .group(ArgGroup::with_name("enable_http").args(&["http", "gui", "staking"]).multiple(true))
 }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1268,5 +1268,11 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .default_value("64")
                 .takes_value(true)
         )
+        .arg(
+            Arg::with_name("disable-duplicate-warn-logs")
+                .long("disable-duplicate-warn-logs")
+                .help("This flag is deprecated and has no effect.")
+                .takes_value(false)
+        )
         .group(ArgGroup::with_name("enable_http").args(&["http", "gui", "staking"]).multiple(true))
 }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1425,9 +1425,6 @@ pub fn set_network_config(
             Some(config_str.parse()?)
         }
     };
-
-    config.disable_duplicate_warn_logs = cli_args.is_present("disable-duplicate-warn-logs");
-
     Ok(())
 }
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -32,6 +32,7 @@ FLAGS:
         --disable-deposit-contract-sync        Explicitly disables syncing of deposit logs from the execution node. This
                                                overrides any previous option that depends on it. Useful if you intend to
                                                run a non-validating beacon node.
+        --disable-duplicate-warn-logs          This flag is deprecated and has no effect.
     -x, --disable-enr-auto-update              Discovery automatically updates the nodes local ENR with an external IP
                                                address and port as seen by other peers on the network. This disables
                                                this feature, fixing the ENR's IP/PORT to those specified on boot.

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -32,11 +32,6 @@ FLAGS:
         --disable-deposit-contract-sync        Explicitly disables syncing of deposit logs from the execution node. This
                                                overrides any previous option that depends on it. Useful if you intend to
                                                run a non-validating beacon node.
-        --disable-duplicate-warn-logs          Disable warning logs for duplicate gossip messages. The WARN level log is
-                                               useful for detecting a duplicate validator key running elsewhere.
-                                               However, this may result in excessive warning logs if the validator is
-                                               broadcasting messages to multiple beacon nodes via the validator client
-                                               --broadcast flag. In this case, disabling these warn logs may be useful.
     -x, --disable-enr-auto-update              Discovery automatically updates the nodes local ENR with an external IP
                                                address and port as seen by other peers on the network. This disables
                                                this feature, fixing the ENR's IP/PORT to those specified on boot.

--- a/book/src/redundancy.md
+++ b/book/src/redundancy.md
@@ -101,10 +101,6 @@ from this list:
 - `none`: Disable all broadcasting. This option only has an effect when provided alone, otherwise
    it is ignored. Not recommended except for expert tweakers.
 
-Broadcasting attestation, blocks and sync committee messages may result in excessive warning logs in the beacon node 
-due to duplicate gossip messages. In this case, it may be desirable to disable warning logs for duplicates using the 
-beacon node `--disable-duplicate-warn-logs` flag.
-
 The default is `--broadcast subscriptions`. To also broadcast blocks for example, use
 `--broadcast subscriptions,blocks`.
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2584,3 +2584,22 @@ fn genesis_state_url_value() {
             assert_eq!(config.genesis_state_url_timeout, Duration::from_secs(42));
         });
 }
+
+#[test]
+fn disable_duplicate_warn_logs_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.network.disable_duplicate_warn_logs, false);
+        });
+}
+
+#[test]
+fn disable_duplicate_warn_logs() {
+    CommandLineTest::new()
+        .flag("disable-duplicate-warn-logs", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.network.disable_duplicate_warn_logs, true);
+        });
+}

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2584,22 +2584,3 @@ fn genesis_state_url_value() {
             assert_eq!(config.genesis_state_url_timeout, Duration::from_secs(42));
         });
 }
-
-#[test]
-fn disable_duplicate_warn_logs_default() {
-    CommandLineTest::new()
-        .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(config.network.disable_duplicate_warn_logs, false);
-        });
-}
-
-#[test]
-fn disable_duplicate_warn_logs() {
-    CommandLineTest::new()
-        .flag("disable-duplicate-warn-logs", None)
-        .run_with_zero_port()
-        .with_config(|config| {
-            assert_eq!(config.network.disable_duplicate_warn_logs, true);
-        });
-}


### PR DESCRIPTION
This undoes parts of #5009 

We are getting a few more reports of seeing these warnings. Mostly because of people using fallback BNs. 

I think the CLI flag approach is probably not necessary. I think most users know if they see these warnings are not going to expect that they are running multiple VC's in a slashable way, rather that they have fallback bns and probably won't react to the warning anyway. 

I am proposing to downgrade these logs by default and simply remove the cli flag.

Wondering what @jimmygchen and @michaelsproul  think about this.