### PR TITLE
Improve network parameters

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -354,7 +354,7 @@ impl Default for Config {
             enr_udp6_port: None,
             enr_quic6_port: None,
             enr_tcp6_port: None,
-            target_peers: 50,
+            target_peers: 100,
             gs_config,
             discv5_config,
             boot_nodes_enr: vec![],

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -59,7 +59,7 @@ const MAX_DISCOVERY_RETRY: usize = 3;
 /// Note: we always allow a single FindPeers query, so we would be
 /// running a maximum of `MAX_CONCURRENT_SUBNET_QUERIES + 1`
 /// discovery queries at a time.
-const MAX_CONCURRENT_SUBNET_QUERIES: usize = 2;
+const MAX_CONCURRENT_SUBNET_QUERIES: usize = 4;
 /// The max number of subnets to search for in a single subnet discovery query.
 const MAX_SUBNETS_IN_QUERY: usize = 3;
 /// The number of closest peers to search for when doing a regular peer search.

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -51,7 +51,7 @@ mod gossip_cache;
 pub mod gossipsub_scoring_parameters;
 pub mod utils;
 /// The number of peers we target per subnet for discovery queries.
-pub const TARGET_SUBNET_PEERS: usize = 6;
+pub const TARGET_SUBNET_PEERS: usize = 3;
 
 const MAX_IDENTIFY_ADDRESSES: usize = 10;
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1122,8 +1122,6 @@ pub fn set_network_config(
         config.target_peers = target_peers_str
             .parse::<usize>()
             .map_err(|_| format!("Invalid number of target peers: {}", target_peers_str))?;
-    } else {
-        config.target_peers = 80; // default value
     }
 
     if let Some(value) = cli_args.value_of("network-load") {


### PR DESCRIPTION
The current state of mainnet is changing due to how clients are subscribing to long lived subnets. The modification has lead to more scarcity in the subnets as we expected. 

We are now seeing issues where clients are unable to find and maintain useful peers to span all subnets, leading to missed attestations and the warning log, failed to publish message with the error `InsufficientPeers`. It is not enough for individual nodes to simply increase their peer counts, because it is often the case that other nodes on the network have already reached their peer limits and non-lighthouse clients often simply reject the connection. The best solution currently (and has been planned for a while) is to increase lighthouse's default `target-peer` count to ~120. However, we want to do this gradually. This PR takes an intermediate approach and sets the default value to 100. 

We have been testing a default value of 100 peers for a while now and load seems acceptable for small home users. See attached:
![peer-counts](https://github.com/sigp/lighthouse/assets/7454587/930cdd39-6ee7-4300-b654-0ab7d044dfa5)

There is a secondary issue where Lighthouse attempts to maintain 6 peers for every required subnet. For nodes with lots of validators this becomes an impossible task with an 80 peer target and results in continuous discovery queries. 

![higher-peer-counts](https://github.com/sigp/lighthouse/assets/7454587/71c25084-8635-49e6-b8f6-a983f8f7b0f6)

With a target peer count of 100, and each peers subscribing to two subnets, a healthy target peer count per subnet is 3. This should result in little to no discovery queries once the right set of peers are found. Having all nodes on the network update to this logic, should allow for more connections between all peers and more stability on the subnets. 