### PR TITLE
Update external LLVM version in preparation for Rust 1.76.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
             - uses: KyleMayes/install-llvm-action@v1
               if: env.SELF_HOSTED_RUNNERS == 'false' && startsWith(matrix.arch, 'x86_64-windows')
               with:
-                version: "15.0"
+                version: "16.0"
                 directory: ${{ runner.temp }}/llvm
             - name: Set LIBCLANG_PATH
               if: startsWith(matrix.arch, 'x86_64-windows')

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -86,7 +86,7 @@ jobs:
 #    - uses: KyleMayes/install-llvm-action@v1
 #         if: env.SELF_HOSTED_RUNNERS == 'false'
 #      with:
-#        version: "15.0"
+#        version: "16.0"
 #        directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV


### PR DESCRIPTION
## Issue Addressed

From [Rust 1.76](https://github.com/rust-lang/rust/blob/master/RELEASES.md) (release in 3 days), minimum external LLVM version will be bumped to v16.

Creating this PR in advance so we don't forget, as we use this in the windows release build. 

**EDIT:** this isn't actually being used for sigp releases as we're running on self hosted runners, but good to keep the CI updated anyway.