### PR TITLE
Fix Rust beta compiler errors (1.77)

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -967,7 +967,7 @@ mod test {
             let spec = &E::default_spec();
             let state: BeaconState<E> = BeaconState::new(0, get_eth1_data(0), spec);
 
-            let blocks = vec![];
+            let blocks = [];
 
             assert_eq!(
                 get_votes_to_consider(

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -51,6 +51,8 @@ const MAX_BLOCK_PRODUCTION_CACHE_DISTANCE: u64 = 4;
 #[derive(Debug)]
 enum Error {
     BeaconChain(BeaconChainError),
+    // We don't use the inner value directly, but it's used in the Debug impl.
+    #[allow(dead_code)]
     HeadMissingFromSnapshotCache(Hash256),
     MaxDistanceExceeded {
         current_slot: Slot,

--- a/beacon_node/beacon_chain/src/state_advance_timer.rs
+++ b/beacon_node/beacon_chain/src/state_advance_timer.rs
@@ -52,8 +52,7 @@ const MAX_BLOCK_PRODUCTION_CACHE_DISTANCE: u64 = 4;
 enum Error {
     BeaconChain(BeaconChainError),
     // We don't use the inner value directly, but it's used in the Debug impl.
-    #[allow(dead_code)]
-    HeadMissingFromSnapshotCache(Hash256),
+    HeadMissingFromSnapshotCache(#[allow(dead_code)] Hash256),
     MaxDistanceExceeded {
         current_slot: Slot,
         head_slot: Slot,

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -54,6 +54,8 @@ impl Operation {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
+// We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
 struct Custom(String);
 
 impl warp::reject::Reject for Custom {}

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -54,9 +54,8 @@ impl Operation {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 // We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
-struct Custom(String);
+struct Custom(#[allow(dead_code)] String);
 
 impl warp::reject::Reject for Custom {}
 

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -487,7 +487,6 @@ pub struct StaticNewPayloadResponse {
     should_import: bool,
 }
 #[derive(Debug)]
-// We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
 struct AuthError(String);
 
 impl warp::reject::Reject for AuthError {}

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -487,6 +487,8 @@ pub struct StaticNewPayloadResponse {
     should_import: bool,
 }
 #[derive(Debug)]
+#[allow(dead_code)]
+// We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
 struct AuthError(String);
 
 impl warp::reject::Reject for AuthError {}
@@ -600,7 +602,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl warp::Reply, Infallible
     let message;
 
     if let Some(e) = err.find::<AuthError>() {
-        message = format!("Authorization error: {:?}", e);
+        message = format!("Authorization error: {}", e.0);
         code = StatusCode::UNAUTHORIZED;
     } else {
         message = "BAD_REQUEST".to_string();

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -487,7 +487,6 @@ pub struct StaticNewPayloadResponse {
     should_import: bool,
 }
 #[derive(Debug)]
-#[allow(dead_code)]
 // We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
 struct AuthError(String);
 

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -601,7 +601,6 @@ async fn handle_rejection(err: Rejection) -> Result<impl warp::Reply, Infallible
 
     if let Some(AuthError(e)) = err.find::<AuthError>() {
         message = format!("Authorization error: {}", e);
-        message = format!("Authorization error: {}", e.0);
         code = StatusCode::UNAUTHORIZED;
     } else {
         message = "BAD_REQUEST".to_string();

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -599,7 +599,8 @@ async fn handle_rejection(err: Rejection) -> Result<impl warp::Reply, Infallible
     let code;
     let message;
 
-    if let Some(e) = err.find::<AuthError>() {
+    if let Some(AuthError(e)) = err.find::<AuthError>() {
+        message = format!("Authorization error: {}", e);
         message = format!("Authorization error: {}", e.0);
         code = StatusCode::UNAUTHORIZED;
     } else {

--- a/beacon_node/http_api/src/attestation_performance.rs
+++ b/beacon_node/http_api/src/attestation_performance.rs
@@ -14,6 +14,8 @@ const MAX_REQUEST_RANGE_EPOCHS: usize = 100;
 const BLOCK_ROOT_CHUNK_SIZE: usize = 100;
 
 #[derive(Debug)]
+// We don't use the inner values directly, but they're used in the Debug impl.
+#[allow(dead_code)]
 enum AttestationPerformanceError {
     BlockReplay(BlockReplayError),
     BeaconState(BeaconStateError),

--- a/beacon_node/http_api/src/attestation_performance.rs
+++ b/beacon_node/http_api/src/attestation_performance.rs
@@ -15,12 +15,11 @@ const BLOCK_ROOT_CHUNK_SIZE: usize = 100;
 
 #[derive(Debug)]
 // We don't use the inner values directly, but they're used in the Debug impl.
-#[allow(dead_code)]
 enum AttestationPerformanceError {
-    BlockReplay(BlockReplayError),
-    BeaconState(BeaconStateError),
-    ParticipationCache(ParticipationCacheError),
-    UnableToFindValidator(usize),
+    BlockReplay(#[allow(dead_code)] BlockReplayError),
+    BeaconState(#[allow(dead_code)] BeaconStateError),
+    ParticipationCache(#[allow(dead_code)] ParticipationCacheError),
+    UnableToFindValidator(#[allow(dead_code)] usize),
 }
 
 impl From<BlockReplayError> for AttestationPerformanceError {

--- a/beacon_node/http_api/src/block_packing_efficiency.rs
+++ b/beacon_node/http_api/src/block_packing_efficiency.rs
@@ -20,11 +20,10 @@ const BLOCK_ROOT_CHUNK_SIZE: usize = 100;
 
 #[derive(Debug)]
 // We don't use the inner values directly, but they're used in the Debug impl.
-#[allow(dead_code)]
 enum PackingEfficiencyError {
-    BlockReplay(BlockReplayError),
-    BeaconState(BeaconStateError),
-    CommitteeStoreError(Slot),
+    BlockReplay(#[allow(dead_code)] BlockReplayError),
+    BeaconState(#[allow(dead_code)] BeaconStateError),
+    CommitteeStoreError(#[allow(dead_code)] Slot),
     InvalidAttestationError,
 }
 

--- a/beacon_node/http_api/src/block_packing_efficiency.rs
+++ b/beacon_node/http_api/src/block_packing_efficiency.rs
@@ -19,6 +19,8 @@ use warp_utils::reject::{beacon_chain_error, custom_bad_request, custom_server_e
 const BLOCK_ROOT_CHUNK_SIZE: usize = 100;
 
 #[derive(Debug)]
+// We don't use the inner values directly, but they're used in the Debug impl.
+#[allow(dead_code)]
 enum PackingEfficiencyError {
     BlockReplay(BlockReplayError),
     BeaconState(BeaconStateError),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1018,7 +1018,8 @@ pub fn serve<T: BeaconChainTypes>(
                                 let epoch = query.epoch.unwrap_or(current_epoch);
                                 Ok((
                                     state
-                                        .get_built_sync_committee(epoch, &chain.spec).cloned()
+                                        .get_built_sync_committee(epoch, &chain.spec)
+                                        .cloned()
                                         .map_err(|e| match e {
                                             BeaconStateError::SyncCommitteeNotKnown { .. } => {
                                                 warp_utils::reject::custom_bad_request(format!(
@@ -2856,7 +2857,8 @@ pub fn serve<T: BeaconChainTypes>(
                                 "0x{}",
                                 hex::encode(
                                     meta_data
-                                        .syncnets().cloned()
+                                        .syncnets()
+                                        .cloned()
                                         .unwrap_or_default()
                                         .into_bytes()
                                 )

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1018,8 +1018,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 let epoch = query.epoch.unwrap_or(current_epoch);
                                 Ok((
                                     state
-                                        .get_built_sync_committee(epoch, &chain.spec)
-                                        .map(|committee| committee.clone())
+                                        .get_built_sync_committee(epoch, &chain.spec).cloned()
                                         .map_err(|e| match e {
                                             BeaconStateError::SyncCommitteeNotKnown { .. } => {
                                                 warp_utils::reject::custom_bad_request(format!(
@@ -2857,8 +2856,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 "0x{}",
                                 hex::encode(
                                     meta_data
-                                        .syncnets()
-                                        .map(|x| x.clone())
+                                        .syncnets().cloned()
                                         .unwrap_or_default()
                                         .into_bytes()
                                 )

--- a/beacon_node/lighthouse_network/src/gossipsub/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/src/gossipsub/behaviour/tests.rs
@@ -174,7 +174,7 @@ fn inject_nodes1() -> InjectNodes<IdentityTransform, AllowAllSubscriptionFilter>
 
 fn add_peer<D, F>(
     gs: &mut Behaviour<D, F>,
-    topic_hashes: &Vec<TopicHash>,
+    topic_hashes: &[TopicHash],
     outbound: bool,
     explicit: bool,
 ) -> (PeerId, RpcReceiver)
@@ -187,7 +187,7 @@ where
 
 fn add_peer_with_addr<D, F>(
     gs: &mut Behaviour<D, F>,
-    topic_hashes: &Vec<TopicHash>,
+    topic_hashes: &[TopicHash],
     outbound: bool,
     explicit: bool,
     address: Multiaddr,
@@ -208,7 +208,7 @@ where
 
 fn add_peer_with_addr_and_kind<D, F>(
     gs: &mut Behaviour<D, F>,
-    topic_hashes: &Vec<TopicHash>,
+    topic_hashes: &[TopicHash],
     outbound: bool,
     explicit: bool,
     address: Multiaddr,
@@ -3218,7 +3218,7 @@ fn test_scoring_p1() {
     );
 }
 
-fn random_message(seq: &mut u64, topics: &Vec<TopicHash>) -> RawMessage {
+fn random_message(seq: &mut u64, topics: &[TopicHash]) -> RawMessage {
     let mut rng = rand::thread_rng();
     *seq += 1;
     RawMessage {
@@ -4080,20 +4080,20 @@ fn test_scoring_p6() {
     //create 5 peers with the same ip
     let addr = Multiaddr::from(Ipv4Addr::new(10, 1, 2, 3));
     let peers = vec![
-        add_peer_with_addr(&mut gs, &vec![], false, false, addr.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], false, false, addr.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], true, false, addr.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], true, false, addr.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], true, true, addr.clone()).0,
+        add_peer_with_addr(&mut gs, &[], false, false, addr.clone()).0,
+        add_peer_with_addr(&mut gs, &[], false, false, addr.clone()).0,
+        add_peer_with_addr(&mut gs, &[], true, false, addr.clone()).0,
+        add_peer_with_addr(&mut gs, &[], true, false, addr.clone()).0,
+        add_peer_with_addr(&mut gs, &[], true, true, addr.clone()).0,
     ];
 
     //create 4 other peers with other ip
     let addr2 = Multiaddr::from(Ipv4Addr::new(10, 1, 2, 4));
     let others = vec![
-        add_peer_with_addr(&mut gs, &vec![], false, false, addr2.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], false, false, addr2.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], true, false, addr2.clone()).0,
-        add_peer_with_addr(&mut gs, &vec![], true, false, addr2.clone()).0,
+        add_peer_with_addr(&mut gs, &[], false, false, addr2.clone()).0,
+        add_peer_with_addr(&mut gs, &[], false, false, addr2.clone()).0,
+        add_peer_with_addr(&mut gs, &[], true, false, addr2.clone()).0,
+        add_peer_with_addr(&mut gs, &[], true, false, addr2.clone()).0,
     ];
 
     //no penalties yet

--- a/beacon_node/lighthouse_network/tests/common.rs
+++ b/beacon_node/lighthouse_network/tests/common.rs
@@ -42,23 +42,23 @@ pub fn fork_context(fork_name: ForkName) -> ForkContext {
     ForkContext::new::<E>(current_slot, Hash256::zero(), &chain_spec)
 }
 
-pub struct Libp2pInstance {
-    service: LibP2PService<ReqId, E>,
+pub struct Libp2pInstance(
+    LibP2PService<ReqId, E>,
     #[allow(dead_code)]
-    /// This field is managed for lifetime purposes may not be used directly, hence the `#[allow(dead_code)]` attribute.
-    exit_signal: exit_future::Signal,
-}
+    // This field is managed for lifetime purposes may not be used directly, hence the `#[allow(dead_code)]` attribute.
+    exit_future::Signal,
+);
 
 impl std::ops::Deref for Libp2pInstance {
     type Target = LibP2PService<ReqId, E>;
     fn deref(&self) -> &Self::Target {
-        &self.service
+        &self.0
     }
 }
 
 impl std::ops::DerefMut for Libp2pInstance {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.service
+        &mut self.0
     }
 }
 
@@ -120,13 +120,13 @@ pub async fn build_libp2p_instance(
         chain_spec: spec,
         libp2p_registry: None,
     };
-    Libp2pInstance {
-        service: LibP2PService::new(executor, libp2p_context, &log)
+    Libp2pInstance(
+        LibP2PService::new(executor, libp2p_context, &log)
             .await
             .expect("should build libp2p instance")
             .0,
-        exit_signal: signal,
-    }
+        signal,
+    )
 }
 
 #[allow(dead_code)]

--- a/beacon_node/lighthouse_network/tests/common.rs
+++ b/beacon_node/lighthouse_network/tests/common.rs
@@ -42,18 +42,23 @@ pub fn fork_context(fork_name: ForkName) -> ForkContext {
     ForkContext::new::<E>(current_slot, Hash256::zero(), &chain_spec)
 }
 
-pub struct Libp2pInstance(LibP2PService<ReqId, E>, exit_future::Signal);
+pub struct Libp2pInstance {
+    service: LibP2PService<ReqId, E>,
+    #[allow(dead_code)]
+    /// This field is managed for lifetime purposes may not be used directly, hence the `#[allow(dead_code)]` attribute.
+    exit_signal: exit_future::Signal,
+}
 
 impl std::ops::Deref for Libp2pInstance {
     type Target = LibP2PService<ReqId, E>;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.service
     }
 }
 
 impl std::ops::DerefMut for Libp2pInstance {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.service
     }
 }
 
@@ -115,13 +120,13 @@ pub async fn build_libp2p_instance(
         chain_spec: spec,
         libp2p_registry: None,
     };
-    Libp2pInstance(
-        LibP2PService::new(executor, libp2p_context, &log)
+    Libp2pInstance {
+        service: LibP2PService::new(executor, libp2p_context, &log)
             .await
             .expect("should build libp2p instance")
             .0,
-        signal,
-    )
+        exit_signal: signal,
+    }
 }
 
 #[allow(dead_code)]

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -253,10 +253,8 @@ mod attestation_service {
             &attestation_service.beacon_chain.spec,
         )
         .unwrap();
-        let expected = vec![
-            SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id)),
-            SubnetServiceMessage::Unsubscribe(Subnet::Attestation(subnet_id)),
-        ];
+        let expected = [SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id)),
+            SubnetServiceMessage::Unsubscribe(Subnet::Attestation(subnet_id))];
 
         // Wait for 1 slot duration to get the unsubscription event
         let events = get_events(

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -253,8 +253,10 @@ mod attestation_service {
             &attestation_service.beacon_chain.spec,
         )
         .unwrap();
-        let expected = [SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id)),
-            SubnetServiceMessage::Unsubscribe(Subnet::Attestation(subnet_id))];
+        let expected = [
+            SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id)),
+            SubnetServiceMessage::Unsubscribe(Subnet::Attestation(subnet_id)),
+        ];
 
         // Wait for 1 slot duration to get the unsubscription event
         let events = get_events(

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1343,7 +1343,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<Hash256, HotColdDBError> {
         high_restore_point
             .get_block_root(slot)
-            .or_else(|_| high_restore_point.get_oldest_block_root()).copied()
+            .or_else(|_| high_restore_point.get_oldest_block_root())
+            .copied()
             .map_err(HotColdDBError::RestorePointBlockHashError)
     }
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1343,8 +1343,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<Hash256, HotColdDBError> {
         high_restore_point
             .get_block_root(slot)
-            .or_else(|_| high_restore_point.get_oldest_block_root())
-            .map(|x| *x)
+            .or_else(|_| high_restore_point.get_oldest_block_root()).copied()
             .map_err(HotColdDBError::RestorePointBlockHashError)
     }
 

--- a/common/validator_dir/src/builder.rs
+++ b/common/validator_dir/src/builder.rs
@@ -214,6 +214,7 @@ impl<'a> Builder<'a> {
                         .write(true)
                         .read(true)
                         .create(true)
+                        .truncate(true)
                         .open(path)
                         .map_err(Error::UnableToSaveDepositData)?
                         .write_all(hex.as_bytes())
@@ -231,6 +232,7 @@ impl<'a> Builder<'a> {
                         .write(true)
                         .read(true)
                         .create(true)
+                        .truncate(true)
                         .open(path)
                         .map_err(Error::UnableToSaveDepositAmount)?
                         .write_all(format!("{}", amount).as_bytes())

--- a/consensus/cached_tree_hash/src/impls.rs
+++ b/consensus/cached_tree_hash/src/impls.rs
@@ -30,9 +30,7 @@ pub fn hash256_iter(
     values.iter().copied().map(Hash256::to_fixed_bytes)
 }
 
-pub fn u64_iter(
-    values: &[u64],
-) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
+pub fn u64_iter(values: &[u64]) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
     let type_size = size_of::<u64>();
     let vals_per_chunk = BYTES_PER_CHUNK / type_size;
     values.chunks(vals_per_chunk).map(move |xs| {

--- a/consensus/cached_tree_hash/src/impls.rs
+++ b/consensus/cached_tree_hash/src/impls.rs
@@ -26,13 +26,13 @@ pub fn u64_leaf_count(len: usize) -> usize {
 
 pub fn hash256_iter(
     values: &[Hash256],
-) -> impl Iterator<Item = [u8; BYTES_PER_CHUNK]> + ExactSizeIterator + '_ {
+) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
     values.iter().copied().map(Hash256::to_fixed_bytes)
 }
 
 pub fn u64_iter(
     values: &[u64],
-) -> impl Iterator<Item = [u8; BYTES_PER_CHUNK]> + ExactSizeIterator + '_ {
+) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
     let type_size = size_of::<u64>();
     let vals_per_chunk = BYTES_PER_CHUNK / type_size;
     values.chunks(vals_per_chunk).map(move |xs| {

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -641,7 +641,7 @@ impl<T: EthSpec> BeaconState<T> {
         if self.slot() <= decision_slot {
             Ok(block_root)
         } else {
-            self.get_block_root(decision_slot).map(|root| *root)
+            self.get_block_root(decision_slot).copied()
         }
     }
 
@@ -657,7 +657,7 @@ impl<T: EthSpec> BeaconState<T> {
         if self.slot() == decision_slot {
             Ok(block_root)
         } else {
-            self.get_block_root(decision_slot).map(|root| *root)
+            self.get_block_root(decision_slot).copied()
         }
     }
 
@@ -683,7 +683,7 @@ impl<T: EthSpec> BeaconState<T> {
         if self.slot() == decision_slot {
             Ok(block_root)
         } else {
-            self.get_block_root(decision_slot).map(|root| *root)
+            self.get_block_root(decision_slot).copied()
         }
     }
 

--- a/consensus/types/src/historical_summary.rs
+++ b/consensus/types/src/historical_summary.rs
@@ -81,7 +81,7 @@ impl<'a, N: Unsigned> CachedTreeHash<TreeHashCache> for HistoricalSummaryCache<'
 
 pub fn leaf_iter(
     values: &[HistoricalSummary],
-) -> impl Iterator<Item = [u8; BYTES_PER_CHUNK]> + ExactSizeIterator + '_ {
+) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
     values
         .iter()
         .map(|value| value.tree_hash_root())

--- a/consensus/types/src/participation_list.rs
+++ b/consensus/types/src/participation_list.rs
@@ -43,7 +43,7 @@ pub fn leaf_count(len: usize) -> usize {
 
 pub fn leaf_iter(
     values: &[ParticipationFlags],
-) -> impl Iterator<Item = [u8; BYTES_PER_CHUNK]> + ExactSizeIterator + '_ {
+) -> impl ExactSizeIterator<Item = [u8; BYTES_PER_CHUNK]> + '_ {
     values.chunks(BYTES_PER_CHUNK).map(|xs| {
         // Zero-pad chunks on the right.
         let mut chunk = [0u8; BYTES_PER_CHUNK];

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -356,6 +356,7 @@ pub fn inspect_db<E: EthSpec>(
 
                 let write_result = fs::OpenOptions::new()
                     .create(true)
+                    .truncate(true)
                     .write(true)
                     .open(&file_path)
                     .map_err(|e| format!("Failed to open file: {:?}", e))

--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -434,7 +434,7 @@ impl<E: EthSpec> Environment<E> {
             async move { rx.next().await.ok_or("Internal shutdown channel exhausted") };
         futures::pin_mut!(inner_shutdown);
 
-        match self.runtime().block_on(async {
+        let register_handlers = async {
             let mut handles = vec![];
 
             // setup for handling SIGTERM
@@ -465,7 +465,9 @@ impl<E: EthSpec> Environment<E> {
             }
 
             future::select(inner_shutdown, future::select_all(handles.into_iter())).await
-        }) {
+        };
+
+        match self.runtime().block_on(register_handlers) {
             future::Either::Left((Ok(reason), _)) => {
                 info!(self.log, "Internal shutdown received"; "reason" => reason.message());
                 Ok(reason)


### PR DESCRIPTION
## Issue Addressed

Fix compilation/lint errors when compiling lighthouse using 1.77 beta compiler.

The fixes for `unused code` aren't ideal, but I can't think of a better way rn (related issue [here](https://github.com/rust-lang/rust/issues/119645)):

```rust
#[derive(Debug)]
// We don't use the inner values directly, but they're used in the Debug impl.
#[allow(dead_code)]
enum AttestationPerformanceError {
    BlockReplay(BlockReplayError),
    BeaconState(BeaconStateError),
    ParticipationCache(ParticipationCacheError),
    UnableToFindValidator(usize),
}
```
