### PR TITLE
Fix backfill stalling

### DIFF
--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -334,7 +334,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     // transitions to a paused state.
                     // We still need to reset the state for all the affected batches, so we should not
                     // short circuit early
-                    if let Err(_) = self.retry_batch_download(network, id) {
+                    if self.retry_batch_download(network, id).is_err() {
                         debug!(
                             self.log,
                             "Batch could not be retried";

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -332,7 +332,16 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     }
                     // If we have run out of peers in which to retry this batch, the backfill state
                     // transitions to a paused state.
-                    self.retry_batch_download(network, id)?;
+                    // We still need to reset the state for all the affected batches, so we should not
+                    // short circuit early
+                    if let Err(_) = self.retry_batch_download(network, id) {
+                        debug!(
+                            self.log,
+                            "Batch could not be retried";
+                            "batch_id" => id,
+                            "error" => "no synced peers"
+                        );
+                    }
                 } else {
                     debug!(self.log, "Batch not found while removing peer";
                         "peer" => %peer_id, "batch" => id)


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Hopefully fixes all backfill stalled issues we have been seeing.

The root cause of the issue is that the `peer_disconnect` function returns early if the call to `retry_batch_download` within it returns an error. This can happen when we have no synced peers to retry from. 
This early return fails to set the `BatchState` for multiple batches from `BatchState::Downloading` to `BatchState::AwaitingDownload` 
If the `processing_target` batch was also one of the batches that failed to change states, then backfill effectively stalls.
When we resume backfill after getting new peers, we do the following which could potentially re-request the target:
1. Call to `resume_batches`
https://github.com/sigp/lighthouse/blob/c7e5dd1098a145c0d2174dc65bd23faeb5074249/beacon_node/network/src/sync/backfill_sync/mod.rs#L1002-L1016
Since the `processing_target` is stuck in `BatchState::Downloading`, it is not requested in this call
2. Call to `request_batches` which does nothing because of this condition:
https://github.com/sigp/lighthouse/blob/c7e5dd1098a145c0d2174dc65bd23faeb5074249/beacon_node/network/src/sync/backfill_sync/mod.rs#L1083-L1091
In most of the logs that I have seen of this issue, `batches.len()` is usually > `BACKFILL_BATCH_BUFFER_SIZE`

Hence, the target can never be requested again and the target state can never change until a restart.
This PR basically handles the error in `peer_disconnect` instead of short circuiting. 
