### PR TITLE
Fix failing cargo-udeps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,8 +1584,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
+source = "git+https://github.com/jimmygchen/curve25519-dalek.git#24019783e9bb9dc1464e7e503732f273a69969c6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1601,8 +1600,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+source = "git+https://github.com/jimmygchen/curve25519-dalek.git#24019783e9bb9dc1464e7e503732f273a69969c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek"
 version = "4.1.1"
-source = "git+https://github.com/jimmygchen/curve25519-dalek.git#24019783e9bb9dc1464e7e503732f273a69969c6"
+source = "git+https://github.com/jimmygchen/curve25519-dalek.git?rev=24019783e9bb9dc1464e7e503732f273a69969c6#24019783e9bb9dc1464e7e503732f273a69969c6"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1600,7 +1600,7 @@ dependencies = [
 [[package]]
 name = "curve25519-dalek-derive"
 version = "0.1.1"
-source = "git+https://github.com/jimmygchen/curve25519-dalek.git#24019783e9bb9dc1464e7e503732f273a69969c6"
+source = "git+https://github.com/jimmygchen/curve25519-dalek.git?rev=24019783e9bb9dc1464e7e503732f273a69969c6#24019783e9bb9dc1464e7e503732f273a69969c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,4 +237,4 @@ codegen-units = 1
 incremental = false
 
 [patch.crates-io]
-curve25519-dalek = { git = "https://github.com/jimmygchen/curve25519-dalek.git" }
+curve25519-dalek = { git = "https://github.com/jimmygchen/curve25519-dalek.git", rev = "24019783e9bb9dc1464e7e503732f273a69969c6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,3 +235,6 @@ inherits = "release"
 lto = "fat"
 codegen-units = 1
 incremental = false
+
+[patch.crates-io]
+curve25519-dalek = { git = "https://github.com/jimmygchen/curve25519-dalek.git" }


### PR DESCRIPTION
## Issue Addressed

CI is currently blocked as the `curve25519-dalek` nightly build has started failing since `rustc 1.78.0-nightly (f067fd608 2024-02-05) `:

https://github.com/sigp/lighthouse/actions/runs/7793900607/job/21254345866

I've submitted a PR to fix this: https://github.com/dalek-cryptography/curve25519-dalek/pull/619

This PR patches the `curve25519-dalek` and should be reverted once they release a fix for this.