### PR TITLE
increment peer per topic count on graft messages

### DIFF
--- a/beacon_node/lighthouse_network/src/gossipsub/behaviour.rs
+++ b/beacon_node/lighthouse_network/src/gossipsub/behaviour.rs
@@ -1380,7 +1380,11 @@ where
                 tracing::error!(peer_id = %peer_id, "Peer non-existent when handling graft");
                 return;
             };
-            connected_peer.topics.insert(topic.clone());
+            if connected_peer.topics.insert(topic.clone()) {
+                if let Some(m) = self.metrics.as_mut() {
+                    m.inc_topic_peers(topic);
+                }
+            }
         }
 
         // we don't GRAFT to/from explicit peers; complain loudly if this happens


### PR DESCRIPTION
## Issue Addressed

 The `topic_peers_counts` metric currently goes negative on some cases, which realistically is a bug, this patch hopefully addresses that by also incrementing the `topic_peer_counts` when a `GRAFT` message is received and the topic is added to `connected_peer` which sent it