### PR TITLE
Use epoch cache in block packing

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -94,6 +94,7 @@ use slot_clock::SlotClock;
 use ssz::Encode;
 use state_processing::{
     common::get_attesting_indices_from_state,
+    epoch_cache::initialize_epoch_cache,
     per_block_processing,
     per_block_processing::{
         errors::AttestationValidationError, get_expected_withdrawals,
@@ -4810,7 +4811,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let attestation_packing_timer =
             metrics::start_timer(&metrics::BLOCK_PRODUCTION_ATTESTATION_TIMES);
 
+        // Epoch cache and total balance cache are required for op pool packing.
         state.build_total_active_balance_cache_at(state.current_epoch(), &self.spec)?;
+        initialize_epoch_cache(&mut state, &self.spec)?;
+
         let mut prev_filter_cache = HashMap::new();
         let prev_attestation_filter = |att: &AttestationRef<T::EthSpec>| {
             self.filter_op_pool_attestation(&mut prev_filter_cache, att, &state)

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -256,6 +256,7 @@ pub enum BlockProductionError {
     UnableToProduceAtSlot(Slot),
     SlotProcessingError(SlotProcessingError),
     BlockProcessingError(BlockProcessingError),
+    EpochCacheError(EpochCacheError),
     ForkChoiceError(ForkChoiceError),
     Eth1ChainError(Eth1ChainError),
     BeaconStateError(BeaconStateError),
@@ -296,3 +297,4 @@ easy_from_to!(SlotProcessingError, BlockProductionError);
 easy_from_to!(Eth1ChainError, BlockProductionError);
 easy_from_to!(StateAdvanceError, BlockProductionError);
 easy_from_to!(ForkChoiceError, BlockProductionError);
+easy_from_to!(EpochCacheError, BlockProductionError);


### PR DESCRIPTION
## Issue Addressed

Resolve a `FIXME` about base reward calculation in the op pool.

## Proposed Changes

- Use the epoch cache to get the cached base reward :tada:
- Ensure the epoch cache is built before calling `get_attestations` from `beacon_chain::BeaconChain`.

## Additional Info

Designed to backport to @dapplion's epoch-processing branch, which we can merge to unstable ahead of the full tree-states changes: https://github.com/dapplion/lighthouse/pull/13
