### PR TITLE
Add build instructions for Fedora/RHEL/CentOS

### DIFF
--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -42,6 +42,16 @@ sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clan
 
 After this, you are ready to [build Lighthouse](#build-lighthouse).
 
+#### Fedora/RHEL/CentOS
+
+Install the following packages:
+
+```bash
+yum -y install git make perl clang cmake
+```
+
+After this, you are ready to [build Lighthouse](#build-lighthouse).
+
 #### macOS
 
 1. Install the [Homebrew][] package manager.


### PR DESCRIPTION
## Issue Addressed

#5124 

## Proposed Changes

Add the dependencies for Fedora/RHEL/CentOS. 

## Additional Info

Tested with docker images downloaded from:

Fedora - https://hub.docker.com/_/fedora
CentOS - https://hub.docker.com/_/centos/
RHEL - https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e?architecture=amd64&image=65bb9881ea06b2e7fb5909f5&container-tabs=gti