### PR TITLE
Deprecate env_log flag in tracing layer

### DIFF
--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -223,7 +223,7 @@ impl TimeLatch {
     }
 }
 
-pub fn create_tracing_layer(base_tracing_log_path: PathBuf, turn_on_terminal_logs: bool) {
+pub fn create_tracing_layer(base_tracing_log_path: PathBuf) {
     let filter_layer = match tracing_subscriber::EnvFilter::try_from_default_env()
         .or_else(|_| tracing_subscriber::EnvFilter::try_new("warn"))
     {
@@ -268,11 +268,6 @@ pub fn create_tracing_layer(base_tracing_log_path: PathBuf, turn_on_terminal_log
 
     if let Err(e) = tracing_subscriber::fmt()
         .with_env_filter(filter_layer)
-        .with_writer(move || {
-            tracing_subscriber::fmt::writer::OptionalWriter::<std::io::Stdout>::from(
-                turn_on_terminal_logs.then(std::io::stdout),
-            )
-        })
         .finish()
         .with(MetricsLayer)
         .with(custom_layer)

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -268,6 +268,7 @@ pub fn create_tracing_layer(base_tracing_log_path: PathBuf) {
 
     if let Err(e) = tracing_subscriber::fmt()
         .with_env_filter(filter_layer)
+        .with_writer(std::io::sink)
         .finish()
         .with(MetricsLayer)
         .with(custom_layer)

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -556,9 +556,7 @@ fn run<E: EthSpec>(
 
     let path = tracing_log_path.clone().unwrap();
 
-    let turn_on_terminal_logs = matches.is_present("env_log");
-
-    logging::create_tracing_layer(path, turn_on_terminal_logs);
+    logging::create_tracing_layer(path);
 
     // Allow Prometheus to export the time at which the process was started.
     metrics::expose_process_start_time(&log);


### PR DESCRIPTION
## Issue Addressed

#5226

## Proposed Changes

Deprecate `-l` flag functionality. Since we are now capturing these logs in separate files, there doesn't seem to be a reason to also have the option to log these to the terminal. Especially considering how noisy these logs can be.

## Additional Info

