### PR TITLE
Add a Prometheus metric hinting at system overload

### DIFF
--- a/beacon_node/beacon_processor/src/metrics.rs
+++ b/beacon_node/beacon_processor/src/metrics.rs
@@ -137,6 +137,10 @@ lazy_static::lazy_static! {
         "beacon_processor_reprocessing_queue_matched_attestations",
         "Number of queued attestations where as matching block has been imported."
     );
+    pub static ref BEACON_PROCESSOR_ATTESTATION_READY_QUEUE_PUT_ERRORS: Result<IntCounter> = try_create_int_counter(
+        "beacon_processor_reprocessing_ready_queue_put_errors",
+        "Number of failures to enqueue a block to be attested."
+    );
 
     /*
      * Light client update reprocessing queue metrics.

--- a/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
@@ -10,7 +10,7 @@
 //!
 //! Aggregated and unaggregated attestations that failed verification due to referencing an unknown
 //! block will be re-queued until their block is imported, or until they expire.
-use crate::metrics;
+use crate::metrics::{self, BEACON_PROCESSOR_ATTESTATION_READY_QUEUE_PUT_ERRORS};
 use crate::{AsyncFn, BlockingFn, Work, WorkEvent};
 use fnv::FnvHashMap;
 use futures::task::Poll;
@@ -680,6 +680,10 @@ impl<S: SlotClock> ReprocessQueue<S> {
                     }
 
                     if failed_to_send_count > 0 {
+                        metrics::inc_counter_by(
+                            &BEACON_PROCESSOR_ATTESTATION_READY_QUEUE_PUT_ERRORS,
+                            failed_to_send_count,
+                        );
                         error!(
                             log,
                             "Ignored scheduled attestation(s) for block";


### PR DESCRIPTION
I see about 30 a day of those (`Ignored scheduled attestation(s) for block [...] hint: system may be overloaded, service: bproc`) on one instance.  The metric allows for greater visibility into the issue.

## Issue Addressed

Improves visibility into nodes being overloaded.

## Proposed Changes

Adds a Prometheus metric for a event that normally requires scouring logs.