### PR TITLE
Add a cli option for the snapshot cache size

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -12,7 +12,7 @@ use crate::light_client_server_cache::LightClientServerCache;
 use crate::migrate::{BackgroundMigrator, MigratorConfig};
 use crate::persisted_beacon_chain::PersistedBeaconChain;
 use crate::shuffling_cache::{BlockShufflingIds, ShufflingCache};
-use crate::snapshot_cache::{SnapshotCache, DEFAULT_SNAPSHOT_CACHE_SIZE};
+use crate::snapshot_cache::SnapshotCache;
 use crate::timeout_rw_lock::TimeoutRwLock;
 use crate::validator_monitor::{ValidatorMonitor, ValidatorMonitorConfig};
 use crate::validator_pubkey_cache::ValidatorPubkeyCache;
@@ -870,6 +870,7 @@ where
         let head_for_snapshot_cache = head_snapshot.clone();
         let canonical_head = CanonicalHead::new(fork_choice, Arc::new(head_snapshot));
         let shuffling_cache_size = self.chain_config.shuffling_cache_size;
+        let snapshot_cache_size = self.chain_config.snapshot_cache_size;
 
         // Calculate the weak subjectivity point in which to backfill blocks to.
         let genesis_backfill_slot = if self.chain_config.genesis_backfill {
@@ -946,7 +947,7 @@ where
             event_handler: self.event_handler,
             head_tracker,
             snapshot_cache: TimeoutRwLock::new(SnapshotCache::new(
-                DEFAULT_SNAPSHOT_CACHE_SIZE,
+                snapshot_cache_size,
                 head_for_snapshot_cache,
             )),
             shuffling_cache: TimeoutRwLock::new(ShufflingCache::new(

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -72,6 +72,8 @@ pub struct ChainConfig {
     pub optimistic_finalized_sync: bool,
     /// The size of the shuffling cache,
     pub shuffling_cache_size: usize,
+    /// The size of the snapshot cache.
+    pub snapshot_cache_size: usize,
     /// If using a weak-subjectivity sync, whether we should download blocks all the way back to
     /// genesis.
     pub genesis_backfill: bool,
@@ -112,6 +114,7 @@ impl Default for ChainConfig {
             // This value isn't actually read except in tests.
             optimistic_finalized_sync: true,
             shuffling_cache_size: crate::shuffling_cache::DEFAULT_CACHE_SIZE,
+            snapshot_cache_size: crate::snapshot_cache::DEFAULT_SNAPSHOT_CACHE_SIZE,
             genesis_backfill: false,
             always_prepare_payload: false,
             progressive_balances_mode: ProgressiveBalancesMode::Fast,

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -50,7 +50,7 @@ mod pre_finalization_cache;
 pub mod proposer_prep_service;
 pub mod schema_change;
 pub mod shuffling_cache;
-mod snapshot_cache;
+pub mod snapshot_cache;
 pub mod state_advance_timer;
 pub mod sync_committee_rewards;
 pub mod sync_committee_verification;

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -9,7 +9,7 @@ use types::{
 };
 
 /// The default size of the cache.
-pub const DEFAULT_SNAPSHOT_CACHE_SIZE: usize = 4;
+pub const DEFAULT_SNAPSHOT_CACHE_SIZE: usize = 3;
 
 /// The minimum block delay to clone the state in the cache instead of removing it.
 /// This helps keep block processing fast during re-orgs from late blocks.

--- a/beacon_node/beacon_chain/src/snapshot_cache.rs
+++ b/beacon_node/beacon_chain/src/snapshot_cache.rs
@@ -174,6 +174,7 @@ impl<T: EthSpec> SnapshotCache<T> {
         self.snapshots.iter().map(|s| s.beacon_block_root).collect()
     }
 
+    #[allow(clippy::len_without_is_empty)]
     /// The number of snapshots contained in `self`.
     pub fn len(&self) -> usize {
         self.snapshots.len()

--- a/beacon_node/http_api/src/blob.py
+++ b/beacon_node/http_api/src/blob.py
@@ -1,0 +1,6 @@
+class BlobSidecar:
+    blob: List[Byte, 4096]
+    proof: G1Point
+    kzg_commitment: G1Point
+
+

--- a/beacon_node/http_api/src/blob.py
+++ b/beacon_node/http_api/src/blob.py
@@ -1,6 +1,0 @@
-class BlobSidecar:
-    blob: List[Byte, 4096]
-    proof: G1Point
-    kzg_commitment: G1Point
-
-

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -622,6 +622,13 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Specifies how many states from the freezer database should cache in memory [default: 1]")
                 .takes_value(true)
         )
+        .arg(
+            Arg::with_name("state-cache-size")
+                .long("state-cache-size")
+                .value_name("STATE_CACHE_SIZE")
+                .help("Specifies the size of the snapshot cache [default: 3]")
+                .takes_value(true)
+        )
         /*
          * Execution Layer Integration
          */

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -170,6 +170,9 @@ pub fn get_config<E: EthSpec>(
     if let Some(cache_size) = clap_utils::parse_optional(cli_args, "shuffling-cache-size")? {
         client_config.chain.shuffling_cache_size = cache_size;
     }
+    if let Some(cache_size) = clap_utils::parse_optional(cli_args, "state-cache-size")? {
+        client_config.chain.snapshot_cache_size = cache_size;
+    }
 
     /*
      * Prometheus metrics HTTP server

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -461,6 +461,9 @@ OPTIONS:
         --slots-per-restore-point <SLOT_COUNT>
             Specifies how often a freezer DB restore point should be stored. Cannot be changed after initialization.
             [default: 8192 (mainnet) or 64 (minimal)]
+        --state-cache-size <STATE_CACHE_SIZE>
+            Specifies the size of the snapshot cache [default: 3]
+
         --suggested-fee-recipient <SUGGESTED-FEE-RECIPIENT>
             Emergency fallback fee recipient for use in case the validator client does not have one configured. You
             should set this flag on the validator client instead of (or in addition to) setting it here.

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -178,7 +178,7 @@ fn snapshot_cache_default() {
         .run_with_zero_port()
         .with_config(|config| {
             assert_eq!(
-                config.chain.shuffling_cache_size,
+                config.chain.snapshot_cache_size,
                 beacon_node::beacon_chain::snapshot_cache::DEFAULT_SNAPSHOT_CACHE_SIZE
             )
         });

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -173,6 +173,26 @@ fn shuffling_cache_set() {
 }
 
 #[test]
+fn snapshot_cache_default() {
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.chain.shuffling_cache_size,
+                beacon_node::beacon_chain::snapshot_cache::DEFAULT_SNAPSHOT_CACHE_SIZE
+            )
+        });
+}
+
+#[test]
+fn snapshot_cache_set() {
+    CommandLineTest::new()
+        .flag("state-cache-size", Some("500"))
+        .run_with_zero_port()
+        .with_config(|config| assert_eq!(config.chain.snapshot_cache_size, 500));
+}
+
+#[test]
 fn fork_choice_before_proposal_timeout_default() {
     CommandLineTest::new()
         .run_with_zero_port()


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Adds a cli option `--state-cache-size` to change the size of the snapshot cache.
Also makes the default size 3 instead of 4.

