### PR TITLE
Fix typos and make block hash calculation public

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
+++ b/beacon_node/execution_layer/src/engine_api/new_payload_request.rs
@@ -86,7 +86,7 @@ impl<'block, E: EthSpec> NewPayloadRequest<'block, E> {
     ///
     /// https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#modified-verify_and_notify_new_payload
     pub fn perform_optimistic_sync_verifications(&self) -> Result<(), Error> {
-        self.verfiy_payload_block_hash()?;
+        self.verify_payload_block_hash()?;
         self.verify_versioned_hashes()?;
 
         Ok(())
@@ -98,7 +98,7 @@ impl<'block, E: EthSpec> NewPayloadRequest<'block, E> {
     ///
     /// Equivalent to `is_valid_block_hash` in the spec:
     /// https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/beacon-chain.md#is_valid_block_hash
-    pub fn verfiy_payload_block_hash(&self) -> Result<(), Error> {
+    pub fn verify_payload_block_hash(&self) -> Result<(), Error> {
         let payload = self.execution_payload_ref();
         let parent_beacon_block_root = self.parent_beacon_block_root().ok().cloned();
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -7,6 +7,7 @@
 use crate::payload_cache::PayloadCache;
 use arc_swap::ArcSwapOption;
 use auth::{strip_prefix, Auth, JwtKey};
+pub use block_hash::calculate_execution_block_hash;
 use builder_client::BuilderHttpClient;
 pub use engine_api::EngineCapabilities;
 use engine_api::Error as ApiError;


### PR DESCRIPTION
## Proposed Changes

* Fix typo `verfiy => verify`
* Make `calculate_execution_block_hash` public again so it can be used downstream by projects like `eleel`.