### PR TITLE
as_store_bytes not fallible

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -614,10 +614,10 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // but absent in the DB. This inconsistency halts pruning and dramastically increases disk
         // size. Ref: https://github.com/sigp/lighthouse/issues/4773
         let head_tracker = self.head_tracker.0.read();
-        batch.push(self.persist_head_in_batch(&head_tracker)?);
+        batch.push(self.persist_head_in_batch(&head_tracker));
 
         let _fork_choice_timer = metrics::start_timer(&metrics::PERSIST_FORK_CHOICE);
-        batch.push(self.persist_fork_choice_in_batch()?);
+        batch.push(self.persist_fork_choice_in_batch());
 
         self.store.hot_db.do_atomically(batch)?;
         drop(head_tracker);
@@ -641,14 +641,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn persist_head_in_batch(
         &self,
         head_tracker_reader: &HeadTrackerReader,
-    ) -> Result<KeyValueStoreOp, DBError> {
+    ) -> KeyValueStoreOp {
         Self::persist_head_in_batch_standalone(self.genesis_block_root, head_tracker_reader)
     }
 
     pub fn persist_head_in_batch_standalone(
         genesis_block_root: Hash256,
         head_tracker_reader: &HeadTrackerReader,
-    ) -> Result<KeyValueStoreOp, DBError> {
+    ) -> KeyValueStoreOp {
         Self::make_persisted_head(genesis_block_root, head_tracker_reader)
             .as_kv_store_op(BEACON_CHAIN_DB_KEY)
     }

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1016,14 +1016,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Return a database operation for writing fork choice to disk.
-    pub fn persist_fork_choice_in_batch(&self) -> Result<KeyValueStoreOp, store::Error> {
+    pub fn persist_fork_choice_in_batch(&self) -> KeyValueStoreOp {
         Self::persist_fork_choice_in_batch_standalone(&self.canonical_head.fork_choice_read_lock())
     }
 
     /// Return a database operation for writing fork choice to disk.
     pub fn persist_fork_choice_in_batch_standalone(
         fork_choice: &BeaconForkChoice<T>,
-    ) -> Result<KeyValueStoreOp, store::Error> {
+    ) -> KeyValueStoreOp {
         let persisted_fork_choice = PersistedForkChoice {
             fork_choice: fork_choice.to_persisted(),
             fork_choice_store: fork_choice.fc_store().to_persisted(),

--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -178,8 +178,8 @@ impl StoreItem for SszEth1 {
         DBColumn::Eth1Cache
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -741,7 +741,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         };
         drop(head_tracker_lock);
         batch.push(StoreOp::KeyValueOp(
-            persisted_head.as_kv_store_op(BEACON_CHAIN_DB_KEY)?,
+            persisted_head.as_kv_store_op(BEACON_CHAIN_DB_KEY),
         ));
 
         store.do_atomically_with_block_and_blobs_cache(batch)?;

--- a/beacon_node/beacon_chain/src/otb_verification_service.rs
+++ b/beacon_node/beacon_chain/src/otb_verification_service.rs
@@ -85,8 +85,8 @@ impl StoreItem for OptimisticTransitionBlock {
         OTBColumn
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {

--- a/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/persisted_beacon_chain.rs
@@ -26,8 +26,8 @@ impl StoreItem for PersistedBeaconChain {
         DBColumn::BeaconChain
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -45,8 +45,8 @@ macro_rules! impl_store_item {
                 DBColumn::ForkChoice
             }
 
-            fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-                Ok(self.as_ssz_bytes())
+            fn as_store_bytes(&self) -> Vec<u8> {
+                self.as_ssz_bytes()
             }
 
             fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v17.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v17.rs
@@ -65,7 +65,7 @@ pub fn upgrade_to_v17<T: BeaconChainTypes>(
         "Removing unused best_justified_checkpoint from fork choice store."
     );
 
-    Ok(vec![v17.as_kv_store_op(FORK_CHOICE_DB_KEY)?])
+    Ok(vec![v17.as_kv_store_op(FORK_CHOICE_DB_KEY)])
 }
 
 pub fn downgrade_from_v17<T: BeaconChainTypes>(
@@ -84,5 +84,5 @@ pub fn downgrade_from_v17<T: BeaconChainTypes>(
         "Adding junk best_justified_checkpoint to fork choice store."
     );
 
-    Ok(vec![v11.as_kv_store_op(FORK_CHOICE_DB_KEY)?])
+    Ok(vec![v11.as_kv_store_op(FORK_CHOICE_DB_KEY)])
 }

--- a/beacon_node/network/src/persisted_dht.rs
+++ b/beacon_node/network/src/persisted_dht.rs
@@ -44,8 +44,8 @@ impl StoreItem for PersistedDht {
         DBColumn::DhtEnrs
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(rlp::encode_list(&self.enrs).to_vec())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        rlp::encode_list(&self.enrs).to_vec()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {

--- a/beacon_node/operation_pool/src/persistence.rs
+++ b/beacon_node/operation_pool/src/persistence.rs
@@ -205,8 +205,8 @@ impl<T: EthSpec> StoreItem for PersistedOperationPoolV5<T> {
         DBColumn::OpPool
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {
@@ -219,8 +219,8 @@ impl<T: EthSpec> StoreItem for PersistedOperationPoolV12<T> {
         DBColumn::OpPool
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {
@@ -233,8 +233,8 @@ impl<T: EthSpec> StoreItem for PersistedOperationPoolV14<T> {
         DBColumn::OpPool
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {
@@ -247,8 +247,8 @@ impl<T: EthSpec> StoreItem for PersistedOperationPoolV15<T> {
         DBColumn::OpPool
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {
@@ -262,8 +262,8 @@ impl<T: EthSpec> StoreItem for PersistedOperationPool<T> {
         DBColumn::OpPool
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, StoreError> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, StoreError> {

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -213,8 +213,8 @@ impl StoreItem for OnDiskStoreConfig {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -129,8 +129,8 @@ impl StoreItem for HDiff {
         DBColumn::BeaconStateDiff
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, crate::Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, crate::Error> {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -449,7 +449,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         // Store execution payload if present.
         if let Some(ref execution_payload) = payload {
-            ops.push(execution_payload.as_kv_store_op(*key)?);
+            ops.push(execution_payload.as_kv_store_op(*key));
         }
 
         // Re-construct block. This should always succeed.
@@ -646,7 +646,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<(), Error> {
         // Write the block root to slot mapping.
         let slot = block.slot();
-        kv_store_ops.push(FrozenBlockSlot(slot).as_kv_store_op(*block_root)?);
+        kv_store_ops.push(FrozenBlockSlot(slot).as_kv_store_op(*block_root));
 
         // Write the slot to block root mapping.
         kv_store_ops.push(KeyValueStoreOp::PutKeyValue(
@@ -738,7 +738,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         execution_payload: &ExecutionPayload<E>,
     ) -> Result<(), Error> {
         self.hot_db
-            .do_atomically(vec![execution_payload.as_kv_store_op(*block_root)?])
+            .do_atomically(vec![execution_payload.as_kv_store_op(*block_root)])
     }
 
     /// Check if the blobs for a block exists on disk.
@@ -1047,7 +1047,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 }
 
                 StoreOp::PutStateTemporaryFlag(state_root) => {
-                    key_value_batch.push(TemporaryFlag.as_kv_store_op(state_root)?);
+                    key_value_batch.push(TemporaryFlag.as_kv_store_op(state_root));
                 }
 
                 StoreOp::DeleteStateTemporaryFlag(state_root) => {
@@ -1252,7 +1252,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let diff_base_slot = self.state_diff_slot(state.slot());
 
         let hot_state_summary = HotStateSummary::new(state_root, state, diff_base_slot)?;
-        let op = hot_state_summary.as_kv_store_op(*state_root)?;
+        let op = hot_state_summary.as_kv_store_op(*state_root);
         ops.push(op);
 
         // On an epoch boundary, consider storing:
@@ -1289,7 +1289,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 let target_buffer = HDiffBuffer::from_state(state.clone());
                 let diff = HDiff::compute(&base_buffer, &target_buffer)?;
                 drop(compute_diff_timer);
-                ops.push(diff.as_kv_store_op(*state_root)?);
+                ops.push(diff.as_kv_store_op(*state_root));
             }
         }
 
@@ -1680,7 +1680,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         slot: Slot,
         ops: &mut Vec<KeyValueStoreOp>,
     ) -> Result<(), Error> {
-        ops.push(ColdStateSummary { slot }.as_kv_store_op(*state_root)?);
+        ops.push(ColdStateSummary { slot }.as_kv_store_op(*state_root));
         ops.push(KeyValueStoreOp::PutKeyValue(
             get_key_for_col(
                 DBColumn::BeaconStateRoots.into(),
@@ -2058,7 +2058,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let column = SchemaVersion::db_column().into();
         let key = SCHEMA_VERSION_KEY.as_bytes();
         let db_key = get_key_for_col(column, key);
-        let op = KeyValueStoreOp::PutKeyValue(db_key, schema_version.as_store_bytes()?);
+        let op = KeyValueStoreOp::PutKeyValue(db_key, schema_version.as_store_bytes());
         ops.push(op);
 
         self.hot_db.do_atomically(ops)
@@ -2115,7 +2115,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<KeyValueStoreOp, Error> {
         let mut anchor_info = self.anchor_info.write();
         if *anchor_info == prev_value {
-            let kv_op = self.store_anchor_info_in_batch(&new_value)?;
+            let kv_op = self.store_anchor_info_in_batch(&new_value);
             *anchor_info = new_value;
             Ok(kv_op)
         } else {
@@ -2142,17 +2142,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///
     /// The argument is intended to be `self.anchor_info`, but is passed manually to avoid issues
     /// with recursive locking.
-    fn store_anchor_info_in_batch(
-        &self,
-        anchor_info: &Option<AnchorInfo>,
-    ) -> Result<KeyValueStoreOp, Error> {
+    fn store_anchor_info_in_batch(&self, anchor_info: &Option<AnchorInfo>) -> KeyValueStoreOp {
         if let Some(ref anchor_info) = anchor_info {
             anchor_info.as_kv_store_op(ANCHOR_INFO_KEY)
         } else {
-            Ok(KeyValueStoreOp::DeleteKey(get_key_for_col(
+            KeyValueStoreOp::DeleteKey(get_key_for_col(
                 DBColumn::BeaconMeta.into(),
                 ANCHOR_INFO_KEY.as_bytes(),
-            )))
+            ))
         }
     }
 
@@ -2197,7 +2194,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ) -> Result<KeyValueStoreOp, Error> {
         let mut blob_info = self.blob_info.write();
         if *blob_info == prev_value {
-            let kv_op = self.store_blob_info_in_batch(&new_value)?;
+            let kv_op = self.store_blob_info_in_batch(&new_value);
             *blob_info = new_value;
             Ok(kv_op)
         } else {
@@ -2224,7 +2221,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     ///
     /// The argument is intended to be `self.blob_info`, but is passed manually to avoid issues
     /// with recursive locking.
-    fn store_blob_info_in_batch(&self, blob_info: &BlobInfo) -> Result<KeyValueStoreOp, Error> {
+    fn store_blob_info_in_batch(&self, blob_info: &BlobInfo) -> KeyValueStoreOp {
         blob_info.as_kv_store_op(BLOB_INFO_KEY)
     }
 
@@ -2306,7 +2303,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     /// Stage the split for storage to disk.
-    pub fn store_split_in_batch(&self) -> Result<KeyValueStoreOp, Error> {
+    pub fn store_split_in_batch(&self) -> KeyValueStoreOp {
         self.split.read_recursive().as_kv_store_op(SPLIT_KEY)
     }
 
@@ -2329,7 +2326,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         ops: &mut Vec<KeyValueStoreOp>,
     ) -> Result<(), Error> {
         let value = &RestorePointHash { state_root };
-        let op = value.as_kv_store_op(Self::restore_point_key(restore_point_index))?;
+        let op = value.as_kv_store_op(Self::restore_point_key(restore_point_index));
         ops.push(op);
         Ok(())
     }
@@ -3016,8 +3013,8 @@ impl StoreItem for Split {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -3060,8 +3057,8 @@ macro_rules! impl_store_item_summary {
                 DBColumn::BeaconStateSummary
             }
 
-            fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-                Ok(self.as_ssz_bytes())
+            fn as_store_bytes(&self) -> Vec<u8> {
+                self.as_ssz_bytes()
             }
 
             fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -3123,8 +3120,8 @@ impl StoreItem for ColdStateSummary {
         DBColumn::BeaconStateSummary
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -3143,8 +3140,8 @@ impl StoreItem for RestorePointHash {
         DBColumn::BeaconRestorePoint
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -3160,8 +3157,8 @@ impl StoreItem for TemporaryFlag {
         DBColumn::BeaconStateTemporary
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(vec![])
+    fn as_store_bytes(&self) -> Vec<u8> {
+        vec![]
     }
 
     fn from_store_bytes(_: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/impls/execution_payload.rs
+++ b/beacon_node/store/src/impls/execution_payload.rs
@@ -12,8 +12,8 @@ macro_rules! impl_store_item {
                 DBColumn::ExecPayload
             }
 
-            fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-                Ok(self.as_ssz_bytes())
+            fn as_store_bytes(&self) -> Vec<u8> {
+                self.as_ssz_bytes()
             }
 
             fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -36,8 +36,8 @@ impl<E: EthSpec> StoreItem for ExecutionPayload<E> {
         DBColumn::ExecPayload
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/impls/frozen_block_slot.rs
+++ b/beacon_node/store/src/impls/frozen_block_slot.rs
@@ -9,8 +9,8 @@ impl StoreItem for FrozenBlockSlot {
         DBColumn::BeaconBlock
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.0.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -156,7 +156,7 @@ pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'stati
         let column = I::db_column().into();
         let key = key.as_bytes();
 
-        self.put_bytes(column, key, &item.as_store_bytes()?)
+        self.put_bytes(column, key, &item.as_store_bytes())
             .map_err(Into::into)
     }
 
@@ -164,7 +164,7 @@ pub trait ItemStore<E: EthSpec>: KeyValueStore<E> + Sync + Send + Sized + 'stati
         let column = I::db_column().into();
         let key = key.as_bytes();
 
-        self.put_bytes_sync(column, key, &item.as_store_bytes()?)
+        self.put_bytes_sync(column, key, &item.as_store_bytes())
             .map_err(Into::into)
     }
 
@@ -339,16 +339,16 @@ pub trait StoreItem: Sized {
     fn db_column() -> DBColumn;
 
     /// Serialize `self` as bytes.
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error>;
+    fn as_store_bytes(&self) -> Vec<u8>;
 
     /// De-serialize `self` from bytes.
     ///
     /// Return an instance of the type and the number of bytes that were read.
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error>;
 
-    fn as_kv_store_op(&self, key: Hash256) -> Result<KeyValueStoreOp, Error> {
+    fn as_kv_store_op(&self, key: Hash256) -> KeyValueStoreOp {
         let db_key = get_key_for_col(Self::db_column().into(), key.as_bytes());
-        Ok(KeyValueStoreOp::PutKeyValue(db_key, self.as_store_bytes()?))
+        KeyValueStoreOp::PutKeyValue(db_key, self.as_store_bytes())
     }
 }
 
@@ -370,8 +370,8 @@ mod tests {
             DBColumn::BeaconBlock
         }
 
-        fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-            Ok(self.as_ssz_bytes())
+        fn as_store_bytes(&self) -> Vec<u8> {
+            self.as_ssz_bytes()
         }
 
         fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -34,8 +34,8 @@ impl StoreItem for SchemaVersion {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.0.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -56,8 +56,8 @@ impl StoreItem for PruningCheckpoint {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.checkpoint.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.checkpoint.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -75,8 +75,8 @@ impl StoreItem for CompactionTimestamp {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.0.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -120,8 +120,8 @@ impl StoreItem for AnchorInfo {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
@@ -149,8 +149,8 @@ impl StoreItem for BlobInfo {
         DBColumn::BeaconMeta
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {

--- a/beacon_node/store/src/validator_pubkey_cache.rs
+++ b/beacon_node/store/src/validator_pubkey_cache.rs
@@ -135,7 +135,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> ValidatorPubkeyCache<E, 
             // See: https://github.com/sigp/lighthouse/issues/2327
             store_ops.push(StoreOp::KeyValueOp(
                 DatabaseValidator::from_immutable_validator(&pubkey, &pubkey_bytes)
-                    .as_kv_store_op(DatabaseValidator::key_for_index(i))?,
+                    .as_kv_store_op(DatabaseValidator::key_for_index(i)),
             ));
 
             self.pubkeys.push(pubkey);
@@ -195,8 +195,8 @@ impl StoreItem for DatabaseValidator {
         DBColumn::PubkeyCache
     }
 
-    fn as_store_bytes(&self) -> Result<Vec<u8>, Error> {
-        Ok(self.as_ssz_bytes())
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.as_ssz_bytes()
     }
 
     fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {


### PR DESCRIPTION
Technical debt of a previous iteration of tree-states.

It's no longer necessary to make as_store_bytes fallible, so let's reduce the diff a bit.


