### PR TITLE
Remove milhouse export aliases

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -1021,7 +1021,7 @@ mod test {
 
     mod collect_valid_votes {
         use super::*;
-        use types::VList;
+        use types::List;
 
         fn get_eth1_data_vec(n: u64, block_number_offset: u64) -> Vec<(Eth1Data, BlockNumber)> {
             (0..n)
@@ -1069,7 +1069,7 @@ mod test {
 
             let votes_to_consider = get_eth1_data_vec(slots, 0);
 
-            *state.eth1_data_votes_mut() = VList::new(
+            *state.eth1_data_votes_mut() = List::new(
                 votes_to_consider[0..slots as usize / 4]
                     .iter()
                     .map(|(eth1_data, _)| eth1_data)
@@ -1100,7 +1100,7 @@ mod test {
                 .expect("should have some eth1 data")
                 .clone();
 
-            *state.eth1_data_votes_mut() = VList::new(
+            *state.eth1_data_votes_mut() = List::new(
                 vec![duplicate_eth1_data.clone(); 4]
                     .iter()
                     .map(|(eth1_data, _)| eth1_data)

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -6,7 +6,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::io::{Read, Write};
 use std::str::FromStr;
-use types::{BeaconState, ChainSpec, EthSpec, Slot, VList};
+use types::{BeaconState, ChainSpec, EthSpec, List, Slot};
 use zstd::{Decoder, Encoder};
 
 #[derive(Debug)]
@@ -91,7 +91,7 @@ impl HDiffBuffer {
 
     pub fn into_state<E: EthSpec>(self, spec: &ChainSpec) -> Result<BeaconState<E>, Error> {
         let mut state = BeaconState::from_ssz_bytes(&self.state, spec).unwrap();
-        *state.balances_mut() = VList::new(self.balances).unwrap();
+        *state.balances_mut() = List::new(self.balances).unwrap();
         Ok(state)
     }
 }

--- a/consensus/state_processing/src/per_epoch_processing/altair/participation_flag_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/altair/participation_flag_updates.rs
@@ -2,7 +2,7 @@ use crate::EpochProcessingError;
 use types::beacon_state::BeaconState;
 use types::eth_spec::EthSpec;
 use types::participation_flags::ParticipationFlags;
-use types::VList;
+use types::List;
 
 pub fn process_participation_flag_updates<T: EthSpec>(
     state: &mut BeaconState<T>,
@@ -10,6 +10,6 @@ pub fn process_participation_flag_updates<T: EthSpec>(
     *state.previous_epoch_participation_mut()? =
         std::mem::take(state.current_epoch_participation_mut()?);
     *state.current_epoch_participation_mut()? =
-        VList::repeat(ParticipationFlags::default(), state.validators().len())?;
+        List::repeat(ParticipationFlags::default(), state.validators().len())?;
     Ok(())
 }

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -3,8 +3,8 @@ use crate::metrics;
 use std::sync::Arc;
 use types::{
     consts::altair::{TIMELY_HEAD_FLAG_INDEX, TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX},
-    BeaconStateError, Epoch, EthSpec, ParticipationFlags, ProgressiveBalancesCache, SyncCommittee,
-    VList, Validator,
+    BeaconStateError, Epoch, EthSpec, List, ParticipationFlags, ProgressiveBalancesCache,
+    SyncCommittee, Validator,
 };
 
 /// Provides a summary of validator participation during the epoch.
@@ -25,20 +25,20 @@ pub enum EpochProcessingSummary<T: EthSpec> {
 #[derive(PartialEq, Debug)]
 pub struct ParticipationEpochSummary<T: EthSpec> {
     /// Copy of the validator registry prior to mutation.
-    validators: VList<Validator, T::ValidatorRegistryLimit>,
+    validators: List<Validator, T::ValidatorRegistryLimit>,
     /// Copy of the participation flags for the previous epoch.
-    previous_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
+    previous_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
     /// Copy of the participation flags for the current epoch.
-    current_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
+    current_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
     previous_epoch: Epoch,
     current_epoch: Epoch,
 }
 
 impl<T: EthSpec> ParticipationEpochSummary<T> {
     pub fn new(
-        validators: VList<Validator, T::ValidatorRegistryLimit>,
-        previous_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
-        current_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
+        validators: List<Validator, T::ValidatorRegistryLimit>,
+        previous_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
+        current_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
         previous_epoch: Epoch,
         current_epoch: Epoch,
     ) -> Self {

--- a/consensus/state_processing/src/per_epoch_processing/resets.rs
+++ b/consensus/state_processing/src/per_epoch_processing/resets.rs
@@ -2,7 +2,7 @@ use super::errors::EpochProcessingError;
 use safe_arith::SafeArith;
 use types::beacon_state::BeaconState;
 use types::eth_spec::EthSpec;
-use types::{Unsigned, VList};
+use types::{List, Unsigned};
 
 pub fn process_eth1_data_reset<T: EthSpec>(
     state: &mut BeaconState<T>,
@@ -13,7 +13,7 @@ pub fn process_eth1_data_reset<T: EthSpec>(
         .safe_rem(T::SlotsPerEth1VotingPeriod::to_u64())?
         == 0
     {
-        *state.eth1_data_votes_mut() = VList::empty();
+        *state.eth1_data_votes_mut() = List::empty();
     }
     Ok(())
 }

--- a/consensus/state_processing/src/upgrade/altair.rs
+++ b/consensus/state_processing/src/upgrade/altair.rs
@@ -4,13 +4,13 @@ use std::mem;
 use std::sync::Arc;
 use types::{
     BeaconState, BeaconStateAltair, BeaconStateError as Error, ChainSpec, EpochCache, EthSpec,
-    Fork, ParticipationFlags, PendingAttestation, RelativeEpoch, SyncCommittee, VList,
+    Fork, List, ParticipationFlags, PendingAttestation, RelativeEpoch, SyncCommittee,
 };
 
 /// Translate the participation information from the epoch prior to the fork into Altair's format.
 pub fn translate_participation<E: EthSpec>(
     state: &mut BeaconState<E>,
-    pending_attestations: &VList<PendingAttestation<E>, E::MaxPendingAttestations>,
+    pending_attestations: &List<PendingAttestation<E>, E::MaxPendingAttestations>,
     spec: &ChainSpec,
 ) -> Result<(), Error> {
     // Previous epoch committee cache is required for `get_attesting_indices`.
@@ -51,8 +51,8 @@ pub fn upgrade_to_altair<E: EthSpec>(
     let pre = pre_state.as_base_mut()?;
 
     let default_epoch_participation =
-        VList::new(vec![ParticipationFlags::default(); pre.validators.len()])?;
-    let inactivity_scores = VList::new(vec![0; pre.validators.len()])?;
+        List::new(vec![ParticipationFlags::default(); pre.validators.len()])?;
+    let inactivity_scores = List::new(vec![0; pre.validators.len()])?;
 
     let temp_sync_committee = Arc::new(SyncCommittee::temporary());
 

--- a/consensus/state_processing/src/upgrade/capella.rs
+++ b/consensus/state_processing/src/upgrade/capella.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use types::{
     BeaconState, BeaconStateCapella, BeaconStateError as Error, ChainSpec, EpochCache, EthSpec,
-    Fork, VList,
+    Fork, List,
 };
 
 /// Transform a `Merge` state into an `Capella` state.
@@ -61,7 +61,7 @@ pub fn upgrade_to_capella<E: EthSpec>(
         // Capella
         next_withdrawal_index: 0,
         next_withdrawal_validator_index: 0,
-        historical_summaries: VList::default(),
+        historical_summaries: List::default(),
         // Caches
         total_active_balance: pre.total_active_balance,
         progressive_balances_cache: mem::take(&mut pre.progressive_balances_cache),

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -4,7 +4,6 @@ use derivative::Derivative;
 use merkle_proof::{MerkleTree, MerkleTreeError};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::{FixedVector, VariableList};
 use std::marker::PhantomData;
 use superstruct::superstruct;
 use test_random_derive::TestRandom;

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -35,7 +35,7 @@ use crate::epoch_cache::EpochCache;
 use crate::historical_summary::HistoricalSummary;
 pub use eth_spec::*;
 pub use iter::BlockRootsIter;
-pub use milhouse::{interface::Interface, List as VList, List, Vector as FixedVector};
+pub use milhouse::{interface::Interface, List, Vector};
 
 #[macro_use]
 mod committee_cache;
@@ -51,8 +51,8 @@ mod tests;
 pub const CACHED_EPOCHS: usize = 3;
 const MAX_RANDOM_BYTE: u64 = (1 << 8) - 1;
 
-pub type Validators<T> = VList<Validator, <T as EthSpec>::ValidatorRegistryLimit>;
-pub type Balances<T> = VList<u64, <T as EthSpec>::ValidatorRegistryLimit>;
+pub type Validators<T> = List<Validator, <T as EthSpec>::ValidatorRegistryLimit>;
+pub type Balances<T> = List<u64, <T as EthSpec>::ValidatorRegistryLimit>;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
@@ -328,12 +328,12 @@ where
     #[metastruct(exclude_from(tree_lists))]
     pub latest_block_header: BeaconBlockHeader,
     #[test_random(default)]
-    pub block_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,
+    pub block_roots: Vector<Hash256, T::SlotsPerHistoricalRoot>,
     #[test_random(default)]
-    pub state_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,
+    pub state_roots: Vector<Hash256, T::SlotsPerHistoricalRoot>,
     // Frozen in Capella, replaced by historical_summaries
     #[test_random(default)]
-    pub historical_roots: VList<Hash256, T::HistoricalRootsLimit>,
+    pub historical_roots: List<Hash256, T::HistoricalRootsLimit>,
 
     // Ethereum 1.0 chain data
     #[metastruct(exclude_from(tree_lists))]
@@ -341,7 +341,7 @@ where
     #[test_random(default)]
     // FIXME(sproul): excluded due to `rebase_on` issue
     #[metastruct(exclude_from(tree_lists))]
-    pub eth1_data_votes: VList<Eth1Data, T::SlotsPerEth1VotingPeriod>,
+    pub eth1_data_votes: List<Eth1Data, T::SlotsPerEth1VotingPeriod>,
     #[superstruct(getter(copy))]
     #[metastruct(exclude_from(tree_lists))]
     #[serde(with = "serde_utils::quoted_u64")]
@@ -349,39 +349,39 @@ where
 
     // Registry
     #[test_random(default)]
-    pub validators: VList<GenericValidator, T::ValidatorRegistryLimit>,
+    pub validators: List<GenericValidator, T::ValidatorRegistryLimit>,
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[compare_fields(as_iter)]
     #[test_random(default)]
-    pub balances: VList<u64, T::ValidatorRegistryLimit>,
+    pub balances: List<u64, T::ValidatorRegistryLimit>,
 
     // Randomness
     #[test_random(default)]
-    pub randao_mixes: FixedVector<Hash256, T::EpochsPerHistoricalVector>,
+    pub randao_mixes: Vector<Hash256, T::EpochsPerHistoricalVector>,
 
     // Slashings
     #[test_random(default)]
     #[serde(with = "ssz_types::serde_utils::quoted_u64_fixed_vec")]
-    pub slashings: FixedVector<u64, T::EpochsPerSlashingsVector>,
+    pub slashings: Vector<u64, T::EpochsPerSlashingsVector>,
 
     // Attestations (genesis fork only)
     // FIXME(sproul): excluded from tree lists due to ResetListDiff
     #[superstruct(only(Base))]
     #[test_random(default)]
     #[metastruct(exclude_from(tree_lists))]
-    pub previous_epoch_attestations: VList<PendingAttestation<T>, T::MaxPendingAttestations>,
+    pub previous_epoch_attestations: List<PendingAttestation<T>, T::MaxPendingAttestations>,
     #[superstruct(only(Base))]
     #[test_random(default)]
     #[metastruct(exclude_from(tree_lists))]
-    pub current_epoch_attestations: VList<PendingAttestation<T>, T::MaxPendingAttestations>,
+    pub current_epoch_attestations: List<PendingAttestation<T>, T::MaxPendingAttestations>,
 
     // Participation (Altair and later)
     #[superstruct(only(Altair, Merge, Capella, Deneb))]
     #[test_random(default)]
-    pub previous_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
+    pub previous_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
     #[superstruct(only(Altair, Merge, Capella, Deneb))]
     #[test_random(default)]
-    pub current_epoch_participation: VList<ParticipationFlags, T::ValidatorRegistryLimit>,
+    pub current_epoch_participation: List<ParticipationFlags, T::ValidatorRegistryLimit>,
 
     // Finality
     #[test_random(default)]
@@ -401,7 +401,7 @@ where
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[superstruct(only(Altair, Merge, Capella, Deneb))]
     #[test_random(default)]
-    pub inactivity_scores: VList<u64, T::ValidatorRegistryLimit>,
+    pub inactivity_scores: List<u64, T::ValidatorRegistryLimit>,
 
     // Light-client sync committees
     #[superstruct(only(Altair, Merge, Capella, Deneb))]
@@ -443,7 +443,7 @@ where
     // Deep history valid from Capella onwards.
     #[superstruct(only(Capella, Deneb))]
     #[test_random(default)]
-    pub historical_summaries: VList<HistoricalSummary, T::HistoricalRootsLimit>,
+    pub historical_summaries: List<HistoricalSummary, T::HistoricalRootsLimit>,
 
     // Caching (not in the spec)
     #[serde(skip_serializing, skip_deserializing)]
@@ -510,28 +510,28 @@ impl<T: EthSpec> BeaconState<T> {
 
             // History
             latest_block_header: BeaconBlock::<T>::empty(spec).temporary_block_header(),
-            block_roots: FixedVector::default(),
-            state_roots: FixedVector::default(),
-            historical_roots: VList::default(),
+            block_roots: Vector::default(),
+            state_roots: Vector::default(),
+            historical_roots: List::default(),
 
             // Eth1
             eth1_data,
-            eth1_data_votes: VList::default(),
+            eth1_data_votes: List::default(),
             eth1_deposit_index: 0,
 
             // Validator registry
-            validators: VList::default(), // Set later.
-            balances: VList::default(),   // Set later.
+            validators: List::default(), // Set later.
+            balances: List::default(),   // Set later.
 
             // Randomness
-            randao_mixes: FixedVector::default(),
+            randao_mixes: Vector::default(),
 
             // Slashings
-            slashings: FixedVector::default(),
+            slashings: Vector::default(),
 
             // Attestations
-            previous_epoch_attestations: VList::default(),
-            current_epoch_attestations: VList::default(),
+            previous_epoch_attestations: List::default(),
+            current_epoch_attestations: List::default(),
 
             // Finality
             justification_bits: BitVector::new(),
@@ -1169,7 +1169,7 @@ impl<T: EthSpec> BeaconState<T> {
 
     /// Fill `randao_mixes` with
     pub fn fill_randao_mixes_with(&mut self, index_root: Hash256) -> Result<(), Error> {
-        *self.randao_mixes_mut() = FixedVector::from_elem(index_root)?;
+        *self.randao_mixes_mut() = Vector::from_elem(index_root)?;
         Ok(())
     }
 
@@ -1303,7 +1303,7 @@ impl<T: EthSpec> BeaconState<T> {
     }
 
     /// Get a reference to the entire `slashings` vector.
-    pub fn get_all_slashings(&self) -> &FixedVector<u64, T::EpochsPerSlashingsVector> {
+    pub fn get_all_slashings(&self) -> &Vector<u64, T::EpochsPerSlashingsVector> {
         self.slashings()
     }
 
@@ -1370,9 +1370,9 @@ impl<T: EthSpec> BeaconState<T> {
         (
             &mut Validators<T>,
             &mut Balances<T>,
-            &VList<ParticipationFlags, T::ValidatorRegistryLimit>,
-            &VList<ParticipationFlags, T::ValidatorRegistryLimit>,
-            &mut VList<u64, T::ValidatorRegistryLimit>,
+            &List<ParticipationFlags, T::ValidatorRegistryLimit>,
+            &List<ParticipationFlags, T::ValidatorRegistryLimit>,
+            &mut List<u64, T::ValidatorRegistryLimit>,
             &mut ProgressiveBalancesCache,
             &mut ExitCache,
             &mut EpochCache,
@@ -1677,7 +1677,7 @@ impl<T: EthSpec> BeaconState<T> {
         epoch: Epoch,
         previous_epoch: Epoch,
         current_epoch: Epoch,
-    ) -> Result<&mut VList<ParticipationFlags, T::ValidatorRegistryLimit>, Error> {
+    ) -> Result<&mut List<ParticipationFlags, T::ValidatorRegistryLimit>, Error> {
         if epoch == current_epoch {
             match self {
                 BeaconState::Base(_) => Err(BeaconStateError::IncorrectStateVariant),
@@ -1928,19 +1928,19 @@ impl<T: EthSpec> BeaconState<T> {
             || self.slashings().has_pending_updates()
             || self
                 .previous_epoch_attestations()
-                .map_or(false, VList::has_pending_updates)
+                .map_or(false, List::has_pending_updates)
             || self
                 .current_epoch_attestations()
-                .map_or(false, VList::has_pending_updates)
+                .map_or(false, List::has_pending_updates)
             || self
                 .previous_epoch_participation()
-                .map_or(false, VList::has_pending_updates)
+                .map_or(false, List::has_pending_updates)
             || self
                 .current_epoch_participation()
-                .map_or(false, VList::has_pending_updates)
+                .map_or(false, List::has_pending_updates)
             || self
                 .inactivity_scores()
-                .map_or(false, VList::has_pending_updates)
+                .map_or(false, List::has_pending_updates)
     }
 
     /// Completely drops the `progressive_balances_cache` cache, replacing it with a new, empty cache.

--- a/consensus/types/src/beacon_state/committee_cache/tests.rs
+++ b/consensus/types/src/beacon_state/committee_cache/tests.rs
@@ -92,7 +92,7 @@ async fn shuffles_for_the_right_epoch() {
         .map(|i| Hash256::from_low_u64_be(i as u64))
         .collect();
 
-    *state.randao_mixes_mut() = FixedVector::try_from_iter(distinct_hashes).unwrap();
+    *state.randao_mixes_mut() = Vector::try_from_iter(distinct_hashes).unwrap();
 
     let previous_seed = state
         .get_seed(state.previous_epoch(), Domain::BeaconAttester, spec)

--- a/consensus/types/src/beacon_state/compact_state.rs
+++ b/consensus/types/src/beacon_state/compact_state.rs
@@ -1,6 +1,6 @@
 use crate::{
     BeaconState, BeaconStateAltair, BeaconStateBase, BeaconStateCapella, BeaconStateDeneb,
-    BeaconStateError as Error, BeaconStateMerge, EthSpec, PublicKeyBytes, VList, Validator,
+    BeaconStateError as Error, BeaconStateMerge, EthSpec, List, PublicKeyBytes, Validator,
     ValidatorMutable,
 };
 use itertools::process_results;
@@ -30,7 +30,7 @@ macro_rules! full_to_compact {
             eth1_deposit_index: $s.eth1_deposit_index,
 
             // Validator registry
-            validators: VList::try_from_iter(
+            validators: List::try_from_iter(
                 $s.validators.into_iter().map(|validator| validator.mutable.clone())
             ).expect("fix this"),
             balances: $s.balances.clone(),
@@ -95,7 +95,7 @@ macro_rules! compact_to_full {
                             mutable: mutable.clone(),
                         }
                     })
-            }), |iter| VList::try_from_iter(iter))??,
+            }), |iter| List::try_from_iter(iter))??,
             balances: $inner.balances,
 
             // Shuffling

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -4,7 +4,7 @@ use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use beacon_chain::types::{
     test_utils::TestRandom, BeaconState, BeaconStateAltair, BeaconStateBase, BeaconStateCapella,
     BeaconStateDeneb, BeaconStateError, BeaconStateMerge, ChainSpec, Domain, Epoch, EthSpec,
-    FixedVector, Hash256, Keypair, MainnetEthSpec, MinimalEthSpec, RelativeEpoch, Slot,
+    Hash256, Keypair, MainnetEthSpec, MinimalEthSpec, RelativeEpoch, Slot, Vector,
 };
 use ssz::Encode;
 use std::ops::Mul;
@@ -250,7 +250,7 @@ mod committees {
 
         let distinct_hashes =
             (0..T::epochs_per_historical_vector()).map(|i| Hash256::from_low_u64_be(i as u64));
-        *new_head_state.randao_mixes_mut() = FixedVector::try_from_iter(distinct_hashes).unwrap();
+        *new_head_state.randao_mixes_mut() = Vector::try_from_iter(distinct_hashes).unwrap();
 
         new_head_state
             .force_build_committee_cache(RelativeEpoch::Previous, spec)

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -1,7 +1,7 @@
 use crate::test_utils::TestRandom;
 use crate::{
     beacon_block_body::BLOB_KZG_COMMITMENTS_INDEX, BeaconBlockHeader, BeaconStateError, Blob,
-    EthSpec, Hash256, SignedBeaconBlockHeader, Slot,
+    EthSpec, FixedVector, Hash256, SignedBeaconBlockHeader, Slot, VariableList,
 };
 use crate::{KzgProofs, SignedBeaconBlock};
 use bls::Signature;
@@ -16,7 +16,6 @@ use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{FixedVector, VariableList};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -6,8 +6,7 @@ use ssz_derive::{Decode, Encode};
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;
 
-// FIXME(sproul): try milhouse FixedVector
-use ssz_types::FixedVector;
+// FIXME(sproul): try milhouse Vector
 
 pub type Transaction<N> = VariableList<u8, N>;
 pub type Transactions<T> = VariableList<

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -8,8 +8,6 @@ use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
 use BeaconStateError;
 
-use ssz_types::{FixedVector, VariableList};
-
 #[superstruct(
     variants(Merge, Capella, Deneb),
     variant_attributes(

--- a/consensus/types/src/historical_batch.rs
+++ b/consensus/types/src/historical_batch.rs
@@ -24,9 +24,9 @@ use tree_hash_derive::TreeHash;
 #[arbitrary(bound = "T: EthSpec")]
 pub struct HistoricalBatch<T: EthSpec> {
     #[test_random(default)]
-    pub block_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,
+    pub block_roots: Vector<Hash256, T::SlotsPerHistoricalRoot>,
     #[test_random(default)]
-    pub state_roots: FixedVector<Hash256, T::SlotsPerHistoricalRoot>,
+    pub state_roots: Vector<Hash256, T::SlotsPerHistoricalRoot>,
 }
 
 #[cfg(test)]

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -221,6 +221,6 @@ pub use bls::{
     Signature, SignatureBytes,
 };
 pub use kzg::{KzgCommitment, KzgProof, VERSIONED_HASH_VERSION_KZG};
-pub use milhouse::{self, Vector as FixedVector};
-pub use ssz_types::{typenum, typenum::Unsigned, BitList, BitVector, VariableList};
+pub use milhouse::{self, List, Vector};
+pub use ssz_types::{typenum, typenum::Unsigned, BitList, BitVector, FixedVector, VariableList};
 pub use superstruct::superstruct;

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,12 +1,11 @@
 use super::{BeaconState, EthSpec, Hash256, SyncCommittee};
 use crate::{
-    light_client_update::*, test_utils::TestRandom, ForkName, ForkVersionDeserialize,
+    light_client_update::*, test_utils::TestRandom, FixedVector, ForkName, ForkVersionDeserialize,
     LightClientHeader,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use ssz_derive::{Decode, Encode};
-use ssz_types::FixedVector;
 use std::sync::Arc;
 use test_random_derive::TestRandom;
 

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -1,12 +1,11 @@
 use super::{EthSpec, Hash256, SignedBeaconBlock, SignedBlindedBeaconBlock, Slot, SyncAggregate};
 use crate::{
-    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, ForkName,
+    light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, FixedVector, ForkName,
     ForkVersionDeserialize, LightClientHeader,
 };
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use ssz_derive::{Decode, Encode};
-use ssz_types::FixedVector;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -1,16 +1,13 @@
 use super::{BeaconBlockHeader, EthSpec, Hash256, Slot, SyncAggregate, SyncCommittee};
 use crate::{
-    beacon_state, test_utils::TestRandom, BeaconBlock, BeaconState, ChainSpec, ForkName,
-    ForkVersionDeserialize, LightClientHeader,
+    beacon_state, test_utils::TestRandom, BeaconBlock, BeaconState, ChainSpec, FixedVector,
+    ForkName, ForkVersionDeserialize, LightClientHeader,
 };
 use safe_arith::ArithError;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use ssz_derive::{Decode, Encode};
-use ssz_types::{
-    typenum::{U5, U6},
-    FixedVector,
-};
+use ssz_types::typenum::{U5, U6};
 use std::sync::Arc;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;

--- a/consensus/types/src/sync_committee.rs
+++ b/consensus/types/src/sync_committee.rs
@@ -1,10 +1,9 @@
 use crate::test_utils::TestRandom;
-use crate::{EthSpec, SyncSubnetId};
+use crate::{EthSpec, FixedVector, SyncSubnetId};
 use bls::PublicKeyBytes;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
-use ssz_types::FixedVector;
 use std::collections::HashMap;
 use test_random_derive::TestRandom;
 use tree_hash_derive::TreeHash;

--- a/testing/ef_tests/src/cases/ssz_generic.rs
+++ b/testing/ef_tests/src/cases/ssz_generic.rs
@@ -9,7 +9,7 @@ use ssz_derive::{Decode, Encode};
 use std::path::{Path, PathBuf};
 use tree_hash_derive::TreeHash;
 use types::typenum::*;
-use types::{BitList, BitVector, FixedVector, ForkName, VariableList};
+use types::{BitList, BitVector, ForkName, VariableList, Vector};
 
 #[derive(Debug, Clone, Deserialize)]
 struct Metadata {
@@ -135,7 +135,7 @@ impl Case for SszGeneric {
                 type_dispatch!(
                     ssz_generic_test,
                     (&self.path),
-                    FixedVector,
+                    Vector,
                     <>,
                     [elem_ty => primitive_type]
                     [length => typenum]
@@ -270,8 +270,8 @@ struct ComplexTestStruct {
     #[serde(deserialize_with = "byte_list_from_hex_str")]
     D: VariableList<u8, U256>,
     E: VarTestStruct,
-    F: FixedVector<FixedTestStruct, U4>,
-    G: FixedVector<VarTestStruct, U2>,
+    F: Vector<FixedTestStruct, U4>,
+    G: Vector<VarTestStruct, U2>,
 }
 
 #[derive(Debug, Clone, PartialEq, Decode, Encode, TreeHash, Deserialize)]


### PR DESCRIPTION
At the moment `tree-states` has a confusing mix of type aliases for the `VariableList`/`FixedVector` types. This PR switches to:

- `VariableList`/`FixedVector`: same as on `stable`, refer to types from `ssz_types`
- `List`/`Vector`: unmodified `milhouse` type names

## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/5141


