### PR TITLE
Run `apt update` before install.

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -408,7 +408,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
-      run: sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+      run: sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
     - name: Use Rust beta
       run: rustup override set beta
     - name: Run make

--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -28,7 +28,7 @@ operating system.
 Install the following packages:
 
 ```bash
-sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
 ```
 
 > Tips:

--- a/book/src/pi.md
+++ b/book/src/pi.md
@@ -22,7 +22,7 @@ terminal and an Internet connection are necessary.
 Install the Ubuntu dependencies:
 
 ```bash
-sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
 ```
 
 > Tips:


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/actions/runs/8029660282/job/21960601201

This CI job is failing due to the apt package not being available on the server. Seems like old version of the `cmake-data` package got pruned. 

Adding an `sudo apt update` to update the package list before installing to avoid this failure.