### PR TITLE
Fix duties override bug in VC

### DIFF
--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -1417,4 +1417,22 @@ mod test {
             }
         }
     }
+
+    /// Test the boundary condition where all subscription slots are *just* expired.
+    #[test]
+    fn subscription_slots_expired() {
+        let current_slot = Slot::new(100);
+        let duty_slot = current_slot + ATTESTATION_SUBSCRIPTION_OFFSETS[0];
+        let subscription_slots = SubscriptionSlots::new(duty_slot, current_slot);
+        for offset in ATTESTATION_SUBSCRIPTION_OFFSETS.into_iter() {
+            let slot = duty_slot - offset;
+            assert!(!subscription_slots.should_send_subscription_at(slot));
+        }
+        assert!(subscription_slots.slots.is_empty());
+
+        // If the duty slot is 1 later, we get a non-empty set of duties.
+        let subscription_slots = SubscriptionSlots::new(duty_slot + 1, current_slot);
+        assert_eq!(subscription_slots.slots.len(), 1);
+        assert!(subscription_slots.should_send_subscription_at(current_slot + 1),);
+    }
 }


### PR DESCRIPTION
## Issue Addressed

Alternative to:

- #5296

## Proposed Changes

I wasn't fully satisfied with the fix from #5296, as while it works, it's a bit of a bandaid.

This PR attempts to address a bug that I found in how we calculate duties which I think is the root cause. We were previously requesting duties for a single validator to work out whether any updates were required, and then making a request for all validators that we determined needed updating. The problem was we would assume that the duties for the single validator were "new" and relevant, and then use them to overwrite existing duties for that validator, thus removing our knowledge of the subscriptions we'd already sent.

This explains why some users noticed that the expired subscription warnings occurred more often on nodes with validators changing their status from pending to active. These validators would be deemed in need of updating, and would allow the update to go through for the single validator (which is not usually the same validator). 

I've also updated the duty update logic to be a bit more defensive about overriding data, logging a warning in cases where we would previously override (which I hope is now unreachable).

## Additional Info

This PR could be merged in addition to #5296 if we want to really guarantee (defense in depth) that we don't send bad subscriptions.