### PR TITLE
Track multiaddr in connection status

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -756,8 +756,8 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
 
                 // Update the connection state
                 match direction {
-                    ConnectionDirection::Incoming => info.connect_ingoing(Some(seen_address)),
-                    ConnectionDirection::Outgoing => info.connect_outgoing(Some(seen_address)),
+                    ConnectionDirection::Incoming => info.connect_ingoing(seen_address),
+                    ConnectionDirection::Outgoing => info.connect_outgoing(seen_address),
                 }
             }
 


### PR DESCRIPTION
It is useful to know which protocol and address we are connected to for each peer. 

This PR keeps track of the multiaddr that created a connection for a peer so that it can be read by our http api in `/lighthouse/peers`. 

This now enables users to see which peers are connected via which protocol and addresses.