### PR TITLE
Fix 5288: Doesn't POST if attestations is empty.

### DIFF
--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -431,7 +431,7 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .unzip();
 
         if attestations.len() == 0 {
-            warn!("WARN: No attestations were published");
+            warn!(log, "WARN: No attestations were published");
             return Ok(None);
         }
 

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -430,8 +430,8 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .flatten()
             .unzip();
 
-        if attestations.len() == 0 {
-            warn!(log, "WARN: No attestations were published");
+        if attestations.is_empty() {
+            warn!(log, "No attestations were published");
             return Ok(None);
         }
 

--- a/validator_client/src/attestation_service.rs
+++ b/validator_client/src/attestation_service.rs
@@ -430,6 +430,11 @@ impl<T: SlotClock + 'static, E: EthSpec> AttestationService<T, E> {
             .flatten()
             .unzip();
 
+        if attestations.len() == 0 {
+            warn!("WARN: No attestations were published");
+            return Ok(None);
+        }
+
         // Post the attestations to the BN.
         match self
             .beacon_nodes


### PR DESCRIPTION
## Issue Addressed

#5288

## Proposed Changes

Checks if the attestations vec is empty then logs a message `WARN No attestations were published` and returns.