### PR TITLE
Improve logging around peer scoring

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1067,7 +1067,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 ScoreTransitionResult::Banned
             }
             (ScoreState::ForcedDisconnect, ScoreState::Banned | ScoreState::Healthy) => {
-                debug!(log, "Peer transitioned to disconnect state"; "peer_id" => %peer_id, "score" => %info.score(), "past_state" => %previous_state);
+                debug!(log, "Peer transitioned to forced disconnect score state"; "peer_id" => %peer_id, "score" => %info.score(), "past_score_state" => %previous_state);
                 // disconnect the peer if it's currently connected or dialing
                 if info.is_connected_or_dialing() {
                     ScoreTransitionResult::Disconnected
@@ -1080,11 +1080,11 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                 }
             }
             (ScoreState::Healthy, ScoreState::ForcedDisconnect) => {
-                debug!(log, "Peer transitioned to healthy state"; "peer_id" => %peer_id, "score" => %info.score(), "past_state" => %previous_state);
+                debug!(log, "Peer transitioned to healthy score state"; "peer_id" => %peer_id, "score" => %info.score(), "past_score_state" => %previous_state);
                 ScoreTransitionResult::NoAction
             }
             (ScoreState::Healthy, ScoreState::Banned) => {
-                debug!(log, "Peer transitioned to healthy state"; "peer_id" => %peer_id, "score" => %info.score(), "past_state" => %previous_state);
+                debug!(log, "Peer transitioned to healthy score state"; "peer_id" => %peer_id, "score" => %info.score(), "past_score_state" => %previous_state);
                 // unban the peer if it was previously banned.
                 ScoreTransitionResult::Unbanned
             }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -168,7 +168,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
     fn score_state_banned_or_disconnected(&self, peer_id: &PeerId) -> bool {
         if let Some(peer) = self.peers.get(peer_id) {
             match peer.score_state() {
-                ScoreState::Banned | ScoreState::Disconnected => true,
+                ScoreState::Banned | ScoreState::ForcedDisconnect => true,
                 _ => self.ip_is_banned(peer).is_some(),
             }
         } else {
@@ -1062,11 +1062,11 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
         log: &slog::Logger,
     ) -> ScoreTransitionResult {
         match (info.score_state(), previous_state) {
-            (ScoreState::Banned, ScoreState::Healthy | ScoreState::Disconnected) => {
+            (ScoreState::Banned, ScoreState::Healthy | ScoreState::ForcedDisconnect) => {
                 debug!(log, "Peer has been banned"; "peer_id" => %peer_id, "score" => %info.score());
                 ScoreTransitionResult::Banned
             }
-            (ScoreState::Disconnected, ScoreState::Banned | ScoreState::Healthy) => {
+            (ScoreState::ForcedDisconnect, ScoreState::Banned | ScoreState::Healthy) => {
                 debug!(log, "Peer transitioned to disconnect state"; "peer_id" => %peer_id, "score" => %info.score(), "past_state" => %previous_state);
                 // disconnect the peer if it's currently connected or dialing
                 if info.is_connected_or_dialing() {
@@ -1079,7 +1079,7 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
                     ScoreTransitionResult::NoAction
                 }
             }
-            (ScoreState::Healthy, ScoreState::Disconnected) => {
+            (ScoreState::Healthy, ScoreState::ForcedDisconnect) => {
                 debug!(log, "Peer transitioned to healthy state"; "peer_id" => %peer_id, "score" => %info.score(), "past_state" => %previous_state);
                 ScoreTransitionResult::NoAction
             }
@@ -1090,7 +1090,9 @@ impl<TSpec: EthSpec> PeerDB<TSpec> {
             }
             // Explicitly ignore states that haven't transitioned.
             (ScoreState::Healthy, ScoreState::Healthy) => ScoreTransitionResult::NoAction,
-            (ScoreState::Disconnected, ScoreState::Disconnected) => ScoreTransitionResult::NoAction,
+            (ScoreState::ForcedDisconnect, ScoreState::ForcedDisconnect) => {
+                ScoreTransitionResult::NoAction
+            }
 
             (ScoreState::Banned, ScoreState::Banned) => ScoreTransitionResult::NoAction,
         }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -104,7 +104,7 @@ pub(crate) enum ScoreState {
     /// We are content with the peers performance. We permit connections and messages.
     Healthy,
     /// The peer should be disconnected. We allow re-connections if the peer is persistent.
-    Disconnected,
+    ForcedDisconnect,
     /// The peer is banned. We disallow new connections until it's score has decayed into a
     /// tolerable threshold.
     Banned,
@@ -115,7 +115,7 @@ impl std::fmt::Display for ScoreState {
         match self {
             ScoreState::Healthy => write!(f, "Healthy"),
             ScoreState::Banned => write!(f, "Banned"),
-            ScoreState::Disconnected => write!(f, "Disconnected"),
+            ScoreState::ForcedDisconnect => write!(f, "Disconnected"),
         }
     }
 }
@@ -313,7 +313,7 @@ impl Score {
     pub(crate) fn state(&self) -> ScoreState {
         match self.score() {
             x if x <= MIN_SCORE_BEFORE_BAN => ScoreState::Banned,
-            x if x <= MIN_SCORE_BEFORE_DISCONNECT => ScoreState::Disconnected,
+            x if x <= MIN_SCORE_BEFORE_DISCONNECT => ScoreState::ForcedDisconnect,
             _ => ScoreState::Healthy,
         }
     }
@@ -407,7 +407,7 @@ mod tests {
         assert!(score.score() < 0.0);
         assert_eq!(score.state(), ScoreState::Healthy);
         score.test_add(-1.0001);
-        assert_eq!(score.state(), ScoreState::Disconnected);
+        assert_eq!(score.state(), ScoreState::ForcedDisconnect);
     }
 
     #[test]


### PR DESCRIPTION
There is some very reasonable confusion around some of the lighthouse logs around our peer scoring. 

The main reason for this confusion is that there are two peer states with the same name. A connection state: disconnected and a score state: disconnected. 

This PR renames the score state to: ForcedDisconnect to remove this confusion and improves the logging around these states.
