### PR TITLE
Skip calculation of boosted_relay_value when builder_boost_factor pro…

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -84,6 +84,10 @@ const EXECUTION_BLOCKS_LRU_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(128);
 const DEFAULT_SUGGESTED_FEE_RECIPIENT: [u8; 20] =
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
+/// If default boost factor is provided in validator/blocks v3 request, we will skip the calculation
+/// to keep the precision.
+const DEFAULT_BOOST_FACTOR: u64 = 100;
+
 /// A payload alongside some information about where it came from.
 pub enum ProvenancedPayload<P> {
     /// A good old fashioned farm-to-table payload from your local EE.
@@ -1111,10 +1115,10 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 let relay_value = *relay.data.message.value();
 
                 let boosted_relay_value = match builder_boost_factor {
-                    Some(builder_boost_factor) => {
+                    Some(builder_boost_factor) if (builder_boost_factor != DEFAULT_BOOST_FACTOR) => {
                         (relay_value / 100).saturating_mul(builder_boost_factor.into())
                     }
-                    None => relay_value,
+                    _ => relay_value,
                 };
 
                 let local_value = *local.block_value();

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -84,10 +84,6 @@ const EXECUTION_BLOCKS_LRU_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(128);
 const DEFAULT_SUGGESTED_FEE_RECIPIENT: [u8; 20] =
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
-/// If default boost factor is provided in validator/blocks v3 request, we will skip the calculation
-/// to keep the precision.
-const DEFAULT_BOOST_FACTOR: u64 = 100;
-
 /// A payload alongside some information about where it came from.
 pub enum ProvenancedPayload<P> {
     /// A good old fashioned farm-to-table payload from your local EE.
@@ -1115,10 +1111,10 @@ impl<T: EthSpec> ExecutionLayer<T> {
                 let relay_value = *relay.data.message.value();
 
                 let boosted_relay_value = match builder_boost_factor {
-                    Some(builder_boost_factor) if (builder_boost_factor != DEFAULT_BOOST_FACTOR) => {
+                    Some(builder_boost_factor) => {
                         (relay_value / 100).saturating_mul(builder_boost_factor.into())
                     }
-                    _ => relay_value,
+                    None => relay_value,
                 };
 
                 let local_value = *local.block_value();


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/5343

## Proposed Changes

When `builder_boost_factor` is provided with default value, we will skip computation of `boosted_relay_value` to avoid precision loss and rather return `relay_value`.

