### PR TITLE
Attempt to publish to at least mesh_n peers

### DIFF
--- a/beacon_node/lighthouse_network/src/gossipsub/behaviour.rs
+++ b/beacon_node/lighthouse_network/src/gossipsub/behaviour.rs
@@ -635,9 +635,33 @@ where
                     || !self.score_below_threshold(p, |ts| ts.publish_threshold).0
             }));
         } else {
-            match self.mesh.get(&raw_message.topic) {
+            match self.mesh.get(&topic_hash) {
                 // Mesh peers
                 Some(mesh_peers) => {
+                    // We have a mesh set. We want to make sure to publish to at least `mesh_n`
+                    // peers (if possible).
+                    let needed_extra_peers = self.config.mesh_n().saturating_sub(mesh_peers.len());
+
+                    if needed_extra_peers > 0 {
+                        // We don't have `mesh_n` peers in our mesh, we will randomly select extras
+                        // and publish to them.
+
+                        let explicit_peers = &self.explicit_peers;
+                        let scores = self.peer_score.as_ref().map(|(score, ..)| score);
+                        // Get a random set of peers that are appropriate to send messages too.
+                        let peer_list = get_random_peers(
+                            &self.connected_peers,
+                            &topic_hash,
+                            needed_extra_peers,
+                            |peer| {
+                                !mesh_peers.contains(peer)
+                                    && !explicit_peers.contains(peer)
+                                    && scores.map(|score| score.score(peer)).unwrap_or(0.0) >= 0.0
+                            },
+                        );
+                        recipient_peers.extend(peer_list);
+                    }
+
                     recipient_peers.extend(mesh_peers);
                 }
                 // Gossipsub peers

--- a/beacon_node/lighthouse_network/src/gossipsub/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/src/gossipsub/behaviour/tests.rs
@@ -741,8 +741,8 @@ fn test_publish_without_flood_publishing() {
     let config: Config = Config::default();
     assert_eq!(
         publishes.len(),
-        config.mesh_n_low(),
-        "Should send a publish message to all known peers"
+        config.mesh_n(),
+        "Should send a publish message to at least mesh_n peers"
     );
 
     assert!(

--- a/beacon_node/lighthouse_network/src/gossipsub/error.rs
+++ b/beacon_node/lighthouse_network/src/gossipsub/error.rs
@@ -36,6 +36,9 @@ pub enum PublishError {
     MessageTooLarge,
     /// The compression algorithm failed.
     TransformFailed(std::io::Error),
+    /// Messages could not be sent because all queues for peers were full. The usize represents the
+    /// number of peers that have full queues.
+    AllQueuesFull(usize),
 }
 
 impl std::fmt::Display for PublishError {


### PR DESCRIPTION
As we have now disabled flood-publish, we only publish to mesh peers. The mesh can be difficult to manage as  the management rules follow the gossipsub specification. 

Thanks to @pawanjay176 - We've noticed that it can be the case that we have connected peers on topics but these peers are not in our mesh (perhaps due to their own mesh requirements). Currently, we fail to publish the message if there are no peers in our mesh. 

This PR adjusts this logic to always attempt to publish to at least `mesh_n` peers. If we have peers that are subscribed to a topic, we will now attempt to publish messages to them (provided they have the required score). 

While I was here, I also separated the error types between insufficient peers and whether the queue is full, to help debugging and avoid any confusion in the future. 
