### PR TITLE
Fix block v3 header decoding

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2721,6 +2721,31 @@ impl ApiTester {
         self
     }
 
+    /// Check that the metadata from the headers & JSON response body are consistent, and that the
+    /// consensus block value is non-zero.
+    fn check_block_v3_metadata(
+        metadata: &ProduceBlockV3Metadata,
+        response: &JsonProduceBlockV3Response<E>,
+    ) {
+        // Compare fork name to ForkVersionedResponse rather than metadata consensus_version, which
+        // is deserialized to a dummy value.
+        assert_eq!(Some(metadata.consensus_version), response.version);
+        assert_eq!(ForkName::Base, response.metadata.consensus_version);
+        assert_eq!(
+            metadata.execution_payload_blinded,
+            response.metadata.execution_payload_blinded
+        );
+        assert_eq!(
+            metadata.execution_payload_value,
+            response.metadata.execution_payload_value
+        );
+        assert_eq!(
+            metadata.consensus_block_value,
+            response.metadata.consensus_block_value
+        );
+        assert!(!metadata.consensus_block_value.is_zero());
+    }
+
     pub async fn test_block_production_v3_ssz(self) -> Self {
         let fork = self.chain.canonical_head.cached_head().head_fork();
         let genesis_validators_root = self.chain.genesis_validators_root;
@@ -3582,11 +3607,12 @@ impl ApiTester {
 
         let (proposer_index, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
@@ -3608,11 +3634,12 @@ impl ApiTester {
 
         let (proposer_index, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, Some(0))
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -3634,11 +3661,12 @@ impl ApiTester {
 
         let (proposer_index, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, Some(u64::MAX))
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
@@ -3738,11 +3766,12 @@ impl ApiTester {
 
         let (proposer_index, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
@@ -3814,11 +3843,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: BlindedPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => {
@@ -3904,11 +3934,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -3990,11 +4021,12 @@ impl ApiTester {
             .unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -4076,11 +4108,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -4160,11 +4193,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -4216,11 +4250,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4282,11 +4317,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4390,11 +4426,12 @@ impl ApiTester {
             .get_test_randao(next_slot, next_slot.epoch(E::slots_per_epoch()))
             .await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(next_slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
@@ -4410,11 +4447,12 @@ impl ApiTester {
             .get_test_randao(next_slot, next_slot.epoch(E::slots_per_epoch()))
             .await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(next_slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4538,11 +4576,12 @@ impl ApiTester {
             .get_test_randao(next_slot, next_slot.epoch(E::slots_per_epoch()))
             .await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(next_slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4568,11 +4607,12 @@ impl ApiTester {
             .get_test_randao(next_slot, next_slot.epoch(E::slots_per_epoch()))
             .await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(next_slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
@@ -4648,11 +4688,12 @@ impl ApiTester {
 
         let (proposer_index, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let payload: FullPayload<E> = match payload_type.data {
             ProduceBlockV3Response::Full(payload) => {
@@ -4717,11 +4758,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Blinded(_) => (),
@@ -4781,11 +4823,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4845,11 +4888,12 @@ impl ApiTester {
 
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),
@@ -4907,11 +4951,12 @@ impl ApiTester {
         let epoch = self.chain.epoch().unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         let _block_contents = match payload_type.data {
             ProduceBlockV3Response::Blinded(payload) => payload,
@@ -4979,11 +5024,12 @@ impl ApiTester {
         let epoch = self.chain.epoch().unwrap();
         let (_, randao_reveal) = self.get_test_randao(slot, epoch).await;
 
-        let (payload_type, _) = self
+        let (payload_type, metadata) = self
             .client
             .get_validator_blocks_v3::<E>(slot, &randao_reveal, None, None)
             .await
             .unwrap();
+        Self::check_block_v3_metadata(&metadata, &payload_type);
 
         match payload_type.data {
             ProduceBlockV3Response::Full(_) => (),

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1710,12 +1710,12 @@ impl TryFrom<&HeaderMap> for ProduceBlockV3Metadata {
             })?;
         let execution_payload_value =
             parse_required_header(headers, EXECUTION_PAYLOAD_VALUE_HEADER, |s| {
-                s.parse::<Uint256>()
+                Uint256::from_dec_str(s)
                     .map_err(|e| format!("invalid {EXECUTION_PAYLOAD_VALUE_HEADER}: {e:?}"))
             })?;
         let consensus_block_value =
             parse_required_header(headers, CONSENSUS_BLOCK_VALUE_HEADER, |s| {
-                s.parse::<Uint256>()
+                Uint256::from_dec_str(s)
                     .map_err(|e| format!("invalid {CONSENSUS_BLOCK_VALUE_HEADER}: {e:?}"))
             })?;
 


### PR DESCRIPTION
## Issue Addressed

The `eth2` client for `blocks/v3` was incorrectly using hex decoding (my bad). This doesn't have any impact on most Lighthouse users, as our VC doesn't care about this value, and the actual value in the response is correct, so other VCs are able to parse it.

This _is_ relevant for projects that import Lighthouse's HTTP client, like `blockdreamer`.

## Proposed Changes

- Use explicit decimal decoding.
- Add tests that assert metadata consistency between headers & JSON response. Checking the block value is non-zero ensures we aren't just checked `Uint256::from_hex("0") == Uint256::from_dec("0")`.
