### PR TITLE
Optimise concurrent block production

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4166,21 +4166,14 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 (re_org_state.pre_state, re_org_state.state_root)
             }
             // Normal case: proposing a block atop the current head using the cache.
-            else if let Some((_, cached_state)) = self
-                .block_production_state
-                .lock()
-                .take()
-                .filter(|(cached_block_root, _)| *cached_block_root == head_block_root)
+            else if let Some((_, cached_state)) =
+                self.get_state_from_block_production_cache(head_block_root)
             {
                 (cached_state.pre_state, cached_state.state_root)
             }
             // Fall back to a direct read of the snapshot cache.
-            else if let Some(pre_state) = self
-                .snapshot_cache
-                .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-                .and_then(|snapshot_cache| {
-                    snapshot_cache.get_state_for_block_production(head_block_root)
-                })
+            else if let Some(pre_state) =
+                self.get_state_from_snapshot_cache_for_block_production(head_block_root)
             {
                 warn!(
                     self.log,
@@ -4219,6 +4212,40 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         drop(state_load_timer);
 
         Ok((state, state_root_opt))
+    }
+
+    /// Get the state cached for block production *if* it matches `head_block_root`.
+    ///
+    /// This will clear the cache regardless of whether the block root matches, so only call this if
+    /// you think the `head_block_root` is likely to match!
+    fn get_state_from_block_production_cache(
+        &self,
+        head_block_root: Hash256,
+    ) -> Option<(Hash256, BlockProductionPreState<T::EthSpec>)> {
+        // Take care to drop the lock as quickly as possible.
+        let mut lock = self.block_production_state.lock();
+        let result = lock
+            .take()
+            .filter(|(cached_block_root, _)| *cached_block_root == head_block_root);
+        drop(lock);
+        result
+    }
+
+    /// Get a state for block production from the snapshot cache.
+    fn get_state_from_snapshot_cache_for_block_production(
+        &self,
+        head_block_root: Hash256,
+    ) -> Option<BlockProductionPreState<T::EthSpec>> {
+        if let Some(lock) = self
+            .snapshot_cache
+            .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
+        {
+            let result = lock.get_state_for_block_production(head_block_root);
+            drop(lock);
+            result
+        } else {
+            None
+        }
     }
 
     /// Fetch the beacon state to use for producing a block if a 1-slot proposer re-org is viable.
@@ -4313,12 +4340,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Only attempt a re-org if we hit the block production cache or snapshot cache.
         let pre_state = self
-            .block_production_state
-            .lock()
-            .take()
-            .and_then(|(cached_block_root, state)| {
-                (cached_block_root == re_org_parent_block).then_some(state)
-            })
+            .get_state_from_block_production_cache(re_org_parent_block)
+            .map(|(_, state)| state)
             .or_else(|| {
                 warn!(
                     self.log,
@@ -4327,11 +4350,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     "slot" => slot,
                     "block_root" => ?re_org_parent_block
                 );
-                self.snapshot_cache
-                    .try_read_for(BLOCK_PROCESSING_CACHE_LOCK_TIMEOUT)
-                    .and_then(|snapshot_cache| {
-                        snapshot_cache.get_state_for_block_production(re_org_parent_block)
-                    })
+                self.get_state_from_snapshot_cache_for_block_production(re_org_parent_block)
             })
             .or_else(|| {
                 debug!(


### PR DESCRIPTION
## Issue Addressed

Closes #5365

## Proposed Changes

Speed up concurrent block production by being stricter about when locks are dropped. We were getting screwed by Rust's auto-drop logic which was not releasing locks in a timely way when they were obtained in the branches of an `if`.

Prior to making this change you can see how staggered the block responses end up (running `blockdreamer` with 4x copies of the same node):

```
Mar 07 06:08:00.111 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773640, status: 200 OK, elapsed: 111.176792ms, module: http_api:205
Mar 07 06:08:00.414 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773640, status: 200 OK, elapsed: 413.336008ms, module: http_api:205
Mar 07 06:08:00.715 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773640, status: 200 OK, elapsed: 714.450081ms, module: http_api:205
Mar 07 06:08:01.027 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773640, status: 200 OK, elapsed: 1.026413336s, module: http_api:205
```

Whereas after making this change (mainly the `block_production_state` locking change), they execute properly in parallel:

```
Mar 07 06:23:48.126 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773719, status: 200 OK, elapsed: 124.879958ms, module: http_api:205
Mar 07 06:23:48.437 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773719, status: 200 OK, elapsed: 436.259608ms, module: http_api:205
Mar 07 06:23:48.449 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773719, status: 200 OK, elapsed: 447.748269ms, module: http_api:205
Mar 07 06:23:48.461 DEBG Processed HTTP API request, method: GET, path: /eth/v3/validator/blocks/7773719, status: 200 OK, elapsed: 459.995933ms, module: http_api:205
```

The first request is 300ms faster than the subsequent 3 because it is able to use the single-use `block_production_state` cache.
