### PR TITLE
Downgrade rate limited log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9960,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "yamux"
 version = "0.13.1"
-source = "git+https://github.com/sigp/rust-yamux.git#6689e227a48258a52347cd1d984adfc94afc6f7a"
+source = "git+https://github.com/sigp/rust-yamux.git#12a23aa0e34b7807c0c5f87f06b3438f7d6c2ed0"
 dependencies = [
  "futures",
  "instant",

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -310,9 +310,13 @@ where
                         Err(RateLimitedErr::TooLarge) => {
                             // we set the batch sizes, so this is a coding/config err for most protocols
                             let protocol = req.versioned_protocol().protocol();
-                            if matches!(protocol, Protocol::BlocksByRange)
-                                || matches!(protocol, Protocol::BlobsByRange)
-                            {
+                            if matches!(
+                                protocol,
+                                Protocol::BlocksByRange
+                                    | Protocol::BlobsByRange
+                                    | Protocol::BlocksByRoot
+                                    | Protocol::BlobsByRoot
+                            ) {
                                 debug!(self.log, "By range request will never be processed"; "request" => %req, "protocol" => %protocol);
                             } else {
                                 crit!(self.log, "Request size too large to ever be processed"; "protocol" => %protocol);

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -317,8 +317,9 @@ where
                                     | Protocol::BlocksByRoot
                                     | Protocol::BlobsByRoot
                             ) {
-                                debug!(self.log, "By range request will never be processed"; "request" => %req, "protocol" => %protocol);
+                                debug!(self.log, "Request too large to process"; "request" => %req, "protocol" => %protocol);
                             } else {
+                                // Other protocols shouldn't be sending large messages, we should flag the peer kind
                                 crit!(self.log, "Request size too large to ever be processed"; "protocol" => %protocol);
                             }
                             // send an error code to the peer.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Downgrade rate limited logs for all protocols where the expected responses > 1
This is not really an issue but we are seeing a few caplin peers on sepolia that are sending us a lot of blobroot requests, so this might happen on other networks too which might lead to a lot of users asking us about it on discord