### PR TITLE
Fix gossip verification of duplicate attester slashings

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -414,14 +414,14 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     /// Maintains a record of slashable message seen over the gossip network or RPC.
     pub observed_slashable: RwLock<ObservedSlashable<T::EthSpec>>,
     /// Maintains a record of which validators have submitted voluntary exits.
-    pub(crate) observed_voluntary_exits: Mutex<ObservedOperations<SignedVoluntaryExit, T::EthSpec>>,
+    pub observed_voluntary_exits: Mutex<ObservedOperations<SignedVoluntaryExit, T::EthSpec>>,
     /// Maintains a record of which validators we've seen proposer slashings for.
-    pub(crate) observed_proposer_slashings: Mutex<ObservedOperations<ProposerSlashing, T::EthSpec>>,
+    pub observed_proposer_slashings: Mutex<ObservedOperations<ProposerSlashing, T::EthSpec>>,
     /// Maintains a record of which validators we've seen attester slashings for.
-    pub(crate) observed_attester_slashings:
+    pub observed_attester_slashings:
         Mutex<ObservedOperations<AttesterSlashing<T::EthSpec>, T::EthSpec>>,
     /// Maintains a record of which validators we've seen BLS to execution changes for.
-    pub(crate) observed_bls_to_execution_changes:
+    pub observed_bls_to_execution_changes:
         Mutex<ObservedOperations<SignedBlsToExecutionChange, T::EthSpec>>,
     /// Provides information from the Ethereum 1 (PoW) chain.
     pub eth1_chain: Option<Eth1Chain<T::Eth1Chain, T::EthSpec>>,

--- a/beacon_node/beacon_chain/src/observed_operations.rs
+++ b/beacon_node/beacon_chain/src/observed_operations.rs
@@ -153,6 +153,11 @@ impl<T: ObservableOperation<E>, E: EthSpec> ObservedOperations<T, E> {
             self.current_fork = head_fork;
         }
     }
+
+    /// Reset the cache. MUST ONLY BE USED IN TESTS.
+    pub fn __reset_for_testing_only(&mut self) {
+        self.observed_validator_indices.clear();
+    }
 }
 
 impl<T: ObservableOperation<E> + VerifyOperationAt<E>, E: EthSpec> ObservedOperations<T, E> {

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -232,11 +232,9 @@ pub fn process_attester_slashings<T: EthSpec>(
     spec: &ChainSpec,
 ) -> Result<(), BlockProcessingError> {
     for (i, attester_slashing) in attester_slashings.iter().enumerate() {
-        verify_attester_slashing(state, attester_slashing, verify_signatures, spec)
-            .map_err(|e| e.into_with_index(i))?;
-
         let slashable_indices =
-            get_slashable_indices(state, attester_slashing).map_err(|e| e.into_with_index(i))?;
+            verify_attester_slashing(state, attester_slashing, verify_signatures, spec)
+                .map_err(|e| e.into_with_index(i))?;
 
         for i in slashable_indices {
             slash_validator(state, i as usize, None, ctxt, spec)?;

--- a/consensus/state_processing/src/per_block_processing/verify_attester_slashing.rs
+++ b/consensus/state_processing/src/per_block_processing/verify_attester_slashing.rs
@@ -13,16 +13,15 @@ fn error(reason: Invalid) -> BlockOperationError<Invalid> {
 /// Indicates if an `AttesterSlashing` is valid to be included in a block in the current epoch of
 /// the given state.
 ///
-/// Returns `Ok(())` if the `AttesterSlashing` is valid, otherwise indicates the reason for
+/// Returns `Ok(indices)` with `indices` being a non-empty vec of validator indices in ascending
+/// order if the `AttesterSlashing` is valid. Otherwise returns `Err(e)` with the reason for
 /// invalidity.
-///
-/// Spec v0.12.1
 pub fn verify_attester_slashing<T: EthSpec>(
     state: &BeaconState<T>,
     attester_slashing: &AttesterSlashing<T>,
     verify_signatures: VerifySignatures,
     spec: &ChainSpec,
-) -> Result<()> {
+) -> Result<Vec<u64>> {
     let attestation_1 = &attester_slashing.attestation_1;
     let attestation_2 = &attester_slashing.attestation_2;
 
@@ -38,14 +37,12 @@ pub fn verify_attester_slashing<T: EthSpec>(
     is_valid_indexed_attestation(state, attestation_2, verify_signatures, spec)
         .map_err(|e| error(Invalid::IndexedAttestation2Invalid(e)))?;
 
-    Ok(())
+    get_slashable_indices(state, attester_slashing)
 }
 
 /// For a given attester slashing, return the indices able to be slashed in ascending order.
 ///
-/// Returns Ok(indices) if `indices.len() > 0`.
-///
-/// Spec v0.12.1
+/// Returns Ok(indices) if `indices.len() > 0`
 pub fn get_slashable_indices<T: EthSpec>(
     state: &BeaconState<T>,
     attester_slashing: &AttesterSlashing<T>,


### PR DESCRIPTION
## Issue Addressed

Replacement for:

- https://github.com/sigp/lighthouse/pull/5375

## Proposed Changes

Move the check for slashing 1+ validators in an attester slashing into `verify_attester_slashing`. This has the effect of preventing Lighthouse from gossiping attester slashings for already slashed validators, where those slashed validators are not present in the `ObservedOperations` cache (e.g. after a restart). See the previous PR linked above for more context.

This PR is preferable to the previous one because it neatly addresses the root cause for attester slashings, without having to modify the logic for other operations (which were already fine). New tests have been added to confirm the correct behaviour for attester slashings, proposer slashings and voluntary exits.

## Additional Info

The consensus code for `process_attester_slashings` is also updated to make use of the new unified `verify_attester_slashing`.

The op pool logic is also slightly affected, as it imports `SigVerifiedOp<AttesterSlashing<..>>`. The op pool has its own logic for determining which attester slashings are useful (i.e. slash unslashed validators) so checking slashing relevance on gossip is at worst redundant, and at best a slight optimisation as it prevents some useless slashings from making it into the pool where they consume memory & processing time. 