### PR TITLE
Fix macOS build by updating `cc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,10 +1354,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -4364,6 +4365,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
+ "libc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+dependencies = [
  "libc",
 ]
 


### PR DESCRIPTION
## Issue Addressed

Fix compilation on newer versions of macOS (14.3-14.4 tested) by bumping the `cc` version.

Without this change `leveldb` fails to compile with an error like:

```

  make[3]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
  make[3]: *** Waiting for unfinished jobs....
  make[2]: *** [CMakeFiles/snappy.dir/all] Error 2
  make[1]: *** [all] Error 2
  thread 'main' panicked at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.50/src/lib.rs:1098:5:

  command did not execute successfully, got: exit status: 2

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
