### PR TITLE
Built-in documentation text width in Lighthouse book

### DIFF
--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -510,3 +510,4 @@ OPTIONS:
             block root should be 0x-prefixed. Note that this flag is for verification only, to perform a checkpoint sync
             from a recent state use --checkpoint-sync-url.
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -105,3 +105,4 @@ SUBCOMMANDS:
     validator_manager    Utilities for managing a Lighthouse validator client via the HTTP API. [aliases: vm,
                          validator-manager, validator_manager]
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -223,3 +223,4 @@ OPTIONS:
         --web3-signer-max-idle-connections <COUNT>
             Maximum number of idle connections to maintain per web3signer host. Default is unlimited.
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -95,3 +95,4 @@ SUBCOMMANDS:
               which can be generated using the "create-validators" command. This command only supports validators
               signing via a keystore on the local file system (i.e., not Web3Signer validators).
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -135,3 +135,4 @@ OPTIONS:
             Path to directory containing eth2_testnet specs. Defaults to a hard-coded Lighthouse testnet. Only effective
             if there is no existing database.
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -99,3 +99,4 @@ OPTIONS:
             A HTTP(S) address of a validator client using the keymanager-API. If this value is not supplied then a 'dry
             run' will be conducted where no changes are made to the validator client. [default: http://localhost:5062]
 ```
+<style> .content main {max-width:88%;} </style>

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -116,3 +116,4 @@ OPTIONS:
         --validators <STRING>
             The validators to be moved. Either a list of 0x-prefixed validator pubkeys or the keyword "all".
 ```
+<style> .content main {max-width:88%;} </style>

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -17,6 +17,9 @@ write_to_file() {
 
     # We need to add the header and the backticks to create the code block.
     printf "# %s\n\n\`\`\`\n%s\n\`\`\`" "$program" "$cmd" > "$file"
+
+    # Adjust the width of the help text and append to the end of file
+    sed -i -e '$a\'$'\n''<style> .content main {max-width:88%;} </style>' "$file"
 }
 
 CMD=./target/release/lighthouse


### PR DESCRIPTION
## Proposed Changes

The current width for this section in Lighthouse book has a horizontal scroll at the bottom of the page, which is not very user friendly:
 
![current](https://github.com/sigp/lighthouse/assets/44791194/e367a048-e4ef-4cfd-a6e5-97a26202e557)

This PR proposes to adjust the width only for this chapter, by modifying the files. After tested, it fits nicely on a 20-inch monitor:

![20inch](https://github.com/sigp/lighthouse/assets/44791194/8a43820a-9f66-4a62-adb9-1f42e9dcdeb4)

If the monitor is larger, e.g., 24-inch, have some white space in the code block:

![24inch](https://github.com/sigp/lighthouse/assets/44791194/18de0781-8310-4f64-afef-bf575f676f34)

Thanks to @macladson @rickimoore and @jimmygchen for the help.
