### PR TITLE
Fix one and hide all beacon-processor flags

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -284,7 +284,7 @@ pub struct BeaconProcessorChannels<E: EthSpec> {
 impl<E: EthSpec> BeaconProcessorChannels<E> {
     pub fn new(config: &BeaconProcessorConfig) -> Self {
         let (beacon_processor_tx, beacon_processor_rx) =
-            mpsc::channel(config.max_scheduled_work_queue_len);
+            mpsc::channel(config.max_work_event_queue_len);
         let (work_reprocessing_tx, work_reprocessing_rx) =
             mpsc::channel(config.max_scheduled_work_queue_len);
 

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1241,6 +1241,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                         this value may increase resource consumption. Reducing the value \
                         may result in decreased resource usage and diminished performance. The \
                         default value is the number of logical CPU cores on the host.")
+                .hidden(true)
                 .takes_value(true)
         )
         .arg(
@@ -1251,6 +1252,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                         Higher values may prevent messages from being dropped while lower values \
                         may help protect the node from becoming overwhelmed.")
                 .default_value("16384")
+                .hidden(true)
                 .takes_value(true)
         )
         .arg(
@@ -1260,6 +1262,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Specifies the length of the queue for messages requiring delayed processing. \
                         Higher values may prevent messages from being dropped while lower values \
                         may help protect the node from becoming overwhelmed.")
+                .hidden(true)
                 .default_value("12288")
                 .takes_value(true)
         )
@@ -1270,6 +1273,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Specifies the number of gossip attestations in a signature verification batch. \
                        Higher values may reduce CPU usage in a healthy network whilst lower values may \
                        increase CPU usage in an unhealthy or hostile network.")
+                .hidden(true)
                 .default_value("64")
                 .takes_value(true)
         )
@@ -1281,6 +1285,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                        verification batch. \
                        Higher values may reduce CPU usage in a healthy network while lower values may \
                        increase CPU usage in an unhealthy or hostile network.")
+                .hidden(true)
                 .default_value("64")
                 .takes_value(true)
         )

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -125,25 +125,6 @@ OPTIONS:
         --auto-compact-db <auto-compact-db>
             Enable or disable automatic compaction of the database on finalization. [default: true]
 
-        --beacon-processor-aggregate-batch-size <INTEGER>
-            Specifies the number of gossip aggregate attestations in a signature verification batch. Higher values may
-            reduce CPU usage in a healthy network while lower values may increase CPU usage in an unhealthy or hostile
-            network. [default: 64]
-        --beacon-processor-attestation-batch-size <INTEGER>
-            Specifies the number of gossip attestations in a signature verification batch. Higher values may reduce CPU
-            usage in a healthy network whilst lower values may increase CPU usage in an unhealthy or hostile network.
-            [default: 64]
-        --beacon-processor-max-workers <INTEGER>
-            Specifies the maximum concurrent tasks for the task scheduler. Increasing this value may increase resource
-            consumption. Reducing the value may result in decreased resource usage and diminished performance. The
-            default value is the number of logical CPU cores on the host.
-        --beacon-processor-reprocess-queue-len <INTEGER>
-            Specifies the length of the queue for messages requiring delayed processing. Higher values may prevent
-            messages from being dropped while lower values may help protect the node from becoming overwhelmed.
-            [default: 12288]
-        --beacon-processor-work-queue-len <INTEGER>
-            Specifies the length of the inbound event queue. Higher values may prevent messages from being dropped while
-            lower values may help protect the node from becoming overwhelmed. [default: 16384]
         --blob-prune-margin-epochs <EPOCHS>
             The margin for blob pruning in epochs. The oldest blobs are pruned up until data_availability_boundary -
             blob_prune_margin_epochs. [default: 0]


### PR DESCRIPTION
## Proposed Changes

- Fix the previously ineffective `beacon-processor-work-queue-len` flag. It was plumbed incorrectly.
- Hide all of the `--beacon-processor-*` flags in preparation for their deprecation and removal.

The argument for hiding the flags is:

- We as devs haven't experimented with different values for these flags enough to recommend setting them to anything other than the default.
- Therefore we don't want users messing with them and creating problems for themselves.
- We should probably eventually remove or simplify these flags.

## Additional Info

See also user confusion about these flags in:

- https://github.com/sigp/lighthouse/issues/5390