### PR TITLE
Fix peer count metrics

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -1256,8 +1256,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         }
     }
 
-    // Update peers per client metrics.
-    fn update_peers_per_client_metrics(&self) {
+    // Update peer count related metrics.
+    fn update_peer_count_metrics(&self) {
         let mut peers_connected = 0;
         let mut clients_per_peer = HashMap::new();
         let mut peers_connected_mutli: HashMap<(&str, &str), i32> = HashMap::new();

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -270,7 +270,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 }
             };
 
-            metrics::inc_gauge(&metrics::PEERS_CONNECTED);
             metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
 
             self.update_peers_per_client_metrics();
@@ -364,7 +363,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 _ => {}
             };
             // Legacy standard metrics.
-            metrics::dec_gauge(&metrics::PEERS_CONNECTED);
             metrics::inc_counter(&metrics::PEER_DISCONNECT_EVENT_COUNT);
 
             self.update_peers_per_client_metrics();

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -245,31 +245,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
 
         // increment prometheus metrics
         if self.metrics_enabled {
-            let remote_addr = endpoint.get_remote_address();
-            let direction = if endpoint.is_dialer() {
-                "outbound"
-            } else {
-                "inbound"
-            };
-
-            match remote_addr.iter().find(|proto| {
-                matches!(
-                    proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_)
-                )
-            }) {
-                Some(multiaddr::Protocol::QuicV1) => {
-                    metrics::inc_gauge_vec(&metrics::PEERS_CONNECTED_MULTI, &[direction, "quic"]);
-                }
-                Some(multiaddr::Protocol::Tcp(_)) => {
-                    metrics::inc_gauge_vec(&metrics::PEERS_CONNECTED_MULTI, &[direction, "tcp"]);
-                }
-                Some(_) => unreachable!(),
-                None => {
-                    error!(self.log, "Connection established via unknown transport"; "addr" => %remote_addr)
-                }
-            };
-
             metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
 
             self.update_peers_per_client_metrics();
@@ -341,27 +316,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         let remote_addr = endpoint.get_remote_address();
         // Update the prometheus metrics
         if self.metrics_enabled {
-            let direction = if endpoint.is_dialer() {
-                "outbound"
-            } else {
-                "inbound"
-            };
-
-            match remote_addr.iter().find(|proto| {
-                matches!(
-                    proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_)
-                )
-            }) {
-                Some(multiaddr::Protocol::QuicV1) => {
-                    metrics::dec_gauge_vec(&metrics::PEERS_CONNECTED_MULTI, &[direction, "quic"]);
-                }
-                Some(multiaddr::Protocol::Tcp(_)) => {
-                    metrics::dec_gauge_vec(&metrics::PEERS_CONNECTED_MULTI, &[direction, "tcp"]);
-                }
-                // If it's an unknown protocol we already logged when connection was established.
-                _ => {}
-            };
             // Legacy standard metrics.
             metrics::inc_counter(&metrics::PEER_DISCONNECT_EVENT_COUNT);
 

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -4,7 +4,7 @@ use std::net::IpAddr;
 use std::task::{Context, Poll};
 
 use futures::StreamExt;
-use libp2p::core::{multiaddr, ConnectedPoint};
+use libp2p::core::ConnectedPoint;
 use libp2p::identity::PeerId;
 use libp2p::swarm::behaviour::{ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm};
 use libp2p::swarm::dial_opts::{DialOpts, PeerCondition};
@@ -285,7 +285,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
     fn on_connection_closed(
         &mut self,
         peer_id: PeerId,
-        endpoint: &ConnectedPoint,
+        _endpoint: &ConnectedPoint,
         remaining_established: usize,
     ) {
         if remaining_established > 0 {
@@ -313,7 +313,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         // reference so that peer manager can track this peer.
         self.inject_disconnect(&peer_id);
 
-        let remote_addr = endpoint.get_remote_address();
         // Update the prometheus metrics
         if self.metrics_enabled {
             // Legacy standard metrics.

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -272,6 +272,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
 
             metrics::inc_gauge(&metrics::PEERS_CONNECTED);
             metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
+
+            self.update_peers_per_client_metrics();
         }
 
         // Count dialing peers in the limit if the peer dialed us.
@@ -364,6 +366,8 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             // Legacy standard metrics.
             metrics::dec_gauge(&metrics::PEERS_CONNECTED);
             metrics::inc_counter(&metrics::PEER_DISCONNECT_EVENT_COUNT);
+
+            self.update_peers_per_client_metrics();
         }
     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -243,11 +243,11 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             self.events.push(PeerManagerEvent::MetaData(peer_id));
         }
 
-        // increment prometheus metrics
+        // Update the prometheus metrics
         if self.metrics_enabled {
             metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
 
-            self.update_peers_per_client_metrics();
+            self.update_peer_count_metrics();
         }
 
         // Count dialing peers in the limit if the peer dialed us.
@@ -319,7 +319,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             // Legacy standard metrics.
             metrics::inc_counter(&metrics::PEER_DISCONNECT_EVENT_COUNT);
 
-            self.update_peers_per_client_metrics();
+            self.update_peer_count_metrics();
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

There was a bug introduced in https://github.com/sigp/lighthouse/pull/5314 where the `libp2p_peers_per_client` metric shows a larger number than the actual number of connected nodes. This PR attempts to fix that.

(Edit) Also I removed the inc/dec for `libp2p_peers` and `libp2p_peers_multi`.

## Proposed Changes

I have changed the approach to setting a specific value for the metrics, rather than using increment/decrement. I have also tested this change locally, and it appears to work fine.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->
