### PR TITLE
feat: add peerdas custody field to ENR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5150,6 +5150,7 @@ dependencies = [
  "hex",
  "hex_fmt",
  "instant",
+ "itertools",
  "lazy_static",
  "libp2p",
  "libp2p-mplex",

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -47,6 +47,7 @@ tracing = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
 either = { workspace = true }
+itertools = { workspace = true }
 
 # Local dependencies
 futures-ticker = "0.0.3"

--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -69,11 +69,12 @@ impl Eth2Enr for Enr {
     }
 
     fn custody_subnet_count<TSpec: EthSpec>(&self) -> Result<u64, &'static str> {
-        // NOTE: given that a minimum is defined, we could map a non-existent key-value to the
-        // minimum value.
+        // NOTE: if the custody value is non-existent in the ENR, then we assume the minimum
+        // custody value defined in the spec.
+        let min_custody_bytes = TSpec::min_custody_requirement().as_ssz_bytes();
         let custody_bytes = self
             .get(PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY)
-            .ok_or("ENR custody subnet countn non-existent")?;
+            .unwrap_or(&min_custody_bytes);
         u64::from_ssz_bytes(custody_bytes)
             .map_err(|_| "Could not decode the ENR custody subnet count")
     }

--- a/consensus/types/src/data_column_subnet_id.rs
+++ b/consensus/types/src/data_column_subnet_id.rs
@@ -67,9 +67,10 @@ impl DataColumnSubnetId {
         while (subnets.len() as u64) < custody_subnet_count {
             let offset_node_id = node_id + U256::from(offset);
             let offset_node_id = offset_node_id.as_u64().to_le_bytes();
-            let hash = ethereum_hashing::hash_fixed(&offset_node_id);
-            let subnet =
-                U256::from_little_endian(&hash).as_u64() % (T::data_column_subnet_count() as u64);
+            let hash: [u8; 32] = ethereum_hashing::hash_fixed(&offset_node_id);
+            let hash_prefix = [hash[0], hash[1], hash[2], hash[3], hash[4], hash[5], hash[6], hash[7]];
+            let hash_prefix_u64 = u64::from_le_bytes(hash_prefix);
+            let subnet = hash_prefix_u64 % (T::data_column_subnet_count() as u64);
 
             if !subnets.contains(&subnet) {
                 subnets.push(subnet);

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -6,7 +6,7 @@ use ssz_types::typenum::{
     bit::B0, UInt, Unsigned, U0, U1024, U1048576, U1073741824, U1099511627776, U128, U131072, U16,
     U16777216, U2, U2048, U256, U32, U4, U4096, U512, U6, U625, U64, U65536, U8, U8192,
 };
-use ssz_types::typenum::{U17, U9};
+use ssz_types::typenum::{U1, U17, U9};
 use std::fmt::{self, Debug};
 use std::str::FromStr;
 
@@ -115,6 +115,7 @@ pub trait EthSpec:
     /*
      * New in PeerDAS
      */
+    type MinCustodyRequirement: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type DataColumnSubnetCount: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type DataColumnCount: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MaxBytesPerColumn: Unsigned + Clone + Sync + Send + Debug + PartialEq;
@@ -296,6 +297,10 @@ pub trait EthSpec:
         Self::DataColumnCount::to_usize()
     }
 
+    fn min_custody_requirement() -> usize {
+        Self::MinCustodyRequirement::to_usize()
+    }
+
     fn data_column_subnet_count() -> usize {
         Self::DataColumnSubnetCount::to_usize()
     }
@@ -353,6 +358,7 @@ impl EthSpec for MainnetEthSpec {
     type FieldElementsPerCell = U64;
     type BytesPerBlob = U131072;
     type KzgCommitmentInclusionProofDepth = U17;
+    type MinCustodyRequirement = U1;
     type DataColumnSubnetCount = U32;
     type DataColumnCount = U128;
     // Column samples are entire columns in 1D DAS.
@@ -396,6 +402,7 @@ impl EthSpec for MinimalEthSpec {
     type MaxBlobCommitmentsPerBlock = U16;
     type KzgCommitmentInclusionProofDepth = U9;
     // DAS spec values copied from `MainnetEthSpec`
+    type MinCustodyRequirement = U1;
     type DataColumnSubnetCount = U32;
     type DataColumnCount = U128;
     type MaxBytesPerColumn = U65536;
@@ -476,6 +483,7 @@ impl EthSpec for GnosisEthSpec {
     type BytesPerBlob = U131072;
     type KzgCommitmentInclusionProofDepth = U17;
     // DAS spec values copied from `MainnetEthSpec`
+    type MinCustodyRequirement = U1;
     type DataColumnSubnetCount = U32;
     type DataColumnCount = U128;
     type MaxBytesPerColumn = U65536;


### PR DESCRIPTION
## Issue Addressed

#4983

## Proposed Changes

* add `custody_subnet_count` field to ENR as defined in EIP-7594 (i.e. peerdas)
* add ENR subnet predicate for data column subnet
* add functions to `DataColumnSubnetId` to compute custody obligations
* add minimum custody requirement to `EthSpec`

## Additional Info

target `das` branch