### PR TITLE
fix: update data col subnet count from 64 to 32

### DIFF
--- a/consensus/types/src/data_column_subnet_id.rs
+++ b/consensus/types/src/data_column_subnet_id.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 use std::ops::{Deref, DerefMut};
 
-const DATA_COLUMN_SUBNET_COUNT: u64 = 64;
+const DATA_COLUMN_SUBNET_COUNT: u64 = 32;
 
 lazy_static! {
     static ref DATA_COLUMN_SUBNET_ID_TO_STRING: Vec<String> = {


### PR DESCRIPTION
## Issue Addressed

#4983

## Proposed Changes

update data column subnet count constant from 64 to 32 as currently specified in the EIP-7594 (i.e. peerdas) spec PR.

## Additional Info

target `das` branch