### PR TITLE
Dedup parent blob requests

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -217,7 +217,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         // Make sure this block is not already downloaded, and that neither it or its parent is
         // being searched for.
         if let Some(parent_lookup) = self.parent_lookups.iter_mut().find(|parent_req| {
-            parent_req.contains_block(&block_root) || parent_req.is_for_block(block_root)
+            parent_req.contains_block(&parent_root) || parent_req.is_for_block(parent_root)
         }) {
             parent_lookup.add_peer(peer_id);
             // we are already searching for this block, ignore it

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -2112,6 +2112,7 @@ mod deneb_only {
             .expect_no_blobs_request()
             .expect_no_block_request();
     }
+
     #[test]
     fn unknown_parent_blob_dup() {
         let Some(tester) =

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1625,6 +1625,16 @@ mod deneb_only {
             self.rig.expect_block_process(ResponseType::Block);
             self
         }
+        fn search_parent_dup(mut self) -> Self {
+            self.bl.search_parent(
+                self.slot,
+                self.block_root,
+                self.block.parent_root(),
+                self.peer_id,
+                &mut self.cx,
+            );
+            self
+        }
     }
 
     fn get_fork_name() -> ForkName {
@@ -2087,5 +2097,32 @@ mod deneb_only {
             .parent_blob_response()
             .expect_no_penalty()
             .expect_block_process();
+    }
+
+    #[test]
+    fn unknown_parent_block_dup() {
+        let Some(tester) =
+            DenebTester::new(RequestTrigger::GossipUnknownParentBlock { num_parents: 1 })
+        else {
+            return;
+        };
+
+        tester
+            .search_parent_dup()
+            .expect_no_blobs_request()
+            .expect_no_block_request();
+    }
+    #[test]
+    fn unknown_parent_blob_dup() {
+        let Some(tester) =
+            DenebTester::new(RequestTrigger::GossipUnknownParentBlob { num_parents: 1 })
+        else {
+            return;
+        };
+
+        tester
+            .search_parent_dup()
+            .expect_no_blobs_request()
+            .expect_no_block_request();
     }
 }


### PR DESCRIPTION
## Issue Addressed

Right now we're de-duplicating parent lookup blob requests based on the current block root when we should be de-duplicating the based on the parent block root
