### PR TITLE
Set default builder_boost_factor to 90

### DIFF
--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -130,7 +130,7 @@ impl Default for Config {
             validator_registration_batch_size: 500,
             enable_web3signer_slashing_protection: true,
             produce_block_v3: false,
-            builder_boost_factor: 90,
+            builder_boost_factor: Some(90),
             prefer_builder_proposals: false,
             distributed: false,
             web3_signer_keep_alive_timeout: Some(Duration::from_secs(90)),

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -130,7 +130,7 @@ impl Default for Config {
             validator_registration_batch_size: 500,
             enable_web3signer_slashing_protection: true,
             produce_block_v3: false,
-            builder_boost_factor: None,
+            builder_boost_factor: 90,
             prefer_builder_proposals: false,
             distributed: false,
             web3_signer_keep_alive_timeout: Some(Duration::from_secs(90)),


### PR DESCRIPTION
## Proposed Changes

## PR Description

In order to help increase censorship resistance, I propose to change the default builder_boost_factor to 90. This means validators will prioritize local block building unless the bid from the external block builder is 10% or higher than what the validator would receive when building locally.

Looking at ([stats](https://censorship.pics/)), it can be seen that currently 63.7% of external builders are censoring transactions compared to 8.53% of validators who do local block building, so setting a minimum 10% as default can help increase the overall censorship resistance of the network.

It is still easy for users to opt out of this by manually setting the flag to 100, but many are likely to use the default which could help with censorship resistance for the network.

## Documentation

- [X] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [X] I thought about adding a changelog entry, and added one if I deemed necessary.
