### PR TITLE
DAS subnet service

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -23,6 +23,7 @@ use crate::chain_config::ChainConfig;
 use crate::data_availability_checker::{
     Availability, AvailabilityCheckError, AvailableBlock, DataAvailabilityChecker,
 };
+use crate::data_column_custody_tracker::DataColumnCustodyTracker;
 use crate::data_column_verification::{GossipDataColumnError, GossipVerifiedDataColumn};
 use crate::early_attester_cache::EarlyAttesterCache;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
@@ -471,6 +472,8 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub light_client_server_cache: LightClientServerCache<T>,
     /// Sender to signal the light_client server to produce new updates
     pub light_client_server_tx: Option<Sender<LightClientProducerEvent<T::EthSpec>>>,
+    /// Used to keep track of column custody requirements for a given epoch
+    pub data_column_custody_tracker: Arc<DataColumnCustodyTracker>,
     /// Sender given to tasks, so that if they encounter a state in which execution cannot
     /// continue they can request that everything shuts down.
     pub shutdown_sender: Sender<ShutdownReason>,

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -974,6 +974,7 @@ where
             early_attester_cache: <_>::default(),
             light_client_server_cache: LightClientServerCache::new(),
             light_client_server_tx: self.light_client_server_tx,
+            data_column_custody_tracker: <_>::default(),
             shutdown_sender: self
                 .shutdown_sender
                 .ok_or("Cannot build without a shutdown sender.")?,

--- a/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
+++ b/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
@@ -1,0 +1,26 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use types::Epoch;
+
+/// Maintains a list of data column custody requirements for a given epoch.
+///
+/// Each time the node transitions to a new epoch, `register_epoch` must be called to populate
+/// custody requirements for the new epoch.
+#[derive(Default, Debug)]
+pub struct DataColumnCustodyTracker(pub RwLock<HashMap<Epoch, Vec<u64>>>);
+
+impl DataColumnCustodyTracker {
+    pub fn register_epoch(&self, epoch: Epoch, data_column_ids: Vec<u64>) {
+        let mut map = self.0.write();
+        map.insert(epoch, data_column_ids);
+    }
+
+    pub fn custody_requirements_for_epoch(&self, epoch: &Epoch) -> Option<Vec<u64>> {
+        self.0.read().get(epoch).cloned()
+    }
+
+    pub fn prune_epoch(&self, epoch: &Epoch) {
+        let mut map = self.0.write();
+        map.remove(epoch);
+    }
+}

--- a/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
+++ b/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
@@ -1,26 +1,21 @@
 use parking_lot::RwLock;
-use std::collections::HashMap;
-use types::Epoch;
 
-/// Maintains a list of data column custody requirements for a given epoch.
+/// Maintains a list of data column custody requirements.
 ///
-/// Each time the node transitions to a new epoch, `register_epoch` must be called to populate
-/// custody requirements for the new epoch.
+/// Each time the node transitions to a new set of data column subnets, `set_custody_requirements` must be called to populate
+/// custody requirements.
 #[derive(Default, Debug)]
-pub struct DataColumnCustodyTracker(pub RwLock<HashMap<Epoch, Vec<u64>>>);
+pub struct DataColumnCustodyTracker {
+    data_column_ids: RwLock<Vec<u64>>,
+}
 
 impl DataColumnCustodyTracker {
-    pub fn register_epoch(&self, epoch: Epoch, data_column_ids: Vec<u64>) {
-        let mut map = self.0.write();
-        map.insert(epoch, data_column_ids);
+    pub fn set_custody_requirements(&self, data_column_ids: Vec<u64>) {
+        let mut write_guard = self.data_column_ids.write();
+        *write_guard = data_column_ids;
     }
 
-    pub fn custody_requirements_for_epoch(&self, epoch: &Epoch) -> Option<Vec<u64>> {
-        self.0.read().get(epoch).cloned()
-    }
-
-    pub fn prune_epoch(&self, epoch: &Epoch) {
-        let mut map = self.0.write();
-        map.remove(epoch);
+    pub fn get_custody_requirements(&self) -> Vec<u64> {
+        self.data_column_ids.read().clone()
     }
 }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -18,6 +18,7 @@ pub mod canonical_head;
 pub mod capella_readiness;
 pub mod chain_config;
 pub mod data_availability_checker;
+pub mod data_column_custody_tracker;
 pub mod data_column_verification;
 pub mod deneb_readiness;
 mod early_attester_cache;

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -336,7 +336,6 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         let data_column_service = DataColumnService::new(
             beacon_chain.clone(),
             network_globals.clone(),
-            &beacon_chain.spec,
             &network_log,
         );
 

--- a/beacon_node/network/src/subnet_service/data_column_subnets.rs
+++ b/beacon_node/network/src/subnet_service/data_column_subnets.rs
@@ -1,0 +1,252 @@
+//! This service keeps track of which data column subnets the beacon node should be subscribed to at any
+//! given time. It schedules subscriptions to data column subnets and requests peer discoveries.
+
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    time::Duration,
+};
+
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use delay_map::HashSetDelay;
+use lighthouse_network::{NetworkGlobals, Subnet, SubnetDiscovery};
+use slog::{debug, o, trace, warn};
+use slot_clock::SlotClock;
+use types::{DataColumnSubnetId, Epoch, EthSpec};
+
+use super::SubnetServiceMessage;
+
+// The minimum number of slots ahead that we attempt to discover peers for a subscription. If the
+/// slot is less than this number, skip the peer discovery process.
+/// Subnet discovery query takes at most 30 secs, 2 slots take 24s.
+const MIN_PEER_DISCOVERY_SLOT_LOOK_AHEAD: u64 = 2;
+
+/// A particular subnet at a given slot.
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
+pub struct ExactSubnet {
+    /// The `DataColumnSubnetId` associated with this subnet.
+    pub data_column_subnet_id: DataColumnSubnetId,
+    /// The epoch until which we need to stay subscribed to the subnet.
+    pub until_epoch: Epoch,
+}
+
+pub struct DataColumnService<T: BeaconChainTypes> {
+    /// Queued events to return to the driving service.
+    events: VecDeque<SubnetServiceMessage>,
+
+    /// A reference to the beacon chain to process data columns.
+    pub(crate) beacon_chain: Arc<BeaconChain<T>>,
+
+    /// A reference to the nodes network globals
+    network_globals: Arc<NetworkGlobals<T::EthSpec>>,
+
+    /// The collection of all currently subscribed data column subnets by epoch.
+    subscriptions: HashMap<DataColumnSubnetId, Epoch>,
+
+    /// A collection of timeouts for when to unsubscribe from a subnet.
+    unsubscriptions: HashSetDelay<DataColumnSubnetId>,
+
+    /// The logger for the data column service.
+    log: slog::Logger,
+}
+
+impl<T: BeaconChainTypes> DataColumnService<T> {
+    pub fn new(
+        beacon_chain: Arc<BeaconChain<T>>,
+        network_globals: Arc<NetworkGlobals<T::EthSpec>>,
+        log: &slog::Logger,
+    ) -> Self {
+        let log = log.new(o!("service" => "data_column_service"));
+        let spec = &beacon_chain.spec;
+        let epoch_duration_secs =
+            beacon_chain.slot_clock.slot_duration().as_secs() * T::EthSpec::slots_per_epoch();
+        let default_timeout =
+            epoch_duration_secs.saturating_mul(spec.epochs_per_sync_committee_period.as_u64());
+
+        Self {
+            events: VecDeque::with_capacity(10),
+            beacon_chain,
+            network_globals,
+            subscriptions: HashMap::new(),
+            unsubscriptions: HashSetDelay::new(Duration::from_secs(default_timeout)),
+            log,
+        }
+    }
+
+    /// Process data column subscriptions for a given epoch
+    /// This will
+    /// - calculate the nodes data column custody requirements based on the epoch.
+    /// - search for peers for the required subnets.
+    /// - request data columns from the required subnets.
+    pub fn data_column_subscriptions(&mut self, epoch: Epoch) {
+        let local_enr = self.network_globals.local_enr();
+
+        // TODO(das) the data columns returned here should be a function of epoch
+        // and local enr/node id
+        let data_column_subnet_ids: Vec<DataColumnSubnetId> = vec![];
+        let mut subnets_to_discover = Vec::new();
+
+        // TODO(das) write column subscription requirements to the beacon chain
+
+        for data_column_subnet_id in data_column_subnet_ids {
+            // TODO(das) update required metrics values
+            trace!(self.log,
+                "data column subscription";
+                "data_column_subnet_id" => ?data_column_subnet_id,
+            );
+
+            let exact_subnet = ExactSubnet {
+                data_column_subnet_id,
+                until_epoch: epoch,
+            };
+
+            subnets_to_discover.push(exact_subnet);
+        }
+
+        // TODO(das) finish this implementation
+    }
+
+    fn discover_peers_request<'a>(
+        &mut self,
+        exact_subnets: impl Iterator<Item = &'a ExactSubnet>,
+    ) -> Result<(), &'static str> {
+        let current_slot = self
+            .beacon_chain
+            .slot_clock
+            .now()
+            .ok_or("Could not get the current slot")?;
+
+        let slots_per_epoch = T::EthSpec::slots_per_epoch();
+
+        let discovery_subnets: Vec<SubnetDiscovery> = exact_subnets
+            .filter_map(|exact_subnet| {
+                let until_slot = exact_subnet.until_epoch.end_slot(slots_per_epoch);
+                // check if there is enough time to perform a discovery lookup
+                if until_slot >= current_slot.saturating_add(MIN_PEER_DISCOVERY_SLOT_LOOK_AHEAD) {
+                    // if the slot is more than epoch away, add an event to start looking for peers
+                    // add one slot to ensure we keep the peer for the subscription slot
+                    let min_ttl = self
+                        .beacon_chain
+                        .slot_clock
+                        .duration_to_slot(until_slot + 1)
+                        .map(|duration| std::time::Instant::now() + duration);
+                    Some(SubnetDiscovery {
+                        subnet: Subnet::DataColumn(exact_subnet.data_column_subnet_id),
+                        min_ttl,
+                    })
+                } else {
+                    // We may want to check the global PeerInfo to see estimated timeouts for each
+                    // peer before they can be removed.
+                    warn!(self.log,
+                        "Not enough time for a discovery search";
+                        "subnet_id" => ?exact_subnet
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        if !discovery_subnets.is_empty() {
+            self.events
+                .push_back(SubnetServiceMessage::DiscoverPeers(discovery_subnets));
+        }
+
+        Ok(())
+    }
+
+    fn subscribe_to_subnet(&mut self, exact_subnet: ExactSubnet) -> Result<(), &'static str> {
+        // Return if we already have a subscription for exact_subnet
+        if self.subscriptions.get(&exact_subnet.data_column_subnet_id)
+            == Some(&exact_subnet.until_epoch)
+        {
+            return Ok(());
+        }
+
+        // Return if we already have subscription set to expire later than the current request.
+        if let Some(until_epoch) = self.subscriptions.get(&exact_subnet.data_column_subnet_id) {
+            if *until_epoch >= exact_subnet.until_epoch {
+                return Ok(());
+            }
+        }
+
+        // initialize timing variables
+        let current_slot = self
+            .beacon_chain
+            .slot_clock
+            .now()
+            .ok_or("Could not get the current slot")?;
+
+        let slots_per_epoch = T::EthSpec::slots_per_epoch();
+        let until_slot = exact_subnet.until_epoch.end_slot(slots_per_epoch);
+        // Calculate the duration to the un-subscription event.
+        let expected_end_subscription_duration = if current_slot >= until_slot {
+            warn!(
+                self.log,
+                "data column subscription is past expiration";
+                "current_slot" => current_slot,
+                "exact_subnet" => ?exact_subnet,
+            );
+            return Ok(());
+        } else {
+            let slot_duration = self.beacon_chain.slot_clock.slot_duration();
+
+            // the duration until we no longer need this subscription. We assume a single slot is
+            // sufficient.
+            self.beacon_chain
+                .slot_clock
+                .duration_to_slot(until_slot)
+                .ok_or("Unable to determine duration to un-subscription slot")?
+                + slot_duration
+        };
+
+        if !self
+            .subscriptions
+            .contains_key(&exact_subnet.data_column_subnet_id)
+        {
+            self.subscriptions.insert(
+                exact_subnet.data_column_subnet_id.clone(),
+                exact_subnet.until_epoch.clone(),
+            );
+            self.events
+                .push_back(SubnetServiceMessage::Subscribe(Subnet::DataColumn(
+                    exact_subnet.data_column_subnet_id,
+                )));
+
+            // add the subnet to the ENR bitfield
+            self.events
+                .push_back(SubnetServiceMessage::EnrAdd(Subnet::DataColumn(
+                    exact_subnet.data_column_subnet_id,
+                )));
+
+            // add an unsubscription event to remove ourselves from the subnet once completed
+            self.unsubscriptions.insert_at(
+                exact_subnet.data_column_subnet_id,
+                expected_end_subscription_duration,
+            );
+        } else {
+            // We are already subscribed, extend the unsubscription duration
+            self.unsubscriptions.update_timeout(
+                &exact_subnet.data_column_subnet_id,
+                expected_end_subscription_duration,
+            );
+        }
+
+        return Ok(());
+    }
+
+    /// A queued unsubscription is ready.
+    fn handle_unsubscriptions(&mut self, data_column_subnet_id: DataColumnSubnetId) {
+        debug!(self.log, "Unsubscribing from subnet"; "subnet" => *data_column_subnet_id);
+
+        self.subscriptions.remove(&data_column_subnet_id);
+        self.events
+            .push_back(SubnetServiceMessage::Unsubscribe(Subnet::DataColumn(
+                data_column_subnet_id,
+            )));
+
+        self.events
+            .push_back(SubnetServiceMessage::EnrRemove(Subnet::DataColumn(
+                data_column_subnet_id,
+            )));
+    }
+}

--- a/beacon_node/network/src/subnet_service/data_column_subnets.rs
+++ b/beacon_node/network/src/subnet_service/data_column_subnets.rs
@@ -107,8 +107,7 @@ impl<T: BeaconChainTypes> DataColumnService<T> {
                 current_epoch,
                 &self.beacon_chain.spec,
             )
-            .unwrap();
-        //.map_or(|_| error!(self.log, "Failed to compute subnets"))?;
+            .map_err(|_| error!(self.log, "Failed to compute subnets"))?;
 
         let next_subscription_slot =
             next_subscription_epoch.start_slot(T::EthSpec::slots_per_epoch());
@@ -195,6 +194,7 @@ impl<T: BeaconChainTypes> DataColumnService<T> {
 
         let slots_per_epoch = T::EthSpec::slots_per_epoch();
 
+        // TODO(das) discovery logic needs to be updated to match das requirements
         let discovery_subnets: Vec<SubnetDiscovery> = exact_subnets
             .filter_map(|exact_subnet| {
                 let until_slot = exact_subnet.until_epoch.end_slot(slots_per_epoch);

--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -1,4 +1,5 @@
 pub mod attestation_subnets;
+pub mod data_column_subnets;
 pub mod sync_subnets;
 
 use lighthouse_network::{Subnet, SubnetDiscovery};


### PR DESCRIPTION
## DAS subnet service

This PR adds a new service, `DataColumnService` that handles
- Rotating data column subnet subscriptions at epoch boundaries
- Initiating peer discovery requests for newly subscribed subnets
- Sharing data column custody requirement info with the beacon chain
- Initiating ENR update requests after subnet subscription changes

The `DataColumnService` is initialized as part of the `NetworkService`. At initialization the `next_subscription_event` field is set to trigger one second in the future. Theres a `Stream` implementation of `DataColumnService` that polls for upcoming `next_subscription_event`

When a new `next_subscripiton_event` is ready, `recompute_subnets` is called. `recompute_subnets` does the following

- Ensures the `next_subscription_event` is scheduled. In the success case `next_subscription_event` is scheduled for the next epoch. In the failure case, it is scheduled for the next slot
- computes the nodes required data column subnets for for the current epoch 
- rotate data column subscriptions. The previous epochs data columns are unsubscribed from, while the current epochs data columns are subscribed to. 
- share the data column custody requirement info with the Beacon Chain via the `data_column_custody_tracker` field.
- initiate peer discover requests for the newly subscribed subnets
- initiate enr changes based on data column subnet subscription changes