### PR TITLE
Dump cached child

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -8,7 +8,7 @@ use crate::sync::block_lookups::{
 use crate::sync::manager::{BlockProcessType, Id, SingleLookupReqId};
 use crate::sync::network_context::SyncNetworkContext;
 use beacon_chain::block_verification_types::RpcBlock;
-use beacon_chain::data_availability_checker::{AvailabilityView, ChildComponents};
+
 use beacon_chain::{get_block_root, BeaconChainTypes};
 use lighthouse_network::rpc::methods::BlobsByRootRequest;
 use lighthouse_network::rpc::BlocksByRootRequest;

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -206,13 +206,6 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     /// the blob parent if we don't end up getting any blobs in the response.
     fn get_parent_root(verified_response: &Self::VerifiedResponseType) -> Option<Hash256>;
 
-    /// Caches the verified response in the lookup if necessary. This is only necessary for lookups
-    /// triggered by `UnknownParent` errors.
-    fn add_to_child_components(
-        verified_response: Self::VerifiedResponseType,
-        components: &mut ChildComponents<T::EthSpec>,
-    );
-
     /// Convert a verified response to the type we send to the beacon processor.
     fn verified_to_reconstructed(
         block_root: Hash256,
@@ -301,13 +294,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L>
 
     fn get_parent_root(verified_response: &Arc<SignedBeaconBlock<T::EthSpec>>) -> Option<Hash256> {
         Some(verified_response.parent_root())
-    }
-
-    fn add_to_child_components(
-        verified_response: Arc<SignedBeaconBlock<T::EthSpec>>,
-        components: &mut ChildComponents<T::EthSpec>,
-    ) {
-        components.merge_block(verified_response);
     }
 
     fn verified_to_reconstructed(
@@ -407,13 +393,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
             .filter_map(|blob| blob.as_ref())
             .map(|blob| blob.block_parent_root())
             .next()
-    }
-
-    fn add_to_child_components(
-        verified_response: FixedBlobSidecarList<T::EthSpec>,
-        components: &mut ChildComponents<T::EthSpec>,
-    ) {
-        components.merge_blobs(verified_response);
     }
 
     fn verified_to_reconstructed(

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -5,16 +5,16 @@ use super::BatchProcessResult;
 use super::{manager::BlockProcessType, network_context::SyncNetworkContext};
 use crate::metrics;
 use crate::network_beacon_processor::ChainSegmentProcessId;
-use crate::sync::block_lookups::common::LookupType;
+
 use crate::sync::block_lookups::parent_lookup::{ParentLookup, RequestError};
 use crate::sync::block_lookups::single_block_lookup::LookupRequestError;
 use crate::sync::manager::{Id, SingleLookupReqId};
 use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
-pub use beacon_chain::data_availability_checker::ChildComponents;
+
 use beacon_chain::data_availability_checker::{
     AvailabilityCheckErrorCategory, DataAvailabilityChecker,
 };
-use beacon_chain::validator_monitor::timestamp_now;
+
 use beacon_chain::{AvailabilityProcessingStatus, BeaconChainTypes, BlockError};
 pub use common::Current;
 pub use common::Lookup;
@@ -27,7 +27,7 @@ use lru_cache::LRUTimeCache;
 pub use single_block_lookup::{BlobRequestState, BlockRequestState};
 use slog::{debug, error, trace, warn, Logger};
 use smallvec::SmallVec;
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use store::Hash256;
@@ -159,7 +159,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
         debug!(
             self.log,
-            "{}", todo!();
+            "Searching for block components";
             "peer_ids" => ?peers,
             "block" => ?block_root,
         );

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -63,13 +63,8 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         da_checker: Arc<DataAvailabilityChecker<T>>,
         cx: &mut SyncNetworkContext<T>,
     ) -> Self {
-        let current_parent_request = SingleBlockLookup::new(
-            parent_root,
-            Some(ChildComponents::empty(block_root)),
-            &[peer_id],
-            da_checker,
-            cx.next_id(),
-        );
+        let current_parent_request =
+            SingleBlockLookup::new(parent_root, &[peer_id], da_checker, cx.next_id());
 
         Self {
             chain_hash: block_root,
@@ -177,10 +172,6 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             .blob_request_state
             .state
             .register_failure_processing();
-        if let Some(components) = self.current_parent_request.child_components.as_mut() {
-            components.downloaded_block = None;
-            components.downloaded_blobs = <_>::default();
-        }
     }
 
     /// Verifies that the received block is what we requested. If so, parent lookup now waits for

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -5,7 +5,7 @@ use crate::sync::block_lookups::common::RequestState;
 use crate::sync::{manager::SLOT_IMPORT_TOLERANCE, network_context::SyncNetworkContext};
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::block_verification_types::RpcBlock;
-use beacon_chain::data_availability_checker::{ChildComponents, DataAvailabilityChecker};
+use beacon_chain::data_availability_checker::{DataAvailabilityChecker};
 use beacon_chain::BeaconChainTypes;
 use itertools::Itertools;
 use std::collections::VecDeque;

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -3,7 +3,7 @@ use crate::sync::block_lookups::common::{Lookup, RequestState};
 use crate::sync::block_lookups::Id;
 use crate::sync::network_context::SyncNetworkContext;
 use beacon_chain::data_availability_checker::{
-    AvailabilityCheckError, DataAvailabilityChecker, MissingBlobs,
+    DataAvailabilityChecker, MissingBlobs,
 };
 use beacon_chain::BeaconChainTypes;
 use lighthouse_network::PeerAction;

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1245,7 +1245,7 @@ mod deneb_only {
                         (Some(block_req_id), Some(blob_req_id), None, None)
                     }
                     RequestTrigger::GossipUnknownParentBlock { .. } => {
-                        bl.search_child_block(
+                        bl.search_block(
                             block_root,
                             ChildComponents::new(block_root, Some(block.clone()), None),
                             &[peer_id],
@@ -1270,7 +1270,7 @@ mod deneb_only {
 
                         let mut lookup_blobs = FixedBlobSidecarList::default();
                         *lookup_blobs.index_mut(0) = Some(single_blob);
-                        bl.search_child_block(
+                        bl.search_block(
                             child_root,
                             ChildComponents::new(child_root, None, Some(lookup_blobs)),
                             &[peer_id],

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1245,12 +1245,7 @@ mod deneb_only {
                         (Some(block_req_id), Some(blob_req_id), None, None)
                     }
                     RequestTrigger::GossipUnknownParentBlock { .. } => {
-                        bl.search_block(
-                            block_root,
-                            ChildComponents::new(block_root, Some(block.clone()), None),
-                            &[peer_id],
-                            &mut cx,
-                        );
+                        bl.search_block(block_root, &[peer_id], &mut cx);
 
                         let blob_req_id = rig.expect_lookup_request(ResponseType::Blob);
                         rig.expect_empty_network(); // expect no block request
@@ -1270,12 +1265,7 @@ mod deneb_only {
 
                         let mut lookup_blobs = FixedBlobSidecarList::default();
                         *lookup_blobs.index_mut(0) = Some(single_blob);
-                        bl.search_block(
-                            child_root,
-                            ChildComponents::new(child_root, None, Some(lookup_blobs)),
-                            &[peer_id],
-                            &mut cx,
-                        );
+                        bl.search_block(child_root, &[peer_id], &mut cx);
 
                         let block_req_id = rig.expect_lookup_request(ResponseType::Block);
                         let blobs_req_id = rig.expect_lookup_request(ResponseType::Blob);

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -47,7 +47,7 @@ use crate::sync::network_context::BlocksAndBlobsByRangeRequest;
 use crate::sync::range_sync::ByRangeRequestType;
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::block_verification_types::RpcBlock;
-use beacon_chain::data_availability_checker::ChildComponents;
+
 use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChain, BeaconChainTypes, BlockError, EngineState,
 };


### PR DESCRIPTION
## Issue Addressed

Currently, when we get an `UnknownParent` request, we send up to 4 separate requests immediately:
1. Parent block
2. Parent blob
3. Current block (if triggered by gossip blob)
4. Current blobs

We trigger all at once, but in the event that a parent request returns another `UnknownParent`, we need to keep track of the current requests.  We want to cache responses to current blobs so they aren't processed first (this would lead to a duplicate `UnknownParent`. This lead to the development of  `CachedChild` and `ChildComponents`. 

@dapplion suggested just getting rid of the current requests (3 and 4 above), and allow us to store a potentially unavailable current block/blobs without current requests until all parents are processed. Then when we attempt to process the current block/blobs, we'll get a `MissingComponent` triggering a normal single block/blobs lookup. 

This would cause the parent lookup process to be slower overall, but it would reduce complexity substantially. It would make it easier to reason about the changes required for DAS. In the context of DA sampling, we might even require a system where we first download the chain of parents and ensure they are a part of our chain, then process them forwards, sampling as we process each. We need to process blocks to even determine which nodes to sample to check for availability.