### PR TITLE
Use hashset to filter validators ids in http_api

### DIFF
--- a/beacon_node/http_api/src/validators.rs
+++ b/beacon_node/http_api/src/validators.rs
@@ -19,7 +19,7 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
                 let epoch = state.current_epoch();
                 let far_future_epoch = chain.spec.far_future_epoch;
                 let ids_filter_set: Option<HashSet<&ValidatorId>> =
-                    query_ids.as_ref().map(|f| HashSet::from_iter(f));
+                    query_ids.as_ref().map(HashSet::from_iter);
 
                 Ok((
                     state

--- a/beacon_node/http_api/src/validators.rs
+++ b/beacon_node/http_api/src/validators.rs
@@ -4,7 +4,7 @@ use eth2::types::{
     self as api_types, ExecutionOptimisticFinalizedResponse, ValidatorBalanceData, ValidatorData,
     ValidatorId, ValidatorStatus,
 };
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 pub fn get_beacon_state_validators<T: BeaconChainTypes>(
     state_id: StateId,
@@ -18,6 +18,8 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
             |state, execution_optimistic, finalized| {
                 let epoch = state.current_epoch();
                 let far_future_epoch = chain.spec.far_future_epoch;
+                let ids_filter_set: Option<HashSet<&ValidatorId>> =
+                    query_ids.as_ref().map(|f| HashSet::from_iter(f));
 
                 Ok((
                     state
@@ -27,13 +29,9 @@ pub fn get_beacon_state_validators<T: BeaconChainTypes>(
                         .enumerate()
                         // filter by validator id(s) if provided
                         .filter(|(index, (validator, _))| {
-                            query_ids.as_ref().map_or(true, |ids| {
-                                ids.iter().any(|id| match id {
-                                    ValidatorId::PublicKey(pubkey) => &validator.pubkey == pubkey,
-                                    ValidatorId::Index(param_index) => {
-                                        *param_index == *index as u64
-                                    }
-                                })
+                            ids_filter_set.as_ref().map_or(true, |ids_set| {
+                                ids_set.contains(&ValidatorId::PublicKey(validator.pubkey))
+                                    || ids_set.contains(&ValidatorId::Index(*index as u64))
                             })
                         })
                         // filter by status(es) if provided and map the result
@@ -83,6 +81,9 @@ pub fn get_beacon_state_validator_balances<T: BeaconChainTypes>(
         .map_state_and_execution_optimistic_and_finalized(
             &chain,
             |state, execution_optimistic, finalized| {
+                let ids_filter_set: Option<HashSet<&ValidatorId>> =
+                    optional_ids.map(|f| HashSet::from_iter(f.iter()));
+
                 Ok((
                     state
                         .validators()
@@ -91,13 +92,9 @@ pub fn get_beacon_state_validator_balances<T: BeaconChainTypes>(
                         .enumerate()
                         // filter by validator id(s) if provided
                         .filter(|(index, (validator, _))| {
-                            optional_ids.map_or(true, |ids| {
-                                ids.iter().any(|id| match id {
-                                    ValidatorId::PublicKey(pubkey) => &validator.pubkey == pubkey,
-                                    ValidatorId::Index(param_index) => {
-                                        *param_index == *index as u64
-                                    }
-                                })
+                            ids_filter_set.as_ref().map_or(true, |ids_set| {
+                                ids_set.contains(&ValidatorId::PublicKey(validator.pubkey))
+                                    || ids_set.contains(&ValidatorId::Index(*index as u64))
                             })
                         })
                         .map(|(index, (_, balance))| ValidatorBalanceData {

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -281,7 +281,7 @@ pub struct FinalityCheckpointsData {
     pub finalized: Checkpoint,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(into = "String")]
 #[serde(try_from = "std::borrow::Cow<str>")]
 pub enum ValidatorId {


### PR DESCRIPTION
## Issue Addressed

When requesting validators or validators balances via the http api, the endpoint filters the state validators by iterating over the input array for each state validator.
This causes a noticeable slowdown when passing a few thousand IDs in the query filter (from 2s to 12+ when passing 8k IDs).

## Proposed Changes

Use a `std::collections::HashSet` to know if a validator ID/pubkey has to be included in the response instead of iterating over the array, doing at most 2 HashSet lookups per state validator.