### PR TITLE
DAS data column custody tracker

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -23,6 +23,7 @@ use crate::chain_config::ChainConfig;
 use crate::data_availability_checker::{
     Availability, AvailabilityCheckError, AvailableBlock, DataAvailabilityChecker,
 };
+use crate::data_column_custody_tracker::DataColumnCustodyTracker;
 use crate::data_column_verification::{GossipDataColumnError, GossipVerifiedDataColumn};
 use crate::early_attester_cache::EarlyAttesterCache;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
@@ -471,6 +472,8 @@ pub struct BeaconChain<T: BeaconChainTypes> {
     pub light_client_server_cache: LightClientServerCache<T>,
     /// Sender to signal the light_client server to produce new updates
     pub light_client_server_tx: Option<Sender<LightClientProducerEvent<T::EthSpec>>>,
+    /// Used to keep track of column custody requirements for a given epoch
+    pub data_column_custody_tracker: Arc<DataColumnCustodyTracker>,
     /// Sender given to tasks, so that if they encounter a state in which execution cannot
     /// continue they can request that everything shuts down.
     pub shutdown_sender: Sender<ShutdownReason>,

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -974,6 +974,7 @@ where
             early_attester_cache: <_>::default(),
             light_client_server_cache: LightClientServerCache::new(),
             light_client_server_tx: self.light_client_server_tx,
+            data_column_custody_tracker: <_>::default(),
             shutdown_sender: self
                 .shutdown_sender
                 .ok_or("Cannot build without a shutdown sender.")?,

--- a/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
+++ b/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
@@ -1,0 +1,32 @@
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use types::Epoch;
+
+/// Maintains a list of data column custody requirements for a given epoch.
+///
+/// Each time the node transitions to a new epoch, `register_epoch` must be called to populate
+/// custody requirements for the new epoch.
+#[derive(Default, Debug)]
+pub struct DataColumnCustodyTracker(pub RwLock<HashMap<Epoch, Vec<u64>>>);
+
+impl DataColumnCustodyTracker {
+    pub fn register_epoch(&self, epoch: Epoch, data_column_ids: Vec<u64>) {
+        let mut map = self.0.write();
+        map.insert(epoch, data_column_ids);
+    }
+
+    // TODO(das) for now this just returns a value in the map, future iterations will
+    // return a value based on the provided epoch
+    pub fn custody_requirements_for_epoch(&self, _epoch: &Epoch) -> Option<Vec<u64>> {
+        if let Some((_, value)) = self.0.read().iter().next() {
+            Some(value.clone())
+        } else {
+            Some(vec![1, 2])
+        }
+    }
+
+    pub fn prune_epoch(&self, epoch: &Epoch) {
+        let mut map = self.0.write();
+        map.remove(epoch);
+    }
+}

--- a/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
+++ b/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
@@ -1,6 +1,4 @@
 use parking_lot::RwLock;
-use std::collections::HashMap;
-use types::Epoch;
 
 /// Maintains a list of data column custody requirements for a given epoch.
 ///

--- a/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
+++ b/beacon_node/beacon_chain/src/data_column_custody_tracker.rs
@@ -7,26 +7,17 @@ use types::Epoch;
 /// Each time the node transitions to a new epoch, `register_epoch` must be called to populate
 /// custody requirements for the new epoch.
 #[derive(Default, Debug)]
-pub struct DataColumnCustodyTracker(pub RwLock<HashMap<Epoch, Vec<u64>>>);
+pub struct DataColumnCustodyTracker {
+    data_column_ids: RwLock<Vec<u64>>,
+}
 
 impl DataColumnCustodyTracker {
-    pub fn register_epoch(&self, epoch: Epoch, data_column_ids: Vec<u64>) {
-        let mut map = self.0.write();
-        map.insert(epoch, data_column_ids);
+    pub fn set_custody_requirements(&self, data_column_ids: Vec<u64>) {
+        let mut write_guard = self.data_column_ids.write();
+        *write_guard = data_column_ids;
     }
 
-    // TODO(das) for now this just returns a value in the map, future iterations will
-    // return a value based on the provided epoch
-    pub fn custody_requirements_for_epoch(&self, _epoch: &Epoch) -> Option<Vec<u64>> {
-        if let Some((_, value)) = self.0.read().iter().next() {
-            Some(value.clone())
-        } else {
-            Some(vec![1, 2])
-        }
-    }
-
-    pub fn prune_epoch(&self, epoch: &Epoch) {
-        let mut map = self.0.write();
-        map.remove(epoch);
+    pub fn get_custody_requirements(&self) -> Vec<u64> {
+        self.data_column_ids.read().clone()
     }
 }

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -18,6 +18,7 @@ pub mod canonical_head;
 pub mod capella_readiness;
 pub mod chain_config;
 pub mod data_availability_checker;
+pub mod data_column_custody_tracker;
 pub mod data_column_verification;
 pub mod deneb_readiness;
 mod early_attester_cache;

--- a/beacon_node/network/src/subnet_service/data_column_subnets.rs
+++ b/beacon_node/network/src/subnet_service/data_column_subnets.rs
@@ -1,0 +1,59 @@
+//! This service keeps track of which data column subnets the beacon node should be subscribed to at any
+//! given time. It schedules subscriptions to data column subnets and requests peer discoveries.
+
+use itertools::Itertools;
+use std::sync::Arc;
+
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use lighthouse_network::{discovery::peer_id_to_node_id, NetworkGlobals};
+use slog::o;
+use types::{DataColumnSubnetId,EthSpec};
+
+
+pub struct DataColumnService<T: BeaconChainTypes> {
+    /// A reference to the beacon chain to process data columns.
+    pub(crate) _beacon_chain: Arc<BeaconChain<T>>,
+
+    /// A reference to the nodes network globals
+    _network_globals: Arc<NetworkGlobals<T::EthSpec>>,
+
+    /// The logger for the data column service.
+    _log: slog::Logger,
+}
+
+impl<T: BeaconChainTypes> DataColumnService<T> {
+    pub fn new(
+        beacon_chain: Arc<BeaconChain<T>>,
+        network_globals: Arc<NetworkGlobals<T::EthSpec>>,
+        log: &slog::Logger,
+    ) -> Self {
+        let log = log.new(o!("service" => "data_column_service"));
+        let peer_id = network_globals.local_peer_id();
+
+        // TODO(das) temporary logic so we can have data column ids avail on the beacon chain
+        // future iteration of the data column subnet service will introduce data column rotation
+        // at epoch boundaries and other relevant logic.
+        if let Ok(slot) = beacon_chain.slot() {
+            if let Ok(node_id) = peer_id_to_node_id(&peer_id) {
+                let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
+
+                let mut data_column_subnet_ids = DataColumnSubnetId::compute_subnets_for_data_column::<
+                    T::EthSpec,
+                >(node_id.raw().into(), &beacon_chain.spec);
+    
+                beacon_chain.data_column_custody_tracker.register_epoch(
+                    epoch,
+                    data_column_subnet_ids
+                        .by_ref()
+                        .map(|data_column| *data_column)
+                        .collect_vec(),
+                );
+            }
+        }
+        Self {
+            _beacon_chain: beacon_chain,
+            _network_globals: network_globals,
+            _log: log,
+        }
+    }
+}

--- a/beacon_node/network/src/subnet_service/data_column_subnets.rs
+++ b/beacon_node/network/src/subnet_service/data_column_subnets.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::{discovery::peer_id_to_node_id, NetworkGlobals};
 use slog::o;
-use types::{DataColumnSubnetId, EthSpec};
+use types::DataColumnSubnetId;
 
 pub struct DataColumnService<T: BeaconChainTypes> {
     /// A reference to the beacon chain to process data columns.

--- a/beacon_node/network/src/subnet_service/data_column_subnets.rs
+++ b/beacon_node/network/src/subnet_service/data_column_subnets.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use lighthouse_network::{discovery::peer_id_to_node_id, NetworkGlobals};
 use slog::o;
-use types::{DataColumnSubnetId,EthSpec};
-
+use types::{DataColumnSubnetId, EthSpec};
 
 pub struct DataColumnService<T: BeaconChainTypes> {
     /// A reference to the beacon chain to process data columns.
@@ -37,10 +36,12 @@ impl<T: BeaconChainTypes> DataColumnService<T> {
             if let Ok(node_id) = peer_id_to_node_id(&peer_id) {
                 let epoch = slot.epoch(T::EthSpec::slots_per_epoch());
 
-                let mut data_column_subnet_ids = DataColumnSubnetId::compute_subnets_for_data_column::<
-                    T::EthSpec,
-                >(node_id.raw().into(), &beacon_chain.spec);
-    
+                let mut data_column_subnet_ids =
+                    DataColumnSubnetId::compute_subnets_for_data_column::<T::EthSpec>(
+                        node_id.raw().into(),
+                        &beacon_chain.spec,
+                    );
+
                 beacon_chain.data_column_custody_tracker.register_epoch(
                     epoch,
                     data_column_subnet_ids

--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -1,9 +1,11 @@
 pub mod attestation_subnets;
+pub mod data_column_subnets;
 pub mod sync_subnets;
 
 use lighthouse_network::{Subnet, SubnetDiscovery};
 
 pub use attestation_subnets::AttestationService;
+pub use data_column_subnets::DataColumnService;
 pub use sync_subnets::SyncCommitteeService;
 
 #[cfg(test)]


### PR DESCRIPTION
## Issue Addressed

Add a data column custody tracker field to `BeaconChain`. At the moment this field is only updated once, during network service initialization. In a future iteration, the data column subnet service will handle custody requirement rotations at epoch boundaries, peer discovery, and data column subnet subscriptions/un-subscriptions. This PR just aims to quickly make data column info available on the beacon chain to unblock DAS related work.

