### PR TITLE
Run fork choice after RPC blob import

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -267,6 +267,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "slot" => %slot,
                     "block_hash" => %hash,
                 );
+                self.chain.recompute_head_at_current_slot().await;
             }
             Ok(AvailabilityProcessingStatus::MissingComponents(_, _)) => {
                 debug!(


### PR DESCRIPTION
## Issue Addressed

Closes #5474:

- https://github.com/sigp/lighthouse/issues/5474

## Proposed Changes

Call `recompute_head_at_current_slot` when a block is imported off the back of importing blobs from RPC.

## Additional Info

I'm still thinking about the best way to test this.
