### PR TITLE
Fix double counted metrics

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -803,9 +803,6 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
         // start a ping and status timer for the peer
         self.status_peers.insert(*peer_id);
 
-        // increment prometheus metrics
-        metrics::inc_counter(&metrics::PEER_CONNECT_EVENT_COUNT);
-
         true
     }
 


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->

This PR addresses the issue where `metrics::PEER_CONNECT_EVENT_COUNT` is being double counted. The metric increment occurs in two places:

- [PeerManager::on_connection_established](https://github.com/sigp/lighthouse/blob/7117772fb358abe6b2ef7924be4ec020acb2a54f/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs#L248)
- [PeerManager::inject_peer_connection](https://github.com/sigp/lighthouse/blob/7117772fb358abe6b2ef7924be4ec020acb2a54f/beacon_node/lighthouse_network/src/peer_manager/mod.rs#L807)

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Removed the metric increment from `PeerManager::inject_peer_connection`. This method is called by `PeerManager::on_connection_established`, which already increments the metric. 

## Additional Info

<!-- Please provide any additional information. For example, future considerations
or information useful for reviewers.-->

N/A