### PR TITLE
Revise `secrets-dir` flag in the VC

### DIFF
--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -62,7 +62,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     "The path where the validator keystore passwords will be stored. \
                     Defaults to ~/.lighthouse/{network}/secrets",
                 )
-                .conflicts_with("datadir")
                 .takes_value(true),
         )
         .arg(

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -185,6 +185,10 @@ OPTIONS:
             only be used if the user has a clear understanding that the broad Ethereum community has elected to override
             this parameter in the event of an attack at the PoS transition block. Incorrect use of this flag can cause
             your node to possibly accept an invalid chain or sync more slowly. Be extremely careful with this flag.
+        --secrets-dir <SECRETS_DIRECTORY>
+            The directory which contains the password to unlock the validator voting keypairs. Each password should be
+            contained in a file where the name is the 0x-prefixed hex representation of the validators voting public
+            key. Defaults to ~/.lighthouse/{network}/secrets.
         --suggested-fee-recipient <FEE-RECIPIENT>
             Once the merge has happened, this address will receive transaction fees from blocks proposed by this
             validator client. If a fee recipient is configured in the validator definitions it takes priority over this

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -185,10 +185,6 @@ OPTIONS:
             only be used if the user has a clear understanding that the broad Ethereum community has elected to override
             this parameter in the event of an attack at the PoS transition block. Incorrect use of this flag can cause
             your node to possibly accept an invalid chain or sync more slowly. Be extremely careful with this flag.
-        --secrets-dir <SECRETS_DIRECTORY>
-            The directory which contains the password to unlock the validator voting keypairs. Each password should be
-            contained in a file where the name is the 0x-prefixed hex representation of the validators voting public
-            key. Defaults to ~/.lighthouse/{network}/secrets.
         --suggested-fee-recipient <FEE-RECIPIENT>
             Once the merge has happened, this address will receive transaction fees from blocks proposed by this
             validator client. If a fee recipient is configured in the validator definitions it takes priority over this

--- a/book/src/validator-management.md
+++ b/book/src/validator-management.md
@@ -77,7 +77,6 @@ recap:
 
 ### Automatic validator discovery
 
-> Note: The description below only applies when the keystore files are created using the [`lighthouse account validator create`](./key-management.md) command, which has been deprecated. 
 
 When the `--disable-auto-discover` flag is **not** provided, the validator client will search the
 `validator-dir` for validators and add any *new* validators to the

--- a/book/src/validator-management.md
+++ b/book/src/validator-management.md
@@ -59,7 +59,9 @@ Each permitted field of the file is listed below for reference:
 - `voting_keystore_password`: The password to the EIP-2335 keystore.
 
 > **Note**: Either `voting_keystore_password_path` or `voting_keystore_password` *must* be
-> supplied. If both are supplied, `voting_keystore_password_path` is ignored.
+> supplied. If both are supplied, `voting_keystore_password_path` is ignored. 
+
+>If you do not wish to have  `voting_keystore_password` being stored in the `validator_definitions.yml` file, you can add the field `voting_keystore_password_path` and point it to a file containing the password. The file can be, e.g., on a mounted portable drive that contains the password so that no password is stored on the validating node. 
 
 ## Populating the `validator_definitions.yml` file
 
@@ -74,6 +76,8 @@ recap:
 - `lighthouse vc --disable-auto-discover`: validators are **not** automatically discovered.
 
 ### Automatic validator discovery
+
+> Note: The description below only applies when the keystore files are created using the [`lighthouse account validator create`](./key-management.md) command, which has been deprecated. 
 
 When the `--disable-auto-discover` flag is **not** provided, the validator client will search the
 `validator-dir` for validators and add any *new* validators to the

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -71,8 +71,6 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                     This flag has been hidden and will be deprecated in the future.",
                 )
                 .takes_value(true)
-                .conflicts_with("datadir")
-                .hidden(true)
         )
         .arg(
             Arg::with_name("init-slashing-protection")

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -67,8 +67,10 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("secrets-dir")
                 .value_name("SECRETS_DIRECTORY")
                 .help(
-                    "This flag is not meant to be used together with the validator client. \
-                    This flag has been hidden and will be deprecated in the future.",
+                    "The directory which contains the password to unlock the validator \
+                    voting keypairs. Each password should be contained in a file where the \
+                    name is the 0x-prefixed hex representation of the validators voting public \
+                    key. Defaults to ~/.lighthouse/{network}/secrets.",
                 )
                 .takes_value(true)
         )

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -67,13 +67,12 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
                 .long("secrets-dir")
                 .value_name("SECRETS_DIRECTORY")
                 .help(
-                    "The directory which contains the password to unlock the validator \
-                    voting keypairs. Each password should be contained in a file where the \
-                    name is the 0x-prefixed hex representation of the validators voting public \
-                    key. Defaults to ~/.lighthouse/{network}/secrets.",
+                    "This flag is not meant to be used together with the validator client. \
+                    This flag has been hidden and will be deprecated in the future.",
                 )
                 .takes_value(true)
                 .conflicts_with("datadir")
+                .hidden(true)
         )
         .arg(
             Arg::with_name("init-slashing-protection")


### PR DESCRIPTION
## Issue Addressed

* #5331 

## Proposed Changes

~~The `secrets-dir` flag in the validator client is not meant to be used together when starting the VC, i.e., `lighthouse vc --secrets-dir ./path` will not direct the VC to read the keystore password from the `./path`. Instead, the `secrets-dir` will be created automatically when using the `lighthouse account validator create` command ([reference](https://lighthouse-book.sigmaprime.io/key-management.html#step-2-create-a-validator)), or when using the `--http-store-passwords-in-secrets-dir` and import the keystore via HTTP API. Therefore, I think it is better to hide the flag, and I also change the description to avoid confusion, and to deprecate the flag in the future.~~

~~When the `secrets-dir` is created using the above methods, it will always follow the `--datadir` of the VC. For example if VC is started with `lighthouse vc --datadir ./folder`, then a folder named `secrets` will be created in the directory `./folder/secrets` alongside with a separate folder for the validator client `./folder/validators`. Hence, this line is remained:~~

~~https://github.com/sigp/lighthouse/blob/5ce16192c769e4b593d7f953edcfb6e548c84167/validator_client/src/cli.rs#L76~~

~~Users who do not wish to store the keystore password in the `validator_definitions.yml` file can use the field `voting_keystore_password_path` and point to a desired directory. An amendment was made in the Lighthouse book to highlight this.~~

Edit: See the comments here: https://github.com/sigp/lighthouse/pull/5480#issuecomment-2059037895
