### PR TITLE
Single lookup improvements

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3038,7 +3038,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         match import_block.await {
             // The block was successfully verified and imported. Yay.
             Ok(status @ AvailabilityProcessingStatus::Imported(block_root)) => {
-                trace!(
+                debug!(
                     self.log,
                     "Beacon block imported";
                     "block_root" => ?block_root,
@@ -3051,7 +3051,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 Ok(status)
             }
             Ok(status @ AvailabilityProcessingStatus::MissingComponents(slot, block_root)) => {
-                trace!(
+                debug!(
                     self.log,
                     "Beacon block awaiting blobs";
                     "block_root" => ?block_root,

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2795,6 +2795,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                             }
                         }
                     }
+                    Err(BlockError::BlockIsAlreadyKnown(block_root)) => {
+                        debug!(self.log,
+                            "Ignoring already known blocks while processing chain segment";
+                            "block_root" => ?block_root);
+                        continue;
+                    }
                     Err(error) => {
                         return ChainSegmentResult::Failed {
                             imported_blocks,

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -7,6 +7,7 @@ use crate::{get_block_root, GossipVerifiedBlock, PayloadVerificationOutcome};
 use derivative::Derivative;
 use ssz_types::VariableList;
 use state_processing::ConsensusContext;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use types::blob_sidecar::{BlobIdentifier, BlobSidecarError, FixedBlobSidecarList};
 use types::{
@@ -27,11 +28,17 @@ use types::{
 /// Note: We make a distinction over blocks received over gossip because
 /// in a post-deneb world, the blobs corresponding to a given block that are received
 /// over rpc do not contain the proposer signature for dos resistance.
-#[derive(Debug, Clone, Derivative)]
+#[derive(Clone, Derivative)]
 #[derivative(Hash(bound = "E: EthSpec"))]
 pub struct RpcBlock<E: EthSpec> {
     block_root: Hash256,
     block: RpcBlockInner<E>,
+}
+
+impl<E: EthSpec> Debug for RpcBlock<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RpcBlock({:?})", self.block_root)
+    }
 }
 
 impl<E: EthSpec> RpcBlock<E> {

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -655,14 +655,6 @@ impl MissingBlobs {
             MissingBlobs::BlobsNotRequired => vec![],
         }
     }
-
-    pub fn clear(&mut self) {
-        match self {
-            MissingBlobs::KnownMissing(ref mut v) => v.clear(),
-            MissingBlobs::PossibleMissing(ref mut v) => v.clear(),
-            MissingBlobs::BlobsNotRequired => (),
-        }
-    }
 }
 
 impl Into<Vec<BlobIdentifier>> for MissingBlobs {

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -110,8 +110,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         self.processing_cache.read().get(&block_root).cloned()
     }
 
-    /// A `None` indicates blobs are not required.
-    ///
     /// If there's no block, all possible ids will be returned that don't exist in the given blobs.
     /// If there no blobs, all possible ids will be returned.
     pub fn get_missing_blob_ids<V: AvailabilityView<T::EthSpec>>(

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -655,6 +655,14 @@ impl MissingBlobs {
             MissingBlobs::BlobsNotRequired => vec![],
         }
     }
+
+    pub fn clear(&mut self) {
+        match self {
+            MissingBlobs::KnownMissing(ref mut v) => v.clear(),
+            MissingBlobs::PossibleMissing(ref mut v) => v.clear(),
+            MissingBlobs::BlobsNotRequired => (),
+        }
+    }
 }
 
 impl Into<Vec<BlobIdentifier>> for MissingBlobs {

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -117,6 +117,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 "Gossip block is being processed";
                 "action" => "sending rpc block to reprocessing queue",
                 "block_root" => %block_root,
+                "process_type" => ?process_type,
             );
 
             // Send message to work reprocess queue to retry the block
@@ -149,6 +150,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             "proposer" => block.message().proposer_index(),
             "slot" => block.slot(),
             "commitments" => commitments_formatted,
+            "process_type" => ?process_type,
         );
 
         let result = self

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -420,7 +420,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         }
                     }
                     (imported_blocks, Ok(_)) => {
-                        debug!(self.log, "Parent lookup processed successfully");
+                        debug!(
+                            self.log, "Parent lookup processed successfully";
+                            "chain_hash" => %chain_head,
+                            "imported_blocks" => imported_blocks
+                        );
                         BatchProcessResult::Success {
                             was_non_empty: imported_blocks > 0,
                         }

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -396,6 +396,8 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
             None => {
                 self.state.state = State::Processing { peer_id };
                 let blobs = std::mem::take(&mut self.blob_download_queue);
+                self.requested_ids.clear();
+
                 Ok(Some(blobs))
             }
         }

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -396,8 +396,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
             None => {
                 self.state.state = State::Processing { peer_id };
                 let blobs = std::mem::take(&mut self.blob_download_queue);
-                self.requested_ids.clear();
-
                 Ok(Some(blobs))
             }
         }

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -371,7 +371,7 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
 
     fn verify_response_inner(
         &mut self,
-        expected_block_root: Hash256,
+        _expected_block_root: Hash256,
         blob: Option<Self::ResponseType>,
         peer_id: PeerId,
     ) -> Result<Option<FixedBlobSidecarList<T::EthSpec>>, LookupVerifyError> {

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -379,11 +379,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
             Some(blob) => {
                 let received_id = blob.id();
                 if !self.requested_ids.contains(&received_id) {
-                    if expected_block_root == received_id.block_root {
-                        // We may have already received this blob via gossip since the lookup,
-                        // so don't return an error here.
-                        return Ok(None);
-                    }
                     self.state.register_failure_downloading();
                     Err(LookupVerifyError::UnrequestedBlobId(received_id))
                 } else {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -157,9 +157,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         }
 
         if let Some(parent_lookup) = self.parent_lookups.iter_mut().find(|parent_req| {
-            parent_req.is_for_block(block_root)
-                || parent_req.contains_block(&block_root)
-                || parent_req.chain_hash() == block_root
+            parent_req.is_for_block(block_root) || parent_req.contains_block(&block_root)
         }) {
             parent_lookup.add_peers(peers);
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -540,7 +540,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             | ParentVerifyError::NoBlockReturned
             | ParentVerifyError::NotEnoughBlobsReturned
             | ParentVerifyError::ExtraBlocksReturned
-            | ParentVerifyError::UnrequestedBlobId
+            | ParentVerifyError::UnrequestedBlobId(_)
             | ParentVerifyError::ExtraBlobsReturned
             | ParentVerifyError::InvalidIndex(_) => {
                 let e = e.into();

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -173,7 +173,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             .any(|(hashes, _last_parent_request)| hashes.contains(&block_root))
         {
             // we are already processing this block, ignore it.
-            debug!(self.log, "Already processing block in a parent from request"; "block_root" => ?block_root);
+            debug!(self.log, "Already processing block in a parent request"; "block_root" => ?block_root);
             return;
         }
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -309,6 +309,12 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         };
 
         let expected_block_root = lookup.block_root();
+        debug!(self.log,
+            "Peer returned block for single lookup";
+            "peer_id" => %peer_id ,
+            "id" => ?id,
+            "block_root" => ?expected_block_root,
+        );
 
         match self.single_lookup_response_inner::<R>(peer_id, response, seen_timestamp, cx, lookup)
         {
@@ -488,6 +494,13 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             }
             return;
         };
+
+        debug!(self.log,
+            "Peer returned block for parent lookup";
+            "peer_id" => %peer_id ,
+            "id" => ?id,
+            "block_root" => ?parent_lookup.current_parent_request.block_request_state.requested_block_root,
+        );
 
         match self.parent_lookup_response_inner::<R>(
             peer_id,
@@ -739,6 +752,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             "Block component processed for lookup";
             "response_type" => ?R::response_type(),
             "block_root" => ?root,
+            "result" => ?result,
+            "id" => target_id,
         );
 
         match result {
@@ -912,7 +927,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                     debug!(self.log, "Parent block processing succeeded"; &parent_lookup, "block_root" => ?block_root)
                 }
                 AvailabilityProcessingStatus::MissingComponents(_, block_root) => {
-                    debug!(self.log, "Parent missing parts, triggering single block lookup "; &parent_lookup,"block_root" => ?block_root)
+                    debug!(self.log, "Parent missing parts, triggering single block lookup"; &parent_lookup,"block_root" => ?block_root)
                 }
             },
             BlockProcessingResult::Err(e) => {
@@ -1234,7 +1249,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     ) -> Result<(), LookupRequestError> {
         match cx.beacon_processor_if_enabled() {
             Some(beacon_processor) => {
-                trace!(self.log, "Sending block for processing"; "block" => ?block_root, "process" => ?process_type);
+                debug!(self.log, "Sending block for processing"; "block" => ?block_root, "process" => ?process_type);
                 if let Err(e) = beacon_processor.send_rpc_beacon_block(
                     block_root,
                     block,

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -220,9 +220,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         // Make sure this block is not already downloaded, and that neither it or its parent is
         // being searched for.
         if let Some(parent_lookup) = self.parent_lookups.iter_mut().find(|parent_req| {
-            block_root == parent_req.chain_hash()
-                || parent_req.contains_block(&parent_root)
-                || parent_req.is_for_block(parent_root)
+            parent_req.contains_block(&parent_root) || parent_req.is_for_block(parent_root)
         }) {
             parent_lookup.add_peer(peer_id);
             // we are already searching for this block, ignore it

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -12,6 +12,7 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 use store::Hash256;
 use strum::IntoStaticStr;
+use types::blob_sidecar::BlobIdentifier;
 
 /// How many attempts we try to find a parent of a block before we give up trying.
 pub(crate) const PARENT_FAIL_TOLERANCE: u8 = 5;
@@ -36,7 +37,7 @@ pub enum ParentVerifyError {
     NoBlockReturned,
     NotEnoughBlobsReturned,
     ExtraBlocksReturned,
-    UnrequestedBlobId,
+    UnrequestedBlobId(BlobIdentifier),
     ExtraBlobsReturned,
     InvalidIndex(u64),
     PreviousFailure { parent_root: Hash256 },
@@ -242,7 +243,7 @@ impl From<LookupVerifyError> for ParentVerifyError {
             E::RootMismatch => ParentVerifyError::RootMismatch,
             E::NoBlockReturned => ParentVerifyError::NoBlockReturned,
             E::ExtraBlocksReturned => ParentVerifyError::ExtraBlocksReturned,
-            E::UnrequestedBlobId => ParentVerifyError::UnrequestedBlobId,
+            E::UnrequestedBlobId(blob_id) => ParentVerifyError::UnrequestedBlobId(blob_id),
             E::ExtraBlobsReturned => ParentVerifyError::ExtraBlobsReturned,
             E::InvalidIndex(index) => ParentVerifyError::InvalidIndex(index),
             E::NotEnoughBlobsReturned => ParentVerifyError::NotEnoughBlobsReturned,

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -115,13 +115,19 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         cx: &SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         let block_already_downloaded = self.block_already_downloaded();
-        let blobs_already_downloaded = self.blobs_already_downloaded();
+        let should_request_blobs = if self.blob_request_state.requested_ids.is_empty() {
+            let blob_ids = self.missing_blob_ids();
+            self.blob_request_state.requested_ids = blob_ids;
+            !self.blob_request_state.requested_ids.is_empty()
+        } else {
+            false
+        };
 
         if !block_already_downloaded {
             self.block_request_state
                 .build_request_and_send(self.id, cx)?;
         }
-        if !blobs_already_downloaded {
+        if should_request_blobs {
             self.blob_request_state
                 .build_request_and_send(self.id, cx)?;
         }
@@ -251,19 +257,6 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         } else {
             self.da_checker.has_block(&self.block_root())
         }
-    }
-
-    /// Updates the `requested_ids` field of the `BlockRequestState` with the most recent picture
-    /// of which blobs still need to be requested. Returns `true` if there are no more blobs to
-    /// request.
-    pub(crate) fn blobs_already_downloaded(&mut self) -> bool {
-        self.update_blobs_request();
-        self.blob_request_state.requested_ids.is_empty()
-    }
-
-    /// Updates this request with the most recent picture of which blobs still need to be requested.
-    pub fn update_blobs_request(&mut self) {
-        self.blob_request_state.requested_ids = self.missing_blob_ids();
     }
 
     /// If `child_components` is `Some`, we know block components won't hit the data

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use store::Hash256;
 use strum::IntoStaticStr;
-use types::blob_sidecar::FixedBlobSidecarList;
+use types::blob_sidecar::{BlobIdentifier, FixedBlobSidecarList};
 use types::EthSpec;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -31,7 +31,7 @@ pub enum LookupVerifyError {
     RootMismatch,
     NoBlockReturned,
     ExtraBlocksReturned,
-    UnrequestedBlobId,
+    UnrequestedBlobId(BlobIdentifier),
     ExtraBlobsReturned,
     NotEnoughBlobsReturned,
     InvalidIndex(u64),

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1790,20 +1790,6 @@ mod deneb_only {
     }
 
     #[test]
-    fn single_block_response_then_too_many_blobs_response_attestation() {
-        let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
-            return;
-        };
-
-        tester
-            .block_response_triggering_process()
-            .invalidate_blobs_too_many()
-            .blobs_response()
-            .expect_penalty()
-            .expect_blobs_request()
-            .expect_no_block_request();
-    }
-    #[test]
     fn too_few_blobs_response_then_block_response_attestation() {
         let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
             return;
@@ -1815,21 +1801,6 @@ mod deneb_only {
             .blobs_response_was_valid()
             .expect_no_penalty()
             .expect_no_blobs_request()
-            .expect_no_block_request()
-            .block_response_triggering_process();
-    }
-
-    #[test]
-    fn too_many_blobs_response_then_block_response_attestation() {
-        let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
-            return;
-        };
-
-        tester
-            .invalidate_blobs_too_many()
-            .blobs_response()
-            .expect_penalty()
-            .expect_blobs_request()
             .expect_no_block_request()
             .block_response_triggering_process();
     }

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1790,6 +1790,21 @@ mod deneb_only {
     }
 
     #[test]
+    fn single_block_response_then_too_many_blobs_response_attestation() {
+        let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
+            return;
+        };
+
+        tester
+            .block_response_triggering_process()
+            .invalidate_blobs_too_many()
+            .blobs_response()
+            .expect_penalty()
+            .expect_blobs_request()
+            .expect_no_block_request();
+    }
+
+    #[test]
     fn too_few_blobs_response_then_block_response_attestation() {
         let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
             return;
@@ -1801,6 +1816,21 @@ mod deneb_only {
             .blobs_response_was_valid()
             .expect_no_penalty()
             .expect_no_blobs_request()
+            .expect_no_block_request()
+            .block_response_triggering_process();
+    }
+
+    #[test]
+    fn too_many_blobs_response_then_block_response_attestation() {
+        let Some(tester) = DenebTester::new(RequestTrigger::AttestationUnknownBlock) else {
+            return;
+        };
+
+        tester
+            .invalidate_blobs_too_many()
+            .blobs_response()
+            .expect_penalty()
+            .expect_blobs_request()
             .expect_no_block_request()
             .block_response_triggering_process();
     }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -831,37 +831,27 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         seen_timestamp: Duration,
     ) {
         match request_id {
-            RequestId::SingleBlock { id } => {
-                debug!(self.log,
-                    "Peer returned block for single lookup";
-                    "peer_id" => %peer_id ,
-                );
-                self.block_lookups
-                    .single_lookup_response::<BlockRequestState<Current>>(
-                        id,
-                        peer_id,
-                        block,
-                        seen_timestamp,
-                        &self.network,
-                    )
-            }
+            RequestId::SingleBlock { id } => self
+                .block_lookups
+                .single_lookup_response::<BlockRequestState<Current>>(
+                    id,
+                    peer_id,
+                    block,
+                    seen_timestamp,
+                    &self.network,
+                ),
             RequestId::SingleBlob { .. } => {
                 crit!(self.log, "Block received during blob request"; "peer_id" => %peer_id  );
             }
-            RequestId::ParentLookup { id } => {
-                debug!(self.log,
-                    "Peer returned block for parent lookup";
-                    "peer_id" => %peer_id ,
-                );
-                self.block_lookups
-                    .parent_lookup_response::<BlockRequestState<Parent>>(
-                        id,
-                        peer_id,
-                        block,
-                        seen_timestamp,
-                        &self.network,
-                    )
-            }
+            RequestId::ParentLookup { id } => self
+                .block_lookups
+                .parent_lookup_response::<BlockRequestState<Parent>>(
+                    id,
+                    peer_id,
+                    block,
+                    seen_timestamp,
+                    &self.network,
+                ),
             RequestId::ParentLookupBlob { id: _ } => {
                 crit!(self.log, "Block received during parent blob request"; "peer_id" => %peer_id  );
             }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -831,27 +831,37 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         seen_timestamp: Duration,
     ) {
         match request_id {
-            RequestId::SingleBlock { id } => self
-                .block_lookups
-                .single_lookup_response::<BlockRequestState<Current>>(
-                    id,
-                    peer_id,
-                    block,
-                    seen_timestamp,
-                    &self.network,
-                ),
+            RequestId::SingleBlock { id } => {
+                debug!(self.log,
+                    "Peer returned block for single lookup";
+                    "peer_id" => %peer_id ,
+                );
+                self.block_lookups
+                    .single_lookup_response::<BlockRequestState<Current>>(
+                        id,
+                        peer_id,
+                        block,
+                        seen_timestamp,
+                        &self.network,
+                    )
+            }
             RequestId::SingleBlob { .. } => {
                 crit!(self.log, "Block received during blob request"; "peer_id" => %peer_id  );
             }
-            RequestId::ParentLookup { id } => self
-                .block_lookups
-                .parent_lookup_response::<BlockRequestState<Parent>>(
-                    id,
-                    peer_id,
-                    block,
-                    seen_timestamp,
-                    &self.network,
-                ),
+            RequestId::ParentLookup { id } => {
+                debug!(self.log,
+                    "Peer returned block for single lookup";
+                    "peer_id" => %peer_id ,
+                );
+                self.block_lookups
+                    .parent_lookup_response::<BlockRequestState<Parent>>(
+                        id,
+                        peer_id,
+                        block,
+                        seen_timestamp,
+                        &self.network,
+                    )
+            }
             RequestId::ParentLookupBlob { id: _ } => {
                 crit!(self.log, "Block received during parent blob request"; "peer_id" => %peer_id  );
             }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -850,7 +850,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             }
             RequestId::ParentLookup { id } => {
                 debug!(self.log,
-                    "Peer returned block for single lookup";
+                    "Peer returned block for parent lookup";
                     "peer_id" => %peer_id ,
                 );
                 self.block_lookups


### PR DESCRIPTION
Includes #5484 and https://github.com/sigp/lighthouse/pull/5477 (modulo the PR feedback)

Copied from #5484:

## Issue Addressed

- add logs
- tighten up lookup de-duplication logic
- an alternative fix to: https://github.com/sigp/lighthouse/pull/5477
    - the core issue in the bug there is that we update `requested_ids` while blobs are still downloading if we download the RPC block in between blobs of the stream. this becomes and issue because `requested_ids` is updated with any blobs that come via gossip.
    - proposed solution here is to only update the blobs if the request state is `AwaitingDownload` which means it has been either completed or not yet started
