### PR TITLE
Use `portable` builds by default 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,8 @@ concurrency:
 env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    # Enable self-hosted runners for the sigp repo only.
-    SELF_HOSTED_RUNNERS: ${{ github.repository == 'antondlr/lighthouse' }}
+    # Enable self-hosted runners for your own repo only.
+    SELF_HOSTED_RUNNERS: ${{ github.repository == 'github.repository_owner/lighthouse' }}
 
 jobs:
     # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
@@ -54,8 +54,8 @@ jobs:
             VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
     build-docker-single-arch:
         name: build-docker-${{ matrix.binary }}-${{ matrix.cpu_arch }}${{ matrix.features.version_suffix }}
-        # Use self-hosted runners only on the sigp repo.
-        runs-on: ${{ github.repository == 'antondlr/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
+        # Use self-hosted runners only on your own repo.
+        runs-on: ${{ github.repository == 'github.repository_owner/lighthouse' && fromJson('["self-hosted", "linux", "X64", "large"]') || 'ubuntu-22.04'  }}
         strategy:
             matrix:
                 binary:   [lighthouse,
@@ -146,7 +146,7 @@ jobs:
 
 
     build-docker-multiarch:
-        name: build-docker-multiarch${{ matrix.modernity }}
+        name: build-docker-${{ matrix.binary }}-multiarch
         runs-on: ubuntu-22.04
         strategy:
             matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,7 +60,7 @@ jobs:
         runs-on: ${{ github.repository == 'antondlr/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         strategy:
             matrix:
-                binary: [aarch64,
+                binary: [aarch64-portable,
                          x86_64-portable]
                 features: [
                     {env: "gnosis,spec-minimal,slasher-lmdb,jemalloc"},
@@ -85,11 +85,6 @@ jobs:
                   cargo install cross
                   env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ matrix.features.env }} make build-${{ matrix.binary }}
 
-#            - name: move binary
-#              run: |
-#                mkdir ./bin; \
-#                find ./target -type f -name "lighthouse" -exec mv {} /bin/ \;
-
             - name: Make bin dir
               run: mkdir ./bin
             - name: Move cross-built binary into Docker scope (if ARM)
@@ -98,7 +93,6 @@ jobs:
             - name: Move cross-built binary into Docker scope (if x86_64)
               if: startsWith(matrix.binary, 'x86_64')
               run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
-
             - name: Map aarch64 to arm64 short arch
               if: startsWith(matrix.binary, 'aarch64')
               run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
@@ -142,13 +136,14 @@ jobs:
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-            - name: Create and push multiarch manifest
-              # not making multiarch manifests for deprecated tags
+            - name: Create and push multiarch manifests
               run: |
                   docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
                       ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
                       ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
-
+                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-modern \
+                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX}-modern \
+                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX}-modern;
 
     build-docker-lcli:
         runs-on: ubuntu-22.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     # Enable self-hosted runners for your own repo only.
-    SELF_HOSTED_RUNNERS: ${{ github.repository == github.repository_owner'/lighthouse' }}
+    SELF_HOSTED_RUNNERS: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') }}
 
 jobs:
     # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
@@ -49,7 +49,7 @@ jobs:
     build-docker-single-arch:
         name: build-docker-${{ matrix.binary }}-${{ matrix.cpu_arch }}${{ matrix.features.version_suffix }}
         # Use self-hosted runners only on your own repo.
-        runs-on: ${{ github.repository == github.repository_owner'/lighthouse' && fromJson('["self-hosted", "linux", "X64", "large"]') || 'ubuntu-22.04' }}
+        runs-on: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') && fromJson('["self-hosted", "linux", "X64", "large"]') || 'ubuntu-22.04' }}
         strategy:
             matrix:
                 binary:   [lighthouse,

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - unstable
             - stable
+            - rework-docker-builds
         tags:
             - v*
 
@@ -18,7 +19,7 @@ env:
     IMAGE_NAME: ${{ github.repository_owner}}/lighthouse
     LCLI_IMAGE_NAME: ${{ github.repository_owner }}/lcli
     # Enable self-hosted runners for the sigp repo only.
-    SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/lighthouse' }}
+    SELF_HOSTED_RUNNERS: ${{ github.repository == 'antondlr/lighthouse' }}
 
 jobs:
     # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
@@ -40,6 +41,11 @@ jobs:
               run: |
                     echo "VERSION=latest" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
+            - name: Extract version (if rework)
+              if: github.event.ref == 'refs/heads/rework-docker-builds'
+              run: |
+                    echo "VERSION=latest" >> $GITHUB_ENV
+                    echo "VERSION_SUFFIX=-rework" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')
               run: |
@@ -51,16 +57,13 @@ jobs:
     build-docker-single-arch:
         name: build-docker-${{ matrix.binary }}${{ matrix.features.version_suffix }}
         # Use self-hosted runners only on the sigp repo.
-        runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
+        runs-on: ${{ github.repository == 'antondlr/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         strategy:
             matrix:
                 binary: [aarch64,
-                         aarch64-portable,
-                         x86_64,
-                         x86_64-portable]
+                         x86_64]
                 features: [
-                    {version_suffix: "", env: "gnosis,slasher-lmdb,slasher-mdbx,jemalloc"},
-                    {version_suffix: "-dev", env: "jemalloc,spec-minimal"}
+                    {env: "gnosis,spec-minimal,portable,slasher-lmdb,jemalloc"},
                 ]
                 include:
                     - profile: maxperf
@@ -69,7 +72,6 @@ jobs:
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-            FEATURE_SUFFIX: ${{ matrix.features.version_suffix }}
         steps:
             - uses: actions/checkout@v4
             - name: Update Rust
@@ -82,23 +84,27 @@ jobs:
               run: |
                   cargo install cross
                   env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ matrix.features.env }} make build-${{ matrix.binary }}
-            - name: Make bin dir
-              run: mkdir ./bin
-            - name: Move cross-built binary into Docker scope (if ARM)
-              if: startsWith(matrix.binary, 'aarch64')
-              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
-            - name: Move cross-built binary into Docker scope (if x86_64)
-              if: startsWith(matrix.binary, 'x86_64')
-              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+
+            - name: move binary
+              run: |
+                mkdir ./bin; \
+                find ./target -type f -name "lighthouse" -exec mv {} /bin/ \;
+
+#            - name: Make bin dir
+#              run: mkdir ./bin
+#            - name: Move cross-built binary into Docker scope (if ARM)
+#              if: startsWith(matrix.binary, 'aarch64')
+#              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+#            - name: Move cross-built binary into Docker scope (if x86_64)
+#              if: startsWith(matrix.binary, 'x86_64')
+#              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+
             - name: Map aarch64 to arm64 short arch
               if: startsWith(matrix.binary, 'aarch64')
               run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
             - name: Map x86_64 to amd64 short arch
               if: startsWith(matrix.binary, 'x86_64')
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV;
-            - name: Set modernity suffix
-              if: endsWith(matrix.binary, '-portable') != true
-              run: echo "MODERNITY_SUFFIX=-modern" >> $GITHUB_ENV;
 
             - name: Install QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
@@ -115,15 +121,16 @@ jobs:
                 context: .
                 platforms: linux/${{ env.SHORT_ARCH }}
                 push: true
-                tags: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}${{ env.MODERNITY_SUFFIX }}${{ env.FEATURE_SUFFIX }}
+                tags: 
+                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
+                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
+                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
 
     build-docker-multiarch:
         name: build-docker-multiarch${{ matrix.modernity }}
         runs-on: ubuntu-22.04
         needs: [build-docker-single-arch, extract-version]
-        strategy:
-            matrix:
-                modernity: ["", "-modern"]
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
@@ -136,10 +143,12 @@ jobs:
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
             - name: Create and push multiarch manifest
+              # not making multiarch manifests for deprecated tags
               run: |
-                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}${{ matrix.modernity }} \
-                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX}${{ matrix.modernity }} \
-                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX}${{ matrix.modernity }};
+                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
+                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
+                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
+
 
     build-docker-lcli:
         runs-on: ubuntu-22.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - unstable
             - stable
-            - rework-docker-builds
         tags:
             - v*
 
@@ -17,7 +16,7 @@ env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
     # Enable self-hosted runners for your own repo only.
-    SELF_HOSTED_RUNNERS: ${{ github.repository == 'github.repository_owner/lighthouse' }}
+    SELF_HOSTED_RUNNERS: ${{ github.repository == github.repository_owner'/lighthouse' }}
 
 jobs:
     # Extract the VERSION which is either `latest` or `vX.Y.Z`, and the VERSION_SUFFIX
@@ -39,11 +38,6 @@ jobs:
               run: |
                     echo "VERSION=latest" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
-            - name: Extract version (if rework)
-              if: github.event.ref == 'refs/heads/rework-docker-builds'
-              run: |
-                    echo "VERSION=latest" >> $GITHUB_ENV
-                    echo "VERSION_SUFFIX=-rework" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')
               run: |
@@ -55,7 +49,7 @@ jobs:
     build-docker-single-arch:
         name: build-docker-${{ matrix.binary }}-${{ matrix.cpu_arch }}${{ matrix.features.version_suffix }}
         # Use self-hosted runners only on your own repo.
-        runs-on: ${{ github.repository == 'github.repository_owner/lighthouse' && fromJson('["self-hosted", "linux", "X64", "large"]') || 'ubuntu-22.04'  }}
+        runs-on: ${{ github.repository == github.repository_owner'/lighthouse' && fromJson('["self-hosted", "linux", "X64", "large"]') || 'ubuntu-22.04' }}
         strategy:
             matrix:
                 binary:   [lighthouse,
@@ -99,7 +93,6 @@ jobs:
 
             - name: Make bin dir
               run: mkdir ./bin
-
             - name: Move cross-built binary into Docker scope
               run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/${{ matrix.binary }} ./bin
 
@@ -125,7 +118,6 @@ jobs:
                 context: .
                 platforms: linux/${{ env.SHORT_ARCH }}
                 push: true
-
                 tags: |
                   ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
                   ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
@@ -169,27 +161,3 @@ jobs:
                   docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX} \
                       ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
                       ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};
-#                  docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX}-modern \
-#                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX}-modern \
-#                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX}-modern;
-
-#    build-docker-lcli:
-#        runs-on: ubuntu-22.04
-#        needs: [extract-version]
-#        env:
-#            VERSION: ${{ needs.extract-version.outputs.VERSION }}
-#            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-#        steps:
-#            - uses: actions/checkout@v4
-#            - name: Dockerhub login
-#              run: |
-#                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-#            - name: Build lcli and push
-#              uses: docker/build-push-action@v5
-#              with:
-#                  build-args: |
-#                      FEATURES=portable
-#                  context: .
-#                  push: true
-#                  file: ./lcli/Dockerfile
-#                  tags: ${{ env.LCLI_IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -81,7 +81,7 @@ jobs:
             - name: Sets env vars for Lighthouse
               if: startsWith(matrix.binary, 'lighthouse')
               run: |
-                echo "CROSS_FEATURES="gnosis,spec-minimal,slasher-lmdb,jemalloc" >> $GITHUB_ENV
+                echo "CROSS_FEATURES=gnosis,spec-minimal,slasher-lmdb,jemalloc" >> $GITHUB_ENV
 
             - name: Set `make` command for lighthouse
               if: startsWith(matrix.binary, 'lighthouse')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -121,11 +121,11 @@ jobs:
                 context: .
                 platforms: linux/${{ env.SHORT_ARCH }}
                 push: true
-                tags: 
-                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
-                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
-                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
-                  - ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
+                tags: |
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
+                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
 
     build-docker-multiarch:
         name: build-docker-multiarch${{ matrix.modernity }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,6 @@ concurrency:
 env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    IMAGE_NAME: ${{ github.repository_owner}}/lighthouse
-    LCLI_IMAGE_NAME: ${{ github.repository_owner }}/lcli
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'antondlr/lighthouse' }}
 
@@ -55,16 +53,15 @@ jobs:
             VERSION: ${{ env.VERSION }}
             VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
     build-docker-single-arch:
-        name: build-docker-${{ matrix.binary }}${{ matrix.features.version_suffix }}
+        name: build-docker-${{ matrix.binary }}-${{ matrix.cpu_arch }}${{ matrix.features.version_suffix }}
         # Use self-hosted runners only on the sigp repo.
         runs-on: ${{ github.repository == 'antondlr/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         strategy:
             matrix:
-                binary: [aarch64-portable,
-                         x86_64-portable]
-                features: [
-                    {env: "gnosis,spec-minimal,slasher-lmdb,jemalloc"},
-                ]
+                binary:   [lighthouse,
+                           lcli]
+                cpu_arch: [aarch64,
+                           x86_64]
                 include:
                     - profile: maxperf
 
@@ -80,50 +77,81 @@ jobs:
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-            - name: Cross build Lighthouse binary
+
+            - name: Sets env vars for Lighthouse
+              if: startsWith(matrix.binary, 'lighthouse')
+              run: |
+                echo "CROSS_FEATURES="gnosis,spec-minimal,slasher-lmdb,jemalloc" >> $GITHUB_ENV
+
+            - name: Set `make` command for lighthouse
+              if: startsWith(matrix.binary, 'lighthouse')
+              run: |
+                echo "MAKE_CMD=build-${{ matrix.cpu_arch }}-portable" >> $GITHUB_ENV
+            - name: Set `make` command for lcli
+              if: startsWith(matrix.binary, 'lcli')
+              run: |
+                echo "MAKE_CMD=build-lcli-${{ matrix.cpu_arch }}" >> $GITHUB_ENV
+
+            - name: Cross build binaries
               run: |
                   cargo install cross
-                  env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ matrix.features.env }} make build-${{ matrix.binary }}
+                  env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ env.CROSS_FEATURES }} make ${{ env.MAKE_CMD }}
 
             - name: Make bin dir
               run: mkdir ./bin
-            - name: Move cross-built binary into Docker scope (if ARM)
-              if: startsWith(matrix.binary, 'aarch64')
-              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
-            - name: Move cross-built binary into Docker scope (if x86_64)
-              if: startsWith(matrix.binary, 'x86_64')
-              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+
+            - name: Move cross-built binary into Docker scope
+              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/${{ matrix.binary }} ./bin
+
             - name: Map aarch64 to arm64 short arch
-              if: startsWith(matrix.binary, 'aarch64')
+              if: startsWith(matrix.cpu_arch, 'aarch64')
               run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
             - name: Map x86_64 to amd64 short arch
-              if: startsWith(matrix.binary, 'x86_64')
+              if: startsWith(matrix.cpu_arch, 'x86_64')
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV;
 
             - name: Install QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
               run: sudo apt-get update && sudo apt-get install -y qemu-user-static
-
             - name: Set up Docker Buildx
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
 
-            - name: Build and push
+            - name: Build and push (Lighthouse)
+              if: startsWith(matrix.binary, 'lighthouse')
               uses: docker/build-push-action@v5
               with:
                 file: ./Dockerfile.cross
                 context: .
                 platforms: linux/${{ env.SHORT_ARCH }}
                 push: true
+
                 tags: |
-                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
-                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
-                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
-                  ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
+
+            - name: Build and push (lcli)
+              if: startsWith(matrix.binary, 'lcli')
+              uses: docker/build-push-action@v5
+              with:
+                file: ./lcli/Dockerfile.cross
+                context: .
+                platforms: linux/${{ env.SHORT_ARCH }}
+                push: true
+
+                tags: |
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+
 
     build-docker-multiarch:
         name: build-docker-multiarch${{ matrix.modernity }}
         runs-on: ubuntu-22.04
+        strategy:
+            matrix:
+                binary: [lighthouse,
+                         lcli]
         needs: [build-docker-single-arch, extract-version]
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
@@ -138,30 +166,30 @@ jobs:
 
             - name: Create and push multiarch manifests
               run: |
-                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX} \
-                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX} \
-                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX};
-                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}-modern \
-                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX}-modern \
-                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX}-modern;
+                  docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX} \
+                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
+                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};
+#                  docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX}-modern \
+#                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX}-modern \
+#                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX}-modern;
 
-    build-docker-lcli:
-        runs-on: ubuntu-22.04
-        needs: [extract-version]
-        env:
-            VERSION: ${{ needs.extract-version.outputs.VERSION }}
-            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-        steps:
-            - uses: actions/checkout@v4
-            - name: Dockerhub login
-              run: |
-                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-            - name: Build lcli and push
-              uses: docker/build-push-action@v5
-              with:
-                  build-args: |
-                      FEATURES=portable
-                  context: .
-                  push: true
-                  file: ./lcli/Dockerfile
-                  tags: ${{ env.LCLI_IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX }}
+#    build-docker-lcli:
+#        runs-on: ubuntu-22.04
+#        needs: [extract-version]
+#        env:
+#            VERSION: ${{ needs.extract-version.outputs.VERSION }}
+#            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
+#        steps:
+#            - uses: actions/checkout@v4
+#            - name: Dockerhub login
+#              run: |
+#                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
+#            - name: Build lcli and push
+#              uses: docker/build-push-action@v5
+#              with:
+#                  build-args: |
+#                      FEATURES=portable
+#                  context: .
+#                  push: true
+#                  file: ./lcli/Dockerfile
+#                  tags: ${{ env.LCLI_IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,19 +85,19 @@ jobs:
                   cargo install cross
                   env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ matrix.features.env }} make build-${{ matrix.binary }}
 
-            - name: move binary
-              run: |
-                mkdir ./bin; \
-                find ./target -type f -name "lighthouse" -exec mv {} /bin/ \;
+#            - name: move binary
+#              run: |
+#                mkdir ./bin; \
+#                find ./target -type f -name "lighthouse" -exec mv {} /bin/ \;
 
-#            - name: Make bin dir
-#              run: mkdir ./bin
-#            - name: Move cross-built binary into Docker scope (if ARM)
-#              if: startsWith(matrix.binary, 'aarch64')
-#              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
-#            - name: Move cross-built binary into Docker scope (if x86_64)
-#              if: startsWith(matrix.binary, 'x86_64')
-#              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+            - name: Make bin dir
+              run: mkdir ./bin
+            - name: Move cross-built binary into Docker scope (if ARM)
+              if: startsWith(matrix.binary, 'aarch64')
+              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+            - name: Move cross-built binary into Docker scope (if x86_64)
+              if: startsWith(matrix.binary, 'x86_64')
+              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
 
             - name: Map aarch64 to arm64 short arch
               if: startsWith(matrix.binary, 'aarch64')

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,9 +61,9 @@ jobs:
         strategy:
             matrix:
                 binary: [aarch64,
-                         x86_64]
+                         x86_64-portable]
                 features: [
-                    {env: "gnosis,spec-minimal,portable,slasher-lmdb,jemalloc"},
+                    {env: "gnosis,spec-minimal,slasher-lmdb,jemalloc"},
                 ]
                 include:
                     - profile: maxperf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ env:
     REPO_NAME: ${{ github.repository_owner }}/lighthouse
     IMAGE_NAME: ${{ github.repository_owner }}/lighthouse
     # Enable self-hosted runners for the sigp repo only.
-    SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/lighthouse' }}
+    SELF_HOSTED_RUNNERS: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') }}
 
 jobs:
     extract-version:
@@ -31,37 +31,21 @@ jobs:
         strategy:
             matrix:
                 arch: [aarch64-unknown-linux-gnu,
-                       aarch64-unknown-linux-gnu-portable,
                        x86_64-unknown-linux-gnu,
-                       x86_64-unknown-linux-gnu-portable,
                        x86_64-apple-darwin,
-                       x86_64-apple-darwin-portable,
-                       x86_64-windows,
-                       x86_64-windows-portable]
+                       x86_64-windows]
                 include:
                     -   arch: aarch64-unknown-linux-gnu
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
-                        profile: maxperf
-                    -   arch: aarch64-unknown-linux-gnu-portable
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
+                        runner: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
                         profile: maxperf
                     -   arch: x86_64-unknown-linux-gnu
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
-                        profile: maxperf
-                    -   arch: x86_64-unknown-linux-gnu-portable
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
+                        runner: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
                         profile: maxperf
                     -   arch: x86_64-apple-darwin
                         runner: macos-latest
                         profile: maxperf
-                    -   arch: x86_64-apple-darwin-portable
-                        runner: macos-latest
-                        profile: maxperf
                     -   arch: x86_64-windows
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "windows", "release"]') || 'windows-2019'  }}
-                        profile: maxperf
-                    -   arch: x86_64-windows-portable
-                        runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "windows", "release"]') || 'windows-2019'  }}
+                        runner: ${{ github.repository == format('{0}/{1}',github.repository_owner ,'lighthouse') && fromJson('["self-hosted", "windows", "release"]') || 'windows-2019'  }}
                         profile: maxperf
 
         runs-on:    ${{ matrix.runner }}
@@ -90,53 +74,29 @@ jobs:
             #       Builds
             # ==============================
 
-            - name: Build Lighthouse for aarch64-unknown-linux-gnu-portable
-              if:   matrix.arch == 'aarch64-unknown-linux-gnu-portable'
-              run:  |
-                cargo install cross
-                env CROSS_PROFILE=${{ matrix.profile }} make build-aarch64-portable
-
             - name: Build Lighthouse for aarch64-unknown-linux-gnu
               if:   matrix.arch == 'aarch64-unknown-linux-gnu'
               run:  |
                 cargo install cross
-                env CROSS_PROFILE=${{ matrix.profile }} make build-aarch64
-
-            - name: Build Lighthouse for x86_64-unknown-linux-gnu-portable
-              if:   matrix.arch == 'x86_64-unknown-linux-gnu-portable'
-              run:  |
-                cargo install cross
-                env CROSS_PROFILE=${{ matrix.profile }} make build-x86_64-portable
+                env CROSS_PROFILE=${{ matrix.profile }} make build-aarch64-portable
 
             - name: Build Lighthouse for x86_64-unknown-linux-gnu
               if:   matrix.arch == 'x86_64-unknown-linux-gnu'
               run:  |
                 cargo install cross
-                env CROSS_PROFILE=${{ matrix.profile }} make build-x86_64
+                env CROSS_PROFILE=${{ matrix.profile }} make build-x86_64-portable
 
             - name: Move cross-compiled binary
-              if:  startsWith(matrix.arch, 'aarch64')
-              run: mv target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ~/.cargo/bin/lighthouse
+              if:  contains(matrix.arch, 'unknown-linux-gnu')
+              run: mv target/${{ matrix.arch }}/${{ matrix.profile }}/lighthouse ~/.cargo/bin/lighthouse
 
-            - name: Move cross-compiled binary
-              if:  startsWith(matrix.arch, 'x86_64-unknown-linux-gnu')
-              run: mv target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ~/.cargo/bin/lighthouse
-
-            - name: Build Lighthouse for x86_64-apple-darwin portable
-              if:   matrix.arch == 'x86_64-apple-darwin-portable'
-              run:  cargo install --path lighthouse --force --locked --features portable,gnosis --profile ${{ matrix.profile }}
-
-            - name: Build Lighthouse for x86_64-apple-darwin modern
+            - name: Build Lighthouse for x86_64-apple-darwin
               if:   matrix.arch == 'x86_64-apple-darwin'
-              run:  cargo install --path lighthouse --force --locked --features modern,gnosis --profile ${{ matrix.profile }}
-
-            - name: Build Lighthouse for Windows portable
-              if:   matrix.arch == 'x86_64-windows-portable'
               run:  cargo install --path lighthouse --force --locked --features portable,gnosis --profile ${{ matrix.profile }}
 
-            - name: Build Lighthouse for Windows modern
+            - name: Build Lighthouse for Windows
               if:   matrix.arch == 'x86_64-windows'
-              run:  cargo install --path lighthouse --force --locked --features modern,gnosis --profile ${{ matrix.profile }}
+              run:  cargo install --path lighthouse --force --locked --features portable,gnosis --profile ${{ matrix.profile }}
 
             - name: Configure GPG and create artifacts
               if: startsWith(matrix.arch, 'x86_64-windows') != true
@@ -151,7 +111,14 @@ jobs:
                   cd artifacts
                   tar -czf lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz lighthouse
                   echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
+                  for ext in "tar.gz" "tar.gz.asc";\
+                  do for f in *.$ext;\
+                    do cp $f "../${f%.$ext}-portable.$ext";\
+                    done;\
+                  done
+ 
                   mv *tar.gz* ..
+                  
 
             - name: Configure GPG and create artifacts Windows
               if: startsWith(matrix.arch, 'x86_64-windows')
@@ -166,6 +133,7 @@ jobs:
                   tar -czf lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz lighthouse.exe
                   gpg --passphrase "$env:GPG_PASSPHRASE" --batch --pinentry-mode loopback -ab lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
                   move *tar.gz* ..
+                  # todo copy to `-portable`
 
             # =======================================================================
             # Upload artifacts
@@ -179,11 +147,27 @@ jobs:
                   path: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz
                   compression-level: 0
 
+            - name: Upload artifact (copy)
+              if: startsWith(matrix.arch, 'x86_64-windows') != true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}-portable.tar.gz
+                  path: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}-portable.tar.gz
+                  compression-level: 0
+
             - name: Upload signature
               uses: actions/upload-artifact@v4
               with:
                   name: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
                   path: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}.tar.gz.asc
+                  compression-level: 0
+
+            - name: Upload signature (copy)
+              if: startsWith(matrix.arch, 'x86_64-windows') != true
+              uses: actions/upload-artifact@v4
+              with:
+                  name: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}-portable.tar.gz.asc
+                  path: lighthouse-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.arch }}-portable.tar.gz.asc
                   compression-level: 0
 
     draft-release:

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0"]
+pre-build = ["apt-get install -y cmake clang-5.0 lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0"]
+pre-build = ["apt-get install -y cmake clang-5.0 lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,5 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0 lld-8"]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+pre-build = ["apt-get install -y cmake clang-5.0"]
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0 lld-8"]
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+pre-build = ["apt-get install -y cmake clang-5.0"]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0 lld"]
+pre-build = ["apt-get install -y cmake clang-5.0 lld-8"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = ["apt-get install -y cmake clang-5.0 lld"]
+pre-build = ["apt-get install -y cmake clang-5.0 lld-8"]
 rustflags = ["-C", "link-arg=-fuse-ld=lld"]

--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,9 @@ build-aarch64-portable:
 	cross build --bin lighthouse --target aarch64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 
 build-lcli-x86_64:
-        cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
+	cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 build-lcli-aarch64:
-        cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
+	cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 
 # Create a `.tar.gz` containing a binary for a specific target.
 define tarball_release_binary

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ build-aarch64:
 build-aarch64-portable:
 	cross build --bin lighthouse --target aarch64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 
+build-lcli-x86_64:
+        cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
+build-lcli-aarch64:
+        cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
+
 # Create a `.tar.gz` containing a binary for a specific target.
 define tarball_release_binary
 	cp $(1)/lighthouse $(BIN_DIR)/lighthouse

--- a/lcli/Dockerfile.cross
+++ b/lcli/Dockerfile.cross
@@ -1,0 +1,6 @@
+# This image is meant to enable cross-architecture builds.
+# It assumes the lcli binary has already been
+# compiled for `$TARGETPLATFORM` and moved to `./bin`.
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
+RUN apt update && apt -y upgrade && apt clean && rm -rf /var/lib/apt/lists/*
+COPY ./bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
## Issue Addressed

Heavily reduces strain on CI infra during docker builds and releases 
(docker builds: 9 -> 4* ; release builds 8 -> 4) 
See #5457

## Proposed Changes

Make `blst-portable` the default across the board and stop offering `force-adx` builds

## Additional Info

In this PR, all current docker tags and direct release links** are preserved but lead to a `portable` build instead, which should work for everyone. 

The idea is to release with these placeholders to try and assess how many downloads we still get on the to-be-deprecated release links.

Before we consider this, we should make absolutely sure that the performance hit, if present, is negligible on modern hardware. 

(* 8 lighthouse and 1 lcli build --> 2 lighthouse and 2 lcli builds)
(** excluding the link for a non-portable windows build)

### Summary of changes

- all lighthouse builds (both binaries and docker) use the portable `blst` library
- `lcli` is built through `cross`, and published as multiplatform image
- regular docker images now include `spec-minimal`
