### PR TITLE
Bump duplicate cache time

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -20,20 +20,6 @@ pub const DEFAULT_TCP_PORT: u16 = 9000u16;
 pub const DEFAULT_DISC_PORT: u16 = 9000u16;
 pub const DEFAULT_QUIC_PORT: u16 = 9001u16;
 
-/// The cache time is set to accommodate the circulation time of an attestation.
-///
-/// The p2p spec declares that we accept attestations within the following range:
-///
-/// ```ignore
-/// ATTESTATION_PROPAGATION_SLOT_RANGE = 32
-/// attestation.data.slot + ATTESTATION_PROPAGATION_SLOT_RANGE >= current_slot >= attestation.data.slot
-/// ```
-///
-/// Therefore, we must accept attestations across a span of 33 slots (where each slot is 12
-/// seconds). We add an additional second to account for the 500ms gossip clock disparity, and
-/// another 500ms for "fudge factor".
-pub const DUPLICATE_CACHE_TIME: Duration = Duration::from_secs(33 * 12 + 1);
-
 /// The maximum size of gossip messages.
 pub fn gossip_max_size(is_merge_enabled: bool, gossip_max_size: usize) -> usize {
     if is_merge_enabled {
@@ -452,6 +438,8 @@ pub fn gossipsub_config(
     network_load: u8,
     fork_context: Arc<ForkContext>,
     gossipsub_config_params: GossipsubConfigParams,
+    seconds_per_slot: u64,
+    slots_per_epoch: u64,
 ) -> gossipsub::Config {
     fn prefix(
         prefix: [u8; 4],
@@ -491,6 +479,13 @@ pub fn gossipsub_config(
 
     let load = NetworkLoad::from(network_load);
 
+    // Since EIP 7045 (activated at the deneb fork), we allow attestations that are
+    // 2 epochs old to be circulated around the p2p network.
+    // To accommodate the increase, we should increase the duplicate cache time to filter older seen messages.
+    // 2 epochs is quite sane for pre-deneb network parameters as well.
+    // Hence we keep the same parameters for pre-deneb networks as well to avoid switching at the fork.
+    let duplicate_cache_time = Duration::from_secs(slots_per_epoch * seconds_per_slot * 2);
+
     gossipsub::ConfigBuilder::default()
         .max_transmit_size(gossip_max_size(
             is_merge_enabled,
@@ -509,7 +504,7 @@ pub fn gossipsub_config(
         .history_gossip(load.history_gossip)
         .validate_messages() // require validation before propagation
         .validation_mode(gossipsub::ValidationMode::Anonymous)
-        .duplicate_cache_time(DUPLICATE_CACHE_TIME)
+        .duplicate_cache_time(duplicate_cache_time)
         .message_id_fn(gossip_message_id)
         .allow_self_origin(true)
         .build()

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -256,6 +256,8 @@ impl<AppReqId: ReqId, TSpec: EthSpec> Network<AppReqId, TSpec> {
                 config.network_load,
                 ctx.fork_context.clone(),
                 gossipsub_config_params,
+                ctx.chain_spec.seconds_per_slot,
+                TSpec::slots_per_epoch(),
             );
 
             // If metrics are enabled for libp2p build the configuration


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Increases the gossipsub duplicate cache time to reject older seen attestations in the allowed time range according to https://github.com/ethereum/consensus-specs/pull/3627

I have not implemented any fork switching logic because the complexity doesn't seem worth it as having 2 epochs worth message ids seems sane for pre-deneb network parameters as well.
Happy to add it if anyone disagrees.

