### PR TITLE
patch libp2p-upnp to address bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,8 +4753,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49cc89949bf0e06869297cd4fe2c132358c23fe93e76ad43950453df4da3d35"
+source = "git+https://github.com/sigp/rust-libp2p.git?branch=fix-upnp#90f1ef8cbcd40129bb068f04c9e408d3009e4948"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7728,9 +7727,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"
 slog-async = "2"
 slog-term = "2"
 sloggers = { version = "2", features = ["json"] }
-smallvec = "1.11.2"
+smallvec = "1.13.2"
 snap = "1"
 ssz_types = "0.5"
 strum = { version = "0.24", features = ["derive"] }
@@ -235,6 +235,7 @@ warp_utils = { path = "common/warp_utils" }
 
 [patch.crates-io]
 yamux = { git = "https://github.com/sigp/rust-yamux.git" }
+libp2p-upnp = { git = "https://github.com/sigp/rust-libp2p.git", branch = "fix-upnp" }
 
 [profile.maxperf]
 inherits = "release"


### PR DESCRIPTION
## Issue Addressed

patches `libp2p-upnp` which has https://github.com/libp2p/rust-libp2p/pull/5273 to address https://github.com/sigp/lighthouse/issues/5498.  
@jimmyisthis can you give this branch a go and confirm if it fixes the issue? Thanks!