### PR TITLE
Impl Ord on ForkName for ChainSpec usage

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -334,12 +334,12 @@ impl ChainSpec {
     }
 
     pub fn inactivity_penalty_quotient_for_fork(&self, fork_name: ForkName) -> u64 {
-        match fork_name {
-            ForkName::Base => self.inactivity_penalty_quotient,
-            ForkName::Altair => self.inactivity_penalty_quotient_altair,
-            ForkName::Merge => self.inactivity_penalty_quotient_bellatrix,
-            ForkName::Capella => self.inactivity_penalty_quotient_bellatrix,
-            ForkName::Deneb | ForkName::Electra => self.inactivity_penalty_quotient_bellatrix,
+        if fork_name >= ForkName::Merge {
+            self.inactivity_penalty_quotient_bellatrix
+        } else if fork_name >= ForkName::Altair {
+            self.inactivity_penalty_quotient_altair
+        } else {
+            self.inactivity_penalty_quotient
         }
     }
 
@@ -348,13 +348,13 @@ impl ChainSpec {
         &self,
         state: &BeaconState<E>,
     ) -> u64 {
-        match state {
-            BeaconState::Base(_) => self.proportional_slashing_multiplier,
-            BeaconState::Altair(_) => self.proportional_slashing_multiplier_altair,
-            BeaconState::Merge(_) => self.proportional_slashing_multiplier_bellatrix,
-            BeaconState::Capella(_) => self.proportional_slashing_multiplier_bellatrix,
-            BeaconState::Deneb(_) => self.proportional_slashing_multiplier_bellatrix,
-            BeaconState::Electra(_) => self.proportional_slashing_multiplier_bellatrix,
+        let fork_name = state.fork_name_unchecked();
+        if fork_name >= ForkName::Merge {
+            self.proportional_slashing_multiplier_bellatrix
+        } else if fork_name >= ForkName::Altair {
+            self.proportional_slashing_multiplier_altair
+        } else {
+            self.proportional_slashing_multiplier
         }
     }
 
@@ -363,13 +363,13 @@ impl ChainSpec {
         &self,
         state: &BeaconState<E>,
     ) -> u64 {
-        match state {
-            BeaconState::Base(_) => self.min_slashing_penalty_quotient,
-            BeaconState::Altair(_) => self.min_slashing_penalty_quotient_altair,
-            BeaconState::Merge(_) => self.min_slashing_penalty_quotient_bellatrix,
-            BeaconState::Capella(_) => self.min_slashing_penalty_quotient_bellatrix,
-            BeaconState::Deneb(_) => self.min_slashing_penalty_quotient_bellatrix,
-            BeaconState::Electra(_) => self.min_slashing_penalty_quotient_bellatrix,
+        let fork_name = state.fork_name_unchecked();
+        if fork_name >= ForkName::Merge {
+            self.min_slashing_penalty_quotient_bellatrix
+        } else if fork_name >= ForkName::Altair {
+            self.min_slashing_penalty_quotient_altair
+        } else {
+            self.min_slashing_penalty_quotient
         }
     }
 
@@ -531,22 +531,19 @@ impl ChainSpec {
     }
 
     pub fn max_blocks_by_root_request(&self, fork_name: ForkName) -> usize {
-        match fork_name {
-            ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
-                self.max_blocks_by_root_request
-            }
-            ForkName::Deneb | ForkName::Electra => self.max_blocks_by_root_request_deneb,
+        if fork_name >= ForkName::Deneb {
+            self.max_blocks_by_root_request_deneb
+        } else {
+            self.max_blocks_by_root_request
         }
     }
 
     pub fn max_request_blocks(&self, fork_name: ForkName) -> usize {
-        let max_request_blocks = match fork_name {
-            ForkName::Base | ForkName::Altair | ForkName::Merge | ForkName::Capella => {
-                self.max_request_blocks
-            }
-            ForkName::Deneb | ForkName::Electra => self.max_request_blocks_deneb,
-        };
-        max_request_blocks as usize
+        if fork_name >= ForkName::Deneb {
+            self.max_request_blocks_deneb as usize
+        } else {
+            self.max_request_blocks as usize
+        }
     }
 
     /// Returns a `ChainSpec` compatible with the Ethereum Foundation specification.

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -4,7 +4,9 @@ use ssz_derive::{Decode, Encode};
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, Decode, Encode, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
 #[serde(try_from = "String")]
 #[serde(into = "String")]
 #[ssz(enum_behaviour = "tag")]

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -274,4 +274,13 @@ mod test {
         }
         assert_eq!(ForkName::latest(), fork);
     }
+
+    #[test]
+    fn fork_ord_consistent() {
+        for (prev_fork, fork) in ForkName::list_all().into_iter().tuple_windows() {
+            assert_eq!(prev_fork.next_fork(), Some(fork));
+            assert_eq!(fork.previous_fork(), Some(prev_fork));
+            assert!(prev_fork < fork);
+        }
+    }
 }


### PR DESCRIPTION
## Issue Addressed

When having fork-dependant logic there's a trade-off between exhaustive match pattern and ordering. LH maintainers should consider that this client is used quite a bit to develop future features, which may also need to implement a fork.

- exhaustive: You ensure that at least one developer considers if this config value has been changed for the new fork.
- ordering: Reverse the above, and reduce the amount of boilerplate a PoC developer has to go through. On an Ethereum mainnet fork, I find it very unlikely that we would forget to update such values. Spec tests cover the state transition values, and the spec diff will make it very obvious that we need to change some networking constants.

Can't ignore the fact that there still quite a bit of fork boiler-plate out there, but hopefully this PR is the first step into a less boiled future :)

Original discussion in https://github.com/sigp/lighthouse/pull/5507#discussion_r1548727242

## Proposed Changes

Impl Ord on ForkName for ChainSpec usage

