### PR TITLE
Improve block lookup logging

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -127,14 +127,14 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             .update_requested_parent_block(next_parent)
     }
 
-    pub fn block_processing_peer(&self) -> Result<PeerId, ()> {
+    pub fn block_processing_peer(&self) -> Result<PeerId, String> {
         self.current_parent_request
             .block_request_state
             .state
             .processing_peer()
     }
 
-    pub fn blob_processing_peer(&self) -> Result<PeerId, ()> {
+    pub fn blob_processing_peer(&self) -> Result<PeerId, String> {
         self.current_parent_request
             .blob_request_state
             .state

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -465,11 +465,10 @@ impl SingleLookupRequestState {
 
     /// Returns the id peer we downloaded from if we have downloaded a verified block, otherwise
     /// returns an error.
-    pub fn processing_peer(&self) -> Result<PeerId, ()> {
-        if let State::Processing { peer_id } = &self.state {
-            Ok(*peer_id)
-        } else {
-            Err(())
+    pub fn processing_peer(&self) -> Result<PeerId, String> {
+        match &self.state {
+            State::Processing { peer_id } => Ok(*peer_id),
+            other => Err(format!("not in processing state: {}", other).to_string()),
         }
     }
 }
@@ -522,6 +521,16 @@ impl slog::Value for SingleLookupRequestState {
         serializer.emit_u8("failed_downloads", self.failed_downloading)?;
         serializer.emit_u8("failed_processing", self.failed_processing)?;
         slog::Result::Ok(())
+    }
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::AwaitingDownload => write!(f, "AwaitingDownload"),
+            State::Downloading { .. } => write!(f, "Downloading"),
+            State::Processing { .. } => write!(f, "Processing"),
+        }
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

When dabbling in https://github.com/sigp/lighthouse/pull/5534, I noticed some code paths that should be covered by logging

## Proposed Changes

Add some extra logs in block lookup

## Additional Info

Noticed that `SyncMessage::UnknownBlockHashFromAttestation` only checks `synced_and_connected` whereas `SyncMessage::UnknownParentBlob` checks also `is_execution_engine_online`. Is this by design or a typo?
