### PR TITLE
Beta compiler fixes

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -22,11 +22,9 @@
 
 use super::*;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
-use crate::transform::{DataTransform, IdentityTransform};
-use crate::types::{RpcOut, RpcReceiver};
-use crate::ValidationError;
+use crate::types::RpcReceiver;
 use crate::{
-    config::Config, config::ConfigBuilder, types::Rpc, IdentTopic as Topic, TopicScoreParams,
+    config::ConfigBuilder, types::Rpc, IdentTopic as Topic, 
 };
 use byteorder::{BigEndian, ByteOrder};
 use libp2p::core::ConnectedPoint;

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -23,9 +23,7 @@
 use super::*;
 use crate::subscription_filter::WhitelistSubscriptionFilter;
 use crate::types::RpcReceiver;
-use crate::{
-    config::ConfigBuilder, types::Rpc, IdentTopic as Topic, 
-};
+use crate::{config::ConfigBuilder, types::Rpc, IdentTopic as Topic};
 use byteorder::{BigEndian, ByteOrder};
 use libp2p::core::ConnectedPoint;
 use rand::Rng;

--- a/beacon_node/lighthouse_network/gossipsub/src/config.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/config.rs
@@ -903,7 +903,6 @@ impl std::fmt::Debug for Config {
 mod test {
     use super::*;
     use crate::topic::IdentityHash;
-    use crate::types::PeerKind;
     use crate::Topic;
     use libp2p::core::UpgradeInfo;
     use std::collections::hash_map::DefaultHasher;

--- a/beacon_node/lighthouse_network/gossipsub/src/mcache.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/mcache.rs
@@ -221,7 +221,7 @@ impl MessageCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IdentTopic as Topic};
+    use crate::IdentTopic as Topic;
 
     fn gen_testm(x: u64, topic: TopicHash) -> (MessageId, RawMessage) {
         let default_id = |message: &RawMessage| {

--- a/beacon_node/lighthouse_network/gossipsub/src/mcache.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/mcache.rs
@@ -221,9 +221,7 @@ impl MessageCache {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::RawMessage;
-    use crate::{IdentTopic as Topic, TopicHash};
-    use libp2p::identity::PeerId;
+    use crate::{IdentTopic as Topic};
 
     fn gen_testm(x: u64, topic: TopicHash) -> (MessageId, RawMessage) {
         let default_id = |message: &RawMessage| {

--- a/beacon_node/lighthouse_network/gossipsub/src/protocol.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/protocol.rs
@@ -508,7 +508,6 @@ impl Decoder for GossipsubCodec {
 mod tests {
     use super::*;
     use crate::config::Config;
-    use crate::protocol::{BytesMut, GossipsubCodec, HandlerEvent};
     use crate::{Behaviour, ConfigBuilder, MessageAuthenticity};
     use crate::{IdentTopic as Topic, Version};
     use libp2p::identity::Keypair;

--- a/beacon_node/lighthouse_network/gossipsub/src/subscription_filter.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/subscription_filter.rs
@@ -212,7 +212,6 @@ impl TopicSubscriptionFilter for RegexSubscriptionFilter {
 mod test {
     use super::*;
     use crate::types::SubscriptionAction::*;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_filter_incoming_allow_all_with_duplicates() {

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -721,7 +721,7 @@ impl<E: EthSpec> OperationPool<E> {
 }
 
 /// Filter up to a maximum number of operations out of an iterator.
-fn filter_limit_operations<'a, T: 'a, V: 'a, I, F, G>(
+fn filter_limit_operations<'a, T, V: 'a, I, F, G>(
     operations: I,
     filter: F,
     mapping: G,
@@ -731,7 +731,7 @@ where
     I: IntoIterator<Item = &'a T>,
     F: Fn(&T) -> bool,
     G: Fn(&T) -> V,
-    T: Clone,
+    T: Clone + 'a,
 {
     operations
         .into_iter()

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1651,7 +1651,6 @@ where
 mod tests {
     use super::*;
     use itertools::Itertools;
-    use safe_arith::SafeArith;
 
     #[test]
     fn test_mainnet_spec_can_be_constructed() {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use types::{
     Attestation, AttesterSlashing, BeaconBlock, BeaconState, BlobSidecar, BlobsList, Checkpoint,
-    EthSpec, ExecutionBlockHash, ForkName, Hash256, IndexedAttestation, KzgProof,
+    ExecutionBlockHash, Hash256, IndexedAttestation, KzgProof,
     ProposerPreparationData, SignedBeaconBlock, Slot, Uint256,
 };
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use types::{
     Attestation, AttesterSlashing, BeaconBlock, BeaconState, BlobSidecar, BlobsList, Checkpoint,
-    ExecutionBlockHash, Hash256, IndexedAttestation, KzgProof,
-    ProposerPreparationData, SignedBeaconBlock, Slot, Uint256,
+    ExecutionBlockHash, Hash256, IndexedAttestation, KzgProof, ProposerPreparationData,
+    SignedBeaconBlock, Slot, Uint256,
 };
 
 #[derive(Default, Debug, PartialEq, Clone, Deserialize, Decode)]

--- a/testing/ef_tests/src/cases/rewards.rs
+++ b/testing/ef_tests/src/cases/rewards.rs
@@ -13,8 +13,7 @@ use state_processing::{
     },
     EpochProcessingError,
 };
-use std::path::{Path, PathBuf};
-use types::{BeaconState, EthSpec, ForkName};
+use types::BeaconState;
 
 #[derive(Debug, Clone, PartialEq, Decode, Encode, CompareFields)]
 pub struct Deltas {


### PR DESCRIPTION
## Issue Addressed

- duplicate imports are being flagged in some tests where we use `use super::*;`
- there's also a new lint about defining trait bounds in two places, this only affects us in one place

