### PR TITLE
Allow 1 count block request to return 0 blocks

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -180,7 +180,7 @@ struct OutboundInfo<Id, E: EthSpec> {
     /// Info over the protocol this substream is handling.
     proto: Protocol,
     /// Number of chunks to be seen from the peer's response.
-    remaining_chunks: Option<u64>,
+    max_remaining_chunks: Option<u64>,
     /// `Id` as given by the application that sent the request.
     req_id: Id,
 }
@@ -664,15 +664,19 @@ where
                     request,
                 } => match substream.poll_next_unpin(cx) {
                     Poll::Ready(Some(Ok(response))) => {
-                        if request.expected_responses() > 1 && !response.close_after() {
+                        if request.expect_exactly_one_response() || response.close_after() {
+                            // either this is a single response request or this response closes the
+                            // stream
+                            entry.get_mut().state = OutboundSubstreamState::Closing(substream);
+                        } else {
                             let substream_entry = entry.get_mut();
                             let delay_key = &substream_entry.delay_key;
                             // chunks left after this one
-                            let remaining_chunks = substream_entry
-                                .remaining_chunks
+                            let max_remaining_chunks = substream_entry
+                                .max_remaining_chunks
                                 .map(|count| count.saturating_sub(1))
                                 .unwrap_or_else(|| 0);
-                            if remaining_chunks == 0 {
+                            if max_remaining_chunks == 0 {
                                 // this is the last expected message, close the stream as all expected chunks have been received
                                 substream_entry.state = OutboundSubstreamState::Closing(substream);
                             } else {
@@ -682,14 +686,10 @@ where
                                         substream,
                                         request,
                                     };
-                                substream_entry.remaining_chunks = Some(remaining_chunks);
+                                substream_entry.max_remaining_chunks = Some(max_remaining_chunks);
                                 self.outbound_substreams_delay
                                     .reset(delay_key, self.resp_timeout);
                             }
-                        } else {
-                            // either this is a single response request or this response closes the
-                            // stream
-                            entry.get_mut().state = OutboundSubstreamState::Closing(substream);
                         }
 
                         // Check what type of response we got and report it accordingly
@@ -725,7 +725,16 @@ where
                         self.outbound_substreams_delay.remove(delay_key);
                         entry.remove_entry();
                         // notify the application error
-                        if request.expected_responses() > 1 {
+                        if request.expect_exactly_one_response() {
+                            // else we return an error, stream should not have closed early.
+                            return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
+                                HandlerEvent::Err(HandlerErr::Outbound {
+                                    id: request_id,
+                                    proto: request.versioned_protocol().protocol(),
+                                    error: RPCError::IncompleteStream,
+                                }),
+                            ));
+                        } else {
                             // return an end of stream result
                             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
                                 HandlerEvent::Ok(RPCReceived::EndOfStream(
@@ -734,16 +743,6 @@ where
                                 )),
                             ));
                         }
-
-                        // else we return an error, stream should not have closed early.
-                        let outbound_err = HandlerErr::Outbound {
-                            id: request_id,
-                            proto: request.versioned_protocol().protocol(),
-                            error: RPCError::IncompleteStream,
-                        };
-                        return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
-                            HandlerEvent::Err(outbound_err),
-                        ));
                     }
                     Poll::Pending => {
                         entry.get_mut().state =
@@ -948,8 +947,14 @@ where
         }
 
         // add the stream to substreams if we expect a response, otherwise drop the stream.
-        let expected_responses = request.expected_responses();
-        if expected_responses > 0 {
+        let max_responses = request.max_responses();
+        if max_responses > 0 {
+            let max_remaining_chunks = if request.expect_exactly_one_response() {
+                // Currently enforced only for multiple responses
+                None
+            } else {
+                Some(max_responses)
+            };
             // new outbound request. Store the stream and tag the output.
             let delay_key = self
                 .outbound_substreams_delay
@@ -957,12 +962,6 @@ where
             let awaiting_stream = OutboundSubstreamState::RequestPendingResponse {
                 substream: Box::new(substream),
                 request,
-            };
-            let expected_responses = if expected_responses > 1 {
-                // Currently enforced only for multiple responses
-                Some(expected_responses)
-            } else {
-                None
             };
             if self
                 .outbound_substreams
@@ -972,7 +971,7 @@ where
                         state: awaiting_stream,
                         delay_key,
                         proto,
-                        remaining_chunks: expected_responses,
+                        max_remaining_chunks,
                         req_id: id,
                     },
                 )

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -483,27 +483,6 @@ impl<E: EthSpec> RPCCodedResponse<E> {
         RPCCodedResponse::Error(code, err)
     }
 
-    /// Specifies which response allows for multiple chunks for the stream handler.
-    pub fn multiple_responses(&self) -> bool {
-        match self {
-            RPCCodedResponse::Success(resp) => match resp {
-                RPCResponse::Status(_) => false,
-                RPCResponse::BlocksByRange(_) => true,
-                RPCResponse::BlocksByRoot(_) => true,
-                RPCResponse::BlobsByRange(_) => true,
-                RPCResponse::BlobsByRoot(_) => true,
-                RPCResponse::Pong(_) => false,
-                RPCResponse::MetaData(_) => false,
-                RPCResponse::LightClientBootstrap(_) => false,
-                RPCResponse::LightClientOptimisticUpdate(_) => false,
-                RPCResponse::LightClientFinalityUpdate(_) => false,
-            },
-            RPCCodedResponse::Error(_, _) => true,
-            // Stream terminations are part of responses that have chunks
-            RPCCodedResponse::StreamTermination(_) => true,
-        }
-    }
-
     /// Returns true if this response always terminates the stream.
     pub fn close_after(&self) -> bool {
         !matches!(self, RPCCodedResponse::Success(_))

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -91,7 +91,7 @@ impl<E: EthSpec> OutboundRequest<E> {
     }
     /* These functions are used in the handler for stream management */
 
-    /// Number of responses expected for this request.
+    /// Maximum number of responses expected for this request.
     pub fn max_responses(&self) -> u64 {
         match self {
             OutboundRequest::Status(_) => 1,

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -92,7 +92,7 @@ impl<E: EthSpec> OutboundRequest<E> {
     /* These functions are used in the handler for stream management */
 
     /// Number of responses expected for this request.
-    pub fn expected_responses(&self) -> u64 {
+    pub fn max_responses(&self) -> u64 {
         match self {
             OutboundRequest::Status(_) => 1,
             OutboundRequest::Goodbye(_) => 0,
@@ -102,6 +102,19 @@ impl<E: EthSpec> OutboundRequest<E> {
             OutboundRequest::BlobsByRoot(req) => req.blob_ids.len() as u64,
             OutboundRequest::Ping(_) => 1,
             OutboundRequest::MetaData(_) => 1,
+        }
+    }
+
+    pub fn expect_exactly_one_response(&self) -> bool {
+        match self {
+            OutboundRequest::Status(_) => true,
+            OutboundRequest::Goodbye(_) => false,
+            OutboundRequest::BlocksByRange(_) => false,
+            OutboundRequest::BlocksByRoot(_) => false,
+            OutboundRequest::BlobsByRange(_) => false,
+            OutboundRequest::BlobsByRoot(_) => false,
+            OutboundRequest::Ping(_) => true,
+            OutboundRequest::MetaData(_) => true,
         }
     }
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -654,8 +654,8 @@ pub enum InboundRequest<E: EthSpec> {
 impl<E: EthSpec> InboundRequest<E> {
     /* These functions are used in the handler for stream management */
 
-    /// Number of responses expected for this request.
-    pub fn expected_responses(&self) -> u64 {
+    /// Maximum number of responses expected for this request.
+    pub fn max_responses(&self) -> u64 {
         match self {
             InboundRequest::Status(_) => 1,
             InboundRequest::Goodbye(_) => 0,

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -228,7 +228,7 @@ impl RPCRateLimiterBuilder {
 
 pub trait RateLimiterItem {
     fn protocol(&self) -> Protocol;
-    fn expected_responses(&self) -> u64;
+    fn max_responses(&self) -> u64;
 }
 
 impl<E: EthSpec> RateLimiterItem for super::InboundRequest<E> {
@@ -236,8 +236,8 @@ impl<E: EthSpec> RateLimiterItem for super::InboundRequest<E> {
         self.versioned_protocol().protocol()
     }
 
-    fn expected_responses(&self) -> u64 {
-        self.expected_responses()
+    fn max_responses(&self) -> u64 {
+        self.max_responses()
     }
 }
 
@@ -246,7 +246,7 @@ impl<E: EthSpec> RateLimiterItem for super::OutboundRequest<E> {
         self.versioned_protocol().protocol()
     }
 
-    fn expected_responses(&self) -> u64 {
+    fn max_responses(&self) -> u64 {
         self.max_responses()
     }
 }
@@ -299,7 +299,7 @@ impl RPCRateLimiter {
         request: &Item,
     ) -> Result<(), RateLimitedErr> {
         let time_since_start = self.init_time.elapsed();
-        let tokens = request.expected_responses().max(1);
+        let tokens = request.max_responses().max(1);
 
         let check =
             |limiter: &mut Limiter<PeerId>| limiter.allows(time_since_start, peer_id, tokens);

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -247,7 +247,7 @@ impl<E: EthSpec> RateLimiterItem for super::OutboundRequest<E> {
     }
 
     fn expected_responses(&self) -> u64 {
-        self.expected_responses()
+        self.max_responses()
     }
 }
 impl RPCRateLimiter {


### PR DESCRIPTION
## Issue Addressed

Noted the following bug in ReqResp logic:
- We issue a ReqResp request for blocks where the count of requested elements is 1
- The peer does not have the requested element and returns 0 elements
- We consider that a protocol violation with `RPCError::IncompleteStream`

Not having a block or blob is tolerated as per the req resp spec. It's the downstream caller that should decide if the peer should have or not that specific element.

## Proposed Changes

Rename `expected_responses` to `max_responses`, as for multiple responses that what the number really represents. The peer is allow to return less than the request count of elements, including 0.

Add a new function `expect_exactly_one_response` to differentiate those request where closing the stream before the first element is actually a protocol violation (e.g. status method)

I have reversed some of the if else cases, (from `if !condition A else B` to `if condition B else A`, but the actual logic is unchanged.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
