### PR TITLE
Nest lookup type into request id SingleBlock and SingleBlob

### DIFF
--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -493,10 +493,7 @@ impl<T: BeaconChainTypes> Router<T> {
     ) {
         let request_id = match request_id {
             RequestId::Sync(sync_id) => match sync_id {
-                SyncId::SingleBlock { .. }
-                | SyncId::SingleBlob { .. }
-                | SyncId::ParentLookup { .. }
-                | SyncId::ParentLookupBlob { .. } => {
+                SyncId::SingleBlock { .. } | SyncId::SingleBlob { .. } => {
                     crit!(self.log, "Block lookups do not request BBRange requests"; "peer_id" => %peer_id);
                     return;
                 }
@@ -561,7 +558,7 @@ impl<T: BeaconChainTypes> Router<T> {
     ) {
         let request_id = match request_id {
             RequestId::Sync(sync_id) => match sync_id {
-                id @ (SyncId::SingleBlock { .. } | SyncId::ParentLookup { .. }) => id,
+                id @ SyncId::SingleBlock { .. } => id,
                 SyncId::BackFillBlocks { .. }
                 | SyncId::RangeBlocks { .. }
                 | SyncId::RangeBlockAndBlobs { .. }
@@ -569,7 +566,7 @@ impl<T: BeaconChainTypes> Router<T> {
                     crit!(self.log, "Batch syncing do not request BBRoot requests"; "peer_id" => %peer_id);
                     return;
                 }
-                SyncId::SingleBlob { .. } | SyncId::ParentLookupBlob { .. } => {
+                SyncId::SingleBlob { .. } => {
                     crit!(self.log, "Blob response to block by roots request"; "peer_id" => %peer_id);
                     return;
                 }
@@ -602,8 +599,8 @@ impl<T: BeaconChainTypes> Router<T> {
     ) {
         let request_id = match request_id {
             RequestId::Sync(sync_id) => match sync_id {
-                id @ (SyncId::SingleBlob { .. } | SyncId::ParentLookupBlob { .. }) => id,
-                SyncId::SingleBlock { .. } | SyncId::ParentLookup { .. } => {
+                id @ SyncId::SingleBlob { .. } => id,
+                SyncId::SingleBlock { .. } => {
                     crit!(self.log, "Block response to blobs by roots request"; "peer_id" => %peer_id);
                     return;
                 }

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -25,7 +25,7 @@ pub enum ResponseType {
     Blob,
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum LookupType {
     Current,
     Parent,
@@ -119,6 +119,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         let id = SingleLookupReqId {
             id,
             req_counter: self.get_state().req_counter,
+            lookup_type: L::lookup_type(),
         };
         Self::make_request(id, peer_id, request, cx)
     }
@@ -265,7 +266,7 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L>
         request: Self::RequestType,
         cx: &SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
-        cx.block_lookup_request(id, peer_id, request, L::lookup_type())
+        cx.block_lookup_request(id, peer_id, request)
             .map_err(LookupRequestError::SendFailed)
     }
 
@@ -365,7 +366,7 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
         request: Self::RequestType,
         cx: &SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
-        cx.blob_lookup_request(id, peer_id, request, L::lookup_type())
+        cx.blob_lookup_request(id, peer_id, request)
             .map_err(LookupRequestError::SendFailed)
     }
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -691,7 +691,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     pub fn parent_lookup_failed<R: RequestState<Parent, T>>(
         &mut self,
         id: SingleLookupReqId,
-        peer_id: PeerId,
+        peer_id: &PeerId,
         cx: &SyncNetworkContext<T>,
         error: RPCError,
     ) {


### PR DESCRIPTION
## Issue Addressed

Part of:
- https://github.com/sigp/lighthouse/issues/5549

It's unnecessary to have distinct RequestIds for parent and current block lookups. The router does not need to be concerned with this distinction, only the block lookups struct needs to know where to route the response.

## Proposed Changes

Nest lookup type into request id SingleBlock and SingleBlob.

This PR does not change any sync logic. It fixes a typo in the test `no_peer_penalty_when_rpc_response_already_known_from_gossip` which was fetching the wrong ID


