### PR TITLE
Make SingleLookupRequestState fields private

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -12,7 +12,6 @@ use beacon_chain::data_availability_checker::ChildComponents;
 use beacon_chain::{get_block_root, BeaconChainTypes};
 use lighthouse_network::rpc::methods::BlobsByRootRequest;
 use lighthouse_network::rpc::BlocksByRootRequest;
-use rand::prelude::IteratorRandom;
 use std::ops::IndexMut;
 use std::sync::Arc;
 use std::time::Duration;
@@ -104,7 +103,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         cx: &SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         // Check if request is necessary.
-        if !matches!(self.get_state().state, State::AwaitingDownload) {
+        if self.get_state().is_awaiting_download() {
             return Ok(());
         }
 
@@ -112,13 +111,12 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         let (peer_id, request) = self.build_request(&cx.chain.spec)?;
 
         // Update request state.
-        self.get_state_mut().state = State::Downloading { peer_id };
-        self.get_state_mut().req_counter += 1;
+        let req_counter = self.get_state_mut().on_download_start(peer_id);
 
         // Make request
         let id = SingleLookupReqId {
             id,
-            req_counter: self.get_state().req_counter,
+            req_counter,
             lookup_type: L::lookup_type(),
         };
         Self::make_request(id, peer_id, request, cx)
@@ -130,8 +128,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         let request_state = self.get_state();
 
         if request_state.failed_attempts() >= max_attempts {
-            let cannot_process =
-                request_state.failed_processing >= request_state.failed_downloading;
+            let cannot_process = request_state.more_failed_processing_attempts();
             Err(LookupRequestError::TooManyAttempts { cannot_process })
         } else {
             Ok(())
@@ -141,15 +138,9 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     /// Get the next peer to request. Draws from the set of peers we think should have both the
     /// block and blob first. If that fails, we draw from the set of peers that may have either.
     fn get_peer(&mut self) -> Result<PeerId, LookupRequestError> {
-        let request_state = self.get_state_mut();
-        let peer_id = request_state
-            .available_peers
-            .iter()
-            .choose(&mut rand::thread_rng())
-            .copied()
-            .ok_or(LookupRequestError::NoPeers)?;
-        request_state.used_peers.insert(peer_id);
-        Ok(peer_id)
+        self.get_state_mut()
+            .use_rand_available_peer()
+            .ok_or(LookupRequestError::NoPeers)
     }
 
     /// Initialize `Self::RequestType`.
@@ -169,29 +160,35 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     fn verify_response(
         &mut self,
         expected_block_root: Hash256,
+        peer_id: PeerId,
         response: Option<Self::ResponseType>,
     ) -> Result<Option<Self::VerifiedResponseType>, LookupVerifyError> {
-        let request_state = self.get_state_mut();
-        match request_state.state {
-            State::AwaitingDownload => {
-                request_state.register_failure_downloading();
-                Err(LookupVerifyError::ExtraBlocksReturned)
+        let result = match *self.get_state().get_state() {
+            State::AwaitingDownload => Err(LookupVerifyError::ExtraBlocksReturned),
+            State::Downloading { peer_id: _ } => {
+                // TODO: We requested a download from Downloading { peer_id }, but the network
+                // injects a response from a different peer_id. What should we do? The peer_id to
+                // track for scoring is the one that actually sent the response, not the state's
+                self.verify_response_inner(expected_block_root, response)
             }
-            State::Downloading { peer_id } => {
-                self.verify_response_inner(expected_block_root, response, peer_id)
-            }
-            State::Processing { peer_id: _ } => match response {
-                Some(_) => {
-                    // We sent the block for processing and received an extra block.
-                    request_state.register_failure_downloading();
-                    Err(LookupVerifyError::ExtraBlocksReturned)
-                }
-                None => {
-                    // This is simply the stream termination and we are already processing the
-                    // block
-                    Ok(None)
-                }
+            State::Processing { .. } | State::Processed => match response {
+                // We sent the block for processing and received an extra block.
+                Some(_) => Err(LookupVerifyError::ExtraBlocksReturned),
+                // This is simply the stream termination and we are already processing the block
+                None => Ok(None),
             },
+        };
+
+        match result {
+            Ok(Some(response)) => {
+                self.get_state_mut().on_download_success(peer_id);
+                Ok(Some(response))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => {
+                self.get_state_mut().on_download_failure();
+                Err(e)
+            }
         }
     }
 
@@ -200,7 +197,6 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         &mut self,
         expected_block_root: Hash256,
         response: Option<Self::ResponseType>,
-        peer_id: PeerId,
     ) -> Result<Option<Self::VerifiedResponseType>, LookupVerifyError>;
 
     /// A getter for the parent root of the response. Returns an `Option` because we won't know
@@ -232,7 +228,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
 
     /// Register a failure to process the block or blob.
     fn register_failure_downloading(&mut self) {
-        self.get_state_mut().register_failure_downloading()
+        self.get_state_mut().on_download_failure()
     }
 
     /* Utility methods */
@@ -274,7 +270,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L>
         &mut self,
         expected_block_root: Hash256,
         response: Option<Self::ResponseType>,
-        peer_id: PeerId,
     ) -> Result<Option<Arc<SignedBeaconBlock<T::EthSpec>>>, LookupVerifyError> {
         match response {
             Some(block) => {
@@ -285,18 +280,13 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L>
                     // return an error and drop the block
                     // NOTE: we take this is as a download failure to prevent counting the
                     // attempt as a chain failure, but simply a peer failure.
-                    self.state.register_failure_downloading();
                     Err(LookupVerifyError::RootMismatch)
                 } else {
                     // Return the block for processing.
-                    self.state.state = State::Processing { peer_id };
                     Ok(Some(block))
                 }
             }
-            None => {
-                self.state.register_failure_downloading();
-                Err(LookupVerifyError::NoBlockReturned)
-            }
+            None => Err(LookupVerifyError::NoBlockReturned),
         }
     }
 
@@ -374,25 +364,20 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
         &mut self,
         expected_block_root: Hash256,
         blob: Option<Self::ResponseType>,
-        peer_id: PeerId,
     ) -> Result<Option<FixedBlobSidecarList<T::EthSpec>>, LookupVerifyError> {
         match blob {
             Some(blob) => {
                 let received_id = blob.id();
 
                 if !self.requested_ids.contains(&received_id) {
-                    Err(LookupVerifyError::UnrequestedBlobId(received_id))
-                } else if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
-                    Err(LookupVerifyError::InvalidInclusionProof)
-                } else if blob.block_root() != expected_block_root {
-                    Err(LookupVerifyError::UnrequestedHeader)
-                } else {
-                    Ok(())
+                    return Err(LookupVerifyError::UnrequestedBlobId(received_id));
                 }
-                .map_err(|e| {
-                    self.state.register_failure_downloading();
-                    e
-                })?;
+                if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
+                    return Err(LookupVerifyError::InvalidInclusionProof);
+                }
+                if blob.block_root() != expected_block_root {
+                    return Err(LookupVerifyError::UnrequestedHeader);
+                }
 
                 // State should remain downloading until we receive the stream terminator.
                 self.requested_ids.remove(&received_id);
@@ -403,7 +388,6 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, 
                 Ok(None)
             }
             None => {
-                self.state.state = State::Processing { peer_id };
                 let blobs = std::mem::take(&mut self.blob_download_queue);
                 Ok(Some(blobs))
             }

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -103,7 +103,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         cx: &SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         // Check if request is necessary.
-        if self.get_state().is_awaiting_download() {
+        if !self.get_state().is_awaiting_download() {
             return Ok(());
         }
 
@@ -171,7 +171,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
                 // track for scoring is the one that actually sent the response, not the state's
                 self.verify_response_inner(expected_block_root, response)
             }
-            State::Processing { .. } | State::Processed => match response {
+            State::Processing { .. } | State::Processed { .. } => match response {
                 // We sent the block for processing and received an extra block.
                 Some(_) => Err(LookupVerifyError::ExtraBlocksReturned),
                 // This is simply the stream termination and we are already processing the block

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -55,6 +55,7 @@ pub enum RequestError {
         cannot_process: bool,
     },
     NoPeers,
+    BadState(String),
 }
 
 impl<T: BeaconChainTypes> ParentLookup<T> {
@@ -253,6 +254,7 @@ impl From<LookupRequestError> for RequestError {
             }
             E::NoPeers => RequestError::NoPeers,
             E::SendFailed(msg) => RequestError::SendFailed(msg),
+            E::BadState(msg) => RequestError::BadState(msg),
         }
     }
 }
@@ -280,6 +282,7 @@ impl RequestError {
             }
             RequestError::TooManyAttempts { cannot_process: _ } => "too_many_downloading_attempts",
             RequestError::NoPeers => "no_peers",
+            RequestError::BadState(_) => "bad_state",
         }
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -8,7 +8,9 @@ use beacon_chain::data_availability_checker::{
     AvailabilityCheckError, DataAvailabilityChecker, MissingBlobs,
 };
 use beacon_chain::BeaconChainTypes;
+use itertools::Itertools;
 use lighthouse_network::PeerAction;
+use rand::seq::IteratorRandom;
 use slog::{trace, Logger};
 use std::collections::HashSet;
 use std::fmt::Debug;
@@ -18,13 +20,6 @@ use store::Hash256;
 use strum::IntoStaticStr;
 use types::blob_sidecar::{BlobIdentifier, FixedBlobSidecarList};
 use types::EthSpec;
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum State {
-    AwaitingDownload,
-    Downloading { peer_id: PeerId },
-    Processing { peer_id: PeerId },
-}
 
 #[derive(Debug, PartialEq, Eq, IntoStaticStr)]
 pub enum LookupVerifyError {
@@ -94,18 +89,16 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         self.block_request_state.requested_block_root = block_root;
         self.block_request_state.state.state = State::AwaitingDownload;
         self.blob_request_state.state.state = State::AwaitingDownload;
-        self.block_request_state.state.component_downloaded = false;
-        self.blob_request_state.state.component_downloaded = false;
-        self.block_request_state.state.component_processed = false;
-        self.blob_request_state.state.component_processed = false;
         self.child_components = Some(ChildComponents::empty(block_root));
     }
 
-    /// Get all unique peers across block and blob requests.
-    pub fn all_peers(&self) -> HashSet<PeerId> {
-        let mut all_peers = self.block_request_state.state.used_peers.clone();
-        all_peers.extend(self.blob_request_state.state.used_peers.clone());
-        all_peers
+    /// Get all unique used peers across block and blob requests.
+    pub fn all_used_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
+        self.block_request_state
+            .state
+            .get_used_peers()
+            .chain(self.blob_request_state.state.get_used_peers())
+            .unique()
     }
 
     /// Send the necessary requests for blocks and/or blobs. This will check whether we have
@@ -206,14 +199,14 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
 
     /// Returns true if the block has already been downloaded.
     pub fn both_components_downloaded(&self) -> bool {
-        self.block_request_state.state.component_downloaded
-            && self.blob_request_state.state.component_downloaded
+        self.block_request_state.state.is_downloaded()
+            && self.blob_request_state.state.is_downloaded()
     }
 
     /// Returns true if the block has already been downloaded.
     pub fn both_components_processed(&self) -> bool {
-        self.block_request_state.state.component_processed
-            && self.blob_request_state.state.component_processed
+        self.block_request_state.state.is_processed()
+            && self.blob_request_state.state.is_processed()
     }
 
     /// Checks both the block and blob request states to see if the peer is disconnected.
@@ -304,7 +297,7 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         if let Some(cached_child) = self.child_components.as_mut() {
             cached_child.clear_blobs();
         }
-        self.blob_request_state.state.register_failure_downloading()
+        self.blob_request_state.state.on_download_failure()
     }
 
     /// This failure occurs after processing, so register a failure processing, penalize the peer
@@ -314,7 +307,7 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
         if let Some(cached_child) = self.child_components.as_mut() {
             cached_child.clear_blobs();
         }
-        self.blob_request_state.state.register_failure_processing()
+        self.blob_request_state.state.on_processing_failure()
     }
 }
 
@@ -375,29 +368,34 @@ pub enum CachedChild<E: EthSpec> {
     /// There was an error during consistency checks between block and blobs.
     Err(AvailabilityCheckError),
 }
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum State {
+    AwaitingDownload,
+    Downloading { peer_id: PeerId },
+    Processing { peer_id: PeerId },
+    Processed,
+}
+
 /// Object representing the state of a single block or blob lookup request.
 #[derive(PartialEq, Eq, Debug)]
 pub struct SingleLookupRequestState {
     /// State of this request.
-    pub state: State,
+    state: State,
     /// Peers that should have this block or blob.
-    pub available_peers: HashSet<PeerId>,
+    available_peers: HashSet<PeerId>,
     /// Peers from which we have requested this block.
-    pub used_peers: HashSet<PeerId>,
+    used_peers: HashSet<PeerId>,
     /// How many times have we attempted to process this block or blob.
-    pub failed_processing: u8,
+    failed_processing: u8,
     /// How many times have we attempted to download this block or blob.
-    pub failed_downloading: u8,
-    /// Whether or not we have downloaded this block or blob.
-    pub component_downloaded: bool,
-    /// Whether or not we have processed this block or blob.
-    pub component_processed: bool,
+    failed_downloading: u8,
     /// Should be incremented everytime this request is retried. The purpose of this is to
     /// differentiate retries of the same block/blob request within a lookup. We currently penalize
     /// peers and retry requests prior to receiving the stream terminator. This means responses
     /// from a prior request may arrive after a new request has been sent, this counter allows
     /// us to differentiate these two responses.
-    pub req_counter: u32,
+    req_counter: u32,
 }
 
 impl SingleLookupRequestState {
@@ -413,28 +411,75 @@ impl SingleLookupRequestState {
             used_peers: HashSet::default(),
             failed_processing: 0,
             failed_downloading: 0,
-            component_downloaded: false,
-            component_processed: false,
             req_counter: 0,
         }
     }
 
-    /// Registers a failure in processing a block.
-    pub fn register_failure_processing(&mut self) {
-        self.failed_processing = self.failed_processing.saturating_add(1);
-        self.state = State::AwaitingDownload;
+    // TODO: Should not leak the enum state
+    pub fn get_state(&self) -> &State {
+        &self.state
+    }
+
+    pub fn is_current_req_counter(&self, req_counter: u32) -> bool {
+        self.req_counter == req_counter
+    }
+
+    pub fn is_awaiting_download(&self) -> bool {
+        matches!(self.state, State::AwaitingDownload)
+    }
+
+    pub fn is_downloaded(&self) -> bool {
+        match self.state {
+            State::AwaitingDownload => false,
+            State::Downloading { .. } => false,
+            State::Processing { .. } => true,
+            State::Processed => true,
+        }
+    }
+
+    pub fn is_processed(&self) -> bool {
+        match self.state {
+            State::AwaitingDownload => false,
+            State::Downloading { .. } => false,
+            State::Processing { .. } => false,
+            State::Processed => true,
+        }
+    }
+
+    pub fn on_download_start(&mut self, peer_id: PeerId) -> u32 {
+        self.state = State::Downloading { peer_id };
+        self.req_counter += 1;
+        self.req_counter
     }
 
     /// Registers a failure in downloading a block. This might be a peer disconnection or a wrong
     /// block.
-    pub fn register_failure_downloading(&mut self) {
+    pub fn on_download_failure(&mut self) {
         self.failed_downloading = self.failed_downloading.saturating_add(1);
         self.state = State::AwaitingDownload;
+    }
+
+    pub fn on_download_success(&mut self, peer_id: PeerId) {
+        self.state = State::Processing { peer_id };
+    }
+
+    /// Registers a failure in processing a block.
+    pub fn on_processing_failure(&mut self) {
+        self.failed_processing = self.failed_processing.saturating_add(1);
+        self.state = State::AwaitingDownload;
+    }
+
+    pub fn on_processing_success(&mut self) {
+        self.state = State::Processed;
     }
 
     /// The total number of failures, whether it be processing or downloading.
     pub fn failed_attempts(&self) -> u8 {
         self.failed_processing + self.failed_downloading
+    }
+
+    pub fn more_failed_processing_attempts(&self) -> bool {
+        self.failed_processing >= self.failed_downloading
     }
 
     /// This method should be used for peers wrapped in `PeerId::BlockAndBlobs`.
@@ -448,7 +493,7 @@ impl SingleLookupRequestState {
         if let State::Downloading { peer_id } = &self.state {
             if peer_id == dc_peer_id {
                 // Peer disconnected before providing a block
-                self.register_failure_downloading();
+                self.on_download_failure();
                 return Err(());
             }
         }
@@ -462,6 +507,21 @@ impl SingleLookupRequestState {
             State::Processing { peer_id } => Ok(*peer_id),
             other => Err(format!("not in processing state: {}", other).to_string()),
         }
+    }
+
+    pub fn get_used_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.used_peers.iter()
+    }
+
+    /// Selects a random peer from available peers if any, inserts it in used peers and returns it.
+    pub fn use_rand_available_peer(&mut self) -> Option<PeerId> {
+        let peer_id = self
+            .available_peers
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .copied()?;
+        self.used_peers.insert(peer_id);
+        Some(peer_id)
     }
 }
 
@@ -509,6 +569,7 @@ impl slog::Value for SingleLookupRequestState {
             State::Processing { peer_id } => {
                 serializer.emit_arguments("processing_peer", &format_args!("{}", peer_id))?
             }
+            State::Processed => "processed".serialize(record, "state", serializer)?,
         }
         serializer.emit_u8("failed_downloads", self.failed_downloading)?;
         serializer.emit_u8("failed_processing", self.failed_processing)?;
@@ -522,6 +583,7 @@ impl std::fmt::Display for State {
             State::AwaitingDownload => write!(f, "AwaitingDownload"),
             State::Downloading { .. } => write!(f, "Downloading"),
             State::Processing { .. } => write!(f, "Processing"),
+            State::Processed => write!(f, "Processed"),
         }
     }
 }
@@ -608,6 +670,7 @@ mod tests {
         <BlockRequestState<TestLookup1> as RequestState<TestLookup1, T>>::verify_response(
             &mut sl.block_request_state,
             block.canonical_root(),
+            peer_id,
             Some(block.into()),
         )
         .unwrap()
@@ -647,7 +710,7 @@ mod tests {
                 &spec,
             )
             .unwrap();
-            sl.block_request_state.state.register_failure_downloading();
+            sl.block_request_state.state.on_download_failure();
         }
 
         // Now we receive the block and send it for processing
@@ -661,13 +724,14 @@ mod tests {
         <BlockRequestState<TestLookup2> as RequestState<TestLookup2, T>>::verify_response(
             &mut sl.block_request_state,
             block.canonical_root(),
+            peer_id,
             Some(block.into()),
         )
         .unwrap()
         .unwrap();
 
         // One processing failure maxes the available attempts
-        sl.block_request_state.state.register_failure_processing();
+        sl.block_request_state.state.on_processing_failure();
         assert_eq!(
             <BlockRequestState<TestLookup2> as RequestState<TestLookup2, T>>::build_request(
                 &mut sl.block_request_state,

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -637,6 +637,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 self.handle_unknown_block_root(peer_id, block_root);
             }
             SyncMessage::Disconnect(peer_id) => {
+                debug!(self.log, "Received disconnected message"; "peer_id" => %peer_id);
                 self.peer_disconnect(&peer_id);
             }
             SyncMessage::RpcError {


### PR DESCRIPTION
## Issue Addressed

`SingleLookupRequestState` fields are public and mutated all over the place. This makes the code unnecessarily difficult to follow. Instead, its fields should be private and mutated through setters such that looking the the implementation of `SingleLookupRequestState` is sufficient to view and understand all possible state transitions.

Part of:
- https://github.com/sigp/lighthouse/issues/5549

## Proposed Changes

- Make SingleLookupRequestState fields private
- Move state transition to download result from `verify_response_inner` (specific per request) to `verify_response` (generic for the trait)
- In `verify_response` use the actual response sending peer instead of the one being tracked in the state. See code comment about potential inconsistencies.

A future PR should add more checks in setters like `on_download_success` such that a state transition from `Processed` -> `Downloading` is not possible
