### PR TITLE
Re-process early sampling requests

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1225,7 +1225,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         if let Some(block) = self.early_attester_cache.get_block(*block_root) {
             return BlockImportStatus::PendingImport(block);
         }
-        if let Ok(true) = self.store.has_block(block_root) {
+        if let Ok(true) = self.store.block_exists(block_root) {
             BlockImportStatus::Imported
         } else {
             BlockImportStatus::Unknown

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1186,7 +1186,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     .transpose()
             })
             .collect::<Result<Vec<_>, _>>()?;
-        // Existance of a column in the data availability cache and downstream caches is exclusive.
+        // Existence of a column in the data availability cache and downstream caches is exclusive.
         // If there's a single match in the availability cache we can safely skip other sources.
         if !columns_from_availability_cache.is_empty() {
             return Ok(columns_from_availability_cache);

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -98,7 +98,11 @@ use store::{Error as DBError, HotStateSummary, KeyValueStore, StoreOp};
 use task_executor::JoinHandle;
 use tree_hash::TreeHash;
 use types::data_column_sidecar::DataColumnSidecarError;
-use types::{BeaconBlockRef, BeaconState, BeaconStateError, BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSubnetId, Epoch, EthSpec, ExecutionBlockHash, FullPayload, Hash256, InconsistentFork, PublicKey, PublicKeyBytes, RelativeEpoch, SignedBeaconBlock, SignedBeaconBlockHeader, Slot};
+use types::{
+    BeaconBlockRef, BeaconState, BeaconStateError, BlobSidecarList, ChainSpec, DataColumnSidecar,
+    DataColumnSubnetId, Epoch, EthSpec, ExecutionBlockHash, FullPayload, Hash256, InconsistentFork,
+    PublicKey, PublicKeyBytes, RelativeEpoch, SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+};
 use types::{BlobSidecar, ExecPayload};
 
 pub const POS_PANDA_BANNER: &str = r#"

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -73,6 +73,7 @@ pub use self::chain_config::ChainConfig;
 pub use self::errors::{BeaconChainError, BlockProductionError};
 pub use self::historical_blocks::HistoricalBlockError;
 pub use attestation_verification::Error as AttestationError;
+pub use beacon_chain::BlockImportStatus;
 pub use beacon_fork_choice_store::{BeaconForkChoiceStore, Error as ForkChoiceStoreError};
 pub use block_verification::{
     get_block_root, BlockError, ExecutionPayloadError, ExecutionPendingBlock, GossipVerifiedBlock,

--- a/beacon_node/beacon_processor/src/metrics.rs
+++ b/beacon_node/beacon_processor/src/metrics.rs
@@ -162,12 +162,12 @@ lazy_static::lazy_static! {
     );
     pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_OPTIMISTIC_UPDATES: Result<IntCounter> = try_create_int_counter(
         "beacon_processor_reprocessing_queue_matched_optimistic_updates",
-        "Number of queued light client optimistic updates where as matching block has been imported."
+        "Number of queued light client optimistic updates where a matching block has been imported."
     );
     // TODO: This should be labeled instead of N single metrics
     pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_SAMPLING_REQUESTS: Result<IntCounter> = try_create_int_counter(
         "beacon_processor_reprocessing_queue_matches_sampling_requests",
-        "Number of queued sampling requests where as matching block has been imported."
+        "Number of queued sampling requests where a matching block has been imported."
     );
 
     /// Errors and Debugging Stats

--- a/beacon_node/beacon_processor/src/metrics.rs
+++ b/beacon_node/beacon_processor/src/metrics.rs
@@ -164,6 +164,11 @@ lazy_static::lazy_static! {
         "beacon_processor_reprocessing_queue_matched_optimistic_updates",
         "Number of queued light client optimistic updates where as matching block has been imported."
     );
+    // TODO: This should be labeled instead of N single metrics
+    pub static ref BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_SAMPLING_REQUESTS: Result<IntCounter> = try_create_int_counter(
+        "beacon_processor_reprocessing_queue_matches_sampling_requests",
+        "Number of queued sampling requests where as matching block has been imported."
+    );
 
     /// Errors and Debugging Stats
     pub static ref BEACON_PROCESSOR_SEND_ERROR_PER_WORK_TYPE: Result<IntCounterVec> =

--- a/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
@@ -685,7 +685,7 @@ impl<S: SlotClock> ReprocessQueue<S> {
                 // Register the delay.
                 let delay_key = self
                     .sampling_requests_delay_queue
-                    .insert(id, QUEUED_LIGHT_CLIENT_UPDATE_DELAY);
+                    .insert(id, QUEUED_SAMPLING_REQUESTS_DELAY);
 
                 self.awaiting_sampling_requests_per_block_root
                     .entry(queued_sampling_request.beacon_block_root)

--- a/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
@@ -51,6 +51,9 @@ pub const QUEUED_LIGHT_CLIENT_UPDATE_DELAY: Duration = Duration::from_secs(12);
 /// For how long to queue rpc blocks before sending them back for reprocessing.
 pub const QUEUED_RPC_BLOCK_DELAY: Duration = Duration::from_secs(4);
 
+/// For how long to queue sampling requests for reprocessing.
+pub const QUEUED_SAMPLING_REQUESTS_DELAY: Duration = Duration::from_secs(12);
+
 /// Set an arbitrary upper-bound on the number of queued blocks to avoid DoS attacks. The fact that
 /// we signature-verify blocks before putting them in the queue *should* protect against this, but
 /// it's nice to have extra protection.

--- a/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
@@ -62,6 +62,10 @@ const MAXIMUM_QUEUED_ATTESTATIONS: usize = 16_384;
 /// How many light client updates we keep before new ones get dropped.
 const MAXIMUM_QUEUED_LIGHT_CLIENT_UPDATES: usize = 128;
 
+/// How many sampling requests we queue before new ones get dropped.
+/// TODO(das): choose a sensible value
+const MAXIMUM_QUEUED_SAMPLING_REQUESTS: usize = 16_384;
+
 // Process backfill batch 50%, 60%, 80% through each slot.
 //
 // Note: use caution to set these fractions in a way that won't cause panic-y
@@ -98,6 +102,8 @@ pub enum ReprocessQueueMessage {
     UnknownBlockAggregate(QueuedAggregate),
     /// A light client optimistic update that references a parent root that has not been seen as a parent.
     UnknownLightClientOptimisticUpdate(QueuedLightClientUpdate),
+    /// A sampling request that references an unknown block.
+    UnknownBlockSamplingRequest(QueuedSamplingRequest),
     /// A new backfill batch that needs to be scheduled for processing.
     BackfillSync(QueuedBackfillBatch),
 }
@@ -110,6 +116,7 @@ pub enum ReadyWork {
     Unaggregate(QueuedUnaggregate),
     Aggregate(QueuedAggregate),
     LightClientUpdate(QueuedLightClientUpdate),
+    SamplingRequest(QueuedSamplingRequest),
     BackfillSync(QueuedBackfillBatch),
 }
 
@@ -131,6 +138,12 @@ pub struct QueuedAggregate {
 /// queued for later.
 pub struct QueuedLightClientUpdate {
     pub parent_root: Hash256,
+    pub process_fn: BlockingFn,
+}
+
+/// A sampling request for which the corresponding block is not known while processing.
+pub struct QueuedSamplingRequest {
+    pub beacon_block_root: Hash256,
     pub process_fn: BlockingFn,
 }
 
@@ -218,6 +231,8 @@ struct ReprocessQueue<S> {
     attestations_delay_queue: DelayQueue<QueuedAttestationId>,
     /// Queue to manage scheduled light client updates.
     lc_updates_delay_queue: DelayQueue<QueuedLightClientUpdateId>,
+    /// Queue to manage scheduled sampling requests
+    sampling_requests_delay_queue: DelayQueue<QueuedSamplingRequestId>,
 
     /* Queued items */
     /// Queued blocks.
@@ -232,6 +247,10 @@ struct ReprocessQueue<S> {
     queued_lc_updates: FnvHashMap<usize, (QueuedLightClientUpdate, DelayKey)>,
     /// Light Client Updates per parent_root.
     awaiting_lc_updates_per_parent_root: HashMap<Hash256, Vec<QueuedLightClientUpdateId>>,
+    /// Queued sampling requests per block root.
+    queued_sampling_requests: FnvHashMap<usize, (QueuedSamplingRequest, DelayKey)>,
+    /// Sampling requests per block root.
+    awaiting_sampling_requests_per_block_root: HashMap<Hash256, Vec<QueuedSamplingRequestId>>,
     /// Queued backfill batches
     queued_backfill_batches: Vec<QueuedBackfillBatch>,
 
@@ -239,15 +258,18 @@ struct ReprocessQueue<S> {
     /// Next attestation id, used for both aggregated and unaggregated attestations
     next_attestation: usize,
     next_lc_update: usize,
+    next_sampling_request_update: usize,
     early_block_debounce: TimeLatch,
     rpc_block_debounce: TimeLatch,
     attestation_delay_debounce: TimeLatch,
     lc_update_delay_debounce: TimeLatch,
+    sampling_request_delay_debounce: TimeLatch,
     next_backfill_batch_event: Option<Pin<Box<tokio::time::Sleep>>>,
     slot_clock: Arc<S>,
 }
 
 pub type QueuedLightClientUpdateId = usize;
+pub type QueuedSamplingRequestId = usize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum QueuedAttestationId {
@@ -403,19 +425,24 @@ impl<S: SlotClock> ReprocessQueue<S> {
             rpc_block_delay_queue: DelayQueue::new(),
             attestations_delay_queue: DelayQueue::new(),
             lc_updates_delay_queue: DelayQueue::new(),
+            sampling_requests_delay_queue: <_>::default(),
             queued_gossip_block_roots: HashSet::new(),
             queued_lc_updates: FnvHashMap::default(),
             queued_aggregates: FnvHashMap::default(),
             queued_unaggregates: FnvHashMap::default(),
+            queued_sampling_requests: <_>::default(),
             awaiting_attestations_per_root: HashMap::new(),
             awaiting_lc_updates_per_parent_root: HashMap::new(),
+            awaiting_sampling_requests_per_block_root: <_>::default(),
             queued_backfill_batches: Vec::new(),
             next_attestation: 0,
             next_lc_update: 0,
+            next_sampling_request_update: 0,
             early_block_debounce: TimeLatch::default(),
             rpc_block_debounce: TimeLatch::default(),
             attestation_delay_debounce: TimeLatch::default(),
             lc_update_delay_debounce: TimeLatch::default(),
+            sampling_request_delay_debounce: <_>::default(),
             next_backfill_batch_event: None,
             slot_clock,
         }
@@ -639,6 +666,35 @@ impl<S: SlotClock> ReprocessQueue<S> {
 
                 self.next_lc_update += 1;
             }
+            InboundEvent::Msg(UnknownBlockSamplingRequest(queued_sampling_request)) => {
+                if self.sampling_requests_delay_queue.len() >= MAXIMUM_QUEUED_SAMPLING_REQUESTS {
+                    if self.sampling_request_delay_debounce.elapsed() {
+                        error!(
+                            log,
+                            "Sampling requests delay queue is full";
+                            "queue_size" => MAXIMUM_QUEUED_SAMPLING_REQUESTS,
+                        );
+                    }
+                    // Drop the inbound message.
+                    return;
+                }
+
+                let id: QueuedSamplingRequestId = self.next_sampling_request_update;
+                self.next_sampling_request_update += 1;
+
+                // Register the delay.
+                let delay_key = self
+                    .sampling_requests_delay_queue
+                    .insert(id, QUEUED_LIGHT_CLIENT_UPDATE_DELAY);
+
+                self.awaiting_sampling_requests_per_block_root
+                    .entry(queued_sampling_request.beacon_block_root)
+                    .or_default()
+                    .push(id);
+
+                self.queued_sampling_requests
+                    .insert(id, (queued_sampling_request, delay_key));
+            }
             InboundEvent::Msg(BlockImported {
                 block_root,
                 parent_root,
@@ -694,6 +750,49 @@ impl<S: SlotClock> ReprocessQueue<S> {
                             "Ignored scheduled attestation(s) for block";
                             "hint" => "system may be overloaded",
                             "parent_root" => ?parent_root,
+                            "block_root" => ?block_root,
+                            "failed_count" => failed_to_send_count,
+                            "sent_count" => sent_count,
+                        );
+                    }
+                }
+                // Unqueue the sampling requests we have for this root, if any.
+                if let Some(queued_ids) = self
+                    .awaiting_sampling_requests_per_block_root
+                    .remove(&block_root)
+                {
+                    let mut sent_count = 0;
+                    let mut failed_to_send_count = 0;
+
+                    for id in queued_ids {
+                        metrics::inc_counter(
+                            &metrics::BEACON_PROCESSOR_REPROCESSING_QUEUE_MATCHED_SAMPLING_REQUESTS,
+                        );
+
+                        if let Some((queued, delay_key)) = self.queued_sampling_requests.remove(&id)
+                        {
+                            // Remove the delay.
+                            self.sampling_requests_delay_queue.remove(&delay_key);
+
+                            // Send the work.
+                            let work = ReadyWork::SamplingRequest(queued);
+
+                            if self.ready_work_tx.try_send(work).is_err() {
+                                failed_to_send_count += 1;
+                            } else {
+                                sent_count += 1;
+                            }
+                        } else {
+                            // This should never happen.
+                            error!(log, "Unknown sampling request for block root"; "block_root" => ?block_root, "id" => ?id);
+                        }
+                    }
+
+                    if failed_to_send_count > 0 {
+                        error!(
+                            log,
+                            "Ignored scheduled sampling requests for block";
+                            "hint" => "system may be overloaded",
                             "block_root" => ?block_root,
                             "failed_count" => failed_to_send_count,
                             "sent_count" => sent_count,

--- a/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
+++ b/beacon_node/beacon_processor/src/work_reprocessing_queue.rs
@@ -250,7 +250,7 @@ struct ReprocessQueue<S> {
     queued_lc_updates: FnvHashMap<usize, (QueuedLightClientUpdate, DelayKey)>,
     /// Light Client Updates per parent_root.
     awaiting_lc_updates_per_parent_root: HashMap<Hash256, Vec<QueuedLightClientUpdateId>>,
-    /// Queued sampling requests per block root.
+    /// Queued sampling requests.
     queued_sampling_requests: FnvHashMap<usize, (QueuedSamplingRequest, DelayKey)>,
     /// Sampling requests per block root.
     awaiting_sampling_requests_per_block_root: HashMap<Hash256, Vec<QueuedSamplingRequestId>>,

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -650,8 +650,15 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         request: DataColumnsByRootRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_data_columns_by_root_request(peer_id, request_id, request);
+        let reprocess_tx = processor.reprocess_tx.clone();
+        let process_fn = move || {
+            processor.handle_data_columns_by_root_request(
+                peer_id,
+                request_id,
+                request,
+                Some(reprocess_tx),
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,

--- a/beacon_node/network/src/sync/sampling.rs
+++ b/beacon_node/network/src/sync/sampling.rs
@@ -174,10 +174,10 @@ pub struct ActiveSamplingRequest<T: BeaconChainTypes> {
 
 #[derive(Debug)]
 pub enum SamplingError {
-    SendFailed(&'static str),
+    SendFailed(#[allow(dead_code)] &'static str),
     ProcessorUnavailable,
     TooManyFailures,
-    BadState(String),
+    BadState(#[allow(dead_code)] String),
     ColumnIndexOutOfBounds,
 }
 

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -573,6 +573,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         })
     }
 
+    pub fn has_block(&self, block_root: &Hash256) -> Result<bool, Error> {
+        self.hot_db
+            .key_exists(DBColumn::BeaconBlock.into(), block_root.as_bytes())
+    }
+
     /// Fetch a block from the store, ignoring which fork variant it *should* be for.
     pub fn get_block_any_variant<Payload: AbstractExecPayload<E>>(
         &self,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -573,11 +573,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         })
     }
 
-    pub fn has_block(&self, block_root: &Hash256) -> Result<bool, Error> {
-        self.hot_db
-            .key_exists(DBColumn::BeaconBlock.into(), block_root.as_bytes())
-    }
-
     /// Fetch a block from the store, ignoring which fork variant it *should* be for.
     pub fn get_block_any_variant<Payload: AbstractExecPayload<E>>(
         &self,


### PR DESCRIPTION
## Issue Addressed

Allow data availability samplers to send requests early as a network-wide optimization to complete sampling faster. A custodial node will queue the requests and resolve them once the block has been imported.

## Next steps

This is a basic (non-tested) implementation, next steps:
- Resolve requests when column arrives, not the whole block
- Separate requests for known block and unknown block, the former can be DOS protected better
- Only allow retry mechanism for recent slots
- Add more metrics

## Design

![photo_2024-04-12 11 08 08](https://github.com/sigp/lighthouse/assets/35266934/a89e9b2a-b7d8-438e-83bb-4e1e02546ea8)

two phases
a) requests at the start of the start of the slot have a long timeout — e.g. 3s (expected time for most of the network to get samples on gossip)
b) then shift into fast timeout mode

At start of the slot, send your sample requests to peers you expect to get your needed samples in (a) mode (long timeout). If they don't respond by timeout, send further queries in (b) mode to various peers, trying to quickly get the final samples

> Forwarded from codex (credit to them) 👇 

The usage of (a) allows for samples queries to be responded to immediately when a peer gets it from gossip, instead of the node waiting until some arbitrary time at the slot that they think people will likely have gotten the sample to start the requests


The messaging primitive I proposed is a request with an explicit timeout. This simple primitive allows us to build a nice dynamic behavior, as you see in the example on the slide. It allows us to have the first period, beneficial for two reasons:
 - reduce traffic explosion on the happy path: if things go well, every sample query will only consume two messages. A request and a response. This is beneficial both in the peerDAS case, and in the later stages, where we would go for individual segments on the 2D encoding grid. 
 - reduce sampling delay close to the minimum: sending the sampling query at the start of the slot allows us to minimize the sampling delay to a single 1-hop latency on top of to diffusion delay (the delay with which the node we queried received the segment or column).

The minimum sampling latency would be what you could achive if you ask, right when you know what samples you need, all your peers that could have the sample. That would however mean that you receive lots of responses, adding considerable extra load. Here we only ask one of them as a compromise between bandwidth efficiency and latency, and our simulations currently show the latency compromise is very limited on the happy path. Obviusly, if we are not on the happy path, we should start doing something. On the slide you find a few proposals, considering that we should still avoid traffic explosion.

There a few other points there, improving dynamic behaviour:
1, anticipate the hunt for peers that could provide samples. We have a few options here:
  - a node could try to keep a few peers (but at least one) for each column. This can be done independent of slots, continously
  - a node can notice at the beginning of the slot, that it misses peers for a column selected for sampling. The node has almost 4 seconds to find a peer and send a query
  - a node can also act if a request was sent out, but a response is not coming close to the 4s mark. If there are other peers for the same sample, send another request. If not, start searching for a peer to request from.

2, to avoid traffic explosion, we also recommend controlling the number of outstanding queries, together with timeouts. This practically means that we can avoid traffic explosion. 
3, we've also proposed the extension of the sample. This is something I'm writing up in an ethresear.ch post 🙂

Regarding the number of queries is stage (a): I think 1 per sample is fine, but of course 2 or 3 can also be used. These are comprimises that can even be made locally, we can't really mandate them anyway. (actually we could, using RLN and similar spam protection, but that would require stake to send DAS queries, which is not what we want now).

Finally, there was another idea on my previous slide on messaging primitives. I would include a have list in the query response message. The reason behind this is that it gives extra information on the state of diffusion that we would not have otherwise. Given the 1D or 2D structure, a have list can be compressed very well to a small bitmap, so it is not much extra bytes, so I think it's worth to add. Eventually, to stay generic on the message primive, we can make it a flag in the request whether you want a have list in the response.

