### PR TITLE
Make beacon processor queue sizes dynamic

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -127,7 +127,7 @@ impl BeaconProcessorQueueLengths {
         let active_validator_count = state
             .get_active_validator_indices(state.slot().epoch(E::slots_per_epoch()), spec)
             .map_err(|e| format!("Error computing active indices: {:?}", e))?
-            .len() as usize;
+            .len();
         let slots_per_epoch = E::slots_per_epoch() as usize;
 
         Ok(Self {
@@ -736,6 +736,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
     ///
     /// The optional `work_journal_tx` allows for an outside process to receive a log of all work
     /// events processed by `self`. This should only be used during testing.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn_manager<S: SlotClock + 'static>(
         mut self,
         event_rx: mpsc::Receiver<WorkEvent<E>>,

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -19,8 +19,8 @@ use beacon_chain::{
     store::{HotColdDB, ItemStore, LevelDB, StoreConfig},
     BeaconChain, BeaconChainTypes, Eth1ChainBackend, MigratorConfig, ServerSentEventHandler,
 };
-use beacon_processor::BeaconProcessorConfig;
 use beacon_processor::{BeaconProcessor, BeaconProcessorChannels};
+use beacon_processor::{BeaconProcessorConfig, BeaconProcessorQueueLengths};
 use environment::RuntimeContext;
 use eth1::{Config as Eth1Config, Service as Eth1Service};
 use eth2::{
@@ -884,6 +884,14 @@ where
                     None,
                     beacon_chain.slot_clock.clone(),
                     beacon_chain.spec.maximum_gossip_clock_disparity(),
+                    BeaconProcessorQueueLengths::from_state(
+                        &beacon_chain
+                            .canonical_head
+                            .cached_head()
+                            .snapshot
+                            .beacon_state,
+                        &beacon_chain.spec,
+                    )?,
                 )?;
             }
 

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -3,7 +3,9 @@ use beacon_chain::{
     test_utils::{BeaconChainHarness, BoxedMutator, Builder, EphemeralHarnessType},
     BeaconChain, BeaconChainTypes,
 };
-use beacon_processor::{BeaconProcessor, BeaconProcessorChannels, BeaconProcessorConfig};
+use beacon_processor::{
+    BeaconProcessor, BeaconProcessorChannels, BeaconProcessorConfig, BeaconProcessorQueueLengths,
+};
 use directory::DEFAULT_ROOT_DIR;
 use eth2::{BeaconNodeHttpClient, Timeouts};
 use lighthouse_network::{
@@ -206,6 +208,11 @@ pub async fn create_api_server<T: BeaconChainTypes>(
         None,
         chain.slot_clock.clone(),
         chain.spec.maximum_gossip_clock_disparity(),
+        BeaconProcessorQueueLengths::from_state(
+            &chain.canonical_head.cached_head().snapshot.beacon_state,
+            &chain.spec,
+        )
+        .unwrap(),
     )
     .unwrap();
 

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -239,6 +239,11 @@ impl TestRig {
             Some(work_journal_tx),
             harness.chain.slot_clock.clone(),
             chain.spec.maximum_gossip_clock_disparity(),
+            BeaconProcessorQueueLengths::from_state(
+                &chain.canonical_head.cached_head().snapshot.beacon_state,
+                &chain.spec,
+            )
+            .unwrap(),
         );
 
         assert!(beacon_processor.is_ok());


### PR DESCRIPTION
## Issue Addressed

Some users have complained of their nodes rejecting attestations due to full queues. The current size of 16k was good before, but it's insufficient for the current mainnet's size. Instead of playing catch with these numbers, we can make them dynamic on the validator set size. The set size is not meant to change significantly between client restarts so sampling once at start-up should be sufficient.

## Proposed Changes

Make beacon processor queue sizes dynamic, and some of its values variable on initial active validator set size. This change allows future testing of the processor where we want to make the queue very short to test their behavior.

**NOTE**: I have not changed any numbers except for `attestation_queue`, `unknown_block_attestation_queue`. Happy to change or justify existing numbers if you have rationales.

