### PR TITLE
Handle sync lookup request streams in network context

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -1,6 +1,6 @@
 use crate::sync::block_lookups::parent_lookup::PARENT_FAIL_TOLERANCE;
 use crate::sync::block_lookups::single_block_lookup::{
-    LookupRequestError, SingleBlockLookup, SingleLookupRequestState, State,
+    LookupRequestError, SingleBlockLookup, SingleLookupRequestState,
 };
 use crate::sync::block_lookups::{
     BlobRequestState, BlockLookups, BlockRequestState, PeerId, SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS,
@@ -12,7 +12,6 @@ use crate::sync::network_context::{
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::data_availability_checker::ChildComponents;
 use beacon_chain::BeaconChainTypes;
-use rand::prelude::IteratorRandom;
 use std::sync::Arc;
 use std::time::Duration;
 use types::blob_sidecar::FixedBlobSidecarList;

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -6,17 +6,17 @@ use crate::sync::block_lookups::{
     BlobRequestState, BlockLookups, BlockRequestState, PeerId, SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS,
 };
 use crate::sync::manager::{BlockProcessType, Id, SingleLookupReqId};
-use crate::sync::network_context::SyncNetworkContext;
+use crate::sync::network_context::{
+    BlobsByRootSingleBlockRequest, BlocksByRootSingleRequest, SyncNetworkContext,
+};
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::data_availability_checker::ChildComponents;
-use beacon_chain::{get_block_root, BeaconChainTypes};
-use lighthouse_network::rpc::methods::BlobsByRootRequest;
-use lighthouse_network::rpc::BlocksByRootRequest;
-use std::ops::IndexMut;
+use beacon_chain::BeaconChainTypes;
+use rand::prelude::IteratorRandom;
 use std::sync::Arc;
 use std::time::Duration;
-use types::blob_sidecar::{BlobIdentifier, FixedBlobSidecarList};
-use types::{BlobSidecar, ChainSpec, Hash256, SignedBeaconBlock};
+use types::blob_sidecar::FixedBlobSidecarList;
+use types::{Hash256, SignedBeaconBlock};
 
 #[derive(Debug, Copy, Clone)]
 pub enum ResponseType {
@@ -73,9 +73,6 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     /// The type of the request .
     type RequestType;
 
-    /// A block or blob response.
-    type ResponseType;
-
     /// The type created after validation.
     type VerifiedResponseType: Clone;
 
@@ -85,14 +82,11 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     /* Request building methods */
 
     /// Construct a new request.
-    fn build_request(
-        &mut self,
-        spec: &ChainSpec,
-    ) -> Result<(PeerId, Self::RequestType), LookupRequestError> {
+    fn build_request(&mut self) -> Result<(PeerId, Self::RequestType), LookupRequestError> {
         // Verify and construct request.
         self.too_many_attempts()?;
         let peer = self.get_peer()?;
-        let request = self.new_request(spec);
+        let request = self.new_request();
         Ok((peer, request))
     }
 
@@ -100,7 +94,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     fn build_request_and_send(
         &mut self,
         id: Id,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         // Check if request is necessary.
         if !self.get_state().is_awaiting_download() {
@@ -108,7 +102,7 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
         }
 
         // Construct request.
-        let (peer_id, request) = self.build_request(&cx.chain.spec)?;
+        let (peer_id, request) = self.build_request()?;
 
         // Update request state.
         let req_counter = self.get_state_mut().on_download_start(peer_id);
@@ -144,14 +138,14 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     }
 
     /// Initialize `Self::RequestType`.
-    fn new_request(&self, spec: &ChainSpec) -> Self::RequestType;
+    fn new_request(&self) -> Self::RequestType;
 
     /// Send the request to the network service.
     fn make_request(
         id: SingleLookupReqId,
         peer_id: PeerId,
         request: Self::RequestType,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError>;
 
     /* Response handling methods */
@@ -159,45 +153,22 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
     /// Verify the response is valid based on what we requested.
     fn verify_response(
         &mut self,
-        expected_block_root: Hash256,
-        peer_id: PeerId,
-        response: Option<Self::ResponseType>,
-    ) -> Result<Option<Self::VerifiedResponseType>, LookupVerifyError> {
-        let result = match *self.get_state().get_state() {
-            State::AwaitingDownload => Err(LookupVerifyError::ExtraBlocksReturned),
-            State::Downloading { peer_id: _ } => {
-                // TODO: We requested a download from Downloading { peer_id }, but the network
-                // injects a response from a different peer_id. What should we do? The peer_id to
-                // track for scoring is the one that actually sent the response, not the state's
-                self.verify_response_inner(expected_block_root, response)
+        response: Self::VerifiedResponseType,
+    ) -> Result<Self::VerifiedResponseType, LookupVerifyError> {
+        let request_state = self.get_state_mut();
+        match request_state.state {
+            State::AwaitingDownload => {
+                request_state.register_failure_downloading();
+                Err(LookupVerifyError::ExtraBlocksReturned)
             }
-            State::Processing { .. } | State::Processed { .. } => match response {
+            State::Downloading { peer_id } => Ok(response),
+            State::Processing { peer_id: _ } => {
                 // We sent the block for processing and received an extra block.
-                Some(_) => Err(LookupVerifyError::ExtraBlocksReturned),
-                // This is simply the stream termination and we are already processing the block
-                None => Ok(None),
-            },
-        };
-
-        match result {
-            Ok(Some(response)) => {
-                self.get_state_mut().on_download_success(peer_id);
-                Ok(Some(response))
-            }
-            Ok(None) => Ok(None),
-            Err(e) => {
-                self.get_state_mut().on_download_failure();
-                Err(e)
+                request_state.register_failure_downloading();
+                Err(LookupVerifyError::ExtraBlocksReturned)
             }
         }
     }
-
-    /// The response verification unique to block or blobs.
-    fn verify_response_inner(
-        &mut self,
-        expected_block_root: Hash256,
-        response: Option<Self::ResponseType>,
-    ) -> Result<Option<Self::VerifiedResponseType>, LookupVerifyError>;
 
     /// A getter for the parent root of the response. Returns an `Option` because we won't know
     /// the blob parent if we don't end up getting any blobs in the response.
@@ -247,47 +218,22 @@ pub trait RequestState<L: Lookup, T: BeaconChainTypes> {
 }
 
 impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L> {
-    type RequestType = BlocksByRootRequest;
-    type ResponseType = Arc<SignedBeaconBlock<T::EthSpec>>;
+    type RequestType = BlocksByRootSingleRequest;
     type VerifiedResponseType = Arc<SignedBeaconBlock<T::EthSpec>>;
     type ReconstructedResponseType = RpcBlock<T::EthSpec>;
 
-    fn new_request(&self, spec: &ChainSpec) -> BlocksByRootRequest {
-        BlocksByRootRequest::new(vec![self.requested_block_root], spec)
+    fn new_request(&self) -> Self::RequestType {
+        self.requested_block_root
     }
 
     fn make_request(
         id: SingleLookupReqId,
         peer_id: PeerId,
         request: Self::RequestType,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         cx.block_lookup_request(id, peer_id, request)
             .map_err(LookupRequestError::SendFailed)
-    }
-
-    fn verify_response_inner(
-        &mut self,
-        expected_block_root: Hash256,
-        response: Option<Self::ResponseType>,
-    ) -> Result<Option<Arc<SignedBeaconBlock<T::EthSpec>>>, LookupVerifyError> {
-        match response {
-            Some(block) => {
-                // Compute the block root using this specific function so that we can get timing
-                // metrics.
-                let block_root = get_block_root(&block);
-                if block_root != expected_block_root {
-                    // return an error and drop the block
-                    // NOTE: we take this is as a download failure to prevent counting the
-                    // attempt as a chain failure, but simply a peer failure.
-                    Err(LookupVerifyError::RootMismatch)
-                } else {
-                    // Return the block for processing.
-                    Ok(Some(block))
-                }
-            }
-            None => Err(LookupVerifyError::NoBlockReturned),
-        }
     }
 
     fn get_parent_root(verified_response: &Arc<SignedBeaconBlock<T::EthSpec>>) -> Option<Hash256> {
@@ -340,58 +286,25 @@ impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlockRequestState<L>
 }
 
 impl<L: Lookup, T: BeaconChainTypes> RequestState<L, T> for BlobRequestState<L, T::EthSpec> {
-    type RequestType = BlobsByRootRequest;
-    type ResponseType = Arc<BlobSidecar<T::EthSpec>>;
+    type RequestType = BlobsByRootSingleBlockRequest;
     type VerifiedResponseType = FixedBlobSidecarList<T::EthSpec>;
     type ReconstructedResponseType = FixedBlobSidecarList<T::EthSpec>;
 
-    fn new_request(&self, spec: &ChainSpec) -> BlobsByRootRequest {
-        let blob_id_vec: Vec<BlobIdentifier> = self.requested_ids.clone().into();
-        BlobsByRootRequest::new(blob_id_vec, spec)
+    fn new_request(&self) -> Self::RequestType {
+        BlobsByRootSingleBlockRequest {
+            block_root: self.block_root,
+            indices: self.requested_ids.indices(),
+        }
     }
 
     fn make_request(
         id: SingleLookupReqId,
         peer_id: PeerId,
         request: Self::RequestType,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), LookupRequestError> {
         cx.blob_lookup_request(id, peer_id, request)
             .map_err(LookupRequestError::SendFailed)
-    }
-
-    fn verify_response_inner(
-        &mut self,
-        expected_block_root: Hash256,
-        blob: Option<Self::ResponseType>,
-    ) -> Result<Option<FixedBlobSidecarList<T::EthSpec>>, LookupVerifyError> {
-        match blob {
-            Some(blob) => {
-                let received_id = blob.id();
-
-                if !self.requested_ids.contains(&received_id) {
-                    return Err(LookupVerifyError::UnrequestedBlobId(received_id));
-                }
-                if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
-                    return Err(LookupVerifyError::InvalidInclusionProof);
-                }
-                if blob.block_root() != expected_block_root {
-                    return Err(LookupVerifyError::UnrequestedHeader);
-                }
-
-                // State should remain downloading until we receive the stream terminator.
-                self.requested_ids.remove(&received_id);
-
-                // The inclusion proof check above ensures `blob.index` is < MAX_BLOBS_PER_BLOCK
-                let blob_index = blob.index;
-                *self.blob_download_queue.index_mut(blob_index as usize) = Some(blob);
-                Ok(None)
-            }
-            None => {
-                let blobs = std::mem::take(&mut self.blob_download_queue);
-                Ok(Some(blobs))
-            }
-        }
     }
 
     fn get_parent_root(verified_response: &FixedBlobSidecarList<T::EthSpec>) -> Option<Hash256> {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -392,7 +392,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                         .get_state_mut()
                         .on_download_success()
                         .map_err(LookupRequestError::BadState)?;
-
                     self.send_block_for_processing(
                         block_root,
                         block,
@@ -403,6 +402,10 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 }
             }
             CachedChild::DownloadIncomplete => {
+                R::request_state_mut(lookup)
+                    .get_state_mut()
+                    .on_download_success()
+                    .map_err(LookupRequestError::BadState)?;
                 // If this was the result of a block request, we can't determine if the block peer
                 // did anything wrong. If we already had both a block and blobs response processed,
                 // we should penalize the blobs peer because they did not provide all blobs on the

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -126,7 +126,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     pub fn trigger_single_lookup(
         &mut self,
         mut single_block_lookup: SingleBlockLookup<Current, T>,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) {
         let block_root = single_block_lookup.block_root();
         match single_block_lookup.request_block_and_blobs(cx) {
@@ -312,36 +312,32 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         lookup_id: SingleLookupReqId,
         peer_id: PeerId,
-        response: Option<R::ResponseType>,
+        response: R::VerifiedResponseType,
         seen_timestamp: Duration,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) {
         let id = lookup_id.id;
         let response_type = R::response_type();
 
         let Some(lookup) = self.get_single_lookup::<R>(lookup_id) else {
-            if response.is_some() {
-                // We don't have the ability to cancel in-flight RPC requests. So this can happen
-                // if we started this RPC request, and later saw the block/blobs via gossip.
-                debug!(
-                    self.log,
-                    "Block returned for single block lookup not present";
-                        "response_type" => ?response_type,
-                );
-            }
+            // We don't have the ability to cancel in-flight RPC requests. So this can happen
+            // if we started this RPC request, and later saw the block/blobs via gossip.
+            debug!(
+                self.log,
+                "Block returned for single block lookup not present";
+                    "response_type" => ?response_type,
+            );
             return;
         };
 
         let expected_block_root = lookup.block_root();
-        if response.is_some() {
-            debug!(self.log,
-                "Peer returned response for single lookup";
-                "peer_id" => %peer_id ,
-                "id" => ?id,
-                "block_root" => ?expected_block_root,
-                "response_type" => ?response_type,
-            );
-        }
+        debug!(self.log,
+            "Peer returned response for single lookup";
+            "peer_id" => %peer_id ,
+            "id" => ?id,
+            "block_root" => ?expected_block_root,
+            "response_type" => ?response_type,
+        );
 
         match self.single_lookup_response_inner::<R>(peer_id, response, seen_timestamp, cx, lookup)
         {
@@ -368,9 +364,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn single_lookup_response_inner<R: RequestState<Current, T>>(
         &self,
         peer_id: PeerId,
-        response: Option<R::ResponseType>,
+        response: R::VerifiedResponseType,
         seen_timestamp: Duration,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         mut lookup: SingleBlockLookup<Current, T>,
     ) -> Result<SingleBlockLookup<Current, T>, LookupRequestError> {
         let response_type = R::response_type();
@@ -378,8 +374,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         let expected_block_root = lookup.block_root();
         let request_state = R::request_state_mut(&mut lookup);
 
-        match request_state.verify_response(expected_block_root, peer_id, response) {
-            Ok(Some(verified_response)) => {
+        match request_state.verify_response(response) {
+            Ok(verified_response) => {
                 self.handle_verified_response::<Current, R>(
                     seen_timestamp,
                     cx,
@@ -388,7 +384,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                     &mut lookup,
                 )?;
             }
-            Ok(None) => {}
             Err(e) => {
                 debug!(
                     log,
@@ -411,7 +406,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn handle_verified_response<L: Lookup, R: RequestState<L, T>>(
         &self,
         seen_timestamp: Duration,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         process_type: BlockProcessType,
         verified_response: R::VerifiedResponseType,
         lookup: &mut SingleBlockLookup<L, T>,
@@ -504,26 +499,22 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: PeerId,
-        response: Option<R::ResponseType>,
+        response: R::VerifiedResponseType,
         seen_timestamp: Duration,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) {
         let Some(mut parent_lookup) = self.get_parent_lookup::<R>(id) else {
-            if response.is_some() {
-                debug!(self.log, "Response for a parent lookup request that was not found"; "peer_id" => %peer_id);
-            }
+            debug!(self.log, "Response for a parent lookup request that was not found"; "peer_id" => %peer_id);
             return;
         };
 
-        if response.is_some() {
-            debug!(self.log,
-                "Peer returned response for parent lookup";
-                "peer_id" => %peer_id ,
-                "id" => ?id,
-                "block_root" => ?parent_lookup.current_parent_request.block_request_state.requested_block_root,
-                "response_type" => ?R::response_type(),
-            );
-        }
+        debug!(self.log,
+            "Peer returned response for parent lookup";
+            "peer_id" => %peer_id ,
+            "id" => ?id,
+            "block_root" => ?parent_lookup.current_parent_request.block_request_state.requested_block_root,
+            "response_type" => ?R::response_type(),
+        );
 
         match self.parent_lookup_response_inner::<R>(
             peer_id,
@@ -551,13 +542,13 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn parent_lookup_response_inner<R: RequestState<Parent, T>>(
         &mut self,
         peer_id: PeerId,
-        response: Option<R::ResponseType>,
+        response: R::VerifiedResponseType,
         seen_timestamp: Duration,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         parent_lookup: &mut ParentLookup<T>,
     ) -> Result<(), RequestError> {
-        match parent_lookup.verify_response::<R>(peer_id, response, &mut self.failed_chains) {
-            Ok(Some(verified_response)) => {
+        match parent_lookup.verify_response::<R>(response, &mut self.failed_chains) {
+            Ok(verified_response) => {
                 self.handle_verified_response::<Parent, R>(
                     seen_timestamp,
                     cx,
@@ -568,7 +559,6 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                     &mut parent_lookup.current_parent_request,
                 )?;
             }
-            Ok(None) => {}
             Err(e) => self.handle_parent_verify_error::<R>(peer_id, parent_lookup, e, cx)?,
         };
         Ok(())
@@ -580,7 +570,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         peer_id: PeerId,
         parent_lookup: &mut ParentLookup<T>,
         e: ParentVerifyError,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), RequestError> {
         match e {
             ParentVerifyError::RootMismatch
@@ -695,7 +685,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: &PeerId,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         error: RPCError,
     ) {
         let msg = error.as_static_str();
@@ -724,7 +714,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: &PeerId,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         error: RPCError,
     ) {
         let msg = error.as_static_str();
@@ -842,7 +832,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     /// blobs peer because they did not provide all blobs on the initial request.
     fn handle_missing_components<R: RequestState<Current, T>>(
         &self,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         lookup: &mut SingleBlockLookup<Current, T>,
     ) -> Result<(), LookupRequestError> {
         let request_state = R::request_state_mut(lookup);
@@ -1008,20 +998,21 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             }
             BlockProcessingResult::Ok(AvailabilityProcessingStatus::Imported(_))
             | BlockProcessingResult::Err(BlockError::BlockIsAlreadyKnown(_)) => {
-                // Check if the beacon processor is available
-                let Some(beacon_processor) = cx.beacon_processor_if_enabled() else {
-                    return trace!(
-                        self.log,
-                        "Dropping parent chain segment that was ready for processing.";
-                        parent_lookup
-                    );
-                };
                 let (chain_hash, blocks, hashes, block_request) =
                     parent_lookup.parts_for_processing();
 
                 let blocks = self.add_child_block_to_chain(chain_hash, blocks, cx).into();
 
                 let process_id = ChainSegmentProcessId::ParentLookup(chain_hash);
+
+                // Check if the beacon processor is available
+                let Some(beacon_processor) = cx.beacon_processor_if_enabled() else {
+                    return trace!(
+                        self.log,
+                        "Dropping parent chain segment that was ready for processing.";
+                        "chain_hash" => %chain_hash,
+                    );
+                };
 
                 match beacon_processor.send_chain_segment(process_id, blocks) {
                     Ok(_) => {
@@ -1075,7 +1066,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         chain_hash: Hash256,
         mut blocks: VecDeque<RpcBlock<T::EthSpec>>,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) -> VecDeque<RpcBlock<T::EthSpec>> {
         // Find the child block that spawned the parent lookup request and add it to the chain
         // to send for processing.
@@ -1128,7 +1119,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     fn handle_parent_block_error(
         &mut self,
         outcome: BlockError<<T as BeaconChainTypes>::EthSpec>,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
         mut parent_lookup: ParentLookup<T>,
     ) {
         // We should always have a block peer.
@@ -1180,7 +1171,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         chain_hash: Hash256,
         result: BatchProcessResult,
-        cx: &SyncNetworkContext<T>,
+        cx: &mut SyncNetworkContext<T>,
     ) {
         let Some((_hashes, request)) = self.processing_parent_lookups.remove(&chain_hash) else {
             return debug!(self.log, "Chain process response for a parent lookup request that was not found"; "chain_hash" => %chain_hash, "result" => ?result);
@@ -1341,7 +1332,11 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     /// Attempts to request the next unknown parent. This method handles peer scoring and dropping
     /// the lookup in the event of failure.
-    fn request_parent(&mut self, mut parent_lookup: ParentLookup<T>, cx: &SyncNetworkContext<T>) {
+    fn request_parent(
+        &mut self,
+        mut parent_lookup: ParentLookup<T>,
+        cx: &mut SyncNetworkContext<T>,
+    ) {
         let response = parent_lookup.request_parent(cx);
 
         match response {

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -606,12 +606,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId, cx: &mut SyncNetworkContext<T>) {
         /* Check disconnection for single lookups */
-        self.single_block_lookups.retain(|id, req| {
+        self.single_block_lookups.retain(|_, req| {
             let should_drop_lookup =
                 req.should_drop_lookup_on_disconnected_peer(peer_id, cx, &self.log);
-            if should_drop_lookup {
-                debug!(self.log, "Dropping lookup after peer disconnected"; "id" => id, "block_root" => %req.block_root());
-            }
 
             !should_drop_lookup
         });
@@ -695,7 +692,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 "error" => ?e,
                 "block_root" => ?block_root,
             );
-            self.single_block_lookups.remove(&id);
+        } else {
+            self.single_block_lookups.insert(id, lookup);
         }
 
         metrics::set_gauge(

--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -1,7 +1,6 @@
-use super::single_block_lookup::{LookupRequestError, LookupVerifyError, SingleBlockLookup};
+use super::single_block_lookup::{LookupRequestError, SingleBlockLookup};
 use super::{DownloadedBlock, PeerId};
 use crate::sync::block_lookups::common::Parent;
-use crate::sync::block_lookups::common::RequestState;
 use crate::sync::{manager::SLOT_IMPORT_TOLERANCE, network_context::SyncNetworkContext};
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::block_verification_types::RpcBlock;
@@ -10,8 +9,6 @@ use beacon_chain::BeaconChainTypes;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use store::Hash256;
-use strum::IntoStaticStr;
-use types::blob_sidecar::BlobIdentifier;
 
 /// How many attempts we try to find a parent of a block before we give up trying.
 pub(crate) const PARENT_FAIL_TOLERANCE: u8 = 5;
@@ -30,22 +27,8 @@ pub(crate) struct ParentLookup<T: BeaconChainTypes> {
     pub current_parent_request: SingleBlockLookup<Parent, T>,
 }
 
-#[derive(Debug, PartialEq, Eq, IntoStaticStr)]
-pub enum ParentVerifyError {
-    RootMismatch,
-    NoBlockReturned,
-    NotEnoughBlobsReturned,
-    ExtraBlocksReturned,
-    UnrequestedBlobId(BlobIdentifier),
-    InvalidInclusionProof,
-    UnrequestedHeader,
-    ExtraBlobsReturned,
-    InvalidIndex(u64),
-    PreviousFailure { parent_root: Hash256 },
-}
-
 #[derive(Debug, PartialEq, Eq)]
-pub enum RequestError {
+pub(crate) enum RequestError {
     SendFailed(&'static str),
     ChainTooLong,
     /// We witnessed too many failures trying to complete this parent lookup.
@@ -186,28 +169,6 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         }
     }
 
-    /// Verifies that the received block is what we requested. If so, parent lookup now waits for
-    /// the processing result of the block.
-    pub fn verify_response<R: RequestState<Parent, T>>(
-        &mut self,
-        block: R::VerifiedResponseType,
-        failed_chains: &mut lru_cache::LRUTimeCache<Hash256>,
-    ) -> Result<R::VerifiedResponseType, ParentVerifyError> {
-        let request_state = R::request_state_mut(&mut self.current_parent_request);
-        let root_and_verified = request_state.verify_response(block)?;
-
-        // check if the parent of this block isn't in the failed cache. If it is, this chain should
-        // be dropped and the peer downscored.
-        if let Some(parent_root) = R::get_parent_root(&root_and_verified) {
-            if failed_chains.contains(&parent_root) {
-                request_state.register_failure_downloading();
-                return Err(ParentVerifyError::PreviousFailure { parent_root });
-            }
-        }
-
-        Ok(root_and_verified)
-    }
-
     pub fn add_peer(&mut self, peer: PeerId) {
         self.current_parent_request.add_peer(peer)
     }
@@ -219,23 +180,6 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
 
     pub fn all_used_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
         self.current_parent_request.all_used_peers()
-    }
-}
-
-impl From<LookupVerifyError> for ParentVerifyError {
-    fn from(e: LookupVerifyError) -> Self {
-        use LookupVerifyError as E;
-        match e {
-            E::RootMismatch => ParentVerifyError::RootMismatch,
-            E::NoBlockReturned => ParentVerifyError::NoBlockReturned,
-            E::ExtraBlocksReturned => ParentVerifyError::ExtraBlocksReturned,
-            E::UnrequestedBlobId(blob_id) => ParentVerifyError::UnrequestedBlobId(blob_id),
-            E::InvalidInclusionProof => ParentVerifyError::InvalidInclusionProof,
-            E::UnrequestedHeader => ParentVerifyError::UnrequestedHeader,
-            E::ExtraBlobsReturned => ParentVerifyError::ExtraBlobsReturned,
-            E::InvalidIndex(index) => ParentVerifyError::InvalidIndex(index),
-            E::NotEnoughBlobsReturned => ParentVerifyError::NotEnoughBlobsReturned,
-        }
     }
 }
 
@@ -276,7 +220,7 @@ impl RequestError {
             }
             RequestError::TooManyAttempts { cannot_process: _ } => "too_many_downloading_attempts",
             RequestError::NoPeers => "no_peers",
-            RequestError::BadState(_) => "bad_state",
+            RequestError::BadState(..) => "bad_state",
         }
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -11,7 +11,7 @@ use beacon_chain::BeaconChainTypes;
 use itertools::Itertools;
 use lighthouse_network::PeerAction;
 use rand::seq::IteratorRandom;
-use slog::{trace, Logger};
+use slog::{debug, Logger};
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::marker::PhantomData;
@@ -221,7 +221,7 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
 
         if block_peer_disconnected || blob_peer_disconnected {
             if let Err(e) = self.request_block_and_blobs(cx) {
-                trace!(log, "Single lookup failed on peer disconnection"; "block_root" => ?block_root, "error" => ?e);
+                debug!(log, "Single lookup failed on peer disconnection"; "block_root" => ?block_root, "error" => ?e);
                 return true;
             }
         }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -75,6 +75,7 @@ impl<L: Lookup, T: BeaconChainTypes> SingleBlockLookup<L, T> {
     /// the next parent.
     pub fn update_requested_parent_block(&mut self, block_root: Hash256) {
         self.block_request_state.requested_block_root = block_root;
+        self.blob_request_state.block_root = block_root;
         self.block_request_state.state.state = State::AwaitingDownload;
         self.blob_request_state.state.state = State::AwaitingDownload;
         self.child_components = Some(ChildComponents::empty(block_root));
@@ -450,11 +451,9 @@ impl SingleLookupRequestState {
                 self.state = State::Processing { peer_id: *peer_id };
                 Ok(())
             }
-            other => {
-                return Err(format!(
-                    "request bad state, expected downloading got {other}"
-                ))
-            }
+            other => Err(format!(
+                "request bad state, expected downloading got {other}"
+            )),
         }
     }
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -15,7 +15,7 @@ use beacon_chain::test_utils::{
     build_log, generate_rand_block_and_blobs, BeaconChainHarness, EphemeralHarnessType, NumBlobs,
 };
 use beacon_processor::WorkEvent;
-use lighthouse_network::rpc::RPCResponseErrorCode;
+use lighthouse_network::rpc::{RPCError, RPCResponseErrorCode};
 use lighthouse_network::types::SyncState;
 use lighthouse_network::{NetworkGlobals, Request};
 use slog::info;

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -343,7 +343,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     /// Reports to the scoring algorithm the behaviour of a peer.
     pub fn report_peer(&self, peer_id: PeerId, action: PeerAction, msg: &'static str) {
-        debug!(self.log, "Sync reporting peer"; "peer_id" => %peer_id, "action" => %action);
+        debug!(self.log, "Sync reporting peer"; "peer_id" => %peer_id, "action" => %action, "msg" => %msg);
         self.network_send
             .send(NetworkMessage::ReportPeer {
                 peer_id,

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -50,28 +50,29 @@ impl ActiveBlocksByRootRequest {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct BlocksByRootSingleRequest(pub Hash256);
 
 impl BlocksByRootSingleRequest {
-    pub fn into_request(&self, spec: &ChainSpec) -> BlocksByRootRequest {
+    pub fn into_request(self, spec: &ChainSpec) -> BlocksByRootRequest {
         BlocksByRootRequest::new(vec![self.0], spec)
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct BlobsByRootSingleBlockRequest {
     pub block_root: Hash256,
     pub indices: Vec<u64>,
 }
 
 impl BlobsByRootSingleBlockRequest {
-    pub fn into_request(&self, spec: &ChainSpec) -> BlobsByRootRequest {
+    pub fn into_request(self, spec: &ChainSpec) -> BlobsByRootRequest {
         BlobsByRootRequest::new(
             self.indices
-                .iter()
+                .into_iter()
                 .map(|index| BlobIdentifier {
                     block_root: self.block_root,
-                    index: *index,
+                    index,
                 })
                 .collect(),
             spec,
@@ -136,7 +137,7 @@ impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
 
     pub fn terminate(self) -> Option<Vec<Arc<BlobSidecar<E>>>> {
         if self.resolved {
-            return None;
+            None
         } else {
             Some(self.blobs)
         }

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -1,0 +1,144 @@
+use beacon_chain::get_block_root;
+use lighthouse_network::rpc::{methods::BlobsByRootRequest, BlocksByRootRequest, RPCError};
+use std::sync::Arc;
+use types::{
+    blob_sidecar::BlobIdentifier, BlobSidecar, ChainSpec, EthSpec, Hash256, SignedBeaconBlock,
+};
+
+pub struct ActiveBlocksByRootRequest {
+    request: BlocksByRootSingleRequest,
+    resolved: bool,
+}
+
+impl ActiveBlocksByRootRequest {
+    pub fn new(request: BlocksByRootSingleRequest) -> Self {
+        Self {
+            request,
+            resolved: false,
+        }
+    }
+
+    /// Append a response to the single chunk request. If the chunk is valid, the request is
+    /// resolved immediately.
+    /// The active request SHOULD be dropped after `add_response` returns an error
+    pub fn add_response<E: EthSpec>(
+        &mut self,
+        block: Arc<SignedBeaconBlock<E>>,
+    ) -> Result<Arc<SignedBeaconBlock<E>>, RPCError> {
+        if self.resolved {
+            return Err(RPCError::InvalidData("too many responses".to_string()));
+        }
+
+        let block_root = get_block_root(&block);
+        if self.request.0 != block_root {
+            return Err(RPCError::InvalidData(format!(
+                "un-requested block root {block_root:?}"
+            )));
+        }
+
+        // Valid data, blocks by root expects a single response
+        self.resolved = true;
+        Ok(block)
+    }
+
+    pub fn terminate(self) -> Result<(), RPCError> {
+        if self.resolved {
+            Ok(())
+        } else {
+            Err(RPCError::InvalidData("no response returned".to_string()))
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BlocksByRootSingleRequest(pub Hash256);
+
+impl BlocksByRootSingleRequest {
+    pub fn into_request(&self, spec: &ChainSpec) -> BlocksByRootRequest {
+        BlocksByRootRequest::new(vec![self.0], spec)
+    }
+}
+
+pub struct BlobsByRootSingleBlockRequest {
+    pub block_root: Hash256,
+    pub indices: Vec<u64>,
+}
+
+impl BlobsByRootSingleBlockRequest {
+    pub fn into_request(&self, spec: &ChainSpec) -> BlobsByRootRequest {
+        BlobsByRootRequest::new(
+            self.indices
+                .iter()
+                .map(|index| BlobIdentifier {
+                    block_root: self.block_root,
+                    index: *index,
+                })
+                .collect(),
+            spec,
+        )
+    }
+}
+
+pub struct ActiveBlobsByRootRequest<E: EthSpec> {
+    request: BlobsByRootSingleBlockRequest,
+    blobs: Vec<Arc<BlobSidecar<E>>>,
+    resolved: bool,
+}
+
+impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
+    pub fn new(request: BlobsByRootSingleBlockRequest) -> Self {
+        Self {
+            request,
+            blobs: vec![],
+            resolved: false,
+        }
+    }
+
+    /// Appends a chunk to this multi-item request. If all expected chunks are received, this
+    /// method returns `Some`, resolving the request before the stream terminator.
+    /// The active request SHOULD be dropped after `add_response` returns an error
+    pub fn add_response(
+        &mut self,
+        blob: Arc<BlobSidecar<E>>,
+    ) -> Result<Option<Vec<Arc<BlobSidecar<E>>>>, RPCError> {
+        if self.resolved {
+            return Err(RPCError::InvalidData("too many responses".to_string()));
+        }
+
+        let block_root = blob.block_root();
+        if self.request.block_root != block_root {
+            return Err(RPCError::InvalidData(format!(
+                "un-requested block root {block_root:?}"
+            )));
+        }
+        if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
+            return Err(RPCError::InvalidData("invalid inclusion proof".to_string()));
+        }
+        if !self.request.indices.contains(&blob.index) {
+            return Err(RPCError::InvalidData(format!(
+                "un-requested blob index {}",
+                blob.index
+            )));
+        }
+        if self.blobs.iter().any(|b| b.index == blob.index) {
+            return Err(RPCError::InvalidData("duplicated data".to_string()));
+        }
+
+        self.blobs.push(blob);
+        if self.blobs.len() >= self.request.indices.len() {
+            // All expected chunks received, return result early
+            self.resolved = true;
+            Ok(Some(std::mem::take(&mut self.blobs)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn terminate(self) -> Option<Vec<Arc<BlobSidecar<E>>>> {
+        if self.resolved {
+            return None;
+        } else {
+            Some(self.blobs)
+        }
+    }
+}


### PR DESCRIPTION
## Issue Addressed

Part of
- https://github.com/sigp/lighthouse/issues/5549

Currently the sync lookup request states deal with tracking streams, retries and their own sync logic (parent chains, etc). The complexities of streams can be abstracted up into the network context to simplify downstream code.

This abstraction would have avoided the previous month bug regarding `ExtraBlocks`

## Proposed Changes

Adopt the same accumulator pattern used today for range blocks + blobs for lookup requests. Allow to merge error handling into the same codepath and remove the concept of response validation from the RequestState trait.

In draft to wait for https://github.com/sigp/lighthouse/pull/5563
