### PR TITLE
Restore Log on Error & Spawn Blocking in Streamer

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_streamer.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_streamer.rs
@@ -429,9 +429,8 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         block_roots: Vec<Hash256>,
     ) -> Result<Vec<(Hash256, LoadResult<T::EthSpec>)>, BeaconChainError> {
         let streamer = self.clone();
-        let chain = streamer.beacon_chain.clone();
         // Loading from the DB is slow -> spawn a blocking task
-        chain
+        self.beacon_chain
             .spawn_blocking_handle(
                 move || {
                     let mut db_blocks = Vec::new();

--- a/beacon_node/beacon_chain/src/beacon_block_streamer.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_streamer.rs
@@ -1,10 +1,9 @@
 use crate::{metrics, BeaconChain, BeaconChainError, BeaconChainTypes};
 use execution_layer::{ExecutionLayer, ExecutionPayloadBodyV1};
-use slog::{crit, debug, Logger};
+use slog::{crit, debug, error, Logger};
 use std::collections::HashMap;
 use std::sync::Arc;
 use store::{DatabaseBlock, ExecutionPayloadDeneb};
-use task_executor::TaskExecutor;
 use tokio::sync::{
     mpsc::{self, UnboundedSender},
     RwLock,
@@ -395,18 +394,18 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
     pub fn new(
         beacon_chain: &Arc<BeaconChain<T>>,
         check_caches: CheckCaches,
-    ) -> Result<Self, BeaconChainError> {
+    ) -> Result<Arc<Self>, BeaconChainError> {
         let execution_layer = beacon_chain
             .execution_layer
             .as_ref()
             .ok_or(BeaconChainError::ExecutionLayerMissing)?
             .clone();
 
-        Ok(Self {
+        Ok(Arc::new(Self {
             execution_layer,
             check_caches,
             beacon_chain: beacon_chain.clone(),
-        })
+        }))
     }
 
     fn check_caches(&self, root: Hash256) -> Option<Arc<SignedBeaconBlock<T::EthSpec>>> {
@@ -425,30 +424,45 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         }
     }
 
-    fn load_payloads(&self, block_roots: Vec<Hash256>) -> Vec<(Hash256, LoadResult<T::EthSpec>)> {
-        let mut db_blocks = Vec::new();
-
-        for root in block_roots {
-            if let Some(cached_block) = self.check_caches(root).map(LoadedBeaconBlock::Full) {
-                db_blocks.push((root, Ok(Some(cached_block))));
-                continue;
-            }
-
-            match self.beacon_chain.store.try_get_full_block(&root) {
-                Err(e) => db_blocks.push((root, Err(e.into()))),
-                Ok(opt_block) => db_blocks.push((
-                    root,
-                    Ok(opt_block.map(|db_block| match db_block {
-                        DatabaseBlock::Full(block) => LoadedBeaconBlock::Full(Arc::new(block)),
-                        DatabaseBlock::Blinded(block) => {
-                            LoadedBeaconBlock::Blinded(Box::new(block))
+    async fn load_payloads(
+        self: &Arc<Self>,
+        block_roots: Vec<Hash256>,
+    ) -> Result<Vec<(Hash256, LoadResult<T::EthSpec>)>, BeaconChainError> {
+        let streamer = self.clone();
+        let chain = streamer.beacon_chain.clone();
+        // Loading from the DB is slow -> spawn a blocking task
+        chain
+            .spawn_blocking_handle(
+                move || {
+                    let mut db_blocks = Vec::new();
+                    for root in block_roots {
+                        if let Some(cached_block) =
+                            streamer.check_caches(root).map(LoadedBeaconBlock::Full)
+                        {
+                            db_blocks.push((root, Ok(Some(cached_block))));
+                            continue;
                         }
-                    })),
-                )),
-            }
-        }
 
-        db_blocks
+                        match streamer.beacon_chain.store.try_get_full_block(&root) {
+                            Err(e) => db_blocks.push((root, Err(e.into()))),
+                            Ok(opt_block) => db_blocks.push((
+                                root,
+                                Ok(opt_block.map(|db_block| match db_block {
+                                    DatabaseBlock::Full(block) => {
+                                        LoadedBeaconBlock::Full(Arc::new(block))
+                                    }
+                                    DatabaseBlock::Blinded(block) => {
+                                        LoadedBeaconBlock::Blinded(Box::new(block))
+                                    }
+                                })),
+                            )),
+                        }
+                    }
+                    db_blocks
+                },
+                "load_beacon_blocks",
+            )
+            .await
     }
 
     /// Pre-process the loaded blocks into execution engine requests.
@@ -549,7 +563,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
 
     // used when the execution engine doesn't support the payload bodies methods
     async fn stream_blocks_fallback(
-        &self,
+        self: Arc<Self>,
         block_roots: Vec<Hash256>,
         sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
     ) {
@@ -575,7 +589,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
     }
 
     async fn stream_blocks(
-        &self,
+        self: Arc<Self>,
         block_roots: Vec<Hash256>,
         sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
     ) {
@@ -584,7 +598,17 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
         let mut n_sent = 0usize;
         let mut engine_requests = 0usize;
 
-        let payloads = self.load_payloads(block_roots);
+        let payloads = match self.load_payloads(block_roots).await {
+            Ok(payloads) => payloads,
+            Err(e) => {
+                error!(
+                    self.beacon_chain.log,
+                    "BeaconBlockStreamer: Failed to load payloads";
+                    "error" => ?e
+                );
+                return;
+            }
+        };
         let requests = self.get_requests(payloads).await;
 
         for (root, request) in requests {
@@ -624,7 +648,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
     }
 
     pub async fn stream(
-        self,
+        self: Arc<Self>,
         block_roots: Vec<Hash256>,
         sender: UnboundedSender<(Hash256, Arc<BlockResult<T::EthSpec>>)>,
     ) {
@@ -650,9 +674,8 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
     }
 
     pub fn launch_stream(
-        self,
+        self: Arc<Self>,
         block_roots: Vec<Hash256>,
-        executor: &TaskExecutor,
     ) -> impl Stream<Item = (Hash256, Arc<BlockResult<T::EthSpec>>)> {
         let (block_tx, block_rx) = mpsc::unbounded_channel();
         debug!(
@@ -660,6 +683,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
             "Launching a BeaconBlockStreamer";
             "blocks" => block_roots.len(),
         );
+        let executor = self.beacon_chain.task_executor.clone();
         executor.spawn(self.stream(block_roots, block_tx), "get_blocks_sender");
         UnboundedReceiverStream::new(block_rx)
     }

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1139,7 +1139,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn get_blocks_checking_caches(
         self: &Arc<Self>,
         block_roots: Vec<Hash256>,
-        executor: &TaskExecutor,
     ) -> Result<
         impl Stream<
             Item = (
@@ -1149,14 +1148,12 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         >,
         Error,
     > {
-        Ok(BeaconBlockStreamer::<T>::new(self, CheckCaches::Yes)?
-            .launch_stream(block_roots, executor))
+        Ok(BeaconBlockStreamer::<T>::new(self, CheckCaches::Yes)?.launch_stream(block_roots))
     }
 
     pub fn get_blocks(
         self: &Arc<Self>,
         block_roots: Vec<Hash256>,
-        executor: &TaskExecutor,
     ) -> Result<
         impl Stream<
             Item = (
@@ -1166,8 +1163,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         >,
         Error,
     > {
-        Ok(BeaconBlockStreamer::<T>::new(self, CheckCaches::No)?
-            .launch_stream(block_roots, executor))
+        Ok(BeaconBlockStreamer::<T>::new(self, CheckCaches::No)?.launch_stream(block_roots))
     }
 
     pub fn get_blobs_checking_early_attester_cache(

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -509,9 +509,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
         let process_fn = async move {
-            let executor = processor.executor.clone();
             processor
-                .handle_blocks_by_range_request(executor, peer_id, request_id, request)
+                .handle_blocks_by_range_request(peer_id, request_id, request)
                 .await;
         };
 
@@ -530,9 +529,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
         let process_fn = async move {
-            let executor = processor.executor.clone();
             processor
-                .handle_blocks_by_root_request(executor, peer_id, request_id, request)
+                .handle_blocks_by_root_request(peer_id, request_id, request)
                 .await;
         };
 

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -152,7 +152,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let log_results = |peer_id, requested_blocks, send_block_count| {
             debug!(
                 self.log,
-                "BlocksByRoot Outgoing Response Processed";
+                "BlocksByRoot outgoing response processed";
                 "peer" => %peer_id,
                 "requested" => requested_blocks,
                 "returned" => %send_block_count
@@ -304,7 +304,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         }
         debug!(
             self.log,
-            "Received BlobsByRoot Request";
+            "BlobsByRoot outgoing response processed";
             "peer" => %peer_id,
             "request_root" => %requested_root,
             "request_indices" => ?requested_indices,
@@ -515,7 +515,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             if blocks_sent < (*req.count() as usize) {
                 debug!(
                     self.log,
-                    "BlocksByRange Outgoing Response Processed";
+                    "BlocksByRange outgoing response processed";
                     "peer" => %peer_id,
                     "msg" => "Failed to return all requested blocks",
                     "start_slot" => req.start_slot(),
@@ -526,7 +526,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             } else {
                 debug!(
                     self.log,
-                    "BlocksByRange Outgoing Response Processed";
+                    "BlocksByRange outgoing response processed";
                     "peer" => %peer_id,
                     "start_slot" => req.start_slot(),
                     "current_slot" => current_slot,
@@ -766,7 +766,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let log_results = |peer_id, req: BlobsByRangeRequest, blobs_sent| {
             debug!(
                 self.log,
-                "BlobsByRange Outgoing Response processed";
+                "BlobsByRange outgoing response processed";
                 "peer" => %peer_id,
                 "start_slot" => req.start_slot,
                 "current_slot" => current_slot,

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -11,7 +11,6 @@ use slog::{debug, error, warn};
 use slot_clock::SlotClock;
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::Arc;
-use task_executor::TaskExecutor;
 use tokio_stream::StreamExt;
 use types::blob_sidecar::BlobIdentifier;
 use types::{Epoch, EthSpec, ForkName, Hash256, Slot};
@@ -129,7 +128,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /// Handle a `BlocksByRoot` request from the peer.
     pub async fn handle_blocks_by_root_request(
         self: Arc<Self>,
-        executor: TaskExecutor,
         peer_id: PeerId,
         request_id: PeerRequestId,
         request: BlocksByRootRequest,
@@ -147,7 +145,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let requested_blocks = request.block_roots().len();
         let mut block_stream = match self
             .chain
-            .get_blocks_checking_caches(request.block_roots().to_vec(), &executor)
+            .get_blocks_checking_caches(request.block_roots().to_vec())
         {
             Ok(block_stream) => block_stream,
             Err(e) => return error!(self.log, "Error getting block stream"; "error" => ?e),
@@ -381,7 +379,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /// Handle a `BlocksByRange` request from the peer.
     pub async fn handle_blocks_by_range_request(
         self: Arc<Self>,
-        executor: TaskExecutor,
         peer_id: PeerId,
         request_id: PeerRequestId,
         req: BlocksByRangeRequest,
@@ -515,7 +512,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             }
         };
 
-        let mut block_stream = match self.chain.get_blocks(block_roots, &executor) {
+        let mut block_stream = match self.chain.get_blocks(block_roots) {
             Ok(block_stream) => block_stream,
             Err(e) => return error!(self.log, "Error getting block stream"; "error" => ?e),
         };


### PR DESCRIPTION
## Issue Addressed

* Some error cases in rpc_methods were no longer logging the results on error. 
* The `BeaconBlockStreamer` now runs the task of loading the blocks in a blocking thread as DB reads are slow