### PR TITLE
Set web3signer keep-alive to 20s by default

### DIFF
--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -218,7 +218,7 @@ OPTIONS:
             The directory which contains the validator keystores, deposit data for each validator along with the common
             slashing protection database and the validator_definitions.yml
         --web3-signer-keep-alive-timeout <MILLIS>
-            Keep-alive timeout for each web3signer connection. Set to 'null' to never timeout [default: 90000]
+            Keep-alive timeout for each web3signer connection. Set to 'null' to never timeout [default: 20000]
 
         --web3-signer-max-idle-connections <COUNT>
             Maximum number of idle connections to maintain per web3signer host. Default is unlimited.

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -1,4 +1,4 @@
-use validator_client::{ApiTopic, Config};
+use validator_client::{config::DEFAULT_WEB3SIGNER_KEEP_ALIVE, ApiTopic, Config};
 
 use crate::exec::CommandLineTestExec;
 use bls::{Keypair, PublicKeyBytes};
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::str::FromStr;
 use std::string::ToString;
+use std::time::Duration;
 use tempfile::TempDir;
 use types::Address;
 
@@ -651,5 +652,28 @@ fn validator_disable_web3_signer_slashing_protection() {
         .run()
         .with_config(|config| {
             assert!(!config.enable_web3signer_slashing_protection);
+        });
+}
+
+#[test]
+fn validator_web3_signer_keep_alive_default() {
+    CommandLineTest::new().run().with_config(|config| {
+        assert_eq!(
+            config.web3_signer_keep_alive_timeout,
+            DEFAULT_WEB3SIGNER_KEEP_ALIVE
+        );
+    });
+}
+
+#[test]
+fn validator_web3_signer_keep_alive_override() {
+    CommandLineTest::new()
+        .flag("web3-signer-keep-alive-timeout", Some("1000"))
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.web3_signer_keep_alive_timeout,
+                Some(Duration::from_secs(1))
+            );
         });
 }

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -391,7 +391,7 @@ pub fn cli_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("web3-signer-keep-alive-timeout")
                 .long("web3-signer-keep-alive-timeout")
                 .value_name("MILLIS")
-                .default_value("90000")
+                .default_value("20000")
                 .help("Keep-alive timeout for each web3signer connection. Set to 'null' to never \
                        timeout")
                 .takes_value(true),

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use types::{Address, GRAFFITI_BYTES_LEN};
 
 pub const DEFAULT_BEACON_NODE: &str = "http://localhost:5052/";
+pub const DEFAULT_WEB3SIGNER_KEEP_ALIVE: Option<Duration> = Some(Duration::from_secs(20));
 
 /// Stores the core configuration for this validator instance.
 #[derive(Clone, Serialize, Deserialize)]
@@ -133,7 +134,7 @@ impl Default for Config {
             builder_boost_factor: None,
             prefer_builder_proposals: false,
             distributed: false,
-            web3_signer_keep_alive_timeout: Some(Duration::from_secs(90)),
+            web3_signer_keep_alive_timeout: DEFAULT_WEB3SIGNER_KEEP_ALIVE,
             web3_signer_max_idle_connections: None,
         }
     }

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -3,7 +3,6 @@ mod beacon_node_fallback;
 mod block_service;
 mod check_synced;
 mod cli;
-mod config;
 mod duties_service;
 mod graffiti_file;
 mod http_metrics;
@@ -14,6 +13,7 @@ mod preparation_service;
 mod signing_method;
 mod sync_committee_service;
 
+pub mod config;
 mod doppelganger_service;
 pub mod http_api;
 pub mod initialized_validators;


### PR DESCRIPTION
## Issue Addressed

Follow-up to:

- #5007

## Proposed Changes

Set the default keep-alive to 20s, which is shorter than web3signer's default 30s.

Several of our users are successfully making use of this flag now, so I think it makes sense to set the default to a value that works. CC @guybrush (of EthPool/beaconcha.in)
