### PR TITLE
Rename Functions to More Closely Match Spec

### DIFF
--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -5,7 +5,7 @@ use eth1::{DepositLog, Eth1Block, Service as Eth1Service};
 use slog::{debug, error, info, trace, Logger};
 use state_processing::{
     eth2_genesis_time, initialize_beacon_state_from_eth1, is_valid_genesis_state,
-    per_block_processing::process_operations::process_deposit, process_activations,
+    per_block_processing::process_operations::apply_deposit, process_activations,
 };
 use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering},
@@ -433,7 +433,7 @@ impl Eth1GenesisService {
                 // is reached _prior_ to `MIN_ACTIVE_VALIDATOR_COUNT`. I suspect this won't be the
                 // case for mainnet, so we defer this optimization.
 
-                process_deposit(&mut state, &deposit, spec, PROOF_VERIFICATION)
+                apply_deposit(&mut state, &deposit, spec, PROOF_VERIFICATION)
                     .map_err(|e| format!("Error whilst processing deposit: {:?}", e))
             })?;
 

--- a/consensus/state_processing/src/common/initiate_validator_exit.rs
+++ b/consensus/state_processing/src/common/initiate_validator_exit.rs
@@ -26,7 +26,7 @@ pub fn initiate_validator_exit<E: EthSpec>(
         .map_or(delayed_epoch, |epoch| max(epoch, delayed_epoch));
     let exit_queue_churn = state.exit_cache().get_churn_at(exit_queue_epoch)?;
 
-    if exit_queue_churn >= state.get_churn_limit(spec)? {
+    if exit_queue_churn >= state.get_validator_churn_limit(spec)? {
         exit_queue_epoch.safe_add_assign(1)?;
     }
 

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -1,5 +1,5 @@
 use super::per_block_processing::{
-    errors::BlockProcessingError, process_operations::process_deposit,
+    errors::BlockProcessingError, process_operations::apply_deposit,
 };
 use crate::common::DepositDataTree;
 use crate::upgrade::{
@@ -37,7 +37,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
             .push_leaf(deposit.data.tree_hash_root())
             .map_err(BlockProcessingError::MerkleTreeError)?;
         state.eth1_data_mut().deposit_root = deposit_tree.root();
-        process_deposit(&mut state, deposit, spec, true)?;
+        apply_deposit(&mut state, deposit, spec, true)?;
     }
 
     process_activations(&mut state, spec)?;

--- a/consensus/state_processing/src/per_block_processing/process_operations.rs
+++ b/consensus/state_processing/src/per_block_processing/process_operations.rs
@@ -371,14 +371,14 @@ pub fn process_deposits<E: EthSpec>(
 
     // Update the state in series.
     for deposit in deposits {
-        process_deposit(state, deposit, spec, false)?;
+        apply_deposit(state, deposit, spec, false)?;
     }
 
     Ok(())
 }
 
 /// Process a single deposit, optionally verifying its merkle proof.
-pub fn process_deposit<E: EthSpec>(
+pub fn apply_deposit<E: EthSpec>(
     state: &mut BeaconState<E>,
     deposit: &Deposit,
     spec: &ChainSpec,

--- a/consensus/state_processing/src/per_epoch_processing/single_pass.rs
+++ b/consensus/state_processing/src/per_epoch_processing/single_pass.rs
@@ -120,7 +120,7 @@ pub fn process_epoch_single_pass<E: EthSpec>(
     let next_epoch = state.next_epoch()?;
     let is_in_inactivity_leak = state.is_in_inactivity_leak(previous_epoch, spec)?;
     let total_active_balance = state.get_total_active_balance()?;
-    let churn_limit = state.get_churn_limit(spec)?;
+    let churn_limit = state.get_validator_churn_limit(spec)?;
     let activation_churn_limit = state.get_activation_churn_limit(spec)?;
     let finalized_checkpoint = state.finalized_checkpoint();
     let fork_name = state.fork_name_unchecked();

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1444,7 +1444,7 @@ impl<E: EthSpec> BeaconState<E> {
     /// Return the churn limit for the current epoch (number of validators who can leave per epoch).
     ///
     /// Uses the current epoch committee cache, and will error if it isn't initialized.
-    pub fn get_churn_limit(&self, spec: &ChainSpec) -> Result<u64, Error> {
+    pub fn get_validator_churn_limit(&self, spec: &ChainSpec) -> Result<u64, Error> {
         Ok(std::cmp::max(
             spec.min_per_epoch_churn_limit,
             (self
@@ -1462,10 +1462,10 @@ impl<E: EthSpec> BeaconState<E> {
             BeaconState::Base(_)
             | BeaconState::Altair(_)
             | BeaconState::Merge(_)
-            | BeaconState::Capella(_) => self.get_churn_limit(spec)?,
+            | BeaconState::Capella(_) => self.get_validator_churn_limit(spec)?,
             BeaconState::Deneb(_) | BeaconState::Electra(_) => std::cmp::min(
                 spec.max_per_epoch_activation_churn_limit,
-                self.get_churn_limit(spec)?,
+                self.get_validator_churn_limit(spec)?,
             ),
         })
     }


### PR DESCRIPTION
## Issue Addressed

The naming of the functions in lighthouse now match the spec names:
* [get_validator_churn_limit()](https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/beacon-chain.md#get_validator_churn_limit)
* [apply_deposit()](https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/beacon-chain.md#deposits)

which will make implementing Electra much cleaner.