### PR TITLE
Delete repetitive execute command in local testnet scripts

### DIFF
--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -112,9 +112,6 @@ sleeping 3
 execute_command_add_PID el_bootnode.log ./el_bootnode.sh
 sleeping 3
 
-execute_command_add_PID el_bootnode.log ./el_bootnode.sh
-sleeping 1
-
 # Start beacon nodes
 BN_udp_tcp_base=9000
 BN_http_port_base=8000


### PR DESCRIPTION
This is a very minor bug in the local-testnet script where the `el_bootnode.sh` is executed twice, causing the outcome that when `stop_local_testnet.sh` is called, the terminal will show: 

`./kill_processes.sh: line 15: kill: (2254405) - No such process`

It doesn't really affect anything though, but it would be nice to delete this so that no error is shown when the testnet is stopped.