### PR TITLE
Only `portable` builds (docker)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,8 +15,6 @@ concurrency:
 env:
     DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    IMAGE_NAME: ${{ github.repository_owner}}/lighthouse
-    LCLI_IMAGE_NAME: ${{ github.repository_owner }}/lcli
     # Enable self-hosted runners for the sigp repo only.
     SELF_HOSTED_RUNNERS: ${{ github.repository == 'sigp/lighthouse' }}
 
@@ -49,19 +47,15 @@ jobs:
             VERSION: ${{ env.VERSION }}
             VERSION_SUFFIX: ${{ env.VERSION_SUFFIX }}
     build-docker-single-arch:
-        name: build-docker-${{ matrix.binary }}${{ matrix.features.version_suffix }}
+        name: build-docker-${{ matrix.binary }}-${{ matrix.cpu_arch }}${{ matrix.features.version_suffix }}
         # Use self-hosted runners only on the sigp repo.
         runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release"]') || 'ubuntu-22.04'  }}
         strategy:
             matrix:
-                binary: [aarch64,
-                         aarch64-portable,
-                         x86_64,
-                         x86_64-portable]
-                features: [
-                    {version_suffix: "", env: "gnosis,slasher-lmdb,slasher-mdbx,jemalloc"},
-                    {version_suffix: "-dev", env: "jemalloc,spec-minimal"}
-                ]
+                binary:   [lighthouse,
+                           lcli]
+                cpu_arch: [aarch64,
+                           x86_64]
                 include:
                     - profile: maxperf
 
@@ -69,7 +63,6 @@ jobs:
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-            FEATURE_SUFFIX: ${{ matrix.features.version_suffix }}
         steps:
             - uses: actions/checkout@v4
             - name: Update Rust
@@ -78,27 +71,40 @@ jobs:
             - name: Dockerhub login
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-            - name: Cross build Lighthouse binary
+
+            - name: Sets env vars for Lighthouse
+              if: startsWith(matrix.binary, 'lighthouse')
+              run: |
+                echo "CROSS_FEATURES=gnosis,spec-minimal,slasher-lmdb,jemalloc" >> $GITHUB_ENV
+
+            - name: Set `make` command for lighthouse
+              if: startsWith(matrix.binary, 'lighthouse')
+              run: |
+                echo "MAKE_CMD=build-${{ matrix.cpu_arch }}-portable" >> $GITHUB_ENV
+
+            - name: Set `make` command for lcli
+              if: startsWith(matrix.binary, 'lcli')
+              run: |
+                echo "MAKE_CMD=build-lcli-${{ matrix.cpu_arch }}" >> $GITHUB_ENV
+
+            - name: Cross build binaries
               run: |
                   cargo install cross
-                  env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ matrix.features.env }} make build-${{ matrix.binary }}
+                  env CROSS_PROFILE=${{ matrix.profile }} CROSS_FEATURES=${{ env.CROSS_FEATURES }} make ${{ env.MAKE_CMD }}
+
             - name: Make bin dir
               run: mkdir ./bin
-            - name: Move cross-built binary into Docker scope (if ARM)
-              if: startsWith(matrix.binary, 'aarch64')
-              run: mv ./target/aarch64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
-            - name: Move cross-built binary into Docker scope (if x86_64)
-              if: startsWith(matrix.binary, 'x86_64')
-              run: mv ./target/x86_64-unknown-linux-gnu/${{ matrix.profile }}/lighthouse ./bin
+
+            - name: Move cross-built binary into Docker scope
+              run: mv ./target/${{ matrix.cpu_arch }}-unknown-linux-gnu/${{ matrix.profile }}/${{ matrix.binary }} ./bin
+
             - name: Map aarch64 to arm64 short arch
-              if: startsWith(matrix.binary, 'aarch64')
+              if: startsWith(matrix.cpu_arch, 'aarch64')
               run: echo "SHORT_ARCH=arm64" >> $GITHUB_ENV
+
             - name: Map x86_64 to amd64 short arch
-              if: startsWith(matrix.binary, 'x86_64')
+              if: startsWith(matrix.cpu_arch, 'x86_64')
               run: echo "SHORT_ARCH=amd64" >> $GITHUB_ENV;
-            - name: Set modernity suffix
-              if: endsWith(matrix.binary, '-portable') != true
-              run: echo "MODERNITY_SUFFIX=-modern" >> $GITHUB_ENV;
 
             - name: Install QEMU
               if: env.SELF_HOSTED_RUNNERS == 'false'
@@ -108,22 +114,41 @@ jobs:
               if: env.SELF_HOSTED_RUNNERS == 'false'
               uses: docker/setup-buildx-action@v3
 
-            - name: Build and push
+            - name: Build and push (Lighthouse)
+              if: startsWith(matrix.binary, 'lighthouse')
               uses: docker/build-push-action@v5
               with:
                 file: ./Dockerfile.cross
                 context: .
                 platforms: linux/${{ env.SHORT_ARCH }}
                 push: true
-                tags: ${{ env.IMAGE_NAME }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}${{ env.MODERNITY_SUFFIX }}${{ env.FEATURE_SUFFIX }}
+                tags: |
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-dev
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}-modern-dev
+
+            - name: Build and push (lcli)
+              if: startsWith(matrix.binary, 'lcli')
+              uses: docker/build-push-action@v5
+              with:
+                file: ./lcli/Dockerfile.cross
+                context: .
+                platforms: linux/${{ env.SHORT_ARCH }}
+                push: true
+
+                tags: |
+                  ${{ github.repository_owner}}/${{ matrix.binary }}:${{ env.VERSION }}-${{ env.SHORT_ARCH }}${{ env.VERSION_SUFFIX }}
+
 
     build-docker-multiarch:
-        name: build-docker-multiarch${{ matrix.modernity }}
+        name: build-docker-${{ matrix.binary }}-multiarch
         runs-on: ubuntu-22.04
-        needs: [build-docker-single-arch, extract-version]
         strategy:
             matrix:
-                modernity: ["", "-modern"]
+                binary: [lighthouse,
+                         lcli]
+        needs: [build-docker-single-arch, extract-version]
         env:
             VERSION: ${{ needs.extract-version.outputs.VERSION }}
             VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
@@ -135,29 +160,9 @@ jobs:
               run: |
                   echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
 
-            - name: Create and push multiarch manifest
+            - name: Create and push multiarch manifests
               run: |
-                  docker buildx imagetools create -t ${IMAGE_NAME}:${VERSION}${VERSION_SUFFIX}${{ matrix.modernity }} \
-                      ${IMAGE_NAME}:${VERSION}-arm64${VERSION_SUFFIX}${{ matrix.modernity }} \
-                      ${IMAGE_NAME}:${VERSION}-amd64${VERSION_SUFFIX}${{ matrix.modernity }};
+                  docker buildx imagetools create -t ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}${VERSION_SUFFIX} \
+                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-arm64${VERSION_SUFFIX} \
+                      ${{ github.repository_owner}}/${{ matrix.binary }}:${VERSION}-amd64${VERSION_SUFFIX};
 
-    build-docker-lcli:
-        runs-on: ubuntu-22.04
-        needs: [extract-version]
-        env:
-            VERSION: ${{ needs.extract-version.outputs.VERSION }}
-            VERSION_SUFFIX: ${{ needs.extract-version.outputs.VERSION_SUFFIX }}
-        steps:
-            - uses: actions/checkout@v4
-            - name: Dockerhub login
-              run: |
-                  echo "${DOCKER_PASSWORD}" | docker login --username ${DOCKER_USERNAME} --password-stdin
-            - name: Build lcli and push
-              uses: docker/build-push-action@v5
-              with:
-                  build-args: |
-                      FEATURES=portable
-                  context: .
-                  push: true
-                  file: ./lcli/Dockerfile
-                  tags: ${{ env.LCLI_IMAGE_NAME }}:${{ env.VERSION }}${{ env.VERSION_SUFFIX }}

--- a/lcli/Dockerfile.cross
+++ b/lcli/Dockerfile.cross
@@ -1,0 +1,6 @@
+# This image is meant to enable cross-architecture builds.
+# It assumes the lcli binary has already been
+# compiled for `$TARGETPLATFORM` and moved to `./bin`.
+FROM --platform=$TARGETPLATFORM ubuntu:22.04
+RUN apt update && apt -y upgrade && apt clean && rm -rf /var/lib/apt/lists/*
+COPY ./bin/lcli /usr/local/bin/lcli


### PR DESCRIPTION
See #5489 for details, this is a cleaner version of the docker part of that PR

For backwards compatibility, we still publish all the different "specialised" (i.e., `-dev`) docker image tags (pointing to one image). This is meant to be phased out as we direct our users towards the regular image tag.
