### PR TITLE
Drop lookup type trait for a simple arg

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_lookup.rs
@@ -1,6 +1,6 @@
+use super::common::LookupType;
 use super::single_block_lookup::{LookupRequestError, SingleBlockLookup};
 use super::{DownloadedBlock, PeerId};
-use crate::sync::block_lookups::common::Parent;
 use crate::sync::{manager::SLOT_IMPORT_TOLERANCE, network_context::SyncNetworkContext};
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::block_verification_types::RpcBlock;
@@ -24,7 +24,7 @@ pub(crate) struct ParentLookup<T: BeaconChainTypes> {
     /// The blocks that have currently been downloaded.
     downloaded_blocks: Vec<DownloadedBlock<T::EthSpec>>,
     /// Request of the last parent.
-    pub current_parent_request: SingleBlockLookup<Parent, T>,
+    pub current_parent_request: SingleBlockLookup<T>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -55,6 +55,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
             &[peer_id],
             da_checker,
             cx.next_id(),
+            LookupType::Parent,
         );
 
         Self {
@@ -132,7 +133,7 @@ impl<T: BeaconChainTypes> ParentLookup<T> {
         Hash256,
         VecDeque<RpcBlock<T::EthSpec>>,
         Vec<Hash256>,
-        SingleBlockLookup<Parent, T>,
+        SingleBlockLookup<T>,
     ) {
         let ParentLookup {
             chain_hash,

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -42,7 +42,6 @@ use super::range_sync::{RangeSync, RangeSyncType, EPOCHS_PER_BATCH};
 use crate::network_beacon_processor::{ChainSegmentProcessId, NetworkBeaconProcessor};
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
-use crate::sync::block_lookups::common::{Current, Parent};
 use crate::sync::block_lookups::{BlobRequestState, BlockRequestState};
 use crate::sync::block_sidecar_coupling::BlocksAndBlobsRequestInfo;
 use beacon_chain::block_verification_types::AsBlock;
@@ -621,14 +620,14 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             } => match process_type {
                 BlockProcessType::SingleBlock { id } => self
                     .block_lookups
-                    .single_block_component_processed::<BlockRequestState<Current>>(
+                    .single_block_component_processed::<BlockRequestState>(
                         id,
                         result,
                         &mut self.network,
                     ),
                 BlockProcessType::SingleBlob { id } => self
                     .block_lookups
-                    .single_block_component_processed::<BlobRequestState<Current, T::EthSpec>>(
+                    .single_block_component_processed::<BlobRequestState<T::EthSpec>>(
                         id,
                         result,
                         &mut self.network,
@@ -834,7 +833,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Ok((block, seen_timestamp)) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_lookup_response::<BlockRequestState<Current>>(
+                        .single_lookup_response::<BlockRequestState>(
                             id,
                             peer_id,
                             block,
@@ -843,7 +842,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         ),
                     LookupType::Parent => self
                         .block_lookups
-                        .parent_lookup_response::<BlockRequestState<Parent>>(
+                        .parent_lookup_response::<BlockRequestState>(
                             id,
                             peer_id,
                             block,
@@ -854,7 +853,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Err(error) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_block_lookup_failed::<BlockRequestState<Current>>(
+                        .single_block_lookup_failed::<BlockRequestState>(
                             id,
                             &peer_id,
                             &mut self.network,
@@ -862,7 +861,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         ),
                     LookupType::Parent => self
                         .block_lookups
-                        .parent_lookup_failed::<BlockRequestState<Parent>>(
+                        .parent_lookup_failed::<BlockRequestState>(
                             id,
                             &peer_id,
                             &mut self.network,
@@ -909,7 +908,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Ok((blobs, seen_timestamp)) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_lookup_response::<BlobRequestState<Current, T::EthSpec>>(
+                        .single_lookup_response::<BlobRequestState<T::EthSpec>>(
                             id,
                             peer_id,
                             blobs,
@@ -918,7 +917,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         ),
                     LookupType::Parent => self
                         .block_lookups
-                        .parent_lookup_response::<BlobRequestState<Parent, T::EthSpec>>(
+                        .parent_lookup_response::<BlobRequestState<T::EthSpec>>(
                             id,
                             peer_id,
                             blobs,
@@ -930,7 +929,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Err(error) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_block_lookup_failed::<BlobRequestState<Current, T::EthSpec>>(
+                        .single_block_lookup_failed::<BlobRequestState<T::EthSpec>>(
                             id,
                             &peer_id,
                             &mut self.network,
@@ -938,7 +937,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         ),
                     LookupType::Parent => self
                         .block_lookups
-                        .parent_lookup_failed::<BlobRequestState<Parent, T::EthSpec>>(
+                        .parent_lookup_failed::<BlobRequestState<T::EthSpec>>(
                             id,
                             &peer_id,
                             &mut self.network,


### PR DESCRIPTION
## Issue Addressed

Part of
- https://github.com/sigp/lighthouse/issues/5549

Passing around a simple `lookup_type: LookupType` to the requester function achieves the same functionality with less machinery. Makes code simpler to extend, related to DAS.

## Proposed Changes

- Drop lookup type trait for a simple arg
- Drop leftover unit tests in `beacon_node/network/src/sync/block_lookups/single_block_lookup.rs`. Their tested scenarios are covered by the event-based tests

