### PR TITLE
Reduce frequency of polling unknown validators to avoid overwhelming the Beacon Node

### DIFF
--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -493,12 +493,7 @@ async fn poll_validator_indices<T: SlotClock + 'static, E: EthSpec>(
             let current_slot_opt = duties_service.slot_clock.now();
 
             if let Some(current_slot) = current_slot_opt {
-                let is_first_slot_of_epoch = {
-                    let current_epoch_first_slot = current_slot
-                        .epoch(E::slots_per_epoch())
-                        .start_slot(E::slots_per_epoch());
-                    current_slot == current_epoch_first_slot
-                };
+               let is_first_slot_of_epoch = current_slot % E::slots_per_epoch() == 0;
 
                 // Query an unknown validator later if it was queried within the last epoch, or if
                 // the current slot is the first slot of an epoch.

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -493,7 +493,7 @@ async fn poll_validator_indices<T: SlotClock + 'static, E: EthSpec>(
             let current_slot_opt = duties_service.slot_clock.now();
 
             if let Some(current_slot) = current_slot_opt {
-               let is_first_slot_of_epoch = current_slot % E::slots_per_epoch() == 0;
+                let is_first_slot_of_epoch = current_slot % E::slots_per_epoch() == 0;
 
                 // Query an unknown validator later if it was queried within the last epoch, or if
                 // the current slot is the first slot of an epoch.

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -455,6 +455,7 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
             slot_clock: slot_clock.clone(),
             beacon_nodes: beacon_nodes.clone(),
             validator_store: validator_store.clone(),
+            unknown_validator_next_poll_slots: <_>::default(),
             spec: context.eth2_config.spec.clone(),
             context: duties_context,
             enable_high_validator_count_metrics: config.enable_high_validator_count_metrics,


### PR DESCRIPTION
## Issue Addressed

Addresses #4388.

A large number of unknown validators on a VC is known to overwhelm the beacon node because the VC triggers a retrieval for each validator per slot. This PR reduces the frequency to one query per unknown validator each epoch. 

## Proposed Changes

1. Poll for all validator indices on startup (unchanged)
2. If any validator is unknown, register to poll again in the 32 slots (1 epoch) instead of the next slot.
3. Avoid polling on the first 1st slot of epoch.

For more details and rationale, see [comment here](https://github.com/sigp/lighthouse/issues/4388#issuecomment-2054233516).
