### PR TITLE
Bump jobserver and fix non-portable builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,6 @@ dependencies = [
  "glob",
  "hex",
  "libc",
- "serde",
 ]
 
 [[package]]
@@ -4386,9 +4385,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,9 @@ bincode = "1"
 bitvec = "1"
 byteorder = "1"
 bytes = "1"
-c-kzg = "1"
+# Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
+# feature ourselves when desired.
+c-kzg = { version = "1", default-features =  false }
 clap = "2"
 compare_fields_derive = { path = "common/compare_fields_derive" }
 criterion = "0.3"


### PR DESCRIPTION
## Issue Addressed

Fix broken builds as in: https://github.com/sigp/lighthouse/actions/runs/8809536524/job/24180492013

Closes:

- https://github.com/sigp/lighthouse/issues/5572

## Proposed Changes

- The main fix is to bump `jobserver` from 0.1.30 to 0.1.31 to remove usage of the `preadv2` syscall that was broken under Cross: https://github.com/rust-lang/jobserver-rs/commit/66782f5e64ccd5b0f2ff1b74fd8f54e4b081b421
- This PR also turns off `default-features` for `c-kzg` so that it's possible to compile Lighthouse _without_ portable blst. Even though we're switching to portable by default (https://github.com/sigp/lighthouse/pull/5615) we may as well unbreak the ability to build non-portable binaries.
