### PR TITLE
Fix execution integration tests

### DIFF
--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use unused_port::unused_tcp4_port;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.26.0";
+const NETHERMIND_BRANCH: &str = "release/1.21.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use unused_port::unused_tcp4_port;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.21.0";
+const NETHERMIND_BRANCH: &str = "release/1.26.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -180,7 +180,7 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
                 // Run the routine to check for online nodes.
                 pair.execution_layer.watchdog_task().await;
 
-                if pair.execution_layer.is_synced().await {
+                if !pair.execution_layer.is_offline_or_erroring().await {
                     break;
                 } else if start_instant + EXECUTION_ENGINE_START_TIMEOUT > Instant::now() {
                     sleep(Duration::from_millis(500)).await;


### PR DESCRIPTION
## Issue Addressed

Broken geth integration tests are due to the fact that it no longer returns "synced" until a CL queries it. This change is to rather than wait for the EL to return "synced", just wait for it to have an "online" state.