### PR TITLE
Add more electra helpers

### DIFF
--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2092,6 +2092,7 @@ impl<E: EthSpec> BeaconState<E> {
             .map_err(Into::into)
     }
 
+    /// Get active balance for the given `validator_index`.
     pub fn get_active_balance(
         &self,
         validator_index: usize,
@@ -2102,7 +2103,6 @@ impl<E: EthSpec> BeaconState<E> {
             .get(validator_index)
             .map(|validator| validator.get_validator_max_effective_balance(spec))
             .ok_or(Error::UnknownValidator(validator_index))?;
-        // TODO(pawan): this is assuming balances and validat
         Ok(std::cmp::min(
             *self
                 .balances()
@@ -2176,6 +2176,7 @@ impl<E: EthSpec> BeaconState<E> {
             .map_err(Into::into)
     }
 
+    /// Change the withdrawal prefix of the given `validator_index` to the compounding withdrawal validator prefix.
     pub fn switch_to_compounding_validator(
         &mut self,
         validator_index: u64,
@@ -2188,10 +2189,9 @@ impl<E: EthSpec> BeaconState<E> {
         if validator.has_eth1_withdrawal_credential(spec) {
             validator.withdrawal_credentials =
                 spec.compounding_withdrawal_prefix_byte + validator.withdrawal_credentials[1..];
-            self.queue_excess_active_balance(validator_index, spec)
-        } else {
-            Ok(())
+            self.queue_excess_active_balance(validator_index, spec)?;
         }
+        Ok(())
     }
 
     pub fn compute_exit_epoch_and_update_churn(

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2113,17 +2113,15 @@ impl<E: EthSpec> BeaconState<E> {
     }
 
     pub fn get_pending_balance_to_withdraw(&self, validator_index: usize) -> Result<u64, Error> {
-        Ok(self
+        let mut pending_balance = 0;
+        for withdrawal in self
             .pending_partial_withdrawals()?
             .iter()
-            .filter_map(|withdrawal| {
-                if withdrawal.index as usize == validator_index {
-                    Some(withdrawal.amount)
-                } else {
-                    None
-                }
-            })
-            .sum())
+            .filter(|withdrawal| withdrawal.index as usize == validator_index)
+        {
+            pending_balance.safe_add_assign(withdrawal.amount)?;
+        }
+        Ok(pending_balance)
     }
 
     // ******* Electra mutators *******

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -153,6 +153,8 @@ impl Validator {
     }
 
     /// Returns `true` if the validator if fully withdrawable.
+    /// 
+    /// Modified in electra.
     pub fn is_fully_withdrawable_validator(
         &self,
         balance: u64,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -153,7 +153,7 @@ impl Validator {
     }
 
     /// Returns `true` if the validator if fully withdrawable.
-    /// 
+    ///
     /// Modified in electra.
     pub fn is_fully_withdrawable_validator(
         &self,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -57,10 +57,10 @@ impl Validator {
 
     /// Returns `true` if the validator is eligible to join the activation queue.
     ///
-    /// Spec v0.12.1
+    /// Modified in electra
     pub fn is_eligible_for_activation_queue(&self, spec: &ChainSpec) -> bool {
         self.activation_eligibility_epoch == spec.far_future_epoch
-            && self.effective_balance == spec.max_effective_balance
+            && self.effective_balance >= spec.min_activation_balance
     }
 
     /// Returns `true` if the validator is eligible to be activated.
@@ -135,10 +135,42 @@ impl Validator {
     }
 
     /// Returns `true` if the validator is partially withdrawable.
+    ///
+    /// Note: Modified in electra.
     pub fn is_partially_withdrawable_validator(&self, balance: u64, spec: &ChainSpec) -> bool {
-        self.has_eth1_withdrawal_credential(spec)
-            && self.effective_balance == spec.max_effective_balance
-            && balance > spec.max_effective_balance
+        let max_effective_balance = self.get_validator_max_effective_balance(spec);
+        let has_max_effective_balance = self.effective_balance == max_effective_balance;
+        let has_excess_balance = balance > max_effective_balance;
+        self.has_execution_withdrawal_credential(spec)
+            && has_max_effective_balance
+            && has_excess_balance
+    }
+
+    /// Returns `true` if the validator has a 0x01 or 0x02 prefixed withdrawal credential.
+    pub fn has_execution_withdrawal_credential(&self, spec: &ChainSpec) -> bool {
+        self.has_compounding_withdrawal_credential(spec)
+            || self.has_eth1_withdrawal_credential(spec)
+    }
+
+    /// Returns `true` if the validator if fully withdrawable.
+    pub fn is_fully_withdrawable_validator(
+        &self,
+        balance: u64,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> bool {
+        self.has_execution_withdrawal_credential(spec)
+            && self.withdrawable_epoch <= epoch
+            && balance > 0
+    }
+
+    /// Returns the max effective balance for a validator in gwei.
+    pub fn get_validator_max_effective_balance(&self, spec: &ChainSpec) -> u64 {
+        if self.has_compounding_withdrawal_credential(spec) {
+            spec.max_effective_balance_electra
+        } else {
+            spec.min_activation_balance
+        }
     }
 }
 

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -130,8 +130,12 @@ impl Validator {
     }
 
     /// Returns `true` if the validator is fully withdrawable at some epoch.
+    ///
+    /// Note: Modified in electra.
     pub fn is_fully_withdrawable_at(&self, balance: u64, epoch: Epoch, spec: &ChainSpec) -> bool {
-        self.has_eth1_withdrawal_credential(spec) && self.withdrawable_epoch <= epoch && balance > 0
+        self.has_execution_withdrawal_credential(spec)
+            && self.withdrawable_epoch <= epoch
+            && balance > 0
     }
 
     /// Returns `true` if the validator is partially withdrawable.
@@ -150,20 +154,6 @@ impl Validator {
     pub fn has_execution_withdrawal_credential(&self, spec: &ChainSpec) -> bool {
         self.has_compounding_withdrawal_credential(spec)
             || self.has_eth1_withdrawal_credential(spec)
-    }
-
-    /// Returns `true` if the validator if fully withdrawable.
-    ///
-    /// Modified in electra.
-    pub fn is_fully_withdrawable_validator(
-        &self,
-        balance: u64,
-        epoch: Epoch,
-        spec: &ChainSpec,
-    ) -> bool {
-        self.has_execution_withdrawal_credential(spec)
-            && self.withdrawable_epoch <= epoch
-            && balance > 0
     }
 
     /// Returns the max effective balance for a validator in gwei.


### PR DESCRIPTION
## Issue Addressed

Partly addresses #5605 
Based on #5652 

## Proposed Changes

Implements the following functions from the electra spec:
- is_eligible_for_activation_queue
- has_execution_withdrawal_credential
- is_fully_withdrawable_validator
- is_partially_withdrawable_validator
- get_validator_max_effective_balance
- get_active_balance
- get_pending_balance_to_withdraw
- switch_to_compounding_validator
- compute_exit_epoch_and_update_churn
- compute_consolidation_epoch_and_update_churn


