### PR TITLE
Deterministic block generation for tests

### DIFF
--- a/consensus/types/src/test_utils/test_random/secret_key.rs
+++ b/consensus/types/src/test_utils/test_random/secret_key.rs
@@ -2,6 +2,8 @@ use super::*;
 
 impl TestRandom for SecretKey {
     fn random_for_test(_rng: &mut impl RngCore) -> Self {
+        // TODO: Not deterministic generation. Using `SecretKey::deserialize` results in
+        // `BlstError(BLST_BAD_ENCODING)`, need to debug with blst source on what encoding expects.
         SecretKey::random()
     }
 }

--- a/consensus/types/src/test_utils/test_random/signature.rs
+++ b/consensus/types/src/test_utils/test_random/signature.rs
@@ -1,11 +1,10 @@
 use super::*;
 
 impl TestRandom for Signature {
-    fn random_for_test(rng: &mut impl RngCore) -> Self {
-        let secret_key = SecretKey::random_for_test(rng);
-        let mut message = vec![0; 32];
-        rng.fill_bytes(&mut message);
-
-        secret_key.sign(Hash256::from_slice(&message))
+    fn random_for_test(_rng: &mut impl RngCore) -> Self {
+        // TODO: `SecretKey::random_for_test` does not return a deterministic signature. Since this
+        // signature will not pass verification we could just return the generator point or the
+        // generator point multiplied by a random scalar if we want disctint signatures.
+        Signature::infinity().expect("infinity signature is valid")
     }
 }


### PR DESCRIPTION
## Issue Addressed

PR 
- https://github.com/sigp/lighthouse/pull/915

broke determinism in block generation. This is very annoying when debugging sync lookup tests, as the block roots keep changing every run.

## Proposed Changes

As the blocks don't contain any BLS pubkey, make the signature generation always default to the G2 point at infinity.
