### PR TITLE
Ignore gossip blob already imported

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -778,23 +778,27 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "block_root" => %block_root,
                 );
             }
+            Err(BlockError::BlockIsAlreadyKnown(_)) => {
+                debug!(
+                    self.log,
+                    "Ignoring gossip blob already imported";
+                    "block_root" => ?block_root,
+                    "blob_index" =>  blob_index,
+                );
+            }
             Err(err) => {
                 debug!(
                     self.log,
                     "Invalid gossip blob";
                     "outcome" => ?err,
-                    "block root" => ?block_root,
-                    "block slot" =>  blob_slot,
-                    "blob index" =>  blob_index,
+                    "block_root" => ?block_root,
+                    "block_slot" =>  blob_slot,
+                    "blob_index" =>  blob_index,
                 );
                 self.gossip_penalize_peer(
                     peer_id,
                     PeerAction::MidToleranceError,
                     "bad_gossip_blob_ssz",
-                );
-                trace!(
-                    self.log,
-                    "Invalid gossip blob ssz";
                 );
             }
         }


### PR DESCRIPTION
`process_gossip_blob` returns an error if the blob is already imported

https://github.com/sigp/lighthouse/blob/3058b96f2560f1da04ada4f9d8ba8e5651794ff6/beacon_node/beacon_chain/src/beacon_chain.rs#L2884-L2889

The gossip blob handler treats that error as a penalizable offense.

Instead, we should ignore the blob and do nothing

Closes https://github.com/sigp/lighthouse/issues/5602

#### TODO / Note

This problem stems from re-using `BlockError` for gossip import, where there are many variants of the enum that do not apply. Maybe we should use a dedicated BlobImportError and explicitly handle each case. This patch addresses https://github.com/sigp/lighthouse/issues/5602 but there are some extra errors that can happen within the `availability_cache` that are internal errors and should not result in downscoring.

