### PR TITLE
Report RPC Errors to the application on peer disconnections

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -374,7 +374,7 @@ where
                 id: outbound_info.req_id,
             })));
         }
-        return Poll::Ready(None);
+        Poll::Ready(None)
     }
 
     fn poll(

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -357,7 +357,10 @@ where
         // Inform the network behaviour of any failed requests
 
         while let Some(substream_id) = self.outbound_substreams.keys().next().cloned() {
-            let outbound_info = self.outbound_substreams.remove(&substream_id).expect("The value must exist for a key");
+            let outbound_info = self
+                .outbound_substreams
+                .remove(&substream_id)
+                .expect("The value must exist for a key");
             // If the state of the connection is closing, we do not need to report this case to
             // the behaviour, as the connection has just closed non-gracefully
             if matches!(outbound_info.state, OutboundSubstreamState::Closing(_)) {
@@ -365,9 +368,13 @@ where
             }
 
             // Register this request as an RPC Error
-            return Poll::Ready(Some(HandlerEvent::Err(HandlerErr::Outbound{ error: RPCError::Disconnected, proto: outbound_info.proto, id: outbound_info.req_id} )));
+            return Poll::Ready(Some(HandlerEvent::Err(HandlerErr::Outbound {
+                error: RPCError::Disconnected,
+                proto: outbound_info.proto,
+                id: outbound_info.req_id,
+            })));
         }
-        return Poll::Ready(None)
+        return Poll::Ready(None);
     }
 
     fn poll(

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -972,6 +972,12 @@ impl<AppReqId: ReqId, E: EthSpec> Network<AppReqId, E> {
             .goodbye_peer(peer_id, reason, source);
     }
 
+    /// Hard (ungraceful) disconnect for testing purposes only
+    /// Use goodbye_peer for disconnections, do not use this function.
+    pub fn __hard_disconnect_testing_only(&mut self, peer_id: PeerId) {
+        let _ = self.swarm.disconnect_peer_id(peer_id);
+    }
+
     /// Returns an iterator over all enr entries in the DHT.
     pub fn enr_entries(&self) -> Vec<Enr> {
         self.discovery().table_entries_enr()


### PR DESCRIPTION
As we are overhaling some internal RPC infrastructure, a desired feature is to report peer disconnects on RPC requests. 

This PR should report an RPCError(Disconnected) if a connection is terminated whilst an RPC request is underway. 