### PR TITLE
Beta compiler fix

### DIFF
--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -87,16 +87,16 @@ pub enum ProcessResult {
 }
 
 /// The ways a backfill sync can fail.
-#[derive(Debug)]
+// The info in the enum variants is displayed in logging, clippy thinks it's dead code.
 pub enum BackFillError {
     /// A batch failed to be downloaded.
-    BatchDownloadFailed(BatchId),
+    BatchDownloadFailed(#[allow(dead_code)] BatchId),
     /// A batch could not be processed.
-    BatchProcessingFailed(BatchId),
+    BatchProcessingFailed(#[allow(dead_code)] BatchId),
     /// A batch entered an invalid state.
-    BatchInvalidState(BatchId, String),
+    BatchInvalidState(#[allow(dead_code)] BatchId, String),
     /// The sync algorithm entered an invalid state.
-    InvalidSyncState(String),
+    InvalidSyncState(#[allow(dead_code)] String),
     /// The chain became paused.
     Paused,
 }

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -95,7 +95,7 @@ pub enum BackFillError {
     /// A batch could not be processed.
     BatchProcessingFailed(#[allow(dead_code)] BatchId),
     /// A batch entered an invalid state.
-    BatchInvalidState(#[allow(dead_code)] BatchId, String),
+    BatchInvalidState(#[allow(dead_code)] BatchId, #[allow(dead_code)] String),
     /// The sync algorithm entered an invalid state.
     InvalidSyncState(#[allow(dead_code)] String),
     /// The chain became paused.

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -88,6 +88,7 @@ pub enum ProcessResult {
 
 /// The ways a backfill sync can fail.
 // The info in the enum variants is displayed in logging, clippy thinks it's dead code.
+#[derive(Debug)]
 pub enum BackFillError {
     /// A batch failed to be downloaded.
     BatchDownloadFailed(#[allow(dead_code)] BatchId),

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -245,7 +245,7 @@ impl<T: BeaconChainTypes> RequestState<T> for BlockRequestState {
     }
 }
 
-impl<T: BeaconChainTypes> RequestState<T> for BlobRequestState<T::EthSpec> {
+impl<T: BeaconChainTypes> RequestState<T> for BlobRequestState {
     type RequestType = BlobsByRootSingleBlockRequest;
     type VerifiedResponseType = FixedBlobSidecarList<T::EthSpec>;
     type ReconstructedResponseType = FixedBlobSidecarList<T::EthSpec>;

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -627,7 +627,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     ),
                 BlockProcessType::SingleBlob { id } => self
                     .block_lookups
-                    .single_block_component_processed::<BlobRequestState<T::EthSpec>>(
+                    .single_block_component_processed::<BlobRequestState>(
                         id,
                         result,
                         &mut self.network,
@@ -908,7 +908,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Ok((blobs, seen_timestamp)) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_lookup_response::<BlobRequestState<T::EthSpec>>(
+                        .single_lookup_response::<BlobRequestState>(
                             id,
                             peer_id,
                             blobs,
@@ -917,7 +917,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         ),
                     LookupType::Parent => self
                         .block_lookups
-                        .parent_lookup_response::<BlobRequestState<T::EthSpec>>(
+                        .parent_lookup_response::<BlobRequestState>(
                             id,
                             peer_id,
                             blobs,
@@ -929,20 +929,20 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 Err(error) => match id.lookup_type {
                     LookupType::Current => self
                         .block_lookups
-                        .single_block_lookup_failed::<BlobRequestState<T::EthSpec>>(
+                        .single_block_lookup_failed::<BlobRequestState>(
                             id,
                             &peer_id,
                             &mut self.network,
                             error,
                         ),
-                    LookupType::Parent => self
-                        .block_lookups
-                        .parent_lookup_failed::<BlobRequestState<T::EthSpec>>(
+                    LookupType::Parent => {
+                        self.block_lookups.parent_lookup_failed::<BlobRequestState>(
                             id,
                             &peer_id,
                             &mut self.network,
                             error,
-                        ),
+                        )
+                    }
                 },
             }
         }

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -256,14 +256,14 @@ pub fn create_tracing_layer(base_tracing_log_path: PathBuf) {
         return;
     };
 
-    let (libp2p_non_blocking_writer, libp2p_guard) = NonBlocking::new(libp2p_writer);
-    let (discv5_non_blocking_writer, discv5_guard) = NonBlocking::new(discv5_writer);
+    let (libp2p_non_blocking_writer, _libp2p_guard) = NonBlocking::new(libp2p_writer);
+    let (discv5_non_blocking_writer, _discv5_guard) = NonBlocking::new(discv5_writer);
 
     let custom_layer = LoggingLayer {
         libp2p_non_blocking_writer,
-        libp2p_guard,
+        _libp2p_guard,
         discv5_non_blocking_writer,
-        discv5_guard,
+        _discv5_guard,
     };
 
     if let Err(e) = tracing_subscriber::fmt()

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -256,12 +256,14 @@ pub fn create_tracing_layer(base_tracing_log_path: PathBuf) {
         return;
     };
 
-    let (libp2p_non_blocking_writer, _) = NonBlocking::new(libp2p_writer);
-    let (discv5_non_blocking_writer, _) = NonBlocking::new(discv5_writer);
+    let (libp2p_non_blocking_writer, libp2p_guard) = NonBlocking::new(libp2p_writer);
+    let (discv5_non_blocking_writer, discv5_guard) = NonBlocking::new(discv5_writer);
 
     let custom_layer = LoggingLayer {
         libp2p_non_blocking_writer,
+        libp2p_guard,
         discv5_non_blocking_writer,
+        discv5_guard,
     };
 
     if let Err(e) = tracing_subscriber::fmt()

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -256,14 +256,12 @@ pub fn create_tracing_layer(base_tracing_log_path: PathBuf) {
         return;
     };
 
-    let (libp2p_non_blocking_writer, libp2p_guard) = NonBlocking::new(libp2p_writer);
-    let (discv5_non_blocking_writer, discv5_guard) = NonBlocking::new(discv5_writer);
+    let (libp2p_non_blocking_writer, _) = NonBlocking::new(libp2p_writer);
+    let (discv5_non_blocking_writer, _) = NonBlocking::new(discv5_writer);
 
     let custom_layer = LoggingLayer {
         libp2p_non_blocking_writer,
-        libp2p_guard,
         discv5_non_blocking_writer,
-        discv5_guard,
     };
 
     if let Err(e) = tracing_subscriber::fmt()

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -7,9 +7,9 @@ use tracing_subscriber::Layer;
 
 pub struct LoggingLayer {
     pub libp2p_non_blocking_writer: NonBlocking,
-    pub libp2p_guard: WorkerGuard,
+    pub _libp2p_guard: WorkerGuard,
     pub discv5_non_blocking_writer: NonBlocking,
-    pub discv5_guard: WorkerGuard,
+    pub _discv5_guard: WorkerGuard,
 }
 
 impl<S> Layer<S> for LoggingLayer

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -7,7 +7,9 @@ use tracing_subscriber::Layer;
 
 pub struct LoggingLayer {
     pub libp2p_non_blocking_writer: NonBlocking,
+    pub libp2p_guard: WorkerGuard,
     pub discv5_non_blocking_writer: NonBlocking,
+    pub discv5_guard: WorkerGuard,
 }
 
 impl<S> Layer<S> for LoggingLayer

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use std::io::Write;
 use tracing::Subscriber;
-use tracing_appender::non_blocking::NonBlocking;
+use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -7,9 +7,7 @@ use tracing_subscriber::Layer;
 
 pub struct LoggingLayer {
     pub libp2p_non_blocking_writer: NonBlocking,
-    pub libp2p_guard: WorkerGuard,
     pub discv5_non_blocking_writer: NonBlocking,
-    pub discv5_guard: WorkerGuard,
 }
 
 impl<S> Layer<S> for LoggingLayer

--- a/common/logging/src/tracing_logging_layer.rs
+++ b/common/logging/src/tracing_logging_layer.rs
@@ -1,7 +1,7 @@
 use chrono::prelude::*;
 use std::io::Write;
 use tracing::Subscriber;
-use tracing_appender::non_blocking::{NonBlocking, WorkerGuard};
+use tracing_appender::non_blocking::NonBlocking;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::Layer;
 

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -88,14 +88,15 @@ const _: () = assert!({
 /// bringing in the entire crate.
 const _: () = assert!(ATTESTATION_SUBSCRIPTION_OFFSETS[0] > 2);
 
+// The info in the enum variants is displayed in logging, clippy thinks it's dead code.
 #[derive(Debug)]
 pub enum Error {
     UnableToReadSlotClock,
-    FailedToDownloadAttesters(String),
-    FailedToProduceSelectionProof(ValidatorStoreError),
-    InvalidModulo(ArithError),
-    Arith(ArithError),
-    SyncDutiesNotFound(u64),
+    FailedToDownloadAttesters(#[allow(dead_code)] String),
+    FailedToProduceSelectionProof(#[allow(dead_code)] ValidatorStoreError),
+    InvalidModulo(#[allow(dead_code)] ArithError),
+    Arith(#[allow(dead_code)] ArithError),
+    SyncDutiesNotFound(#[allow(dead_code)] u64),
 }
 
 impl From<ArithError> for Error {

--- a/validator_client/src/http_metrics/mod.rs
+++ b/validator_client/src/http_metrics/mod.rs
@@ -17,8 +17,8 @@ use warp::{http::Response, Filter};
 
 #[derive(Debug)]
 pub enum Error {
-    Warp(warp::Error),
-    Other(String),
+    Warp(#[allow(dead_code)] warp::Error),
+    Other(#[allow(dead_code)] String),
 }
 
 impl From<warp::Error> for Error {


### PR DESCRIPTION
## Issue Addressed

- rename guards in the `LoggingLayer` struct so they aren't flagged as unused
- there are some errors including unnamed fields that we log out but don't use otherwise. I added `#[allow(dead_code)]` to the unnamed fields
- `BlobRequestState`'s `blob_download_queue` is no longer used since https://github.com/sigp/lighthouse/pull/5583 but is now being flagged as unused, so I removed that