### PR TITLE
pin macos release runner to `macos-13`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
                         runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "release", "large"]') || 'ubuntu-latest'  }}
                         profile: maxperf
                     -   arch: x86_64-apple-darwin
-                        runner: macos-latest
+                        runner: macos-13
                         profile: maxperf
                     -   arch: x86_64-apple-darwin-portable
                         runner: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
                         runner: macos-13
                         profile: maxperf
                     -   arch: x86_64-apple-darwin-portable
-                        runner: macos-latest
+                        runner: macos-13
                         profile: maxperf
                     -   arch: x86_64-windows
                         runner: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "windows", "release"]') || 'windows-2019'  }}


### PR DESCRIPTION
## Issue Addressed

the `macOS-latest` runners have switched over to ARM based hardware, which will result in a failed release pipeline. 
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
