### PR TITLE
 delete spammy log

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -602,7 +602,6 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 );
             }
             SyncMessage::UnknownBlockHashFromAttestation(peer_id, block_root) => {
-                debug!(self.log, "Received unknown block hash message"; "block_root" => %block_root);
                 self.handle_unknown_block_root(peer_id, block_root);
             }
             SyncMessage::Disconnect(peer_id) => {


### PR DESCRIPTION
## Issue Addressed

This log happens once per attestation so is very spammy. Don't think it's worth having for tracing either.

`Searching for block components` currently is only ever triggered by this code path, if there's an unknown parent triggering the lookup we would get `Searching for block components`, so we aren't losing info here