### PR TITLE
Ensure block only range requests don't fail on download

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -97,7 +97,7 @@ impl<E: EthSpec> RpcBlock<E> {
 
     /// Constructs a new `BlockAndBlobs` variant after making consistency
     /// checks between the provided blocks and blobs. This struct makes no
-    /// guaruntees about whether blobs should be present, only that they are
+    /// guarantees about whether blobs should be present, only that they are
     /// consistent with the block. An empty list passed in for `blobs` is
     /// viewed the same as `None` passed in.
     pub fn new(

--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -96,13 +96,18 @@ impl<E: EthSpec> RpcBlock<E> {
     }
 
     /// Constructs a new `BlockAndBlobs` variant after making consistency
-    /// checks between the provided blocks and blobs.
+    /// checks between the provided blocks and blobs. This struct makes no
+    /// guaruntees about whether blobs should be present, only that they are
+    /// consistent with the block. An empty list passed in for `blobs` is
+    /// viewed the same as `None` passed in.
     pub fn new(
         block_root: Option<Hash256>,
         block: Arc<SignedBeaconBlock<E>>,
         blobs: Option<BlobSidecarList<E>>,
     ) -> Result<Self, AvailabilityCheckError> {
         let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
+        // Treat empty blob lists as if they are missing.
+        let blobs = blobs.filter(|b| !b.is_empty());
 
         if let (Some(blobs), Ok(block_commitments)) = (
             blobs.as_ref(),


### PR DESCRIPTION
## Issue Addressed

I noticed backfill getting stuck:
```
Apr 30 16:18:13.313 WARN Blocks and blobs request for range received invalid data, error: MissingBlobs, sender_id: BackfillSync { batch_id: Epoch(40840) }, peer_id: 16Uiu2HAm99wjuFBKfbnnvAE3Bcpqy29s6SCNgreVo3pYvfxnbXha, service: sync, module: network::sync::manager:933
```

I think in this PR https://github.com/sigp/lighthouse/pull/5561/files, when we starting using the same response handling for block + blob and block only range requests, we started creating `RpcBlock`s with empty lists of blobs in block only responses. If a list of blobs is passed into `RpcBlock`, it'll check its length matches the kzg commitments in a block, which would throw an error for blocks with pruned blobs. This PR makes it so `RpcBlock` will treat an empty list of blobs as if no blobs at all were present. The check for whether blobs *should* exist happens elsewhere, during the processing of `RpcBlock`.