### PR TITLE
Add data columns by root to currently supported protocol list

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -373,6 +373,8 @@ impl SupportedProtocol {
             supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::BlobsByRootV1, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::BlobsByRangeV1, Encoding::SSZSnappy),
+                // TODO(das): add to PeerDAS fork
+                ProtocolId::new(SupportedProtocol::DataColumnsByRootV1, Encoding::SSZSnappy),
             ]);
         }
         supported


### PR DESCRIPTION
## Issue Addressed

This was missed in #5196 hence we're getting unsupported protocol errors during sampling.

Also added missing `DataColumnsByRoot` handling code. Now we're able to see sampling going to completion 🎉

<img width="947" alt="image" src="https://github.com/sigp/lighthouse/assets/742762/59f88e21-30e4-411f-9535-367177cbb0b5">
