### PR TITLE
Check da_checker before doing a block lookup request

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -244,10 +244,18 @@ lazy_static! {
         "sync_parent_block_lookups",
         "Number of parent block lookups underway"
     );
+    pub static ref SYNC_LOOKUP_CREATED: Result<IntCounter> = try_create_int_counter(
+        "sync_lookups_created_total",
+        "Total count of sync lookups created",
+    );
     pub static ref SYNC_LOOKUP_DROPPED: Result<IntCounterVec> = try_create_int_counter_vec(
         "sync_lookups_dropped_total",
         "Total count of sync lookups dropped by reason",
         &["reason"]
+    );
+    pub static ref SYNC_LOOKUP_COMPLETED: Result<IntCounter> = try_create_int_counter(
+        "sync_lookups_completed_total",
+        "Total count of sync lookups completed",
     );
 
     /*

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -89,7 +89,9 @@ pub trait RequestState<T: BeaconChainTypes> {
         Ok(())
     }
 
-    /// Send the request to the network service.
+    /// Request the network context to prepare a request of a component of `block_root`. If the
+    /// request is not necessary because the component is already known / processed, return false.
+    /// Return true if it sent a request and we can expect an event back from the network.
     fn make_request(
         &self,
         id: Id,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -298,6 +298,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     /// Request block of `block_root` if necessary by checking:
     /// - If the da_checker has a pending block from gossip or a previous request
+    ///
+    /// Returns false if no request was made, because the block is already imported
     pub fn block_lookup_request(
         &mut self,
         lookup_id: SingleLookupId,
@@ -341,7 +343,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     /// - If the da_checker has a pending block
     /// - If the da_checker has pending blobs from gossip
     ///
-    /// Returns false if no request was made, because we don't need to fetch (more) blobs.
+    /// Returns false if no request was made, because we don't need to import (more) blobs.
     pub fn blob_lookup_request(
         &mut self,
         lookup_id: SingleLookupId,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -306,7 +306,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         peer_id: PeerId,
         block_root: Hash256,
     ) -> Result<bool, &'static str> {
-        if self.chain.data_availability_checker.has_block(&block_root) {
+        if self
+            .chain
+            .reqresp_pre_import_cache
+            .read()
+            .contains_key(&block_root)
+        {
             return Ok(false);
         }
 


### PR DESCRIPTION
## Issue Addressed

Testing of v5.2.0 shows many more `rpc_block` than usual. This is due this sequence of events:

- Block is known to the da_checker but not yet imported into fork-choice
- The event `UnknownBlockHashFromAttestation` is sent at least once every block (this is likely a bug and should be fixed separately)
- A new lookup is created for the block, downloads block, and sends for processing

In current stable the single lookup checks against the da_checker if the block is known before sending a request, but after 
- https://github.com/sigp/lighthouse/pull/5655

this check was dropped by mistake

## Proposed Changes

- Add a check in `SyncNetworkContext::block_lookup_request` and skip the download if the block is already known

However, now we need to handle the case where a lookup goes directly from created -> completed. This takes a bit of refactoring, and to handle this gracefully and safely for all cases I have introduced the `LookupResult` with a `must_use` directive.

