### PR TITLE
Ignore unknown block root events for processing blocks

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1146,6 +1146,15 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         Ok(BeaconBlockStreamer::<T>::new(self, CheckCaches::No)?.launch_stream(block_roots))
     }
 
+    /// Returns true if the given block_root is known but has not yet been imported. Checks caches
+    /// only, and does not check fork-choice nor the database.
+    pub fn contains_block_not_imported(self: &Arc<Self>, block_root: &Hash256) -> bool {
+        self.reqresp_pre_import_cache
+            .read()
+            .contains_key(block_root)
+            || self.early_attester_cache.contains_block(*block_root)
+    }
+
     pub fn get_blobs_checking_early_attester_cache(
         &self,
         block_root: &Hash256,

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -81,6 +81,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let processor = self.clone();
         let process_individual = move |package: GossipAttestationPackage<T::EthSpec>| {
             let reprocess_tx = processor.reprocess_tx.clone();
+            let duplicate_cache = processor.duplicate_cache.clone();
             processor.process_gossip_attestation(
                 package.message_id,
                 package.peer_id,
@@ -88,6 +89,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 package.subnet_id,
                 package.should_import,
                 Some(reprocess_tx),
+                duplicate_cache,
                 package.seen_timestamp,
             )
         };
@@ -96,7 +98,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let processor = self.clone();
         let process_batch = move |attestations| {
             let reprocess_tx = processor.reprocess_tx.clone();
-            processor.process_gossip_attestation_batch(attestations, Some(reprocess_tx))
+            let duplicate_cache = processor.duplicate_cache.clone();
+            processor.process_gossip_attestation_batch(
+                attestations,
+                Some(reprocess_tx),
+                duplicate_cache,
+            )
         };
 
         self.try_send(BeaconWorkEvent {
@@ -128,11 +135,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let processor = self.clone();
         let process_individual = move |package: GossipAggregatePackage<T::EthSpec>| {
             let reprocess_tx = processor.reprocess_tx.clone();
+            let duplicate_cache = processor.duplicate_cache.clone();
             processor.process_gossip_aggregate(
                 package.message_id,
                 package.peer_id,
                 package.aggregate,
                 Some(reprocess_tx),
+                duplicate_cache,
                 package.seen_timestamp,
             )
         };
@@ -141,7 +150,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let processor = self.clone();
         let process_batch = move |aggregates| {
             let reprocess_tx = processor.reprocess_tx.clone();
-            processor.process_gossip_aggregate_batch(aggregates, Some(reprocess_tx))
+            let duplicate_cache = processor.duplicate_cache.clone();
+            processor.process_gossip_aggregate_batch(
+                aggregates,
+                Some(reprocess_tx),
+                duplicate_cache,
+            )
         };
 
         let beacon_block_root = aggregate.message.aggregate.data.beacon_block_root;


### PR DESCRIPTION
## Issue Addressed

From testing on v5.2.0 of Sepolia and Gnosis there is a very large volume of `UnknownBlockHashFromAttestation` and one single block lookup created every slot.

`UnknownBlockHashFromAttestation` errors are triggered if the block is not on fork-choice, but we may have the block stuck somewhere in the processing pipeline.

## Proposed Changes

This PR attempts to prevent `UnknownBlockHashFromAttestation` events for blocks that are not yet on fork-choice but we are processing.

## Caveats

If a single peer imports the block before we receive it and sends us an attestation we will still have the problem of constant lookups for blocks that arrive anyway. Not sure if this is an issue at all, but worth to think about it.

We have an ample collection of places a block may be stuck into:
- database
- fork-choice
- early attester cache
- da_checker
- pre_import_cache (former processing_cache)
- duplicate_cache

ReqResp lookups only check the da_checker (from https://github.com/sigp/lighthouse/pull/5681) while other codepaths check more places. Might be worth it to consolidate their usage a bit to have more consistency. 