### PR TITLE
Add metric for current epoch total balance

### DIFF
--- a/consensus/state_processing/src/metrics.rs
+++ b/consensus/state_processing/src/metrics.rs
@@ -17,6 +17,10 @@ lazy_static! {
         "beacon_participation_prev_epoch_source_attesting_gwei_total",
         "Total effective balance (gwei) of validators who attested to the source in the previous epoch"
     );
+    pub static ref PARTICIPATION_CURRENT_EPOCH_TOTAL_ACTIVE_GWEI_TOTAL: Result<IntGauge> = try_create_int_gauge(
+        "beacon_participation_current_epoch_active_gwei_total",
+        "Total effective balance (gwei) of validators who are active in the current epoch"
+    );
     /*
      * Processing metrics
      */

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -100,6 +100,10 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
             &metrics::PARTICIPATION_PREV_EPOCH_SOURCE_ATTESTING_GWEI_TOTAL,
             self.previous_epoch_source_attesting_balance()? as i64,
         );
+        metrics::set_gauge(
+            &metrics::PARTICIPATION_CURRENT_EPOCH_TOTAL_ACTIVE_GWEI_TOTAL,
+            self.current_epoch_total_active_balance() as i64,
+        );
 
         Ok(())
     }

--- a/validator_client/src/duties_service.rs
+++ b/validator_client/src/duties_service.rs
@@ -897,7 +897,7 @@ async fn poll_beacon_attesters_for_epoch<T: SlotClock + 'static, E: EthSpec>(
                         "Attester duties re-org";
                         "prior_dependent_root" => %prior_dependent_root,
                         "dependent_root" => %dependent_root,
-                        "msg" => "this may happen from time to time"
+                        "note" => "this may happen from time to time"
                     )
                 }
                 *mut_value = (dependent_root, duty_and_proof);


### PR DESCRIPTION
## Proposed Changes

Add a new metric `beacon_participation_current_epoch_active_gwei_total` to replace the metric `beacon_participation_prev_epoch_active_gwei_total` which was deleted in:

- https://github.com/sigp/lighthouse/pull/5279

The new metric is better for calculating the participation rate because for justification and finalization the total active balance for the current epoch is always used.
