### PR TITLE
web3Signer: set header "Accept: application/json" as we expect json in the response

### DIFF
--- a/validator_client/src/signing_method.rs
+++ b/validator_client/src/signing_method.rs
@@ -7,7 +7,7 @@ use crate::http_metrics::metrics;
 use eth2_keystore::Keystore;
 use lockfile::Lockfile;
 use parking_lot::Mutex;
-use reqwest::Client;
+use reqwest::{Client, header::ACCEPT};
 use std::path::PathBuf;
 use std::sync::Arc;
 use task_executor::TaskExecutor;
@@ -243,6 +243,7 @@ impl SigningMethod {
                 // Request a signature from the Web3Signer instance via HTTP(S).
                 let response: SigningResponse = http_client
                     .post(signing_url.clone())
+                    .header(ACCEPT, "application/json")
                     .json(&request)
                     .send()
                     .await

--- a/validator_client/src/signing_method.rs
+++ b/validator_client/src/signing_method.rs
@@ -7,7 +7,7 @@ use crate::http_metrics::metrics;
 use eth2_keystore::Keystore;
 use lockfile::Lockfile;
 use parking_lot::Mutex;
-use reqwest::{Client, header::ACCEPT};
+use reqwest::{header::ACCEPT, Client};
 use std::path::PathBuf;
 use std::sync::Arc;
 use task_executor::TaskExecutor;


### PR DESCRIPTION
## Issue Addressed

#5691

## Proposed Changes

This PR sets the request header for the web3signer to `Accept: application/json`. This is required to indicate to a remote signer that json is the acceptable return type (instead of `plain/text`)

## Additional Info

the web3signer [api](https://consensys.github.io/web3signer/web3signer-eth2.html) indicates that both `application/json` and `text/plain` are acceptable response types for signing requests.

The web3signer handler in lighthouse requires a json response. Setting the header "Accept: application/json" indicates to the web3signer that json is an acceptable response.