### PR TITLE
Component search loop

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -237,7 +237,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     /// Searches for a single block hash. If the blocks parent is unknown, a chain of blocks is
     /// constructed.
-    /// Returns true if the lookup is created or already exists
+    /// Returns true if the lookup is created, already exists, or was already completed.
     fn new_current_lookup(
         &mut self,
         block_root: Hash256,
@@ -249,7 +249,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     ) -> bool {
         // If the lookup is complete, don't create a new one.
         if self.completed_lookups.contains(&block_root) {
-            return false;
+            return true;
         }
 
         // If this block or it's parent is part of a known failed chain, ignore it.


### PR DESCRIPTION
## Issue Addressed

Addresses: https://github.com/sigp/lighthouse/issues/5693

- Suggestion by @dapplion: Adds a `completed_lookups` time cache, similar to the `failed_chains` cache as a simple way to track and suppress lookups that have already been completed but are still being processed somewhere

- I also realized this PR https://github.com/sigp/lighthouse/pull/5672 would keep us from being able to distinguish current lookups triggered by unknown parents vs attestations easily in the logs, so I added a new enum `LookupTrigger` solely for the purpose of distinguishing the two 