### PR TITLE
Make modified helpers in electra fork aware

### DIFF
--- a/consensus/state_processing/src/per_block_processing.rs
+++ b/consensus/state_processing/src/per_block_processing.rs
@@ -508,6 +508,7 @@ pub fn get_expected_withdrawals<E: EthSpec>(
     let mut withdrawal_index = state.next_withdrawal_index()?;
     let mut validator_index = state.next_withdrawal_validator_index()?;
     let mut withdrawals = vec![];
+    let fork_name = state.fork_name_unchecked();
 
     let bound = std::cmp::min(
         state.validators().len() as u64,
@@ -518,7 +519,7 @@ pub fn get_expected_withdrawals<E: EthSpec>(
         let balance = *state.balances().get(validator_index as usize).ok_or(
             BeaconStateError::BalancesOutOfBounds(validator_index as usize),
         )?;
-        if validator.is_fully_withdrawable_at(balance, epoch, spec) {
+        if validator.is_fully_withdrawable_at(balance, epoch, spec, fork_name) {
             withdrawals.push(Withdrawal {
                 index: withdrawal_index,
                 validator_index,
@@ -528,7 +529,7 @@ pub fn get_expected_withdrawals<E: EthSpec>(
                 amount: balance,
             });
             withdrawal_index.safe_add_assign(1)?;
-        } else if validator.is_partially_withdrawable_validator(balance, spec) {
+        } else if validator.is_partially_withdrawable_validator(balance, spec, fork_name) {
             withdrawals.push(Withdrawal {
                 index: withdrawal_index,
                 validator_index,

--- a/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -19,19 +19,20 @@ pub fn process_registry_updates<E: EthSpec>(
         validator.is_active_at(current_epoch)
             && validator.effective_balance <= spec.ejection_balance
     };
+    let fork_name = state.fork_name_unchecked();
     let indices_to_update: Vec<_> = state
         .validators()
         .iter()
         .enumerate()
         .filter(|(_, validator)| {
-            validator.is_eligible_for_activation_queue(spec) || is_ejectable(validator)
+            validator.is_eligible_for_activation_queue(&fork_name, spec) || is_ejectable(validator)
         })
         .map(|(idx, _)| idx)
         .collect();
 
     for index in indices_to_update {
         let validator = state.get_validator_mut(index)?;
-        if validator.is_eligible_for_activation_queue(spec) {
+        if validator.is_eligible_for_activation_queue(&fork_name, spec) {
             validator.activation_eligibility_epoch = current_epoch.safe_add(1)?;
         }
         if is_ejectable(validator) {

--- a/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
+++ b/consensus/state_processing/src/per_epoch_processing/registry_updates.rs
@@ -25,14 +25,14 @@ pub fn process_registry_updates<E: EthSpec>(
         .iter()
         .enumerate()
         .filter(|(_, validator)| {
-            validator.is_eligible_for_activation_queue(&fork_name, spec) || is_ejectable(validator)
+            validator.is_eligible_for_activation_queue(spec, fork_name) || is_ejectable(validator)
         })
         .map(|(idx, _)| idx)
         .collect();
 
     for index in indices_to_update {
         let validator = state.get_validator_mut(index)?;
-        if validator.is_eligible_for_activation_queue(&fork_name, spec) {
+        if validator.is_eligible_for_activation_queue(spec, fork_name) {
             validator.activation_eligibility_epoch = current_epoch.safe_add(1)?;
         }
         if is_ejectable(validator) {

--- a/consensus/state_processing/src/per_epoch_processing/single_pass.rs
+++ b/consensus/state_processing/src/per_epoch_processing/single_pass.rs
@@ -466,7 +466,7 @@ fn process_single_registry_update(
 ) -> Result<(), Error> {
     let current_epoch = state_ctxt.current_epoch;
 
-    if validator.is_eligible_for_activation_queue(spec) {
+    if validator.is_eligible_for_activation_queue(&state_ctxt.fork_name, spec) {
         validator.make_mut()?.activation_eligibility_epoch = current_epoch.safe_add(1)?;
     }
 

--- a/consensus/state_processing/src/per_epoch_processing/single_pass.rs
+++ b/consensus/state_processing/src/per_epoch_processing/single_pass.rs
@@ -466,7 +466,7 @@ fn process_single_registry_update(
 ) -> Result<(), Error> {
     let current_epoch = state_ctxt.current_epoch;
 
-    if validator.is_eligible_for_activation_queue(&state_ctxt.fork_name, spec) {
+    if validator.is_eligible_for_activation_queue(spec, state_ctxt.fork_name) {
         validator.make_mut()?.activation_eligibility_epoch = current_epoch.safe_add(1)?;
     }
 

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -57,26 +57,23 @@ impl Validator {
 
     /// Returns `true` if the validator is eligible to join the activation queue.
     ///
-    /// Calls the appropriate function given the fork_name.
+    /// Calls the correct function depending on the provided `fork_name`.
     pub fn is_eligible_for_activation_queue(
         &self,
-        current_fork: &ForkName,
         spec: &ChainSpec,
+        current_fork: ForkName,
     ) -> bool {
-        match current_fork {
-            ForkName::Base
-            | ForkName::Altair
-            | ForkName::Bellatrix
-            | ForkName::Capella
-            | ForkName::Deneb => self.is_eligible_for_activation_queue_base(spec),
-            ForkName::Electra => self.is_eligible_for_activation_queue_electra(spec),
+        if current_fork >= ForkName::Electra {
+            self.is_eligible_for_activation_queue_electra(spec)
+        } else {
+            self.is_eligible_for_activation_queue_base(spec)
         }
     }
 
     /// Returns `true` if the validator is eligible to join the activation queue.
     ///
     /// Spec v0.12.1
-    pub fn is_eligible_for_activation_queue_base(&self, spec: &ChainSpec) -> bool {
+    fn is_eligible_for_activation_queue_base(&self, spec: &ChainSpec) -> bool {
         self.activation_eligibility_epoch == spec.far_future_epoch
             && self.effective_balance == spec.max_effective_balance
     }
@@ -84,7 +81,7 @@ impl Validator {
     /// Returns `true` if the validator is eligible to join the activation queue.
     ///
     /// Modified in electra as part of EIP 7251.
-    pub fn is_eligible_for_activation_queue_electra(&self, spec: &ChainSpec) -> bool {
+    fn is_eligible_for_activation_queue_electra(&self, spec: &ChainSpec) -> bool {
         self.activation_eligibility_epoch == spec.far_future_epoch
             && self.effective_balance >= spec.min_activation_balance
     }
@@ -157,17 +154,77 @@ impl Validator {
 
     /// Returns `true` if the validator is fully withdrawable at some epoch.
     ///
-    /// Note: Modified in electra.
-    pub fn is_fully_withdrawable_at(&self, balance: u64, epoch: Epoch, spec: &ChainSpec) -> bool {
+    /// Calls the correct function depending on the provided `fork_name`.
+    pub fn is_fully_withdrawable_at(
+        &self,
+        balance: u64,
+        epoch: Epoch,
+        spec: &ChainSpec,
+        current_fork: ForkName,
+    ) -> bool {
+        if current_fork >= ForkName::Electra {
+            self.is_fully_withdrawable_at_electra(balance, epoch, spec)
+        } else {
+            self.is_fully_withdrawable_at_capella(balance, epoch, spec)
+        }
+    }
+
+    /// Returns `true` if the validator is fully withdrawable at some epoch.
+    fn is_fully_withdrawable_at_capella(
+        &self,
+        balance: u64,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> bool {
+        self.has_eth1_withdrawal_credential(spec) && self.withdrawable_epoch <= epoch && balance > 0
+    }
+
+    /// Returns `true` if the validator is fully withdrawable at some epoch.
+    ///
+    /// Modified in electra as part of EIP 7251.
+    fn is_fully_withdrawable_at_electra(
+        &self,
+        balance: u64,
+        epoch: Epoch,
+        spec: &ChainSpec,
+    ) -> bool {
         self.has_execution_withdrawal_credential(spec)
             && self.withdrawable_epoch <= epoch
             && balance > 0
     }
 
     /// Returns `true` if the validator is partially withdrawable.
+    /// 
+    /// Calls the correct function depending on the provided `fork_name`.
+    pub fn is_partially_withdrawable_validator(
+        &self,
+        balance: u64,
+        spec: &ChainSpec,
+        current_fork: ForkName,
+    ) -> bool {
+        if current_fork >= ForkName::Electra {
+            self.is_partially_withdrawable_validator_electra(balance, spec)
+        }
+        else {
+            self.is_partially_withdrawable_validator_capella(balance, spec)
+        }
+    }
+
+    /// Returns `true` if the validator is partially withdrawable.
+    fn is_partially_withdrawable_validator_capella(&self, balance: u64, spec: &ChainSpec) -> bool {
+        self.has_eth1_withdrawal_credential(spec)
+            && self.effective_balance == spec.max_effective_balance
+            && balance > spec.max_effective_balance
+    }
+
+    /// Returns `true` if the validator is partially withdrawable.
     ///
-    /// Note: Modified in electra.
-    pub fn is_partially_withdrawable_validator(&self, balance: u64, spec: &ChainSpec) -> bool {
+    /// Modified in electra as part of EIP 7251.
+    pub fn is_partially_withdrawable_validator_electra(
+        &self,
+        balance: u64,
+        spec: &ChainSpec,
+    ) -> bool {
         let max_effective_balance = self.get_validator_max_effective_balance(spec);
         let has_max_effective_balance = self.effective_balance == max_effective_balance;
         let has_excess_balance = balance > max_effective_balance;

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -194,7 +194,7 @@ impl Validator {
     }
 
     /// Returns `true` if the validator is partially withdrawable.
-    /// 
+    ///
     /// Calls the correct function depending on the provided `fork_name`.
     pub fn is_partially_withdrawable_validator(
         &self,
@@ -204,8 +204,7 @@ impl Validator {
     ) -> bool {
         if current_fork >= ForkName::Electra {
             self.is_partially_withdrawable_validator_electra(balance, spec)
-        }
-        else {
+        } else {
             self.is_partially_withdrawable_validator_capella(balance, spec)
         }
     }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

In https://github.com/sigp/lighthouse/pull/5653/ , we modified a bunch of functions for electra without making them fork aware.
This PR aims to make the functions that the spec marks as "Modified in electra" fork aware.

## Additional info
I intend to create pre and post electra versions for existing functions that are modified in the electra spec even if the logic doesn't change to make sure we don't shoot ourself in the foot in cases like these in the future.