### PR TITLE
Improve logging and metrics for block publication

### DIFF
--- a/beacon_node/http_api/src/metrics.rs
+++ b/beacon_node/http_api/src/metrics.rs
@@ -34,9 +34,10 @@ lazy_static::lazy_static! {
         "Time between start of the slot and when the block completed broadcast and processing",
         &["provenance"]
     );
-    pub static ref HTTP_API_BLOCK_GOSSIP_TIMES: Result<HistogramVec> = try_create_histogram_vec(
+    pub static ref HTTP_API_BLOCK_GOSSIP_TIMES: Result<HistogramVec> = try_create_histogram_vec_with_buckets(
         "http_api_block_gossip_times",
         "Time between receiving the block on HTTP and publishing it on gossip",
+        decimal_buckets(-2, 2),
         &["provenance"]
     );
     pub static ref HTTP_API_BLOCK_PUBLISHED_LATE_TOTAL: Result<IntCounter> = try_create_int_counter(

--- a/beacon_node/http_api/src/metrics.rs
+++ b/beacon_node/http_api/src/metrics.rs
@@ -31,7 +31,12 @@ lazy_static::lazy_static! {
     );
     pub static ref HTTP_API_BLOCK_BROADCAST_DELAY_TIMES: Result<HistogramVec> = try_create_histogram_vec(
         "http_api_block_broadcast_delay_times",
-        "Time between start of the slot and when the block was broadcast",
+        "Time between start of the slot and when the block completed broadcast and processing",
+        &["provenance"]
+    );
+    pub static ref HTTP_API_BLOCK_GOSSIP_TIMES: Result<HistogramVec> = try_create_histogram_vec(
+        "http_api_block_gossip_times",
+        "Time between receiving the block on HTTP and publishing it on gossip",
         &["provenance"]
     );
     pub static ref HTTP_API_BLOCK_PUBLISHED_LATE_TOTAL: Result<IntCounter> = try_create_int_counter(

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -60,6 +60,11 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
         ProvenancedBlock::Local(block_contents, _) => (block_contents, true),
         ProvenancedBlock::Builder(block_contents, _) => (block_contents, false),
     };
+    let provenance = if is_locally_built_block {
+        "local"
+    } else {
+        "builder"
+    };
     let block = block_contents.inner_block().clone();
     let delay = get_block_delay_ms(seen_timestamp, block.message(), &chain.slot_clock);
     debug!(log, "Signed block received in HTTP API"; "slot" => block.slot());
@@ -75,7 +80,18 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
             .checked_sub(seen_timestamp)
             .unwrap_or_else(|| Duration::from_secs(0));
 
-        info!(log, "Signed block published to network via HTTP API"; "slot" => block.slot(), "publish_delay" => ?publish_delay);
+        metrics::observe_timer_vec(
+            &metrics::HTTP_API_BLOCK_GOSSIP_TIMES,
+            &[provenance],
+            publish_delay,
+        );
+
+        info!(
+            log,
+            "Signed block published to network via HTTP API";
+            "slot" => block.slot(),
+            "publish_delay_ms" => publish_delay.as_millis()
+        );
 
         match block.as_ref() {
             SignedBeaconBlock::Base(_)

--- a/beacon_node/network/src/sync/block_lookups/parent_chain.rs
+++ b/beacon_node/network/src/sync/block_lookups/parent_chain.rs
@@ -55,7 +55,7 @@ pub(crate) fn compute_parent_chains(nodes: &[Node]) -> Vec<NodeChain> {
     // Iterate blocks with no children
     for tip in nodes {
         let mut block_root = tip.block_root;
-        if parent_to_child.get(&block_root).is_none() {
+        if !parent_to_child.contains_key(&block_root) {
             let mut chain = vec![];
 
             // Resolve chain of blocks

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -23,7 +23,7 @@ pub const POOL_SIZE: u32 = 1;
 #[cfg(not(test))]
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(test)]
-pub const CONNECTION_TIMEOUT: Duration = Duration::from_millis(500);
+pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Supported version of the interchange format.
 pub const SUPPORTED_INTERCHANGE_FORMAT_VERSION: u64 = 5;


### PR DESCRIPTION
## Proposed Changes

- Print the block publish delay in milliseconds, which makes it easier to parse and process. This is a change that some relays have previously asked for.
- Add a new metric tracking block gossip time in the HTTP API, which matches the `publish_delay_ms` log.
- Fix Clippy for Rust 1.78 just released
