### PR TITLE
Notify lookup sync of gossip processing results

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -314,6 +314,26 @@ pub struct BlockImportData<E: EthSpec> {
     pub consensus_context: ConsensusContext<E>,
 }
 
+impl<E: EthSpec> BlockImportData<E> {
+    pub fn __new_for_test(
+        block_root: Hash256,
+        state: BeaconState<E>,
+        parent_block: SignedBeaconBlock<E, BlindedPayload<E>>,
+    ) -> Self {
+        Self {
+            block_root,
+            state,
+            parent_block,
+            parent_eth1_finalization_data: Eth1FinalizationData {
+                eth1_data: <_>::default(),
+                eth1_deposit_index: 0,
+            },
+            confirmed_state_roots: vec![],
+            consensus_context: ConsensusContext::new(Slot::new(0)),
+        }
+    }
+}
+
 pub type GossipVerifiedBlockContents<E> =
     (GossipVerifiedBlock<E>, Option<GossipVerifiedBlobList<E>>);
 

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -84,7 +84,7 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
         })
     }
 
-    /// Checks if the block root is currenlty in the availability cache awaiting processing because
+    /// Checks if the block root is currenlty in the availability cache awaiting import because
     /// of missing components.
     pub fn has_block(&self, block_root: &Hash256) -> bool {
         self.availability_cache.has_block(block_root)

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -86,8 +86,9 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
     /// Checks if the block root is currenlty in the availability cache awaiting import because
     /// of missing components.
-    pub fn has_block(&self, block_root: &Hash256) -> bool {
-        self.availability_cache.has_block(block_root)
+    pub fn has_execution_valid_block(&self, block_root: &Hash256) -> bool {
+        self.availability_cache
+            .has_execution_valid_block(block_root)
     }
 
     /// Return the required blobs `block_root` expects if the block is currenlty in the cache.

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -432,11 +432,6 @@ impl<T: BeaconChainTypes> Critical<T> {
         Ok(())
     }
 
-    /// Returns true if the block root is known, without altering the LRU ordering
-    pub fn has_block(&self, block_root: &Hash256) -> bool {
-        self.in_memory.peek(block_root).is_some() || self.store_keys.contains(block_root)
-    }
-
     /// This only checks for the blobs in memory
     pub fn peek_blob(
         &self,
@@ -549,8 +544,12 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
     }
 
     /// Returns true if the block root is known, without altering the LRU ordering
-    pub fn has_block(&self, block_root: &Hash256) -> bool {
-        self.critical.read().has_block(block_root)
+    pub fn has_execution_valid_block(&self, block_root: &Hash256) -> bool {
+        if let Some(pending_components) = self.critical.read().peek_pending_components(block_root) {
+            pending_components.executed_block.is_some()
+        } else {
+            false
+        }
     }
 
     /// Fetch a blob from the cache without affecting the LRU ordering

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2,10 +2,7 @@ use crate::{
     metrics,
     network_beacon_processor::{InvalidBlockStorage, NetworkBeaconProcessor},
     service::NetworkMessage,
-    sync::{
-        manager::{BlockProcessSource, BlockProcessType},
-        SyncMessage,
-    },
+    sync::SyncMessage,
 };
 use beacon_chain::blob_verification::{GossipBlobError, GossipVerifiedBlob};
 use beacon_chain::block_verification_types::AsBlock;
@@ -1266,10 +1263,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             );
         }
 
-        self.send_sync_message(SyncMessage::BlockComponentProcessed {
-            process_type: BlockProcessType::SingleBlock,
-            source: BlockProcessSource::Gossip(block_root),
-            result: result.into(),
+        self.send_sync_message(SyncMessage::GossipBlockProcessResult {
+            block_root,
+            imported: matches!(result, Ok(AvailabilityProcessingStatus::Imported(_))),
         });
     }
 

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -115,6 +115,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 "Rpc block is being processed";
                 "action" => "sending rpc block to reprocessing queue",
                 "block_root" => %block_root,
+                "process_type" => ?process_type,
             );
 
             // Send message to work reprocess queue to retry the block
@@ -147,6 +148,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             "proposer" => block.message().proposer_index(),
             "slot" => block.slot(),
             "commitments" => commitments_formatted,
+            "process_type" => ?process_type,
         );
 
         let result = self

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -112,7 +112,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let Some(handle) = duplicate_cache.check_and_insert(block_root) else {
             debug!(
                 self.log,
-                "Rpc block is being processed";
+                "Gossip block is being processed";
                 "action" => "sending rpc block to reprocessing queue",
                 "block_root" => %block_root,
                 "process_type" => ?process_type,

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -2,8 +2,8 @@ use crate::sync::block_lookups::single_block_lookup::{
     LookupRequestError, SingleBlockLookup, SingleLookupRequestState,
 };
 use crate::sync::block_lookups::{BlobRequestState, BlockRequestState, PeerId};
-use crate::sync::manager::{BlockProcessType, Id, SLOT_IMPORT_TOLERANCE};
-use crate::sync::network_context::SyncNetworkContext;
+use crate::sync::manager::{Id, SLOT_IMPORT_TOLERANCE};
+use crate::sync::network_context::{LookupRequestResult, SyncNetworkContext};
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::BeaconChainTypes;
 use std::sync::Arc;
@@ -45,7 +45,7 @@ pub trait RequestState<T: BeaconChainTypes> {
         peer_id: PeerId,
         downloaded_block_expected_blobs: Option<usize>,
         cx: &mut SyncNetworkContext<T>,
-    ) -> Result<bool, LookupRequestError>;
+    ) -> Result<LookupRequestResult, LookupRequestError>;
 
     /* Response handling methods */
 
@@ -80,7 +80,7 @@ impl<T: BeaconChainTypes> RequestState<T> for BlockRequestState<T::EthSpec> {
         peer_id: PeerId,
         _: Option<usize>,
         cx: &mut SyncNetworkContext<T>,
-    ) -> Result<bool, LookupRequestError> {
+    ) -> Result<LookupRequestResult, LookupRequestError> {
         cx.block_lookup_request(id, peer_id, self.requested_block_root)
             .map_err(LookupRequestError::SendFailed)
     }
@@ -97,10 +97,10 @@ impl<T: BeaconChainTypes> RequestState<T> for BlockRequestState<T::EthSpec> {
             peer_id: _,
         } = download_result;
         cx.send_block_for_processing(
+            id,
             block_root,
             RpcBlock::new_without_blobs(Some(block_root), value),
             seen_timestamp,
-            BlockProcessType::SingleBlock { id },
         )
         .map_err(LookupRequestError::SendFailed)
     }
@@ -128,7 +128,7 @@ impl<T: BeaconChainTypes> RequestState<T> for BlobRequestState<T::EthSpec> {
         peer_id: PeerId,
         downloaded_block_expected_blobs: Option<usize>,
         cx: &mut SyncNetworkContext<T>,
-    ) -> Result<bool, LookupRequestError> {
+    ) -> Result<LookupRequestResult, LookupRequestError> {
         cx.blob_lookup_request(
             id,
             peer_id,
@@ -149,13 +149,8 @@ impl<T: BeaconChainTypes> RequestState<T> for BlobRequestState<T::EthSpec> {
             seen_timestamp,
             peer_id: _,
         } = download_result;
-        cx.send_blobs_for_processing(
-            block_root,
-            value,
-            seen_timestamp,
-            BlockProcessType::SingleBlob { id },
-        )
-        .map_err(LookupRequestError::SendFailed)
+        cx.send_blobs_for_processing(id, block_root, value, seen_timestamp)
+            .map_err(LookupRequestError::SendFailed)
     }
 
     fn response_type() -> ResponseType {

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1261,17 +1261,17 @@ fn test_parent_lookup_disconnection_no_peers_left() {
 }
 
 #[test]
-fn test_parent_lookup_disconnection_peer_left() {
+fn test_lookup_disconnection_peer_left() {
     let mut rig = TestRig::test_setup();
     let peer_ids = (0..2).map(|_| rig.new_connected_peer()).collect::<Vec<_>>();
-    let trigger_block = rig.rand_block();
+    let block_root = Hash256::random();
     // lookup should have two peers associated with the same block
     for peer_id in peer_ids.iter() {
-        rig.trigger_unknown_parent_block(*peer_id, trigger_block.clone().into());
+        rig.trigger_unknown_block_from_attestation(block_root, *peer_id);
     }
     // Disconnect the first peer only, which is the one handling the request
     rig.peer_disconnected(*peer_ids.first().unwrap());
-    rig.assert_parent_lookups_count(1);
+    rig.assert_single_lookups_count(1);
 }
 
 #[test]

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -341,7 +341,8 @@ impl TestRig {
 
     fn single_block_component_processed(&mut self, id: Id, result: BlockProcessingResult<E>) {
         self.send_sync_message(SyncMessage::BlockComponentProcessed {
-            process_type: BlockProcessType::SingleBlock { id },
+            process_type: BlockProcessType::SingleBlock,
+            source: BlockProcessSource::Rpc(id),
             result,
         })
     }
@@ -356,7 +357,8 @@ impl TestRig {
 
     fn single_blob_component_processed(&mut self, id: Id, result: BlockProcessingResult<E>) {
         self.send_sync_message(SyncMessage::BlockComponentProcessed {
-            process_type: BlockProcessType::SingleBlob { id },
+            process_type: BlockProcessType::SingleBlob,
+            source: BlockProcessSource::Rpc(id),
             result,
         })
     }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -4,13 +4,13 @@
 use self::requests::{ActiveBlobsByRootRequest, ActiveBlocksByRootRequest};
 pub use self::requests::{BlobsByRootSingleBlockRequest, BlocksByRootSingleRequest};
 use super::block_sidecar_coupling::BlocksAndBlobsRequestInfo;
-use super::manager::{BlockProcessType, Id, RequestId as SyncRequestId};
+use super::manager::{Id, RequestId as SyncRequestId};
 use super::range_sync::{BatchId, ByRangeRequestType, ChainId};
 use crate::network_beacon_processor::NetworkBeaconProcessor;
 use crate::service::{NetworkMessage, RequestId};
 use crate::status::ToStatusMessage;
 use crate::sync::block_lookups::SingleLookupId;
-use crate::sync::manager::SingleLookupReqId;
+use crate::sync::manager::{BlockProcessSource, SingleLookupReqId};
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::validator_monitor::timestamp_now;
 use beacon_chain::{BeaconChain, BeaconChainTypes, EngineState};
@@ -79,6 +79,18 @@ impl From<LookupVerifyError> for LookupFailure {
     fn from(e: LookupVerifyError) -> Self {
         LookupFailure::LookupVerifyError(e)
     }
+}
+
+pub enum LookupRequestResult {
+    /// A request is sent. Sync MUST receive an event from the network in the future for either:
+    /// completed response or failed request
+    RequestSent,
+    /// No request is sent, and no further action is necessary to consider this request completed
+    NoRequestNeeded,
+    /// No request is sent, but the request is not completed. Request is processing from a different
+    /// source (i.e. block received from gossip) and sync MUST receive an event with that processing
+    /// result.
+    AwaitingOtherSource,
 }
 
 /// Wraps a Network channel to employ various RPC related network functionality for the Sync manager. This includes management of a global RPC request Id.
@@ -305,14 +317,20 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         lookup_id: SingleLookupId,
         peer_id: PeerId,
         block_root: Hash256,
-    ) -> Result<bool, &'static str> {
+    ) -> Result<LookupRequestResult, &'static str> {
+        // da_checker includes block that are execution verified, but are missing components
+        if self.chain.data_availability_checker.has_block(&block_root) {
+            return Ok(LookupRequestResult::NoRequestNeeded);
+        }
+
+        // reqresp_pre_import_cache includes blocks that may not be yet execution verified
         if self
             .chain
             .reqresp_pre_import_cache
             .read()
             .contains_key(&block_root)
         {
-            return Ok(false);
+            return Ok(LookupRequestResult::AwaitingOtherSource);
         }
 
         let id = SingleLookupReqId {
@@ -340,7 +358,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.blocks_by_root_requests
             .insert(id, ActiveBlocksByRootRequest::new(request));
 
-        Ok(true)
+        Ok(LookupRequestResult::RequestSent)
     }
 
     /// Request necessary blobs for `block_root`. Requests only the necessary blobs by checking:
@@ -355,7 +373,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         peer_id: PeerId,
         block_root: Hash256,
         downloaded_block_expected_blobs: Option<usize>,
-    ) -> Result<bool, &'static str> {
+    ) -> Result<LookupRequestResult, &'static str> {
         let expected_blobs = downloaded_block_expected_blobs
             .or_else(|| {
                 self.chain
@@ -387,7 +405,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         if indices.is_empty() {
             // No blobs required, do not issue any request
-            return Ok(false);
+            return Ok(LookupRequestResult::NoRequestNeeded);
         }
 
         let id = SingleLookupReqId {
@@ -419,7 +437,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.blobs_by_root_requests
             .insert(id, ActiveBlobsByRootRequest::new(request));
 
-        Ok(true)
+        Ok(LookupRequestResult::RequestSent)
     }
 
     pub fn is_execution_engine_online(&self) -> bool {
@@ -595,19 +613,19 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     pub fn send_block_for_processing(
         &self,
+        id: Id,
         block_root: Hash256,
         block: RpcBlock<T::EthSpec>,
         duration: Duration,
-        process_type: BlockProcessType,
     ) -> Result<(), &'static str> {
         match self.beacon_processor_if_enabled() {
             Some(beacon_processor) => {
-                debug!(self.log, "Sending block for processing"; "block" => ?block_root, "process" => ?process_type);
+                debug!(self.log, "Sending block for processing"; "block" => ?block_root, "id" => id);
                 if let Err(e) = beacon_processor.send_rpc_beacon_block(
                     block_root,
                     block,
                     duration,
-                    process_type,
+                    BlockProcessSource::Rpc(id),
                 ) {
                     error!(
                         self.log,
@@ -628,17 +646,20 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     pub fn send_blobs_for_processing(
         &self,
+        id: Id,
         block_root: Hash256,
         blobs: FixedBlobSidecarList<T::EthSpec>,
         duration: Duration,
-        process_type: BlockProcessType,
     ) -> Result<(), &'static str> {
         match self.beacon_processor_if_enabled() {
             Some(beacon_processor) => {
-                debug!(self.log, "Sending blobs for processing"; "block" => ?block_root, "process_type" => ?process_type);
-                if let Err(e) =
-                    beacon_processor.send_rpc_blobs(block_root, blobs, duration, process_type)
-                {
+                debug!(self.log, "Sending blobs for processing"; "block" => ?block_root, "id" => id);
+                if let Err(e) = beacon_processor.send_rpc_blobs(
+                    block_root,
+                    blobs,
+                    duration,
+                    BlockProcessSource::Rpc(id),
+                ) {
                     error!(
                         self.log,
                         "Failed to send sync blobs to processor";

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -319,7 +319,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         block_root: Hash256,
     ) -> Result<LookupRequestResult, &'static str> {
         // da_checker includes block that are execution verified, but are missing components
-        if self.chain.data_availability_checker.has_block(&block_root) {
+        if self
+            .chain
+            .data_availability_checker
+            .has_execution_valid_block(&block_root)
+        {
             return Ok(LookupRequestResult::NoRequestNeeded);
         }
 


### PR DESCRIPTION
## General problem

Lookup sync and gossip interact in very racy ways. They interact at all because we want to prevent downloading things via ReqResp that we are already processing. Note that this optimization carries complexity, which we may decide if it's worth it at all.

<img width="926" alt="Screenshot 2024-05-06 at 23 11 48" src="https://github.com/sigp/lighthouse/assets/35266934/4784df3c-cc28-46a7-8fef-f46700968404">

Consider the image above, we can receive an attestation referencing a block not yet imported into fork-choice at these moments in time:

- `A` before processing: Easy, download and process the block
- `B` during processing: Block is already processing, should skip download. However, we must consider:
  - What to do if processing fails?
  - Should we create a lookup at all? If not, what to do if we receive a second attestation referencing the child of this block?
- `C` while waiting blobs: Block is fully processed but not yet in fork-choice. In this case we don't have to worry about processing failures, but the child lookup issue remains.
- `D` after import: This trigger should never happen. If it does we will download all block components and get a `BlockAreadyKnown` error.

## Issues with current unstable da9d38698d9ea25202511ed924f8d7baddbf1f27

- https://github.com/sigp/lighthouse/pull/5681

^ introduces the optimization to prevent downloads for triggers `B` and `C`. However, it fails to explicitly handle both pitfalls listed above. If processing fails, a lookup may get stuck.

Also, it creates a spammy situation where a lookup get dropped immediately if the block is still processing, once per attestation

- https://github.com/sigp/lighthouse/pull/5696

^ Fixed the spammy loop, but now it make the case of processing failure worse. Completed chains remain in a hashset for 60 seconds, so a failing lookup will be blocked from being retried for that period.

## Proposed Changes

Sync lookup must be aware of gossip processing results. I think there's no way around that.

The least invasive way to achieve that IMO is:
- If block is the processing cache, mark lookup request as processing
- When gossip processing completes, send sync message `BlockComponentProcessed`

With the above we tackle:
1. Immediately retry lookups for blocks that fail processing, don't wait 60 seconds
2. Immediately continue or drop child lookup of blocks from gossip
3. No spammy loop, lookups are not marked completed until imported into fork-choice

## Pitfalls

This PR relies on these assumptions:
- If `availability_checker.has_block(block)` returns true, the block is permanently valid and is missing blobs
- If `reqresp_pre_import_cache.contains_key(block)` returns true, a `BlockComponentProcessed` event MUST be emitted some time in the future

We don't have e2e to assert those conditions at the moment. I think code comments should be good for now but it would be great to codify them in the future somehow

## Todo

- [ ] Update lookup tests, behaviour has slightly changed

Closes https://github.com/sigp/lighthouse/issues/5693
