### PR TITLE
Do not request current child lookup peers

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -134,7 +134,10 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 block_root,
                 Some(block_component),
                 Some(parent_root),
-                &[peer_id],
+                // On a `UnknownParentBlock` or `UnknownParentBlob` event the peer is not required
+                // to have the rest of the block components (refer to decoupled blob gossip). Create
+                // the lookup with zero peers to house the block components.
+                &[],
                 cx,
             );
         }


### PR DESCRIPTION
## Issue Addressed

Description of the problem ⬇️ 
- https://github.com/sigp/lighthouse/issues/5707

## Proposed Changes

Implement solution 1 from https://github.com/sigp/lighthouse/issues/5707

- Only add peers to a lookup that MUST be able to serve the lookup's components
- Allow lookups to have zero peers ONLY IF they are awaiting a parent (some future event will make progress)

## Todo

- [ ] Update lookup tests, behaviour has slightly changed

Closes https://github.com/sigp/lighthouse/issues/5707
