### PR TITLE
Fix simulator tests on `das` branch

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,33 +34,33 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
-      - name: Check that the pull request is not targeting the stable branch
-        run: test ${{ github.base_ref }} != "stable"
+        - name: Check that the pull request is not targeting the stable branch
+          run: test ${{ github.base_ref }} != "stable"
   release-tests-ubuntu:
     name: release-tests-ubuntu
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
-        env:
+      env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Foundry (anvil)
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
-      - name: Run tests in release
-        run: make nextest-release
-      - name: Show cache stats
-        if: env.SELF_HOSTED_RUNNERS == 'true'
-        run: sccache --show-stats
+    - name: Install Foundry (anvil)
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
+    - name: Run tests in release
+      run: make nextest-release
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      run: sccache --show-stats
   # FIXME(das): disabled for now as the c-kzg-4844 `das` branch doesn't build on windows.
   #  release-tests-windows:
   #    name: release-tests-windows
@@ -101,155 +101,155 @@ jobs:
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
-      - name: Run beacon_chain tests for all known forks
-        run: make test-beacon-chain
-      - name: Show cache stats
-        if: env.SELF_HOSTED_RUNNERS == 'true'
-        run: sccache --show-stats
+    - name: Run beacon_chain tests for all known forks
+      run: make test-beacon-chain
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      run: sccache --show-stats
   op-pool-tests:
     name: op-pool-tests
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
-      - name: Run operation_pool tests for all known forks
-        run: make test-op-pool
+    - name: Run operation_pool tests for all known forks
+      run: make test-op-pool
   network-tests:
     name: network-tests
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
-          channel: stable
-          cache-target: release
-          bins: cargo-nextest
-      - name: Run network tests for all known forks
-        run: make test-network
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+        channel: stable
+        cache-target: release
+        bins: cargo-nextest
+    - name: Run network tests for all known forks
+      run: make test-network
   slasher-tests:
     name: slasher-tests
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
-      - name: Run slasher tests for all supported backends
-        run: make test-slasher
+    - name: Run slasher tests for all supported backends
+      run: make test-slasher
   debug-tests-ubuntu:
     name: debug-tests-ubuntu
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           bins: cargo-nextest
-      - name: Install Foundry (anvil)
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
-      - name: Run tests in debug
-        run: make nextest-debug
-      - name: Show cache stats
-        if: env.SELF_HOSTED_RUNNERS == 'true'
-        run: sccache --show-stats
+    - name: Install Foundry (anvil)
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: foundry-rs/foundry-toolchain@v1
+      with:
+        version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
+    - name: Run tests in debug
+      run: make nextest-debug
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      run: sccache --show-stats
   state-transition-vectors-ubuntu:
     name: state-transition-vectors-ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
-      - name: Run state_transition_vectors in release.
-        run: make run-state-transition-tests
+    - name: Run state_transition_vectors in release.
+      run: make run-state-transition-tests
   ef-tests-ubuntu:
     name: ef-tests-ubuntu
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           bins: cargo-nextest
-      - name: Run consensus-spec-tests with blst and fake_crypto
-        run: make nextest-ef
-      - name: Show cache stats
-        if: env.SELF_HOSTED_RUNNERS == 'true'
-        run: sccache --show-stats
+    - name: Run consensus-spec-tests with blst and fake_crypto
+      run: make nextest-ef
+    - name: Show cache stats
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      run: sccache --show-stats
   dockerfile-ubuntu:
     name: dockerfile-ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Build the root Dockerfile
-        run: docker build --build-arg FEATURES=portable -t lighthouse:local .
-      - name: Test the built image
-        run: docker run -t lighthouse:local lighthouse --version
+    - uses: actions/checkout@v4
+    - name: Build the root Dockerfile
+      run: docker build --build-arg FEATURES=portable -t lighthouse:local .
+    - name: Test the built image
+      run: docker run -t lighthouse:local lighthouse --version
   basic-simulator-ubuntu:
     name: basic-simulator-ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
-      - name: Run a basic beacon chain sim that starts from Bellatrix
-        run: cargo run --release --bin simulator basic-sim
+    - name: Run a basic beacon chain sim that starts from Bellatrix
+      run: cargo run --release --bin simulator basic-sim
   fallback-simulator-ubuntu:
     name: fallback-simulator-ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
-      - name: Run a beacon chain sim which tests VC fallback behaviour
-        run: cargo run --release --bin simulator fallback-sim
+    - name: Run a beacon chain sim which tests VC fallback behaviour
+      run: cargo run --release --bin simulator fallback-sim
   doppelganger-protection-test:
     name: doppelganger-protection-test
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
@@ -257,111 +257,111 @@ jobs:
       # Enable portable to prevent issues with caching `blst` for the wrong CPU type
       FEATURES: jemalloc,portable
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
-      - name: Install geth
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        run: |
+    - name: Install geth
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      run: |
           sudo add-apt-repository -y ppa:ethereum/ethereum
           sudo apt-get update
           sudo apt-get install ethereum
-      - name: Install lighthouse
-        run: |
+    - name: Install lighthouse
+      run: |
           make
-      - name: Install lcli
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        run: make install-lcli
-      - name: Run the doppelganger protection failure test script
-        run: |
+    - name: Install lcli
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      run: make install-lcli
+    - name: Run the doppelganger protection failure test script
+      run: |
           cd scripts/tests
           ./doppelganger_protection.sh failure genesis.json
-          - name: Run the doppelganger protection success test script
-            run: |
-              cd scripts/tests
-              ./doppelganger_protection.sh success genesis.json
+    - name: Run the doppelganger protection success test script
+      run: |
+          cd scripts/tests
+          ./doppelganger_protection.sh success genesis.json
   execution-engine-integration-ubuntu:
     name: execution-engine-integration-ubuntu
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        if: env.SELF_HOSTED_RUNNERS == 'false'
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      if: env.SELF_HOSTED_RUNNERS == 'false'
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           cache: false
-        env:
+      env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add go compiler to $PATH
-        if: env.SELF_HOSTED_RUNNERS == 'true'
-        run: echo "/usr/local/go/bin" >> $GITHUB_PATH
-      - name: Run exec engine integration tests in release
-        run: make test-exec-engine
+    - name: Add go compiler to $PATH
+      if: env.SELF_HOSTED_RUNNERS == 'true'
+      run: echo "/usr/local/go/bin" >> $GITHUB_PATH
+    - name: Run exec engine integration tests in release
+      run: make test-exec-engine
   check-code:
     name: check-code
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: 1
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: stable
           cache-target: release
           components: rustfmt,clippy
           bins: cargo-audit
-      - name: Check formatting with cargo fmt
-        run: make cargo-fmt
-      - name: Lint code for quality and style with Clippy
-        run: make lint
-      - name: Certify Cargo.lock freshness
-        run: git diff --exit-code Cargo.lock
-      - name: Typecheck benchmark code without running it
-        run: make check-benches
-      - name: Validate state_processing feature arbitrary-fuzz
-        run: make arbitrary-fuzz
-      - name: Run cargo audit
-        run: make audit-CI
-      - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
-        run: CARGO_HOME=$(readlink -f $HOME) make vendor
+    - name: Check formatting with cargo fmt
+      run: make cargo-fmt
+    - name: Lint code for quality and style with Clippy
+      run: make lint
+    - name: Certify Cargo.lock freshness
+      run: git diff --exit-code Cargo.lock
+    - name: Typecheck benchmark code without running it
+      run: make check-benches
+    - name: Validate state_processing feature arbitrary-fuzz
+      run:  make arbitrary-fuzz
+    - name: Run cargo audit
+      run: make audit-CI
+    - name: Run cargo vendor to make sure dependencies can be vendored for packaging, reproducibility and archival purpose
+      run:  CARGO_HOME=$(readlink -f $HOME) make vendor
   check-msrv:
     name: check-msrv
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust at Minimum Supported Rust Version (MSRV)
-        run: |
-          metadata=$(cargo metadata --no-deps --format-version 1)
-          msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "lighthouse")) | .[0].rust_version')
-          rustup override set $msrv
-      - name: Run cargo check
-        run: cargo check --workspace
+    - uses: actions/checkout@v4
+    - name: Install Rust at Minimum Supported Rust Version (MSRV)
+      run: |
+        metadata=$(cargo metadata --no-deps --format-version 1)
+        msrv=$(echo $metadata | jq -r '.packages | map(select(.name == "lighthouse")) | .[0].rust_version')
+        rustup override set $msrv
+    - name: Run cargo check
+      run: cargo check --workspace
   cargo-udeps:
     name: cargo-udeps
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of nightly Rust
-        uses: moonrepo/setup-rust@v1
-        with:
+    - uses: actions/checkout@v4
+    - name: Get latest version of nightly Rust
+      uses: moonrepo/setup-rust@v1
+      with:
           channel: nightly
           bins: cargo-udeps
           cache: false
-        env:
+      env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Cargo config dir
-        run: mkdir -p .cargo
-      - name: Install custom Cargo config
-        run: cp -f .github/custom/config.toml .cargo/config.toml
-      - name: Run cargo udeps to identify unused crates in the dependency graph
-        run: make udeps
+    - name: Create Cargo config dir
+      run: mkdir -p .cargo
+    - name: Install custom Cargo config
+      run: cp -f .github/custom/config.toml .cargo/config.toml
+    - name: Run cargo udeps to identify unused crates in the dependency graph
+      run: make udeps
     env:
       # Allow warnings on Nightly
       RUSTFLAGS: ""
@@ -369,25 +369,25 @@ jobs:
     name: compile-with-beta-compiler
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
-      - name: Use Rust beta
-        run: rustup override set beta
-      - name: Run make
-        run: make
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+    - name: Use Rust beta
+      run: rustup override set beta
+    - name: Run make
+      run: make
   cli-check:
     name: cli-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Get latest version of stable Rust
-        uses: moonrepo/setup-rust@v1
-        with:
-          channel: stable
-          cache-target: release
-      - name: Run Makefile to trigger the bash script
-        run: make cli
+    - uses: actions/checkout@v4
+    - name: Get latest version of stable Rust
+      uses: moonrepo/setup-rust@v1
+      with:
+        channel: stable
+        cache-target: release
+    - name: Run Makefile to trigger the bash script
+      run: make cli
   # This job succeeds ONLY IF all others succeed. It is used by the merge queue to determine whether
   # a PR is safe to merge. New jobs should be added here.
   test-suite-success:

--- a/testing/simulator/src/basic_sim.rs
+++ b/testing/simulator/src/basic_sim.rs
@@ -16,7 +16,7 @@ use tokio::time::sleep;
 use types::{Epoch, EthSpec, MinimalEthSpec};
 
 const END_EPOCH: u64 = 16;
-const GENESIS_DELAY: u64 = 32;
+const GENESIS_DELAY: u64 = 60;
 const ALTAIR_FORK_EPOCH: u64 = 0;
 const BELLATRIX_FORK_EPOCH: u64 = 0;
 const CAPELLA_FORK_EPOCH: u64 = 1;

--- a/testing/simulator/src/fallback_sim.rs
+++ b/testing/simulator/src/fallback_sim.rs
@@ -15,7 +15,7 @@ use tokio::time::sleep;
 use types::{Epoch, EthSpec, MinimalEthSpec};
 
 const END_EPOCH: u64 = 16;
-const GENESIS_DELAY: u64 = 32;
+const GENESIS_DELAY: u64 = 60;
 const ALTAIR_FORK_EPOCH: u64 = 0;
 const BELLATRIX_FORK_EPOCH: u64 = 0;
 const CAPELLA_FORK_EPOCH: u64 = 1;


### PR DESCRIPTION
## Issue Addressed

Fixes the following CI failures on `das` branch:
- Failing simulator tests due to longer kzg initialization time
- Failing doppelgänger tests due to incorrect spacing in `test-suite.yml` from an incorrect merge.

### Additional Info

Simulator tests have been failing quite consistently on the `das` branch due to this error in subtracting duration:

```
2024-05-03T12:47:49.4509388Z thread 'main' panicked at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/time.rs:1126:31:
2024-05-03T12:47:49.4509578Z overflow when subtracting durations
2024-05-03T12:47:49.4510022Z note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

The panic is triggered here:
https://github.com/sigp/lighthouse/blob/67f8405921750f6a21e5c21d54688ecf31d4e825/testing/simulator/src/local_network.rs#L473

This is because we allow for 30 seconds for all 6 nodes to startup successfully - this is pretty fast on `unstable` but significantly slower on `das` branch due to more expensive kzg initialisation:

```
2024-05-03T12:47:07.8919197Z Basic Simulator:
...
2024-05-03T12:47:25.9307373Z Adding a proposer node
2024-05-03T12:47:33.4803277Z Adding a proposer node
2024-05-03T12:47:41.1356949Z Adding a proposer node
2024-05-03T12:47:49.4509388Z thread 'main' panicked at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/time.rs:1126:31:
```

Notice that it takes 42 seconds to get to the duration calculation, and in this case I think we do want it to panic if we've already passed genesis time (as the various checks assumes we're at genesis).

The fix in this PR is to increase the genesis delay from `32` to `60`.