### PR TITLE
fix get attesting indices

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -1309,7 +1309,9 @@ pub fn obtain_indexed_attestation_and_committees_per_slot<T: BeaconChainTypes>(
                 attesting_indices_electra::get_indexed_attestation(&committees, att)
                     .map(|attestation| (attestation, committees_per_slot))
                     .map_err(|e| {
-                        if e == BlockOperationError::BeaconStateError(NoCommitteeFound) {
+                        if e == BlockOperationError::BeaconStateError(NoCommitteeFound(
+                            att.committee_index(),
+                        )) {
                             Error::NoCommitteeForSlotAndIndex {
                                 slot: att.data.slot,
                                 index: att.committee_index(),

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -1309,12 +1309,11 @@ pub fn obtain_indexed_attestation_and_committees_per_slot<T: BeaconChainTypes>(
                 attesting_indices_electra::get_indexed_attestation(&committees, att)
                     .map(|attestation| (attestation, committees_per_slot))
                     .map_err(|e| {
-                        if e == BlockOperationError::BeaconStateError(NoCommitteeFound(
-                            att.committee_index(),
-                        )) {
+                        let index = att.committee_index();
+                        if e == BlockOperationError::BeaconStateError(NoCommitteeFound(index)) {
                             Error::NoCommitteeForSlotAndIndex {
                                 slot: att.data.slot,
-                                index: att.committee_index(),
+                                index,
                             }
                         } else {
                             Error::Invalid(e)

--- a/consensus/state_processing/src/common/get_attesting_indices.rs
+++ b/consensus/state_processing/src/common/get_attesting_indices.rs
@@ -119,7 +119,7 @@ pub mod attesting_indices_electra {
             if let Some(&beacon_committee) = committees_map.get(&index) {
                 // This check is new to the spec's `process_attestation` in Electra.
                 if index >= committee_count_per_slot {
-                    return Err(BeaconStateError::InvalidBitfield);
+                    return Err(BeaconStateError::InvalidCommitteeIndex(index));
                 }
                 participant_count.safe_add_assign(beacon_committee.committee.len() as u64)?;
                 let committee_attesters = beacon_committee
@@ -140,7 +140,7 @@ pub mod attesting_indices_electra {
 
                 committee_offset.safe_add(beacon_committee.committee.len())?;
             } else {
-                return Err(Error::NoCommitteeFound);
+                return Err(Error::NoCommitteeFound(index));
             }
         }
 

--- a/consensus/state_processing/src/common/get_attesting_indices.rs
+++ b/consensus/state_processing/src/common/get_attesting_indices.rs
@@ -113,11 +113,15 @@ pub mod attesting_indices_electra {
             .map(|committee| (committee.index, committee))
             .collect();
 
+        let committee_count_per_slot = committees.len() as u64;
+        let mut participant_count = 0;
         for index in committee_indices {
             if let Some(&beacon_committee) = committees_map.get(&index) {
-                if aggregation_bits.len() != beacon_committee.committee.len() {
+                // This check is new to the spec's `process_attestation` in Electra.
+                if index >= committee_count_per_slot {
                     return Err(BeaconStateError::InvalidBitfield);
                 }
+                participant_count.safe_add_assign(beacon_committee.committee.len() as u64)?;
                 let committee_attesters = beacon_committee
                     .committee
                     .iter()
@@ -138,8 +142,11 @@ pub mod attesting_indices_electra {
             } else {
                 return Err(Error::NoCommitteeFound);
             }
+        }
 
-            // TODO(electra) what should we do when theres no committee found for a given index?
+        // This check is new to the spec's `process_attestation` in Electra.
+        if participant_count as usize != aggregation_bits.len() {
+            return Err(BeaconStateError::InvalidBitfield);
         }
 
         let mut indices = output.into_iter().collect_vec();

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -159,7 +159,8 @@ pub enum Error {
     IndexNotSupported(usize),
     InvalidFlagIndex(usize),
     MerkleTreeError(merkle_proof::MerkleTreeError),
-    NoCommitteeFound,
+    NoCommitteeFound(CommitteeIndex),
+    InvalidCommitteeIndex(CommitteeIndex),
 }
 
 /// Control whether an epoch-indexed field can be indexed at the next epoch or not.


### PR DESCRIPTION
## Issue Addressed

This check comes from `process_attestation` in the spec and has been updated:
`aggregation_bits.len() != beacon_committee.committee.len()`

This is the new spec logic: 

```
    committee_indices = get_committee_indices(attestation.committee_bits)
    participants_count = 0
    for index in committee_indices:
        assert index < get_committee_count_per_slot(state, data.target.epoch)
        committee = get_beacon_committee(state, data.slot, index)
        participants_count += len(committee)

    assert len(attestation.aggregation_bits) == participants_count
```