### PR TITLE
Builder docker image on `das` branch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - unstable
             - stable
+            - das
         tags:
             - v*
 
@@ -38,6 +39,11 @@ jobs:
               run: |
                     echo "VERSION=latest" >> $GITHUB_ENV
                     echo "VERSION_SUFFIX=-unstable" >> $GITHUB_ENV
+            - name: Extract version (if das)
+              if: github.event.ref == 'refs/heads/das'
+              run: |
+                echo "VERSION=das" >> $GITHUB_ENV
+                echo "VERSION_SUFFIX=" >> $GITHUB_ENV
             - name: Extract version (if tagged release)
               if: startsWith(github.event.ref, 'refs/tags')
               run: |


### PR DESCRIPTION
## Issue Addressed

Build a `das` docker image each time we push a merge to the branch. This will be useful for testing.
