### PR TITLE
Fetch custody columns in range sync

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification_types.rs
+++ b/beacon_node/beacon_chain/src/block_verification_types.rs
@@ -156,11 +156,9 @@ impl<E: EthSpec> RpcBlock<E> {
     ) -> Result<Self, AvailabilityCheckError> {
         let block_root = block_root.unwrap_or_else(|| get_block_root(&block));
 
-        if let Ok(block_commitments) = block.message().body().blob_kzg_commitments() {
+        if block.num_expected_blobs() > 0 && custody_columns.is_empty() {
             // The number of required custody columns is out of scope here.
-            if !block_commitments.is_empty() && custody_columns.is_empty() {
-                return Err(AvailabilityCheckError::MissingCustodyColumns);
-            }
+            return Err(AvailabilityCheckError::MissingCustodyColumns);
         }
         // Treat empty blob lists as if they are missing.
         let inner = if custody_columns.is_empty() {

--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -91,8 +91,8 @@ pub struct RateLimiterConfig {
     pub(super) blocks_by_root_quota: Quota,
     pub(super) blobs_by_range_quota: Quota,
     pub(super) blobs_by_root_quota: Quota,
-    pub(super) data_columns_by_root_quota: Quota,
     pub(super) data_columns_by_range_quota: Quota,
+    pub(super) data_columns_by_root_quota: Quota,
     pub(super) light_client_bootstrap_quota: Quota,
     pub(super) light_client_optimistic_update_quota: Quota,
     pub(super) light_client_finality_update_quota: Quota,
@@ -107,8 +107,9 @@ impl RateLimiterConfig {
     pub const DEFAULT_BLOCKS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
     pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(768, 10);
     pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
-    pub const DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
+    // TODO(das): random value without thought
     pub const DEFAULT_DATA_COLUMNS_BY_RANGE_QUOTA: Quota = Quota::n_every(128, 10);
+    pub const DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
     pub const DEFAULT_LIGHT_CLIENT_BOOTSTRAP_QUOTA: Quota = Quota::one_every(10);
     pub const DEFAULT_LIGHT_CLIENT_OPTIMISTIC_UPDATE_QUOTA: Quota = Quota::one_every(10);
     pub const DEFAULT_LIGHT_CLIENT_FINALITY_UPDATE_QUOTA: Quota = Quota::one_every(10);
@@ -125,8 +126,8 @@ impl Default for RateLimiterConfig {
             blocks_by_root_quota: Self::DEFAULT_BLOCKS_BY_ROOT_QUOTA,
             blobs_by_range_quota: Self::DEFAULT_BLOBS_BY_RANGE_QUOTA,
             blobs_by_root_quota: Self::DEFAULT_BLOBS_BY_ROOT_QUOTA,
-            data_columns_by_root_quota: Self::DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA,
             data_columns_by_range_quota: Self::DEFAULT_DATA_COLUMNS_BY_RANGE_QUOTA,
+            data_columns_by_root_quota: Self::DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA,
             light_client_bootstrap_quota: Self::DEFAULT_LIGHT_CLIENT_BOOTSTRAP_QUOTA,
             light_client_optimistic_update_quota:
                 Self::DEFAULT_LIGHT_CLIENT_OPTIMISTIC_UPDATE_QUOTA,
@@ -157,6 +158,10 @@ impl Debug for RateLimiterConfig {
             .field("blobs_by_range", fmt_q!(&self.blobs_by_range_quota))
             .field("blobs_by_root", fmt_q!(&self.blobs_by_root_quota))
             .field(
+                "data_columns_by_range",
+                fmt_q!(&self.data_columns_by_range_quota),
+            )
+            .field(
                 "data_columns_by_root",
                 fmt_q!(&self.data_columns_by_root_quota),
             )
@@ -180,8 +185,8 @@ impl FromStr for RateLimiterConfig {
         let mut blocks_by_root_quota = None;
         let mut blobs_by_range_quota = None;
         let mut blobs_by_root_quota = None;
-        let mut data_columns_by_root_quota = None;
         let mut data_columns_by_range_quota = None;
+        let mut data_columns_by_root_quota = None;
         let mut light_client_bootstrap_quota = None;
         let mut light_client_optimistic_update_quota = None;
         let mut light_client_finality_update_quota = None;
@@ -196,11 +201,11 @@ impl FromStr for RateLimiterConfig {
                 Protocol::BlocksByRoot => blocks_by_root_quota = blocks_by_root_quota.or(quota),
                 Protocol::BlobsByRange => blobs_by_range_quota = blobs_by_range_quota.or(quota),
                 Protocol::BlobsByRoot => blobs_by_root_quota = blobs_by_root_quota.or(quota),
-                Protocol::DataColumnsByRoot => {
-                    data_columns_by_root_quota = data_columns_by_root_quota.or(quota)
-                }
                 Protocol::DataColumnsByRange => {
                     data_columns_by_range_quota = data_columns_by_range_quota.or(quota)
+                }
+                Protocol::DataColumnsByRoot => {
+                    data_columns_by_root_quota = data_columns_by_root_quota.or(quota)
                 }
                 Protocol::Ping => ping_quota = ping_quota.or(quota),
                 Protocol::MetaData => meta_data_quota = meta_data_quota.or(quota),
@@ -229,10 +234,10 @@ impl FromStr for RateLimiterConfig {
             blobs_by_range_quota: blobs_by_range_quota
                 .unwrap_or(Self::DEFAULT_BLOBS_BY_RANGE_QUOTA),
             blobs_by_root_quota: blobs_by_root_quota.unwrap_or(Self::DEFAULT_BLOBS_BY_ROOT_QUOTA),
-            data_columns_by_root_quota: data_columns_by_root_quota
-                .unwrap_or(Self::DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA),
             data_columns_by_range_quota: data_columns_by_range_quota
                 .unwrap_or(Self::DEFAULT_DATA_COLUMNS_BY_RANGE_QUOTA),
+            data_columns_by_root_quota: data_columns_by_root_quota
+                .unwrap_or(Self::DEFAULT_DATA_COLUMNS_BY_ROOT_QUOTA),
             light_client_bootstrap_quota: light_client_bootstrap_quota
                 .unwrap_or(Self::DEFAULT_LIGHT_CLIENT_BOOTSTRAP_QUOTA),
             light_client_optimistic_update_quota: light_client_optimistic_update_quota

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -300,17 +300,17 @@ impl BlobsByRangeRequest {
 pub struct DataColumnsByRangeRequest {
     /// The starting slot to request data columns.
     pub start_slot: u64,
-
     /// The number of slots from the start slot.
     pub count: u64,
-
-    /// The list of beacon block roots and column indices being requested.
-    pub data_column_ids: Vec<DataColumnIdentifier>,
+    /// The list column indices being requested.
+    pub columns: Vec<ColumnIndex>,
 }
 
 impl DataColumnsByRangeRequest {
-    pub fn max_data_columns_requested<E: EthSpec>(&self) -> u64 {
-        self.count.saturating_mul(E::max_blobs_per_block() as u64)
+    pub fn max_requested<E: EthSpec>(&self) -> u64 {
+        self.count
+            .saturating_mul(E::max_blobs_per_block() as u64)
+            .saturating_mul(self.columns.len() as u64)
     }
 }
 

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -36,8 +36,8 @@ pub enum OutboundRequest<E: EthSpec> {
     BlocksByRoot(BlocksByRootRequest),
     BlobsByRange(BlobsByRangeRequest),
     BlobsByRoot(BlobsByRootRequest),
-    DataColumnsByRoot(DataColumnsByRootRequest),
     DataColumnsByRange(DataColumnsByRangeRequest),
+    DataColumnsByRoot(DataColumnsByRootRequest),
     Ping(Ping),
     MetaData(MetadataRequest<E>),
 }
@@ -111,7 +111,7 @@ impl<E: EthSpec> OutboundRequest<E> {
             OutboundRequest::BlobsByRange(req) => req.max_blobs_requested::<E>(),
             OutboundRequest::BlobsByRoot(req) => req.blob_ids.len() as u64,
             OutboundRequest::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
-            OutboundRequest::DataColumnsByRange(req) => req.data_column_ids.len() as u64,
+            OutboundRequest::DataColumnsByRange(req) => req.max_requested::<E>(),
             OutboundRequest::Ping(_) => 1,
             OutboundRequest::MetaData(_) => 1,
         }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -382,6 +382,7 @@ impl SupportedProtocol {
                 ProtocolId::new(SupportedProtocol::BlobsByRangeV1, Encoding::SSZSnappy),
                 // TODO(das): add to PeerDAS fork
                 ProtocolId::new(SupportedProtocol::DataColumnsByRootV1, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::DataColumnsByRangeV1, Encoding::SSZSnappy),
             ]);
         }
         supported
@@ -704,7 +705,7 @@ impl<E: EthSpec> InboundRequest<E> {
             InboundRequest::BlobsByRange(req) => req.max_blobs_requested::<E>(),
             InboundRequest::BlobsByRoot(req) => req.blob_ids.len() as u64,
             InboundRequest::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
-            InboundRequest::DataColumnsByRange(req) => req.data_column_ids.len() as u64,
+            InboundRequest::DataColumnsByRange(req) => req.max_requested::<E>(),
             InboundRequest::Ping(_) => 1,
             InboundRequest::MetaData(_) => 1,
             InboundRequest::LightClientBootstrap(_) => 1,

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -97,10 +97,10 @@ pub struct RPCRateLimiter {
     blbrange_rl: Limiter<PeerId>,
     /// BlobsByRoot rate limiter.
     blbroot_rl: Limiter<PeerId>,
+    /// DataColumnssByRange rate limiter.
+    dcbrange_rl: Limiter<PeerId>,
     /// DataColumnssByRoot rate limiter.
     dcbroot_rl: Limiter<PeerId>,
-    /// DataColumnsByRange rate limiter.
-    dcbrange_rl: Limiter<PeerId>,
     /// LightClientBootstrap rate limiter.
     lc_bootstrap_rl: Limiter<PeerId>,
     /// LightClientOptimisticUpdate rate limiter.
@@ -137,10 +137,10 @@ pub struct RPCRateLimiterBuilder {
     blbrange_quota: Option<Quota>,
     /// Quota for the BlobsByRoot protocol.
     blbroot_quota: Option<Quota>,
-    /// Quota for the DataColumnsByRoot protocol.
-    dcbroot_quota: Option<Quota>,
     /// Quota for the DataColumnsByRange protocol.
     dcbrange_quota: Option<Quota>,
+    /// Quota for the DataColumnsByRoot protocol.
+    dcbroot_quota: Option<Quota>,
     /// Quota for the LightClientBootstrap protocol.
     lcbootstrap_quota: Option<Quota>,
     /// Quota for the LightClientOptimisticUpdate protocol.
@@ -162,8 +162,8 @@ impl RPCRateLimiterBuilder {
             Protocol::BlocksByRoot => self.bbroots_quota = q,
             Protocol::BlobsByRange => self.blbrange_quota = q,
             Protocol::BlobsByRoot => self.blbroot_quota = q,
-            Protocol::DataColumnsByRoot => self.dcbroot_quota = q,
             Protocol::DataColumnsByRange => self.dcbrange_quota = q,
+            Protocol::DataColumnsByRoot => self.dcbroot_quota = q,
             Protocol::LightClientBootstrap => self.lcbootstrap_quota = q,
             Protocol::LightClientOptimisticUpdate => self.lc_optimistic_update_quota = q,
             Protocol::LightClientFinalityUpdate => self.lc_finality_update_quota = q,
@@ -196,18 +196,15 @@ impl RPCRateLimiterBuilder {
         let blbrange_quota = self
             .blbrange_quota
             .ok_or("BlobsByRange quota not specified")?;
-
         let blbroots_quota = self
             .blbroot_quota
             .ok_or("BlobsByRoot quota not specified")?;
-
-        let dcbroot_quota = self
-            .dcbroot_quota
-            .ok_or("DataColumnsByRoot quota not specified")?;
-
         let dcbrange_quota = self
             .dcbrange_quota
             .ok_or("DataColumnsByRange quota not specified")?;
+        let dcbroot_quota = self
+            .dcbroot_quota
+            .ok_or("DataColumnsByRoot quota not specified")?;
 
         // create the rate limiters
         let ping_rl = Limiter::from_quota(ping_quota)?;
@@ -218,8 +215,8 @@ impl RPCRateLimiterBuilder {
         let bbrange_rl = Limiter::from_quota(bbrange_quota)?;
         let blbrange_rl = Limiter::from_quota(blbrange_quota)?;
         let blbroot_rl = Limiter::from_quota(blbroots_quota)?;
-        let dcbroot_rl = Limiter::from_quota(dcbroot_quota)?;
         let dcbrange_rl = Limiter::from_quota(dcbrange_quota)?;
+        let dcbroot_rl = Limiter::from_quota(dcbroot_quota)?;
         let lc_bootstrap_rl = Limiter::from_quota(lc_bootstrap_quota)?;
         let lc_optimistic_update_rl = Limiter::from_quota(lc_optimistic_update_quota)?;
         let lc_finality_update_rl = Limiter::from_quota(lc_finality_update_quota)?;
@@ -238,8 +235,8 @@ impl RPCRateLimiterBuilder {
             bbrange_rl,
             blbrange_rl,
             blbroot_rl,
-            dcbroot_rl,
             dcbrange_rl,
+            dcbroot_rl,
             lc_bootstrap_rl,
             lc_optimistic_update_rl,
             lc_finality_update_rl,
@@ -284,8 +281,8 @@ impl RPCRateLimiter {
             blocks_by_root_quota,
             blobs_by_range_quota,
             blobs_by_root_quota,
-            data_columns_by_root_quota,
             data_columns_by_range_quota,
+            data_columns_by_root_quota,
             light_client_bootstrap_quota,
             light_client_optimistic_update_quota,
             light_client_finality_update_quota,
@@ -300,8 +297,8 @@ impl RPCRateLimiter {
             .set_quota(Protocol::BlocksByRoot, blocks_by_root_quota)
             .set_quota(Protocol::BlobsByRange, blobs_by_range_quota)
             .set_quota(Protocol::BlobsByRoot, blobs_by_root_quota)
-            .set_quota(Protocol::DataColumnsByRoot, data_columns_by_root_quota)
             .set_quota(Protocol::DataColumnsByRange, data_columns_by_range_quota)
+            .set_quota(Protocol::DataColumnsByRoot, data_columns_by_root_quota)
             .set_quota(Protocol::LightClientBootstrap, light_client_bootstrap_quota)
             .set_quota(
                 Protocol::LightClientOptimisticUpdate,
@@ -338,8 +335,8 @@ impl RPCRateLimiter {
             Protocol::BlocksByRoot => &mut self.bbroots_rl,
             Protocol::BlobsByRange => &mut self.blbrange_rl,
             Protocol::BlobsByRoot => &mut self.blbroot_rl,
-            Protocol::DataColumnsByRoot => &mut self.dcbroot_rl,
             Protocol::DataColumnsByRange => &mut self.dcbrange_rl,
+            Protocol::DataColumnsByRoot => &mut self.dcbroot_rl,
             Protocol::LightClientBootstrap => &mut self.lc_bootstrap_rl,
             Protocol::LightClientOptimisticUpdate => &mut self.lc_optimistic_update_rl,
             Protocol::LightClientFinalityUpdate => &mut self.lc_finality_update_rl,
@@ -357,6 +354,8 @@ impl RPCRateLimiter {
         self.bbroots_rl.prune(time_since_start);
         self.blbrange_rl.prune(time_since_start);
         self.blbroot_rl.prune(time_since_start);
+        self.dcbrange_rl.prune(time_since_start);
+        self.dcbroot_rl.prune(time_since_start);
     }
 }
 

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -6,7 +6,9 @@ use types::{
     LightClientOptimisticUpdate, SignedBeaconBlock,
 };
 
-use crate::rpc::methods::{BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRootRequest};
+use crate::rpc::methods::{
+    BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRangeRequest, DataColumnsByRootRequest,
+};
 use crate::rpc::{
     methods::{
         BlocksByRangeRequest, BlocksByRootRequest, LightClientBootstrapRequest,
@@ -15,8 +17,6 @@ use crate::rpc::{
     },
     OutboundRequest, SubstreamId,
 };
-
-use super::methods::DataColumnsByRangeRequest;
 
 /// Identifier of requests sent by a peer.
 pub type PeerRequestId = (ConnectionId, SubstreamId);
@@ -84,8 +84,8 @@ impl<E: EthSpec> std::convert::From<Request> for OutboundRequest<E> {
             }
             Request::BlobsByRange(r) => OutboundRequest::BlobsByRange(r),
             Request::BlobsByRoot(r) => OutboundRequest::BlobsByRoot(r),
-            Request::DataColumnsByRoot(r) => OutboundRequest::DataColumnsByRoot(r),
             Request::DataColumnsByRange(r) => OutboundRequest::DataColumnsByRange(r),
+            Request::DataColumnsByRoot(r) => OutboundRequest::DataColumnsByRoot(r),
             Request::Status(s) => OutboundRequest::Status(s),
         }
     }

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -521,7 +521,7 @@ impl<T: BeaconChainTypes> Router<T> {
     ) {
         let request_id = match request_id {
             RequestId::Sync(sync_id) => match sync_id {
-                id @ SyncId::RangeBlockAndBlobs { .. } => id,
+                id @ SyncId::RangeBlockComponents { .. } => id,
                 other => {
                     crit!(self.log, "BlocksByRange response on incorrect request"; "request" => ?other);
                     return;

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -929,7 +929,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
     ) -> Result<(), BackFillError> {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             let (request, is_blob_batch) = batch.to_blocks_by_range_request();
-            match network.blocks_and_blobs_by_range_request(
+            match network.block_components_by_range_request(
                 peer,
                 is_blob_batch,
                 request,

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -5,7 +5,6 @@ use crate::sync::manager::{
     DataColumnsByRootRequestId, DataColumnsByRootRequester, RequestId as SyncRequestId,
     SingleLookupReqId, SyncManager,
 };
-use crate::sync::network_context::custody::CustodyRequester;
 use crate::sync::sampling::{SamplingConfig, SamplingRequester};
 use crate::sync::{SamplingId, SyncMessage};
 use crate::NetworkMessage;
@@ -612,11 +611,7 @@ impl TestRig {
         let lookup_id = if let DataColumnsByRootRequester::Custody(id) =
             sampling_ids.first().unwrap().0.requester
         {
-            if let CustodyRequester::Lookup(id) = id.id {
-                id.lookup_id
-            } else {
-                panic!("not a lookup requester");
-            }
+            id.id.0.lookup_id
         } else {
             panic!("not a custody requester")
         };

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,78 +1,90 @@
 use beacon_chain::{
-    block_verification_types::RpcBlock, data_column_verification::CustodyDataColumn,
+    block_verification_types::RpcBlock, data_column_verification::CustodyDataColumn, get_block_root,
 };
 use ssz_types::VariableList;
-use std::{collections::VecDeque, sync::Arc};
-use types::{BlobSidecar, EthSpec, SignedBeaconBlock};
-
-use super::range_sync::ByRangeRequestType;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+};
+use types::{BlobSidecar, ColumnIndex, EthSpec, Hash256, SignedBeaconBlock};
 
 #[derive(Debug)]
-pub struct BlocksAndBlobsRequestInfo<E: EthSpec> {
+pub struct RangeBlockComponentsRequest<E: EthSpec> {
     /// Blocks we have received awaiting for their corresponding sidecar.
-    accumulated_blocks: VecDeque<Arc<SignedBeaconBlock<E>>>,
+    blocks: VecDeque<Arc<SignedBeaconBlock<E>>>,
     /// Sidecars we have received awaiting for their corresponding block.
-    accumulated_sidecars: VecDeque<Arc<BlobSidecar<E>>>,
-    accumulated_custody_columns: VecDeque<CustodyDataColumn<E>>,
+    blobs: VecDeque<Arc<BlobSidecar<E>>>,
+    custody_columns: VecDeque<CustodyDataColumn<E>>,
     /// Whether the individual RPC request for blocks is finished or not.
     is_blocks_stream_terminated: bool,
     /// Whether the individual RPC request for sidecars is finished or not.
     is_sidecars_stream_terminated: bool,
-    is_custody_columns_stream_terminated: bool,
+    custody_columns_streams_terminated: usize,
     /// Used to determine if this accumulator should wait for a sidecars stream termination
-    request_type: ByRangeRequestType,
+    expects_blobs: bool,
+    expects_custody_columns: Option<Vec<ColumnIndex>>,
 }
 
-impl<E: EthSpec> BlocksAndBlobsRequestInfo<E> {
-    pub fn new(request_type: ByRangeRequestType) -> Self {
+impl<E: EthSpec> RangeBlockComponentsRequest<E> {
+    pub fn new(expects_blobs: bool, expects_custody_columns: Option<Vec<ColumnIndex>>) -> Self {
         Self {
-            accumulated_blocks: <_>::default(),
-            accumulated_sidecars: <_>::default(),
-            accumulated_custody_columns: <_>::default(),
-            is_blocks_stream_terminated: <_>::default(),
-            is_sidecars_stream_terminated: <_>::default(),
-            is_custody_columns_stream_terminated: <_>::default(),
-            request_type,
+            blocks: <_>::default(),
+            blobs: <_>::default(),
+            custody_columns: <_>::default(),
+            is_blocks_stream_terminated: false,
+            is_sidecars_stream_terminated: false,
+            custody_columns_streams_terminated: 0,
+            expects_blobs,
+            expects_custody_columns,
         }
     }
 
-    pub fn get_request_type(&self) -> ByRangeRequestType {
-        self.request_type
+    // TODO: This function should be deprecated when simplying the retry mechanism of this range
+    // requests.
+    pub fn get_requirements(&self) -> (bool, Option<Vec<ColumnIndex>>) {
+        (self.expects_blobs, self.expects_custody_columns.clone())
     }
 
     pub fn add_block_response(&mut self, block_opt: Option<Arc<SignedBeaconBlock<E>>>) {
         match block_opt {
-            Some(block) => self.accumulated_blocks.push_back(block),
+            Some(block) => self.blocks.push_back(block),
             None => self.is_blocks_stream_terminated = true,
         }
     }
 
     pub fn add_sidecar_response(&mut self, sidecar_opt: Option<Arc<BlobSidecar<E>>>) {
         match sidecar_opt {
-            Some(sidecar) => self.accumulated_sidecars.push_back(sidecar),
+            Some(sidecar) => self.blobs.push_back(sidecar),
             None => self.is_sidecars_stream_terminated = true,
         }
     }
 
     pub fn add_custody_column(&mut self, column_opt: Option<CustodyDataColumn<E>>) {
         match column_opt {
-            Some(column) => self.accumulated_custody_columns.push_back(column),
-            None => self.is_custody_columns_stream_terminated = true,
+            Some(column) => self.custody_columns.push_back(column),
+            // TODO(das): this mechanism is dangerous, if somehow there are two requests for the
+            // same column index it can terminate early. This struct should track that all requests
+            // for all custody columns terminate.
+            None => self.custody_columns_streams_terminated += 1,
         }
     }
 
     pub fn into_responses(self) -> Result<Vec<RpcBlock<E>>, String> {
-        let BlocksAndBlobsRequestInfo {
-            accumulated_blocks,
-            accumulated_sidecars,
-            ..
-        } = self;
+        if let Some(expects_custody_columns) = self.expects_custody_columns.clone() {
+            self.into_responses_with_custody_columns(expects_custody_columns)
+        } else {
+            self.into_responses_with_blobs()
+        }
+    }
+
+    fn into_responses_with_blobs(self) -> Result<Vec<RpcBlock<E>>, String> {
+        let RangeBlockComponentsRequest { blocks, blobs, .. } = self;
 
         // There can't be more more blobs than blocks. i.e. sending any blob (empty
         // included) for a skipped slot is not permitted.
-        let mut responses = Vec::with_capacity(accumulated_blocks.len());
-        let mut blob_iter = accumulated_sidecars.into_iter().peekable();
-        for block in accumulated_blocks.into_iter() {
+        let mut responses = Vec::with_capacity(blocks.len());
+        let mut blob_iter = blobs.into_iter().peekable();
+        for block in blocks.into_iter() {
             let mut blob_list = Vec::with_capacity(E::max_blobs_per_block());
             while {
                 let pair_next_blob = blob_iter
@@ -108,27 +120,116 @@ impl<E: EthSpec> BlocksAndBlobsRequestInfo<E> {
         Ok(responses)
     }
 
+    fn into_responses_with_custody_columns(
+        self,
+        expects_custody_columns: Vec<ColumnIndex>,
+    ) -> Result<Vec<RpcBlock<E>>, String> {
+        let RangeBlockComponentsRequest {
+            blocks,
+            custody_columns,
+            ..
+        } = self;
+
+        // Group data columns by block_root and index
+        let mut custody_columns_by_block =
+            HashMap::<Hash256, HashMap<ColumnIndex, CustodyDataColumn<E>>>::new();
+
+        for column in custody_columns {
+            let block_root = column.as_data_column().block_root();
+            let index = column.index();
+            if custody_columns_by_block
+                .entry(block_root)
+                .or_default()
+                .insert(index, column)
+                .is_some()
+            {
+                return Err(format!(
+                    "Repeated column block_root {block_root:?} index {index}"
+                ));
+            }
+        }
+
+        // Now iterate all blocks ensuring that the block roots of each block and data column match,
+        // plus we have columns for our custody requirements
+        let mut rpc_blocks = Vec::with_capacity(blocks.len());
+
+        for block in blocks {
+            let block_root = get_block_root(&block);
+            rpc_blocks.push(if block.num_expected_blobs() > 0 {
+                let Some(mut custody_columns_by_index) =
+                    custody_columns_by_block.remove(&block_root)
+                else {
+                    // This PR ignores the fix from https://github.com/sigp/lighthouse/pull/5675
+                    // which allows blobs to not match blocks.
+                    // TODO(das): on the initial version of PeerDAS the beacon chain does not check
+                    // rpc custody requirements and dropping this check can allow the block to have
+                    // an inconsistent DB.
+                    return Err(format!("No columns for block {block_root:?} with data"));
+                };
+
+                let mut custody_columns = vec![];
+                for index in &expects_custody_columns {
+                    let Some(custody_column) = custody_columns_by_index.remove(index) else {
+                        return Err(format!("No column for block {block_root:?} index {index}"));
+                    };
+                    custody_columns.push(custody_column);
+                }
+
+                // Assert that there are no columns left
+                if !custody_columns_by_index.is_empty() {
+                    let remaining_indices = custody_columns_by_index.keys().collect::<Vec<_>>();
+                    return Err(format!(
+                        "Not all columns consumed for block {block_root:?}: {remaining_indices:?}"
+                    ));
+                }
+
+                RpcBlock::new_with_custody_columns(Some(block_root), block, custody_columns)
+                    .map_err(|e| format!("{e:?}"))?
+            } else {
+                RpcBlock::new_without_blobs(Some(block_root), block)
+            });
+        }
+
+        // Assert that there are no columns left for other blocks
+        if !custody_columns_by_block.is_empty() {
+            let remaining_roots = custody_columns_by_block.keys().collect::<Vec<_>>();
+            return Err(format!("Not all columns consumed: {remaining_roots:?}"));
+        }
+
+        Ok(rpc_blocks)
+    }
+
     pub fn is_finished(&self) -> bool {
-        let blobs_requested = matches!(self.request_type, ByRangeRequestType::BlocksAndBlobs);
-        let custody_columns_requested =
-            matches!(self.request_type, ByRangeRequestType::BlocksAndColumns);
-        self.is_blocks_stream_terminated
-            && (!blobs_requested || self.is_sidecars_stream_terminated)
-            && (!custody_columns_requested || self.is_custody_columns_stream_terminated)
+        if !self.is_blocks_stream_terminated {
+            return false;
+        }
+        if self.expects_blobs && !self.is_sidecars_stream_terminated {
+            return false;
+        }
+        if let Some(expects_custody_columns) = &self.expects_custody_columns {
+            if self.custody_columns_streams_terminated < expects_custody_columns.len() {
+                return false;
+            }
+        }
+        true
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::BlocksAndBlobsRequestInfo;
-    use crate::sync::range_sync::ByRangeRequestType;
-    use beacon_chain::test_utils::{generate_rand_block_and_blobs, NumBlobs};
+    use super::RangeBlockComponentsRequest;
+    use beacon_chain::{
+        data_column_verification::CustodyDataColumn,
+        test_utils::{
+            generate_rand_block_and_blobs, generate_rand_block_and_data_columns, NumBlobs,
+        },
+    };
     use rand::SeedableRng;
     use types::{test_utils::XorShiftRng, ForkName, MinimalEthSpec as E};
 
     #[test]
     fn no_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::Blocks);
+        let mut info = RangeBlockComponentsRequest::<E>::new(false, None);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| generate_rand_block_and_blobs::<E>(ForkName::Base, NumBlobs::None, &mut rng).0)
@@ -147,7 +248,7 @@ mod tests {
 
     #[test]
     fn empty_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::BlocksAndBlobs);
+        let mut info = RangeBlockComponentsRequest::<E>::new(true, None);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| {
@@ -168,6 +269,62 @@ mod tests {
         // This makes sure we don't expect blobs here when they have expired. Checking this logic should
         // be hendled elsewhere.
         assert!(info.is_finished());
+        info.into_responses().unwrap();
+    }
+
+    #[test]
+    fn rpc_block_with_custody_columns() {
+        let expects_custody_columns = vec![1, 2, 3, 4];
+        let mut info =
+            RangeBlockComponentsRequest::<E>::new(false, Some(expects_custody_columns.clone()));
+        let mut rng = XorShiftRng::from_seed([42; 16]);
+        let blocks = (0..4)
+            .map(|_| {
+                generate_rand_block_and_data_columns::<E>(
+                    ForkName::Deneb,
+                    NumBlobs::Number(1),
+                    &mut rng,
+                )
+            })
+            .collect::<Vec<_>>();
+
+        // Send blocks and complete terminate response
+        for block in &blocks {
+            info.add_block_response(Some(block.0.clone().into()));
+        }
+        info.add_block_response(None);
+        // Assert response is not finished
+        assert!(!info.is_finished());
+
+        // Send data columns interleaved
+        for block in &blocks {
+            for column in &block.1 {
+                if expects_custody_columns.contains(&column.index) {
+                    info.add_custody_column(Some(CustodyDataColumn::from_asserted_custody(
+                        column.clone().into(),
+                    )));
+                }
+            }
+        }
+
+        // Terminate the requests
+        for (i, _column_index) in expects_custody_columns.iter().enumerate() {
+            info.add_custody_column(None);
+
+            if i < expects_custody_columns.len() - 1 {
+                assert!(
+                    !info.is_finished(),
+                    "requested should not be finished at loop {i}"
+                );
+            } else {
+                assert!(
+                    info.is_finished(),
+                    "request should be finishied at loop {i}"
+                );
+            }
+        }
+
+        // All completed construct response
         info.into_responses().unwrap();
     }
 }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -47,7 +47,7 @@ use crate::status::ToStatusMessage;
 use crate::sync::block_lookups::{
     BlobRequestState, BlockComponent, BlockRequestState, CustodyRequestState, DownloadResult,
 };
-use crate::sync::block_sidecar_coupling::BlocksAndBlobsRequestInfo;
+use crate::sync::block_sidecar_coupling::RangeBlockComponentsRequest;
 use crate::sync::network_context::PeerGroup;
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::block_verification_types::RpcBlock;
@@ -1135,7 +1135,10 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     self.network.insert_range_blocks_and_blobs_request(
                         id,
                         resp.sender_id,
-                        BlocksAndBlobsRequestInfo::new(resp.request_type),
+                        RangeBlockComponentsRequest::new(
+                            resp.expects_blobs,
+                            resp.expects_custody_columns,
+                        ),
                     );
                     // inform range that the request needs to be treated as failed
                     // With time we will want to downgrade this log

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -9,7 +9,7 @@ use self::requests::{
 pub use self::requests::{
     BlobsByRootSingleBlockRequest, BlocksByRootSingleRequest, DataColumnsByRootSingleBlockRequest,
 };
-use super::block_sidecar_coupling::BlocksAndBlobsRequestInfo;
+use super::block_sidecar_coupling::RangeBlockComponentsRequest;
 use super::manager::{
     BlockProcessType, DataColumnsByRootRequestId, DataColumnsByRootRequester, Id,
     RequestId as SyncRequestId,
@@ -25,7 +25,7 @@ use beacon_chain::data_column_verification::CustodyDataColumn;
 use beacon_chain::validator_monitor::timestamp_now;
 use beacon_chain::{BeaconChain, BeaconChainTypes, EngineState};
 use fnv::FnvHashMap;
-use lighthouse_network::rpc::methods::BlobsByRangeRequest;
+use lighthouse_network::rpc::methods::{BlobsByRangeRequest, DataColumnsByRangeRequest};
 use lighthouse_network::rpc::{BlocksByRangeRequest, GoodbyeReason, RPCError};
 use lighthouse_network::{
     Client, Eth2Enr, NetworkGlobals, PeerAction, PeerId, ReportSource, Request,
@@ -40,7 +40,7 @@ use tokio::sync::mpsc;
 use types::blob_sidecar::FixedBlobSidecarList;
 use types::{
     BlobSidecar, ColumnIndex, DataColumnSidecar, DataColumnSubnetId, Epoch, EthSpec, Hash256,
-    SignedBeaconBlock,
+    SignedBeaconBlock, Slot,
 };
 
 pub mod custody;
@@ -49,7 +49,8 @@ mod requests;
 pub struct BlocksAndBlobsByRangeResponse<E: EthSpec> {
     pub sender_id: RangeRequestId,
     pub responses: Result<Vec<RpcBlock<E>>, String>,
-    pub request_type: ByRangeRequestType,
+    pub expects_blobs: bool,
+    pub expects_custody_columns: Option<Vec<ColumnIndex>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -129,8 +130,8 @@ pub struct SyncNetworkContext<T: BeaconChainTypes> {
     custody_by_root_requests: FnvHashMap<CustodyRequester, ActiveCustodyRequest<T>>,
 
     /// BlocksByRange requests paired with BlobsByRange
-    range_blocks_and_blobs_requests:
-        FnvHashMap<Id, (RangeRequestId, BlocksAndBlobsRequestInfo<T::EthSpec>)>,
+    range_block_components_requests:
+        FnvHashMap<Id, (RangeRequestId, RangeBlockComponentsRequest<T::EthSpec>)>,
 
     /// Whether the ee is online. If it's not, we don't allow access to the
     /// `beacon_processor_send`.
@@ -179,7 +180,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             blobs_by_root_requests: <_>::default(),
             data_columns_by_root_requests: <_>::default(),
             custody_by_root_requests: <_>::default(),
-            range_blocks_and_blobs_requests: FnvHashMap::default(),
+            range_block_components_requests: FnvHashMap::default(),
             network_beacon_processor,
             chain,
             log,
@@ -253,19 +254,22 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
     }
 
-    /// A blocks by range request for the range sync algorithm.
-    pub fn blocks_by_range_request(
+    /// A blocks by range request sent by the range sync algorithm
+    pub fn block_components_by_range_request(
         &mut self,
         peer_id: PeerId,
         batch_type: ByRangeRequestType,
         request: BlocksByRangeRequest,
+        sender_id: RangeRequestId,
     ) -> Result<Id, &'static str> {
+        let epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
         let id = self.next_id();
-        trace!(
+        debug!(
             self.log,
             "Sending BlocksByRange request";
             "method" => "BlocksByRange",
             "count" => request.count(),
+            "epoch" => epoch,
             "peer" => %peer_id,
         );
         self.send_network_msg(NetworkMessage::SendRequest {
@@ -274,12 +278,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             request_id: RequestId::Sync(SyncRequestId::RangeBlockAndBlobs { id }),
         })?;
 
-        if matches!(batch_type, ByRangeRequestType::BlocksAndBlobs) {
+        let expected_blobs = if matches!(batch_type, ByRangeRequestType::BlocksAndBlobs) {
             debug!(
                 self.log,
                 "Sending BlobsByRange requests";
                 "method" => "BlobsByRange",
                 "count" => request.count(),
+                "epoch" => epoch,
                 "peer" => %peer_id,
             );
 
@@ -292,28 +297,62 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 }),
                 request_id: RequestId::Sync(SyncRequestId::RangeBlockAndBlobs { id }),
             })?;
-        }
+            true
+        } else {
+            false
+        };
 
-        Ok(id)
-    }
+        let expects_custody_columns = if matches!(batch_type, ByRangeRequestType::BlocksAndColumns)
+        {
+            let custody_indexes = self.network_globals().custody_columns(epoch)?;
 
-    /// A blocks by range request sent by the range sync algorithm
-    pub fn blocks_and_blobs_by_range_request(
-        &mut self,
-        peer_id: PeerId,
-        batch_type: ByRangeRequestType,
-        request: BlocksByRangeRequest,
-        sender_id: RangeRequestId,
-    ) -> Result<Id, &'static str> {
-        let id = self.blocks_by_range_request(peer_id, batch_type, request)?;
-        self.range_blocks_and_blobs_requests
-            .insert(id, (sender_id, BlocksAndBlobsRequestInfo::new(batch_type)));
+            for column_index in &custody_indexes {
+                let custody_peer_ids = self.get_custodial_peers(epoch, *column_index);
+                let Some(custody_peer) = custody_peer_ids.first().cloned() else {
+                    // TODO(das): this will be pretty bad UX. To improve we should:
+                    // - Attempt to fetch custody requests first, before requesting blocks
+                    // - Handle the no peers case gracefully, maybe add some timeout and give a few
+                    //   minutes / seconds to the peer manager to locate peers on this subnet before
+                    //   abandoing progress on the chain completely.
+                    return Err("no custody peer");
+                };
+
+                debug!(
+                    self.log,
+                    "Sending DataColumnsByRange requests";
+                    "method" => "DataColumnsByRange",
+                    "count" => request.count(),
+                    "epoch" => epoch,
+                    "index" => column_index,
+                    "peer" => %custody_peer,
+                );
+
+                // Create the blob request based on the blocks request.
+                self.send_network_msg(NetworkMessage::SendRequest {
+                    peer_id: custody_peer,
+                    request: Request::DataColumnsByRange(DataColumnsByRangeRequest {
+                        start_slot: *request.start_slot(),
+                        count: *request.count(),
+                        columns: vec![*column_index],
+                    }),
+                    request_id: RequestId::Sync(SyncRequestId::RangeBlockAndBlobs { id }),
+                })?;
+            }
+
+            Some(custody_indexes)
+        } else {
+            None
+        };
+
+        let info = RangeBlockComponentsRequest::new(expected_blobs, expects_custody_columns);
+        self.range_block_components_requests
+            .insert(id, (sender_id, info));
         Ok(id)
     }
 
     pub fn range_request_failed(&mut self, request_id: Id) -> Option<RangeRequestId> {
         let sender_id = self
-            .range_blocks_and_blobs_requests
+            .range_block_components_requests
             .remove(&request_id)
             .map(|(sender_id, _info)| sender_id);
         if let Some(sender_id) = sender_id {
@@ -337,7 +376,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         request_id: Id,
         block_or_blob: BlockOrBlob<T::EthSpec>,
     ) -> Option<BlocksAndBlobsByRangeResponse<T::EthSpec>> {
-        match self.range_blocks_and_blobs_requests.entry(request_id) {
+        match self.range_block_components_requests.entry(request_id) {
             Entry::Occupied(mut entry) => {
                 let (_, info) = entry.get_mut();
                 match block_or_blob {
@@ -348,11 +387,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 if info.is_finished() {
                     // If the request is finished, dequeue everything
                     let (sender_id, info) = entry.remove();
-                    let request_type = info.get_request_type();
+                    let (expects_blobs, expects_custody_columns) = info.get_requirements();
                     Some(BlocksAndBlobsByRangeResponse {
                         sender_id,
-                        request_type,
                         responses: info.into_responses(),
+                        expects_blobs,
+                        expects_custody_columns,
                     })
                 } else {
                     None
@@ -727,13 +767,18 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             "To deal with alignment with deneb boundaries, batches need to be of just one epoch"
         );
 
-        if let Some(data_availability_boundary) = self.chain.data_availability_boundary() {
-            if epoch >= data_availability_boundary {
-                // TODO(das): After peerdas fork, return `BlocksAndColumns`
-                ByRangeRequestType::BlocksAndBlobs
-            } else {
-                ByRangeRequestType::Blocks
-            }
+        if self
+            .chain
+            .data_availability_checker
+            .data_columns_required_for_epoch(epoch)
+        {
+            ByRangeRequestType::BlocksAndColumns
+        } else if self
+            .chain
+            .data_availability_checker
+            .blobs_required_for_epoch(epoch)
+        {
+            ByRangeRequestType::BlocksAndBlobs
         } else {
             ByRangeRequestType::Blocks
         }
@@ -743,9 +788,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &mut self,
         id: Id,
         sender_id: RangeRequestId,
-        info: BlocksAndBlobsRequestInfo<T::EthSpec>,
+        info: RangeBlockComponentsRequest<T::EthSpec>,
     ) {
-        self.range_blocks_and_blobs_requests
+        self.range_block_components_requests
             .insert(id, (sender_id, info));
     }
 

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -1,4 +1,4 @@
-use crate::sync::manager::{Id, SingleLookupReqId};
+use crate::sync::manager::SingleLookupReqId;
 
 use self::request::ActiveColumnSampleRequest;
 use beacon_chain::data_column_verification::CustodyDataColumn;
@@ -17,11 +17,10 @@ pub struct CustodyId {
     pub column_index: ColumnIndex,
 }
 
+/// Downstream components that perform custody by root requests.
+/// Currently, it's only single block lookups, so not using an enum
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-pub enum CustodyRequester {
-    Lookup(SingleLookupReqId),
-    RangeSync(Id),
-}
+pub struct CustodyRequester(pub SingleLookupReqId);
 
 type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
 

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -109,6 +109,8 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
                 } else {
                     // Peer does not have the requested data.
                     // TODO(das) what to do?
+                    // TODO(das): If the peer is in the lookup peer set it claims to have imported
+                    // the block AND its custody columns. So in this case we can downscore
                     debug!(self.log, "Sampling peer claims to not have the data"; "block_root" => %self.block_root, "column_index" => column_index);
                     // TODO(das) tolerate this failure if you are not sure the block has data
                     request.on_download_success()?;

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -884,7 +884,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     ) -> ProcessingResult {
         if let Some(batch) = self.batches.get_mut(&batch_id) {
             let (request, batch_type) = batch.to_blocks_by_range_request();
-            match network.blocks_and_blobs_by_range_request(
+            match network.block_components_by_range_request(
                 peer,
                 batch_type,
                 request,

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -554,7 +554,7 @@ mod tests {
         ) -> (ChainId, BatchId, Id) {
             if blob_req_opt.is_some() {
                 match block_req {
-                    RequestId::Sync(crate::sync::manager::RequestId::RangeBlockAndBlobs { id }) => {
+                    RequestId::Sync(crate::sync::manager::RequestId::RangeBlockComponents(id)) => {
                         let _ = self
                             .cx
                             .range_block_and_blob_response(id, BlockOrBlob::Block(None));
@@ -570,7 +570,7 @@ mod tests {
                 }
             } else {
                 match block_req {
-                    RequestId::Sync(crate::sync::manager::RequestId::RangeBlockAndBlobs { id }) => {
+                    RequestId::Sync(crate::sync::manager::RequestId::RangeBlockComponents(id)) => {
                         let response = self
                             .cx
                             .range_block_and_blob_response(id, BlockOrBlob::Block(None))


### PR DESCRIPTION
## Issue Addressed

Part of 
- https://github.com/sigp/lighthouse/issues/4983

Allows nodes to fulfill their custody requirements during forward sync and backfill sync.

## Proposed Changes

- Some changes on the boilerplate to follow the same ordering as other protocols (usually by_range first then by_root)

- Update `handle_data_columns_by_range_request` handler to use `terminate_response_stream`

- Rename `BlocksAndBlobsRequestInfo` to `RangeBlockComponentsRequest` and:
  - handle multiple requests of columns
  - new `into_responses_with_custody_columns` function with strict matching to produce `RpcBlocks`

**Note / warning**: Custody lookup sync is able to retry individual column requests. Range sync is not. However both costudy range sync and costudy lookup suffer from:
- Not having peers on a single column of interest is a hard error that will fail the entire request
- Use all connected peers to decide what peer to fetch from, instead of using the set of peers grouped in that batch

