### PR TITLE
Compute on chain aggregate impl

### DIFF
--- a/beacon_node/operation_pool/src/attestation_storage.rs
+++ b/beacon_node/operation_pool/src/attestation_storage.rs
@@ -283,9 +283,7 @@ impl<E: EthSpec> AttestationMap<E> {
         let Some(attestation_map) = self.checkpoint_map.get_mut(&checkpoint_key) else {
             return;
         };
-        for (_, compact_indexed_attestations) in
-            attestation_map.attestations.iter_mut()
-        {
+        for (_, compact_indexed_attestations) in attestation_map.attestations.iter_mut() {
             let unaggregated_attestations = std::mem::take(compact_indexed_attestations);
             let mut aggregated_attestations: Vec<CompactIndexedAttestation<E>> = vec![];
 
@@ -313,7 +311,6 @@ impl<E: EthSpec> AttestationMap<E> {
                     } else {
                         aggregated_attestations.push(committee_attestation);
                     }
-
                 } else {
                     best_attestations_by_committee.insert(
                         committee_attestation.committee_index(),
@@ -321,7 +318,6 @@ impl<E: EthSpec> AttestationMap<E> {
                     );
                 }
             }
-
 
             // TODO(electra): aggregate all the best attestations by committee
             // (use btreemap sort order to get order by committee index)


### PR DESCRIPTION
Added logic to compute the on chain aggregate attestation for electra


`aggregate_across_committees`

iterates through a list of attestations with a shared `Checkpoint`. We then aggregate these attestations by committee. If they are electra attestations we further aggregate via `compute_on_chain_aggregate`
