### PR TITLE
Remove `BlobSidecar` construction and publish after PeerDAS activated

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3006,6 +3006,11 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(BlockError::BlockIsAlreadyKnown(blob.block_root()));
         }
 
+        // No need to process and import blobs beyond the PeerDAS epoch.
+        if self.spec.is_peer_das_enabled_for_epoch(blob.epoch()) {
+            return Err(BlockError::BlobNotRequired(blob.slot()));
+        }
+
         if let Some(event_handler) = self.event_handler.as_ref() {
             if event_handler.has_blob_sidecar_subscribers() {
                 event_handler.register(EventKind::BlobSidecar(SseBlobSidecar::from_blob_sidecar(

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -17,7 +17,9 @@ use ssz_types::VariableList;
 use std::time::Duration;
 use tree_hash::TreeHash;
 use types::blob_sidecar::BlobIdentifier;
-use types::{BeaconStateError, BlobSidecar, EthSpec, Hash256, SignedBeaconBlockHeader, Slot};
+use types::{
+    BeaconStateError, BlobSidecar, Epoch, EthSpec, Hash256, SignedBeaconBlockHeader, Slot,
+};
 
 /// An error occurred while validating a gossip blob.
 #[derive(Debug)]
@@ -230,6 +232,9 @@ impl<T: BeaconChainTypes> GossipVerifiedBlob<T> {
     }
     pub fn slot(&self) -> Slot {
         self.blob.blob.slot()
+    }
+    pub fn epoch(&self) -> Epoch {
+        self.slot().epoch(T::EthSpec::slots_per_epoch())
     }
     pub fn index(&self) -> u64 {
         self.blob.blob.index

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -419,14 +419,14 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     /// Determines the blob requirements for a block. If the block is pre-deneb, no blobs are required.
     /// If the epoch is from prior to the data availability boundary, no blobs are required.
     pub fn blobs_required_for_epoch(&self, epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(epoch) && !self.is_peer_das_enabled_for_epoch(epoch)
+        self.da_check_required_for_epoch(epoch) && !self.spec.is_peer_das_enabled_for_epoch(epoch)
     }
 
     /// Determines the data column requirements for an epoch.
     /// - If the epoch is pre-peerdas, no data columns are required.
     /// - If the epoch is from prior to the data availability boundary, no data columns are required.
     pub fn data_columns_required_for_epoch(&self, epoch: Epoch) -> bool {
-        self.da_check_required_for_epoch(epoch) && self.is_peer_das_enabled_for_epoch(epoch)
+        self.da_check_required_for_epoch(epoch) && self.spec.is_peer_das_enabled_for_epoch(epoch)
     }
 
     /// See `Self::blobs_required_for_epoch`
@@ -437,15 +437,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     /// See `Self::data_columns_required_for_epoch`
     fn data_columns_required_for_block(&self, block: &SignedBeaconBlock<T::EthSpec>) -> bool {
         block.num_expected_blobs() > 0 && self.data_columns_required_for_epoch(block.epoch())
-    }
-
-    /// Returns true if the given epoch is greater than or equal to the `EIP7594_FORK_EPOCH`.
-    fn is_peer_das_enabled_for_epoch(&self, block_epoch: Epoch) -> bool {
-        self.spec
-            .eip7594_fork_epoch
-            .map_or(false, |eip7594_fork_epoch| {
-                block_epoch >= eip7594_fork_epoch
-            })
     }
 
     /// The epoch at which we require a data availability check in block processing.

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -39,7 +39,7 @@ use crate::store::{DBColumn, KeyValueStore};
 use crate::BeaconChainTypes;
 use lru::LruCache;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-use slog::{debug, trace, Logger};
+use slog::{trace, Logger};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
@@ -235,7 +235,7 @@ impl<E: EthSpec> PendingComponents<E> {
     ) -> bool {
         match block_import_requirement {
             BlockImportRequirement::AllBlobs => {
-                debug!(
+                trace!(
                     log,
                     "Checking block and blob importability";
                     "block_root" => %self.block_root,
@@ -250,7 +250,6 @@ impl<E: EthSpec> PendingComponents<E> {
             }
             BlockImportRequirement::CustodyColumns(num_expected_columns) => {
                 let num_received_data_columns = self.num_received_data_columns();
-
                 trace!(
                     log,
                     "Checking block and data column importability";
@@ -790,10 +789,7 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
             .epoch()
             .ok_or(AvailabilityCheckError::UnableToDetermineImportRequirement)?;
 
-        let peer_das_enabled = self
-            .spec
-            .eip7594_fork_epoch
-            .map_or(false, |eip7594_fork_epoch| epoch >= eip7594_fork_epoch);
+        let peer_das_enabled = self.spec.is_peer_das_enabled_for_epoch(epoch);
         if peer_das_enabled {
             Ok(BlockImportRequirement::CustodyColumns(
                 self.custody_column_count,

--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -53,6 +53,11 @@ impl<E: EthSpec> DietAvailabilityPendingExecutedBlock<E> {
             .cloned()
             .unwrap_or_default()
     }
+
+    /// Returns the epoch corresponding to `self.slot()`.
+    pub fn epoch(&self) -> Epoch {
+        self.block.slot().epoch(E::slots_per_epoch())
+    }
 }
 
 /// This LRU cache holds BeaconStates used for block import. If the cache overflows,

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -183,6 +183,10 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
             .collect::<Vec<_>>();
         VariableList::from(blobs)
     });
+    // TODO(das): We could potentially get rid of these conversions and pass `GossipVerified` types
+    // to `publish_block`, i.e. have `GossipVerified` types in `PubsubMessage`?
+    // This saves us from extra code and provides guarantee that published
+    // components are verified.
     let data_cols_opt = gossip_verified_data_columns
         .as_ref()
         .map(|gossip_verified_data_columns| {

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -173,6 +173,10 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
             }
         };
 
+    // TODO(das): We could potentially get rid of these conversions and pass `GossipVerified` types
+    // to `publish_block`, i.e. have `GossipVerified` types in `PubsubMessage`?
+    // This saves us from extra code and provides guarantee that published
+    // components are verified.
     // Clone here, so we can take advantage of the `Arc`. The block in `BlockContents` is not,
     // `Arc`'d but blobs are.
     let block = gossip_verified_block.block.block_cloned();
@@ -183,10 +187,6 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
             .collect::<Vec<_>>();
         VariableList::from(blobs)
     });
-    // TODO(das): We could potentially get rid of these conversions and pass `GossipVerified` types
-    // to `publish_block`, i.e. have `GossipVerified` types in `PubsubMessage`?
-    // This saves us from extra code and provides guarantee that published
-    // components are verified.
     let data_cols_opt = gossip_verified_data_columns
         .as_ref()
         .map(|gossip_verified_data_columns| {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1158,6 +1158,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 );
                 return None;
             }
+            Err(e @ BlockError::BlobNotRequired(_)) => {
+                // TODO(das): penalty not implemented yet as other clients may still send us blobs
+                // during early stage of implementation.
+                debug!(self.log, "Received blobs for slot after PeerDAS epoch from peer";
+                    "error" => %e,
+                    "peer_id" => %peer_id,
+                );
+                self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
+                return None;
+            }
         };
 
         metrics::inc_counter(&metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_VERIFIED_TOTAL);

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -397,6 +397,13 @@ impl ChainSpec {
         }
     }
 
+    /// Returns true if the given epoch is greater than or equal to the `EIP7594_FORK_EPOCH`.
+    pub fn is_peer_das_enabled_for_epoch(&self, block_epoch: Epoch) -> bool {
+        self.eip7594_fork_epoch.map_or(false, |eip7594_fork_epoch| {
+            block_epoch >= eip7594_fork_epoch
+        })
+    }
+
     /// Returns a full `Fork` struct for a given epoch.
     pub fn fork_at_epoch(&self, epoch: Epoch) -> Fork {
         let current_fork_name = self.fork_name_at_epoch(epoch);


### PR DESCRIPTION
## Issue Addressed

- Remove construction and publish of  `BlobSidecars` once PeerDAS is activated. 
  - This also save the proposer some time from computing blob inclusion proofs and verifying blob sidecars when it's no longer necessary. This saves some time when proposing a block after PeerDAS.
- Ignore gossip blobs with a slot greater than peer das activation epoch. We get them because:
  1. we haven't implemented blob subnet unsubscription; 
  2. even after we implement that, we could still get blobs due to subnet unsubscription delay (2 epochs). 
- Fix a bug in `make_available`, where a block is considered available (all columns received), but failed to get imported because the function still expects the blobs to be present.
  - This prevents the import delay and unnecessary blob lookups (hence why we're seeing `Unexpected` error, and unexpected blob lookups)
