### PR TITLE
Fix hot state disk leak

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1382,18 +1382,20 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
         let catchup_timer = metrics::start_timer(&metrics::BLOCK_PROCESSING_CATCHUP_STATE);
 
         // Stage a batch of operations to be completed atomically if this block is imported
-        // successfully. We include the state root of the pre-state, which may be an advanced state
-        // that was stored in the DB with a `temporary` flag.
+        // successfully. If there is a skipped slot, we include the state root of the pre-state,
+        // which may be an advanced state that was stored in the DB with a `temporary` flag.
         let mut state = parent.pre_state;
 
-        let mut confirmed_state_roots = if state.slot() > parent.beacon_block.slot() {
-            // Advanced pre-state. Delete its temporary flag.
-            let pre_state_root = state.update_tree_hash_cache()?;
-            vec![pre_state_root]
-        } else {
-            // Pre state is parent state. It is already stored in the DB without temporary status.
-            vec![]
-        };
+        let mut confirmed_state_roots =
+            if block.slot() > state.slot() && state.slot() > parent.beacon_block.slot() {
+                // Advanced pre-state. Delete its temporary flag.
+                let pre_state_root = state.update_tree_hash_cache()?;
+                vec![pre_state_root]
+            } else {
+                // Pre state is either unadvanced, or should not be stored long-term because there
+                // is no skipped slot between `parent` and `block`.
+                vec![]
+            };
 
         // The block must have a higher slot than its parent.
         if block.slot() <= parent.beacon_block.slot() {

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -703,6 +703,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
         ));
 
         store.do_atomically_with_block_and_blobs_cache(batch)?;
+
+        // Do a quick separate pass to delete obsoleted hot states, usually pre-states from the state
+        // advance which are not canonical due to blocks being applied on top.
+        store.prune_old_hot_states()?;
+
         debug!(log, "Database pruning complete");
 
         Ok(PruningOutcome::Successful {

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2507,7 +2507,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
             if summary.slot <= split.slot {
                 let old = summary.slot < split.slot;
-                let non_canonical = summary.slot == split.slot && state_root != split.state_root;
+                let non_canonical = summary.slot == split.slot
+                    && state_root != split.state_root
+                    && !split.state_root.is_zero();
                 if old || non_canonical {
                     let reason = if old {
                         "old dangling state"


### PR DESCRIPTION
## Issue Addressed

Fix an issue whereby the v5.2.0-RC hot database grows indefinitely.

## Proposed Changes

The main reason for the unbounded growth is the storage of extra hot states.

I accidentally introduced the bug in:

- https://github.com/sigp/lighthouse/pull/5533

In that PR, we added logic to both:

1. Store advanced states in the database with a "temporary flag".
2. Delete temporary flags for advanced states during block processing.

The problem is, we were deleting the temporary flags for _all_ advanced states, when we should have only been doing this at skipped slots. For example, with 2 consecutive blocks at slots `N` and `N + 1` we would store (forever) the advanced pre-state for `N + 1`. Our pruning logic would never delete this state because it was not marked temporary, and it was not found by the `prune_abandoned_forks` logic because it did not lie on any side chains. To fix this bug, we now only delete the temporary flag when a skipped slot occurs.

In addition to this, states with temporary flags were previously only deleted on startup. To allow pruning of these states without restaring, I've ported over some of the state pruning code from full `tree-states`, which iterates the `HotStateSummary`s in the database and deletes all states older than the `split.slot` (or equal to the split slot with a different state root). This is safe even in the case where the split block lies at a slot prior to the split slot, because the database only stores the split slot's _advanced_ (epoch-aligned) state in this case, and we do not risk deleting a canonical state by deleting states with `slot < split.slot`.

Thanks to @antondlr for noticing the state growth on the testnet deployment.