### PR TITLE
PeerDAS spec tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,6 +2158,7 @@ dependencies = [
  "fs2",
  "hex",
  "kzg",
+ "lazy_static",
  "logging",
  "rayon",
  "serde",

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -134,7 +134,7 @@ pub use crate::beacon_block_body::{
 pub use crate::beacon_block_header::BeaconBlockHeader;
 pub use crate::beacon_committee::{BeaconCommittee, OwnedBeaconCommittee};
 pub use crate::beacon_state::{Error as BeaconStateError, *};
-pub use crate::blob_sidecar::{BlobSidecar, BlobSidecarList, BlobsList};
+pub use crate::blob_sidecar::{BlobIdentifier, BlobSidecar, BlobSidecarList, BlobsList};
 pub use crate::bls_to_execution_change::BlsToExecutionChange;
 pub use crate::chain_spec::{ChainSpec, Config, Domain};
 pub use crate::checkpoint::Checkpoint;
@@ -143,7 +143,7 @@ pub use crate::config_and_preset::{
 };
 pub use crate::consolidation::Consolidation;
 pub use crate::contribution_and_proof::ContributionAndProof;
-pub use crate::data_column_sidecar::{ColumnIndex, DataColumnSidecar};
+pub use crate::data_column_sidecar::{ColumnIndex, DataColumnIdentifier, DataColumnSidecar};
 pub use crate::data_column_subnet_id::DataColumnSubnetId;
 pub use crate::deposit::{Deposit, DEPOSIT_TREE_DEPTH};
 pub use crate::deposit_data::DepositData;

--- a/testing/ef_tests/Cargo.toml
+++ b/testing/ef_tests/Cargo.toml
@@ -40,3 +40,4 @@ store = { workspace = true }
 fork_choice = { workspace = true }
 execution_layer = { workspace = true }
 logging = { workspace = true }
+lazy_static = { workspace = true }

--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.4.0-beta.6
+TESTS_TAG := v1.5.0-alpha.2
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -20,6 +20,8 @@ tests_dir_filename = sys.argv[2]
 # following regular expressions, we will assume they are to be ignored (i.e., we are purposefully
 # *not* running the spec tests).
 excluded_paths = [
+    # TODO(das): remove once electra tests are on unstable
+    "tests/.*/electra/",
     # Eth1Block and PowBlock
     #
     # Intentionally omitted, as per https://github.com/sigp/lighthouse/issues/1835
@@ -34,7 +36,7 @@ excluded_paths = [
     # Unused kzg methods
     "tests/.*/.*/kzg/compute_cells",
     "tests/.*/.*/kzg/recover_all_cells",
-    "tests/.*/.*/kzg/verify_cell_kzg_batch",
+    "tests/.*/.*/kzg/verify_cell_kzg_proof",
     # One of the EF researchers likes to pack the tarballs on a Mac
     ".*\.DS_Store.*",
     # More Mac weirdness.

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -41,6 +41,7 @@ excluded_paths = [
     ".*\.DS_Store.*",
     # More Mac weirdness.
     "tests/mainnet/bellatrix/operations/deposit/pyspec_tests/deposit_with_previous_fork_version__valid_ineffective/._meta.yaml",
+    "tests/mainnet/eip7594/networking/get_custody_columns/pyspec_tests/get_custody_columns__short_node_id/._meta.yaml",
     # bls tests are moved to bls12-381-tests directory
     "tests/general/phase0/bls",
     # some bls tests are not included now

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -31,6 +31,10 @@ excluded_paths = [
     "tests/.*/.*/ssz_static/LightClientStore",
     # LightClientSnapshot
     "tests/.*/.*/ssz_static/LightClientSnapshot",
+    # Unused kzg methods
+    "tests/.*/.*/kzg/compute_cells",
+    "tests/.*/.*/kzg/recover_all_cells",
+    "tests/.*/.*/kzg/verify_cell_kzg_batch",
     # One of the EF researchers likes to pack the tarballs on a Mac
     ".*\.DS_Store.*",
     # More Mac weirdness.

--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -77,7 +77,9 @@ pub enum FeatureName {
 
 impl Display for FeatureName {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str("eip7594")
+        match self {
+            FeatureName::Eip7594 => f.write_str("eip7594"),
+        }
     }
 }
 

--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rayon::prelude::*;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 use types::ForkName;
 
@@ -18,6 +18,7 @@ mod fork;
 mod fork_choice;
 mod genesis_initialization;
 mod genesis_validity;
+mod get_custody_columns;
 mod kzg_blob_to_kzg_commitment;
 mod kzg_compute_blob_kzg_proof;
 mod kzg_compute_kzg_proof;
@@ -48,6 +49,7 @@ pub use epoch_processing::*;
 pub use fork::ForkTest;
 pub use genesis_initialization::*;
 pub use genesis_validity::*;
+pub use get_custody_columns::*;
 pub use kzg_blob_to_kzg_commitment::*;
 pub use kzg_compute_blob_kzg_proof::*;
 pub use kzg_compute_kzg_proof::*;
@@ -63,6 +65,16 @@ pub use shuffling::*;
 pub use ssz_generic::*;
 pub use ssz_static::*;
 pub use transition::TransitionTest;
+
+pub enum FeatureName {
+    Eip7594,
+}
+
+impl Display for FeatureName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("eip7594")
+    }
+}
 
 pub trait LoadCase: Sized {
     /// Load the test case from a test case directory.

--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -21,9 +21,11 @@ mod genesis_validity;
 mod get_custody_columns;
 mod kzg_blob_to_kzg_commitment;
 mod kzg_compute_blob_kzg_proof;
+mod kzg_compute_cells_and_kzg_proofs;
 mod kzg_compute_kzg_proof;
 mod kzg_verify_blob_kzg_proof;
 mod kzg_verify_blob_kzg_proof_batch;
+mod kzg_verify_cell_kzg_proof_batch;
 mod kzg_verify_kzg_proof;
 mod merkle_proof_validity;
 mod operations;
@@ -52,9 +54,11 @@ pub use genesis_validity::*;
 pub use get_custody_columns::*;
 pub use kzg_blob_to_kzg_commitment::*;
 pub use kzg_compute_blob_kzg_proof::*;
+pub use kzg_compute_cells_and_kzg_proofs::*;
 pub use kzg_compute_kzg_proof::*;
 pub use kzg_verify_blob_kzg_proof::*;
 pub use kzg_verify_blob_kzg_proof_batch::*;
+pub use kzg_verify_cell_kzg_proof_batch::*;
 pub use kzg_verify_kzg_proof::*;
 pub use merkle_proof_validity::*;
 pub use operations::*;
@@ -66,6 +70,7 @@ pub use ssz_generic::*;
 pub use ssz_static::*;
 pub use transition::TransitionTest;
 
+#[derive(Debug, PartialEq)]
 pub enum FeatureName {
     Eip7594,
 }
@@ -93,6 +98,13 @@ pub trait Case: Debug + Sync {
     ///
     /// Returns `true` by default.
     fn is_enabled_for_fork(_fork_name: ForkName) -> bool {
+        true
+    }
+
+    /// Whether or not this test exists for the given `feature_name`.
+    ///
+    /// Returns `true` by default.
+    fn is_enabled_for_feature(_feature_name: FeatureName) -> bool {
         true
     }
 

--- a/testing/ef_tests/src/cases/get_custody_columns.rs
+++ b/testing/ef_tests/src/cases/get_custody_columns.rs
@@ -1,0 +1,39 @@
+use super::*;
+use ethereum_types::U256;
+use serde::Deserialize;
+use std::marker::PhantomData;
+use types::DataColumnSubnetId;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+pub struct GetCustodyColumns<E: EthSpec> {
+    pub node_id: String,
+    pub custody_subnet_count: u64,
+    pub result: Vec<u64>,
+    #[serde(skip)]
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> LoadCase for GetCustodyColumns<E> {
+    fn load_from_dir(path: &Path, _fork_name: ForkName) -> Result<Self, Error> {
+        decode::yaml_decode_file(path.join("meta.yaml").as_path())
+    }
+}
+
+impl<E: EthSpec> Case for GetCustodyColumns<E> {
+    fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
+        let node_id = U256::from_dec_str(&self.node_id)
+            .map_err(|e| Error::FailedToParseTest(format!("{e:?}")))?;
+        let computed =
+            DataColumnSubnetId::compute_custody_columns::<E>(node_id, self.custody_subnet_count)
+                .collect::<Vec<_>>();
+        let expected = &self.result;
+        if computed == *expected {
+            Ok(())
+        } else {
+            Err(Error::NotEqual(format!(
+                "Got {computed:?}\nExpected {expected:?}"
+            )))
+        }
+    }
+}

--- a/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
+++ b/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
@@ -36,10 +36,8 @@ impl<E: EthSpec> Case for KZGBlobToKZGCommitment<E> {
     }
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
-        let kzg = get_kzg()?;
-
         let commitment = parse_blob::<E>(&self.input.blob).and_then(|blob| {
-            blob_to_kzg_commitment::<E>(&kzg, &blob).map_err(|e| {
+            blob_to_kzg_commitment::<E>(&KZG, &blob).map_err(|e| {
                 Error::InternalError(format!("Failed to compute kzg commitment: {:?}", e))
             })
         });

--- a/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
+++ b/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
@@ -31,6 +31,10 @@ impl<E: EthSpec> Case for KZGBlobToKZGCommitment<E> {
         fork_name == ForkName::Deneb
     }
 
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
+    }
+
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let kzg = get_kzg()?;
 

--- a/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
@@ -43,9 +43,8 @@ impl<E: EthSpec> Case for KZGComputeBlobKZGProof<E> {
             Ok((blob, commitment))
         };
 
-        let kzg = get_kzg()?;
         let proof = parse_input(&self.input).and_then(|(blob, commitment)| {
-            compute_blob_kzg_proof::<E>(&kzg, &blob, commitment)
+            compute_blob_kzg_proof::<E>(&KZG, &blob, commitment)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
@@ -32,6 +32,10 @@ impl<E: EthSpec> Case for KZGComputeBlobKZGProof<E> {
         fork_name == ForkName::Deneb
     }
 
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
+    }
+
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGComputeBlobKZGProofInput| -> Result<_, Error> {
             let blob = parse_blob::<E>(&input.blob)?;

--- a/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::case_result::compare_result;
+use kzg::KzgProof;
+use kzg::{Blob as KzgBlob, Cell};
+use serde::Deserialize;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KZGComputeCellsAndKzgProofsInput {
+    pub blob: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+pub struct KZGComputeCellsAndKZGProofs<E: EthSpec> {
+    pub input: KZGComputeCellsAndKzgProofsInput,
+    pub output: Option<(Vec<String>, Vec<String>)>,
+    #[serde(skip)]
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> LoadCase for KZGComputeCellsAndKZGProofs<E> {
+    fn load_from_dir(path: &Path, _fork_name: ForkName) -> Result<Self, Error> {
+        decode::yaml_decode_file(path.join("data.yaml").as_path())
+    }
+}
+
+impl<E: EthSpec> Case for KZGComputeCellsAndKZGProofs<E> {
+    fn is_enabled_for_fork(fork_name: ForkName) -> bool {
+        fork_name == ForkName::Deneb
+    }
+
+    fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
+        // TODO(das): lazy init Kzg as a static ref
+        let kzg = get_kzg()?;
+        let cells_and_proofs = parse_blob::<E>(&self.input.blob).and_then(|blob| {
+            let blob = KzgBlob::from_bytes(&blob).map_err(|e| {
+                Error::InternalError(format!("Failed to convert blob to kzg blob: {e:?}"))
+            })?;
+            kzg.compute_cells_and_proofs(&blob).map_err(|e| {
+                Error::InternalError(format!("Failed to compute cells and kzg proofs: {e:?}"))
+            })
+        });
+
+        let expected = self.output.as_ref().and_then(|(cells, proofs)| {
+            parse_cells_and_proofs::<E>(cells, proofs)
+                .map(|(cells, proofs)| {
+                    (
+                        cells
+                            .try_into()
+                            .map_err(|e| {
+                                Error::FailedToParseTest(format!("Failed to parse cells: {e:?}"))
+                            })
+                            .unwrap(),
+                        proofs
+                            .try_into()
+                            .map_err(|e| {
+                                Error::FailedToParseTest(format!("Failed to parse proofs: {e:?}"))
+                            })
+                            .unwrap(),
+                    )
+                })
+                .ok()
+        });
+
+        compare_result::<(Box<[Cell; 128]>, Box<[KzgProof; 128]>), _>(&cells_and_proofs, &expected)
+    }
+}

--- a/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
@@ -39,6 +39,10 @@ impl<E: EthSpec> Case for KZGComputeKZGProof<E> {
         fork_name == ForkName::Deneb
     }
 
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
+    }
+
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGComputeKZGProofInput| -> Result<_, Error> {
             let blob = parse_blob::<E>(&input.blob)?;

--- a/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
@@ -50,9 +50,8 @@ impl<E: EthSpec> Case for KZGComputeKZGProof<E> {
             Ok((blob, z))
         };
 
-        let kzg = get_kzg()?;
         let proof = parse_input(&self.input).and_then(|(blob, z)| {
-            compute_kzg_proof::<E>(&kzg, &blob, z)
+            compute_kzg_proof::<E>(&KZG, &blob, z)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::case_result::compare_result;
 use beacon_chain::kzg_utils::validate_blob;
 use eth2_network_config::TRUSTED_SETUP_BYTES;
-use kzg::{Error as KzgError, Kzg, KzgCommitment, KzgProof, TrustedSetup};
+use kzg::{Cell, Error as KzgError, Kzg, KzgCommitment, KzgProof, TrustedSetup};
 use serde::Deserialize;
 use std::marker::PhantomData;
 use types::Blob;
@@ -12,6 +12,33 @@ pub fn get_kzg() -> Result<Kzg, Error> {
         .map_err(|e| Error::InternalError(format!("Failed to initialize kzg: {:?}", e)))?;
     Kzg::new_from_trusted_setup(trusted_setup)
         .map_err(|e| Error::InternalError(format!("Failed to initialize kzg: {:?}", e)))
+}
+
+// TODO(das) `EthSpec` can be removed once KZG lib exposes the `BytesPerCell` constant.
+pub fn parse_cells_and_proofs<E: EthSpec>(
+    cells: &Vec<String>,
+    proofs: &Vec<String>,
+) -> Result<(Vec<Cell>, Vec<KzgProof>), Error> {
+    let cells = cells
+        .iter()
+        .map(|s| parse_cell::<E>(s.as_str()))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    let proofs = proofs
+        .iter()
+        .map(|s| parse_proof(s.as_str()))
+        .collect::<Result<Vec<_>, Error>>()?;
+
+    Ok((cells, proofs))
+}
+
+pub fn parse_cell<E: EthSpec>(cell: &str) -> Result<Cell, Error> {
+    hex::decode(strip_0x(cell)?)
+        .map_err(|e| Error::FailedToParseTest(format!("Failed to parse cell: {:?}", e)))
+        .and_then(|bytes| {
+            Cell::from_bytes(bytes.as_ref())
+                .map_err(|e| Error::FailedToParseTest(format!("Failed to parse proof: {:?}", e)))
+        })
 }
 
 pub fn parse_proof(proof: &str) -> Result<KzgProof, Error> {
@@ -78,6 +105,10 @@ impl<E: EthSpec> LoadCase for KZGVerifyBlobKZGProof<E> {
 impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
     fn is_enabled_for_fork(fork_name: ForkName) -> bool {
         fork_name == ForkName::Deneb
+    }
+
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
     }
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -20,8 +20,8 @@ lazy_static! {
 }
 
 pub fn parse_cells_and_proofs(
-    cells: &Vec<String>,
-    proofs: &Vec<String>,
+    cells: &[String],
+    proofs: &[String],
 ) -> Result<(Vec<Cell>, Vec<KzgProof>), Error> {
     let cells = cells
         .iter()

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -57,12 +57,10 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
             Ok((commitments, blobs, proofs))
         };
 
-        let kzg = get_kzg()?;
-
         let result =
             parse_input(&self.input).and_then(
                 |(commitments, blobs, proofs)| match validate_blobs::<E>(
-                    &kzg,
+                    &KZG,
                     &commitments,
                     blobs.iter().collect(),
                     &proofs,

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -33,6 +33,10 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
         fork_name == ForkName::Deneb
     }
 
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
+    }
+
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGVerifyBlobKZGProofBatchInput| -> Result<_, Error> {
             let blobs = input

--- a/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
@@ -1,0 +1,78 @@
+use super::*;
+use crate::case_result::compare_result;
+use kzg::{Bytes48, Error as KzgError};
+use serde::Deserialize;
+use std::marker::PhantomData;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct KZGVerifyCellKZGProofBatchInput {
+    pub row_commitments: Vec<String>,
+    pub row_indices: Vec<usize>,
+    pub column_indices: Vec<usize>,
+    pub cells: Vec<String>,
+    pub proofs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+pub struct KZGVerifyCellKZGProofBatch<E: EthSpec> {
+    pub input: KZGVerifyCellKZGProofBatchInput,
+    pub output: Option<bool>,
+    #[serde(skip)]
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> LoadCase for KZGVerifyCellKZGProofBatch<E> {
+    fn load_from_dir(path: &Path, _fork_name: ForkName) -> Result<Self, Error> {
+        decode::yaml_decode_file(path.join("data.yaml").as_path())
+    }
+}
+
+impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
+    fn is_enabled_for_fork(fork_name: ForkName) -> bool {
+        fork_name == ForkName::Deneb
+    }
+
+    fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
+        let parse_input = |input: &KZGVerifyCellKZGProofBatchInput| -> Result<_, Error> {
+            let (cells, proofs) = parse_cells_and_proofs::<E>(&input.cells, &input.proofs)?;
+            let row_commitments = input
+                .row_commitments
+                .iter()
+                .map(|s| parse_commitment(s))
+                .collect::<Result<Vec<_>, _>>()?;
+            let coordinates = input
+                .row_indices
+                .iter()
+                .zip(&input.column_indices)
+                .map(|(&row, &col)| (row as u64, col as u64))
+                .collect::<Vec<_>>();
+
+            Ok((cells, proofs, coordinates, row_commitments))
+        };
+
+        let kzg = get_kzg()?;
+
+        let result =
+            parse_input(&self.input).and_then(|(cells, proofs, coordinates, commitments)| {
+                let proofs: Vec<Bytes48> = proofs.iter().map(|&proof| proof.into()).collect();
+                let commitments: Vec<Bytes48> = commitments.iter().map(|&c| c.into()).collect();
+                match kzg.verify_cell_proof_batch(
+                    cells.as_slice(),
+                    &proofs,
+                    &coordinates,
+                    &commitments,
+                ) {
+                    Ok(_) => Ok(true),
+                    Err(KzgError::KzgVerificationFailed) => Ok(false),
+                    Err(e) => Err(Error::InternalError(format!(
+                        "Failed to validate cells: {:?}",
+                        e
+                    ))),
+                }
+            });
+
+        compare_result::<bool, _>(&result, &self.output)
+    }
+}

--- a/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
@@ -36,7 +36,7 @@ impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGVerifyCellKZGProofBatchInput| -> Result<_, Error> {
-            let (cells, proofs) = parse_cells_and_proofs::<E>(&input.cells, &input.proofs)?;
+            let (cells, proofs) = parse_cells_and_proofs(&input.cells, &input.proofs)?;
             let row_commitments = input
                 .row_commitments
                 .iter()
@@ -52,13 +52,11 @@ impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
             Ok((cells, proofs, coordinates, row_commitments))
         };
 
-        let kzg = get_kzg()?;
-
         let result =
             parse_input(&self.input).and_then(|(cells, proofs, coordinates, commitments)| {
                 let proofs: Vec<Bytes48> = proofs.iter().map(|&proof| proof.into()).collect();
                 let commitments: Vec<Bytes48> = commitments.iter().map(|&c| c.into()).collect();
-                match kzg.verify_cell_proof_batch(
+                match KZG.verify_cell_proof_batch(
                     cells.as_slice(),
                     &proofs,
                     &coordinates,

--- a/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
@@ -33,6 +33,10 @@ impl<E: EthSpec> Case for KZGVerifyKZGProof<E> {
         fork_name == ForkName::Deneb
     }
 
+    fn is_enabled_for_feature(feature_name: FeatureName) -> bool {
+        feature_name != FeatureName::Eip7594
+    }
+
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGVerifyKZGProofInput| -> Result<_, Error> {
             let commitment = parse_commitment(&input.commitment)?;

--- a/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
@@ -46,9 +46,8 @@ impl<E: EthSpec> Case for KZGVerifyKZGProof<E> {
             Ok((commitment, z, y, proof))
         };
 
-        let kzg = get_kzg()?;
         let result = parse_input(&self.input).and_then(|(commitment, z, y, proof)| {
-            verify_kzg_proof::<E>(&kzg, commitment, proof, z, y)
+            verify_kzg_proof::<E>(&KZG, commitment, proof, z, y)
                 .map_err(|e| Error::InternalError(format!("Failed to validate proof: {:?}", e)))
         });
 

--- a/testing/ef_tests/src/lib.rs
+++ b/testing/ef_tests/src/lib.rs
@@ -1,10 +1,10 @@
 pub use case_result::CaseResult;
 pub use cases::WithdrawalsPayload;
 pub use cases::{
-    Case, EffectiveBalanceUpdates, Eth1DataReset, HistoricalRootsUpdate, HistoricalSummariesUpdate,
-    InactivityUpdates, JustificationAndFinalization, ParticipationFlagUpdates,
-    ParticipationRecordUpdates, RandaoMixesReset, RegistryUpdates, RewardsAndPenalties, Slashings,
-    SlashingsReset, SyncCommitteeUpdates,
+    Case, EffectiveBalanceUpdates, Eth1DataReset, FeatureName, HistoricalRootsUpdate,
+    HistoricalSummariesUpdate, InactivityUpdates, JustificationAndFinalization,
+    ParticipationFlagUpdates, ParticipationRecordUpdates, RandaoMixesReset, RegistryUpdates,
+    RewardsAndPenalties, Slashings, SlashingsReset, SyncCommitteeUpdates,
 };
 pub use decode::log_file_access;
 pub use error::Error;

--- a/testing/ef_tests/src/type_name.rs
+++ b/testing/ef_tests/src/type_name.rs
@@ -1,5 +1,4 @@
 //! Mapping from types to canonical string identifiers used in testing.
-use types::blob_sidecar::BlobIdentifier;
 use types::historical_summary::HistoricalSummary;
 use types::*;
 
@@ -52,7 +51,9 @@ type_name_generic!(BeaconBlockBodyDeneb, "BeaconBlockBody");
 type_name!(BeaconBlockHeader);
 type_name_generic!(BeaconState);
 type_name!(BlobIdentifier);
+type_name!(DataColumnIdentifier);
 type_name_generic!(BlobSidecar);
+type_name_generic!(DataColumnSidecar);
 type_name!(Checkpoint);
 type_name_generic!(ContributionAndProof);
 type_name!(Deposit);

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -214,10 +214,11 @@ macro_rules! ssz_static_test_no_run {
 
 #[cfg(feature = "fake_crypto")]
 mod ssz_static {
-    use ef_tests::{Handler, SszStaticHandler, SszStaticTHCHandler, SszStaticWithSpecHandler};
-    use types::blob_sidecar::BlobIdentifier;
+    use ef_tests::{
+        FeatureName, Handler, SszStaticHandler, SszStaticTHCHandler, SszStaticWithSpecHandler,
+    };
     use types::historical_summary::HistoricalSummary;
-    use types::{LightClientBootstrapAltair, *};
+    use types::*;
 
     ssz_static_test!(aggregate_and_proof, AggregateAndProof<_>);
     ssz_static_test!(attestation, Attestation<_>);
@@ -515,6 +516,22 @@ mod ssz_static {
     fn historical_summary() {
         SszStaticHandler::<HistoricalSummary, MinimalEthSpec>::capella_and_later().run();
         SszStaticHandler::<HistoricalSummary, MainnetEthSpec>::capella_and_later().run();
+    }
+
+    #[test]
+    fn data_column_sidecar() {
+        SszStaticHandler::<DataColumnSidecar<MinimalEthSpec>, MinimalEthSpec>::deneb_only()
+            .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+        SszStaticHandler::<DataColumnSidecar<MainnetEthSpec>, MainnetEthSpec>::deneb_only()
+            .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+    }
+
+    #[test]
+    fn data_column_identifier() {
+        SszStaticHandler::<DataColumnIdentifier, MinimalEthSpec>::deneb_only()
+            .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+        SszStaticHandler::<DataColumnIdentifier, MainnetEthSpec>::deneb_only()
+            .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
     }
 }
 

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -751,3 +751,12 @@ fn get_custody_columns() {
     GetCustodyColumnsHandler::<MainnetEthSpec>::default().run_for_feature(FeatureName::Eip7594);
     GetCustodyColumnsHandler::<MinimalEthSpec>::default().run_for_feature(FeatureName::Eip7594);
 }
+
+#[test]
+#[cfg(feature = "fake_crypto")]
+fn kzg_inclusion_merkle_proof_validity_eip7594() {
+    KzgInclusionMerkleProofValidityHandler::<MainnetEthSpec>::default()
+        .run_for_feature(FeatureName::Eip7594);
+    KzgInclusionMerkleProofValidityHandler::<MinimalEthSpec>::default()
+        .run_for_feature(FeatureName::Eip7594);
+}

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -745,3 +745,9 @@ fn rewards() {
         RewardsHandler::<MainnetEthSpec>::new(handler).run();
     }
 }
+
+#[test]
+fn get_custody_columns() {
+    GetCustodyColumnsHandler::<MainnetEthSpec>::default().run_for_feature(FeatureName::Eip7594);
+    GetCustodyColumnsHandler::<MinimalEthSpec>::default().run_for_feature(FeatureName::Eip7594);
+}

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -751,12 +751,3 @@ fn get_custody_columns() {
     GetCustodyColumnsHandler::<MainnetEthSpec>::default().run_for_feature(FeatureName::Eip7594);
     GetCustodyColumnsHandler::<MinimalEthSpec>::default().run_for_feature(FeatureName::Eip7594);
 }
-
-#[test]
-#[cfg(feature = "fake_crypto")]
-fn kzg_inclusion_merkle_proof_validity_eip7594() {
-    KzgInclusionMerkleProofValidityHandler::<MainnetEthSpec>::default()
-        .run_for_feature(FeatureName::Eip7594);
-    KzgInclusionMerkleProofValidityHandler::<MinimalEthSpec>::default()
-        .run_for_feature(FeatureName::Eip7594);
-}

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -727,6 +727,18 @@ fn kzg_verify_kzg_proof() {
 }
 
 #[test]
+fn kzg_compute_cells_and_proofs() {
+    KZGComputeCellsAndKZGProofHandler::<MainnetEthSpec>::default()
+        .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+}
+
+#[test]
+fn kzg_verify_cell_proof_batch() {
+    KZGVerifyCellKZGProofBatchHandler::<MainnetEthSpec>::default()
+        .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+}
+
+#[test]
 fn merkle_proof_validity() {
     MerkleProofValidityHandler::<MainnetEthSpec>::default().run();
 }
@@ -748,6 +760,8 @@ fn rewards() {
 
 #[test]
 fn get_custody_columns() {
-    GetCustodyColumnsHandler::<MainnetEthSpec>::default().run_for_feature(FeatureName::Eip7594);
-    GetCustodyColumnsHandler::<MinimalEthSpec>::default().run_for_feature(FeatureName::Eip7594);
+    GetCustodyColumnsHandler::<MainnetEthSpec>::default()
+        .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
+    GetCustodyColumnsHandler::<MinimalEthSpec>::default()
+        .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);
 }


### PR DESCRIPTION
## Issue Addressed

Part of #4983.

- Add PeerDAS spec tests
- Fix overflow and ordering in `get_custody_columns` function
- Load KZG only once to speed up tests
