### PR TITLE
PeerDAS spec tests

### DIFF
--- a/testing/ef_tests/src/cases.rs
+++ b/testing/ef_tests/src/cases.rs
@@ -1,6 +1,6 @@
 use super::*;
 use rayon::prelude::*;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display, Formatter};
 use std::path::{Path, PathBuf};
 use types::ForkName;
 
@@ -18,6 +18,7 @@ mod fork;
 mod fork_choice;
 mod genesis_initialization;
 mod genesis_validity;
+mod get_custody_columns;
 mod kzg_blob_to_kzg_commitment;
 mod kzg_compute_blob_kzg_proof;
 mod kzg_compute_kzg_proof;
@@ -48,6 +49,7 @@ pub use epoch_processing::*;
 pub use fork::ForkTest;
 pub use genesis_initialization::*;
 pub use genesis_validity::*;
+pub use get_custody_columns::*;
 pub use kzg_blob_to_kzg_commitment::*;
 pub use kzg_compute_blob_kzg_proof::*;
 pub use kzg_compute_kzg_proof::*;
@@ -63,6 +65,16 @@ pub use shuffling::*;
 pub use ssz_generic::*;
 pub use ssz_static::*;
 pub use transition::TransitionTest;
+
+pub enum FeatureName {
+    Eip7594,
+}
+
+impl Display for FeatureName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("eip7594")
+    }
+}
 
 pub trait LoadCase: Sized {
     /// Load the test case from a test case directory.

--- a/testing/ef_tests/src/cases/get_custody_columns.rs
+++ b/testing/ef_tests/src/cases/get_custody_columns.rs
@@ -1,0 +1,39 @@
+use super::*;
+use ethereum_types::U256;
+use serde::Deserialize;
+use std::marker::PhantomData;
+use types::DataColumnSubnetId;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(bound = "E: EthSpec", deny_unknown_fields)]
+pub struct GetCustodyColumns<E: EthSpec> {
+    pub node_id: String,
+    pub custody_subnet_count: u64,
+    pub result: Vec<u64>,
+    #[serde(skip)]
+    _phantom: PhantomData<E>,
+}
+
+impl<E: EthSpec> LoadCase for GetCustodyColumns<E> {
+    fn load_from_dir(path: &Path, _fork_name: ForkName) -> Result<Self, Error> {
+        decode::yaml_decode_file(path.join("meta.yaml").as_path())
+    }
+}
+
+impl<E: EthSpec> Case for GetCustodyColumns<E> {
+    fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
+        let node_id = U256::from_dec_str(&self.node_id)
+            .map_err(|e| Error::FailedToParseTest(format!("{e:?}")))?;
+        let computed =
+            DataColumnSubnetId::compute_custody_columns::<E>(node_id, self.custody_subnet_count)
+                .collect::<Vec<_>>();
+        let expected = &self.result;
+        if computed == *expected {
+            Ok(())
+        } else {
+            Err(Error::NotEqual(format!(
+                "Got {computed:?}\nExpected {expected:?}"
+            )))
+        }
+    }
+}

--- a/testing/ef_tests/src/lib.rs
+++ b/testing/ef_tests/src/lib.rs
@@ -1,10 +1,10 @@
 pub use case_result::CaseResult;
 pub use cases::WithdrawalsPayload;
 pub use cases::{
-    Case, EffectiveBalanceUpdates, Eth1DataReset, HistoricalRootsUpdate, HistoricalSummariesUpdate,
-    InactivityUpdates, JustificationAndFinalization, ParticipationFlagUpdates,
-    ParticipationRecordUpdates, RandaoMixesReset, RegistryUpdates, RewardsAndPenalties, Slashings,
-    SlashingsReset, SyncCommitteeUpdates,
+    Case, EffectiveBalanceUpdates, Eth1DataReset, FeatureName, HistoricalRootsUpdate,
+    HistoricalSummariesUpdate, InactivityUpdates, JustificationAndFinalization,
+    ParticipationFlagUpdates, ParticipationRecordUpdates, RandaoMixesReset, RegistryUpdates,
+    RewardsAndPenalties, Slashings, SlashingsReset, SyncCommitteeUpdates,
 };
 pub use decode::log_file_access;
 pub use error::Error;

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -745,3 +745,9 @@ fn rewards() {
         RewardsHandler::<MainnetEthSpec>::new(handler).run();
     }
 }
+
+#[test]
+fn get_custody_columns() {
+    GetCustodyColumnsHandler::<MainnetEthSpec>::default().run_for_feature(FeatureName::Eip7594);
+    GetCustodyColumnsHandler::<MinimalEthSpec>::default().run_for_feature(FeatureName::Eip7594);
+}


### PR DESCRIPTION
## Issue Addressed

- Add PeerDAS spec tests
- Fix overflow and ordering in `get_custody_columns` function
