### PR TITLE
Trigger sampling on sync events

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -6830,10 +6830,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// TODO(das): check if the block is still within the da_window
     pub fn should_sample_slot(&self, slot: Slot) -> bool {
         self.spec
-            .eip7594_fork_epoch
-            .map_or(false, |eip7594_fork_epoch| {
-                slot.epoch(T::EthSpec::slots_per_epoch()) >= eip7594_fork_epoch
-            })
+            .is_peer_das_enabled_for_epoch(slot.epoch(T::EthSpec::slots_per_epoch()))
     }
 
     pub fn logger(&self) -> &Logger {

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1225,6 +1225,10 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
     pub fn block_root(&self) -> Hash256 {
         self.block_root
     }
+
+    pub fn slot(&self) -> Slot {
+        self.block.slot()
+    }
 }
 
 impl<T: BeaconChainTypes> IntoExecutionPendingBlock<T> for SignatureVerifiedBlock<T> {

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1362,7 +1362,7 @@ async fn add_base_block_to_altair_chain() {
             )
             .await,
         ChainSegmentResult::Failed {
-            imported_blocks: 0,
+            imported_blocks: vec![],
             error: BlockError::InconsistentFork(InconsistentFork {
                 fork_at_slot: ForkName::Altair,
                 object_fork: ForkName::Base,
@@ -1497,7 +1497,7 @@ async fn add_altair_block_to_base_chain() {
             )
             .await,
         ChainSegmentResult::Failed {
-            imported_blocks: 0,
+            imported_blocks: vec![],
             error: BlockError::InconsistentFork(InconsistentFork {
                 fork_at_slot: ForkName::Base,
                 object_fork: ForkName::Altair,

--- a/beacon_node/beacon_chain/tests/block_verification.rs
+++ b/beacon_node/beacon_chain/tests/block_verification.rs
@@ -1362,7 +1362,7 @@ async fn add_base_block_to_altair_chain() {
             )
             .await,
         ChainSegmentResult::Failed {
-            imported_blocks: vec![],
+            ..
             error: BlockError::InconsistentFork(InconsistentFork {
                 fork_at_slot: ForkName::Altair,
                 object_fork: ForkName::Base,
@@ -1497,7 +1497,7 @@ async fn add_altair_block_to_base_chain() {
             )
             .await,
         ChainSegmentResult::Failed {
-            imported_blocks: vec![],
+            ..
             error: BlockError::InconsistentFork(InconsistentFork {
                 fork_at_slot: ForkName::Base,
                 object_fork: ForkName::Altair,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1278,20 +1278,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let block = verified_block.block.block_cloned();
         let block_root = verified_block.block_root;
 
+        // TODO(das) Might be too early to issue a request here. We haven't checked that the block
+        // actually includes blob transactions and thus has data. A peer could send a block is
+        // garbage commitments, and make us trigger sampling for a block that does not have data.
         if block.num_expected_blobs() > 0 {
             // Trigger sampling for block not yet execution valid. At this point column custodials are
             // unlikely to have received their columns. Triggering sampling so early is only viable with
             // either:
             // - Sync delaying sampling until some latter window
             // - Re-processing early sampling requests: https://github.com/sigp/lighthouse/pull/5569
-            if self
-                .chain
-                .spec
-                .eip7594_fork_epoch
-                .map_or(false, |eip7594_fork_epoch| {
-                    block.epoch() >= eip7594_fork_epoch
-                })
-            {
+            if self.chain.should_sample_slot(block.slot()) {
                 self.send_sync_message(SyncMessage::SampleBlock(block_root, block.slot()));
             }
         }


### PR DESCRIPTION
## Issue Addressed

Currently we only trigger sampling on gossip blocks.

## Proposed Changes

Trigger sampling for blocks:
- Imported on range sync
- Imported on lookup sync
