### PR TITLE
Enforce sync lookup receives a single result

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -2,7 +2,7 @@ use super::common::ResponseType;
 use super::{BlockComponent, PeerId, SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS};
 use crate::sync::block_lookups::common::RequestState;
 use crate::sync::block_lookups::Id;
-use crate::sync::network_context::{LookupRequestResult, SyncNetworkContext};
+use crate::sync::network_context::{LookupRequestResult, ReqId, SyncNetworkContext};
 use beacon_chain::BeaconChainTypes;
 use itertools::Itertools;
 use rand::seq::IteratorRandom;
@@ -41,6 +41,13 @@ pub enum LookupRequestError {
     Failed,
     /// Attempted to retrieve a not known lookup id
     UnknownLookup,
+    /// Received a download result for a different request id than the in-flight request.
+    /// There should only exist a single request at a time. Having multiple requests is a bug and
+    /// can result in undefined state, so it's treated as a hard error and the lookup is dropped.
+    UnexpectedRequestId {
+        expected_req_id: ReqId,
+        req_id: ReqId,
+    },
 }
 
 pub struct SingleBlockLookup<T: BeaconChainTypes> {
@@ -185,7 +192,9 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             };
 
             match request.make_request(id, peer_id, downloaded_block_expected_blobs, cx)? {
-                LookupRequestResult::RequestSent => request.get_state_mut().on_download_start()?,
+                LookupRequestResult::RequestSent(req_id) => {
+                    request.get_state_mut().on_download_start(req_id)?
+                }
                 LookupRequestResult::NoRequestNeeded => {
                     request.get_state_mut().on_completed_request()?
                 }
@@ -272,7 +281,7 @@ pub struct DownloadResult<T: Clone> {
 #[derive(Debug, PartialEq, Eq, IntoStaticStr)]
 pub enum State<T: Clone> {
     AwaitingDownload,
-    Downloading,
+    Downloading(ReqId),
     AwaitingProcess(DownloadResult<T>),
     /// Request is processing, sent by lookup sync
     Processing(DownloadResult<T>),
@@ -355,10 +364,10 @@ impl<T: Clone> SingleLookupRequestState<T> {
     }
 
     /// Switch to `Downloading` if the request is in `AwaitingDownload` state, otherwise returns None.
-    pub fn on_download_start(&mut self) -> Result<(), LookupRequestError> {
+    pub fn on_download_start(&mut self, req_id: ReqId) -> Result<(), LookupRequestError> {
         match &self.state {
             State::AwaitingDownload => {
-                self.state = State::Downloading;
+                self.state = State::Downloading(req_id);
                 Ok(())
             }
             other => Err(LookupRequestError::BadState(format!(
@@ -369,9 +378,15 @@ impl<T: Clone> SingleLookupRequestState<T> {
 
     /// Registers a failure in downloading a block. This might be a peer disconnection or a wrong
     /// block.
-    pub fn on_download_failure(&mut self) -> Result<(), LookupRequestError> {
+    pub fn on_download_failure(&mut self, req_id: ReqId) -> Result<(), LookupRequestError> {
         match &self.state {
-            State::Downloading => {
+            State::Downloading(expected_req_id) => {
+                if req_id != *expected_req_id {
+                    return Err(LookupRequestError::UnexpectedRequestId {
+                        expected_req_id: *expected_req_id,
+                        req_id,
+                    });
+                }
                 self.failed_downloading = self.failed_downloading.saturating_add(1);
                 self.state = State::AwaitingDownload;
                 Ok(())
@@ -384,10 +399,17 @@ impl<T: Clone> SingleLookupRequestState<T> {
 
     pub fn on_download_success(
         &mut self,
+        req_id: ReqId,
         result: DownloadResult<T>,
     ) -> Result<(), LookupRequestError> {
         match &self.state {
-            State::Downloading => {
+            State::Downloading(expected_req_id) => {
+                if req_id != *expected_req_id {
+                    return Err(LookupRequestError::UnexpectedRequestId {
+                        expected_req_id: *expected_req_id,
+                        req_id,
+                    });
+                }
                 self.state = State::AwaitingProcess(result);
                 Ok(())
             }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -819,7 +819,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_single_block_response(id, block) {
             self.block_lookups
                 .on_download_response::<BlockRequestState<T::EthSpec>>(
-                    id.lookup_id,
+                    id,
                     peer_id,
                     resp,
                     &mut self.network,
@@ -861,7 +861,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         if let Some(resp) = self.network.on_single_blob_response(id, blob) {
             self.block_lookups
                 .on_download_response::<BlobRequestState<T::EthSpec>>(
-                    id.lookup_id,
+                    id,
                     peer_id,
                     resp,
                     &mut self.network,

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -81,10 +81,13 @@ impl From<LookupVerifyError> for LookupFailure {
     }
 }
 
+/// Sequential ID that uniquely identifies ReqResp outgoing requests
+pub type ReqId = u32;
+
 pub enum LookupRequestResult {
     /// A request is sent. Sync MUST receive an event from the network in the future for either:
     /// completed response or failed request
-    RequestSent,
+    RequestSent(ReqId),
     /// No request is sent, and no further action is necessary to consider this request completed
     NoRequestNeeded,
     /// No request is sent, but the request is not completed. Sync MUST receive some future event
@@ -341,10 +344,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Ok(LookupRequestResult::Pending);
         }
 
-        let id = SingleLookupReqId {
-            lookup_id,
-            req_id: self.next_id(),
-        };
+        let req_id = self.next_id();
+        let id = SingleLookupReqId { lookup_id, req_id };
 
         debug!(
             self.log,
@@ -366,7 +367,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.blocks_by_root_requests
             .insert(id, ActiveBlocksByRootRequest::new(request));
 
-        Ok(LookupRequestResult::RequestSent)
+        Ok(LookupRequestResult::RequestSent(req_id))
     }
 
     /// Request necessary blobs for `block_root`. Requests only the necessary blobs by checking:
@@ -416,10 +417,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Ok(LookupRequestResult::NoRequestNeeded);
         }
 
-        let id = SingleLookupReqId {
-            lookup_id,
-            req_id: self.next_id(),
-        };
+        let req_id = self.next_id();
+        let id = SingleLookupReqId { lookup_id, req_id };
 
         debug!(
             self.log,
@@ -445,7 +444,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.blobs_by_root_requests
             .insert(id, ActiveBlobsByRootRequest::new(request));
 
-        Ok(LookupRequestResult::RequestSent)
+        Ok(LookupRequestResult::RequestSent(req_id))
     }
 
     pub fn is_execution_engine_online(&self) -> bool {


### PR DESCRIPTION
## Issue Addressed

Current stable lookup requests include an internal request counter to differentiate requests. Because each lookup manages retries and streams it must handle interleaved packets from different requests.

PR removed the need for this internal counter, where network context handles streams and uniquely tags each request
- https://github.com/sigp/lighthouse/pull/5583

However, a bug may break the invariant of 1 request at a time per lookup. If this happens, it will result in undefined behavior.

## Proposed Changes

- Each lookup keeps a unique ID of the current inflight requests.
- If it gets a download result from any other ID, consider it an internal bug and hard error

This change is quite strict but ensures that in the case of duplicate requests, we don't mix errors and results from other requests. The hard error is easy to pick up from metrics (in `sync_lookups_dropped_total{reason = "BadState"}`) and logs.
