### PR TITLE
Log stuck lookups

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -257,6 +257,10 @@ lazy_static! {
         "sync_lookups_completed_total",
         "Total count of sync lookups completed",
     );
+    pub static ref SYNC_LOOKUPS_STUCK: Result<IntGauge> = try_create_int_gauge(
+        "sync_lookups_stuck",
+        "Current count of sync lookups that may be stuck",
+    );
 
     /*
      * Block Delay Metrics

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -678,6 +678,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     }
 
     pub fn log_stuck_lookups(&self) {
+        let mut stuck_count = 0;
         for lookup in self.single_block_lookups.values() {
             if lookup.elapsed_since_created() > Duration::from_secs(LOOKUP_MAX_DURATION_SECS) {
                 debug!(self.log, "Lookup maybe stuck";
@@ -687,7 +688,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                     "block_root" => ?lookup.block_root(),
                     "summary" => ?lookup,
                 );
+                stuck_count += 1;
             }
         }
+        metrics::set_gauge(&metrics::SYNC_LOOKUPS_STUCK, stuck_count);
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -681,6 +681,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         for lookup in self.single_block_lookups.values() {
             if lookup.elapsed_since_created() > Duration::from_secs(LOOKUP_MAX_DURATION_SECS) {
                 debug!(self.log, "Lookup maybe stuck";
+                    // Fields id and block_root are also part of the summary. However, logging them
+                    // here allows log parsers o index them and have better search
                     "id" => lookup.id,
                     "block_root" => ?lookup.block_root(),
                     "summary" => ?lookup,

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -43,7 +43,6 @@ pub enum LookupRequestError {
     UnknownLookup,
 }
 
-#[derive(Debug)]
 pub struct SingleBlockLookup<T: BeaconChainTypes> {
     pub id: Id,
     pub block_request_state: BlockRequestState<T::EthSpec>,
@@ -549,5 +548,19 @@ impl<T: Clone> std::fmt::Debug for State<T> {
             Self::Processing(d) => write!(f, "Processing({:?})", d.peer_id),
             Self::Processed(_) => write!(f, "Processed"),
         }
+    }
+}
+
+// TODO: Manual implementation of Debug, otherwise T must be bounded by Debug
+impl<T: BeaconChainTypes> std::fmt::Debug for SingleBlockLookup<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SingleBlockLookup")
+            .field("id", &self.id)
+            .field("block_root", &self.block_root)
+            .field("awaiting_parent", &self.awaiting_parent)
+            .field("created", &self.created)
+            .field("block_request_state", &self.block_request_state)
+            .field("blob_request_state", &self.blob_request_state)
+            .finish()
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -292,7 +292,7 @@ pub enum State<T: Clone> {
 }
 
 /// Object representing the state of a single block or blob lookup request.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq)]
 pub struct SingleLookupRequestState<T: Clone> {
     /// State of this request.
     state: State<T>,
@@ -562,6 +562,19 @@ impl<T: BeaconChainTypes> std::fmt::Debug for SingleBlockLookup<T> {
             .field("created", &self.created)
             .field("block_request_state", &self.block_request_state)
             .field("blob_request_state", &self.blob_request_state)
+            // Log peers once for block and blob requests as are identical
+            .field("peers", &self.block_request_state.state.available_peers)
+            .finish()
+    }
+}
+
+impl<T: Clone> std::fmt::Debug for SingleLookupRequestState<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("State")
+            .field("state", &self.state)
+            .field("failed_downloading", &self.failed_downloading)
+            .field("failed_processing", &self.failed_processing)
+            // Do not log available peers here, do it once in SingleBlockLookup
             .finish()
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -560,8 +560,8 @@ impl<T: BeaconChainTypes> std::fmt::Debug for SingleBlockLookup<T> {
             .field("block_root", &self.block_root)
             .field("awaiting_parent", &self.awaiting_parent)
             .field("created", &self.created)
-            .field("block_request_state", &self.block_request_state)
-            .field("blob_request_state", &self.blob_request_state)
+            .field("block_request_state", &self.block_request_state.state)
+            .field("blob_request_state", &self.blob_request_state.state)
             // Log peers once for block and blob requests as are identical
             .field("peers", &self.block_request_state.state.available_peers)
             .finish()

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -560,11 +560,11 @@ impl<T: Clone> std::fmt::Display for State<T> {
 impl<T: Clone> std::fmt::Debug for State<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AwaitingDownload => write!(f, "AwaitingDownload"),
+            Self::AwaitingDownload { .. } => write!(f, "AwaitingDownload"),
             Self::Downloading(req_id) => write!(f, "Downloading({:?})", req_id),
             Self::AwaitingProcess(d) => write!(f, "AwaitingProcess({:?})", d.peer_id),
             Self::Processing(d) => write!(f, "Processing({:?})", d.peer_id),
-            Self::Processed(_) => write!(f, "Processed"),
+            Self::Processed { .. } => write!(f, "Processed"),
         }
     }
 }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -576,7 +576,7 @@ impl<T: Clone> std::fmt::Debug for State<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::AwaitingDownload => write!(f, "AwaitingDownload"),
-            Self::Downloading => write!(f, "Downloading"),
+            Self::Downloading(req_id) => write!(f, "Downloading({:?})", req_id),
             Self::AwaitingProcess(d) => write!(f, "AwaitingProcess({:?})", d.peer_id),
             Self::Processing(d) => write!(f, "Processing({:?})", d.peer_id),
             Self::Processed(_) => write!(f, "Processed"),

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -90,6 +90,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.awaiting_parent = None;
     }
 
+    /// Returns the time elapsed since this lookup was created
     pub fn elapsed_since_created(&self) -> Duration {
         self.created.elapsed()
     }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -547,6 +547,8 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             futures::stream::iter(ee_responsiveness_watch.await).flatten()
         };
 
+        let mut interval = tokio::time::interval(Duration::from_secs(10));
+
         // process any inbound messages
         loop {
             tokio::select! {
@@ -555,6 +557,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                 },
                 Some(engine_state) = check_ee_stream.next(), if check_ee => {
                     self.handle_new_execution_engine_state(engine_state);
+                }
+                _ = interval.tick() => {
+                    self.block_lookups.log_stuck_lookups();
                 }
             }
         }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -547,7 +547,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             futures::stream::iter(ee_responsiveness_watch.await).flatten()
         };
 
-        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        // LOOKUP_MAX_DURATION_SECS is 60 seconds. Logging every 30 seconds allows enough timely
+        // visbility while being sparse and not increasing the debug log volume in a noticeable way
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
 
         // process any inbound messages
         loop {


### PR DESCRIPTION
## Issue Addressed

Debugging sync lookup issues that involve a lookup being stuck are very time consuming. To locate which lookup is actually stuck one needs to correlate events from a log indexer and deduce which one has not been dropped.

Then, there's no clear visibility on the state of the lookup. One has to reconstruct the state from a sequence of events, which is possible but very time consuming.

Debugging could be much faster if we knew two things:
- Which lookup is stuck
- What is its internal state

We can expose that data over HTTP API but it's a bit ugly since sync should regularly post this data on a global state. Using metrics is problematic as labeling by block_root would increase the cardinality of metrics too much. So dumping to debug logs is easy to implement, and easy to consume.

## Proposed Changes

- Dump a short summary of all block lookups if they still exist 60 seconds after creation.
- Add metric to track lookups that are older than 60 seconds
