### PR TITLE
Implement unconditional reconstruction for supernodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "c-kzg"
 version = "1.0.2"
-source = "git+https://github.com/ethereum/c-kzg-4844?rev=26d3b4156f7aec477d7e43e6a2334cade6679405#26d3b4156f7aec477d7e43e6a2334cade6679405"
+source = "git+https://github.com/ethereum/c-kzg-4844?rev=114fa0382990e9b74b1f90f3b0dc5f97c2f8a7ad#114fa0382990e9b74b1f90f3b0dc5f97c2f8a7ad"
 dependencies = [
  "blst",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,8 +1131,8 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.0"
-source = "git+https://github.com/ethereum/c-kzg-4844?branch=das#e08f22ef65a5ba4ea808e0d3a9e845fbd6faea2f"
+version = "1.0.2"
+source = "git+https://github.com/ethereum/c-kzg-4844?rev=26d3b4156f7aec477d7e43e6a2334cade6679405#26d3b4156f7aec477d7e43e6a2334cade6679405"
 dependencies = [
  "blst",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 # TODO(das): switch to c-kzg crate before merging back to unstable (and disable default-features) if possible
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", branch = "das" }
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "26d3b4156f7aec477d7e43e6a2334cade6679405" }
 clap = "2"
 compare_fields_derive = { path = "common/compare_fields_derive" }
 criterion = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ bytes = "1"
 # TODO(das): switch to c-kzg crate before merging back to unstable (and disable default-features) if possible
 # Turn off c-kzg's default features which include `blst/portable`. We can turn on blst's portable
 # feature ourselves when desired.
-c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "26d3b4156f7aec477d7e43e6a2334cade6679405" }
+c-kzg = { git = "https://github.com/ethereum/c-kzg-4844", rev = "114fa0382990e9b74b1f90f3b0dc5f97c2f8a7ad" }
 clap = "2"
 compare_fields_derive = { path = "common/compare_fields_derive" }
 criterion = "0.3"

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -799,12 +799,7 @@ fn build_gossip_verified_data_columns<T: BeaconChainTypes>(
             let mut gossip_verified_data_columns = vec![];
             for sidecar in sidecars {
                 let subnet =
-                    DataColumnSubnetId::try_from_column_index::<T::EthSpec>(sidecar.index as usize)
-                        .map_err(|_| {
-                            BlockContentsError::<T::EthSpec>::DataColumnSidecarError(
-                                DataColumnSidecarError::DataColumnIndexOutOfBounds,
-                            )
-                        })?;
+                    DataColumnSubnetId::from_column_index::<T::EthSpec>(sidecar.index as usize);
                 let column = GossipVerifiedDataColumn::new(sidecar, subnet.into(), chain)?;
                 gossip_verified_data_columns.push(column);
             }

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -35,11 +35,14 @@ use crate::block_verification_types::{
 };
 use crate::data_availability_checker::{Availability, AvailabilityCheckError};
 use crate::data_column_verification::{KzgVerifiedCustodyDataColumn, KzgVerifiedDataColumn};
+use crate::kzg_utils::reconstruct_data_columns;
+use crate::metrics;
 use crate::store::{DBColumn, KeyValueStore};
 use crate::BeaconChainTypes;
+use kzg::Kzg;
 use lru::LruCache;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
-use slog::{trace, Logger};
+use slog::{debug, trace, Logger};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use ssz_types::{FixedVector, VariableList};
@@ -48,6 +51,8 @@ use std::{collections::HashSet, sync::Arc};
 use types::blob_sidecar::BlobIdentifier;
 use types::data_column_sidecar::DataColumnIdentifier;
 use types::{BlobSidecar, ChainSpec, ColumnIndex, DataColumnSidecar, Epoch, EthSpec, Hash256};
+
+pub type DataColumnsToPublish<E> = Option<Vec<Arc<DataColumnSidecar<E>>>>;
 
 /// This represents the components of a partially available block
 ///
@@ -230,7 +235,7 @@ impl<E: EthSpec> PendingComponents<E> {
     /// matches the number of expected blobs / custody columns.
     pub fn is_available(
         &self,
-        block_import_requirement: BlockImportRequirement,
+        block_import_requirement: &BlockImportRequirement,
         log: &Logger,
     ) -> bool {
         match block_import_requirement {
@@ -259,7 +264,7 @@ impl<E: EthSpec> PendingComponents<E> {
 
                 if let Some(num_expected_blobs) = self.num_expected_blobs() {
                     // No data columns when there are 0 blobs
-                    num_expected_blobs == 0 || num_expected_columns == num_received_data_columns
+                    num_expected_blobs == 0 || *num_expected_columns == num_received_data_columns
                 } else {
                     false
                 }
@@ -807,13 +812,16 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn put_kzg_verified_data_columns<
         I: IntoIterator<Item = KzgVerifiedCustodyDataColumn<T::EthSpec>>,
     >(
         &self,
+        kzg: &Kzg,
         block_root: Hash256,
         kzg_verified_data_columns: I,
-    ) -> Result<Availability<T::EthSpec>, AvailabilityCheckError> {
+    ) -> Result<(Availability<T::EthSpec>, DataColumnsToPublish<T::EthSpec>), AvailabilityCheckError>
+    {
         let mut write_lock = self.critical.write();
 
         // Grab existing entry or create a new entry.
@@ -825,20 +833,94 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
         pending_components.merge_data_columns(kzg_verified_data_columns)?;
 
         let block_import_requirement = self.block_import_requirement(&pending_components)?;
-        if pending_components.is_available(block_import_requirement, &self.log) {
+
+        // Potentially trigger reconstruction if:
+        // - Our custody requirement is all columns
+        // - We >= 50% of columns
+        let data_columns_to_publish =
+            if self.should_reconstruct(&block_import_requirement, &pending_components) {
+                let timer = metrics::start_timer(&metrics::DATA_AVAILABILITY_RECONSTRUCTION_TIME);
+
+                // Will only return an error if:
+                // - < 50% of columns
+                // - There are duplicates
+                let all_data_columns = reconstruct_data_columns(
+                    kzg,
+                    &pending_components
+                        .verified_data_columns
+                        .iter()
+                        .map(|d| d.clone_arc())
+                        .collect::<Vec<_>>(),
+                )?;
+
+                pending_components.verified_data_columns = all_data_columns
+                    .iter()
+                    .map(|d| {
+                        KzgVerifiedCustodyDataColumn::from_asserted_custody(
+                            KzgVerifiedDataColumn::pinky_promise_trust_me_its_verified(d.clone()),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .into();
+
+                let existing_column_indices = pending_components
+                    .verified_data_columns
+                    .iter()
+                    .map(|d| d.index())
+                    .collect::<HashSet<_>>();
+                let data_columns_to_publish = all_data_columns
+                    .into_iter()
+                    .filter(|d| !existing_column_indices.contains(&d.index))
+                    .collect::<Vec<_>>();
+
+                metrics::stop_timer(timer);
+                metrics::inc_counter_by(
+                    &metrics::DATA_AVAILABILITY_RECONSTRUCTED_COLUMNS,
+                    data_columns_to_publish.len() as u64,
+                );
+                debug!(self.log, "Reconstructed columns"; "count" => data_columns_to_publish.len());
+
+                Some(data_columns_to_publish)
+            } else {
+                None
+            };
+
+        if pending_components.is_available(&block_import_requirement, &self.log) {
             // No need to hold the write lock anymore
             drop(write_lock);
-            pending_components.make_available(&self.spec, |diet_block| {
-                self.state_cache.recover_pending_executed_block(diet_block)
-            })
+            pending_components
+                .make_available(&self.spec, |diet_block| {
+                    self.state_cache.recover_pending_executed_block(diet_block)
+                })
+                .map(|availability| (availability, data_columns_to_publish))
         } else {
             write_lock.put_pending_components(
                 block_root,
                 pending_components,
                 &self.overflow_store,
             )?;
-            Ok(Availability::MissingComponents(block_root))
+            Ok((
+                Availability::MissingComponents(block_root),
+                data_columns_to_publish,
+            ))
         }
+    }
+
+    /// Potentially trigger reconstruction if:
+    /// - Our custody requirement is all columns
+    /// - We >= 50% of columns
+    fn should_reconstruct(
+        &self,
+        block_import_requirement: &BlockImportRequirement,
+        pending_components: &PendingComponents<T::EthSpec>,
+    ) -> bool {
+        let BlockImportRequirement::CustodyColumns(num_expected_columns) = block_import_requirement
+        else {
+            return false;
+        };
+
+        *num_expected_columns == T::EthSpec::number_of_columns()
+            && pending_components.verified_data_columns.len() >= T::EthSpec::number_of_columns() / 2
     }
 
     pub fn put_kzg_verified_blobs<I: IntoIterator<Item = KzgVerifiedBlob<T::EthSpec>>>(
@@ -865,7 +947,7 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
         pending_components.merge_blobs(fixed_blobs);
 
         let block_import_requirement = self.block_import_requirement(&pending_components)?;
-        if pending_components.is_available(block_import_requirement, &self.log) {
+        if pending_components.is_available(&block_import_requirement, &self.log) {
             // No need to hold the write lock anymore
             drop(write_lock);
             pending_components.make_available(&self.spec, |diet_block| {
@@ -905,7 +987,7 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
 
         // Check if we have all components and entire set is consistent.
         let block_import_requirement = self.block_import_requirement(&pending_components)?;
-        if pending_components.is_available(block_import_requirement, &self.log) {
+        if pending_components.is_available(&block_import_requirement, &self.log) {
             // No need to hold the write lock anymore
             drop(write_lock);
             pending_components.make_available(&self.spec, |diet_block| {

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -161,6 +161,9 @@ impl<E: EthSpec> KzgVerifiedDataColumn<E> {
     pub fn new(data_column: Arc<DataColumnSidecar<E>>, kzg: &Kzg) -> Result<Self, KzgError> {
         verify_kzg_for_data_column(data_column, kzg)
     }
+    pub fn pinky_promise_trust_me_its_verified(data: Arc<DataColumnSidecar<E>>) -> Self {
+        Self { data }
+    }
     pub fn to_data_column(self) -> Arc<DataColumnSidecar<E>> {
         self.data
     }

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -1,5 +1,5 @@
 use crate::block_verification::{process_block_slash_info, BlockSlashInfo};
-use crate::kzg_utils::{reconstruct_data_columns, validate_data_column};
+use crate::kzg_utils::validate_data_column;
 use crate::{metrics, BeaconChain, BeaconChainError, BeaconChainTypes};
 use derivative::Derivative;
 use kzg::{Error as KzgError, Kzg};
@@ -242,7 +242,7 @@ impl<E: EthSpec> KzgVerifiedCustodyDataColumn<E> {
         // Will only return an error if:
         // - < 50% of columns
         // - There are duplicates
-        let all_data_columns = reconstruct_data_columns(
+        let all_data_columns = DataColumnSidecar::reconstruct(
             kzg,
             &partial_set_of_columns
                 .iter()

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,7 +1,7 @@
 use kzg::{Blob as KzgBlob, Bytes48, Cell as KzgCell, Error as KzgError, Kzg};
 use std::sync::Arc;
-use types::data_column_sidecar::Cell;
-use types::{Blob, DataColumnSidecar, EthSpec, Hash256, KzgCommitment, KzgProof};
+use types::data_column_sidecar::{Cell, DataColumn};
+use types::{Blob, DataColumnSidecar, EthSpec, Hash256, KzgCommitment, KzgProof, KzgProofs};
 
 /// Converts a blob ssz List object to an array to be used with the kzg
 /// crypto library.
@@ -69,6 +69,102 @@ where
         .collect::<Vec<_>>();
 
     kzg.verify_cell_proof_batch(&cells, &proofs, &coordinates, &commitments)
+}
+
+pub fn reconstruct_data_columns<E: EthSpec>(
+    kzg: &Kzg,
+    data_columns: &[Arc<DataColumnSidecar<E>>],
+) -> Result<Vec<Arc<DataColumnSidecar<E>>>, KzgError> {
+    let mut columns = vec![Vec::with_capacity(E::max_blobs_per_block()); E::number_of_columns()];
+    let mut column_kzg_proofs =
+        vec![Vec::with_capacity(E::max_blobs_per_block()); E::number_of_columns()];
+
+    for col in 0..E::number_of_columns() {
+        let mut cells: Vec<KzgCell> = vec![];
+        let mut cell_ids: Vec<u64> = vec![];
+        for data_column in data_columns {
+            let cell = data_column
+                .column
+                .get(col)
+                .ok_or(KzgError::InconsistentArrayLength(format!(
+                    "Missing data column at index {col}"
+                )))?;
+
+            cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
+            cell_ids.push(data_column.index);
+        }
+        // recover_all_cells does not expect sorted
+        let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
+        let blob = kzg.cells_to_blob(&all_cells)?;
+        // Note: This function computes all cells and proofs. According to Justin this is okay,
+        // computing a partial set may be more expensive and requires code paths that don't exist.
+        // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
+        // for simplicity.
+        let (blob_cells, blob_cell_proofs) = kzg.compute_cells_and_proofs(&blob)?;
+
+        // we iterate over each column, and we construct the column from "top to bottom",
+        // pushing on the cell and the corresponding proof at each column index. we do this for
+        // each blob (i.e. the outer loop).
+        let cell = blob_cells
+            .get(col)
+            .ok_or(KzgError::InconsistentArrayLength(format!(
+                "Missing blob cell at index {col}"
+            )))?;
+        let cell: Vec<u8> = cell
+            .into_inner()
+            .into_iter()
+            .flat_map(|data| (*data).into_iter())
+            .collect();
+        let cell = Cell::<E>::from(cell);
+
+        let proof = blob_cell_proofs
+            .get(col)
+            .ok_or(KzgError::InconsistentArrayLength(format!(
+                "Missing blob cell KZG proof at index {col}"
+            )))?;
+
+        let column = columns
+            .get_mut(col)
+            .ok_or(KzgError::InconsistentArrayLength(format!(
+                "Missing data column at index {col}"
+            )))?;
+        let column_proofs =
+            column_kzg_proofs
+                .get_mut(col)
+                .ok_or(KzgError::InconsistentArrayLength(format!(
+                    "Missing data column proofs at index {col}"
+                )))?;
+
+        column.push(cell);
+        column_proofs.push(*proof);
+    }
+
+    // Clone sidecar elements from existing data column, no need to re-compute
+    let first_data_column = data_columns
+        .first()
+        .ok_or(KzgError::InconsistentArrayLength(
+            "data_columns should have at least one element".to_string(),
+        ))?;
+    let kzg_commitments = &first_data_column.kzg_commitments;
+    let signed_block_header = &first_data_column.signed_block_header;
+    let kzg_commitments_inclusion_proof = &first_data_column.kzg_commitments_inclusion_proof;
+
+    let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
+        .into_iter()
+        .zip(column_kzg_proofs)
+        .enumerate()
+        .map(|(index, (col, proofs))| {
+            Arc::new(DataColumnSidecar {
+                index: index as u64,
+                column: DataColumn::<E>::from(col),
+                kzg_commitments: kzg_commitments.clone(),
+                kzg_proofs: KzgProofs::<E>::from(proofs),
+                signed_block_header: signed_block_header.clone(),
+                kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
+            })
+        })
+        .collect();
+    Ok(sidecars)
 }
 
 /// Validate a batch of blob-commitment-proof triplets from multiple `BlobSidecars`.

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1180,6 +1180,14 @@ lazy_static! {
             "data_availability_overflow_store_cache_size",
             "Number of entries in the data availability overflow store cache."
         );
+    pub static ref DATA_AVAILABILITY_RECONSTRUCTION_TIME: Result<Histogram> = try_create_histogram(
+        "data_availability_reconstruction_time_seconds",
+        "Time taken to reconstruct columns"
+    );
+    pub static ref DATA_AVAILABILITY_RECONSTRUCTED_COLUMNS: Result<IntCounter> = try_create_int_counter(
+        "data_availability_reconstructed_columns_total",
+        "Total count of reconstructed columns"
+    );
 
     /*
     * light_client server metrics

--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -118,12 +118,9 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
                 }
                 if let Some(data_col_sidecars) = data_cols_opt {
                     for data_col in data_col_sidecars {
-                        let subnet = DataColumnSubnetId::try_from_column_index::<T::EthSpec>(
+                        let subnet = DataColumnSubnetId::from_column_index::<T::EthSpec>(
                             data_col.index as usize,
-                        )
-                        .map_err(|e| {
-                            BeaconChainError::UnableToBuildColumnSidecar(format!("{e:?}"))
-                        })?;
+                        );
                         pubsub_messages.push(PubsubMessage::DataColumnSidecar(Box::new((
                             subnet, data_col,
                         ))));

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -179,10 +179,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 messages: data_columns_to_publish
                     .iter()
                     .map(|d| {
-                        let subnet = DataColumnSubnetId::try_from_column_index::<T::EthSpec>(
-                            d.index as usize,
-                        )
-                        .expect("todo");
+                        let subnet =
+                            DataColumnSubnetId::from_column_index::<T::EthSpec>(d.index as usize);
                         PubsubMessage::DataColumnSidecar(Box::new((subnet, d.clone())))
                     })
                     .collect(),

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -4,7 +4,6 @@ use crate::{
     service::NetworkMessage,
     sync::SyncMessage,
 };
-use beacon_chain::blob_verification::{GossipBlobError, GossipVerifiedBlob};
 use beacon_chain::block_verification_types::AsBlock;
 use beacon_chain::data_column_verification::GossipVerifiedDataColumn;
 use beacon_chain::store::Error;
@@ -19,7 +18,13 @@ use beacon_chain::{
     AvailabilityProcessingStatus, BeaconChainError, BeaconChainTypes, BlockError, ForkChoiceError,
     GossipVerifiedBlock, NotifyExecutionLayer,
 };
-use lighthouse_network::{Client, MessageAcceptance, MessageId, PeerAction, PeerId, ReportSource};
+use beacon_chain::{
+    blob_verification::{GossipBlobError, GossipVerifiedBlob},
+    data_availability_checker::DataColumnsToPublish,
+};
+use lighthouse_network::{
+    Client, MessageAcceptance, MessageId, PeerAction, PeerId, PubsubMessage, ReportSource,
+};
 use operation_pool::ReceivedPreCapella;
 use slog::{crit, debug, error, info, trace, warn, Logger};
 use slot_clock::SlotClock;
@@ -163,6 +168,26 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             source: ReportSource::Gossipsub,
             msg,
         })
+    }
+
+    pub(crate) fn handle_data_columns_to_publish(
+        &self,
+        data_columns_to_publish: DataColumnsToPublish<T::EthSpec>,
+    ) {
+        if let Some(data_columns_to_publish) = data_columns_to_publish {
+            self.send_network_message(NetworkMessage::Publish {
+                messages: data_columns_to_publish
+                    .iter()
+                    .map(|d| {
+                        let subnet = DataColumnSubnetId::try_from_column_index::<T::EthSpec>(
+                            d.index as usize,
+                        )
+                        .expect("todo");
+                        PubsubMessage::DataColumnSidecar(Box::new((subnet, d.clone())))
+                    })
+                    .collect(),
+            });
+        }
     }
 
     /// Send a message on `message_tx` that the `message_id` sent by `peer_id` should be propagated on
@@ -890,24 +915,34 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .process_gossip_data_column(verified_data_column)
             .await
         {
-            Ok(AvailabilityProcessingStatus::Imported(block_root)) => {
-                // Note: Reusing block imported metric here
-                metrics::inc_counter(&metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_IMPORTED_TOTAL);
-                info!(
-                    self.log,
-                    "Gossipsub data column processed, imported fully available block";
-                    "block_root" => %block_root
-                );
-                self.chain.recompute_head_at_current_slot().await;
-            }
-            Ok(AvailabilityProcessingStatus::MissingComponents(slot, block_root)) => {
-                trace!(
-                    self.log,
-                    "Processed data column, waiting for other components";
-                    "slot" => %slot,
-                    "data_column_index" => %data_column_index,
-                    "block_root" => %block_root,
-                );
+            Ok((availability, data_columns_to_publish)) => {
+                self.handle_data_columns_to_publish(data_columns_to_publish);
+
+                match availability {
+                    AvailabilityProcessingStatus::Imported(block_root) => {
+                        // Note: Reusing block imported metric here
+                        metrics::inc_counter(
+                            &metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_IMPORTED_TOTAL,
+                        );
+                        info!(
+                            self.log,
+                            "Gossipsub data column processed, imported fully available block";
+                            "block_root" => %block_root
+                        );
+                        self.chain.recompute_head_at_current_slot().await;
+                    }
+                    AvailabilityProcessingStatus::MissingComponents(slot, block_root) => {
+                        trace!(
+                            self.log,
+                            "Processed data column, waiting for other components";
+                            "slot" => %slot,
+                            "data_column_index" => %data_column_index,
+                            "block_root" => %block_root,
+                        );
+
+                        // Potentially trigger reconstruction
+                    }
+                }
             }
             Err(err) => {
                 debug!(

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -9,7 +9,7 @@ use bls::Signature;
 use derivative::Derivative;
 #[cfg_attr(test, double)]
 use kzg::Kzg;
-use kzg::{Blob as KzgBlob, Error as KzgError};
+use kzg::{Blob as KzgBlob, Cell as KzgCell, Error as KzgError};
 use kzg::{KzgCommitment, KzgProof};
 use merkle_proof::MerkleTreeError;
 #[cfg(test)]
@@ -169,6 +169,106 @@ impl<E: EthSpec> DataColumnSidecar<E> {
         Ok(sidecars)
     }
 
+    pub fn reconstruct(kzg: &Kzg, data_columns: &[Arc<Self>]) -> Result<Vec<Arc<Self>>, KzgError> {
+        let mut columns =
+            vec![Vec::with_capacity(E::max_blobs_per_block()); E::number_of_columns()];
+        let mut column_kzg_proofs =
+            vec![Vec::with_capacity(E::max_blobs_per_block()); E::number_of_columns()];
+
+        let first_data_column = data_columns
+            .first()
+            .ok_or(KzgError::InconsistentArrayLength(
+                "data_columns should have at least one element".to_string(),
+            ))?;
+        let num_of_blobs = first_data_column.kzg_commitments.len();
+
+        for row_index in 0..num_of_blobs {
+            let mut cells: Vec<KzgCell> = vec![];
+            let mut cell_ids: Vec<u64> = vec![];
+            for data_column in data_columns {
+                let cell =
+                    data_column
+                        .column
+                        .get(row_index)
+                        .ok_or(KzgError::InconsistentArrayLength(format!(
+                            "Missing data column at index {row_index}"
+                        )))?;
+
+                cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
+                cell_ids.push(data_column.index);
+            }
+            // recover_all_cells does not expect sorted
+            let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
+            let blob = kzg.cells_to_blob(&all_cells)?;
+
+            // Note: This function computes all cells and proofs. According to Justin this is okay,
+            // computing a partial set may be more expensive and requires code paths that don't exist.
+            // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
+            // for simplicity.
+            let (blob_cells, blob_cell_proofs) = kzg.compute_cells_and_proofs(&blob)?;
+
+            // we iterate over each column, and we construct the column from "top to bottom",
+            // pushing on the cell and the corresponding proof at each column index. we do this for
+            // each blob (i.e. the outer loop).
+            for col in 0..E::number_of_columns() {
+                let cell = blob_cells
+                    .get(col)
+                    .ok_or(KzgError::InconsistentArrayLength(format!(
+                        "Missing blob cell at index {col}"
+                    )))?;
+                let cell: Vec<u8> = cell
+                    .into_inner()
+                    .into_iter()
+                    .flat_map(|data| (*data).into_iter())
+                    .collect();
+                let cell = Cell::<E>::from(cell);
+
+                let proof = blob_cell_proofs
+                    .get(col)
+                    .ok_or(KzgError::InconsistentArrayLength(format!(
+                        "Missing blob cell KZG proof at index {col}"
+                    )))?;
+
+                let column = columns
+                    .get_mut(col)
+                    .ok_or(KzgError::InconsistentArrayLength(format!(
+                        "Missing data column at index {col}"
+                    )))?;
+                let column_proofs =
+                    column_kzg_proofs
+                        .get_mut(col)
+                        .ok_or(KzgError::InconsistentArrayLength(format!(
+                            "Missing data column proofs at index {col}"
+                        )))?;
+
+                column.push(cell);
+                column_proofs.push(*proof);
+            }
+        }
+
+        // Clone sidecar elements from existing data column, no need to re-compute
+        let kzg_commitments = &first_data_column.kzg_commitments;
+        let signed_block_header = &first_data_column.signed_block_header;
+        let kzg_commitments_inclusion_proof = &first_data_column.kzg_commitments_inclusion_proof;
+
+        let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
+            .into_iter()
+            .zip(column_kzg_proofs)
+            .enumerate()
+            .map(|(index, (col, proofs))| {
+                Arc::new(DataColumnSidecar {
+                    index: index as u64,
+                    column: DataColumn::<E>::from(col),
+                    kzg_commitments: kzg_commitments.clone(),
+                    kzg_proofs: KzgProofs::<E>::from(proofs),
+                    signed_block_header: signed_block_header.clone(),
+                    kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
+                })
+            })
+            .collect();
+        Ok(sidecars)
+    }
+
     pub fn min_size() -> usize {
         // min size is one cell
         Self {
@@ -271,6 +371,12 @@ pub type DataColumnSidecarList<E> =
     VariableList<Arc<DataColumnSidecar<E>>, <E as EthSpec>::DataColumnCount>;
 pub type FixedDataColumnSidecarList<E> =
     FixedVector<Option<Arc<DataColumnSidecar<E>>>, <E as EthSpec>::DataColumnCount>;
+
+/// Converts a cell ssz List object to an array to be used with the kzg
+/// crypto library.
+fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCell, KzgError> {
+    KzgCell::from_bytes(cell.as_ref()).map_err(Into::into)
+}
 
 #[cfg(test)]
 mod test {

--- a/consensus/types/src/data_column_subnet_id.rs
+++ b/consensus/types/src/data_column_subnet_id.rs
@@ -41,9 +41,12 @@ impl DataColumnSubnetId {
         id.into()
     }
 
-    pub fn try_from_column_index<E: EthSpec>(column_index: usize) -> Result<Self, Error> {
-        let id = column_index.safe_rem(E::data_column_subnet_count())? as u64;
-        Ok(id.into())
+    pub fn from_column_index<E: EthSpec>(column_index: usize) -> Self {
+        (column_index
+            .safe_rem(E::data_column_subnet_count())
+            .expect("data_column_subnet_count should never be zero if this function is called")
+            as u64)
+            .into()
     }
 
     #[allow(clippy::arithmetic_side_effects)]

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -46,6 +46,7 @@ impl Kzg {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
                 &trusted_setup.g2_points(),
+                0,
             )?,
         })
     }
@@ -201,13 +202,12 @@ impl Kzg {
         &self,
         cell_ids: &[u64],
         cells: &[Cell],
-    ) -> Result<[Cell; c_kzg::CELLS_PER_EXT_BLOB], Error> {
-        let all_cells = c_kzg::Cell::recover_all_cells(cell_ids, cells, &self.trusted_setup)?;
-        all_cells.try_into().map_err(|_| {
-            Error::InconsistentArrayLength(
-                "recover_all_cells returned unexpected length".to_string(),
-            )
-        })
+    ) -> Result<Box<[Cell; c_kzg::CELLS_PER_EXT_BLOB]>, Error> {
+        Ok(c_kzg::Cell::recover_all_cells(
+            cell_ids,
+            cells,
+            &self.trusted_setup,
+        )?)
     }
 }
 


### PR DESCRIPTION


Part of
- https://github.com/sigp/lighthouse/issues/4983

After inserting a valid custody data column into the da_checker, if the following conditions are met:
- Custody requirements == all columns
- Count of verified columns >= 50% of columns

Reconstruct all columns, import the block components, and gossip publish the new columns.

This flow is triggered by columns received from gossip and lookup sync.


