### PR TITLE
Subscribe to the correct subnets for electra attestations

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -816,8 +816,7 @@ impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
         committees_per_slot: u64,
         subnet_id: Option<SubnetId>,
         chain: &BeaconChain<T>,
-    ) -> Result<(u64, SubnetId), Error> {
-        // TODO(electra) if we want
+    ) -> Result<(u64, SubnetId), Error> { 
         let expected_subnet_id = SubnetId::compute_subnet_for_attestation::<T::EthSpec>(
             &attestation,
             committees_per_slot,

--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -817,8 +817,9 @@ impl<'a, T: BeaconChainTypes> IndexedUnaggregatedAttestation<'a, T> {
         subnet_id: Option<SubnetId>,
         chain: &BeaconChain<T>,
     ) -> Result<(u64, SubnetId), Error> {
-        let expected_subnet_id = SubnetId::compute_subnet_for_attestation_data::<T::EthSpec>(
-            indexed_attestation.data(),
+        // TODO(electra) if we want
+        let expected_subnet_id = SubnetId::compute_subnet_for_attestation::<T::EthSpec>(
+            &attestation,
             committees_per_slot,
             &chain.spec,
         )

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -1168,8 +1168,8 @@ where
                             agg_sig
                         };
 
-                        let subnet_id = SubnetId::compute_subnet_for_attestation_data::<E>(
-                            attestation.data(),
+                        let subnet_id = SubnetId::compute_subnet_for_attestation::<E>(
+                            &attestation.to_ref(),
                             committee_count,
                             &self.chain.spec,
                         )

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -146,8 +146,8 @@ fn get_valid_unaggregated_attestation<T: BeaconChainTypes>(
         )
         .expect("should sign attestation");
 
-    let subnet_id = SubnetId::compute_subnet_for_attestation_data::<E>(
-        valid_attestation.data(),
+    let subnet_id = SubnetId::compute_subnet_for_attestation::<E>(
+        &valid_attestation.to_ref(),
         head.beacon_state
             .get_committee_count_at_slot(current_slot)
             .expect("should get committee count"),

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -1,5 +1,5 @@
 //! Identifies each shard by an integer identifier.
-use crate::{AttestationData, ChainSpec, CommitteeIndex, Epoch, EthSpec, Slot};
+use crate::{AttestationRef, ChainSpec, CommitteeIndex, Epoch, EthSpec, Slot};
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};
@@ -37,16 +37,16 @@ impl SubnetId {
         id.into()
     }
 
-    /// Compute the subnet for an attestation with `attestation_data` where each slot in the
+    /// Compute the subnet for an attestation where each slot in the
     /// attestation epoch contains `committee_count_per_slot` committees.
-    pub fn compute_subnet_for_attestation_data<E: EthSpec>(
-        attestation_data: &AttestationData,
+    pub fn compute_subnet_for_attestation<E: EthSpec>(
+        attestation: &AttestationRef<E>,
         committee_count_per_slot: u64,
         spec: &ChainSpec,
     ) -> Result<SubnetId, ArithError> {
         Self::compute_subnet::<E>(
-            attestation_data.slot,
-            attestation_data.index,
+            attestation.data().slot,
+            attestation.committee_index(),
             committee_count_per_slot,
             spec,
         )


### PR DESCRIPTION
Attestation subnet subscription logic was using `AttestationData.index` for electra attestations. This PR fixes this by looking at the first set bit in the `committee_bits` field to calculate the correct subnet for electra attestations.
