### PR TITLE
Verify inclusion proof should not be fallible

### DIFF
--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -10,7 +10,6 @@ use crate::block_verification::{
 use crate::kzg_utils::{validate_blob, validate_blobs};
 use crate::{metrics, BeaconChainError};
 use kzg::{Error as KzgError, Kzg, KzgCommitment};
-use merkle_proof::MerkleTreeError;
 use slog::debug;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
@@ -127,13 +126,6 @@ pub enum GossipBlobError<E: EthSpec> {
     ///
     /// The blob sidecar is invalid and the peer is faulty.
     KzgError(kzg::Error),
-
-    /// The kzg commitment inclusion proof failed.
-    ///
-    /// ## Peer scoring
-    ///
-    /// The blob sidecar is invalid
-    InclusionProof(MerkleTreeError),
 
     /// The pubkey cache timed out.
     ///
@@ -459,10 +451,7 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes>(
 
     // Verify the inclusion proof in the sidecar
     let _timer = metrics::start_timer(&metrics::BLOB_SIDECAR_INCLUSION_PROOF_VERIFICATION);
-    if !blob_sidecar
-        .verify_blob_sidecar_inclusion_proof()
-        .map_err(GossipBlobError::InclusionProof)?
-    {
+    if !blob_sidecar.verify_blob_sidecar_inclusion_proof() {
         return Err(GossipBlobError::InvalidInclusionProof);
     }
     drop(_timer);

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -690,7 +690,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     | GossipBlobError::InvalidSubnet { .. }
                     | GossipBlobError::InvalidInclusionProof
                     | GossipBlobError::KzgError(_)
-                    | GossipBlobError::InclusionProof(_)
                     | GossipBlobError::NotFinalizedDescendant { .. } => {
                         warn!(
                             self.log,

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -120,7 +120,7 @@ impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
         if self.request.block_root != block_root {
             return Err(LookupVerifyError::UnrequestedBlockRoot(block_root));
         }
-        if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
+        if !blob.verify_blob_sidecar_inclusion_proof() {
             return Err(LookupVerifyError::InvalidInclusionProof);
         }
         if !self.request.indices.contains(&blob.index) {

--- a/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
+++ b/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
@@ -1,0 +1,96 @@
+use rand::Rng;
+
+use kzg::{KzgCommitment, KzgProof};
+
+use crate::beacon_block_body::KzgCommitments;
+use crate::*;
+
+use super::*;
+
+type BlobsBundle<E> = (KzgCommitments<E>, KzgProofs<E>, BlobsList<E>);
+
+pub fn generate_rand_block_and_blobs<E: EthSpec>(
+    fork_name: ForkName,
+    num_blobs: usize,
+    rng: &mut impl Rng,
+) -> (SignedBeaconBlock<E, FullPayload<E>>, Vec<BlobSidecar<E>>) {
+    let inner = map_fork_name!(fork_name, BeaconBlock, <_>::random_for_test(rng));
+    let mut block = SignedBeaconBlock::from_block(inner, Signature::random_for_test(rng));
+    let mut blob_sidecars = vec![];
+
+    if block.fork_name_unchecked() < ForkName::Deneb {
+        return (block, blob_sidecars);
+    }
+
+    let (commitments, proofs, blobs) = generate_blobs::<E>(num_blobs).unwrap();
+    *block
+        .message_mut()
+        .body_mut()
+        .blob_kzg_commitments_mut()
+        .expect("kzg commitment expected from Deneb") = commitments.clone();
+
+    for (index, ((blob, kzg_commitment), kzg_proof)) in blobs
+        .into_iter()
+        .zip(commitments.into_iter())
+        .zip(proofs.into_iter())
+        .enumerate()
+    {
+        blob_sidecars.push(BlobSidecar {
+            index: index as u64,
+            blob: blob.clone(),
+            kzg_commitment,
+            kzg_proof,
+            signed_block_header: block.signed_block_header(),
+            kzg_commitment_inclusion_proof: block
+                .message()
+                .body()
+                .kzg_commitment_merkle_proof(index)
+                .unwrap(),
+        });
+    }
+    (block, blob_sidecars)
+}
+
+pub fn generate_blobs<E: EthSpec>(n_blobs: usize) -> Result<BlobsBundle<E>, String> {
+    let (mut commitments, mut proofs, mut blobs) = BlobsBundle::<E>::default();
+
+    for blob_index in 0..n_blobs {
+        blobs
+            .push(Blob::<E>::default())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+        commitments
+            .push(KzgCommitment::empty_for_testing())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+        proofs
+            .push(KzgProof::empty())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+    }
+
+    Ok((commitments, proofs, blobs))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::thread_rng;
+
+    #[test]
+    fn test_verify_blob_inclusion_proof() {
+        let (_block, blobs) =
+            generate_rand_block_and_blobs::<MainnetEthSpec>(ForkName::Deneb, 6, &mut thread_rng());
+        for blob in blobs {
+            assert!(blob.verify_blob_sidecar_inclusion_proof());
+        }
+    }
+
+    #[test]
+    fn test_verify_blob_inclusion_proof_invalid() {
+        let (_block, blobs) =
+            generate_rand_block_and_blobs::<MainnetEthSpec>(ForkName::Deneb, 6, &mut thread_rng());
+
+        for mut blob in blobs {
+            blob.kzg_commitment_inclusion_proof = FixedVector::random_for_test(&mut thread_rng());
+            assert!(!blob.verify_blob_sidecar_inclusion_proof());
+        }
+    }
+}

--- a/consensus/types/src/test_utils/mod.rs
+++ b/consensus/types/src/test_utils/mod.rs
@@ -15,6 +15,8 @@ use tree_hash::TreeHash;
 #[macro_use]
 mod macros;
 mod generate_deterministic_keypairs;
+#[cfg(test)]
+mod generate_random_block_and_blobs;
 mod test_random;
 
 pub fn test_ssz_tree_hash_pair<T, U>(v1: &T, v2: &U)


### PR DESCRIPTION
## Issue Addressed

Adding the verify inclusion proof function for data columns I noticed that `verify_blob_sidecar_inclusion_proof` is fallible due to the need to do math with the EthSpec variables.

## Proposed Changes

Since the EthSpec values are non-configurable and properly chosen, it's not necessary to make `verify_blob_sidecar_inclusion_proof` fallible. A unit test in EthSpec ensures that the values are correctly chosen and then we can safely expect.


