### PR TITLE
Skip CI's `test-suite` when the `skip-ci` label is present

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -29,6 +29,31 @@ env:
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
   TEST_FEATURES: portable
 jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    name: Check for 'skip-ci' label
+    outputs:
+      skip_ci: ${{ steps.set-output.outputs.SKIP_CI }}
+    steps:
+     - name: check for skip-ci label
+       id: set-output
+       env:
+         LABELS: ${{ toJson(github.event.pull_request.labels) }}
+       run: |
+         SKIP_CI="false"
+         if [ -z "${LABELS}" ]; then
+           LABELS="none";
+         else
+           LABELS=$(echo ${LABELS} | jq -r '.[].name')
+         fi
+         for label in ${LABELS}; do
+           if [ "$label" = "skip-ci" ]; then
+             SKIP_CI="true"
+             break
+           fi
+         done
+         echo "::set-output name=skip_ci::$SKIP_CI"
+
   target-branch-check:
     name: target-branch-check
     runs-on: ubuntu-latest
@@ -38,6 +63,8 @@ jobs:
           run: test ${{ github.base_ref }} != "stable"
   release-tests-ubuntu:
     name: release-tests-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
@@ -63,6 +90,8 @@ jobs:
       run: sccache --show-stats
   release-tests-windows:
     name: release-tests-windows
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "windows", "CI"]') || 'windows-2019'  }}
     steps:
     - uses: actions/checkout@v4
@@ -97,6 +126,8 @@ jobs:
       run: sccache --show-stats
   beacon-chain-tests:
     name: beacon-chain-tests
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
@@ -117,6 +148,8 @@ jobs:
       run: sccache --show-stats
   op-pool-tests:
     name: op-pool-tests
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -132,6 +165,8 @@ jobs:
       run: make test-op-pool
   network-tests:
     name: network-tests
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -147,6 +182,8 @@ jobs:
       run: make test-network
   slasher-tests:
     name: slasher-tests
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -162,6 +199,8 @@ jobs:
       run: make test-slasher
   debug-tests-ubuntu:
     name: debug-tests-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     env:
@@ -186,6 +225,8 @@ jobs:
       run: sccache --show-stats
   state-transition-vectors-ubuntu:
     name: state-transition-vectors-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -198,6 +239,8 @@ jobs:
       run: make run-state-transition-tests
   ef-tests-ubuntu:
     name: ef-tests-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     # Use self-hosted runners only on the sigp repo.
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     env:
@@ -218,6 +261,8 @@ jobs:
       run: sccache --show-stats
   dockerfile-ubuntu:
     name: dockerfile-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -227,6 +272,8 @@ jobs:
       run: docker run -t lighthouse:local lighthouse --version
   basic-simulator-ubuntu:
     name: basic-simulator-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -239,6 +286,8 @@ jobs:
       run: cargo run --release --bin simulator basic-sim
   fallback-simulator-ubuntu:
     name: fallback-simulator-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -251,6 +300,8 @@ jobs:
       run: cargo run --release --bin simulator fallback-sim
   doppelganger-protection-test:
     name: doppelganger-protection-test
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     env:
       # Enable portable to prevent issues with caching `blst` for the wrong CPU type
@@ -285,6 +336,8 @@ jobs:
           ./doppelganger_protection.sh success genesis.json
   execution-engine-integration-ubuntu:
     name: execution-engine-integration-ubuntu
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "small"]') || 'ubuntu-latest'  }}
     steps:
     - uses: actions/checkout@v4
@@ -344,6 +397,8 @@ jobs:
       run: cargo check --workspace
   cargo-udeps:
     name: cargo-udeps
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -366,6 +421,8 @@ jobs:
       RUSTFLAGS: ""
   compile-with-beta-compiler:
     name: compile-with-beta-compiler
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -377,6 +434,8 @@ jobs:
       run: make
   cli-check:
     name: cli-check
+    needs: [check-labels]
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -391,8 +450,10 @@ jobs:
   # a PR is safe to merge. New jobs should be added here.
   test-suite-success:
     name: test-suite-success
+    if: needs.check-labels.outputs.skip_ci != 'true'
     runs-on: ubuntu-latest
     needs: [
+      'check-labels',
       'target-branch-check',
       'release-tests-ubuntu',
       'release-tests-windows',


### PR DESCRIPTION
## Issue Addressed

This allows to skip CI tests for a WIP branch, to save on resources
To do so, add the `skip-ci` label to a PR and most of the `test-suite` will be skipped. 