### PR TITLE
Re enable precomp table

### DIFF
--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -46,7 +46,8 @@ impl Kzg {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
                 &trusted_setup.g2_points(),
-                0,
+                // Enable precomputed table for 8 bits
+                8,
             )?,
         })
     }


### PR DESCRIPTION
## Issue Addressed

PR
- https://github.com/sigp/lighthouse/pull/5781

does not enable an optimization for peerdas kzg, that doubles the time to compute cells and proofs.

## Proposed Changes

Set to 8 bits, recommended value by Justin
