### PR TITLE
Update subscription filter.

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -240,7 +240,8 @@ impl<AppReqId: ReqId, E: EthSpec> Network<AppReqId, E> {
             let max_topics = ctx.chain_spec.attestation_subnet_count as usize
                 + SYNC_COMMITTEE_SUBNET_COUNT as usize
                 + ctx.chain_spec.blob_sidecar_subnet_count as usize
-                + ctx.chain_spec.data_column_sidecar_subnet_count as usize
+                // TODO: move to chainspec
+                + E::data_column_subnet_count()
                 + BASE_CORE_TOPICS.len()
                 + ALTAIR_CORE_TOPICS.len()
                 + CAPELLA_CORE_TOPICS.len()
@@ -254,11 +255,11 @@ impl<AppReqId: ReqId, E: EthSpec> Network<AppReqId, E> {
                     ctx.chain_spec.attestation_subnet_count,
                     SYNC_COMMITTEE_SUBNET_COUNT,
                     ctx.chain_spec.blob_sidecar_subnet_count,
-                    ctx.chain_spec.data_column_sidecar_subnet_count,
+                    E::data_column_subnet_count() as u64,
                 ),
                 // during a fork we subscribe to both the old and new topics
                 max_subscribed_topics: max_topics * 4,
-                // 162 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics) * 2
+                // 209 in theory = (64 attestation + 4 sync committee + 7 core topics + 6 blob topics + 64 column topics) * 2
                 max_subscriptions_per_request: max_topics * 2,
             };
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -227,7 +227,6 @@ pub struct ChainSpec {
     pub max_request_data_column_sidecars: u64,
     pub min_epochs_for_blob_sidecars_requests: u64,
     pub blob_sidecar_subnet_count: u64,
-    pub data_column_sidecar_subnet_count: u64,
 
     /*
      * Networking Derived
@@ -804,7 +803,6 @@ impl ChainSpec {
             max_request_data_column_sidecars: default_max_request_data_column_sidecars(),
             min_epochs_for_blob_sidecars_requests: default_min_epochs_for_blob_sidecars_requests(),
             blob_sidecar_subnet_count: default_blob_sidecar_subnet_count(),
-            data_column_sidecar_subnet_count: default_data_column_sidecar_subnet_count(),
 
             /*
              * Derived Deneb Specific
@@ -1115,7 +1113,6 @@ impl ChainSpec {
             max_request_data_column_sidecars: default_max_request_data_column_sidecars(),
             min_epochs_for_blob_sidecars_requests: 16384,
             blob_sidecar_subnet_count: default_blob_sidecar_subnet_count(),
-            data_column_sidecar_subnet_count: default_data_column_sidecar_subnet_count(),
 
             /*
              * Derived Deneb Specific
@@ -1316,9 +1313,6 @@ pub struct Config {
     #[serde(default = "default_blob_sidecar_subnet_count")]
     #[serde(with = "serde_utils::quoted_u64")]
     blob_sidecar_subnet_count: u64,
-    #[serde(default = "default_data_column_sidecar_subnet_count")]
-    #[serde(with = "serde_utils::quoted_u64")]
-    data_column_sidecar_subnet_count: u64,
 
     #[serde(default = "default_min_per_epoch_churn_limit_electra")]
     #[serde(with = "serde_utils::quoted_u64")]
@@ -1442,10 +1436,6 @@ const fn default_min_epochs_for_blob_sidecars_requests() -> u64 {
 
 const fn default_blob_sidecar_subnet_count() -> u64 {
     6
-}
-
-const fn default_data_column_sidecar_subnet_count() -> u64 {
-    32
 }
 
 const fn default_min_per_epoch_churn_limit_electra() -> u64 {
@@ -1655,7 +1645,6 @@ impl Config {
             max_request_data_column_sidecars: spec.max_request_data_column_sidecars,
             min_epochs_for_blob_sidecars_requests: spec.min_epochs_for_blob_sidecars_requests,
             blob_sidecar_subnet_count: spec.blob_sidecar_subnet_count,
-            data_column_sidecar_subnet_count: spec.data_column_sidecar_subnet_count,
 
             min_per_epoch_churn_limit_electra: spec.min_per_epoch_churn_limit_electra,
             max_per_epoch_activation_exit_churn_limit: spec
@@ -1729,7 +1718,6 @@ impl Config {
             max_request_data_column_sidecars,
             min_epochs_for_blob_sidecars_requests,
             blob_sidecar_subnet_count,
-            data_column_sidecar_subnet_count,
 
             min_per_epoch_churn_limit_electra,
             max_per_epoch_activation_exit_churn_limit,
@@ -1795,7 +1783,6 @@ impl Config {
             max_request_data_column_sidecars,
             min_epochs_for_blob_sidecars_requests,
             blob_sidecar_subnet_count,
-            data_column_sidecar_subnet_count,
 
             min_per_epoch_churn_limit_electra,
             max_per_epoch_activation_exit_churn_limit,

--- a/consensus/types/src/data_column_subnet_id.rs
+++ b/consensus/types/src/data_column_subnet_id.rs
@@ -204,4 +204,17 @@ mod test {
             }
         }
     }
+
+    #[test]
+    fn test_columns_subnet_conversion() {
+        for subnet in 0..E::data_column_subnet_count() as u64 {
+            let subnet_id = DataColumnSubnetId::new(subnet);
+            for column_index in subnet_id.columns::<E>() {
+                assert_eq!(
+                    subnet_id,
+                    DataColumnSubnetId::from_column_index::<E>(column_index as usize)
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Issue Addressed

I observed that one of the nodes were unable to subscribe to all column subnets after bumping the column subnet count. 

This is due to an outdated subscription filter, and using an incorrect configuration. 

This should fix the constant occurence of "unknown parent for column". 