### PR TITLE
Fix incorrect penalty on duplicate gossip columns

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1013,6 +1013,14 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     }
                 }
             }
+            Err(BlockError::BlockIsAlreadyKnown(_)) => {
+                debug!(
+                    self.log,
+                    "Ignoring gossip column already imported";
+                    "block_root" => ?block_root,
+                    "data_column_index" =>  data_column_index,
+                );
+            }
             Err(err) => {
                 debug!(
                     self.log,
@@ -1026,10 +1034,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     peer_id,
                     PeerAction::MidToleranceError,
                     "bad_gossip_data_column_ssz",
-                );
-                trace!(
-                    self.log,
-                    "Invalid gossip data column ssz";
                 );
             }
         }


### PR DESCRIPTION
## Issue Addressed

Fix incorrect penalty on duplicate gossip columns.

Duplicate columns are expected to happen occasionally due to reconstruction. We should not downscore peers for this.