### PR TITLE
Revert DAS config for interop

### DIFF
--- a/consensus/types/src/data_column_subnet_id.rs
+++ b/consensus/types/src/data_column_subnet_id.rs
@@ -5,7 +5,7 @@ use ethereum_types::U256;
 use itertools::Itertools;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
+use std::collections::HashSet;
 use std::fmt::{self, Display};
 use std::ops::{Deref, DerefMut};
 
@@ -67,7 +67,7 @@ impl DataColumnSubnetId {
         // TODO(das): we could perform check on `custody_subnet_count` here to ensure that it is a valid
         // value, but here we assume it is valid.
 
-        let mut subnets = SmallVec::<[u64; 32]>::new();
+        let mut subnets: HashSet<u64> = HashSet::new();
         let mut current_id = node_id;
         while (subnets.len() as u64) < custody_subnet_count {
             let mut node_id_bytes = [0u8; 32];
@@ -80,7 +80,7 @@ impl DataColumnSubnetId {
             let subnet = hash_prefix_u64 % (E::data_column_subnet_count() as u64);
 
             if !subnets.contains(&subnet) {
-                subnets.push(subnet);
+                subnets.insert(subnet);
             }
 
             if current_id == U256::MAX {

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -429,8 +429,8 @@ impl EthSpec for MainnetEthSpec {
     type BytesPerBlob = U131072;
     type BytesPerCell = U2048;
     type KzgCommitmentInclusionProofDepth = U17;
-    type CustodyRequirement = U4;
-    type DataColumnSidecarSubnetCount = U64;
+    type CustodyRequirement = U1;
+    type DataColumnSidecarSubnetCount = U32;
     type NumberOfColumns = U128;
     type KzgCommitmentsInclusionProofDepth = U4; // inclusion of the whole list of commitments
     type SyncSubcommitteeSize = U128; // 512 committee size / 4 sync committee subnet count
@@ -482,8 +482,8 @@ impl EthSpec for MinimalEthSpec {
     type FieldElementsPerCell = U64;
     type FieldElementsPerExtBlob = U8192;
     type BytesPerCell = U2048;
-    type CustodyRequirement = U4;
-    type DataColumnSidecarSubnetCount = U64;
+    type CustodyRequirement = U1;
+    type DataColumnSidecarSubnetCount = U32;
     type NumberOfColumns = U128;
     type KzgCommitmentsInclusionProofDepth = U4;
 
@@ -575,8 +575,8 @@ impl EthSpec for GnosisEthSpec {
     type FieldElementsPerCell = U64;
     type FieldElementsPerExtBlob = U8192;
     type BytesPerCell = U2048;
-    type CustodyRequirement = U4;
-    type DataColumnSidecarSubnetCount = U64;
+    type CustodyRequirement = U1;
+    type DataColumnSidecarSubnetCount = U32;
     type NumberOfColumns = U128;
     type KzgCommitmentsInclusionProofDepth = U4;
 

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -775,9 +775,7 @@ fn rewards() {
     }
 }
 
-// TODO(das): ignore until new spec test release with column subnet count = 64.
 #[test]
-#[ignore]
 fn get_custody_columns() {
     GetCustodyColumnsHandler::<MainnetEthSpec>::default()
         .run_for_feature(ForkName::Deneb, FeatureName::Eip7594);


### PR DESCRIPTION
## Issue Addressed

PeerDAS config in LH are currently not configurable, and other clients are having trouble with interop testing with LH due to config mismatch. 