### PR TITLE
Suppress RPC Error disconnect log

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1383,14 +1383,21 @@ impl<AppReqId: ReqId, E: EthSpec> Network<AppReqId, E> {
             // Silencing this event breaks the API contract with RPC where every request ends with
             // - A stream termination event, or
             // - An RPCError event
-            if !matches!(event.event, HandlerEvent::Err(HandlerErr::Outbound { .. })) {
+            return if let HandlerEvent::Err(HandlerErr::Outbound {
+                id: RequestId::Application(id),
+                error,
+                ..
+            }) = event.event
+            {
+                Some(NetworkEvent::RPCFailed { peer_id, id, error })
+            } else {
                 debug!(
                     self.log,
                     "Ignoring rpc message of disconnecting peer";
                     event
                 );
-                return None;
-            }
+                None
+            };
         }
 
         let handler_id = event.conn_id;


### PR DESCRIPTION
## Issue Addressed

Debugging das interop, noticed a noisy debug log:

```
May 17 06:12:23.708 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
May 17 06:12:23.708 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
May 17 06:12:23.708 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
May 17 06:12:23.708 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
May 17 06:12:23.708 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
May 17 06:12:23.709 DEBG RPC Error, direction: Outgoing, score: -0.7364966123883209, peer_id: 16Uiu2HAky14JjrYDFhkEjnVW9P8k8ysx87f4LcvzLRrVBnLEkqMU, client: Prysm: version: a1466d26b86470bab79e94c7d553033be4b8530e, os_version: unknown, err: G
racefully Disconnected, protocol: data_column_sidecars_by_root, service: libp2p, module: lighthouse_network::peer_manager:489
```

This log is emitted from the peermanager, and is a consequence of allowing RPCError for disconnected peers through. If a peer disconnects and has 100 active ReqResp request, the log will appear 100 times.

## Proposed Changes

If we allow to propagate the RPCError to the application, do not log it in the peer manager

