### PR TITLE
Multithread compute_cells_and_proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ version = "0.2.0"
 dependencies = [
  "bitvec 1.0.1",
  "bls",
+ "criterion",
  "derivative",
  "environment",
  "eth1",

--- a/beacon_node/beacon_chain/Cargo.toml
+++ b/beacon_node/beacon_chain/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Paul Hauner <paul@paulhauner.com>", "Age Manning <Age@AgeManning.com
 edition = { workspace = true }
 autotests = false # using a single test binary compiles faster
 
+[[bench]]
+name = "benches"
+harness = false
+
 [features]
 default = ["participation_metrics"]
 write_ssz_files = []  # Writes debugging .ssz files to /tmp during block processing.
@@ -17,6 +21,7 @@ test_backfill = []
 maplit = { workspace = true }
 environment = { workspace = true }
 serde_json = { workspace = true }
+criterion = { workspace = true }
 
 [dependencies]
 bitvec = { workspace = true }

--- a/beacon_node/beacon_chain/benches/benches.rs
+++ b/beacon_node/beacon_chain/benches/benches.rs
@@ -1,0 +1,66 @@
+#![allow(deprecated)]
+
+use std::sync::Arc;
+
+use bls::Signature;
+use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Benchmark};
+use eth2_network_config::TRUSTED_SETUP_BYTES;
+use kzg::{Kzg, KzgCommitment, TrustedSetup};
+use types::{
+    beacon_block_body::KzgCommitments, BeaconBlock, BeaconBlockDeneb, Blob, BlobsList, ChainSpec,
+    DataColumnSidecar, EmptyBlock, EthSpec, MainnetEthSpec, SignedBeaconBlock,
+};
+
+fn create_test_block_and_blobs<E: EthSpec>(
+    num_of_blobs: usize,
+    spec: &ChainSpec,
+) -> (SignedBeaconBlock<E>, BlobsList<E>) {
+    let mut block = BeaconBlock::Deneb(BeaconBlockDeneb::empty(spec));
+    let mut body = block.body_mut();
+    let blob_kzg_commitments = body.blob_kzg_commitments_mut().unwrap();
+    *blob_kzg_commitments =
+        KzgCommitments::<E>::new(vec![KzgCommitment::empty_for_testing(); num_of_blobs]).unwrap();
+
+    let signed_block = SignedBeaconBlock::from_block(block, Signature::empty());
+
+    let blobs = (0..num_of_blobs)
+        .map(|_| Blob::<E>::default())
+        .collect::<Vec<_>>()
+        .into();
+
+    (signed_block, blobs)
+}
+
+fn all_benches(c: &mut Criterion) {
+    type E = MainnetEthSpec;
+
+    let trusted_setup: TrustedSetup = serde_json::from_reader(TRUSTED_SETUP_BYTES)
+        .map_err(|e| format!("Unable to read trusted setup file: {}", e))
+        .expect("should have trusted setup");
+    let kzg = Arc::new(Kzg::new_from_trusted_setup(trusted_setup).expect("should create kzg"));
+
+    for blob_count in [1, 2, 3, 6] {
+        let kzg = kzg.clone();
+        let spec = E::default_spec();
+        let (signed_block, blob_sidecars) = create_test_block_and_blobs::<E>(blob_count, &spec);
+
+        let column_sidecars =
+            DataColumnSidecar::build_sidecars(&blob_sidecars, &signed_block, &kzg.clone()).unwrap();
+
+        c.bench(
+            &format!("reconstruct_{}", blob_count),
+            Benchmark::new("kzg/reconstruct", move |b| {
+                b.iter(|| {
+                    black_box(DataColumnSidecar::reconstruct(
+                        &kzg,
+                        &column_sidecars.iter().as_slice()[0..column_sidecars.len() / 2],
+                    ))
+                })
+            }),
+        );
+    }
+}
+
+criterion_group!(benches, all_benches,);
+criterion_main!(benches);

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -14,6 +14,7 @@ use kzg::{KzgCommitment, KzgProof};
 use merkle_proof::verify_merkle_proof;
 #[cfg(test)]
 use mockall_double::double;
+use rayon::prelude::*;
 use safe_arith::ArithError;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
@@ -197,31 +198,35 @@ impl<E: EthSpec> DataColumnSidecar<E> {
             ))?;
         let num_of_blobs = first_data_column.kzg_commitments.len();
 
-        for row_index in 0..num_of_blobs {
-            let mut cells: Vec<KzgCell> = vec![];
-            let mut cell_ids: Vec<u64> = vec![];
-            for data_column in data_columns {
-                let cell =
-                    data_column
-                        .column
-                        .get(row_index)
-                        .ok_or(KzgError::InconsistentArrayLength(format!(
+        let blob_cells_and_proofs_vec = (0..num_of_blobs)
+            .into_par_iter()
+            .map(|row_index| {
+                let mut cells: Vec<KzgCell> = vec![];
+                let mut cell_ids: Vec<u64> = vec![];
+                for data_column in data_columns {
+                    let cell = data_column.column.get(row_index).ok_or(
+                        KzgError::InconsistentArrayLength(format!(
                             "Missing data column at index {row_index}"
-                        )))?;
+                        )),
+                    )?;
 
-                cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
-                cell_ids.push(data_column.index);
-            }
-            // recover_all_cells does not expect sorted
-            let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
-            let blob = kzg.cells_to_blob(&all_cells)?;
+                    cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
+                    cell_ids.push(data_column.index);
+                }
+                // recover_all_cells does not expect sorted
+                let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
+                let blob = kzg.cells_to_blob(&all_cells)?;
 
-            // Note: This function computes all cells and proofs. According to Justin this is okay,
-            // computing a partial set may be more expensive and requires code paths that don't exist.
-            // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
-            // for simplicity.
-            let (blob_cells, blob_cell_proofs) = kzg.compute_cells_and_proofs(&blob)?;
+                // Note: This function computes all cells and proofs. According to Justin this is okay,
+                // computing a partial set may be more expensive and requires code paths that don't exist.
+                // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
+                // for simplicity.
+                let (blob_cells, blob_cell_proofs) = kzg.compute_cells_and_proofs(&blob)?;
+                Ok((blob_cells, blob_cell_proofs))
+            })
+            .collect::<Result<Vec<_>, KzgError>>()?;
 
+        for (blob_cells, blob_cell_proofs) in blob_cells_and_proofs_vec.iter() {
             // we iterate over each column, and we construct the column from "top to bottom",
             // pushing on the cell and the corresponding proof at each column index. we do this for
             // each blob (i.e. the outer loop).

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -46,7 +46,8 @@ impl Kzg {
             trusted_setup: KzgSettings::load_trusted_setup(
                 &trusted_setup.g1_points(),
                 &trusted_setup.g2_points(),
-                // Enable precomputed table for 8 bits
+                // Enable precomputed table for 8 bits, with 96MB of memory overhead per process
+                // Ref: https://notes.ethereum.org/@jtraglia/windowed_multiplications
                 8,
             )?,
         })


### PR DESCRIPTION
## Issue Addressed

`compute_cells_and_proofs` is used for block production and reconstruction. It is easy parallelizable per each blob.

Benchmarks without mutli-thread (current das branch) for [1,2,3,6] blobs, on Macbook air M2 (4 perf cores, 4 efficiency cores):

```
reconstruct_1/kzg/reconstruct
                        time:   [363.17 ms 374.46 ms 385.56 ms]
                        change: [+8.5343% +14.393% +19.741%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  11 (11.00%) low mild
  1 (1.00%) high severe

Benchmarking reconstruct_2/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 78.0s, or reduce sample count to 10.
reconstruct_2/kzg/reconstruct
                        time:   [614.80 ms 638.15 ms 662.23 ms]
                        change: [+85.709% +92.498% +100.30%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking reconstruct_3/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 107.4s, or reduce sample count to 10.
reconstruct_3/kzg/reconstruct
                        time:   [907.64 ms 936.73 ms 965.99 ms]
                        change: [+149.63% +157.49% +165.35%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking reconstruct_6/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 174.1s, or reduce sample count to 10.
reconstruct_6/kzg/reconstruct
                        time:   [1.7883 s 1.8228 s 1.8591 s]
                        change: [+216.92% +231.50% +247.15%] (p = 0.00 < 0.05)
```

Multithreaded (this PR)

```
Benchmarking reconstruct_1/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 30.0s, or reduce sample count to 10.
reconstruct_1/kzg/reconstruct
                        time:   [316.03 ms 327.35 ms 341.87 ms]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking reconstruct_2/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 34.5s, or reduce sample count to 10.
reconstruct_2/kzg/reconstruct
                        time:   [329.55 ms 331.51 ms 333.82 ms]
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

Benchmarking reconstruct_3/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 38.7s, or reduce sample count to 10.
reconstruct_3/kzg/reconstruct
                        time:   [360.20 ms 363.79 ms 367.47 ms]

Benchmarking reconstruct_6/kzg/reconstruct: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 46.5s, or reduce sample count to 10.
reconstruct_6/kzg/reconstruct
                        time:   [527.79 ms 549.86 ms 572.52 ms]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
