### PR TITLE
Avoid reconstructing data columns if we already have all the columns

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -317,6 +317,13 @@ pub enum BlockError<E: EthSpec> {
     ///
     /// This indicates the peer is sending an unexpected gossip blob and should be penalised.
     BlobNotRequired(Slot),
+    /// An internal error has occurred when processing the block or sidecars.
+    ///
+    /// ## Peer scoring
+    ///
+    /// We were unable to process this block due to an internal error. It's unclear if the block is
+    /// valid.
+    InternalError(String),
 }
 
 impl<E: EthSpec> From<AvailabilityCheckError> for BlockError<E> {

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -906,7 +906,7 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
 
     /// Potentially trigger reconstruction if:
     /// - Our custody requirement is all columns
-    /// - We >= 50% of columns
+    /// - We >= 50% of columns, but not all columns
     fn should_reconstruct(
         &self,
         block_import_requirement: &BlockImportRequirement,
@@ -917,9 +917,13 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
             return false;
         };
 
-        !pending_components.reconstruction_started
-            && *num_expected_columns == T::EthSpec::number_of_columns()
-            && pending_components.verified_data_columns.len() >= T::EthSpec::number_of_columns() / 2
+        let num_of_columns = T::EthSpec::number_of_columns();
+        let has_missing_columns = pending_components.verified_data_columns.len() < num_of_columns;
+
+        has_missing_columns
+            && !pending_components.reconstruction_started
+            && *num_expected_columns == num_of_columns
+            && pending_components.verified_data_columns.len() >= num_of_columns / 2
     }
 
     pub fn put_kzg_verified_blobs<I: IntoIterator<Item = KzgVerifiedBlob<T::EthSpec>>>(

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -981,7 +981,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         match self
             .chain
-            .process_gossip_data_column(verified_data_column)
+            .process_gossip_data_columns(vec![verified_data_column])
             .await
         {
             Ok((availability, data_columns_to_publish)) => {
@@ -1262,6 +1262,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Err(e @ BlockError::AvailabilityCheck(_)) => {
                 crit!(self.log, "Internal block gossip validation error. Availability check during
                  gossip validation";
+                    "error" => %e
+                );
+                return None;
+            }
+            Err(e @ BlockError::InternalError(_)) => {
+                error!(self.log, "Internal block gossip validation error";
                     "error" => %e
                 );
                 return None;


### PR DESCRIPTION
## Issue Addressed

For a block proposal from a supernode (subscribe to all data columns), we are already publishing all the columns and there's no need to perform reconstruction