### PR TITLE
Use JSON header by default for `/eth/v1/beacon/deposit_snapshot`

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2121,14 +2121,7 @@ pub fn serve<T: BeaconChainTypes>(
              task_spawner: TaskSpawner<T::EthSpec>,
              eth1_service: eth1::Service| {
                 task_spawner.blocking_response_task(Priority::P1, move || match accept_header {
-                    Some(api_types::Accept::Json) | Some(api_types::Accept::Any) | None => {
-                        let snapshot = eth1_service.get_deposit_snapshot();
-                        Ok(
-                            warp::reply::json(&api_types::GenericResponse::from(snapshot))
-                                .into_response(),
-                        )
-                    }
-                    _ => eth1_service
+                    Some(api_types::Accept::Ssz) => eth1_service
                         .get_deposit_snapshot()
                         .map(|snapshot| {
                             Response::builder()
@@ -2154,6 +2147,13 @@ pub fn serve<T: BeaconChainTypes>(
                                     ))
                                 })
                         }),
+                    _ => {
+                        let snapshot = eth1_service.get_deposit_snapshot();
+                        Ok(
+                            warp::reply::json(&api_types::GenericResponse::from(snapshot))
+                                .into_response(),
+                        )
+                    }
                 })
             },
         );

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2121,7 +2121,7 @@ pub fn serve<T: BeaconChainTypes>(
              task_spawner: TaskSpawner<T::EthSpec>,
              eth1_service: eth1::Service| {
                 task_spawner.blocking_response_task(Priority::P1, move || match accept_header {
-                    Some(api_types::Accept::Json) | None => {
+                    Some(api_types::Accept::Json) | Some(api_types::Accept::Any) | None => {
                         let snapshot = eth1_service.get_deposit_snapshot();
                         Ok(
                             warp::reply::json(&api_types::GenericResponse::from(snapshot))


### PR DESCRIPTION
Most of current Lighthouse beacon API uses JSON by default when the header is not specified in querying the beacon API. The `/eth/v1/beacon/deposit_snapshot` uses SSZ when the header is not specified. This PR changes it to use JSON to be consistent with others.

Thanks @michaelsproul for the guidance.