### PR TITLE
Electra slashing handling

### DIFF
--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -115,6 +115,22 @@ impl<E: EthSpec> IndexedAttestation<E> {
             IndexedAttestation::Electra(att) => att.attesting_indices.first(),
         }
     }
+
+    pub fn to_electra(self) -> Result<IndexedAttestationElectra<E>, ssz_types::Error> {
+        Ok(match self {
+            Self::Base(att) => {
+                let extended_attesting_indices: VariableList<u64, E::MaxValidatorsPerSlot> =
+                    VariableList::new(att.attesting_indices.to_vec())?;
+
+                IndexedAttestationElectra {
+                    attesting_indices: extended_attesting_indices,
+                    data: att.data,
+                    signature: att.signature,
+                }
+            }
+            Self::Electra(att) => att,
+        })
+    }
 }
 
 impl<'a, E: EthSpec> IndexedAttestationRef<'a, E> {

--- a/slasher/src/array.rs
+++ b/slasher/src/array.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use flate2::bufread::{ZlibDecoder, ZlibEncoder};
 use serde::{Deserialize, Serialize};
+use slog::Logger;
 use std::borrow::Borrow;
 use std::collections::{btree_map::Entry, BTreeMap, HashSet};
 use std::io::Read;
@@ -485,6 +486,7 @@ pub fn update<E: EthSpec>(
     batch: Vec<Arc<IndexedAttesterRecord<E>>>,
     current_epoch: Epoch,
     config: &Config,
+    log: &Logger,
 ) -> Result<HashSet<AttesterSlashing<E>>, Error> {
     // Split the batch up into horizontal segments.
     // Map chunk indexes in the range `0..self.config.chunk_size` to attestations
@@ -504,6 +506,7 @@ pub fn update<E: EthSpec>(
         &chunk_attestations,
         current_epoch,
         config,
+        log,
     )?;
     slashings.extend(update_array::<_, MaxTargetChunk>(
         db,
@@ -512,6 +515,7 @@ pub fn update<E: EthSpec>(
         &chunk_attestations,
         current_epoch,
         config,
+        log,
     )?);
 
     // Update all current epochs.
@@ -570,6 +574,7 @@ pub fn update_array<E: EthSpec, T: TargetArrayChunk>(
     chunk_attestations: &BTreeMap<usize, Vec<Arc<IndexedAttesterRecord<E>>>>,
     current_epoch: Epoch,
     config: &Config,
+    log: &Logger,
 ) -> Result<HashSet<AttesterSlashing<E>>, Error> {
     let mut slashings = HashSet::new();
     // Map from chunk index to updated chunk at that index.
@@ -603,8 +608,19 @@ pub fn update_array<E: EthSpec, T: TargetArrayChunk>(
                     current_epoch,
                     config,
                 )?;
-                if let Some(slashing) = slashing_status.into_slashing(&attestation.indexed) {
-                    slashings.insert(slashing);
+                match slashing_status.into_slashing(&attestation.indexed) {
+                    Ok(Some(slashing)) => {
+                        slashings.insert(slashing);
+                    }
+                    Err(e) => {
+                        slog::error!(
+                            log,
+                            "Invalid slashing conversion";
+                            "validator_index" => validator_index,
+                            "error" => e
+                        );
+                    }
+                    Ok(None) => {}
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed

Currently doesn't look like we have attestation slashing handling if we get a surround slashing across forks. So this adds that.
