### PR TITLE
Misc custody lookup improvements

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -699,7 +699,7 @@ impl TestRig {
         let lookup_id = if let DataColumnsByRootRequester::Custody(id) =
             sampling_ids.first().unwrap().0.requester
         {
-            id.id.0.lookup_id
+            id.requester.0.lookup_id
         } else {
             panic!("not a custody requester")
         };

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -658,8 +658,8 @@ impl TestRig {
         data_columns: Vec<Arc<DataColumnSidecar<E>>>,
     ) {
         for id in ids {
+            self.log(&format!("return valid data column for {id:?}"));
             let indices = &id.1;
-            self.log(&format!("return valid data column for {id:?} {indices:?}"));
             let columns_to_send = indices
                 .iter()
                 .map(|&i| data_columns[i as usize].clone())
@@ -710,8 +710,8 @@ impl TestRig {
         let first_column = data_columns.first().cloned().unwrap();
 
         for id in ids {
+            self.log(&format!("return valid data column for {id:?}"));
             let indices = &id.1;
-            self.log(&format!("return valid data column for {id:?} {indices:?}"));
             let columns_to_send = indices
                 .iter()
                 .map(|&i| data_columns[i as usize].clone())

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -121,12 +121,18 @@ impl From<LookupVerifyError> for RpcResponseError {
     }
 }
 
+/// Represents a group of peers that served a block component.
 #[derive(Clone, Debug)]
 pub struct PeerGroup {
+    /// Peers group by which indexed section of the block component they served. For example:
+    /// - PeerA served = [blob index 0, blob index 2]
+    /// - PeerA served = [blob index 1]
     peers: HashMap<PeerId, Vec<usize>>,
 }
 
 impl PeerGroup {
+    /// Return a peer group where a single peer returned all parts of a block component. For
+    /// example, a block has a single component (the block = index 0/1).
     pub fn from_single(peer: PeerId) -> Self {
         Self {
             peers: HashMap::from_iter([(peer, vec![0])]),

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -1,20 +1,21 @@
-use crate::sync::manager::SingleLookupReqId;
+use crate::sync::manager::{DataColumnsByRootRequester, SingleLookupReqId};
+use crate::sync::network_context::DataColumnsByRootSingleBlockRequest;
 
-use self::request::ActiveColumnSampleRequest;
 use beacon_chain::data_column_verification::CustodyDataColumn;
 use beacon_chain::BeaconChainTypes;
 use fnv::FnvHashMap;
 use lighthouse_network::PeerId;
 use slog::{debug, warn};
-use std::{marker::PhantomData, sync::Arc};
+use std::{collections::HashMap, marker::PhantomData, sync::Arc};
+use types::EthSpec;
 use types::{data_column_sidecar::ColumnIndex, DataColumnSidecar, Epoch, Hash256};
 
-use super::{PeerGroup, RpcResponseResult, SyncNetworkContext};
+use super::{LookupRequestResult, PeerGroup, ReqId, RpcResponseResult, SyncNetworkContext};
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct CustodyId {
-    pub id: CustodyRequester,
-    pub column_index: ColumnIndex,
+    pub requester: CustodyRequester,
+    pub req_id: ReqId,
 }
 
 /// Downstream components that perform custody by root requests.
@@ -27,9 +28,11 @@ type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
 pub struct ActiveCustodyRequest<T: BeaconChainTypes> {
     block_root: Hash256,
     block_epoch: Epoch,
-    requester_id: CustodyRequester,
-    column_requests: FnvHashMap<ColumnIndex, ActiveColumnSampleRequest>,
-    columns: Vec<CustodyDataColumn<T::EthSpec>>,
+    custody_id: CustodyId,
+    /// List of column indices this request needs to download to complete successfully
+    column_requests: FnvHashMap<ColumnIndex, ColumnRequest<T::EthSpec>>,
+    /// Active requests for 1 or more columns each
+    active_batch_columns_requests: FnvHashMap<ReqId, ActiveBatchColumnsRequest>,
     /// Logger for the `SyncNetworkContext`.
     pub log: slog::Logger,
     _phantom: PhantomData<T>,
@@ -43,25 +46,30 @@ pub enum Error {
     NoPeers(ColumnIndex),
 }
 
+struct ActiveBatchColumnsRequest {
+    indices: Vec<ColumnIndex>,
+}
+
 type CustodyRequestResult<E> = Result<Option<(Vec<CustodyDataColumn<E>>, PeerGroup)>, Error>;
 
 impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
     pub(crate) fn new(
         block_root: Hash256,
-        requester_id: CustodyRequester,
-        column_indexes: Vec<ColumnIndex>,
+        custody_id: CustodyId,
+        column_indices: &[ColumnIndex],
         log: slog::Logger,
     ) -> Self {
         Self {
             block_root,
             // TODO(das): use actual epoch if there's rotation
             block_epoch: Epoch::new(0),
-            requester_id,
-            column_requests: column_indexes
-                .into_iter()
-                .map(|index| (index, ActiveColumnSampleRequest::new(index)))
-                .collect(),
-            columns: vec![],
+            custody_id,
+            column_requests: HashMap::from_iter(
+                column_indices
+                    .iter()
+                    .map(|index| (*index, ColumnRequest::new())),
+            ),
+            active_batch_columns_requests: <_>::default(),
             log,
             _phantom: PhantomData,
         }
@@ -77,50 +85,96 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
     /// - `Ok(None)`: Sampling request still active
     pub(crate) fn on_data_column_downloaded(
         &mut self,
-        _peer_id: PeerId,
-        column_index: ColumnIndex,
+        peer_id: PeerId,
+        req_id: ReqId,
         resp: RpcResponseResult<DataColumnSidecarList<T::EthSpec>>,
         cx: &mut SyncNetworkContext<T>,
     ) -> CustodyRequestResult<T::EthSpec> {
         // TODO(das): Should downscore peers for verify errors here
 
-        let Some(request) = self.column_requests.get_mut(&column_index) else {
-            warn!(
-                self.log,
-                "Received sampling response for unrequested column index"
+        let Some(batch_request) = self.active_batch_columns_requests.get_mut(&req_id) else {
+            warn!(self.log,
+                "Received custody column response for unrequested index";
+                "id" => ?self.custody_id,
+                "block_root" => ?self.block_root,
+                "req_id" => req_id,
             );
             return Ok(None);
         };
 
         match resp {
-            Ok((mut data_columns, _seen_timestamp)) => {
-                debug!(self.log, "Sample download success"; "block_root" => %self.block_root, "column_index" => column_index, "count" => data_columns.len());
+            Ok((data_columns, _seen_timestamp)) => {
+                debug!(self.log,
+                    "Custody column download success";
+                    "id" => ?self.custody_id,
+                    "block_root" => ?self.block_root,
+                    "req_id" => req_id,
+                    "count" => data_columns.len()
+                );
 
-                // No need to check data_columns has len > 1, as the SyncNetworkContext ensure that
-                // only requested is returned (or none);
-                if let Some(data_column) = data_columns.pop() {
-                    request.on_download_success()?;
+                let mut data_columns = HashMap::<ColumnIndex, _>::from_iter(
+                    data_columns.into_iter().map(|d| (d.index, d)),
+                );
+                let mut missing_column_indexes = vec![];
 
-                    // If on_download_success is successful, we are expecting a columna for this
-                    // custody requirement.
-                    self.columns
-                        .push(CustodyDataColumn::from_asserted_custody(data_column));
-                } else {
+                for column_index in &batch_request.indices {
+                    let column_request = self
+                        .column_requests
+                        .get_mut(column_index)
+                        .ok_or(Error::BadState("unknown column_index".to_owned()))?;
+
+                    if let Some(data_column) = data_columns.remove(column_index) {
+                        // If on_download_success is successful, we are expecting a columns for this
+                        // custody requirement.
+                        column_request.on_download_success(
+                            peer_id,
+                            CustodyDataColumn::from_asserted_custody(data_column),
+                        )?;
+                    } else {
+                        // TODO(das) do not consider this case a success. We know for sure the block has
+                        // data. However we allow the peer to return empty as we can't attribute fault.
+                        column_request.on_dont_have_data()?;
+                        // TODO: Should track which columns are missing and eventually give up
+                        missing_column_indexes.push(column_index);
+                    }
+                }
+
+                // Note: no need to check data_columns is empty, SyncNetworkContext ensures that
+                // successful responses only contain requested data.
+
+                if !missing_column_indexes.is_empty() {
                     // Peer does not have the requested data.
+                    // Note: Batch logging that columns are missing to not spam logger
                     // TODO(das) what to do?
                     // TODO(das): If the peer is in the lookup peer set it claims to have imported
                     // the block AND its custody columns. So in this case we can downscore
-                    debug!(self.log, "Sampling peer claims to not have the data"; "block_root" => %self.block_root, "column_index" => column_index);
-                    // TODO(das) tolerate this failure if you are not sure the block has data
-                    request.on_download_success()?;
+                    debug!(self.log,
+                        "Custody column peer claims to not have some data";
+                        "id" => ?self.custody_id,
+                        "block_root" => ?self.block_root,
+                        // TODO(das): this property can become very noisy, being the full range 0..128
+                        "missing_column_indexes" => ?missing_column_indexes,
+                        "req_id" => req_id,
+                    );
                 }
             }
             Err(err) => {
-                debug!(self.log, "Sample download error"; "block_root" => %self.block_root, "column_index" => column_index, "error" => ?err);
+                debug!(self.log,
+                    "Custody column download error";
+                    "id" => ?self.custody_id,
+                    "block_root" => ?self.block_root,
+                    "req_id" => req_id,
+                    "error" => ?err
+                );
 
                 // Error downloading, maybe penalize peer and retry again.
                 // TODO(das) with different peer or different peer?
-                request.on_download_error()?;
+                for column_index in &batch_request.indices {
+                    self.column_requests
+                        .get_mut(column_index)
+                        .ok_or(Error::BadState("unknown column_index".to_owned()))?
+                        .on_download_error()?;
+                }
             }
         };
 
@@ -131,156 +185,177 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         &mut self,
         cx: &mut SyncNetworkContext<T>,
     ) -> CustodyRequestResult<T::EthSpec> {
-        // First check if sampling is completed, by computing `required_successes`
-        let mut successes = 0;
+        if self.column_requests.values().all(|r| r.is_downloaded()) {
+            // All requests have completed successfully.
+            let mut peers = HashMap::<PeerId, Vec<usize>>::new();
+            let columns = std::mem::take(&mut self.column_requests)
+                .into_values()
+                .map(|request| {
+                    let (peer, data_column) = request.complete()?;
+                    peers
+                        .entry(peer)
+                        .or_default()
+                        .push(data_column.as_data_column().index as usize);
+                    Ok(data_column)
+                })
+                .collect::<Result<Vec<_>, _>>()?;
 
-        for request in self.column_requests.values() {
-            if request.is_downloaded() {
-                successes += 1;
-            }
-        }
-
-        // All requests have completed successfully. We may not have all the expected columns if the
-        // serving peers claim that this block has no data.
-        if successes == self.column_requests.len() {
-            let columns = std::mem::take(&mut self.columns);
-
-            let peers = self
-                .column_requests
-                .values()
-                .filter_map(|r| r.peer())
-                .collect::<Vec<_>>();
             let peer_group = PeerGroup::from_set(peers);
-
             return Ok(Some((columns, peer_group)));
         }
 
-        for (_, request) in self.column_requests.iter_mut() {
-            request.request(self.block_root, self.block_epoch, self.requester_id, cx)?;
+        let mut columns_to_request_by_peer = HashMap::<PeerId, Vec<ColumnIndex>>::new();
+
+        // Need to:
+        // - track how many active requests a peer has for load balancing
+        // - which peers have failures to attempt others
+        // - which peer returned what to have PeerGroup attributability
+
+        for (column_index, request) in self.column_requests.iter_mut() {
+            if request.is_awaiting_download() {
+                // TODO: When is a fork and only a subset of your peers know about a block, sampling should only
+                // be queried on the peers on that fork. Should this case be handled? How to handle it?
+                let peer_ids = cx.get_custodial_peers(self.block_epoch, *column_index);
+
+                // TODO(das) randomize custodial peer and avoid failing peers
+                let Some(peer_id) = peer_ids.first().cloned() else {
+                    // Do not tolerate not having custody peers, hard error.
+                    // TODO(das): we might implement some grace period. The request will pause for X
+                    // seconds expecting the peer manager to find peers before failing the request.
+                    return Err(Error::NoPeers(*column_index));
+                };
+
+                columns_to_request_by_peer
+                    .entry(peer_id)
+                    .or_default()
+                    .push(*column_index);
+            }
+        }
+
+        for (peer_id, indices) in columns_to_request_by_peer.into_iter() {
+            let request_result = cx
+                .data_column_lookup_request(
+                    DataColumnsByRootRequester::Custody(self.custody_id),
+                    peer_id,
+                    DataColumnsByRootSingleBlockRequest {
+                        block_root: self.block_root,
+                        indices: indices.clone(),
+                    },
+                )
+                .map_err(Error::SendFailed)?;
+
+            match request_result {
+                LookupRequestResult::RequestSent(req_id) => {
+                    for column_index in &indices {
+                        let column_request = self
+                            .column_requests
+                            .get_mut(column_index)
+                            .ok_or(Error::BadState("unknown column_index".to_owned()))?;
+
+                        column_request.on_download_start(req_id)?;
+                    }
+
+                    self.active_batch_columns_requests
+                        .insert(req_id, ActiveBatchColumnsRequest { indices });
+                }
+                LookupRequestResult::NoRequestNeeded => unreachable!(),
+                LookupRequestResult::Pending => unreachable!(),
+            }
         }
 
         Ok(None)
     }
 }
 
-mod request {
-    use super::{CustodyId, CustodyRequester, Error};
-    use crate::sync::{
-        manager::DataColumnsByRootRequester,
-        network_context::{DataColumnsByRootSingleBlockRequest, SyncNetworkContext},
-    };
-    use beacon_chain::BeaconChainTypes;
-    use lighthouse_network::PeerId;
-    use types::{data_column_sidecar::ColumnIndex, Epoch, Hash256};
+/// TODO(das): this attempt count is nested into the existing lookup request count.
+const MAX_CUSTODY_COLUMN_DOWNLOAD_ATTEMPTS: usize = 3;
 
-    /// TODO(das): this attempt count is nested into the existing lookup request count.
-    const MAX_CUSTODY_COLUMN_DOWNLOAD_ATTEMPTS: usize = 3;
+struct ColumnRequest<E: EthSpec> {
+    status: Status<E>,
+    download_failures: usize,
+}
 
-    pub(crate) struct ActiveColumnSampleRequest {
-        column_index: ColumnIndex,
-        status: Status,
-        download_failures: usize,
+#[derive(Debug, Clone)]
+enum Status<E: EthSpec> {
+    NotStarted,
+    Downloading(ReqId),
+    Downloaded(PeerId, CustodyDataColumn<E>),
+}
+
+impl<E: EthSpec> ColumnRequest<E> {
+    fn new() -> Self {
+        Self {
+            status: Status::NotStarted,
+            download_failures: 0,
+        }
     }
 
-    #[derive(Debug, Clone)]
-    enum Status {
-        NotStarted,
-        Downloading(PeerId),
-        Downloaded(PeerId),
+    fn is_awaiting_download(&self) -> bool {
+        match self.status {
+            Status::NotStarted => true,
+            Status::Downloading { .. } | Status::Downloaded { .. } => false,
+        }
     }
 
-    impl ActiveColumnSampleRequest {
-        pub(crate) fn new(column_index: ColumnIndex) -> Self {
-            Self {
-                column_index,
-                status: Status::NotStarted,
-                download_failures: 0,
-            }
+    fn is_downloaded(&self) -> bool {
+        match self.status {
+            Status::NotStarted | Status::Downloading { .. } => false,
+            Status::Downloaded { .. } => true,
         }
+    }
 
-        pub(crate) fn is_downloaded(&self) -> bool {
-            match self.status {
-                Status::NotStarted | Status::Downloading(_) => false,
-                Status::Downloaded(_) => true,
+    fn on_download_start(&mut self, req_id: ReqId) -> Result<(), Error> {
+        match self.status.clone() {
+            Status::NotStarted => {
+                self.status = Status::Downloading(req_id);
+                Ok(())
             }
+            other => Err(Error::BadState(format!(
+                "bad state on_download_start expected NotStarted got {other:?}"
+            ))),
         }
+    }
 
-        pub(crate) fn peer(&self) -> Option<PeerId> {
-            match self.status {
-                Status::NotStarted | Status::Downloading(_) => None,
-                Status::Downloaded(peer) => Some(peer),
+    fn on_download_error(&mut self) -> Result<(), Error> {
+        match self.status.clone() {
+            Status::Downloading(_) => {
+                self.download_failures += 1;
+                self.status = Status::NotStarted;
+                Ok(())
             }
+            other => Err(Error::BadState(format!(
+                "bad state on_sampling_error expected Sampling got {other:?}"
+            ))),
         }
+    }
 
-        pub(crate) fn request<T: BeaconChainTypes>(
-            &mut self,
-            block_root: Hash256,
-            block_epoch: Epoch,
-            requester: CustodyRequester,
-            cx: &mut SyncNetworkContext<T>,
-        ) -> Result<bool, Error> {
-            match &self.status {
-                Status::NotStarted => {}                    // Ok to continue
-                Status::Downloading(_) => return Ok(false), // Already downloading
-                Status::Downloaded(_) => return Ok(false),  // Already completed
+    fn on_dont_have_data(&mut self) -> Result<(), Error> {
+        // TODO(das): Should track which peers don't have data
+        self.on_download_error()
+    }
+
+    fn on_download_success(
+        &mut self,
+        peer_id: PeerId,
+        data_column: CustodyDataColumn<E>,
+    ) -> Result<(), Error> {
+        match &self.status {
+            Status::Downloading(_) => {
+                self.status = Status::Downloaded(peer_id, data_column);
+                Ok(())
             }
-
-            if self.download_failures > MAX_CUSTODY_COLUMN_DOWNLOAD_ATTEMPTS {
-                return Err(Error::TooManyFailures);
-            }
-
-            // TODO: When is a fork and only a subset of your peers know about a block, sampling should only
-            // be queried on the peers on that fork. Should this case be handled? How to handle it?
-            let peer_ids = cx.get_custodial_peers(block_epoch, self.column_index);
-
-            // TODO(das) randomize custodial peer and avoid failing peers
-            let Some(peer_id) = peer_ids.first().cloned() else {
-                // Do not tolerate not having custody peers, hard error.
-                // TODO(das): we might implement some grace period. The request will pause for X
-                // seconds expecting the peer manager to find peers before failing the request.
-                return Err(Error::NoPeers(self.column_index));
-            };
-
-            cx.data_column_lookup_request(
-                DataColumnsByRootRequester::Custody(CustodyId {
-                    id: requester,
-                    column_index: self.column_index,
-                }),
-                peer_id,
-                DataColumnsByRootSingleBlockRequest {
-                    block_root,
-                    indices: vec![self.column_index],
-                },
-            )
-            .map_err(Error::SendFailed)?;
-
-            self.status = Status::Downloading(peer_id);
-            Ok(true)
+            other => Err(Error::BadState(format!(
+                "bad state on_sampling_success expected Sampling got {other:?}"
+            ))),
         }
+    }
 
-        pub(crate) fn on_download_error(&mut self) -> Result<PeerId, Error> {
-            match self.status.clone() {
-                Status::Downloading(peer_id) => {
-                    self.download_failures += 1;
-                    self.status = Status::NotStarted;
-                    Ok(peer_id)
-                }
-                other => Err(Error::BadState(format!(
-                    "bad state on_sampling_error expected Sampling got {other:?}"
-                ))),
-            }
-        }
-
-        pub(crate) fn on_download_success(&mut self) -> Result<(), Error> {
-            match &self.status {
-                Status::Downloading(peer) => {
-                    self.status = Status::Downloaded(*peer);
-                    Ok(())
-                }
-                other => Err(Error::BadState(format!(
-                    "bad state on_sampling_success expected Sampling got {other:?}"
-                ))),
-            }
+    fn complete(self) -> Result<(PeerId, CustodyDataColumn<E>), Error> {
+        match self.status {
+            Status::Downloaded(peer_id, data_column) => Ok((peer_id, data_column)),
+            other => Err(Error::BadState(format!(
+                "bad state complete expected Downloaded got {other:?}"
+            ))),
         }
     }
 }

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -183,17 +183,15 @@ impl DataColumnsByRootSingleBlockRequest {
     }
 }
 
-pub struct ActiveDataColumnsByRootRequest<E: EthSpec, T: Copy> {
-    pub requester: T,
+pub struct ActiveDataColumnsByRootRequest<E: EthSpec> {
     request: DataColumnsByRootSingleBlockRequest,
     items: Vec<Arc<DataColumnSidecar<E>>>,
     resolved: bool,
 }
 
-impl<E: EthSpec, T: Copy> ActiveDataColumnsByRootRequest<E, T> {
-    pub fn new(request: DataColumnsByRootSingleBlockRequest, requester: T) -> Self {
+impl<E: EthSpec> ActiveDataColumnsByRootRequest<E> {
+    pub fn new(request: DataColumnsByRootSingleBlockRequest) -> Self {
         Self {
-            requester,
             request,
             items: vec![],
             resolved: false,


### PR DESCRIPTION
## Issue Addressed

Misc TODO items that arise in the interop regarding custody

## Proposed Changes

- Do not issue 1 request per column if same peer. Batch requests per peer if possible
- Load balance requests among custodial peers, same as range sync. Prefer peers with least number of active requests
- Track peers that cause download errors and de-prioritize them for some seconds
- Track req_id in each custody request to ensure no mixups (same as current unstable for other lookup requests)
- Do not donwload custody columns on a lookup, until block is downloaded

