### PR TITLE
Drop stuck lookups

### DIFF
--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -257,9 +257,9 @@ lazy_static! {
         "sync_lookups_completed_total",
         "Total count of sync lookups completed",
     );
-    pub static ref SYNC_LOOKUPS_STUCK: Result<IntGauge> = try_create_int_gauge(
-        "sync_lookups_stuck",
-        "Current count of sync lookups that may be stuck",
+    pub static ref SYNC_LOOKUPS_STUCK: Result<IntCounter> = try_create_int_counter(
+        "sync_lookups_stuck_total",
+        "Total count of sync lookups that are stuck and dropped",
     );
 
     /*

--- a/beacon_node/network/src/sync/block_lookups/common.rs
+++ b/beacon_node/network/src/sync/block_lookups/common.rs
@@ -2,7 +2,7 @@ use crate::sync::block_lookups::single_block_lookup::{
     LookupRequestError, SingleBlockLookup, SingleLookupRequestState,
 };
 use crate::sync::block_lookups::{BlobRequestState, BlockRequestState, PeerId};
-use crate::sync::manager::{Id, SLOT_IMPORT_TOLERANCE};
+use crate::sync::manager::Id;
 use crate::sync::network_context::{LookupRequestResult, SyncNetworkContext};
 use beacon_chain::block_verification_types::RpcBlock;
 use beacon_chain::BeaconChainTypes;
@@ -18,11 +18,6 @@ pub enum ResponseType {
     Block,
     Blob,
 }
-
-/// The maximum depth we will search for a parent block. In principle we should have sync'd any
-/// canonical chain to its head once the peer connects. A chain should not appear where it's depth
-/// is further back than the most recent head slot.
-pub(crate) const PARENT_DEPTH_TOLERANCE: usize = SLOT_IMPORT_TOLERANCE * 2;
 
 /// This trait unifies common single block lookup functionality across blocks and blobs. This
 /// includes making requests, verifying responses, and handling processing results. A

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use super::*;
 
-use crate::sync::block_lookups::common::{ResponseType, PARENT_DEPTH_TOLERANCE};
+use crate::sync::block_lookups::common::ResponseType;
 use beacon_chain::blob_verification::GossipVerifiedBlob;
 use beacon_chain::block_verification_types::{BlockImportData, RpcBlock};
 use beacon_chain::builder::Witness;

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -561,7 +561,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     self.handle_new_execution_engine_state(engine_state);
                 }
                 _ = interval.tick() => {
-                    self.block_lookups.log_stuck_lookups();
+                    self.block_lookups.drop_stuck_lookups();
                 }
             }
         }


### PR DESCRIPTION
## Issue Addressed

PR
- https://github.com/sigp/lighthouse/pull/5778

Makes us aware of the extent of the problem of sync lookups randomly getting stuck.

While useful I believe we should:
- Take it one step further and actively drop lookups that get stuck
- Increase the log level of "lookup stuck alarm"

While
- Fix underlying bugs that cause lookups to get stuck, both find by us and reported by users

The trade-off is quite good:
- A healthy lookup needing to exist for > 16 minutes is highly unlikely. Even if it's the case, range sync can rescue the node eventually
- So far, bugs that cause lookups to get stuck are sporadic, usually dependent of a specific sequence of events that may not repeat in a while.

Therefore dropping stuck lookups should be a net positive

## Proposed Changes

- If a lookup lasts more than LOOKUP_MAX_DURATION_SECS this function will find its oldest ancestor and then drop it and all its children.
- Increase the "lookup stuck" log from debug to warn, as now it will log only once per lookup id


