### PR TITLE
don't block mev boost till genesis finalization

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -6385,9 +6385,8 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// account the current slot when accounting for skips.
     pub fn is_healthy(&self, parent_root: &Hash256) -> Result<ChainHealth, Error> {
         let cached_head = self.canonical_head.cached_head();
-        // Check if the merge has been finalized.
-        if let Some(finalized_hash) = cached_head.forkchoice_update_parameters().finalized_hash {
-            if ExecutionBlockHash::zero() == finalized_hash {
+        if let Some(head_hash) = cached_head.forkchoice_update_parameters().head_hash {
+            if ExecutionBlockHash::zero() == head_hash {
                 return Ok(ChainHealth::PreMerge);
             }
         } else {


### PR DESCRIPTION
## Issue Addressed

We added a check not to use mev boost until the merge finalizes. This was done by checking the finalized block hash was not the zero hash. This check is no longer necessary on mainnet, and now just causes issues in testnets (no mev boost usage until two epochs past genesis) which is annoying. This just updates the check to ensure the head block hash isn't zero, so has a similar effect of disabling mev boost pre merge but doesn't wait an extra couple epochs.