### PR TITLE
Report sync of block import via blob import

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -753,7 +753,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let blob_slot = verified_blob.slot();
         let blob_index = verified_blob.id().index;
 
-        match self.chain.process_gossip_blob(verified_blob).await {
+        let result = self.chain.process_gossip_blob(verified_blob).await;
+
+        match &result {
             Ok(AvailabilityProcessingStatus::Imported(block_root)) => {
                 // Note: Reusing block imported metric here
                 metrics::inc_counter(&metrics::BEACON_PROCESSOR_GOSSIP_BLOCK_IMPORTED_TOTAL);
@@ -801,6 +803,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "bad_gossip_blob_ssz",
                 );
             }
+        }
+
+        // If a block is in the da_checker, sync maybe awaiting for an event when block is finally
+        // imported. A block can become imported both after processing a block or blob. If a
+        // importing a block results in `Imported`, notify. Do not notify of blob errors.
+        if matches!(result, Ok(AvailabilityProcessingStatus::Imported(_))) {
+            self.send_sync_message(SyncMessage::GossipBlockProcessResult {
+                block_root,
+                imported: true,
+            });
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

Fix lookup stuck incident reported in 
- https://github.com/sigp/lighthouse/issues/5833#issuecomment-2129566873

Sync should be notified when a block abandons the da_checker to continue its child lookups. Block import can be completed both via block gossip import and blob import.

I am not 100% sure this fix is strictly necessary, but it's a good to have that can unstuck lookups if the logic to de-duplicate blob requests fails.

## Proposed Changes

Emit `GossipBlockProcessResult` also from blob import if the block gets imported

