### PR TITLE
Do not drop lookups without peers while awaiting events

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -137,9 +137,17 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.block_root() == block_root
     }
 
-    /// Get all unique peers that claim to have imported this set of block components
-    pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
-        self.peers.iter()
+    /// Returns true if the block has already been downloaded.
+    pub fn both_components_processed(&self) -> bool {
+        self.block_request_state.state.is_processed()
+            && self.blob_request_state.state.is_processed()
+    }
+
+    /// Returns true if this request is expecting some event to make progress
+    pub fn is_awaiting_event(&self) -> bool {
+        self.awaiting_parent.is_some()
+            || self.block_request_state.state.is_awaiting_event()
+            || self.blob_request_state.state.is_awaiting_event()
     }
 
     /// Makes progress on all requests of this lookup. Any error is not recoverable and must result
@@ -189,13 +197,9 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             }
 
             let Some(peer_id) = self.use_rand_available_peer() else {
-                if awaiting_parent {
-                    // Allow lookups awaiting for a parent to have zero peers. If when the parent
-                    // resolve they still have zero peers the lookup will fail gracefully.
-                    return Ok(());
-                } else {
-                    return Err(LookupRequestError::NoPeers);
-                }
+                // Allow lookup to not have any peers. In that case do nothing. If the lookup does
+                // not have peers for some time, it will be dropped.
+                return Ok(());
             };
 
             let request = R::request_state_mut(self);
@@ -226,16 +230,15 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         Ok(())
     }
 
+    /// Get all unique peers that claim to have imported this set of block components
+    pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
+        self.peers.iter()
+    }
+
     /// Add peer to all request states. The peer must be able to serve this request.
     /// Returns true if the peer was newly inserted into some request state.
     pub fn add_peer(&mut self, peer_id: PeerId) -> bool {
         self.peers.insert(peer_id)
-    }
-
-    /// Returns true if the block has already been downloaded.
-    pub fn both_components_processed(&self) -> bool {
-        self.block_request_state.state.is_processed()
-            && self.blob_request_state.state.is_processed()
     }
 
     /// Remove peer from available peers. Return true if there are no more available peers and all
@@ -348,6 +351,24 @@ impl<T: Clone> SingleLookupRequestState<T> {
             | State::AwaitingProcess { .. }
             | State::Processing { .. } => false,
             State::Processed { .. } => true,
+        }
+    }
+
+    /// Returns true if we can expect some future event to progress this block component request
+    /// specifically.
+    pub fn is_awaiting_event(&self) -> bool {
+        match self.state {
+            // No event will progress this request specifically, but the request may be put on hold
+            // due to some external event
+            State::AwaitingDownload { .. } => false,
+            // Network will emit a download success / error event
+            State::Downloading { .. } => true,
+            // Not awaiting any external event
+            State::AwaitingProcess { .. } => false,
+            // Beacon processor will emit a processing result event
+            State::Processing { .. } => true,
+            // Request complete, no future event left
+            State::Processed { .. } => false,
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

Lookups without peers should be allowed to exist for some time. See this common race condition:
1. Receive unknown block parent event
2. Create child lookup with zero peers
3. Parent is processed, before receiving any attestation for the child block
4. Child lookup is attempted to make progress but has no peers
5. We receive an attestion for child block and add a peer to the child block lookup

In step 4 we could drop the lookup because we attempt to issue a request with no peers available. This has two issues:
- We may drop the lookup while some other block component is processing, triggering an unknown lookup error. This can potentially cause unrelated child lookups to also be dropped when calling `drop_lookup_and_children`.
- We lose all progress of the lookup, and have to re-download its components that we may already have there cached.

Instead, there's no negative for keeping lookups with no peers around for some time. If we regularly prune them, it should not be a memory concern (TODO: maybe yes!).

---

This PR fixes the race condition seen in first issue of:
- https://github.com/sigp/lighthouse/issues/5833

## Proposed Changes

Do not immediately drop a lookup when attempting to do a download and it has no peers. Instead wait for all the following conditions before dropping it:
- Lookup has no peers
- Lookup is not awaiting any event (i.e. not processing a block component)
- Some time has elapsed since its creation
