### PR TITLE
Ensure lookup sync checks caches correctly

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -337,6 +337,22 @@ struct PartialBeaconBlock<E: EthSpec> {
     bls_to_execution_changes: Vec<SignedBlsToExecutionChange>,
 }
 
+pub enum BlockProcessStatus {
+    /// Block is not in any pre-import cache. Block may be in the data-base or in the fork-choice.
+    Unknown,
+    /// Block is currently processing but not yet validated.
+    NotValidated {
+        slot: Slot,
+        blob_kzg_commitments_count: usize,
+    },
+    /// Block is fully valid, but not yet imported. It's cached in the da_checker while awaiting
+    /// missing block components.
+    ExecutionValidated {
+        slot: Slot,
+        blob_kzg_commitments_count: usize,
+    },
+}
+
 pub type LightClientProducerEvent<T> = (Hash256, Slot, SyncAggregate<T>);
 
 pub type BeaconForkChoice<T> = ForkChoice<
@@ -1235,6 +1251,33 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         block_root: &Hash256,
     ) -> Result<Option<SignedBlindedBeaconBlock<T::EthSpec>>, Error> {
         Ok(self.store.get_blinded_block(block_root)?)
+    }
+
+    /// Return the status of a block as it progresses through the various caches of the beacon
+    /// chain. Used by sync to learn the status of a block and prevent repeated downloads /
+    /// processing attempts.
+    pub fn get_block_process_status(&self, block_root: &Hash256) -> BlockProcessStatus {
+        if let Some(execution_valid_block) = self
+            .data_availability_checker
+            .get_execution_valid_block_summary(block_root)
+        {
+            return BlockProcessStatus::ExecutionValidated {
+                slot: execution_valid_block.slot,
+                blob_kzg_commitments_count: execution_valid_block.blob_kzg_commitments_count,
+            };
+        }
+
+        if let Some(block) = self.reqresp_pre_import_cache.read().get(block_root) {
+            // A block is on the `reqresp_pre_import_cache` but NOT in the
+            // `data_availability_checker` only if it is actively processing. We can expect a future
+            // event with the result of processing
+            return BlockProcessStatus::NotValidated {
+                slot: block.slot(),
+                blob_kzg_commitments_count: block.num_expected_blobs(),
+            };
+        }
+
+        BlockProcessStatus::Unknown
     }
 
     /// Returns the state at the given root, if any.

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -96,14 +96,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
             .get_execution_valid_block_summary(block_root)
     }
 
-    /// Return the required blobs `block_root` expects if the block is currenlty in the cache.
-    pub fn num_expected_blobs(&self, block_root: &Hash256) -> Option<usize> {
-        self.availability_cache
-            .peek_pending_components(block_root, |components| {
-                components.and_then(|components| components.num_expected_blobs())
-            })
-    }
-
     /// Return the set of imported blob indexes for `block_root`. Returns None if there is no block
     /// component for `block_root`.
     pub fn imported_blob_indexes(&self, block_root: &Hash256) -> Option<Vec<u64>> {

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -23,6 +23,8 @@ mod state_lru_cache;
 pub use error::{Error as AvailabilityCheckError, ErrorCategory as AvailabilityCheckErrorCategory};
 use types::non_zero_usize::new_non_zero_usize;
 
+use self::overflow_lru_cache::ExecutionValidBlockSummary;
+
 /// The LRU Cache stores `PendingComponents` which can store up to
 /// `MAX_BLOBS_PER_BLOCK = 6` blobs each. A `BlobSidecar` is 0.131256 MB. So
 /// the maximum size of a `PendingComponents` is ~ 0.787536 MB. Setting this
@@ -86,9 +88,12 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
     /// Checks if the block root is currenlty in the availability cache awaiting import because
     /// of missing components.
-    pub fn has_execution_valid_block(&self, block_root: &Hash256) -> bool {
+    pub fn get_execution_valid_block_summary(
+        &self,
+        block_root: &Hash256,
+    ) -> Option<ExecutionValidBlockSummary> {
         self.availability_cache
-            .has_execution_valid_block(block_root)
+            .get_execution_valid_block_summary(block_root)
     }
 
     /// Return the required blobs `block_root` expects if the block is currenlty in the cache.

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -23,8 +23,6 @@ mod state_lru_cache;
 pub use error::{Error as AvailabilityCheckError, ErrorCategory as AvailabilityCheckErrorCategory};
 use types::non_zero_usize::new_non_zero_usize;
 
-use self::overflow_lru_cache::ExecutionValidBlockSummary;
-
 /// The LRU Cache stores `PendingComponents` which can store up to
 /// `MAX_BLOBS_PER_BLOCK = 6` blobs each. A `BlobSidecar` is 0.131256 MB. So
 /// the maximum size of a `PendingComponents` is ~ 0.787536 MB. Setting this
@@ -88,12 +86,12 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
     /// Checks if the block root is currenlty in the availability cache awaiting import because
     /// of missing components.
-    pub fn get_execution_valid_block_summary(
+    pub fn get_execution_valid_block(
         &self,
         block_root: &Hash256,
-    ) -> Option<ExecutionValidBlockSummary> {
+    ) -> Option<Arc<SignedBeaconBlock<T::EthSpec>>> {
         self.availability_cache
-            .get_execution_valid_block_summary(block_root)
+            .get_execution_valid_block(block_root)
     }
 
     /// Return the set of imported blob indexes for `block_root`. Returns None if there is no block

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -44,7 +44,7 @@ use ssz_types::{FixedVector, VariableList};
 use std::num::NonZeroUsize;
 use std::{collections::HashSet, sync::Arc};
 use types::blob_sidecar::BlobIdentifier;
-use types::{BlobSidecar, ChainSpec, Epoch, EthSpec, Hash256};
+use types::{BlobSidecar, ChainSpec, Epoch, EthSpec, Hash256, Slot};
 
 /// This represents the components of a partially available block
 ///
@@ -55,6 +55,11 @@ pub struct PendingComponents<E: EthSpec> {
     pub block_root: Hash256,
     pub verified_blobs: FixedVector<Option<KzgVerifiedBlob<E>>, E::MaxBlobsPerBlock>,
     pub executed_block: Option<DietAvailabilityPendingExecutedBlock<E>>,
+}
+
+pub struct ExecutionValidBlockSummary {
+    pub slot: Slot,
+    pub blob_kzg_commitments_count: usize,
 }
 
 impl<E: EthSpec> PendingComponents<E> {
@@ -544,12 +549,22 @@ impl<T: BeaconChainTypes> OverflowLRUCache<T> {
     }
 
     /// Returns true if the block root is known, without altering the LRU ordering
-    pub fn has_execution_valid_block(&self, block_root: &Hash256) -> bool {
-        if let Some(pending_components) = self.critical.read().peek_pending_components(block_root) {
-            pending_components.executed_block.is_some()
-        } else {
-            false
-        }
+    pub fn get_execution_valid_block_summary(
+        &self,
+        block_root: &Hash256,
+    ) -> Option<ExecutionValidBlockSummary> {
+        self.critical
+            .read()
+            .peek_pending_components(block_root)
+            .and_then(|pending_components| {
+                pending_components
+                    .executed_block
+                    .as_ref()
+                    .map(|block| ExecutionValidBlockSummary {
+                        slot: block.as_block().slot(),
+                        blob_kzg_commitments_count: block.num_blobs_expected(),
+                    })
+            })
     }
 
     /// Fetch a blob from the cache without affecting the LRU ordering

--- a/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/state_lru_cache.rs
@@ -37,6 +37,10 @@ impl<E: EthSpec> DietAvailabilityPendingExecutedBlock<E> {
         &self.block
     }
 
+    pub fn block_cloned(&self) -> Arc<SignedBeaconBlock<E>> {
+        self.block.clone()
+    }
+
     pub fn num_blobs_expected(&self) -> usize {
         self.block
             .message()

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -62,9 +62,10 @@ pub mod validator_pubkey_cache;
 
 pub use self::beacon_chain::{
     AttestationProcessingOutcome, AvailabilityProcessingStatus, BeaconBlockResponse,
-    BeaconBlockResponseWrapper, BeaconChain, BeaconChainTypes, BeaconStore, ChainSegmentResult,
-    ForkChoiceError, LightClientProducerEvent, OverrideForkchoiceUpdate, ProduceBlockVerification,
-    StateSkipConfig, WhenSlotSkipped, INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON,
+    BeaconBlockResponseWrapper, BeaconChain, BeaconChainTypes, BeaconStore, BlockProcessStatus,
+    ChainSegmentResult, ForkChoiceError, LightClientProducerEvent, OverrideForkchoiceUpdate,
+    ProduceBlockVerification, StateSkipConfig, WhenSlotSkipped,
+    INVALID_FINALIZED_MERGE_TRANSITION_BLOCK_SHUTDOWN_REASON,
     INVALID_JUSTIFIED_PAYLOAD_SHUTDOWN_REASON,
 };
 pub use self::beacon_snapshot::BeaconSnapshot;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1192,6 +1192,7 @@ pub fn scrape_for_metrics<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) {
     }
 
     let attestation_stats = beacon_chain.op_pool.attestation_stats();
+    let chain_metrics = beacon_chain.metrics();
 
     set_gauge_by_usize(
         &BLOCK_PROCESSING_SNAPSHOT_CACHE_SIZE,
@@ -1200,7 +1201,7 @@ pub fn scrape_for_metrics<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) {
 
     set_gauge_by_usize(
         &BEACON_REQRESP_PRE_IMPORT_CACHE_SIZE,
-        beacon_chain.reqresp_pre_import_cache.read().len(),
+        chain_metrics.reqresp_pre_import_cache_len,
     );
 
     let da_checker_metrics = beacon_chain.data_availability_checker.metrics();

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1452,13 +1452,16 @@ fn block_in_processing_cache_becomes_invalid() {
     let peer_id = r.new_connected_peer();
     r.insert_block_to_processing_cache(block.clone().into());
     r.trigger_unknown_block_from_attestation(block_root, peer_id);
+    // Should trigger blob request
+    let id = r.expect_blob_lookup_request(block_root);
     // Should not trigger block request
     r.expect_empty_network();
     // Simulate invalid block, removing it from processing cache
     r.simulate_block_gossip_processing_becomes_invalid(block_root);
     // Should download block, then issue blobs request
     r.complete_lookup_block_download(block);
-    let id = r.expect_blob_lookup_request(block_root);
+    // Should not trigger block or blob request
+    r.expect_empty_network();
     r.complete_lookup_block_import_valid(block_root, false);
     // Resolve blob and expect lookup completed
     r.complete_single_lookup_blob_lookup_valid(id, peer_id, blobs, true);
@@ -1475,11 +1478,14 @@ fn block_in_processing_cache_becomes_valid_imported() {
     let peer_id = r.new_connected_peer();
     r.insert_block_to_processing_cache(block.clone().into());
     r.trigger_unknown_block_from_attestation(block_root, peer_id);
+    // Should trigger blob request
+    let id = r.expect_blob_lookup_request(block_root);
     // Should not trigger block request
     r.expect_empty_network();
     // Resolve the block from processing step
     r.simulate_block_gossip_processing_becomes_valid_missing_components(block.into());
-    let id = r.expect_blob_lookup_request(block_root);
+    // Should not trigger block or blob request
+    r.expect_empty_network();
     // Resolve blob and expect lookup completed
     r.complete_single_lookup_blob_lookup_valid(id, peer_id, blobs, true);
     r.expect_no_active_lookups();

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -397,14 +397,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             // can assert that this is the correct value of `blob_kzg_commitments_count`.
             match self.chain.get_block_process_status(&block_root) {
                 BlockProcessStatus::Unknown => None,
-                BlockProcessStatus::NotValidated {
-                    blob_kzg_commitments_count,
-                    ..
-                }
-                | BlockProcessStatus::ExecutionValidated {
-                    blob_kzg_commitments_count,
-                    ..
-                } => Some(blob_kzg_commitments_count),
+                BlockProcessStatus::NotValidated(block)
+                | BlockProcessStatus::ExecutionValidated(block) => Some(block.num_expected_blobs()),
             }
         }) else {
             // Wait to download the block before downloading blobs. Then we can be sure that the


### PR DESCRIPTION
## Issue Addressed

Sync lookup needs to have a view of what's currently being processed to prevent double downloads and not get lookups stuck.

Part of an issue in https://github.com/sigp/lighthouse/issues/5833 was caused because blob requests don't check into the processing cache (`reqresp_pre_import_cache`). If the block is already processing, blob requests should continue.

To prevent futures issues like this I think we should encapsulate the details of the beacon_chain caches to there. And then expose only the minimum information sync needs to know with a simple enum `BlockProcessStatus`.

## Proposed Changes

- Add `get_block_process_status` to not leak cache details into sync lookup
- When attempting a `blob_lookup_request`, consider blocks in `NotValidated` state as download and continue the download of blobs
