### PR TITLE
fix: serde rename camel case for execution payload body

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -720,6 +720,7 @@ impl From<ForkchoiceUpdatedResponse> for JsonForkchoiceUpdatedV1Response {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "E: EthSpec")]
+#[serde(rename_all = "camelCase")]
 pub struct JsonExecutionPayloadBodyV1<E: EthSpec> {
     #[serde(with = "ssz_types::serde_utils::list_of_hex_var_list")]
     pub transactions: Transactions<E>,


### PR DESCRIPTION
## Issue Addressed

I'm not exactly sure if this is the right branch to target, or if this is even an issue at all, but I noticed the get payload responses don't use camelCase

## Proposed Changes

rename camelCase 

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
