### PR TITLE
Fix BitVectors TestRandom implementation

### DIFF
--- a/consensus/types/src/test_utils/test_random/bitfield.rs
+++ b/consensus/types/src/test_utils/test_random/bitfield.rs
@@ -26,6 +26,15 @@ impl<N: Unsigned + Clone> TestRandom for BitVector<N> {
     fn random_for_test(rng: &mut impl RngCore) -> Self {
         let mut raw_bytes = smallvec![0; std::cmp::max(1, (N::to_usize() + 7) / 8)];
         rng.fill_bytes(&mut raw_bytes);
+        // If N isn't divisible by 8
+        // zero out bits greater than N
+        if let Some(last_byte) = raw_bytes.last_mut() {
+            let mut mask = 0;
+            for i in 0..N::to_usize() % 8 {
+                mask |= 1 << i;
+            }
+            *last_byte &= mask;
+        }
         Self::from_bytes(raw_bytes).expect("we generate a valid BitVector")
     }
 }


### PR DESCRIPTION
## Issue Addressed

For electra attestations a new field `committee_bits: BitVector<E::MaxCommitteesPerSlot>` is introduced

Theres some assumptions in `BitVector`s `TestRandom` impl that `N` is divisible by 8. For the minimal spec `MaxCommitteesPerSlot` = 4. In this case, when generating a random bit vector, a `raw_bytes` vec of length 1 is created that is filled with a randomly generated value. In some cases the randomly generated value has bits set that are higher than `raw_bytes.len()`. This PR introduces some bit masking logic to the `TestRandom` impl for `BitVector` to ensure that we zero out bits > `raw_bytes.len()` in the case where `N` isn't divisible by 8.

This change should fix some failing electra networking tests. This PR along with other electra attestation PR's should get us passing CI for electra attestation changes. Thanks Michael for the assistance!