### PR TITLE
Add peers to parent lookups

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -833,8 +833,8 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     /// be able to make progress, but we add peers to them anyway for completeness.
     /// Note: Takes a `lookup_id` as argument to allow recursion on mutable lookups, without having
     /// to duplicate the code to add peers to a lookup
-    fn add_peers_to_lookup_and_ancestors<'a>(
-        &'a mut self,
+    fn add_peers_to_lookup_and_ancestors(
+        &mut self,
         lookup_id: SingleLookupId,
         peers: &[PeerId],
         cx: &mut SyncNetworkContext<T>,

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -273,10 +273,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 warn!(self.log, "Error adding peers to ancestor lookup"; "error" => ?e);
             }
 
-            // When attempting to continue lookups in `add_peers_to_lookup_and_ancestors`, this
-            // lookup may be dropped due to any error in the chain of ancestor lookups. Explictly
-            // check if this lookup still exists.
-            return self.single_block_lookups.contains_key(&lookup_id);
+            return true;
         }
 
         // Ensure that awaiting parent exists, otherwise this lookup won't be able to make progress

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -85,6 +85,9 @@ pub struct BlockLookups<T: BeaconChainTypes> {
     log: Logger,
 }
 
+#[cfg(test)]
+pub(crate) type BlockLookupSummary = (Id, Hash256, Option<Hash256>, Vec<PeerId>);
+
 impl<T: BeaconChainTypes> BlockLookups<T> {
     pub fn new(log: Logger) -> Self {
         Self {
@@ -107,10 +110,17 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn active_single_lookups(&self) -> Vec<(Id, Hash256, Option<Hash256>)> {
+    pub(crate) fn active_single_lookups(&self) -> Vec<BlockLookupSummary> {
         self.single_block_lookups
             .iter()
-            .map(|(id, e)| (*id, e.block_root(), e.awaiting_parent()))
+            .map(|(id, l)| {
+                (
+                    *id,
+                    l.block_root(),
+                    l.awaiting_parent(),
+                    l.all_peers().copied().collect(),
+                )
+            })
             .collect()
     }
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -258,7 +258,7 @@ impl TestRig {
             .active_single_lookups()
             .into_iter()
             .find(|l| l.1 == block_root)
-            .expect(&format!("no lookup for {block_root}"));
+            .unwrap_or_else(|| panic!("no lookup for {block_root}"));
         lookup.3.sort();
         expected_peers.sort();
         assert_eq!(

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -280,7 +280,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn active_single_lookups(&self) -> Vec<(Id, Hash256, Option<Hash256>)> {
+    pub(crate) fn active_single_lookups(&self) -> Vec<super::block_lookups::BlockLookupSummary> {
         self.block_lookups.active_single_lookups()
     }
 


### PR DESCRIPTION
## Issue Addressed

Previous PR
- https://github.com/sigp/lighthouse/pull/5655

Dropped the following feature: If a peers claims to have imported a block, we assume that it must have imported all its parents and will be considered to fetch data from any parent lookup

Having this feature is important to ensure that parent lookups don't "thin-out". Also, malicious peers can strategically send unknown data first to create lookups with a single peer.

## Proposed Changes

Add peers that claim to have imported a block to all lookups that are an ancestor of that block

Closes https://github.com/sigp/lighthouse/issues/5708

