### PR TITLE
Always build `lcli` on CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -324,7 +324,6 @@ jobs:
       run: |
           make
     - name: Install lcli
-      if: env.SELF_HOSTED_RUNNERS == 'false'
       run: make install-lcli
     - name: Run the doppelganger protection failure test script
       run: |


### PR DESCRIPTION
## Issue Addressed

The PR removes the "Install lcli" condition and always build lcli on CI, given it now only [takes less than 3 minutes](https://github.com/sigp/lighthouse/actions/runs/9264856460/job/25485751293) on the self-hosted runners. 

So far we've had to comment out / uncomment the condition every time there's a breaking change.