### PR TITLE
Reject `octet-stream` content type when we expect `json`

### DIFF
--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -10,7 +10,9 @@ use eth2::{
     types::{
         BlockId as CoreBlockId, ForkChoiceNode, ProduceBlockV3Response, StateId as CoreStateId, *,
     },
-    BeaconNodeHttpClient, Error, StatusCode, Timeouts,
+    BeaconNodeHttpClient, Error,
+    Error::ServerMessage,
+    StatusCode, Timeouts,
 };
 use execution_layer::test_utils::{
     MockBuilder, Operation, DEFAULT_BUILDER_PAYLOAD_VALUE_WEI, DEFAULT_MOCK_EL_PAYLOAD_VALUE_WEI,
@@ -795,6 +797,39 @@ impl ApiTester {
             );
 
             assert_eq!(result, expected, "{:?}", state_id);
+        }
+
+        self
+    }
+
+    pub async fn post_beacon_states_validator_balances_unsupported_media_failure(self) -> Self {
+        for state_id in self.interesting_state_ids() {
+            for validator_indices in self.interesting_validator_indices() {
+                let validator_index_ids = validator_indices
+                    .iter()
+                    .cloned()
+                    .map(|i| ValidatorId::Index(i))
+                    .collect::<Vec<ValidatorId>>();
+
+                let unsupported_media_response = self
+                    .client
+                    .post_beacon_states_validator_balances_with_ssz_header(
+                        state_id.0,
+                        validator_index_ids,
+                    )
+                    .await;
+
+                if let Err(unsupported_media_response) = unsupported_media_response {
+                    match unsupported_media_response {
+                        ServerMessage(error) => {
+                            assert_eq!(error.code, 415)
+                        }
+                        _ => panic!("Should error with unsupported media response"),
+                    }
+                } else {
+                    panic!("Should error with unsupported media response");
+                }
+            }
         }
 
         self
@@ -5610,6 +5645,14 @@ async fn get_events_from_genesis() {
     ApiTester::new_from_genesis()
         .await
         .test_get_events_from_genesis()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unsupported_media_response() {
+    ApiTester::new()
+        .await
+        .post_beacon_states_validator_balances_unsupported_media_failure()
         .await;
 }
 

--- a/common/warp_utils/src/json.rs
+++ b/common/warp_utils/src/json.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use eth2::{CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
 use serde::de::DeserializeOwned;
 use std::error::Error as StdError;
 use warp::{Filter, Rejection};
@@ -16,7 +17,18 @@ impl Json {
 }
 
 pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error = Rejection> + Copy {
-    warp::body::bytes().and_then(|bytes: Bytes| async move {
-        Json::decode(bytes).map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
-    })
+    warp::header::optional::<String>(CONTENT_TYPE_HEADER)
+        .and(warp::body::bytes())
+        .and_then(|header: Option<String>, bytes: Bytes| async move {
+            if let Some(header) = header {
+                if header == SSZ_CONTENT_TYPE_HEADER {
+                    return Err(reject::unsupported_media_type(format!(
+                        "Unsupported media type {}",
+                        header
+                    )));
+                }
+            }
+            Json::decode(bytes)
+                .map_err(|err| reject::custom_deserialize_error(format!("{:?}", err)))
+        })
 }

--- a/common/warp_utils/src/json.rs
+++ b/common/warp_utils/src/json.rs
@@ -22,10 +22,9 @@ pub fn json<T: DeserializeOwned + Send>() -> impl Filter<Extract = (T,), Error =
         .and_then(|header: Option<String>, bytes: Bytes| async move {
             if let Some(header) = header {
                 if header == SSZ_CONTENT_TYPE_HEADER {
-                    return Err(reject::unsupported_media_type(format!(
-                        "Unsupported media type {}",
-                        header
-                    )));
+                    return Err(reject::unsupported_media_type(
+                        "The request's content-type is not supported".to_string(),
+                    ));
                 }
             }
             Json::decode(bytes)

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -179,6 +179,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     if err.is_not_found() {
         code = StatusCode::NOT_FOUND;
         message = "NOT_FOUND".to_string();
+    } else if err.find::<crate::reject::UnsupportedMediaType>().is_some() {
+        code = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+        message = "UNSUPPORTED_MEDIA_TYPE".to_string();
     } else if let Some(e) = err.find::<crate::reject::CustomDeserializeError>() {
         message = format!("BAD_REQUEST: body deserialize error: {}", e.0);
         code = StatusCode::BAD_REQUEST;
@@ -239,9 +242,6 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
         code = StatusCode::METHOD_NOT_ALLOWED;
         message = "METHOD_NOT_ALLOWED".to_string();
-    } else if err.find::<warp::reject::UnsupportedMediaType>().is_some() {
-        code = StatusCode::UNSUPPORTED_MEDIA_TYPE;
-        message = "UNSUPPORTED_MEDIA_TYPE".to_string();
     } else {
         code = StatusCode::INTERNAL_SERVER_ERROR;
         message = "UNHANDLED_REJECTION".to_string();

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -137,6 +137,15 @@ pub fn invalid_auth(msg: String) -> warp::reject::Rejection {
 }
 
 #[derive(Debug)]
+pub struct UnsupportedMediaType(pub String);
+
+impl Reject for UnsupportedMediaType {}
+
+pub fn unsupported_media_type(msg: String) -> warp::reject::Rejection {
+    warp::reject::custom(UnsupportedMediaType(msg))
+}
+
+#[derive(Debug)]
 pub struct IndexedBadRequestErrors {
     pub message: String,
     pub failures: Vec<Failure>,
@@ -230,6 +239,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
         code = StatusCode::METHOD_NOT_ALLOWED;
         message = "METHOD_NOT_ALLOWED".to_string();
+    } else if err.find::<warp::reject::UnsupportedMediaType>().is_some() {
+        code = StatusCode::UNSUPPORTED_MEDIA_TYPE;
+        message = "UNSUPPORTED_MEDIA_TYPE".to_string();
     } else {
         code = StatusCode::INTERNAL_SERVER_ERROR;
         message = "UNHANDLED_REJECTION".to_string();


### PR DESCRIPTION
## Issue Addressed

Closes #5855 

## Proposed Changes

The issue is a side effect from https://github.com/sigp/lighthouse/pull/4575 . We ignore content type headers for endpoints that expect a json request body. Theres really only two content-type headers that are relevant to us `json` and `octet-stream`. 

This PR adds the following logic: 
If an endpoint that only supports `json` attempts to serve a request with an `octet-stream` content type header, it will reject the request with a 415 status code. All other content-type headers are left unchecked.

