### PR TITLE
Fix attestations not getting added to the aggregation pool

### DIFF
--- a/beacon_node/network/src/subnet_service/attestation_subnets.rs
+++ b/beacon_node/network/src/subnet_service/attestation_subnets.rs
@@ -477,8 +477,16 @@ impl<T: BeaconChainTypes> AttestationService<T> {
             time_to_subscription_slot.saturating_sub(advance_subscription_duration)
         };
 
+        let mut time_to_subscription_slot = self
+            .beacon_chain
+            .slot_clock
+            .duration_to_slot(slot)
+            .unwrap_or_default(); // If this is a past slot we will just get a 0 duration.
+
+        time_to_subscription_slot += slot_duration * 2;
+
         if let Some(tracked_vals) = self.aggregate_validators_on_subnet.as_mut() {
-            tracked_vals.insert(ExactSubnet { subnet_id, slot });
+            tracked_vals.insert_at(ExactSubnet { subnet_id, slot }, time_to_subscription_slot);
         }
 
         // If the subscription should be done in the future, schedule it. Otherwise subscribe

--- a/beacon_node/network/src/subnet_service/attestation_subnets.rs
+++ b/beacon_node/network/src/subnet_service/attestation_subnets.rs
@@ -29,6 +29,10 @@ pub(crate) const MIN_PEER_DISCOVERY_SLOT_LOOK_AHEAD: u64 = 2;
 /// Currently a whole slot ahead.
 const ADVANCE_SUBSCRIBE_SLOT_FRACTION: u32 = 1;
 
+/// The number of slots after an aggregator duty where we remove the entry from
+/// `aggregate_validators_on_subnet` delay map.
+const UNSUBSCRIBE_AFTER_AGGREGATOR_DUTY: u32 = 2;
+
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub(crate) enum SubscriptionKind {
     /// Long lived subscriptions.
@@ -462,31 +466,27 @@ impl<T: BeaconChainTypes> AttestationService<T> {
     ) -> Result<(), &'static str> {
         let slot_duration = self.beacon_chain.slot_clock.slot_duration();
 
-        // Calculate how long before we need to subscribe to the subnet.
-        let time_to_subscription_start = {
-            // The short time we schedule the subscription before it's actually required. This
-            // ensures we are subscribed on time, and allows consecutive subscriptions to the same
-            // subnet to overlap, reducing subnet churn.
-            let advance_subscription_duration = slot_duration / ADVANCE_SUBSCRIBE_SLOT_FRACTION;
-            // The time to the required slot.
-            let time_to_subscription_slot = self
-                .beacon_chain
-                .slot_clock
-                .duration_to_slot(slot)
-                .unwrap_or_default(); // If this is a past slot we will just get a 0 duration.
-            time_to_subscription_slot.saturating_sub(advance_subscription_duration)
-        };
-
-        let mut time_to_subscription_slot = self
+        // The short time we schedule the subscription before it's actually required. This
+        // ensures we are subscribed on time, and allows consecutive subscriptions to the same
+        // subnet to overlap, reducing subnet churn.
+        let advance_subscription_duration = slot_duration / ADVANCE_SUBSCRIBE_SLOT_FRACTION;
+        // The time to the required slot.
+        let time_to_subscription_slot = self
             .beacon_chain
             .slot_clock
             .duration_to_slot(slot)
             .unwrap_or_default(); // If this is a past slot we will just get a 0 duration.
 
-        time_to_subscription_slot += slot_duration * 2;
+        // Calculate how long before we need to subscribe to the subnet.
+        let time_to_subscription_start =
+            time_to_subscription_slot.saturating_sub(advance_subscription_duration);
 
+        // The time after a duty slot where we no longer need it in the `aggregate_validators_on_subnet`
+        // delay map.
+        let time_to_unsubscribe =
+            time_to_subscription_slot + UNSUBSCRIBE_AFTER_AGGREGATOR_DUTY * slot_duration;
         if let Some(tracked_vals) = self.aggregate_validators_on_subnet.as_mut() {
-            tracked_vals.insert_at(ExactSubnet { subnet_id, slot }, time_to_subscription_slot);
+            tracked_vals.insert_at(ExactSubnet { subnet_id, slot }, time_to_unsubscribe);
         }
 
         // If the subscription should be done in the future, schedule it. Otherwise subscribe


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

On receiving unaggregated attestations from the network, lighthouse sets the `should_process` variable on attestations depending on if we have a connected validator having aggregation duties for the same slot .
For `should_process == false`, we only validate and forward the attestation, otherwise, we add it to the naive_aggregation_pool so that we can aggregate them.

The `should_process` calculation happens in the subnet service where it checks if the duty slot and subnet exists in a delay map.
https://github.com/sigp/lighthouse/blob/3058b96f2560f1da04ada4f9d8ba8e5651794ff6/beacon_node/network/src/subnet_service/attestation_subnets.rs#L390-L393

The bug is that during insertion into the delay map, we use the default expiration delay of a single slot duration(12s). 

Since we implemented https://github.com/sigp/lighthouse/pull/4806 to reduce subscription spam, we don't send subscriptions every slot before the duty, so we get a situation where an entry into the delay map gets evicted before it has been read. 

Hence, the `should_process_attestation` function almost always returns false unless `import-all-attestations` flag is turned on, leading to Lighthouse producing bad quality aggregate attestations.