### PR TITLE
Re-export "useful" crates from `lighthouse`

### DIFF
--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -26,6 +26,7 @@ slasher-lmdb = ["slasher/lmdb"]
 jemalloc = ["malloc_utils/jemalloc"]
 
 [dependencies]
+lighthouse_network = { workspace = true }
 beacon_node = { workspace = true }
 slog = { workspace = true }
 types = { workspace = true }

--- a/lighthouse/src/lib.rs
+++ b/lighthouse/src/lib.rs
@@ -1,14 +1,13 @@
-pub use beacon_node;
-pub use environment;
-pub use types as eth2_types;
-pub use eth2_network_config;
-pub use task_executor;
-pub use boot_node;
 pub use account_manager;
-pub use validator_client;
+pub use beacon_node;
+pub use boot_node;
 pub use database_manager;
-pub use slasher;
-pub use validator_manager;
-pub use lighthouse_version;
+pub use environment;
+pub use eth2_network_config;
 pub use lighthouse_network;
-
+pub use lighthouse_version;
+pub use slasher;
+pub use task_executor;
+pub use types as eth2_types;
+pub use validator_client;
+pub use validator_manager;

--- a/lighthouse/src/lib.rs
+++ b/lighthouse/src/lib.rs
@@ -8,6 +8,6 @@ pub use lighthouse_network;
 pub use lighthouse_version;
 pub use slasher;
 pub use task_executor;
-pub use types as eth2_types;
+pub use types;
 pub use validator_client;
 pub use validator_manager;

--- a/lighthouse/src/lib.rs
+++ b/lighthouse/src/lib.rs
@@ -1,0 +1,16 @@
+mod metrics;
+
+pub use beacon_node;
+pub use environment;
+pub use types as eth2_types;
+pub use eth2_network_config;
+pub use task_executor;
+pub use boot_node;
+pub use account_manager;
+pub use validator_client;
+pub use database_manager;
+pub use slasher;
+pub use validator_manager;
+pub use lighthouse_version;
+pub use lighthouse_network;
+

--- a/lighthouse/src/lib.rs
+++ b/lighthouse/src/lib.rs
@@ -1,5 +1,3 @@
-mod metrics;
-
 pub use beacon_node;
 pub use environment;
 pub use types as eth2_types;

--- a/lighthouse/src/lib.rs
+++ b/lighthouse/src/lib.rs
@@ -1,12 +1,15 @@
 pub use account_manager;
 pub use beacon_node;
 pub use boot_node;
-pub use database_manager;
 pub use environment;
+pub use eth2 as http;
 pub use eth2_network_config;
+pub use execution_layer;
 pub use lighthouse_network;
 pub use lighthouse_version;
 pub use slasher;
+pub use slot_clock;
+pub use store;
 pub use task_executor;
 pub use types;
 pub use validator_client;


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

 - Add a library entry for the `lighthouse` crate
 - Re-export the following crates from this new library entry point so that they're accessible via `use lighthouse::foo::bar`
   - `beacon_node`
   - `environment`
   - `types` (as `eth2_types`)
   - `eth2_network_config`
   - `task_executor`
   - `boot_node`
   - `account_manager`
   - `validator_client`
   - `database_manager`
   - `slasher`
   - `validator_manager`
   - `lighthouse_version`
   - `lighthouse_network`

## Additional Info

Consider the problem of starting Lighthouse programmatically; i.e., an external program that wishes to run code in-process with Lighthouse. Currently, the imports for this look like:

```rust
use beacon_node::{ClientConfig, ProductionBeaconNode};
use environment::{
    Environment, EnvironmentBuilder, LoggerConfig, RuntimeContext,
};
use eth2::types::eth_spec::MainnetEthSpec;
use eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK};
use task_executor::ShutdownReason;
```

(For a full demonstration, consult [this gist](https://gist.github.com/jmcph4/80b61b4c0bfb5da0376e2e85558670a9)).

With this PR, these imports would change to:

```rust
use lighthouse::{
    beacon_node::{ClientConfig, ProductionBeaconNode},
    environment::{
        Environment, EnvironmentBuilder, LoggerConfig, RuntimeContext,
    },
    eth2_network_config::{Eth2NetworkConfig, DEFAULT_HARDCODED_NETWORK},
    eth2_types::eth_spec::MainnetEthSpec,
    task_executor::ShutdownReason,
};
```

Additionally, specifying dependencies becomes vastly simpler. Compare:

```toml
lighthouse = { git = "https://github.com/sigp/lighthouse" }
beacon_node = { git = "https://github.com/sigp/lighthouse" }
task_executor = { git = "https://github.com/sigp/lighthouse" }
eth2 = { git = "https://github.com/sigp/lighthouse" }
environment = { git = "https://github.com/sigp/lighthouse" }
eth2_network_config = { git = "https://github.com/sigp/lighthouse" }
```

to:

```toml
lighthouse = { git = "https://github.com/sigp/lighthouse" }
```