### PR TITLE
Allow all RPC messages on disconnect

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1378,10 +1378,10 @@ impl<AppReqId: ReqId, E: EthSpec> Network<AppReqId, E> {
     ) -> Option<NetworkEvent<AppReqId, E>> {
         let peer_id = event.peer_id;
 
+        // Do not permit Inbound events from peers that are being disconnected, or RPC requests.
         if !self.peer_manager().is_connected(&peer_id)
-            // Do not permit Inbound events from peers that are being disconnected
-            && matches!(event.event, HandlerEvent::Err(HandlerErr::Inbound { .. }))
-            && matches!(event.event, HandlerEvent::Ok(RPCReceived::Request(..)))
+            && (matches!(event.event, HandlerEvent::Err(HandlerErr::Inbound { .. }))
+                || matches!(event.event, HandlerEvent::Ok(RPCReceived::Request(..))))
         {
             debug!(
                 self.log,


### PR DESCRIPTION
This PR makes it more permissive for outbound RPC messages to reach the application layer. 

Previously, RPC requests were not getting stream terminations in race conditions between a peer disconnecting and the RPC handler propagating the message up. 

This PR now allows messages to pass up to the application layer in the events that we start disconnecting from a peer. This will even allow slower messages to be sent to the application layer after peers have been disconnected. 

This should help resolve further sync lookup bugs. 
