### PR TITLE
Increase slog buffer size

### DIFF
--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -36,7 +36,7 @@ use {futures::channel::oneshot, std::cell::RefCell};
 
 pub use task_executor::test_utils::null_logger;
 
-const LOG_CHANNEL_SIZE: usize = 2048;
+const LOG_CHANNEL_SIZE: usize = 16384;
 const SSE_LOG_CHANNEL_SIZE: usize = 2048;
 /// The maximum time in seconds the client will wait for all internal tasks to shutdown.
 const MAXIMUM_SHUTDOWN_TIME: u64 = 15;


### PR DESCRIPTION
## Proposed Changes

Increase the `slog` buffer size to 16K to reduce the occurrence of:

> ERRO slog-async: logger dropped messages due to channel overflow, count: 4

These errors sometimes occur on our Holesky BNs which are receiving attestations from 100K validators each. They also occur occasionally on other BNs supporting large numbers of validators.

Examples of messages that overflow the channel include:

- `DEBG Attempted to publish duplicate message`
- `INFO Started monitoring validator`
- `DEBG Unable to obtain indexed form of attestation for slasher` (reduced by #5006)

Arguably some of these should be debounced, but for others it's not obvious that they should be. Increasing the buffer size temporarily at least gives us a full view of the logs until some of these spammier logs are toned down. It's frustrating to miss important ERRO/CRIT logs due to overflows.

## Additional Info


