### PR TITLE
Fix getClientVersionV1 for Geth 1.13

### DIFF
--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -755,6 +755,9 @@ pub mod serde_logs_bloom {
 #[serde(rename_all = "camelCase")]
 pub struct JsonClientVersionV1 {
     pub code: String,
+    // This `default` is required until Geth v1.13.x is no longer supported on mainnet.
+    // See: https://github.com/ethereum/go-ethereum/pull/29351
+    #[serde(default)]
     pub name: String,
     pub version: String,
     pub commit: String,


### PR DESCRIPTION
## Issue Addressed

Fix an incompatibility with Geth 1.13 which does not follow the spec for `engine_getClientVersionV1`:

- https://github.com/ethereum/go-ethereum/pull/29351

## Proposed Changes

If Lighthouse is used with this buggy version of Geth we set the `name` to `""`. Lighthouse doesn't use the name for anything at present, so IMO there's no point adding complexity to read the `clientName` field.
