### PR TITLE
Store data columns individually in store and caches

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use task_executor::TaskExecutor;
 use types::blob_sidecar::{BlobIdentifier, BlobSidecar, FixedBlobSidecarList};
 use types::{
-    BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSidecarList, Epoch, EthSpec, Hash256,
+    BlobSidecarList, ChainSpec, DataColumnSidecar, DataColumnSidecarVec, Epoch, EthSpec, Hash256,
     RuntimeVariableList, SignedBeaconBlock,
 };
 
@@ -309,16 +309,11 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                     block,
                     blobs: None,
                     blobs_available_timestamp: None,
-                    // TODO(das): update store type to prevent this conversion
                     data_columns: Some(
-                        RuntimeVariableList::new(
-                            data_column_list
-                                .into_iter()
-                                .map(|d| d.clone_arc())
-                                .collect(),
-                            self.spec.number_of_columns,
-                        )
-                        .expect("data column list is within bounds"),
+                        data_column_list
+                            .into_iter()
+                            .map(|d| d.clone_arc())
+                            .collect(),
                     ),
                     spec: self.spec.clone(),
                 }))
@@ -409,13 +404,8 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
                         block,
                         blobs: None,
                         blobs_available_timestamp: None,
-                        // TODO(das): update store type to prevent this conversion
                         data_columns: data_columns.map(|data_columns| {
-                            RuntimeVariableList::new(
-                                data_columns.into_iter().map(|d| d.into_inner()).collect(),
-                                self.spec.number_of_columns,
-                            )
-                            .expect("data column list is within bounds")
+                            data_columns.into_iter().map(|d| d.into_inner()).collect()
                         }),
                         spec: self.spec.clone(),
                     })
@@ -605,7 +595,7 @@ pub struct AvailableBlock<E: EthSpec> {
     blobs: Option<BlobSidecarList<E>>,
     /// Timestamp at which this block first became available (UNIX timestamp, time since 1970).
     blobs_available_timestamp: Option<Duration>,
-    data_columns: Option<DataColumnSidecarList<E>>,
+    data_columns: Option<DataColumnSidecarVec<E>>,
     pub spec: Arc<ChainSpec>,
 }
 
@@ -614,7 +604,7 @@ impl<E: EthSpec> AvailableBlock<E> {
         block_root: Hash256,
         block: Arc<SignedBeaconBlock<E>>,
         blobs: Option<BlobSidecarList<E>>,
-        data_columns: Option<DataColumnSidecarList<E>>,
+        data_columns: Option<DataColumnSidecarVec<E>>,
         spec: Arc<ChainSpec>,
     ) -> Self {
         Self {
@@ -643,7 +633,7 @@ impl<E: EthSpec> AvailableBlock<E> {
         self.blobs_available_timestamp
     }
 
-    pub fn data_columns(&self) -> Option<&DataColumnSidecarList<E>> {
+    pub fn data_columns(&self) -> Option<&DataColumnSidecarVec<E>> {
         self.data_columns.as_ref()
     }
 
@@ -654,7 +644,7 @@ impl<E: EthSpec> AvailableBlock<E> {
         Hash256,
         Arc<SignedBeaconBlock<E>>,
         Option<BlobSidecarList<E>>,
-        Option<DataColumnSidecarList<E>>,
+        Option<DataColumnSidecarVec<E>>,
     ) {
         let AvailableBlock {
             block_root,

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -349,16 +349,11 @@ impl<E: EthSpec> PendingComponents<E> {
             block,
             blobs,
             blobs_available_timestamp,
-            // TODO(das): Update store types to prevent this conversion
             data_columns: Some(
-                RuntimeVariableList::new(
-                    verified_data_columns
-                        .into_iter()
-                        .map(|d| d.into_inner())
-                        .collect(),
-                    spec.number_of_columns,
-                )
-                .expect("data column list is within bounds"),
+                verified_data_columns
+                    .into_iter()
+                    .map(|d| d.into_inner())
+                    .collect(),
             ),
             spec: spec.clone(),
         };

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -22,7 +22,7 @@ pub struct CacheItem<E: EthSpec> {
      */
     block: Arc<SignedBeaconBlock<E>>,
     blobs: Option<BlobSidecarList<E>>,
-    data_columns: Option<DataColumnSidecarList<E>>,
+    data_columns: Option<DataColumnSidecarVec<E>>,
     proto_block: ProtoBlock,
 }
 
@@ -169,7 +169,7 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
     }
 
     /// Returns the data columns, if `block_root` matches the cached item.
-    pub fn get_data_columns(&self, block_root: Hash256) -> Option<DataColumnSidecarList<E>> {
+    pub fn get_data_columns(&self, block_root: Hash256) -> Option<DataColumnSidecarVec<E>> {
         self.item
             .read()
             .as_ref()

--- a/beacon_node/beacon_chain/src/test_utils.rs
+++ b/beacon_node/beacon_chain/src/test_utils.rs
@@ -2593,9 +2593,7 @@ pub fn generate_rand_block_and_data_columns<E: EthSpec>(
 ) {
     let (block, blobs) = generate_rand_block_and_blobs(fork_name, num_blobs, rng);
     let blob: BlobsList<E> = blobs.into_iter().map(|b| b.blob).collect::<Vec<_>>().into();
-    let data_columns = DataColumnSidecar::build_sidecars(&blob, &block, &KZG, spec)
-        .unwrap()
-        .into();
+    let data_columns = DataColumnSidecar::build_sidecars(&blob, &block, &KZG, spec).unwrap();
 
     (block, data_columns)
 }

--- a/beacon_node/network/src/sync/network_context/custody.rs
+++ b/beacon_node/network/src/sync/network_context/custody.rs
@@ -30,7 +30,7 @@ const FAILED_PEERS_CACHE_EXPIRY_SECONDS: u64 = 5;
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct CustodyRequester(pub SingleLookupReqId);
 
-type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
+type DataColumnSidecarVec<E> = Vec<Arc<DataColumnSidecar<E>>>;
 
 pub struct ActiveCustodyRequest<T: BeaconChainTypes> {
     block_root: Hash256,
@@ -107,7 +107,7 @@ impl<T: BeaconChainTypes> ActiveCustodyRequest<T> {
         &mut self,
         peer_id: PeerId,
         req_id: DataColumnsByRootRequestId,
-        resp: RpcResponseResult<DataColumnSidecarList<T::EthSpec>>,
+        resp: RpcResponseResult<DataColumnSidecarVec<T::EthSpec>>,
         cx: &mut SyncNetworkContext<T>,
     ) -> CustodyRequestResult<T::EthSpec> {
         // TODO(das): Should downscore peers for verify errors here

--- a/beacon_node/network/src/sync/sampling.rs
+++ b/beacon_node/network/src/sync/sampling.rs
@@ -25,7 +25,7 @@ pub enum SamplingRequester {
     ImportedBlock(Hash256),
 }
 
-type DataColumnSidecarList<E> = Vec<Arc<DataColumnSidecar<E>>>;
+type DataColumnSidecarVec<E> = Vec<Arc<DataColumnSidecar<E>>>;
 
 pub struct Sampling<T: BeaconChainTypes> {
     // TODO(das): stalled sampling request are never cleaned up
@@ -102,7 +102,7 @@ impl<T: BeaconChainTypes> Sampling<T> {
         &mut self,
         id: SamplingId,
         peer_id: PeerId,
-        resp: Result<(DataColumnSidecarList<T::EthSpec>, Duration), RpcResponseError>,
+        resp: Result<(DataColumnSidecarVec<T::EthSpec>, Duration), RpcResponseError>,
         cx: &mut SyncNetworkContext<T>,
     ) -> Option<(SamplingRequester, SamplingResult)> {
         let Some(request) = self.requests.get_mut(&id.id) else {
@@ -237,7 +237,7 @@ impl<T: BeaconChainTypes> ActiveSamplingRequest<T> {
         &mut self,
         _peer_id: PeerId,
         column_index: ColumnIndex,
-        resp: Result<(DataColumnSidecarList<T::EthSpec>, Duration), RpcResponseError>,
+        resp: Result<(DataColumnSidecarVec<T::EthSpec>, Duration), RpcResponseError>,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<Option<()>, SamplingError> {
         // Select columns to sample

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -20,8 +20,8 @@ use crate::metadata::{
 use crate::metrics;
 use crate::state_cache::{PutStateOutcome, StateCache};
 use crate::{
-    get_key_for_col, ChunkWriter, DBColumn, DatabaseBlock, Error, ItemStore, KeyValueStoreOp,
-    PartialBeaconState, StoreItem, StoreOp,
+    get_data_column_key, get_key_for_col, ChunkWriter, DBColumn, DatabaseBlock, Error, ItemStore,
+    KeyValueStoreOp, PartialBeaconState, StoreItem, StoreOp,
 };
 use itertools::process_results;
 use leveldb::iterator::LevelDBIterator;
@@ -36,6 +36,7 @@ use state_processing::{
     SlotProcessingError,
 };
 use std::cmp::min;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::path::Path;
@@ -89,7 +90,7 @@ pub struct HotColdDB<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> {
 struct BlockCache<E: EthSpec> {
     block_cache: LruCache<Hash256, SignedBeaconBlock<E>>,
     blob_cache: LruCache<Hash256, BlobSidecarList<E>>,
-    data_column_cache: LruCache<Hash256, DataColumnSidecarList<E>>,
+    data_column_cache: LruCache<Hash256, HashMap<ColumnIndex, Arc<DataColumnSidecar<E>>>>,
 }
 
 impl<E: EthSpec> BlockCache<E> {
@@ -106,12 +107,10 @@ impl<E: EthSpec> BlockCache<E> {
     pub fn put_blobs(&mut self, block_root: Hash256, blobs: BlobSidecarList<E>) {
         self.blob_cache.put(block_root, blobs);
     }
-    pub fn put_data_columns(
-        &mut self,
-        block_root: Hash256,
-        data_columns: DataColumnSidecarList<E>,
-    ) {
-        self.data_column_cache.put(block_root, data_columns);
+    pub fn put_data_column(&mut self, block_root: Hash256, data_column: Arc<DataColumnSidecar<E>>) {
+        self.data_column_cache
+            .get_or_insert_mut(block_root, Default::default)
+            .insert(data_column.index, data_column);
     }
     pub fn get_block<'a>(&'a mut self, block_root: &Hash256) -> Option<&'a SignedBeaconBlock<E>> {
         self.block_cache.get(block_root)
@@ -119,11 +118,14 @@ impl<E: EthSpec> BlockCache<E> {
     pub fn get_blobs<'a>(&'a mut self, block_root: &Hash256) -> Option<&'a BlobSidecarList<E>> {
         self.blob_cache.get(block_root)
     }
-    pub fn get_data_columns<'a>(
+    pub fn get_data_column<'a>(
         &'a mut self,
         block_root: &Hash256,
-    ) -> Option<&'a DataColumnSidecarList<E>> {
-        self.data_column_cache.get(block_root)
+        column_index: &ColumnIndex,
+    ) -> Option<&'a Arc<DataColumnSidecar<E>>> {
+        self.data_column_cache
+            .get(block_root)
+            .and_then(|map| map.get(column_index))
     }
     pub fn delete_block(&mut self, block_root: &Hash256) {
         let _ = self.block_cache.pop(block_root);
@@ -672,15 +674,20 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
     pub fn data_columns_as_kv_store_ops(
         &self,
-        key: &Hash256,
-        data_columns: DataColumnSidecarList<E>,
+        block_root: &Hash256,
+        data_columns: DataColumnSidecarVec<E>,
         ops: &mut Vec<KeyValueStoreOp>,
     ) {
-        let db_key = get_key_for_col(DBColumn::BeaconDataColumn.into(), key.as_bytes());
-        ops.push(KeyValueStoreOp::PutKeyValue(
-            db_key,
-            data_columns.as_ssz_bytes(),
-        ));
+        for data_column in data_columns {
+            let db_key = get_key_for_col(
+                DBColumn::BeaconDataColumn.into(),
+                &get_data_column_key(block_root, &data_column.index),
+            );
+            ops.push(KeyValueStoreOp::PutKeyValue(
+                db_key,
+                data_column.as_ssz_bytes(),
+            ));
+        }
     }
 
     pub fn put_state_summary(
@@ -998,10 +1005,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     key_value_batch.push(KeyValueStoreOp::DeleteKey(key));
                 }
 
-                StoreOp::DeleteDataColumns(block_root) => {
-                    let key =
-                        get_key_for_col(DBColumn::BeaconDataColumn.into(), block_root.as_bytes());
-                    key_value_batch.push(KeyValueStoreOp::DeleteKey(key));
+                StoreOp::DeleteDataColumns(block_root, column_indices) => {
+                    for index in column_indices {
+                        let key = get_key_for_col(
+                            DBColumn::BeaconDataColumn.into(),
+                            &get_data_column_key(&block_root, &index),
+                        );
+                        key_value_batch.push(KeyValueStoreOp::DeleteKey(key));
+                    }
                 }
 
                 StoreOp::DeleteState(state_root, slot) => {
@@ -1054,9 +1065,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                     }
                     true
                 }
-                StoreOp::DeleteDataColumns(block_root) => {
+                StoreOp::DeleteDataColumns(block_root, _column_indices) => {
+                    // TODO(das): use _column_indices when pruning is implemented
                     match self.get_data_columns(block_root) {
-                        Ok(Some(data_column_sidecar_list)) => {
+                        Ok(data_column_sidecar_list) => {
+                            // Must push the same number of items as StoreOp::DeleteDataColumns items to
+                            // prevent a `HotColdDBError::Rollback` error below in case of rollback
                             data_columns_to_delete.push((*block_root, data_column_sidecar_list));
                         }
                         Err(e) => {
@@ -1066,7 +1080,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                                 "error" => ?e
                             );
                         }
-                        _ => (),
                     }
                     true
                 }
@@ -1101,14 +1114,15 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             for op in blob_cache_ops.iter_mut() {
                 let reverse_op = match op {
                     StoreOp::PutBlobs(block_root, _) => StoreOp::DeleteBlobs(*block_root),
-                    StoreOp::PutDataColumns(block_root, _) => {
-                        StoreOp::DeleteDataColumns(*block_root)
+                    StoreOp::PutDataColumns(block_root, data_columns) => {
+                        let indices = data_columns.iter().map(|c| c.index).collect();
+                        StoreOp::DeleteDataColumns(*block_root, indices)
                     }
                     StoreOp::DeleteBlobs(_) => match blobs_to_delete.pop() {
                         Some((block_root, blobs)) => StoreOp::PutBlobs(block_root, blobs),
                         None => return Err(HotColdDBError::Rollback.into()),
                     },
-                    StoreOp::DeleteDataColumns(_) => match data_columns_to_delete.pop() {
+                    StoreOp::DeleteDataColumns(_, _) => match data_columns_to_delete.pop() {
                         Some((block_root, data_columns)) => {
                             StoreOp::PutDataColumns(block_root, data_columns)
                         }
@@ -1152,7 +1166,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
                 StoreOp::DeleteBlobs(_) => (),
 
-                StoreOp::DeleteDataColumns(_) => (),
+                StoreOp::DeleteDataColumns(_, _) => (),
 
                 StoreOp::DeleteExecutionPayload(_) => (),
 
@@ -1653,30 +1667,49 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
     }
 
-    /// Fetch data_columns for a given block from the store.
+    /// Fetch all data_columns for a given block from the store.
     pub fn get_data_columns(
         &self,
         block_root: &Hash256,
-    ) -> Result<Option<DataColumnSidecarList<E>>, Error> {
+    ) -> Result<Vec<Arc<DataColumnSidecar<E>>>, Error> {
+        let mut items = vec![];
+        for entry_result in self.blobs_db.iter_column_from::<Vec<u8>>(
+            DBColumn::BeaconDataColumn,
+            &get_data_column_key(block_root, &0),
+            &get_data_column_key(block_root, &u64::max_value()),
+        ) {
+            let (_, value_bytes) = entry_result?;
+            items.push(Arc::new(DataColumnSidecar::from_ssz_bytes(&value_bytes)?));
+        }
+        Ok(items)
+    }
+
+    /// Fetch a single data_column for a given block from the store.
+    pub fn get_data_column(
+        &self,
+        block_root: &Hash256,
+        column_index: &ColumnIndex,
+    ) -> Result<Option<Arc<DataColumnSidecar<E>>>, Error> {
         // Check the cache.
-        if let Some(data_columns) = self.block_cache.lock().get_data_columns(block_root) {
+        if let Some(data_column) = self
+            .block_cache
+            .lock()
+            .get_data_column(block_root, column_index)
+        {
             metrics::inc_counter(&metrics::BEACON_DATA_COLUMNS_CACHE_HIT_COUNT);
-            return Ok(Some(data_columns.clone()));
+            return Ok(Some(data_column.clone()));
         }
 
-        match self
-            .blobs_db
-            .get_bytes(DBColumn::BeaconDataColumn.into(), block_root.as_bytes())?
-        {
-            Some(ref data_columns_bytes) => {
-                let data_columns = RuntimeVariableList::from_ssz_bytes(
-                    data_columns_bytes,
-                    self.spec.number_of_columns,
-                )?;
+        match self.blobs_db.get_bytes(
+            DBColumn::BeaconDataColumn.into(),
+            &get_data_column_key(block_root, column_index),
+        )? {
+            Some(ref data_column_bytes) => {
+                let data_column = Arc::new(DataColumnSidecar::from_ssz_bytes(data_column_bytes)?);
                 self.block_cache
                     .lock()
-                    .put_data_columns(*block_root, data_columns.clone());
-                Ok(Some(data_columns))
+                    .put_data_column(*block_root, data_column.clone());
+                Ok(Some(data_column))
             }
             None => Ok(None),
         }

--- a/beacon_node/store/src/memory_store.rs
+++ b/beacon_node/store/src/memory_store.rs
@@ -78,16 +78,17 @@ impl<E: EthSpec> KeyValueStore<E> for MemoryStore<E> {
         Ok(())
     }
 
-    fn iter_column_from<K: Key>(&self, column: DBColumn, from: &[u8]) -> ColumnIter<K> {
+    fn iter_column_from<K: Key>(&self, column: DBColumn, from: &[u8], to: &[u8]) -> ColumnIter<K> {
         // We use this awkward pattern because we can't lock the `self.db` field *and* maintain a
         // reference to the lock guard across calls to `.next()`. This would be require a
         // struct with a field (the iterator) which references another field (the lock guard).
         let start_key = BytesKey::from_vec(get_key_for_col(column.as_str(), from));
+        let end_key = BytesKey::from_vec(get_key_for_col(column.as_str(), to));
         let col = column.as_str();
         let keys = self
             .db
             .read()
-            .range(start_key..)
+            .range(start_key..end_key)
             .take_while(|(k, _)| k.remove_column_variable(column).is_some())
             .filter_map(|(k, _)| k.remove_column_variable(column).map(|k| k.to_vec()))
             .collect::<Vec<_>>();

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -1,8 +1,8 @@
 use crate::beacon_block_body::{KzgCommitments, BLOB_KZG_COMMITMENTS_INDEX};
 use crate::test_utils::TestRandom;
 use crate::{
-    BeaconBlockHeader, ChainSpec, EthSpec, Hash256, KzgProofs, RuntimeVariableList,
-    SignedBeaconBlock, SignedBeaconBlockHeader, Slot,
+    BeaconBlockHeader, ChainSpec, EthSpec, Hash256, KzgProofs, SignedBeaconBlock,
+    SignedBeaconBlockHeader, Slot,
 };
 use crate::{BeaconStateError, BlobsList};
 use bls::Signature;
@@ -41,7 +41,7 @@ pub struct DataColumnIdentifier {
     pub index: ColumnIndex,
 }
 
-pub type DataColumnSidecarList<E> = RuntimeVariableList<Arc<DataColumnSidecar<E>>>;
+pub type DataColumnSidecarVec<E> = Vec<Arc<DataColumnSidecar<E>>>;
 
 #[derive(
     Debug,
@@ -106,10 +106,10 @@ impl<E: EthSpec> DataColumnSidecar<E> {
         block: &SignedBeaconBlock<E>,
         kzg: &Kzg,
         spec: &ChainSpec,
-    ) -> Result<DataColumnSidecarList<E>, DataColumnSidecarError> {
+    ) -> Result<DataColumnSidecarVec<E>, DataColumnSidecarError> {
         let number_of_columns = spec.number_of_columns;
         if blobs.is_empty() {
-            return Ok(RuntimeVariableList::empty(number_of_columns));
+            return Ok(vec![]);
         }
         let kzg_commitments = block
             .message()
@@ -189,7 +189,6 @@ impl<E: EthSpec> DataColumnSidecar<E> {
                 })
             })
             .collect();
-        let sidecars = RuntimeVariableList::from_vec(sidecars, number_of_columns);
 
         Ok(sidecars)
     }

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -144,7 +144,7 @@ pub use crate::config_and_preset::{
 pub use crate::consolidation::Consolidation;
 pub use crate::contribution_and_proof::ContributionAndProof;
 pub use crate::data_column_sidecar::{
-    ColumnIndex, DataColumnIdentifier, DataColumnSidecar, DataColumnSidecarList,
+    ColumnIndex, DataColumnIdentifier, DataColumnSidecar, DataColumnSidecarVec,
 };
 pub use crate::data_column_subnet_id::DataColumnSubnetId;
 pub use crate::deposit::{Deposit, DEPOSIT_TREE_DEPTH};


### PR DESCRIPTION
## Issue Addressed

Currently data columns are stored in the same bucket on the `BeaconDataColumn` DB column as a runtime list. In the case of a supernode, that's 128 items in that one key. However, a peer may only request a single-column index from us via data columns by range or by root. We then have to do x128 more i/o than necessary.

Note that blobs are currently stored in the same concatenated form. Since blob access patterns are more uniform (everyone is likely to request everything always) it makes sense.

## Proposed Changes

Change the `BeaconDataColumn` key from just `block_root` to `block_root | column_index`. Retrieve columns one by one on columns by range / by root requests.

Note that pruning is not yet implemented, so there a bit of legwork todo still to delete on columns on the same block root efficiently.


