### PR TITLE
Check known parent on rpc blob process

### DIFF
--- a/beacon_node/beacon_chain/tests/events.rs
+++ b/beacon_node/beacon_chain/tests/events.rs
@@ -62,13 +62,17 @@ async fn blob_sidecar_event_on_process_rpc_blobs() {
     let kzg = harness.chain.kzg.as_ref().unwrap();
     let mut rng = StdRng::seed_from_u64(0xDEADBEEF0BAD5EEDu64);
 
-    let blob_1 = BlobSidecar::random_valid(&mut rng, kzg)
-        .map(Arc::new)
-        .unwrap();
-    let blob_2 = Arc::new(BlobSidecar {
+    let mut blob_1 = BlobSidecar::random_valid(&mut rng, kzg).unwrap();
+    let mut blob_2 = BlobSidecar {
         index: 1,
         ..BlobSidecar::random_valid(&mut rng, kzg).unwrap()
-    });
+    };
+    let parent_root = harness.chain.head().head_block_root();
+    blob_1.signed_block_header.message.parent_root = parent_root;
+    blob_2.signed_block_header.message.parent_root = parent_root;
+    let blob_1 = Arc::new(blob_1);
+    let blob_2 = Arc::new(blob_2);
+
     let blobs = FixedBlobSidecarList::from(vec![Some(blob_1.clone()), Some(blob_2.clone())]);
     let expected_sse_blobs = vec![
         SseBlobSidecar::from_blob_sidecar(blob_1.as_ref()),

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -1,4 +1,3 @@
-use super::common::ResponseType;
 use super::{BlockComponent, PeerId, SINGLE_BLOCK_LOOKUP_MAX_ATTEMPTS};
 use crate::sync::block_lookups::common::RequestState;
 use crate::sync::network_context::{
@@ -188,7 +187,6 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             .state
             .peek_downloaded_data()
             .cloned();
-        let block_is_processed = self.block_request_state.state.is_processed();
         let request = R::request_state_mut(self);
 
         // Attempt to progress awaiting downloads
@@ -241,12 +239,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         // Otherwise, attempt to progress awaiting processing
         // If this request is awaiting a parent lookup to be processed, do not send for processing.
         // The request will be rejected with unknown parent error.
-        //
-        // TODO: The condition `block_is_processed || Block` can be dropped after checking for
-        // unknown parent root when import RPC blobs
-        } else if !awaiting_parent
-            && (block_is_processed || matches!(R::response_type(), ResponseType::Block))
-        {
+        } else if !awaiting_parent {
             // maybe_start_processing returns Some if state == AwaitingProcess. This pattern is
             // useful to conditionally access the result data.
             if let Some(result) = request.get_state_mut().maybe_start_processing() {


### PR DESCRIPTION
## Issue Addressed

We currently do not check that a blob from RPC is a descendant of a known block. Since we don't check the proposer signature we can insert data into the da_checker that is completely fabricated or descendant of invalid data.

I don't see any good reason on why to not check that parent is known before inserting into the da_checker. We may also want to check the proposer signature, and correct proposer.

Lookup sync today gets around this issues by:
- do not fetch blobs for some root until having downloaded that block. This forces an attacker into sending us _some_ block and get down-scored if it's not valid
- do not send blobs for processing until having processed the block. This patches the issue of not checking for unknown parent on blobs, but it slows down a bit lookup sync.

## Proposed Changes

Resolve this TODO

https://github.com/sigp/lighthouse/blob/4e675cf5da22990aecf75a4a008dd9f336d50bf4/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs#L245-L246

Check known parent on RPC blob process

Depends on this PR to make the `ParentUnknown` error not expect an RpcBlock

- https://github.com/sigp/lighthouse/pull/5735
