### PR TITLE
Soft fork gossip topic activation and deactivation

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -380,7 +380,10 @@ impl SupportedProtocol {
             supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::BlobsByRootV1, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::BlobsByRangeV1, Encoding::SSZSnappy),
-                // TODO(das): add to PeerDAS fork
+            ]);
+        }
+        if fork_context.peerdas_fork_scheduled() {
+            supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::DataColumnsByRootV1, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::DataColumnsByRangeV1, Encoding::SSZSnappy),
             ]);

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -382,7 +382,7 @@ impl SupportedProtocol {
                 ProtocolId::new(SupportedProtocol::BlobsByRangeV1, Encoding::SSZSnappy),
             ]);
         }
-        if fork_context.peerdas_fork_scheduled() {
+        if fork_context.is_peer_das_scheduled() {
             supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::DataColumnsByRootV1, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::DataColumnsByRangeV1, Encoding::SSZSnappy),

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -17,7 +17,7 @@ pub use pubsub::{PubsubMessage, SnappyTransform};
 pub use subnet::{Subnet, SubnetDiscovery};
 pub use sync_state::{BackFillState, SyncState};
 pub use topics::{
-    attestation_sync_committee_topics, core_topics_to_subscribe, fork_core_topics,
-    subnet_from_topic_hash, GossipEncoding, GossipKind, GossipTopic, ALTAIR_CORE_TOPICS,
-    BASE_CORE_TOPICS, CAPELLA_CORE_TOPICS, DENEB_CORE_TOPICS, LIGHT_CLIENT_GOSSIP_TOPICS,
+    all_topics, all_topics_at_fork, core_topics_to_subscribe, max_topic_count,
+    new_topics_to_subscribe_at_epoch, old_topics_to_unsubscribe_at_epoch, subnet_from_topic_hash,
+    GossipEncoding, GossipKind, GossipTopic, TopicSubscriptionOpts,
 };

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -448,6 +448,13 @@ impl ChainSpec {
         })
     }
 
+    /// Returns true if `EIP7594_FORK_EPOCH` is set and is not set to `FAR_FUTURE_EPOCH`.
+    pub fn is_peer_das_scheduled(&self) -> bool {
+        self.eip7594_fork_epoch.map_or(false, |eip7594_fork_epoch| {
+            eip7594_fork_epoch != self.far_future_epoch
+        })
+    }
+
     /// Returns a full `Fork` struct for a given epoch.
     pub fn fork_at_epoch(&self, epoch: Epoch) -> Fork {
         let current_fork_name = self.fork_name_at_epoch(epoch);

--- a/consensus/types/src/fork_context.rs
+++ b/consensus/types/src/fork_context.rs
@@ -133,9 +133,8 @@ impl ForkContext {
         self.digest_to_fork.keys().cloned().collect()
     }
 
-    /// Returns true if peerdas fork is schduled for some epoch != FAR_FUTURE_EPOCH
-    pub fn peerdas_fork_scheduled(&self) -> bool {
-        self.spec
-            .is_peer_das_enabled_for_epoch(Epoch::max_value().saturating_sub(Epoch::new(1)))
+    /// Returns true if `EIP7594_FORK_EPOCH` is set and is not set to `FAR_FUTURE_EPOCH`.
+    pub fn is_peer_das_scheduled(&self) -> bool {
+        self.spec.is_peer_das_scheduled()
     }
 }


### PR DESCRIPTION
## Issue Addressed

PeerDAS requires new features not available in current gossip topic machinery:

- Unsubscribe from a topic kind at a fork boundary (so far we only added)
- Change core topics at an epoch that does not align with a ForkName fork
- Change core topics without changing fork-digest

Most of the changes from this PR can be back-ported to unstable but I want to make sure they align with what we need for PeerDAS

## Proposed Changes

- Move logic to compute what to subscribe to the function `core_topics_to_subscribe(epoch, opts)`. It consolidates logic that is fork dependant with other user options like `subscribe-all-subnets`. The previous approach was very rigid expecting a set of topics for every ForkName. Now the set of topics change depending on peer das epoch
- Define a list of **"fork transitions"** which include your beloved altair, capella, etc and now a non-fork transition "peerdas".
- Add two functions `new_topics_to_subscribe_at_epoch` and `old_topics_to_unsubscribe_at_epoch` which diff the output of `core_topics_to_subscribe` across a "fork transition". Then, at the fork transition epoch subscribe the new topics, and forget the old ones

---

Closes https://github.com/sigp/lighthouse/issues/5894
