### PR TITLE
Undo some CLI flag breakages

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1101,6 +1101,8 @@ pub fn cli_app() -> Command {
                        [Enabled by default].")
                 .action(ArgAction::Set)
                 .default_value("true")
+                .num_args(0..=1)
+                .default_missing_value("true")
                 .display_order(0)
         )
         .arg(

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -356,7 +356,7 @@ Options:
       --slasher-backend <DATABASE>
           Set the database backend to be used by the slasher. [possible values:
           lmdb, disabled]
-      --slasher-broadcast <slasher-broadcast>
+      --slasher-broadcast [<slasher-broadcast>]
           Broadcast slashings found by the slasher to the rest of the network
           [Enabled by default]. [default: true]
       --slasher-chunk-size <EPOCHS>

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2178,6 +2178,21 @@ fn slasher_broadcast_flag_no_default() {
         });
 }
 #[test]
+fn slasher_broadcast_flag_no_argument() {
+    CommandLineTest::new()
+        .flag("slasher", None)
+        .flag("slasher-max-db-size", Some("1"))
+        .flag("slasher-broadcast", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            let slasher_config = config
+                .slasher
+                .as_ref()
+                .expect("Unable to parse Slasher config");
+            assert!(slasher_config.broadcast);
+        });
+}
+#[test]
 fn slasher_broadcast_flag_true() {
     CommandLineTest::new()
         .flag("slasher", None)

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -593,12 +593,22 @@ fn wrong_broadcast_flag() {
 }
 
 #[test]
-fn latency_measurement_service() {
+fn disable_latency_measurement_service() {
     CommandLineTest::new()
         .flag("disable-latency-measurement-service", None)
         .run()
         .with_config(|config| {
             assert!(!config.enable_latency_measurement_service);
+        });
+}
+#[test]
+fn latency_measurement_service() {
+    // This flag is DEPRECATED so has no effect, but should still be accepted.
+    CommandLineTest::new()
+        .flag("latency-measurement-service", Some("false"))
+        .run()
+        .with_config(|config| {
+            assert!(config.enable_latency_measurement_service);
         });
 }
 

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -407,6 +407,15 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("latency-measurement-service")
+                .long("latency-measurement-service")
+                .help("DEPRECATED")
+                .action(ArgAction::Set)
+                .help_heading(FLAG_HEADER)
+                .display_order(0)
+                .hide(true)
+        )
+        .arg(
             Arg::new("validator-registration-batch-size")
                 .long("validator-registration-batch-size")
                 .value_name("INTEGER")

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -412,6 +412,17 @@ impl Config {
         config.enable_latency_measurement_service =
             !cli_args.get_flag("disable-latency-measurement-service");
 
+        if cli_args
+            .get_one::<String>("latency-measurement-service")
+            .is_some()
+        {
+            warn!(
+                log,
+                "latency-measurement-service flag";
+                "note" => "deprecated flag has no effect and should be removed"
+            );
+        }
+
         config.validator_registration_batch_size =
             parse_required(cli_args, "validator-registration-batch-size")?;
         if config.validator_registration_batch_size == 0 {


### PR DESCRIPTION
## Issue Addressed

The clap upgrade introduced a few hard breaking changes without deprecation warnings:

- https://github.com/sigp/lighthouse/pull/5273

## Proposed Changes

We've had users be caught out by these sorts of breakages in the past, so I've removed the hard breaking changes for two of the flags more likely to be in use: `--slasher-broadcast` and `--latency-measurement-service`:

- `--slasher-broadcast` without args is no longer deprecated. It works using [`default_missing_value`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.default_missing_value), even if we ignore `clap`'s advice about using `.require_equals(true)`. We may need to change this or deprecate this in future. I couldn't work out at a glance how to tell whether the flag was provided with no value in order to deprecate _just_ that usage. So I figure we may as well keep it for now with no deprecation.
- `--latency-measurement-service` is readded but is deprecated (and hidden). Lighthouse logs a warning if it is provided, rather than failing to start.
