### PR TITLE
Store linear blocks in freezer db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7985,6 +7985,7 @@ dependencies = [
  "strum",
  "tempfile",
  "types",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,6 +181,7 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = { version = "0.3.7", default-features = false, features = ["tls"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
 zip = "0.6"
+zstd = "0.11.2"
 
 # Local crates.
 account_utils = { path = "common/account_utils" }

--- a/beacon_node/beacon_chain/src/beacon_block_streamer.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_streamer.rs
@@ -441,7 +441,7 @@ impl<T: BeaconChainTypes> BeaconBlockStreamer<T> {
                             continue;
                         }
 
-                        match streamer.beacon_chain.store.try_get_full_block(&root) {
+                        match streamer.beacon_chain.store.try_get_full_block(&root, None) {
                             Err(e) => db_blocks.push((root, Err(e.into()))),
                             Ok(opt_block) => db_blocks.push((
                                 root,

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -315,7 +315,7 @@ where
             metrics::inc_counter(&metrics::BALANCES_CACHE_MISSES);
             let justified_block = self
                 .store
-                .get_blinded_block(&self.justified_checkpoint.root)
+                .get_blinded_block(&self.justified_checkpoint.root, None)
                 .map_err(Error::FailedToReadBlock)?
                 .ok_or(Error::MissingBlock(self.justified_checkpoint.root))?
                 .deconstruct()

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1212,7 +1212,7 @@ mod test {
         assert_eq!(
             chain
                 .store
-                .get_blinded_block(&Hash256::zero())
+                .get_blinded_block(&Hash256::zero(), None)
                 .expect("should read db")
                 .expect("should find genesis block"),
             block.clone_as_blinded(),

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -292,7 +292,7 @@ where
             .ok_or("Fork choice not found in store")?;
 
         let genesis_block = store
-            .get_blinded_block(&chain.genesis_block_root)
+            .get_blinded_block(&chain.genesis_block_root, Some(Slot::new(0)))
             .map_err(|e| descriptive_db_error("genesis block", &e))?
             .ok_or("Genesis block not found in store")?;
         let genesis_state = store
@@ -732,7 +732,7 @@ where
         // Try to decode the head block according to the current fork, if that fails, try
         // to backtrack to before the most recent fork.
         let (head_block_root, head_block, head_reverted) =
-            match store.get_full_block(&initial_head_block_root) {
+            match store.get_full_block(&initial_head_block_root, None) {
                 Ok(Some(block)) => (initial_head_block_root, block, false),
                 Ok(None) => return Err("Head block not found in store".into()),
                 Err(StoreError::SszDecodeError(_)) => {

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -295,7 +295,7 @@ impl<T: BeaconChainTypes> CanonicalHead<T> {
         let fork_choice_view = fork_choice.cached_fork_choice_view();
         let beacon_block_root = fork_choice_view.head_block_root;
         let beacon_block = store
-            .get_full_block(&beacon_block_root)?
+            .get_full_block(&beacon_block_root, None)?
             .ok_or(Error::MissingBeaconBlock(beacon_block_root))?;
         let current_slot = fork_choice.fc_store().get_current_slot();
         let (_, beacon_state) = store
@@ -651,7 +651,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             let mut new_snapshot = {
                 let beacon_block = self
                     .store
-                    .get_full_block(&new_view.head_block_root)?
+                    .get_full_block(&new_view.head_block_root, None)?
                     .ok_or(Error::MissingBeaconBlock(new_view.head_block_root))?;
 
                 let (_, beacon_state) = self

--- a/beacon_node/beacon_chain/src/fork_revert.rs
+++ b/beacon_node/beacon_chain/src/fork_revert.rs
@@ -105,7 +105,7 @@ pub fn reset_fork_choice_to_finalization<E: EthSpec, Hot: ItemStore<E>, Cold: It
     let finalized_checkpoint = head_state.finalized_checkpoint();
     let finalized_block_root = finalized_checkpoint.root;
     let finalized_block = store
-        .get_full_block(&finalized_block_root)
+        .get_full_block(&finalized_block_root, None)
         .map_err(|e| format!("Error loading finalized block: {:?}", e))?
         .ok_or_else(|| {
             format!(

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -84,13 +84,12 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         let signature_slot = block_slot;
         let attested_block_root = block_parent_root;
 
-        let attested_block =
-            store
-                .get_full_block(attested_block_root)?
-                .ok_or(BeaconChainError::DBInconsistent(format!(
-                    "Block not available {:?}",
-                    attested_block_root
-                )))?;
+        let attested_block = store.get_full_block(attested_block_root, None)?.ok_or(
+            BeaconChainError::DBInconsistent(format!(
+                "Block not available {:?}",
+                attested_block_root
+            )),
+        )?;
 
         let cached_parts = self.get_or_compute_prev_block_cache(
             store.clone(),
@@ -130,7 +129,7 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         if is_latest_finality & !cached_parts.finalized_block_root.is_zero() {
             // Immediately after checkpoint sync the finalized block may not be available yet.
             if let Some(finalized_block) =
-                store.get_full_block(&cached_parts.finalized_block_root)?
+                store.get_full_block(&cached_parts.finalized_block_root, None)?
             {
                 *self.latest_finality_update.write() = Some(LightClientFinalityUpdate::new(
                     &attested_block,

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -527,7 +527,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
             // so delete it from the head tracker but leave it and its states in the database
             // This is suboptimal as it wastes disk space, but it's difficult to fix. A re-sync
             // can be used to reclaim the space.
-            let head_state_root = match store.get_blinded_block(&head_hash) {
+            let head_state_root = match store.get_blinded_block(&head_hash, Some(head_slot)) {
                 Ok(Some(block)) => block.state_root(),
                 Ok(None) => {
                     return Err(BeaconStateError::MissingBeaconBlock(head_hash.into()).into())

--- a/beacon_node/beacon_chain/src/pre_finalization_cache.rs
+++ b/beacon_node/beacon_chain/src/pre_finalization_cache.rs
@@ -73,7 +73,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         // 2. Check on disk.
-        if self.store.get_blinded_block(&block_root)?.is_some() {
+        if self.store.get_blinded_block(&block_root, None)?.is_some() {
             cache.block_roots.put(block_root, ());
             return Ok(true);
         }

--- a/beacon_node/beacon_chain/src/schema_change.rs
+++ b/beacon_node/beacon_chain/src/schema_change.rs
@@ -2,6 +2,7 @@
 mod migration_schema_v17;
 mod migration_schema_v18;
 mod migration_schema_v19;
+mod migration_schema_v20;
 
 use crate::beacon_chain::BeaconChainTypes;
 use crate::types::ChainSpec;
@@ -77,6 +78,13 @@ pub fn migrate_schema<T: BeaconChainTypes>(
         (SchemaVersion(19), SchemaVersion(18)) => {
             let ops = migration_schema_v19::downgrade_from_v19::<T>(db.clone(), log)?;
             db.store_schema_version_atomically(to, ops)
+        }
+        (SchemaVersion(19), SchemaVersion(20)) => {
+            let ops = migration_schema_v20::upgrade_to_v20::<T>(db.clone(), log)?;
+            db.store_schema_version_atomically(to, ops)
+        }
+        (SchemaVersion(20), SchemaVersion(19)) => {
+            unimplemented!()
         }
         // Anything else is an error.
         (_, _) => Err(HotColdDBError::UnsupportedSchemaVersion {

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v18.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v18.rs
@@ -17,7 +17,7 @@ fn get_slot_clock<T: BeaconChainTypes>(
     log: &Logger,
 ) -> Result<Option<T::SlotClock>, Error> {
     let spec = db.get_chain_spec();
-    let Some(genesis_block) = db.get_blinded_block(&Hash256::zero())? else {
+    let Some(genesis_block) = db.get_blinded_block(&Hash256::zero(), Some(Slot::new(0)))? else {
         error!(log, "Missing genesis block");
         return Ok(None);
     };

--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v20.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v20.rs
@@ -1,0 +1,108 @@
+use crate::BeaconChainTypes;
+use slog::{info, Logger};
+use std::sync::Arc;
+use store::{get_key_for_col, DBColumn, Error, HotColdDB, KeyValueStore, KeyValueStoreOp};
+use types::{Hash256, Slot};
+
+/// Chunk size for freezer block roots in the old database schema.
+const OLD_SCHEMA_CHUNK_SIZE: u64 = 128;
+
+fn old_schema_chunk_key(cindex: u64) -> [u8; 8] {
+    (cindex + 1).to_be_bytes()
+}
+
+pub fn upgrade_to_v20<T: BeaconChainTypes>(
+    db: Arc<HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>>,
+    log: Logger,
+) -> Result<Vec<KeyValueStoreOp>, Error> {
+    info!(log, "Upgrading freezer database schema");
+    upgrade_freezer_database::<T>(&db, &log)?;
+
+    // No hot DB changes
+    return Ok(vec![]);
+}
+
+fn upgrade_freezer_database<T: BeaconChainTypes>(
+    db: &HotColdDB<T::EthSpec, T::HotStore, T::ColdStore>,
+    log: &Logger,
+) -> Result<(), Error> {
+    let mut cold_db_ops = vec![];
+
+    // Re-write the beacon block roots array.
+    let mut freezer_block_roots = vec![];
+    let oldest_block_slot = db.get_oldest_block_slot();
+    let mut current_slot = oldest_block_slot;
+
+    for result in db
+        .cold_db
+        .iter_column::<Vec<u8>>(DBColumn::BeaconBlockRoots)
+    {
+        let (chunk_key, chunk_bytes) = result?;
+
+        // Stage this chunk for deletion.
+        cold_db_ops.push(KeyValueStoreOp::DeleteKey(get_key_for_col(
+            DBColumn::BeaconBlockRoots.into(),
+            &chunk_key,
+        )));
+
+        // Skip the 0x0 key which is for the genesis block.
+        if chunk_key.iter().all(|b| *b == 0u8) {
+            continue;
+        }
+        // Skip the 0x00..01 key which is for slot 0.
+        if chunk_key == old_schema_chunk_key(0).as_slice() && current_slot != 0 {
+            continue;
+        }
+
+        let current_chunk_index = current_slot.as_u64() / OLD_SCHEMA_CHUNK_SIZE;
+        if chunk_key != old_schema_chunk_key(current_chunk_index).as_slice() {
+            return Err(Error::DBError {
+                message: format!(
+                    "expected chunk index {} but got {:?}",
+                    current_chunk_index, chunk_key
+                ),
+            });
+        }
+
+        for (i, block_root_bytes) in chunk_bytes.chunks_exact(32).enumerate() {
+            let block_root = Hash256::from_slice(block_root_bytes);
+
+            if block_root.is_zero() {
+                continue;
+            }
+
+            let slot = Slot::new(current_chunk_index * OLD_SCHEMA_CHUNK_SIZE + i as u64);
+            if slot != current_slot {
+                return Err(Error::DBError {
+                    message: format!(
+                        "expected block root for slot {} but got {}",
+                        current_slot, slot
+                    ),
+                });
+            }
+            freezer_block_roots.push((slot, block_root));
+            current_slot += 1;
+        }
+    }
+
+    // Write the freezer block roots in the new schema.
+    for (slot, block_root) in freezer_block_roots {
+        cold_db_ops.push(KeyValueStoreOp::PutKeyValue(
+            get_key_for_col(
+                DBColumn::BeaconBlockRoots.into(),
+                &slot.as_u64().to_be_bytes(),
+            ),
+            block_root.as_bytes().to_vec(),
+        ));
+    }
+
+    db.cold_db.do_atomically(cold_db_ops)?;
+    info!(
+        log,
+        "Freezer database upgrade complete";
+        "oldest_block_slot" => oldest_block_slot,
+        "newest_block_slot" => current_slot - 1
+    );
+
+    Ok(())
+}

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -1059,7 +1059,7 @@ async fn attestation_that_skips_epochs() {
     let block_slot = harness
         .chain
         .store
-        .get_blinded_block(&block_root)
+        .get_blinded_block(&block_root, None)
         .expect("should not error getting block")
         .expect("should find attestation block")
         .message()

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -316,7 +316,7 @@ impl InvalidPayloadRig {
                     self.harness
                         .chain
                         .store
-                        .get_full_block(&block_root)
+                        .get_full_block(&block_root, None)
                         .unwrap()
                         .unwrap(),
                     *block,

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -608,7 +608,7 @@ async fn epoch_boundary_state_attestation_processing() {
         // load_epoch_boundary_state is idempotent!
         let block_root = attestation.data.beacon_block_root;
         let block = store
-            .get_blinded_block(&block_root)
+            .get_blinded_block(&block_root, None)
             .unwrap()
             .expect("block exists");
         let epoch_boundary_state = store
@@ -849,7 +849,7 @@ async fn delete_blocks_and_states() {
     );
 
     let faulty_head_block = store
-        .get_blinded_block(&faulty_head.into())
+        .get_blinded_block(&faulty_head.into(), None)
         .expect("no errors")
         .expect("faulty head block exists");
 
@@ -891,7 +891,7 @@ async fn delete_blocks_and_states() {
             break;
         }
         store.delete_block(&block_root).unwrap();
-        assert_eq!(store.get_blinded_block(&block_root).unwrap(), None);
+        assert_eq!(store.get_blinded_block(&block_root, None).unwrap(), None);
     }
 
     // Deleting frozen states should do nothing
@@ -1135,7 +1135,7 @@ fn get_state_for_block(harness: &TestHarness, block_root: Hash256) -> BeaconStat
     let head_block = harness
         .chain
         .store
-        .get_blinded_block(&block_root)
+        .get_blinded_block(&block_root, None)
         .unwrap()
         .unwrap();
     harness
@@ -2355,7 +2355,7 @@ async fn weak_subjectivity_sync_test(slots: Vec<Slot>, checkpoint_slot: Slot) {
     let wss_block = harness
         .chain
         .store
-        .get_full_block(&wss_block_root)
+        .get_full_block(&wss_block_root, None)
         .unwrap()
         .unwrap();
     let wss_blobs_opt = harness.chain.store.get_blobs(&wss_block_root).unwrap();
@@ -2576,7 +2576,7 @@ async fn weak_subjectivity_sync_test(slots: Vec<Slot>, checkpoint_slot: Slot) {
         .unwrap()
         .map(Result::unwrap)
     {
-        let block = store.get_blinded_block(&block_root).unwrap().unwrap();
+        let block = store.get_blinded_block(&block_root, None).unwrap().unwrap();
         if block_root != prev_block_root {
             assert_eq!(block.slot(), slot);
         }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -923,6 +923,16 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("compression-level")
+                .long("compression-level")
+                .value_name("LEVEL")
+                .help("Compression level (-99 to 22) for zstd compression applied to states on disk \
+                       [default: 1]. You may change the compression level freely without re-syncing.")
+                .action(ArgAction::Set)
+                .default_value("1")
+                .display_order(0)
+        )
+        .arg(
             Arg::new("prune-payloads")
                 .long("prune-payloads")
                 .help("Prune execution payloads from Lighthouse's database. This saves space but \

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -25,3 +25,4 @@ lru = { workspace = true }
 sloggers = { workspace = true }
 directory = { workspace = true }
 strum = { workspace = true }
+zstd = { workspace = true }

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -10,6 +10,8 @@ pub const PREV_DEFAULT_SLOTS_PER_RESTORE_POINT: u64 = 2048;
 pub const DEFAULT_SLOTS_PER_RESTORE_POINT: u64 = 8192;
 pub const DEFAULT_BLOCK_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(5);
 pub const DEFAULT_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(128);
+pub const DEFAULT_COMPRESSION_LEVEL: i32 = 1;
+const EST_COMPRESSION_FACTOR: usize = 2;
 pub const DEFAULT_HISTORIC_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(1);
 pub const DEFAULT_EPOCHS_PER_BLOB_PRUNE: u64 = 1;
 pub const DEFAULT_BLOB_PUNE_MARGIN_EPOCHS: u64 = 0;
@@ -25,6 +27,8 @@ pub struct StoreConfig {
     pub block_cache_size: NonZeroUsize,
     /// Maximum number of states to store in the in-memory state cache.
     pub state_cache_size: NonZeroUsize,
+    /// Compression level for blocks, state diffs and other compressed values.
+    pub compression_level: i32,
     /// Maximum number of states from freezer database to store in the in-memory state cache.
     pub historic_state_cache_size: NonZeroUsize,
     /// Whether to compact the database on initialization.
@@ -33,6 +37,8 @@ pub struct StoreConfig {
     pub compact_on_prune: bool,
     /// Whether to prune payloads on initialization and finalization.
     pub prune_payloads: bool,
+    /// Whether to store finalized blocks compressed and linearised in the freezer database.
+    pub linear_blocks: bool,
     /// Whether to prune blobs older than the blob data availability boundary.
     pub prune_blobs: bool,
     /// Frequency of blob pruning in epochs. Default: 1 (every epoch).
@@ -61,10 +67,12 @@ impl Default for StoreConfig {
             slots_per_restore_point_set_explicitly: false,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
             state_cache_size: DEFAULT_STATE_CACHE_SIZE,
+            compression_level: DEFAULT_COMPRESSION_LEVEL,
             historic_state_cache_size: DEFAULT_HISTORIC_STATE_CACHE_SIZE,
             compact_on_init: false,
             compact_on_prune: true,
             prune_payloads: true,
+            linear_blocks: true,
             prune_blobs: true,
             epochs_per_blob_prune: DEFAULT_EPOCHS_PER_BLOB_PRUNE,
             blob_prune_margin_epochs: DEFAULT_BLOB_PUNE_MARGIN_EPOCHS,
@@ -90,6 +98,25 @@ impl StoreConfig {
             });
         }
         Ok(())
+    }
+
+    /// Estimate the size of `len` bytes after compression at the current compression level.
+    pub fn estimate_compressed_size(&self, len: usize) -> usize {
+        if self.compression_level == 0 {
+            len
+        } else {
+            len / EST_COMPRESSION_FACTOR
+        }
+    }
+
+    /// Estimate the size of `len` compressed bytes after decompression at the current compression
+    /// level.
+    pub fn estimate_decompressed_size(&self, len: usize) -> usize {
+        if self.compression_level == 0 {
+            len
+        } else {
+            len * EST_COMPRESSION_FACTOR
+        }
     }
 }
 

--- a/beacon_node/store/src/errors.rs
+++ b/beacon_node/store/src/errors.rs
@@ -43,6 +43,7 @@ pub enum Error {
         computed: Hash256,
     },
     BlockReplayError(BlockReplayError),
+    Compression(std::io::Error),
     AddPayloadLogicError,
     SlotClockUnavailableForMigration,
     InvalidKey,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -6,7 +6,10 @@ use crate::config::{
     PREV_DEFAULT_SLOTS_PER_RESTORE_POINT,
 };
 use crate::forwards_iter::{HybridForwardsBlockRootsIterator, HybridForwardsStateRootsIterator};
-use crate::impls::beacon_state::{get_full_state, store_full_state};
+use crate::impls::{
+    beacon_state::{get_full_state, store_full_state},
+    frozen_block_slot::FrozenBlockSlot,
+};
 use crate::iter::{BlockRootsIterator, ParentRootBlockIterator, RootsIterator};
 use crate::leveldb_store::BytesKey;
 use crate::leveldb_store::LevelDB;
@@ -35,12 +38,15 @@ use state_processing::{
     SlotProcessingError,
 };
 use std::cmp::min;
+use std::convert::TryInto;
+use std::io::{Read, Write};
 use std::marker::PhantomData;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use types::*;
+use zstd::{Decoder, Encoder};
 
 /// On-disk database that stores finalized states efficiently.
 ///
@@ -432,6 +438,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     pub fn try_get_full_block(
         &self,
         block_root: &Hash256,
+        slot: Option<Slot>,
     ) -> Result<Option<DatabaseBlock<E>>, Error> {
         metrics::inc_counter(&metrics::BEACON_BLOCK_GET_COUNT);
 
@@ -442,7 +449,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         }
 
         // Load the blinded block.
-        let Some(blinded_block) = self.get_blinded_block(block_root)? else {
+        let Some(blinded_block) = self.get_blinded_block(block_root, slot)? else {
             return Ok(None);
         };
 
@@ -490,8 +497,9 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     pub fn get_full_block(
         &self,
         block_root: &Hash256,
+        slot: Option<Slot>,
     ) -> Result<Option<SignedBeaconBlock<E>>, Error> {
-        match self.try_get_full_block(block_root)? {
+        match self.try_get_full_block(block_root, slot)? {
             Some(DatabaseBlock::Full(block)) => Ok(Some(block)),
             Some(DatabaseBlock::Blinded(block)) => Err(
                 HotColdDBError::MissingFullBlockExecutionPayloadPruned(*block_root, block.slot())
@@ -522,10 +530,113 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     pub fn get_blinded_block(
         &self,
         block_root: &Hash256,
-    ) -> Result<Option<SignedBeaconBlock<E, BlindedPayload<E>>>, Error> {
+        slot: Option<Slot>,
+    ) -> Result<Option<SignedBlindedBeaconBlock<E>>, Error> {
+        let split = self.get_split_info();
+        if let Some(slot) = slot {
+            if (slot < split.slot || slot == 0) && *block_root != split.block_root {
+                // To the freezer DB.
+                self.get_cold_blinded_block_by_slot(slot)
+            } else {
+                self.get_hot_blinded_block(block_root)
+            }
+        } else {
+            match self.get_hot_blinded_block(block_root)? {
+                Some(block) => Ok(Some(block)),
+                None => self.get_cold_blinded_block_by_root(block_root),
+            }
+        }
+    }
+
+    pub fn get_hot_blinded_block(
+        &self,
+        block_root: &Hash256,
+    ) -> Result<Option<SignedBlindedBeaconBlock<E>>, Error> {
         self.get_block_with(block_root, |bytes| {
             SignedBeaconBlock::from_ssz_bytes(bytes, &self.spec)
         })
+    }
+
+    pub fn get_cold_blinded_block_by_root(
+        &self,
+        block_root: &Hash256,
+    ) -> Result<Option<SignedBlindedBeaconBlock<E>>, Error> {
+        // Load slot.
+        if let Some(FrozenBlockSlot(block_slot)) = self.cold_db.get(block_root)? {
+            self.get_cold_blinded_block_by_slot(block_slot)
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_cold_blinded_block_by_slot(
+        &self,
+        slot: Slot,
+    ) -> Result<Option<SignedBlindedBeaconBlock<E>>, Error> {
+        let Some(bytes) = self.cold_db.get_bytes(
+            DBColumn::BeaconBlockFrozen.into(),
+            &slot.as_u64().to_be_bytes(),
+        )?
+        else {
+            return Ok(None);
+        };
+
+        let mut ssz_bytes = Vec::with_capacity(self.config.estimate_decompressed_size(bytes.len()));
+        let mut decoder = Decoder::new(&*bytes).map_err(Error::Compression)?;
+        decoder
+            .read_to_end(&mut ssz_bytes)
+            .map_err(Error::Compression)?;
+        Ok(Some(SignedBeaconBlock::from_ssz_bytes(
+            &ssz_bytes, &self.spec,
+        )?))
+    }
+
+    pub fn put_cold_blinded_block(
+        &self,
+        block_root: &Hash256,
+        block: &SignedBlindedBeaconBlock<E>,
+    ) -> Result<(), Error> {
+        let mut ops = Vec::with_capacity(2);
+        self.blinded_block_as_cold_kv_store_ops(block_root, block, &mut ops)?;
+        self.cold_db.do_atomically(ops)
+    }
+
+    pub fn blinded_block_as_cold_kv_store_ops(
+        &self,
+        block_root: &Hash256,
+        block: &SignedBlindedBeaconBlock<E>,
+        kv_store_ops: &mut Vec<KeyValueStoreOp>,
+    ) -> Result<(), Error> {
+        // Write the block root to slot mapping.
+        let slot = block.slot();
+        kv_store_ops.push(FrozenBlockSlot(slot).as_kv_store_op(*block_root));
+
+        // Write the slot to block root mapping.
+        kv_store_ops.push(KeyValueStoreOp::PutKeyValue(
+            get_key_for_col(
+                DBColumn::BeaconBlockRoots.into(),
+                &slot.as_u64().to_be_bytes(),
+            ),
+            block_root.as_bytes().to_vec(),
+        ));
+
+        // Write the block keyed by slot.
+        let db_key = get_key_for_col(
+            DBColumn::BeaconBlockFrozen.into(),
+            &slot.as_u64().to_be_bytes(),
+        );
+
+        let ssz_bytes = block.as_ssz_bytes();
+        let mut compressed_value =
+            Vec::with_capacity(self.config.estimate_compressed_size(ssz_bytes.len()));
+        let mut encoder = Encoder::new(&mut compressed_value, self.config.compression_level)
+            .map_err(Error::Compression)?;
+        encoder.write_all(&ssz_bytes).map_err(Error::Compression)?;
+        encoder.finish().map_err(Error::Compression)?;
+
+        kv_store_ops.push(KeyValueStoreOp::PutKeyValue(db_key, compressed_value));
+
+        Ok(())
     }
 
     /// Fetch a block from the store, ignoring which fork variant it *should* be for.
@@ -589,10 +700,14 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .key_exists(DBColumn::BeaconBlob.into(), block_root.as_bytes())
     }
 
-    /// Determine whether a block exists in the database.
+    /// Determine whether a block exists in the database (hot *or* cold).
     pub fn block_exists(&self, block_root: &Hash256) -> Result<bool, Error> {
-        self.hot_db
-            .key_exists(DBColumn::BeaconBlock.into(), block_root.as_bytes())
+        Ok(self
+            .hot_db
+            .key_exists(DBColumn::BeaconBlock.into(), block_root.as_bytes())?
+            || self
+                .cold_db
+                .key_exists(DBColumn::BeaconBlock.into(), block_root.as_bytes())?)
     }
 
     /// Delete a block from the store and the block cache.

--- a/beacon_node/store/src/impls.rs
+++ b/beacon_node/store/src/impls.rs
@@ -1,2 +1,3 @@
 pub mod beacon_state;
 pub mod execution_payload;
+pub mod frozen_block_slot;

--- a/beacon_node/store/src/impls/frozen_block_slot.rs
+++ b/beacon_node/store/src/impls/frozen_block_slot.rs
@@ -1,0 +1,19 @@
+use crate::{DBColumn, Error, StoreItem};
+use ssz::{Decode, Encode};
+use types::Slot;
+
+pub struct FrozenBlockSlot(pub Slot);
+
+impl StoreItem for FrozenBlockSlot {
+    fn db_column() -> DBColumn {
+        DBColumn::BeaconBlock
+    }
+
+    fn as_store_bytes(&self) -> Vec<u8> {
+        self.0.as_ssz_bytes()
+    }
+
+    fn from_store_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(FrozenBlockSlot(Slot::from_ssz_bytes(bytes)?))
+    }
+}

--- a/beacon_node/store/src/iter.rs
+++ b/beacon_node/store/src/iter.rs
@@ -189,7 +189,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> RootsIterator<'a, E,
         block_hash: Hash256,
     ) -> Result<Self, Error> {
         let block = store
-            .get_blinded_block(&block_hash)?
+            .get_blinded_block(&block_hash, None)?
             .ok_or_else(|| BeaconStateError::MissingBeaconBlock(block_hash.into()))?;
         let state = store
             .get_state(&block.state_root(), Some(block.slot()))?
@@ -286,7 +286,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
             let block = if self.decode_any_variant {
                 self.store.get_block_any_variant(&block_root)
             } else {
-                self.store.get_blinded_block(&block_root)
+                self.store.get_blinded_block(&block_root, None)
             }?
             .ok_or(Error::BlockNotFound(block_root))?;
             self.next_block_root = block.message().parent_root();
@@ -329,7 +329,8 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BlockIterator<'a, E,
     fn do_next(&mut self) -> Result<Option<SignedBeaconBlock<E, BlindedPayload<E>>>, Error> {
         if let Some(result) = self.roots.next() {
             let (root, _slot) = result?;
-            self.roots.inner.store.get_blinded_block(&root)
+            // Don't use slot hint here as it could be a skipped slot.
+            self.roots.inner.store.get_blinded_block(&root, None)
         } else {
             Ok(None)
         }

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -222,8 +222,19 @@ pub enum DBColumn {
     /// For data related to the database itself.
     #[strum(serialize = "bma")]
     BeaconMeta,
+    /// Data related to blocks.
+    ///
+    /// - Key: `Hash256` block root.
+    /// - Value in hot DB: SSZ-encoded blinded block.
+    /// - Value in cold DB: 8-byte slot of block.
     #[strum(serialize = "blk")]
     BeaconBlock,
+    /// Frozen beacon blocks.
+    ///
+    /// - Key: 8-byte slot.
+    /// - Value: ZSTD-compressed SSZ-encoded blinded block.
+    #[strum(serialize = "bbf")]
+    BeaconBlockFrozen,
     #[strum(serialize = "blb")]
     BeaconBlob,
     /// For full `BeaconState`s in the hot database (finalized or fork-boundary states).
@@ -312,7 +323,8 @@ impl DBColumn {
             | Self::BeaconStateRoots
             | Self::BeaconHistoricalRoots
             | Self::BeaconHistoricalSummaries
-            | Self::BeaconRandaoMixes => 8,
+            | Self::BeaconRandaoMixes
+            | Self::BeaconBlockFrozen => 8,
         }
     }
 }

--- a/beacon_node/store/src/metadata.rs
+++ b/beacon_node/store/src/metadata.rs
@@ -4,7 +4,7 @@ use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use types::{Checkpoint, Hash256, Slot};
 
-pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(19);
+pub const CURRENT_SCHEMA_VERSION: SchemaVersion = SchemaVersion(20);
 
 // All the keys that get stored under the `BeaconMeta` column.
 //

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -75,7 +75,7 @@ where
                     None
                 } else {
                     Some(
-                        self.get_blinded_block(&block_root)?
+                        self.get_blinded_block(&block_root, Some(slot))?
                             .ok_or(Error::BlockNotFound(block_root))?,
                     )
                 };


### PR DESCRIPTION
## Issue Addressed

Part of tree-states Disk Edition ™️  

Currently Lighthouse stores blocks by root in the same bucket as unfinalized blocks. Storing finalized blocks in a separate bucket allows faster reads of sequential slot ranges. It also simplifies pruning logic and can allow us to drop the head-tracker which has been a source of bugs in the past:
- https://github.com/sigp/lighthouse/pull/1132
- https://github.com/sigp/lighthouse/issues/4773
- https://github.com/sigp/lighthouse/pull/5084

## Proposed Changes

- [x] Given a block ID read from either hot or cold DB based on a slot hint
- [x] On finalization move finalized blocks from hot DB to the freezer on a new column `BeaconBlockFrozen` and compress them
- [ ] Migrate existing blocks to freezer

