### PR TITLE
Fix skip-ci on `stable`

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,7 +41,7 @@ jobs:
          LABELS: ${{ toJson(github.event.pull_request.labels) }}
        run: |
          SKIP_CI="false"
-         if [ -z "${LABELS}" ]; then
+         if [ -z "${LABELS}" ]  || [ "${LABELS}" = "null" ]; then
            LABELS="none";
          else
            LABELS=$(echo ${LABELS} | jq -r '.[].name')
@@ -52,7 +52,7 @@ jobs:
              break
            fi
          done
-         echo "::set-output name=skip_ci::$SKIP_CI"
+         echo "skip_ci=$SKIP_CI" >> $GITHUB_OUTPUT
 
   target-branch-check:
     name: target-branch-check


### PR DESCRIPTION
## Issue Addressed

Fix `skip-ci` job triggered by pushing to branches. Also replaced the [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) `::set-output` command.

I've tested this on a push to my fork, and it evaluates `null` without failing:
https://github.com/jimmygchen/lighthouse/actions/runs/9457252549/job/26050717847
