### PR TITLE
Beta compiler fixes

### DIFF
--- a/common/logging/src/async_record.rs
+++ b/common/logging/src/async_record.rs
@@ -123,12 +123,10 @@ impl Serializer for ToSendSerializer {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())
     }
-    #[cfg(integer128)]
     fn emit_u128(&mut self, key: Key, val: u128) -> slog::Result {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())
     }
-    #[cfg(integer128)]
     fn emit_i128(&mut self, key: Key, val: i128) -> slog::Result {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -39,8 +39,6 @@ pub enum Error {
     /// generally caused by supplying an `amount` at deposit-time that is different to the one used
     /// at generation-time.
     Eth1DepositRootMismatch,
-    #[cfg(feature = "unencrypted_keys")]
-    SszKeypairError(String),
 }
 
 /// Information required to submit a deposit to the Eth1 deposit contract.

--- a/validator_client/slashing_protection/src/interchange.rs
+++ b/validator_client/slashing_protection/src/interchange.rs
@@ -7,7 +7,7 @@ use types::{Epoch, Hash256, PublicKeyBytes, Slot};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct InterchangeMetadata {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub interchange_format_version: u64,
@@ -16,7 +16,7 @@ pub struct InterchangeMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct InterchangeData {
     pub pubkey: PublicKeyBytes,
     pub signed_blocks: Vec<SignedBlock>,
@@ -25,7 +25,7 @@ pub struct InterchangeData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct SignedBlock {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub slot: Slot,
@@ -35,7 +35,7 @@ pub struct SignedBlock {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct SignedAttestation {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub source_epoch: Epoch,
@@ -46,7 +46,7 @@ pub struct SignedAttestation {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct Interchange {
     pub metadata: InterchangeMetadata,
     pub data: Vec<InterchangeData>,

--- a/validator_client/slashing_protection/src/interchange_test.rs
+++ b/validator_client/slashing_protection/src/interchange_test.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 use types::{Epoch, Hash256, PublicKeyBytes, Slot};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultiTestCase {
     pub name: String,
     pub genesis_validators_root: Hash256,
@@ -17,7 +17,7 @@ pub struct MultiTestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestCase {
     pub should_succeed: bool,
     pub contains_slashable_data: bool,
@@ -27,7 +27,7 @@ pub struct TestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestBlock {
     pub pubkey: PublicKeyBytes,
     pub slot: Slot,
@@ -37,7 +37,7 @@ pub struct TestBlock {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestAttestation {
     pub pubkey: PublicKeyBytes,
     pub source_epoch: Epoch,


### PR DESCRIPTION
## Issue Addressed

latest rust beta compiler fixes related to unused `cfg`s

- `integer128` looked unused in our logging crate

- `unencrypted_keys` feature was previously deleted
https://github.com/sigp/lighthouse/issues/1160

- in `slashing_protection`, the `arbitrary` feature looks like it should be `arbitrary-fuzz`
https://github.com/sigp/lighthouse/blob/f1d88ba4
