### PR TITLE
Fix panic on startup in debug build

### DIFF
--- a/account_manager/src/lib.rs
+++ b/account_manager/src/lib.rs
@@ -18,7 +18,7 @@ pub const WALLETS_DIR_FLAG: &str = "wallets-dir";
 
 pub fn cli_app() -> Command {
     Command::new(CMD)
-        .visible_aliases(["a", "am", "account", CMD])
+        .visible_aliases(["a", "am", "account"])
         .about("Utilities for generating and managing Ethereum 2.0 accounts.")
         .display_order(0)
         .arg(

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -9,7 +9,7 @@ Usage: lighthouse [OPTIONS] [COMMAND]
 Commands:
   account_manager
           Utilities for generating and managing Ethereum 2.0 accounts. [aliases:
-          a, am, account, account_manager]
+          a, am, account]
   beacon_node
           The primary component which connects to the Ethereum 2.0 P2P network
           and downloads, verifies and stores blocks. Provides a HTTP API for
@@ -30,7 +30,7 @@ Commands:
           validator]
   validator_manager
           Utilities for managing a Lighthouse validator client via the HTTP API.
-          [aliases: vm, validator-manager, validator_manager]
+          [aliases: vm, validator-manager]
   help
           Print this message or the help of the given subcommand(s)
 

--- a/validator_manager/src/lib.rs
+++ b/validator_manager/src/lib.rs
@@ -40,7 +40,7 @@ impl DumpConfig {
 
 pub fn cli_app() -> Command {
     Command::new(CMD)
-        .visible_aliases(["vm", "validator-manager", CMD])
+        .visible_aliases(["vm", "validator-manager"])
         .display_order(0)
         .styles(get_color_style())
         .about("Utilities for managing a Lighthouse validator client via the HTTP API.")


### PR DESCRIPTION
## Issue Addressed

 Lighthouse in debug build panics on startup with the following error:

```
$ cargo build --bin lighthouse
$ target/debug/lighthouse bn

thread 'main' panicked at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/debug_asserts.rs:341:13:
Command Lighthouse: command `account_manager` alias `account_manager` is duplicated
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
   2: clap_builder::builder::debug_asserts::assert_app
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/debug_asserts.rs:341:13
   3: clap_builder::builder::command::Command::_build_self
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:4123:13
   4: clap_builder::builder::command::Command::_do_parse
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:3994:9
   5: clap_builder::builder::command::Command::try_get_matches_from_mut
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:830:9
   6: clap_builder::builder::command::Command::get_matches_from
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:701:9
   7: clap_builder::builder::command::Command::get_matches
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:610:9
   8: lighthouse::main
             at ./lighthouse/src/main.rs:79:19
   9: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

```
thread 'main' panicked at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/debug_asserts.rs:341:13:
Command Lighthouse: command `validator_manager` alias `validator_manager` is duplicated
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
   2: clap_builder::builder::debug_asserts::assert_app
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/debug_asserts.rs:341:13
   3: clap_builder::builder::command::Command::_build_self
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:4123:13
   4: clap_builder::builder::command::Command::_do_parse
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:3994:9
   5: clap_builder::builder::command::Command::try_get_matches_from_mut
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:830:9
   6: clap_builder::builder::command::Command::get_matches_from
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:701:9
   7: clap_builder::builder::command::Command::get_matches
             at /Users/akihito/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.2/src/builder/command.rs:610:9
   8: lighthouse::main
             at ./lighthouse/src/main.rs:79:19
   9: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

## Proposed Changes
<!--
Please list or describe the changes introduced by this PR.
-->

It was because the alias was specified as the same as the subcommand name, so I removed it.

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->