### PR TITLE
Remove `extern crate`

### DIFF
--- a/beacon_node/client/src/lib.rs
+++ b/beacon_node/client/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate slog;
-
 mod compute_light_client_updates;
 pub mod config;
 mod metrics;

--- a/beacon_node/eth1/src/lib.rs
+++ b/beacon_node/eth1/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod block_cache;
 mod deposit_cache;
 mod inner;

--- a/beacon_node/eth1/src/metrics.rs
+++ b/beacon_node/eth1/src/metrics.rs
@@ -1,5 +1,7 @@
 pub use lighthouse_metrics::*;
 
+use lazy_static::lazy_static;
+
 lazy_static! {
     /*
      * Eth1 blocks

--- a/beacon_node/execution_layer/src/versioned_hashes.rs
+++ b/beacon_node/execution_layer/src/versioned_hashes.rs
@@ -1,5 +1,3 @@
-extern crate alloy_consensus;
-extern crate alloy_rlp;
 use alloy_consensus::TxEnvelope;
 use alloy_rlp::Decodable;
 use types::{EthSpec, ExecutionPayloadRef, Hash256, Unsigned, VersionedHash};

--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -2,9 +2,6 @@
 /// all required libp2p functionality.
 ///
 /// This crate builds and manages the libp2p services required by the beacon node.
-#[macro_use]
-extern crate lazy_static;
-
 mod config;
 pub mod service;
 

--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -1,5 +1,7 @@
 pub use lighthouse_metrics::*;
 
+use lazy_static::lazy_static;
+
 lazy_static! {
     pub static ref NAT_OPEN: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "nat_open",

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -6,6 +6,7 @@
 //!
 //! The scoring algorithms are currently experimental.
 use crate::service::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
+use lazy_static::lazy_static;
 use serde::Serialize;
 use std::time::Instant;
 use strum::AsRefStr;

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -3,6 +3,7 @@ use crate::rpc::codec::{base::BaseInboundCodec, ssz_snappy::SSZSnappyInboundCode
 use futures::future::BoxFuture;
 use futures::prelude::{AsyncRead, AsyncWrite};
 use futures::{FutureExt, StreamExt};
+use lazy_static::lazy_static;
 use libp2p::core::{InboundUpgrade, UpgradeInfo};
 use ssz::Encode;
 use ssz_types::VariableList;

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 /// This crate provides the network server for Lighthouse.
 pub mod error;
 #[allow(clippy::mutable_key_type)] // PeerId in hashmaps are no longer permitted by clippy

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -5,6 +5,7 @@ use beacon_chain::{
     sync_committee_verification::Error as SyncCommitteeError,
 };
 use fnv::FnvHashMap;
+use lazy_static::lazy_static;
 pub use lighthouse_metrics::*;
 use lighthouse_network::{
     peer_manager::peerdb::client::ClientKind, types::GossipKind, GossipTopic, Gossipsub,

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate clap;
-
 mod cli;
 mod config;
 

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -7,9 +7,6 @@
 //!
 //! Provides a simple API for storing/retrieving all types that sometimes needs type-hints. See
 //! tests for implementation examples.
-#[macro_use]
-extern crate lazy_static;
-
 mod chunk_writer;
 pub mod chunked_iter;
 pub mod chunked_vector;

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -1,6 +1,7 @@
 pub use lighthouse_metrics::{set_gauge, try_create_int_gauge, *};
 
 use directory::size_of_dir;
+use lazy_static::lazy_static;
 use std::path::Path;
 
 lazy_static! {

--- a/common/compare_fields_derive/src/lib.rs
+++ b/common/compare_fields_derive/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/common/eth2_interop_keypairs/src/lib.rs
+++ b/common/eth2_interop_keypairs/src/lib.rs
@@ -16,11 +16,9 @@
 //!
 //! This implementation passes the [reference implementation
 //! tests](https://github.com/ethereum/eth2.0-pm/blob/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start/keygen_test_vector.yaml).
-#[macro_use]
-extern crate lazy_static;
-
 use bls::{Keypair, PublicKey, SecretKey};
 use ethereum_hashing::hash;
+use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::fs::File;

--- a/common/lighthouse_metrics/src/lib.rs
+++ b/common/lighthouse_metrics/src/lib.rs
@@ -20,8 +20,7 @@
 //! ## Example
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate lazy_static;
+//! use lazy_static::lazy_static;
 //! use lighthouse_metrics::*;
 //!
 //! // These metrics are "magically" linked to the global registry defined in `lighthouse_metrics`.

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
-
+use lazy_static::lazy_static;
 use lighthouse_metrics::{
     inc_counter, try_create_int_counter, IntCounter, Result as MetricsResult,
 };

--- a/common/logging/src/tracing_metrics_layer.rs
+++ b/common/logging/src/tracing_metrics_layer.rs
@@ -1,5 +1,6 @@
 //! Exposes [`MetricsLayer`]: A tracing layer that registers metrics of logging events.
 
+use lazy_static::lazy_static;
 use lighthouse_metrics as metrics;
 use tracing_log::NormalizeEvent;
 

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod manual_slot_clock;
 mod metrics;
 mod system_time_slot_clock;

--- a/common/slot_clock/src/metrics.rs
+++ b/common/slot_clock/src/metrics.rs
@@ -1,4 +1,5 @@
 use crate::SlotClock;
+use lazy_static::lazy_static;
 pub use lighthouse_metrics::*;
 use types::{EthSpec, Slot};
 

--- a/common/test_random_derive/src/lib.rs
+++ b/common/test_random_derive/src/lib.rs
@@ -1,6 +1,4 @@
-extern crate proc_macro;
-
-use crate::proc_macro::TokenStream;
+use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 

--- a/consensus/types/src/beacon_state/committee_cache/tests.rs
+++ b/consensus/types/src/beacon_state/committee_cache/tests.rs
@@ -2,6 +2,7 @@
 use crate::test_utils::*;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use beacon_chain::types::*;
+use lazy_static::lazy_static;
 use swap_or_not_shuffle::shuffle_list;
 
 pub const VALIDATOR_COUNT: usize = 16;

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -6,6 +6,7 @@ use beacon_chain::types::{
     ChainSpec, Domain, Epoch, EthSpec, Hash256, Keypair, MainnetEthSpec, MinimalEthSpec,
     RelativeEpoch, Slot, Vector,
 };
+use lazy_static::lazy_static;
 use ssz::Encode;
 use std::ops::Mul;
 use swap_or_not_shuffle::compute_shuffled_index;

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -10,8 +10,6 @@
 )]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 pub mod test_utils;
 
 pub mod aggregate_and_proof;

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -1,5 +1,6 @@
 //! Identifies each shard by an integer identifier.
 use crate::{AttestationData, ChainSpec, CommitteeIndex, Epoch, EthSpec, Slot};
+use lazy_static::lazy_static;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};

--- a/consensus/types/src/sync_subnet_id.rs
+++ b/consensus/types/src/sync_subnet_id.rs
@@ -1,6 +1,7 @@
 //! Identifies each sync committee subnet by an integer identifier.
 use crate::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
 use crate::EthSpec;
+use lazy_static::lazy_static;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz_types::typenum::Unsigned;

--- a/lcli/src/block_root.rs
+++ b/lcli/src/block_root.rs
@@ -32,6 +32,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::BlockId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use types::{EthSpec, FullPayload, SignedBeaconBlock};

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate log;
 mod block_root;
 mod check_deposit_data;
 mod generate_bootnode_enr;

--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -1,6 +1,7 @@
 use clap::ArgMatches;
 use clap_utils::parse_required;
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use serde::Serialize;
 use snap::raw::Decoder;
 use ssz::Decode;

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -50,6 +50,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use ssz::Encode;
 use state_processing::state_advance::{complete_state_advance, partial_state_advance};
 use state_processing::AllCaches;

--- a/lcli/src/state_root.rs
+++ b/lcli/src/state_root.rs
@@ -4,6 +4,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use types::{BeaconState, EthSpec};

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -72,6 +72,7 @@ use eth2::{
     BeaconNodeHttpClient, SensitiveUrl, Timeouts,
 };
 use eth2_network_config::Eth2NetworkConfig;
+use log::{debug, info};
 use ssz::Encode;
 use state_processing::state_advance::complete_state_advance;
 use state_processing::{

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -10,9 +10,6 @@
 //! simulation uses `println` to communicate some info. It might be nice if the nodes logged to
 //! easy-to-find files and stdout only contained info from the simulation.
 //!
-
-extern crate clap;
-
 mod basic_sim;
 mod checks;
 mod cli;


### PR DESCRIPTION
## Proposed Changes

As of Rust 2018 (which we use), `extern crate` is unnecessary, and kinda janky.

This PR removes all uses of `extern crate` in favour of regular `use`s.
