### PR TITLE
Append new `committee_bits` field to `Attestation`

### DIFF
--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -69,9 +69,9 @@ pub struct Attestation<E: EthSpec> {
     #[superstruct(only(Electra), partial_getter(rename = "aggregation_bits_electra"))]
     pub aggregation_bits: BitList<E::MaxValidatorsPerSlot>,
     pub data: AttestationData,
+    pub signature: AggregateSignature,
     #[superstruct(only(Electra))]
     pub committee_bits: BitVector<E::MaxCommitteesPerSlot>,
-    pub signature: AggregateSignature,
 }
 
 // TODO(electra): think about how to handle fork variants here


### PR DESCRIPTION
latest spec changes move `committee_bits` to the last field in the struct. Probably to be compatible with stable container stuff