### PR TITLE
Rust 1.79 lints

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -685,7 +685,7 @@ mod test {
     fn get_eth1_data(i: u64) -> Eth1Data {
         Eth1Data {
             block_hash: Hash256::from_low_u64_be(i),
-            deposit_root: Hash256::from_low_u64_be(u64::max_value() - i),
+            deposit_root: Hash256::from_low_u64_be(u64::MAX - i),
             deposit_count: i,
         }
     }

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -2068,7 +2068,7 @@ pub fn timestamp_now() -> Duration {
 }
 
 fn u64_to_i64(n: impl Into<u64>) -> i64 {
-    i64::try_from(n.into()).unwrap_or(i64::max_value())
+    i64::try_from(n.into()).unwrap_or(i64::MAX)
 }
 
 /// Returns the delay between the start of `block.slot` and `seen_timestamp`.

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -721,10 +721,10 @@ fn eth1_logging<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>, log: &Logger
     }
 }
 
-/// Returns the peer count, returning something helpful if it's `usize::max_value` (effectively a
+/// Returns the peer count, returning something helpful if it's `usize::MAX` (effectively a
 /// `None` value).
 fn peer_count_pretty(peer_count: usize) -> String {
-    if peer_count == usize::max_value() {
+    if peer_count == usize::MAX {
         String::from("--")
     } else {
         format!("{}", peer_count)
@@ -824,7 +824,7 @@ impl Speedo {
 
     /// Returns the average of the speeds between each observation.
     ///
-    /// Does not gracefully handle slots that are above `u32::max_value()`.
+    /// Does not gracefully handle slots that are above `u32::MAX`.
     pub fn slots_per_second(&self) -> Option<f64> {
         let speeds = self
             .0

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -853,7 +853,7 @@ impl Service {
         let max_log_requests_per_update = self
             .config()
             .max_log_requests_per_update
-            .unwrap_or_else(|| usize::MAX);
+            .unwrap_or(usize::MAX);
 
         let range = {
             match new_block_numbers {
@@ -996,10 +996,7 @@ impl Service {
     ) -> Result<BlockCacheUpdateOutcome, Error> {
         let client = self.client();
         let block_cache_truncation = self.config().block_cache_truncation;
-        let max_blocks_per_update = self
-            .config()
-            .max_blocks_per_update
-            .unwrap_or_else(|| usize::MAX);
+        let max_blocks_per_update = self.config().max_blocks_per_update.unwrap_or(usize::MAX);
 
         let range = {
             match new_block_numbers {

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -853,7 +853,7 @@ impl Service {
         let max_log_requests_per_update = self
             .config()
             .max_log_requests_per_update
-            .unwrap_or_else(usize::max_value);
+            .unwrap_or_else(|| usize::MAX);
 
         let range = {
             match new_block_numbers {
@@ -999,7 +999,7 @@ impl Service {
         let max_blocks_per_update = self
             .config()
             .max_blocks_per_update
-            .unwrap_or_else(usize::max_value);
+            .unwrap_or_else(|| usize::MAX);
 
         let range = {
             match new_block_numbers {
@@ -1025,7 +1025,7 @@ impl Service {
                 let range_size = range.end() - range.start();
                 let max_size = block_cache_truncation
                     .map(|n| n as u64)
-                    .unwrap_or_else(u64::max_value);
+                    .unwrap_or_else(|| u64::MAX);
                 if range_size > max_size {
                     // If the range of required blocks is larger than `max_size`, drop all
                     // existing blocks and download `max_size` count of blocks.

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -412,7 +412,7 @@ pub mod deposit_methods {
                     .ok_or("Block number was not string")?,
             )?;
 
-            if number <= usize::max_value() as u64 {
+            if number <= usize::MAX as u64 {
                 Ok(Block {
                     hash,
                     timestamp,

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2178,7 +2178,7 @@ fn verify_builder_bid<E: EthSpec>(
 
     // Avoid logging values that we can't represent with our Prometheus library.
     let payload_value_gwei = bid.data.message.value() / 1_000_000_000;
-    if payload_value_gwei <= Uint256::from(i64::max_value()) {
+    if payload_value_gwei <= Uint256::from(i64::MAX) {
         metrics::set_gauge_vec(
             &metrics::EXECUTION_LAYER_PAYLOAD_BIDS,
             &[metrics::BUILDER],

--- a/beacon_node/execution_layer/src/metrics.rs
+++ b/beacon_node/execution_layer/src/metrics.rs
@@ -81,7 +81,7 @@ lazy_static::lazy_static! {
     );
     pub static ref EXECUTION_LAYER_PAYLOAD_BIDS: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "execution_layer_payload_bids",
-        "The gwei bid value of payloads received by local EEs or builders. Only shows values up to i64::max_value.",
+        "The gwei bid value of payloads received by local EEs or builders. Only shows values up to i64::MAX.",
         &["source"]
     );
 }

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2266,9 +2266,9 @@ impl ApiTester {
             vec![validator_count],
             vec![validator_count, 1],
             vec![validator_count, 1, 3],
-            vec![u64::max_value()],
-            vec![u64::max_value(), 1],
-            vec![u64::max_value(), 1, 3],
+            vec![u64::MAX],
+            vec![u64::MAX, 1],
+            vec![u64::MAX, 1, 3],
         ];
 
         interesting.push((0..validator_count).collect());

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -561,8 +561,8 @@ impl<E: EthSpec> Discovery<E> {
     /// Updates the `eth2` field of our local ENR.
     pub fn update_eth2_enr(&mut self, enr_fork_id: EnrForkId) {
         // to avoid having a reference to the spec constant, for the logging we assume
-        // FAR_FUTURE_EPOCH is u64::max_value()
-        let next_fork_epoch_log = if enr_fork_id.next_fork_epoch == u64::max_value() {
+        // FAR_FUTURE_EPOCH is u64::MAX
+        let next_fork_epoch_log = if enr_fork_id.next_fork_epoch == u64::MAX {
             String::from("No other fork")
         } else {
             format!("{:?}", enr_fork_id.next_fork_epoch)

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -793,9 +793,7 @@ async fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod
     let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Empty the op pool.
-    rig.chain
-        .op_pool
-        .prune_attestations(u64::max_value().into());
+    rig.chain.op_pool.prune_attestations(u64::MAX.into());
     assert_eq!(rig.chain.op_pool.num_attestations(), 0);
 
     // Send the attestation but not the block, and check that it was not imported.

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -602,7 +602,7 @@ impl<E: EthSpec> OperationPool<E> {
                         })
             },
             |address_change| address_change.as_inner().clone(),
-            usize::max_value(),
+            usize::MAX,
         );
         changes.shuffle(&mut thread_rng());
         changes
@@ -1343,7 +1343,7 @@ mod release_tests {
         // Set of indices covered by previous attestations in `best_attestations`.
         let mut seen_indices = BTreeSet::<u64>::new();
         // Used for asserting that rewards are in decreasing order.
-        let mut prev_reward = u64::max_value();
+        let mut prev_reward = u64::MAX;
 
         let mut reward_cache = RewardCache::default();
         reward_cache.update(&state).unwrap();

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
         let mut deposit_data = DepositData {
             pubkey: keypair.pk.into(),
             withdrawal_credentials: Hash256::from_slice(&[42; 32]),
-            amount: u64::max_value(),
+            amount: u64::MAX,
             signature: Signature::empty().into(),
         };
         deposit_data.signature = deposit_data.create_signature(&keypair.sk, spec);

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -285,17 +285,17 @@ impl ForkChoiceTestDefinition {
     }
 }
 
-/// Gives a root that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a root that is not the zero hash (unless i is `usize::MAX)`.
 fn get_root(i: u64) -> Hash256 {
     Hash256::from_low_u64_be(i + 1)
 }
 
-/// Gives a hash that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a hash that is not the zero hash (unless i is `usize::MAX)`.
 fn get_hash(i: u64) -> ExecutionBlockHash {
     ExecutionBlockHash::from_root(get_root(i))
 }
 
-/// Gives a checkpoint with a root that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a checkpoint with a root that is not the zero hash (unless i is `usize::MAX)`.
 /// `Epoch` will always equal `i`.
 fn get_checkpoint(i: u64) -> Checkpoint {
     Checkpoint {

--- a/consensus/proto_array/src/fork_choice_test_definition/votes.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/votes.rs
@@ -738,7 +738,7 @@ pub fn get_votes_test_definition() -> ForkChoiceTestDefinition {
     // Ensure that pruning below the prune threshold does not prune.
     ops.push(Operation::Prune {
         finalized_root: get_root(5),
-        prune_threshold: usize::max_value(),
+        prune_threshold: usize::MAX,
         expected_len: 11,
     });
 

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -995,7 +995,7 @@ mod test_compute_deltas {
     use super::*;
     use types::MainnetEthSpec;
 
-    /// Gives a hash that is not the zero hash (unless i is `usize::max_value)`.
+    /// Gives a hash that is not the zero hash (unless i is `usize::MAX)`.
     fn hash_from_index(i: usize) -> Hash256 {
         Hash256::from_low_u64_be(i as u64 + 1)
     }

--- a/consensus/safe_arith/src/lib.rs
+++ b/consensus/safe_arith/src/lib.rs
@@ -155,12 +155,12 @@ mod test {
 
     #[test]
     fn errors() {
-        assert!(u32::max_value().safe_add(1).is_err());
-        assert!(u32::min_value().safe_sub(1).is_err());
-        assert!(u32::max_value().safe_mul(2).is_err());
-        assert!(u32::max_value().safe_div(0).is_err());
-        assert!(u32::max_value().safe_rem(0).is_err());
-        assert!(u32::max_value().safe_shl(32).is_err());
-        assert!(u32::max_value().safe_shr(32).is_err());
+        assert!(u32::MAX.safe_add(1).is_err());
+        assert!(u32::MIN.safe_sub(1).is_err());
+        assert!(u32::MAX.safe_mul(2).is_err());
+        assert!(u32::MAX.safe_div(0).is_err());
+        assert!(u32::MAX.safe_rem(0).is_err());
+        assert!(u32::MAX.safe_shl(32).is_err());
+        assert!(u32::MAX.safe_shr(32).is_err());
     }
 }

--- a/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
@@ -30,7 +30,7 @@ impl Default for InclusionInfo {
     /// Defaults to `delay` at its maximum value and `proposer_index` at zero.
     fn default() -> Self {
         Self {
-            delay: u64::max_value(),
+            delay: u64::MAX,
             proposer_index: 0,
         }
     }

--- a/consensus/swap_or_not_shuffle/src/compute_shuffled_index.rs
+++ b/consensus/swap_or_not_shuffle/src/compute_shuffled_index.rs
@@ -17,7 +17,7 @@ use std::cmp::max;
 ///  - `list_size == 0`
 ///  - `index >= list_size`
 ///  - `list_size > 2**24`
-///  - `list_size > usize::max_value() / 2`
+///  - `list_size > usize::MAX / 2`
 pub fn compute_shuffled_index(
     index: usize,
     list_size: usize,
@@ -26,7 +26,7 @@ pub fn compute_shuffled_index(
 ) -> Option<usize> {
     if list_size == 0
         || index >= list_size
-        || list_size > usize::max_value() / 2
+        || list_size > usize::MAX / 2
         || list_size > 2_usize.pow(24)
     {
         return None;
@@ -140,7 +140,7 @@ mod tests {
     fn returns_none_for_too_large_list() {
         assert_eq!(
             None,
-            compute_shuffled_index(100, usize::max_value() / 2, &[42, 42], 90)
+            compute_shuffled_index(100, usize::MAX / 2, &[42, 42], 90)
         );
     }
 }

--- a/consensus/swap_or_not_shuffle/src/shuffle_list.rs
+++ b/consensus/swap_or_not_shuffle/src/shuffle_list.rs
@@ -75,7 +75,7 @@ impl Buf {
 /// Returns `None` under any of the following conditions:
 ///  - `list_size == 0`
 ///  - `list_size > 2**24`
-///  - `list_size > usize::max_value() / 2`
+///  - `list_size > usize::MAX / 2`
 pub fn shuffle_list(
     mut input: Vec<usize>,
     rounds: u8,
@@ -84,10 +84,7 @@ pub fn shuffle_list(
 ) -> Option<Vec<usize>> {
     let list_size = input.len();
 
-    if input.is_empty()
-        || list_size > usize::max_value() / 2
-        || list_size > 2_usize.pow(24)
-        || rounds == 0
+    if input.is_empty() || list_size > usize::MAX / 2 || list_size > 2_usize.pow(24) || rounds == 0
     {
         return None;
     }

--- a/consensus/types/benches/benches.rs
+++ b/consensus/types/benches/benches.rs
@@ -36,8 +36,8 @@ fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
                 slashed: false,
                 activation_eligibility_epoch: Epoch::new(0),
                 activation_epoch: Epoch::new(0),
-                exit_epoch: Epoch::from(u64::max_value()),
-                withdrawable_epoch: Epoch::from(u64::max_value()),
+                exit_epoch: Epoch::from(u64::MAX),
+                withdrawable_epoch: Epoch::from(u64::MAX),
             })
             .collect(),
     )

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -86,7 +86,7 @@ impl CommitteeCache {
         }
 
         // The use of `NonZeroUsize` reduces the maximum number of possible validators by one.
-        if state.validators().len() == usize::max_value() {
+        if state.validators().len() == usize::MAX {
             return Err(Error::TooManyValidators);
         }
 

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -70,7 +70,7 @@ impl Slot {
     }
 
     pub fn max_value() -> Slot {
-        Slot(u64::max_value())
+        Slot(u64::MAX)
     }
 }
 
@@ -80,7 +80,7 @@ impl Epoch {
     }
 
     pub fn max_value() -> Epoch {
-        Epoch(u64::max_value())
+        Epoch(u64::MAX)
     }
 
     /// The first slot in the epoch.
@@ -176,10 +176,10 @@ mod epoch_tests {
         let slots_per_epoch = 32;
 
         // The last epoch which can be represented by u64.
-        let epoch = Epoch::new(u64::max_value() / slots_per_epoch);
+        let epoch = Epoch::new(u64::MAX / slots_per_epoch);
 
         // A slot number on the epoch should be equal to u64::max_value.
-        assert_eq!(epoch.end_slot(slots_per_epoch), Slot::new(u64::max_value()));
+        assert_eq!(epoch.end_slot(slots_per_epoch), Slot::new(u64::MAX));
     }
 
     #[test]

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -352,7 +352,7 @@ macro_rules! new_tests {
         fn new() {
             assert_eq!($type(0), $type::new(0));
             assert_eq!($type(3), $type::new(3));
-            assert_eq!($type(u64::max_value()), $type::new(u64::max_value()));
+            assert_eq!($type(u64::MAX), $type::new(u64::MAX));
         }
     };
 }
@@ -368,7 +368,7 @@ macro_rules! from_into_tests {
             let x: $other = $type(3).into();
             assert_eq!(x, 3);
 
-            let x: $other = $type(u64::max_value()).into();
+            let x: $other = $type(u64::MAX).into();
             // Note: this will fail on 32 bit systems. This is expected as we don't have a proper
             // 32-bit system strategy in place.
             assert_eq!(x, $other::max_value());
@@ -378,7 +378,7 @@ macro_rules! from_into_tests {
         fn from() {
             assert_eq!($type(0), $type::from(0_u64));
             assert_eq!($type(3), $type::from(3_u64));
-            assert_eq!($type(u64::max_value()), $type::from($other::max_value()));
+            assert_eq!($type(u64::MAX), $type::from($other::max_value()));
         }
     };
 }
@@ -396,8 +396,8 @@ macro_rules! math_between_tests {
 
             assert_partial_ord(1, Ordering::Less, 2);
             assert_partial_ord(2, Ordering::Greater, 1);
-            assert_partial_ord(0, Ordering::Less, u64::max_value());
-            assert_partial_ord(u64::max_value(), Ordering::Greater, 0);
+            assert_partial_ord(0, Ordering::Less, u64::MAX);
+            assert_partial_ord(u64::MAX, Ordering::Greater, 0);
         }
 
         #[test]
@@ -412,9 +412,9 @@ macro_rules! math_between_tests {
             assert_partial_eq(1, 0, false);
             assert_partial_eq(1, 1, true);
 
-            assert_partial_eq(u64::max_value(), u64::max_value(), true);
-            assert_partial_eq(0, u64::max_value(), false);
-            assert_partial_eq(u64::max_value(), 0, false);
+            assert_partial_eq(u64::MAX, u64::MAX, true);
+            assert_partial_eq(0, u64::MAX, false);
+            assert_partial_eq(u64::MAX, 0, false);
         }
 
         #[test]
@@ -436,8 +436,8 @@ macro_rules! math_between_tests {
             assert_add(7, 7, 14);
 
             // Addition should be saturating.
-            assert_add(u64::max_value(), 1, u64::max_value());
-            assert_add(u64::max_value(), u64::max_value(), u64::max_value());
+            assert_add(u64::MAX, 1, u64::MAX);
+            assert_add(u64::MAX, u64::MAX, u64::MAX);
         }
 
         #[test]
@@ -455,8 +455,8 @@ macro_rules! math_between_tests {
             assert_sub(1, 0, 1);
             assert_sub(2, 1, 1);
             assert_sub(14, 7, 7);
-            assert_sub(u64::max_value(), 1, u64::max_value() - 1);
-            assert_sub(u64::max_value(), u64::max_value(), 0);
+            assert_sub(u64::MAX, 1, u64::MAX - 1);
+            assert_sub(u64::MAX, u64::MAX, 0);
 
             // Subtraction should be saturating
             assert_sub(0, 1, 0);
@@ -480,7 +480,7 @@ macro_rules! math_between_tests {
             assert_mul(0, 2, 0);
 
             // Multiplication should be saturating.
-            assert_mul(u64::max_value(), 2, u64::max_value());
+            assert_mul(u64::MAX, 2, u64::MAX);
         }
 
         #[test]
@@ -499,7 +499,7 @@ macro_rules! math_between_tests {
             assert_div(2, 2, 1);
             assert_div(100, 50, 2);
             assert_div(128, 2, 64);
-            assert_div(u64::max_value(), 2, 2_u64.pow(63) - 1);
+            assert_div(u64::MAX, 2, 2_u64.pow(63) - 1);
         }
 
         #[test]
@@ -544,8 +544,8 @@ macro_rules! math_tests {
             assert_saturating_sub(1, 0, 1);
             assert_saturating_sub(2, 1, 1);
             assert_saturating_sub(14, 7, 7);
-            assert_saturating_sub(u64::max_value(), 1, u64::max_value() - 1);
-            assert_saturating_sub(u64::max_value(), u64::max_value(), 0);
+            assert_saturating_sub(u64::MAX, 1, u64::MAX - 1);
+            assert_saturating_sub(u64::MAX, u64::MAX, 0);
 
             // Subtraction should be saturating
             assert_saturating_sub(0, 1, 0);
@@ -565,8 +565,8 @@ macro_rules! math_tests {
             assert_saturating_add(7, 7, 14);
 
             // Addition should be saturating.
-            assert_saturating_add(u64::max_value(), 1, u64::max_value());
-            assert_saturating_add(u64::max_value(), u64::max_value(), u64::max_value());
+            assert_saturating_add(u64::MAX, 1, u64::MAX);
+            assert_saturating_add(u64::MAX, u64::MAX, u64::MAX);
         }
 
         #[test]
@@ -581,11 +581,11 @@ macro_rules! math_tests {
             assert_checked_div(2, 2, Some(1));
             assert_checked_div(100, 50, Some(2));
             assert_checked_div(128, 2, Some(64));
-            assert_checked_div(u64::max_value(), 2, Some(2_u64.pow(63) - 1));
+            assert_checked_div(u64::MAX, 2, Some(2_u64.pow(63) - 1));
 
             assert_checked_div(2, 0, None);
             assert_checked_div(0, 0, None);
-            assert_checked_div(u64::max_value(), 0, None);
+            assert_checked_div(u64::MAX, 0, None);
         }
 
         #[test]
@@ -607,7 +607,7 @@ macro_rules! math_tests {
             assert_is_power_of_two(4, true);
 
             assert_is_power_of_two(2_u64.pow(4), true);
-            assert_is_power_of_two(u64::max_value(), false);
+            assert_is_power_of_two(u64::MAX, false);
         }
 
         #[test]
@@ -619,8 +619,8 @@ macro_rules! math_tests {
 
             assert_ord(1, Ordering::Less, 2);
             assert_ord(2, Ordering::Greater, 1);
-            assert_ord(0, Ordering::Less, u64::max_value());
-            assert_ord(u64::max_value(), Ordering::Greater, 0);
+            assert_ord(0, Ordering::Less, u64::MAX);
+            assert_ord(u64::MAX, Ordering::Greater, 0);
         }
     };
 }
@@ -647,8 +647,8 @@ macro_rules! all_tests {
                 let x = $type(3).as_u64();
                 assert_eq!(x, 3);
 
-                let x = $type(u64::max_value()).as_u64();
-                assert_eq!(x, u64::max_value());
+                let x = $type(u64::MAX).as_u64();
+                assert_eq!(x, u64::MAX);
             }
         }
 
@@ -665,8 +665,8 @@ macro_rules! all_tests {
                 let x = $type(3).as_usize();
                 assert_eq!(x, 3);
 
-                let x = $type(u64::max_value()).as_usize();
-                assert_eq!(x, usize::max_value());
+                let x = $type(u64::MAX).as_usize();
+                assert_eq!(x, usize::MAX);
             }
         }
     };

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -371,14 +371,14 @@ macro_rules! from_into_tests {
             let x: $other = $type(u64::MAX).into();
             // Note: this will fail on 32 bit systems. This is expected as we don't have a proper
             // 32-bit system strategy in place.
-            assert_eq!(x, $other::max_value());
+            assert_eq!(x, $other::MAX);
         }
 
         #[test]
         fn from() {
             assert_eq!($type(0), $type::from(0_u64));
             assert_eq!($type(3), $type::from(3_u64));
-            assert_eq!($type(u64::MAX), $type::from($other::max_value()));
+            assert_eq!($type(u64::MAX), $type::from($other::MAX));
         }
     };
 }

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -254,12 +254,12 @@ impl Default for Validator {
         Self {
             pubkey: PublicKeyBytes::empty(),
             withdrawal_credentials: Hash256::default(),
-            activation_eligibility_epoch: Epoch::from(std::u64::MAX),
-            activation_epoch: Epoch::from(std::u64::MAX),
-            exit_epoch: Epoch::from(std::u64::MAX),
-            withdrawable_epoch: Epoch::from(std::u64::MAX),
+            activation_eligibility_epoch: Epoch::from(u64::MAX),
+            activation_epoch: Epoch::from(u64::MAX),
+            exit_epoch: Epoch::from(u64::MAX),
+            withdrawable_epoch: Epoch::from(u64::MAX),
             slashed: false,
-            effective_balance: std::u64::MAX,
+            effective_balance: u64::MAX,
         }
     }
 }

--- a/crypto/eth2_key_derivation/tests/tests.rs
+++ b/crypto/eth2_key_derivation/tests/tests.rs
@@ -22,7 +22,7 @@ fn deterministic() {
 fn children_deterministic() {
     let master = DerivedKey::from_seed(&[42]).unwrap();
     assert_eq!(
-        master.child(u32::max_value()).secret(),
-        master.child(u32::max_value()).secret(),
+        master.child(u32::MAX).secret(),
+        master.child(u32::MAX).secret(),
     )
 }

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -179,7 +179,7 @@ impl Wallet {
     ///
     /// - If `wallet_password` is unable to decrypt `self`.
     /// - If `keystore_password.is_empty()`.
-    /// - If `self.nextaccount == u32::max_value()`.
+    /// - If `self.nextaccount == u32::MAX`.
     pub fn next_validator(
         &mut self,
         wallet_password: &[u8],

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -78,6 +78,6 @@ fi
 # Stop local testnet
 kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/kurtosis-tech/ethereum-package --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -1,4 +1,4 @@
-# Full configuration reference [here](https://github.com/kurtosis-tech/ethereum-package?tab=readme-ov-file#configuration).
+# Full configuration reference [here](https://github.com/ethpandaops/ethereum-package?tab=readme-ov-file#configuration).
 participants:
   - el_type: geth
     el_image: ethereum/client-go:latest

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -1115,7 +1115,7 @@ mod test {
             )
             // All validators should still be disabled.
             .assert_all_disabled()
-            // The states of all validators should be jammed with `u64::max_value()`.
+            // The states of all validators should be jammed with `u64:MAX`.
             .assert_all_states(&DoppelgangerState {
                 next_check_epoch: starting_epoch + 1,
                 remaining_epochs: u64::MAX,
@@ -1347,7 +1347,7 @@ mod test {
             )
             .assert_all_states(&DoppelgangerState {
                 next_check_epoch: initial_epoch + 1,
-                remaining_epochs: u64::max_value(),
+                remaining_epochs: u64::MAX,
             });
     }
 

--- a/watch/src/blockprint/database.rs
+++ b/watch/src/blockprint/database.rs
@@ -33,6 +33,7 @@ pub struct WatchBlockprint {
 }
 
 #[derive(Debug, QueryableByName, diesel::FromSqlRow)]
+#[allow(dead_code)]
 pub struct WatchValidatorBlockprint {
     #[diesel(sql_type = Integer)]
     pub proposer_index: i32,

--- a/watch/src/blockprint/mod.rs
+++ b/watch/src/blockprint/mod.rs
@@ -24,6 +24,7 @@ pub use server::blockprint_routes;
 const TIMEOUT: Duration = Duration::from_secs(50);
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     Reqwest(reqwest::Error),
     Url(url::ParseError),

--- a/watch/src/blockprint/mod.rs
+++ b/watch/src/blockprint/mod.rs
@@ -64,7 +64,7 @@ pub struct BlockprintResponse {
 }
 
 impl WatchBlockprintClient {
-    async fn get(&self, url: Url) -> Result<Response, Error> {
+    pub async fn get(&self, url: Url) -> Result<Response, Error> {
         let mut builder = self.client.get(url).timeout(TIMEOUT);
         if let Some(username) = &self.username {
             builder = builder.basic_auth(username, self.password.as_ref());

--- a/watch/src/blockprint/mod.rs
+++ b/watch/src/blockprint/mod.rs
@@ -64,7 +64,7 @@ pub struct BlockprintResponse {
 }
 
 impl WatchBlockprintClient {
-    pub async fn get(&self, url: Url) -> Result<Response, Error> {
+    async fn get(&self, url: Url) -> Result<Response, Error> {
         let mut builder = self.client.get(url).timeout(TIMEOUT);
         if let Some(username) = &self.username {
             builder = builder.basic_auth(username, self.password.as_ref());

--- a/watch/src/server/error.rs
+++ b/watch/src/server/error.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use std::io::Error as IoError;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     Axum(AxumError),
     Hyper(HyperError),

--- a/watch/src/updater/error.rs
+++ b/watch/src/updater/error.rs
@@ -5,6 +5,7 @@ use eth2::{Error as Eth2Error, SensitiveError};
 use std::fmt;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     BeaconChain(BeaconChainError),
     Eth2(Eth2Error),

--- a/watch/src/updater/handler.rs
+++ b/watch/src/updater/handler.rs
@@ -9,6 +9,7 @@ use eth2::{
 };
 use log::{debug, error, info, warn};
 use std::collections::HashSet;
+use std::marker::PhantomData;
 use types::{BeaconBlockHeader, EthSpec, Hash256, SignedBeaconBlock, Slot};
 
 use crate::updater::{get_beacon_block, get_header, get_validators};
@@ -47,7 +48,7 @@ pub struct UpdateHandler<E: EthSpec> {
     pub blockprint: Option<WatchBlockprintClient>,
     pub config: Config,
     pub slots_per_epoch: u64,
-    pub spec: WatchSpec<E>,
+    pub _phantom: PhantomData<E>,
 }
 
 impl<E: EthSpec> UpdateHandler<E> {
@@ -84,7 +85,7 @@ impl<E: EthSpec> UpdateHandler<E> {
             blockprint,
             config: config.updater,
             slots_per_epoch: spec.slots_per_epoch(),
-            spec,
+            _phantom: PhantomData,
         })
     }
 


### PR DESCRIPTION
## Issue Addressed

fixing 1.79 lints including:
- using `u64::MAX` instead of `u64::max_value()` or `std::u64::MAX`
- some errors trigger a dead code lint when the field isn't read, but errors as fields are useful when printing via debug, so I just added `#[allow(dead_code)]` to these errors
- removed `spec: WatchSpec<E>` from `UpdateHandler` as this was unused - wasn't sure if this field was intentionally there and should be kept?