### PR TITLE
Remove some easy Electra TODOs

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1985,39 +1985,10 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     excess_blob_gas: deneb_block.excess_blob_gas,
                 })
             }
-            ExecutionBlockWithTransactions::Electra(electra_block) => {
-                let withdrawals = VariableList::new(
-                    electra_block
-                        .withdrawals
-                        .into_iter()
-                        .map(Into::into)
-                        .collect(),
-                )
-                .map_err(ApiError::DeserializeWithdrawals)?;
-                ExecutionPayload::Electra(ExecutionPayloadElectra {
-                    parent_hash: electra_block.parent_hash,
-                    fee_recipient: electra_block.fee_recipient,
-                    state_root: electra_block.state_root,
-                    receipts_root: electra_block.receipts_root,
-                    logs_bloom: electra_block.logs_bloom,
-                    prev_randao: electra_block.prev_randao,
-                    block_number: electra_block.block_number,
-                    gas_limit: electra_block.gas_limit,
-                    gas_used: electra_block.gas_used,
-                    timestamp: electra_block.timestamp,
-                    extra_data: electra_block.extra_data,
-                    base_fee_per_gas: electra_block.base_fee_per_gas,
-                    block_hash: electra_block.block_hash,
-                    transactions: convert_transactions(electra_block.transactions)?,
-                    withdrawals,
-                    blob_gas_used: electra_block.blob_gas_used,
-                    excess_blob_gas: electra_block.excess_blob_gas,
-                    // TODO(electra)
-                    // deposit_receipts: electra_block.deposit_receipts,
-                    // withdrawal_requests: electra_block.withdrawal_requests,
-                    deposit_receipts: <_>::default(),
-                    withdrawal_requests: <_>::default(),
-                })
+            ExecutionBlockWithTransactions::Electra(_) => {
+                return Err(ApiError::UnsupportedForkVariant(format!(
+                    "legacy payload construction for {fork} is not implemented"
+                )));
             }
         };
 

--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -133,7 +133,6 @@ where
     #[superstruct(only(Electra))]
     pub earliest_consolidation_epoch: Epoch,
 
-    // TODO(electra) should these be optional?
     #[superstruct(only(Electra))]
     pub pending_balance_deposits: List<PendingBalanceDeposit, E::PendingBalanceDepositsLimit>,
     #[superstruct(only(Electra))]

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -120,7 +120,6 @@ impl<E: EthSpec> ExecutionPayloadHeader<E> {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn ssz_max_var_len_for_fork(fork_name: ForkName) -> usize {
         // Matching here in case variable fields are added in future forks.
-        // TODO(electra): review electra changes
         match fork_name {
             ForkName::Base
             | ForkName::Altair


### PR DESCRIPTION
## Proposed Changes

Remove 3 TODOs related to Electra:

- Delete legacy payload reconstruction for Electra. We don't even have _proper_ payload reconstruction specced yet for Electra (see https://github.com/sigp/lighthouse/pull/5743), and I'm doubtful we will need or want the legacy reconstruction. I'm actually tempted to delete legacy payload reconstruction entirely, but it _is_ a little bit useful for sanity-checking the EL genesis block and preventing mistakes similar to Holesky v1.0 (see `bellatrix_readiness.rs` which does genesis block checks).
- Confirm that non-optional fields are OK in `PartialBeaconState`. This is going away soon with tree-states anyway.
- Remove comment from `ExecutionPayloadHeader::ssz_max_var_len_for_fork`. The extra data is still the only variable-length field in `ExecutionPayloadHeader`, so this function is still correct. If the spec changes, the light client tests should catch any discrepancy here too.