### PR TITLE
Clean up Electra observed aggregates

### DIFF
--- a/beacon_node/beacon_chain/src/attestation_verification.rs
+++ b/beacon_node/beacon_chain/src/attestation_verification.rs
@@ -35,8 +35,10 @@
 mod batch;
 
 use crate::{
-    beacon_chain::VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT, metrics,
-    observed_aggregates::ObserveOutcome, observed_attesters::Error as ObservedAttestersError,
+    beacon_chain::VALIDATOR_PUBKEY_CACHE_LOCK_TIMEOUT,
+    metrics,
+    observed_aggregates::{ObserveOutcome, ObservedAttestationKey},
+    observed_attesters::Error as ObservedAttestersError,
     BeaconChain, BeaconChainError, BeaconChainTypes,
 };
 use bls::verify_signature_sets;
@@ -58,9 +60,8 @@ use state_processing::{
 use std::borrow::Cow;
 use strum::AsRefStr;
 use tree_hash::TreeHash;
-use tree_hash_derive::TreeHash;
 use types::{
-    Attestation, AttestationData, AttestationRef, BeaconCommittee, BeaconStateError,
+    Attestation, AttestationRef, BeaconCommittee, BeaconStateError,
     BeaconStateError::NoCommitteeFound, ChainSpec, CommitteeIndex, Epoch, EthSpec, ForkName,
     Hash256, IndexedAttestation, SelectionProof, SignedAggregateAndProof, Slot, SubnetId,
 };
@@ -307,12 +308,6 @@ struct IndexedAggregatedAttestation<'a, T: BeaconChainTypes> {
     signed_aggregate: &'a SignedAggregateAndProof<T::EthSpec>,
     indexed_attestation: IndexedAttestation<T::EthSpec>,
     observed_attestation_key_root: Hash256,
-}
-
-#[derive(TreeHash)]
-pub struct ObservedAttestationKey {
-    pub committee_index: u64,
-    pub attestation_data: AttestationData,
 }
 
 /// Wraps a `Attestation` that has been verified up until the point that an `IndexedAttestation` can

--- a/beacon_node/beacon_chain/src/lib.rs
+++ b/beacon_node/beacon_chain/src/lib.rs
@@ -39,7 +39,7 @@ mod light_client_server_cache;
 pub mod metrics;
 pub mod migrate;
 mod naive_aggregation_pool;
-mod observed_aggregates;
+pub mod observed_aggregates;
 mod observed_attesters;
 mod observed_blob_sidecars;
 pub mod observed_block_producers;

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -2,8 +2,8 @@
 
 use beacon_chain::attestation_verification::{
     batch_verify_aggregated_attestations, batch_verify_unaggregated_attestations, Error,
-    ObservedAttestationKey,
 };
+use beacon_chain::observed_aggregates::ObservedAttestationKey;
 use beacon_chain::test_utils::{MakeAttestationOptions, HARNESS_GENESIS_TIME};
 use beacon_chain::{
     attestation_verification::Error as AttnError,
@@ -852,7 +852,9 @@ async fn aggregated_gossip_verification() {
                     err,
                     AttnError::AttestationSupersetKnown(hash)
                     if hash == ObservedAttestationKey {
-                        committee_index: tester.valid_aggregate.message().aggregate().expect("should get committee index"),
+                        committee_index: tester.valid_aggregate.message().aggregate()
+                            .committee_index()
+                            .expect("should get committee index"),
                         attestation_data: tester.valid_aggregate.message().aggregate().data().clone(),
                     }.tree_hash_root()
                 ))


### PR DESCRIPTION
## Proposed Changes

Fix some bugs and TODOs related to the observed aggregates cache.

1. Ensure that attestation roots are always calculated using the committee index, i.e. `ObservedAttestationKey`. Previously we were ok because we were using the key consistently in `attestation_verification.rs`, but if the code were refactored to depend on `SubsetItem::root`, it would break due to the `root` method ignoring the committee index. This would lead to false positives for subset aggregates, as aggregates would be compared for different committees.
2. Remove `expect`s and `unwrap`s by adding a few new error variants. These should be hard to reach, but not necessarily impossible, so I think an error is better than an `expect`, or an attempt to make the methods infallible.
