### PR TITLE
Update start_local_testnet.sh to use correct package name

### DIFF
--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -37,8 +37,6 @@ while getopts "e:b:n:phc" flag; do
   esac
 done
 
-LH_IMAGE_NAME=$(yq eval ".participants[0].cl_image" $NETWORK_PARAMS_FILE)
-
 if ! command -v docker &> /dev/null; then
     echo "Docker is not installed. Please install Docker and try again."
     exit 1
@@ -52,6 +50,8 @@ fi
 if ! command -v yq &> /dev/null; then
     echo "yq not found. Please install yq and try again."
 fi
+
+LH_IMAGE_NAME=$(yq eval ".participants[0].cl_image" $NETWORK_PARAMS_FILE)
 
 if [ "$BUILDER_PROPOSALS" = true ]; then
   yq eval '.participants[0].vc_extra_params = ["--builder-proposals"]' -i $NETWORK_PARAMS_FILE
@@ -78,6 +78,6 @@ fi
 # Stop local testnet
 kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/kurtosis-tech/ethereum-package --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"


### PR DESCRIPTION
## Issue Addressed

When I tried to run the `start_local_testnet.sh` script it would fail with
```bash
There was an error interpreting Starlark code 
Error occurred while validating /kurtosis-data/repositories/kurtosis-tech/ethereum-package/kurtosis.yml
	Caused by: The package name in kurtosis.yml must match the location it is in. Package name is 'github.com/ethpandaops/ethereum-package' and kurtosis.yml is found here: 'github.com/kurtosis-tech/ethereum-package'
```

The check for `yq` is also done after it is first being used which I fixed here also.

## Proposed Changes

Looking up the repository it mentions that it has been moved to `github.com/ethpandaops/ethereum-package` which is what I changed here. 

## Additional Info

I ran the suggested changes locally and verified it fixed my issues. 

**edit:** I now see this change has already been merged into unstable through #5927 , but would still be nice to have it on stable already as that is the default branch. 