### PR TITLE
Add `FUNDING.json` for DRIPS

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,0 +1,7 @@
+{
+    "drips": {
+        "ethereum": {
+            "ownedBy": "0x25c4a76E7d118705e7Ea2e9b7d8C59930d8aCD3b"
+        }
+    }
+}


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds `FUNDING.json` for [DRIPS](https://drips.network) based on this example: https://github.com/drips-network/app/blob/main/FUNDING.json

The ETH address is our donation address from our [README.md](./README.md).

## Additional Info

NA
