### PR TITLE
Update CI nethermind and LLVM versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             - uses: KyleMayes/install-llvm-action@v1
               if: env.SELF_HOSTED_RUNNERS == 'false' && startsWith(matrix.arch, 'x86_64-windows')
               with:
-                version: "16.0"
+                version: "17.0"
                 directory: ${{ runner.temp }}/llvm
             - name: Set LIBCLANG_PATH
               if: startsWith(matrix.arch, 'x86_64-windows')

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -112,11 +112,6 @@ jobs:
     - name: Install make
       if: env.SELF_HOSTED_RUNNERS == 'false'
       run: choco install -y make
-#    - uses: KyleMayes/install-llvm-action@v1
-#         if: env.SELF_HOSTED_RUNNERS == 'false'
-#      with:
-#        version: "16.0"
-#        directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - name: Run tests in release

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -70,11 +70,10 @@ impl NethermindEngine {
             .join("nethermind")
             .join("src")
             .join("Nethermind")
-            .join("Nethermind.Runner")
+            .join("artifacts")
             .join("bin")
-            .join("Release")
-            .join("net7.0")
-            .join("linux-x64")
+            .join("Nethermind.Runner")
+            .join("release")
             .join("nethermind")
     }
 }

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use unused_port::unused_tcp4_port;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.21.0";
+const NETHERMIND_BRANCH: &str = "release/1.27.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {


### PR DESCRIPTION
## Issue Addressed

Update nethermind and LLVM versions.

- Rust 1.79 [updates the minimum external LLVM to 17](https://github.com/rust-lang/rust/blob/1.79.0/RELEASES.md#compatibility-notes). Note we no longer use GitHub hosted runners for release and I think our windows runners use latest version. (FYI @antondlr in case if we run into any issues)
- Update Nethermind version to latest release.