### PR TITLE
Lower tolerance of stale blobs on gossip

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -701,7 +701,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             "index" => %index,
                             "commitment" => %commitment,
                         );
-                        // Prevent recurring behaviour by penalizing the peer slightly.
+                        // Prevent recurring behaviour by penalizing the peer.
                         self.gossip_penalize_peer(
                             peer_id,
                             PeerAction::LowToleranceError,
@@ -714,7 +714,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         );
                     }
                     GossipBlobError::FutureSlot { .. } | GossipBlobError::RepeatBlob { .. } => {
-                        warn!(
+                        debug!(
                             self.log,
                             "Could not verify blob sidecar for gossip. Ignoring the blob sidecar";
                             "error" => ?err,
@@ -736,7 +736,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         );
                     }
                     GossipBlobError::PastFinalizedSlot { .. } => {
-                        warn!(
+                        debug!(
                             self.log,
                             "Could not verify blob sidecar for gossip. Ignoring the blob sidecar";
                             "error" => ?err,
@@ -745,7 +745,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             "index" => %index,
                             "commitment" => %commitment,
                         );
-                        // Prevent recurring behaviour by penalizing the peer slightly.
+                        // Prevent recurring behaviour by penalizing the peer. A low-tolerance
+                        // error is fine because there's no reason for peers to be propagating old
+                        // blobs on gossip, even if their view of finality is lagging.
                         self.gossip_penalize_peer(
                             peer_id,
                             PeerAction::LowToleranceError,


### PR DESCRIPTION
## Proposed Changes

Some peers are spamming old blobs from prior to finalization on gossip. We don't ban them quickly enough due to the high-tolerance peer penalty. This PR changes the penalty to a low-tolerance one.

From the peers that I spot-checked, all the spam seemed to be coming from Erigon/Caplin peers. I've communicated this to the Caplin devs, so new releases of Caplin shouldn't have this problem and won't suffer from by being banned by Lighthouse.

I've kept the gossipsub behaviour as `Ignore` rather than combining with the `Reject` block above. We are required to `Ignore` these blobs by the spec: https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/p2p-interface.md#blob-subnets
