### PR TITLE
chore: add `recover_cells_and_compute_proofs` method

### DIFF
--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -226,15 +226,7 @@ impl<E: EthSpec> DataColumnSidecar<E> {
                     cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
                     cell_ids.push(data_column.index);
                 }
-                // recover_all_cells does not expect sorted
-                let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
-                let blob = kzg.cells_to_blob(&all_cells)?;
-
-                // Note: This function computes all cells and proofs. According to Justin this is okay,
-                // computing a partial set may be more expensive and requires code paths that don't exist.
-                // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
-                // for simplicity.
-                kzg.compute_cells_and_proofs(&blob)
+                kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells)
             })
             .collect::<Result<Vec<_>, KzgError>>()?;
 

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -196,20 +196,24 @@ impl Kzg {
         }
     }
 
-    pub fn cells_to_blob(&self, cells: &[Cell; c_kzg::CELLS_PER_EXT_BLOB]) -> Result<Blob, Error> {
+    fn cells_to_blob(&self, cells: &[Cell; c_kzg::CELLS_PER_EXT_BLOB]) -> Result<Blob, Error> {
         Ok(Blob::cells_to_blob(cells)?)
     }
 
-    pub fn recover_all_cells(
+    pub fn recover_cells_and_compute_kzg_proofs(
         &self,
         cell_ids: &[u64],
         cells: &[Cell],
-    ) -> Result<Box<[Cell; c_kzg::CELLS_PER_EXT_BLOB]>, Error> {
-        Ok(c_kzg::Cell::recover_all_cells(
-            cell_ids,
-            cells,
-            &self.trusted_setup,
-        )?)
+    ) -> Result<
+        (
+            Box<[Cell; CELLS_PER_EXT_BLOB]>,
+            Box<[KzgProof; CELLS_PER_EXT_BLOB]>,
+        ),
+        Error,
+    > {
+        let all_cells = c_kzg::Cell::recover_all_cells(cell_ids, cells, &self.trusted_setup)?;
+        let blob = self.cells_to_blob(&all_cells)?;
+        self.compute_cells_and_proofs(&blob)
     }
 }
 

--- a/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::case_result::compare_result;
-use kzg::{Blob as KzgBlob, Cell};
-use kzg::{KzgProof, CELLS_PER_EXT_BLOB};
+use kzg::{Blob as KzgBlob, CellsAndKzgProofs};
 use serde::Deserialize;
 use std::marker::PhantomData;
 
@@ -62,12 +61,6 @@ impl<E: EthSpec> Case for KZGComputeCellsAndKZGProofs<E> {
                 .ok()
         });
 
-        compare_result::<
-            (
-                Box<[Cell; CELLS_PER_EXT_BLOB]>,
-                Box<[KzgProof; CELLS_PER_EXT_BLOB]>,
-            ),
-            _,
-        >(&cells_and_proofs, &expected)
+        compare_result::<CellsAndKzgProofs, _>(&cells_and_proofs, &expected)
     }
 }


### PR DESCRIPTION
## Issue Addressed

This PR makes the KZG API stricter. Instead of exposing recover_cells, and cells_to_blob, we have a method which recovers the cells and computes the proofs.

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
