### PR TITLE
Ensure all handler events are covered

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -374,6 +374,12 @@ where
                 id: outbound_info.req_id,
             })));
         }
+
+        // Also handle any events that are awaiting to be sent to the behaviour
+        if !self.events_out.is_empty() {
+            return Poll::Ready(Some(self.events_out.remove(0)));
+        }
+
         Poll::Ready(None)
     }
 


### PR DESCRIPTION
## Issue Addressed

Logs indicated an RPC message was being dropped when the shutdown timer expired. 

I couldn't see any obvious places where this could happen. The catch-all for this should be in the `poll_close()`. The only case I could think of would be events waiting to be processed in the handler. 

This PR handles this edge case by ensuring all events are also handled before the handler is completely terminated. 

As it stands, this should capture any currently in-flight messages and all events that are remaining to be processed. 
