### PR TITLE
chore: change `impl Into<T> for U` to `impl From<U> for T`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ lint:
 		-D clippy::manual_let_else \
 		-D warnings \
 		-A clippy::derive_partial_eq_without_eq \
-		-A clippy::from-over-into \
 		-A clippy::upper-case-acronyms \
 		-A clippy::vec-init-then-push \
 		-A clippy::question-mark \

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -389,35 +389,35 @@ pub struct PersistedForkChoiceStore {
     pub equivocating_indices: BTreeSet<u64>,
 }
 
-impl Into<PersistedForkChoiceStore> for PersistedForkChoiceStoreV11 {
-    fn into(self) -> PersistedForkChoiceStore {
+impl From<PersistedForkChoiceStoreV11> for PersistedForkChoiceStore {
+    fn from(from: PersistedForkChoiceStoreV11) -> PersistedForkChoiceStore {
         PersistedForkChoiceStore {
-            balances_cache: self.balances_cache,
-            time: self.time,
-            finalized_checkpoint: self.finalized_checkpoint,
-            justified_checkpoint: self.justified_checkpoint,
-            justified_balances: self.justified_balances,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
-            proposer_boost_root: self.proposer_boost_root,
-            equivocating_indices: self.equivocating_indices,
+            balances_cache: from.balances_cache,
+            time: from.time,
+            finalized_checkpoint: from.finalized_checkpoint,
+            justified_checkpoint: from.justified_checkpoint,
+            justified_balances: from.justified_balances,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
+            proposer_boost_root: from.proposer_boost_root,
+            equivocating_indices: from.equivocating_indices,
         }
     }
 }
 
-impl Into<PersistedForkChoiceStoreV11> for PersistedForkChoiceStore {
-    fn into(self) -> PersistedForkChoiceStoreV11 {
+impl From<PersistedForkChoiceStore> for PersistedForkChoiceStoreV11 {
+    fn from(from: PersistedForkChoiceStore) -> PersistedForkChoiceStoreV11 {
         PersistedForkChoiceStoreV11 {
-            balances_cache: self.balances_cache,
-            time: self.time,
-            finalized_checkpoint: self.finalized_checkpoint,
-            justified_checkpoint: self.justified_checkpoint,
-            justified_balances: self.justified_balances,
+            balances_cache: from.balances_cache,
+            time: from.time,
+            finalized_checkpoint: from.finalized_checkpoint,
+            justified_checkpoint: from.justified_checkpoint,
+            justified_balances: from.justified_balances,
             best_justified_checkpoint: JUNK_BEST_JUSTIFIED_CHECKPOINT,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
-            proposer_boost_root: self.proposer_boost_root,
-            equivocating_indices: self.equivocating_indices,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
+            proposer_boost_root: from.proposer_boost_root,
+            equivocating_indices: from.equivocating_indices,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -20,20 +20,20 @@ pub struct PersistedForkChoice {
     pub fork_choice_store: PersistedForkChoiceStoreV17,
 }
 
-impl Into<PersistedForkChoice> for PersistedForkChoiceV11 {
-    fn into(self) -> PersistedForkChoice {
+impl From<PersistedForkChoiceV11> for PersistedForkChoice {
+    fn from(from: PersistedForkChoiceV11) -> PersistedForkChoice {
         PersistedForkChoice {
-            fork_choice: self.fork_choice,
-            fork_choice_store: self.fork_choice_store.into(),
+            fork_choice: from.fork_choice,
+            fork_choice_store: from.fork_choice_store.into(),
         }
     }
 }
 
-impl Into<PersistedForkChoiceV11> for PersistedForkChoice {
-    fn into(self) -> PersistedForkChoiceV11 {
+impl From<PersistedForkChoice> for PersistedForkChoiceV11 {
+    fn from(from: PersistedForkChoice) -> PersistedForkChoiceV11 {
         PersistedForkChoiceV11 {
-            fork_choice: self.fork_choice,
-            fork_choice_store: self.fork_choice_store.into(),
+            fork_choice: from.fork_choice,
+            fork_choice_store: from.fork_choice_store.into(),
         }
     }
 }

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -257,9 +257,9 @@ pub mod deposit_methods {
         Latest,
     }
 
-    impl Into<u64> for Eth1Id {
-        fn into(self) -> u64 {
-            match self {
+    impl From<Eth1Id> for u64 {
+        fn from(from: Eth1Id) -> u64 {
+            match from {
                 Eth1Id::Mainnet => 1,
                 Eth1Id::Custom(id) => id,
             }

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1700,11 +1700,11 @@ impl<E: EthSpec> ForkVersionDeserialize for FullBlockContents<E> {
     }
 }
 
-impl<E: EthSpec> Into<BeaconBlock<E>> for FullBlockContents<E> {
-    fn into(self) -> BeaconBlock<E> {
-        match self {
-            Self::BlockContents(block_and_sidecars) => block_and_sidecars.block,
-            Self::Block(block) => block,
+impl<E: EthSpec> From<FullBlockContents<E>> for BeaconBlock<E> {
+    fn from(from: FullBlockContents<E>) -> BeaconBlock<E> {
+        match from {
+            FullBlockContents::<E>::BlockContents(block_and_sidecars) => block_and_sidecars.block,
+            FullBlockContents::<E>::Block(block) => block,
         }
     }
 }

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -145,24 +145,24 @@ impl TryInto<ProtoNode> for ProtoNodeV16 {
     }
 }
 
-impl Into<ProtoNodeV16> for ProtoNode {
-    fn into(self) -> ProtoNodeV16 {
+impl From<ProtoNode> for ProtoNodeV16 {
+    fn from(from: ProtoNode) -> ProtoNodeV16 {
         ProtoNodeV16 {
-            slot: self.slot,
-            state_root: self.state_root,
-            target_root: self.target_root,
-            current_epoch_shuffling_id: self.current_epoch_shuffling_id,
-            next_epoch_shuffling_id: self.next_epoch_shuffling_id,
-            root: self.root,
-            parent: self.parent,
-            justified_checkpoint: Some(self.justified_checkpoint),
-            finalized_checkpoint: Some(self.finalized_checkpoint),
-            weight: self.weight,
-            best_child: self.best_child,
-            best_descendant: self.best_descendant,
-            execution_status: self.execution_status,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
+            slot: from.slot,
+            state_root: from.state_root,
+            target_root: from.target_root,
+            current_epoch_shuffling_id: from.current_epoch_shuffling_id,
+            next_epoch_shuffling_id: from.next_epoch_shuffling_id,
+            root: from.root,
+            parent: from.parent,
+            justified_checkpoint: Some(from.justified_checkpoint),
+            finalized_checkpoint: Some(from.finalized_checkpoint),
+            weight: from.weight,
+            best_child: from.best_child,
+            best_descendant: from.best_descendant,
+            execution_status: from.execution_status,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
         }
     }
 }

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -55,19 +55,19 @@ impl TryInto<SszContainer> for SszContainerV16 {
     }
 }
 
-impl Into<SszContainerV16> for SszContainer {
-    fn into(self) -> SszContainerV16 {
-        let nodes = self.nodes.into_iter().map(Into::into).collect();
+impl From<SszContainer> for SszContainerV16 {
+    fn from(from: SszContainer) -> SszContainerV16 {
+        let nodes = from.nodes.into_iter().map(Into::into).collect();
 
         SszContainerV16 {
-            votes: self.votes,
-            balances: self.balances,
-            prune_threshold: self.prune_threshold,
-            justified_checkpoint: self.justified_checkpoint,
-            finalized_checkpoint: self.finalized_checkpoint,
+            votes: from.votes,
+            balances: from.balances,
+            prune_threshold: from.prune_threshold,
+            justified_checkpoint: from.justified_checkpoint,
+            finalized_checkpoint: from.finalized_checkpoint,
             nodes,
-            indices: self.indices,
-            previous_proposer_boost: self.previous_proposer_boost,
+            indices: from.indices,
+            previous_proposer_boost: from.previous_proposer_boost,
         }
     }
 }

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -37,9 +37,9 @@ impl From<[u8; GRAFFITI_BYTES_LEN]> for Graffiti {
     }
 }
 
-impl Into<[u8; GRAFFITI_BYTES_LEN]> for Graffiti {
-    fn into(self) -> [u8; GRAFFITI_BYTES_LEN] {
-        self.0
+impl From<Graffiti> for [u8; GRAFFITI_BYTES_LEN] {
+    fn from(from: Graffiti) -> [u8; GRAFFITI_BYTES_LEN] {
+        from.0
     }
 }
 
@@ -77,9 +77,9 @@ impl<'de> Deserialize<'de> for GraffitiString {
     }
 }
 
-impl Into<Graffiti> for GraffitiString {
-    fn into(self) -> Graffiti {
-        let graffiti_bytes = self.0.as_bytes();
+impl From<GraffitiString> for Graffiti {
+    fn from(from: GraffitiString) -> Graffiti {
+        let graffiti_bytes = from.0.as_bytes();
         let mut graffiti = [0; GRAFFITI_BYTES_LEN];
 
         let graffiti_len = std::cmp::min(graffiti_bytes.len(), GRAFFITI_BYTES_LEN);

--- a/consensus/types/src/selection_proof.rs
+++ b/consensus/types/src/selection_proof.rs
@@ -77,9 +77,9 @@ impl SelectionProof {
     }
 }
 
-impl Into<Signature> for SelectionProof {
-    fn into(self) -> Signature {
-        self.0
+impl From<SelectionProof> for Signature {
+    fn from(from: SelectionProof) -> Signature {
+        from.0
     }
 }
 

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -6,9 +6,9 @@ macro_rules! impl_from_into_u64 {
             }
         }
 
-        impl Into<u64> for $main {
-            fn into(self) -> u64 {
-                self.0
+        impl From<$main> for u64 {
+            fn from(from: $main) -> u64 {
+                from.0
             }
         }
 
@@ -28,9 +28,9 @@ macro_rules! impl_from_into_usize {
             }
         }
 
-        impl Into<usize> for $main {
-            fn into(self) -> usize {
-                self.0 as usize
+        impl From<$main> for usize {
+            fn from(from: $main) -> usize {
+                from.0 as usize
             }
         }
 

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -150,15 +150,15 @@ impl From<u64> for SubnetId {
     }
 }
 
-impl Into<u64> for SubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<SubnetId> for u64 {
+    fn from(from: SubnetId) -> u64 {
+        from.0
     }
 }
 
-impl Into<u64> for &SubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<&SubnetId> for u64 {
+    fn from(from: &SubnetId) -> u64 {
+        from.0
     }
 }
 

--- a/consensus/types/src/sync_selection_proof.rs
+++ b/consensus/types/src/sync_selection_proof.rs
@@ -90,9 +90,9 @@ impl SyncSelectionProof {
     }
 }
 
-impl Into<Signature> for SyncSelectionProof {
-    fn into(self) -> Signature {
-        self.0
+impl From<SyncSelectionProof> for Signature {
+    fn from(from: SyncSelectionProof) -> Signature {
+        from.0
     }
 }
 

--- a/consensus/types/src/sync_subnet_id.rs
+++ b/consensus/types/src/sync_subnet_id.rs
@@ -78,15 +78,15 @@ impl From<u64> for SyncSubnetId {
     }
 }
 
-impl Into<u64> for SyncSubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<SyncSubnetId> for u64 {
+    fn from(from: SyncSubnetId) -> u64 {
+        from.0
     }
 }
 
-impl Into<u64> for &SyncSubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<&SyncSubnetId> for u64 {
+    fn from(from: &SyncSubnetId) -> u64 {
+        from.0
     }
 }
 

--- a/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
@@ -14,9 +14,9 @@ pub enum ChecksumFunction {
     Sha256,
 }
 
-impl Into<String> for ChecksumFunction {
-    fn into(self) -> String {
-        match self {
+impl From<ChecksumFunction> for String {
+    fn from(from: ChecksumFunction) -> String {
+        match from {
             ChecksumFunction::Sha256 => "sha256".into(),
         }
     }
@@ -38,8 +38,8 @@ impl TryFrom<String> for ChecksumFunction {
 #[serde(try_from = "Value", into = "Value")]
 pub struct EmptyMap;
 
-impl Into<Value> for EmptyMap {
-    fn into(self) -> Value {
+impl From<EmptyMap> for Value {
+    fn from(_from: EmptyMap) -> Value {
         Value::Object(Map::default())
     }
 }

--- a/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
@@ -13,9 +13,9 @@ pub enum CipherFunction {
     Aes128Ctr,
 }
 
-impl Into<String> for CipherFunction {
-    fn into(self) -> String {
-        match self {
+impl From<CipherFunction> for String {
+    fn from(from: CipherFunction) -> String {
+        match from {
             CipherFunction::Aes128Ctr => "aes-128-ctr".into(),
         }
     }

--- a/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
+++ b/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
@@ -25,9 +25,9 @@ impl From<Vec<u8>> for HexBytes {
     }
 }
 
-impl Into<String> for HexBytes {
-    fn into(self) -> String {
-        hex::encode(self.0)
+impl From<HexBytes> for String {
+    fn from(from: HexBytes) -> String {
+        hex::encode(from.0)
     }
 }
 

--- a/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
@@ -23,8 +23,8 @@ pub struct KdfModule {
 #[serde(try_from = "String", into = "String")]
 pub struct EmptyString;
 
-impl Into<String> for EmptyString {
-    fn into(self) -> String {
+impl From<EmptyString> for String {
+    fn from(_from: EmptyString) -> String {
         "".into()
     }
 }
@@ -91,9 +91,9 @@ pub enum KdfFunction {
     Pbkdf2,
 }
 
-impl Into<String> for KdfFunction {
-    fn into(self) -> String {
-        match self {
+impl From<KdfFunction> for String {
+    fn from(from: KdfFunction) -> String {
+        match from {
             KdfFunction::Scrypt => "scrypt".into(),
             KdfFunction::Pbkdf2 => "pbkdf2".into(),
         }

--- a/crypto/eth2_wallet/src/json_wallet/mod.rs
+++ b/crypto/eth2_wallet/src/json_wallet/mod.rs
@@ -39,9 +39,9 @@ pub enum TypeField {
     Hd,
 }
 
-impl Into<String> for TypeField {
-    fn into(self) -> String {
-        match self {
+impl From<TypeField> for String {
+    fn from(from: TypeField) -> String {
+        match from {
             TypeField::Hd => "hierarchical deterministic".into(),
         }
     }

--- a/crypto/kzg/src/kzg_proof.rs
+++ b/crypto/kzg/src/kzg_proof.rs
@@ -38,9 +38,9 @@ impl From<[u8; BYTES_PER_PROOF]> for KzgProof {
     }
 }
 
-impl Into<[u8; BYTES_PER_PROOF]> for KzgProof {
-    fn into(self) -> [u8; BYTES_PER_PROOF] {
-        self.0
+impl From<KzgProof> for [u8; BYTES_PER_PROOF] {
+    fn from(from: KzgProof) -> [u8; BYTES_PER_PROOF] {
+        from.0
     }
 }
 

--- a/validator_client/slashing_protection/src/lib.rs
+++ b/validator_client/slashing_protection/src/lib.rs
@@ -67,9 +67,9 @@ impl From<Hash256> for SigningRoot {
     }
 }
 
-impl Into<Hash256> for SigningRoot {
-    fn into(self) -> Hash256 {
-        self.0
+impl From<SigningRoot> for Hash256 {
+    fn from(from: SigningRoot) -> Hash256 {
+        from.0
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Following https://doc.rust-lang.org/std/convert/trait.From.html it is preferred to impl From over Into. There might be specific reasons to using Into in this repository, if so feel free to close the PR. 

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
