### PR TITLE
Add kurtosis config for DAS testing

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -12,3 +12,6 @@ network_params:
   seconds_per_slot: 3
 global_log_level: debug
 snooper_enabled: false
+additional_services:
+  - dora
+  - prometheus_grafana

--- a/scripts/local_testnet/network_params_das_devnet_1.yaml
+++ b/scripts/local_testnet/network_params_das_devnet_1.yaml
@@ -1,0 +1,8 @@
+participants:
+  - cl_type: lighthouse
+    cl_image: lighthouse:local
+network_params:
+  network: peerdas-devnet-1
+global_log_level: debug
+additional_services:
+  - prometheus_grafana

--- a/scripts/local_testnet/network_params_das_interop.yaml
+++ b/scripts/local_testnet/network_params_das_interop.yaml
@@ -1,0 +1,32 @@
+participants:
+  - cl_type: prysm
+    cl_image: ethpandaops/prysm-beacon-chain:peerDAS
+
+  - cl_type: lighthouse
+    cl_extra_params: [
+      --subscribe-all-data-column-subnets,
+    ]
+    cl_image: ethpandaops/lighthouse:das
+
+  - cl_type: lighthouse
+    cl_image: ethpandaops/lighthouse:das
+
+  - cl_type: teku
+    cl_image: ethpandaops/teku:nashatyrev-das
+
+  - cl_type: nimbus
+    cl_image: ethpandaops/nimbus-eth2:kzgpeerdas
+
+  - cl_type: grandine
+    cl_image: ethpandaops/grandine:das
+
+  # - cl_type: lodestar
+  #   cl_image: ethpandaops/lodestar:peerDAS
+network_params:
+  eip7594_fork_epoch: 0
+  eip7594_fork_version: "0x50000038"
+snooper_enabled: true
+global_log_level: debug
+additional_services:
+  - dora
+  - goomy_blob

--- a/scripts/local_testnet/network_params_das_interop.yaml
+++ b/scripts/local_testnet/network_params_das_interop.yaml
@@ -6,26 +6,26 @@ participants:
     cl_extra_params: [
       --subscribe-all-data-column-subnets,
     ]
-    cl_image: ethpandaops/lighthouse:das
+    cl_image: lighthouse:local
 
   - cl_type: lighthouse
-    cl_image: ethpandaops/lighthouse:das
+    cl_image: lighthouse:local
 
   - cl_type: teku
     cl_image: ethpandaops/teku:nashatyrev-das
 
-  - cl_type: nimbus
-    cl_image: ethpandaops/nimbus-eth2:kzgpeerdas
-
-  - cl_type: grandine
-    cl_image: ethpandaops/grandine:das
-
-  # - cl_type: lodestar
-  #   cl_image: ethpandaops/lodestar:peerDAS
+#  - cl_type: nimbus
+#    cl_image: ethpandaops/nimbus-eth2:kzgpeerdas
+#
+#  - cl_type: grandine
+#    cl_image: ethpandaops/grandine:das
+#
+#   - cl_type: lodestar
+#     cl_image: ethpandaops/lodestar:peerDAS
 network_params:
   eip7594_fork_epoch: 0
   eip7594_fork_version: "0x50000038"
-snooper_enabled: true
+snooper_enabled: false
 global_log_level: debug
 additional_services:
   - dora

--- a/scripts/local_testnet/network_params_das_local.yaml
+++ b/scripts/local_testnet/network_params_das_local.yaml
@@ -1,0 +1,22 @@
+participants:
+  - cl_type: lighthouse
+    cl_image: lighthouse:local
+    cl_max_mem: 4096
+    cl_extra_params:
+      - --subscribe-all-data-column-subnets
+      - --target-peers 2
+    count: 2
+  - cl_type: lighthouse
+    cl_image: lighthouse:local
+    cl_max_mem: 2048
+    cl_extra_params:
+      - --target-peers 2`
+    count: 1
+network_params:
+  eip7594_fork_epoch: 0
+  seconds_per_slot: 6
+global_log_level: debug
+snooper_enabled: false
+additional_services:
+  - dora
+  - prometheus_grafana

--- a/scripts/local_testnet/network_params_das_local.yaml
+++ b/scripts/local_testnet/network_params_das_local.yaml
@@ -4,13 +4,13 @@ participants:
     cl_max_mem: 4096
     cl_extra_params:
       - --subscribe-all-data-column-subnets
-      - --target-peers 2
+      - --target-peers=2
     count: 2
   - cl_type: lighthouse
     cl_image: lighthouse:local
     cl_max_mem: 2048
     cl_extra_params:
-      - --target-peers 2`
+      - --target-peers=2
     count: 1
 network_params:
   eip7594_fork_epoch: 0
@@ -19,4 +19,4 @@ global_log_level: debug
 snooper_enabled: false
 additional_services:
   - dora
-  - prometheus_grafana
+  - goomy_blob

--- a/scripts/local_testnet/network_params_das_local.yaml
+++ b/scripts/local_testnet/network_params_das_local.yaml
@@ -1,22 +1,20 @@
 participants:
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    cl_max_mem: 4096
     cl_extra_params:
       - --subscribe-all-data-column-subnets
       - --target-peers=2
     count: 2
   - cl_type: lighthouse
     cl_image: lighthouse:local
-    cl_max_mem: 2048
     cl_extra_params:
       - --target-peers=2
     count: 1
 network_params:
   eip7594_fork_epoch: 0
   seconds_per_slot: 6
-global_log_level: debug
 snooper_enabled: false
+global_log_level: debug
 additional_services:
   - dora
   - goomy_blob

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -62,9 +62,6 @@ if [ "$CI" = true ]; then
   # TODO: run assertoor tests
   yq eval '.additional_services = []' -i $NETWORK_PARAMS_FILE
   echo "Running without additional services (CI mode)."
-else
-  yq eval '.additional_services = ["dora", "prometheus_grafana"]' -i $NETWORK_PARAMS_FILE
-  echo "Additional services dora and prometheus_grafana added to network_params.yaml"
 fi
 
 if [ "$BUILD_IMAGE" = true ]; then


### PR DESCRIPTION
## Issue Addressed

Add kurtosis config for DAS testing:
-  `scripts/local_testnet/network_params_das_interop.yaml`: for interop testing with all das-ready clients
- `scripts/local_testnet/network_params_das_interop.yaml`: for Lighthouse local testing.

To test locally:

```
cd scripts/local_testnet
./start_local_testnet.sh -n ./network_params_das_local.yaml
```