### PR TITLE
Remove all batches related to a peer on disconnect

### DIFF
--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::Protocol;
-use lighthouse_network::rpc::{methods::*, RPCError};
+use lighthouse_network::rpc::methods::*;
 use lighthouse_network::{rpc::max_rpc_size, NetworkEvent, ReportSource, Request, Response};
 use slog::{debug, warn, Level};
 use ssz::Encode;
@@ -998,98 +998,6 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                         // stop sending messages
                         return;
                     }
-                }
-            }
-        };
-
-        tokio::select! {
-            _ = sender_future => {}
-            _ = receiver_future => {}
-            _ = sleep(Duration::from_secs(30)) => {
-                panic!("Future timed out");
-            }
-        }
-    })
-}
-
-#[test]
-fn test_disconnect_triggers_rpc_error() {
-    // set up the logging. The level and enabled logging or not
-    let log_level = Level::Debug;
-    let enable_logging = false;
-
-    let log = common::build_log(log_level, enable_logging);
-    let spec = E::default_spec();
-
-    let rt = Arc::new(Runtime::new().unwrap());
-    // get sender/receiver
-    rt.block_on(async {
-        let (mut sender, mut receiver) = common::build_node_pair(
-            Arc::downgrade(&rt),
-            &log,
-            ForkName::Base,
-            &spec,
-            Protocol::Tcp,
-        )
-        .await;
-
-        // BlocksByRoot Request
-        let rpc_request = Request::BlocksByRoot(BlocksByRootRequest::new(
-            // Must have at least one root for the request to create a stream
-            vec![Hash256::from_low_u64_be(0)],
-            &spec,
-        ));
-
-        // build the sender future
-        let sender_future = async {
-            loop {
-                match sender.next_event().await {
-                    NetworkEvent::PeerConnectedOutgoing(peer_id) => {
-                        // Send a STATUS message
-                        debug!(log, "Sending RPC");
-                        sender
-                            .send_request(peer_id, 42, rpc_request.clone())
-                            .unwrap();
-                    }
-                    NetworkEvent::RPCFailed { error, id: 42, .. } => match error {
-                        RPCError::Disconnected => return,
-                        other => panic!("received unexpected error {:?}", other),
-                    },
-                    other => {
-                        warn!(log, "Ignoring other event {:?}", other);
-                    }
-                }
-            }
-        };
-
-        // determine messages to send (PeerId, RequestId). If some, indicates we still need to send
-        // messages
-        let mut sending_peer = None;
-        let receiver_future = async {
-            loop {
-                // this future either drives the sending/receiving or times out allowing messages to be
-                // sent in the timeout
-                match futures::future::select(
-                    Box::pin(receiver.next_event()),
-                    Box::pin(tokio::time::sleep(Duration::from_secs(1))),
-                )
-                .await
-                {
-                    futures::future::Either::Left((ev, _)) => match ev {
-                        NetworkEvent::RequestReceived { peer_id, .. } => {
-                            sending_peer = Some(peer_id);
-                        }
-                        other => {
-                            warn!(log, "Ignoring other event {:?}", other);
-                        }
-                    },
-                    futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
-                }
-
-                // if we need to send messages send them here. This will happen after a delay
-                if let Some(peer_id) = sending_peer.take() {
-                    warn!(log, "Receiver got request, disconnecting peer");
-                    receiver.__hard_disconnect_testing_only(peer_id);
                 }
             }
         };

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -320,7 +320,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
         }
 
         if let Some(batch_ids) = self.active_requests.remove(peer_id) {
-            // fail the batches
+            // fail the batches.
             for id in batch_ids {
                 if let Some(batch) = self.batches.get_mut(&id) {
                     match batch.download_failed(false) {
@@ -335,7 +335,7 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                     // If we have run out of peers in which to retry this batch, the backfill state
                     // transitions to a paused state.
                     // We still need to reset the state for all the affected batches, so we should not
-                    // short circuit early
+                    // short circuit early.
                     if self.retry_batch_download(network, id).is_err() {
                         debug!(
                             self.log,

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -307,7 +307,11 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
     /// A peer has disconnected.
     /// If the peer has active batches, those are considered failed and re-requested.
     #[must_use = "A failure here indicates the backfill sync has failed and the global sync state should be updated"]
-    pub fn peer_disconnected(&mut self, peer_id: &PeerId) -> Result<(), BackFillError> {
+    pub fn peer_disconnected(
+        &mut self,
+        peer_id: &PeerId,
+        network: &mut SyncNetworkContext<T>,
+    ) -> Result<(), BackFillError> {
         if matches!(
             self.state(),
             BackFillState::Failed | BackFillState::NotRequired
@@ -315,7 +319,37 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
             return Ok(());
         }
 
-        self.active_requests.remove(peer_id);
+        if let Some(batch_ids) = self.active_requests.remove(peer_id) {
+            // fail the batches
+            for id in batch_ids {
+                if let Some(batch) = self.batches.get_mut(&id) {
+                    match batch.download_failed(false) {
+                        Ok(BatchOperationOutcome::Failed { blacklist: _ }) => {
+                            self.fail_sync(BackFillError::BatchDownloadFailed(id))?;
+                        }
+                        Ok(BatchOperationOutcome::Continue) => {}
+                        Err(e) => {
+                            self.fail_sync(BackFillError::BatchInvalidState(id, e.0))?;
+                        }
+                    }
+                    // If we have run out of peers in which to retry this batch, the backfill state
+                    // transitions to a paused state.
+                    // We still need to reset the state for all the affected batches, so we should not
+                    // short circuit early
+                    if self.retry_batch_download(network, id).is_err() {
+                        debug!(
+                            self.log,
+                            "Batch could not be retried";
+                            "batch_id" => id,
+                            "error" => "no synced peers"
+                        );
+                    }
+                } else {
+                    debug!(self.log, "Batch not found while removing peer";
+                        "peer" => %peer_id, "batch" => id)
+                }
+            }
+        }
 
         // Remove the peer from the participation list
         self.participating_peers.remove(peer_id);

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -2,7 +2,7 @@ use self::parent_chain::{compute_parent_chains, NodeChain};
 pub use self::single_block_lookup::DownloadResult;
 use self::single_block_lookup::{LookupRequestError, LookupResult, SingleBlockLookup};
 use super::manager::{BlockProcessType, BlockProcessingResult, SLOT_IMPORT_TOLERANCE};
-use super::network_context::{RpcResponseResult, SyncNetworkContext};
+use super::network_context::{RpcResponseError, SyncNetworkContext};
 use crate::metrics;
 use crate::sync::block_lookups::common::ResponseType;
 use crate::sync::block_lookups::parent_chain::find_oldest_fork_ancestor;
@@ -337,7 +337,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: PeerId,
-        response: RpcResponseResult<R::VerifiedResponseType>,
+        response: Result<(R::VerifiedResponseType, Duration), RpcResponseError>,
         cx: &mut SyncNetworkContext<T>,
     ) {
         let result = self.on_download_response_inner::<R>(id, peer_id, response, cx);
@@ -349,7 +349,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: PeerId,
-        response: RpcResponseResult<R::VerifiedResponseType>,
+        response: Result<(R::VerifiedResponseType, Duration), RpcResponseError>,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<LookupResult, LookupRequestError> {
         // Note: no need to downscore peers here, already downscored on network context

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -779,12 +779,12 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             };
 
             if stuck_lookup.id == ancestor_stuck_lookup.id {
-                warn!(self.log, "Notify the devs, a sync lookup is stuck";
+                warn!(self.log, "Notify the devs a sync lookup is stuck";
                     "block_root" => ?stuck_lookup.block_root(),
                     "lookup" => ?stuck_lookup,
                 );
             } else {
-                warn!(self.log, "Notify the devs, a sync lookup is stuck";
+                warn!(self.log, "Notify the devs a sync lookup is stuck";
                     "block_root" => ?stuck_lookup.block_root(),
                     "lookup" => ?stuck_lookup,
                     "ancestor_block_root" => ?ancestor_stuck_lookup.block_root(),

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -1,3 +1,19 @@
+//! Implements block lookup sync.
+//!
+//! Block lookup sync is triggered when a peer claims to have imported a block we don't know about.
+//! For example, a peer attesting to a head block root that is not in our fork-choice. Lookup sync
+//! is recursive in nature, as we may discover that this attested head block root has a parent that
+//! is also unknown to us.
+//!
+//! Block lookup is implemented as an event driven state machine. It sends events to the network and
+//! beacon processor, and expects some set of events back. A discrepancy in the expected event API
+//! will result in lookups getting "stuck". A lookup becomes stuck when there is no future event
+//! that will trigger the lookup to make progress. There's a fallback mechanism that drops lookups
+//! that live for too long, logging the line "Notify the devs a sync lookup is stuck".
+//!
+//! The expected event API is documented in the code paths that are making assumptions  with the
+//! comment prefix "Lookup sync event safety:"
+
 use self::parent_chain::{compute_parent_chains, NodeChain};
 pub use self::single_block_lookup::DownloadResult;
 use self::single_block_lookup::{LookupRequestError, LookupResult, SingleBlockLookup};

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -410,11 +410,11 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     /* Error responses */
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
-        /* Check disconnection for single lookups */
+        // Check disconnection for single lookups.
         self.single_block_lookups.retain(|_, lookup| {
             lookup.remove_peer(peer_id);
             // Keep the lookup if it was some peers that can drive progress
-            // or if it has some downloaded components that can be processed
+            // or if it has some downloaded components that can be processed.
             !lookup.has_no_peers() || lookup.can_progress_without_peer()
         })
     }

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -411,16 +411,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
         /* Check disconnection for single lookups */
-        self.single_block_lookups.retain(|_, req| {
-            let should_drop_lookup =
-                req.should_drop_lookup_on_disconnected_peer(peer_id );
-
-            if should_drop_lookup {
-                debug!(self.log, "Dropping single lookup after peer disconnection"; "block_root" => %req.block_root());
-            }
-
-            !should_drop_lookup
-        });
+        for (_, lookup) in self.single_block_lookups.iter_mut() {
+            lookup.remove_peer(peer_id);
+        }
     }
 
     /* Processing responses */

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -411,9 +411,12 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
         /* Check disconnection for single lookups */
-        for (_, lookup) in self.single_block_lookups.iter_mut() {
+        self.single_block_lookups.retain(|_, lookup| {
             lookup.remove_peer(peer_id);
-        }
+            // Keep the lookup if it was some peers that can drive progress
+            // or if it has some downloaded components that can be processed
+            !lookup.has_no_peers() || lookup.can_progress_without_peer()
+        })
     }
 
     /* Processing responses */

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -410,20 +410,16 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     /* Error responses */
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
-        self.single_block_lookups.retain(|_, lookup| {
-            lookup.remove_peer(peer_id);
+        /* Check disconnection for single lookups */
+        self.single_block_lookups.retain(|_, req| {
+            let should_drop_lookup =
+                req.should_drop_lookup_on_disconnected_peer(peer_id );
 
-            // Note: this condition should be removed in the future. It's not strictly necessary to drop a
-            // lookup if there are no peers left. Lookup should only be dropped if it can not make progress
-            if lookup.has_no_peers() {
-                debug!(self.log,
-                    "Dropping single lookup after peer disconnection";
-                    "block_root" => ?lookup.block_root()
-                );
-                false
-            } else {
-                true
+            if should_drop_lookup {
+                debug!(self.log, "Dropping single lookup after peer disconnection"; "block_root" => %req.block_root());
             }
+
+            !should_drop_lookup
         });
     }
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -5,7 +5,7 @@
 //! is recursive in nature, as we may discover that this attested head block root has a parent that
 //! is also unknown to us.
 //!
-//! Block lookup is implemented as an event driven state machine. It sends events to the network and
+//! Block lookup is implemented as an event-driven state machine. It sends events to the network and
 //! beacon processor, and expects some set of events back. A discrepancy in the expected event API
 //! will result in lookups getting "stuck". A lookup becomes stuck when there is no future event
 //! that will trigger the lookup to make progress. There's a fallback mechanism that drops lookups
@@ -13,6 +13,12 @@
 //!
 //! The expected event API is documented in the code paths that are making assumptions  with the
 //! comment prefix "Lookup sync event safety:"
+//!
+//! Block lookup sync attempts to not re-download or re-process data that we already have. Block
+//! components are cached temporarily in multiple places before they are imported into fork-choice.
+//! Therefore, block lookup sync must peek these caches correctly to decide when to skip a download
+//! or consider a lookup complete. These caches are read from the `SyncNetworkContext` and its state
+//! returned to this module as `LookupRequestResult` variants.
 
 use self::parent_chain::{compute_parent_chains, NodeChain};
 pub use self::single_block_lookup::DownloadResult;

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -2,7 +2,7 @@ use self::parent_chain::{compute_parent_chains, NodeChain};
 pub use self::single_block_lookup::DownloadResult;
 use self::single_block_lookup::{LookupRequestError, LookupResult, SingleBlockLookup};
 use super::manager::{BlockProcessType, BlockProcessingResult, SLOT_IMPORT_TOLERANCE};
-use super::network_context::{RpcResponseError, SyncNetworkContext};
+use super::network_context::{RpcResponseResult, SyncNetworkContext};
 use crate::metrics;
 use crate::sync::block_lookups::common::ResponseType;
 use crate::sync::block_lookups::parent_chain::find_oldest_fork_ancestor;
@@ -337,7 +337,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: PeerId,
-        response: Result<(R::VerifiedResponseType, Duration), RpcResponseError>,
+        response: RpcResponseResult<R::VerifiedResponseType>,
         cx: &mut SyncNetworkContext<T>,
     ) {
         let result = self.on_download_response_inner::<R>(id, peer_id, response, cx);
@@ -349,7 +349,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         id: SingleLookupReqId,
         peer_id: PeerId,
-        response: Result<(R::VerifiedResponseType, Duration), RpcResponseError>,
+        response: RpcResponseResult<R::VerifiedResponseType>,
         cx: &mut SyncNetworkContext<T>,
     ) -> Result<LookupResult, LookupRequestError> {
         // Note: no need to downscore peers here, already downscored on network context

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -410,13 +410,9 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     /* Error responses */
 
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
-        // Check disconnection for single lookups.
-        self.single_block_lookups.retain(|_, lookup| {
+        for (_, lookup) in self.single_block_lookups.iter_mut() {
             lookup.remove_peer(peer_id);
-            // Keep the lookup if it was some peers that can drive progress
-            // or if it has some downloaded components that can be processed.
-            !lookup.has_no_peers() || lookup.can_progress_without_peer()
-        })
+        }
     }
 
     /* Processing responses */

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -254,12 +254,6 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.peers.remove(peer_id);
     }
 
-    /// Returns true if a lookup has some downloaded components that can be processed.
-    pub fn can_progress_without_peer(&self) -> bool {
-        self.block_request_state.state.can_progress_without_peer()
-            || self.blob_request_state.state.can_progress_without_peer()
-    }
-
     /// Returns true if this lookup has zero peers
     pub fn has_no_peers(&self) -> bool {
         self.peers.is_empty()
@@ -354,15 +348,6 @@ impl<T: Clone> SingleLookupRequestState<T> {
             | State::AwaitingProcess { .. }
             | State::Processing { .. }
             | State::Processed { .. } => false,
-        }
-    }
-
-    pub fn can_progress_without_peer(&self) -> bool {
-        match self.state {
-            State::AwaitingDownload { .. } | State::Downloading { .. } => false,
-            State::AwaitingProcess { .. } | State::Processing { .. } | State::Processed { .. } => {
-                true
-            }
         }
     }
 

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -197,8 +197,12 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             }
 
             let Some(peer_id) = self.use_rand_available_peer() else {
-                // Allow lookup to not have any peers. In that case do nothing. If the lookup does
-                // not have peers for some time, it will be dropped.
+                // Allow lookup to not have any peers and do nothing. This is an optimization to not
+                // lose progress of lookups created from a block with unknown parent before we receive
+                // attestations for said block.
+                // Lookup sync event safety: If a lookup requires peers to make progress, and does
+                // not receive any new peers for some time it will be dropped. If it receives a new
+                // peer it must attempt to make progress.
                 return Ok(());
             };
 

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -205,13 +205,21 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             let request = R::request_state_mut(self);
             match request.make_request(id, peer_id, downloaded_block_expected_blobs, cx)? {
                 LookupRequestResult::RequestSent(req_id) => {
+                    // Lookup sync event safety: If make_request returns `RequestSent`, we are
+                    // guaranteed that `BlockLookups::on_download_response` will be called exactly
+                    // with this `req_id`.
                     request.get_state_mut().on_download_start(req_id)?
                 }
                 LookupRequestResult::NoRequestNeeded => {
+                    // Lookup sync event safety: Advances this request to the terminal `Processed`
+                    // state. If all requests reach this state, the request is marked as completed
+                    // in `Self::continue_requests`.
                     request.get_state_mut().on_completed_request()?
                 }
                 // Sync will receive a future event to make progress on the request, do nothing now
                 LookupRequestResult::Pending(reason) => {
+                    // Lookup sync event safety: Refer to the code paths constructing
+                    // `LookupRequestResult::Pending`
                     request
                         .get_state_mut()
                         .update_awaiting_download_status(reason);
@@ -222,15 +230,27 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         // Otherwise, attempt to progress awaiting processing
         // If this request is awaiting a parent lookup to be processed, do not send for processing.
         // The request will be rejected with unknown parent error.
+        //
+        // TODO: The condition `block_is_processed || Block` can be dropped after checking for
+        // unknown parent root when import RPC blobs
         } else if !awaiting_parent
             && (block_is_processed || matches!(R::response_type(), ResponseType::Block))
         {
             // maybe_start_processing returns Some if state == AwaitingProcess. This pattern is
             // useful to conditionally access the result data.
             if let Some(result) = request.get_state_mut().maybe_start_processing() {
+                // Lookup sync event safety: If `send_for_processing` returns Ok() we are guaranteed
+                // that `BlockLookups::on_processing_result` will be called exactly once with this
+                // lookup_id
                 return R::send_for_processing(id, result, cx);
             }
+            // Lookup sync event safety: If the request is not in `AwaitingDownload` or
+            // `AwaitingProcessing` state it is guaranteed to receive some event to make progress.
         }
+
+        // Lookup sync event safety: If a lookup is awaiting a parent we are guaranteed to either:
+        // (1) attempt to make progress with `BlockLookups::continue_child_lookups` if the parent
+        // lookup completes, or (2) get dropped if the parent fails and is dropped.
 
         Ok(())
     }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -199,6 +199,9 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             let Some(peer_id) = self.use_rand_available_peer() else {
                 // Allow lookup to not have any peers. In that case do nothing. If the lookup does
                 // not have peers for some time, it will be dropped.
+                R::request_state_mut(self)
+                    .get_state_mut()
+                    .update_awaiting_download_status("no peers");
                 return Ok(());
             };
 

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -261,6 +261,14 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
     fn use_rand_available_peer(&mut self) -> Option<PeerId> {
         self.peers.iter().choose(&mut rand::thread_rng()).copied()
     }
+    /// Checks if the peer is disconnected.
+    ///
+    /// Returns true if the lookup should be dropped.
+    pub fn should_drop_lookup_on_disconnected_peer(&mut self, peer_id: &PeerId) -> bool {
+        self.remove_peer(peer_id);
+
+        return self.has_no_peers();
+    }
 }
 
 /// The state of the blob request component of a `SingleBlockLookup`.

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -261,14 +261,6 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
     fn use_rand_available_peer(&mut self) -> Option<PeerId> {
         self.peers.iter().choose(&mut rand::thread_rng()).copied()
     }
-    /// Checks if the peer is disconnected.
-    ///
-    /// Returns true if the lookup should be dropped.
-    pub fn should_drop_lookup_on_disconnected_peer(&mut self, peer_id: &PeerId) -> bool {
-        self.remove_peer(peer_id);
-
-        return self.has_no_peers();
-    }
 }
 
 /// The state of the blob request component of a `SingleBlockLookup`.

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -290,6 +290,7 @@ impl TestRig {
             .0
     }
 
+    #[track_caller]
     fn expect_no_active_single_lookups(&self) {
         assert!(
             self.active_single_lookups().is_empty(),
@@ -298,6 +299,7 @@ impl TestRig {
         );
     }
 
+    #[track_caller]
     fn expect_no_active_lookups(&self) {
         self.expect_no_active_single_lookups();
     }
@@ -1039,8 +1041,8 @@ fn test_single_block_lookup_peer_disconnected_then_rpc_error() {
 
     // The peer disconnect event reaches sync before the rpc error.
     rig.peer_disconnected(peer_id);
-    // Only peer and no progress on lookup, so lookup should be removed.
-    rig.expect_no_active_lookups();
+    // The lookup is not removed as it can still potentially make progress.
+    rig.assert_single_lookups_count(1);
     // The request fails.
     rig.single_lookup_failed(id, peer_id, RPCError::Disconnected);
     rig.expect_block_lookup_request(block_hash);
@@ -1311,10 +1313,9 @@ fn test_lookup_peer_disconnected_no_peers_left_while_request() {
     rig.trigger_unknown_parent_block(peer_id, trigger_block.into());
     rig.peer_disconnected(peer_id);
     rig.rpc_error_all_active_requests(peer_id);
-    // Erroring all rpc requests and disconnecting the peer shouldn't remove the active
-    // request as we can still progress.
-    // The parent lookup trigger in this case can still be progressed so it shouldn't be removed.
-    rig.assert_single_lookups_count(1);
+    // Erroring all rpc requests and disconnecting the peer shouldn't remove the requests
+    // from the lookups map as they can still progress.
+    rig.assert_single_lookups_count(2);
 }
 
 #[test]

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1039,8 +1039,11 @@ fn test_single_block_lookup_peer_disconnected_then_rpc_error() {
 
     // The peer disconnect event reaches sync before the rpc error
     rig.peer_disconnected(peer_id);
+    // Only peer and no progress on lookup, so lookup should be removed
+    rig.expect_no_active_lookups();
     // The request fails
     rig.single_lookup_failed(id, peer_id, RPCError::Disconnected);
+    rig.expect_block_lookup_request(block_hash);
     // The request should be removed from the network context on disconnection
     rig.expect_empty_network();
 }

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -560,6 +560,8 @@ impl TestRig {
                 error: RPCError::Disconnected,
             });
         }
+    }
+
     fn peer_disconnected(&mut self, peer_id: PeerId) {
         self.send_sync_message(SyncMessage::Disconnect(peer_id));
     }

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1033,18 +1033,18 @@ fn test_single_block_lookup_peer_disconnected_then_rpc_error() {
     let block_hash = Hash256::random();
     let peer_id = rig.new_connected_peer();
 
-    // Trigger the request
+    // Trigger the request.
     rig.trigger_unknown_block_from_attestation(block_hash, peer_id);
     let id = rig.expect_block_lookup_request(block_hash);
 
-    // The peer disconnect event reaches sync before the rpc error
+    // The peer disconnect event reaches sync before the rpc error.
     rig.peer_disconnected(peer_id);
-    // Only peer and no progress on lookup, so lookup should be removed
+    // Only peer and no progress on lookup, so lookup should be removed.
     rig.expect_no_active_lookups();
-    // The request fails
+    // The request fails.
     rig.single_lookup_failed(id, peer_id, RPCError::Disconnected);
     rig.expect_block_lookup_request(block_hash);
-    // The request should be removed from the network context on disconnection
+    // The request should be removed from the network context on disconnection.
     rig.expect_empty_network();
 }
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -539,10 +539,6 @@ impl TestRig {
         })
     }
 
-    fn peer_disconnected(&mut self, disconnected_peer_id: PeerId) {
-        self.send_sync_message(SyncMessage::Disconnect(disconnected_peer_id));
-    }
-
     /// Return RPCErrors for all active requests of peer
     fn rpc_error_all_active_requests(&mut self, disconnected_peer_id: PeerId) {
         self.drain_network_rx();

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -560,6 +560,8 @@ impl TestRig {
                 error: RPCError::Disconnected,
             });
         }
+    fn peer_disconnected(&mut self, peer_id: PeerId) {
+        self.send_sync_message(SyncMessage::Disconnect(peer_id));
     }
 
     fn drain_network_rx(&mut self) {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -18,7 +18,7 @@ pub struct BlocksAndBlobsRequestInfo<E: EthSpec> {
     is_sidecars_stream_terminated: bool,
     /// Used to determine if this accumulator should wait for a sidecars stream termination
     request_type: ByRangeRequestType,
-    /// TODO(pawan): would this be multiple peer ids?
+    /// The peer the request was made to.
     pub(crate) peer_id: PeerId,
 }
 
@@ -113,12 +113,14 @@ mod tests {
     use super::BlocksAndBlobsRequestInfo;
     use crate::sync::range_sync::ByRangeRequestType;
     use beacon_chain::test_utils::{generate_rand_block_and_blobs, NumBlobs};
+    use lighthouse_network::PeerId;
     use rand::SeedableRng;
     use types::{test_utils::XorShiftRng, ForkName, MinimalEthSpec as E};
 
     #[test]
     fn no_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::Blocks);
+        let peer_id = PeerId::random();
+        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::Blocks, peer_id);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| generate_rand_block_and_blobs::<E>(ForkName::Base, NumBlobs::None, &mut rng).0)
@@ -137,7 +139,9 @@ mod tests {
 
     #[test]
     fn empty_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::BlocksAndBlobs);
+        let peer_id = PeerId::random();
+        let mut info =
+            BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::BlocksAndBlobs, peer_id);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| {

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,4 +1,5 @@
 use beacon_chain::block_verification_types::RpcBlock;
+use lighthouse_network::PeerId;
 use ssz_types::VariableList;
 use std::{collections::VecDeque, sync::Arc};
 use types::{BlobSidecar, EthSpec, SignedBeaconBlock};
@@ -17,16 +18,19 @@ pub struct BlocksAndBlobsRequestInfo<E: EthSpec> {
     is_sidecars_stream_terminated: bool,
     /// Used to determine if this accumulator should wait for a sidecars stream termination
     request_type: ByRangeRequestType,
+    /// TODO(pawan): would this be multiple peer ids?
+    pub(crate) peer_id: PeerId,
 }
 
 impl<E: EthSpec> BlocksAndBlobsRequestInfo<E> {
-    pub fn new(request_type: ByRangeRequestType) -> Self {
+    pub fn new(request_type: ByRangeRequestType, peer_id: PeerId) -> Self {
         Self {
             accumulated_blocks: <_>::default(),
             accumulated_sidecars: <_>::default(),
             is_blocks_stream_terminated: <_>::default(),
             is_sidecars_stream_terminated: <_>::default(),
             request_type,
+            peer_id,
         }
     }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -35,7 +35,9 @@
 
 use super::backfill_sync::{BackFillSync, ProcessResult, SyncStart};
 use super::block_lookups::BlockLookups;
-use super::network_context::{BlockOrBlob, RangeRequestId, RpcEvent, SyncNetworkContext};
+use super::network_context::{
+    BlockOrBlob, RangeRequestId, RpcEvent, RpcResponseResult, SyncNetworkContext,
+};
 use super::peer_sync_info::{remote_sync_type, PeerSyncType};
 use super::range_sync::{RangeSync, RangeSyncType, EPOCHS_PER_BATCH};
 use crate::network_beacon_processor::{ChainSegmentProcessId, NetworkBeaconProcessor};
@@ -860,21 +862,24 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: PeerId,
         block: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) {
-        if let Some(resp) = self.network.on_single_block_response(id, peer_id, block) {
-            self.block_lookups
+        match self.network.on_single_block_response(id, peer_id, block) {
+            RpcResponseResult::Response(resp) => self
+                .block_lookups
                 .on_download_response::<BlockRequestState<T::EthSpec>>(
                     id,
                     peer_id,
                     resp,
                     &mut self.network,
-                )
-        } else {
-            debug!(
-                self.log,
-                "RPC error for block lookup has no associated entry in network context, ungraceful disconnect";
-                "peer_id" => %peer_id,
-                "request_id" => ?id,
-            );
+                ),
+            RpcResponseResult::RequestNotFound => {
+                debug!(
+                    self.log,
+                    "RPC error for block lookup has no associated entry in network context, ungraceful disconnect";
+                    "peer_id" => %peer_id,
+                    "request_id" => ?id,
+                );
+            }
+            RpcResponseResult::NoOp | RpcResponseResult::StreamTermination => {}
         }
     }
 
@@ -909,21 +914,24 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         peer_id: PeerId,
         blob: RpcEvent<Arc<BlobSidecar<T::EthSpec>>>,
     ) {
-        if let Some(resp) = self.network.on_single_blob_response(id, peer_id, blob) {
-            self.block_lookups
+        match self.network.on_single_blob_response(id, peer_id, blob) {
+            RpcResponseResult::Response(resp) => self
+                .block_lookups
                 .on_download_response::<BlobRequestState<T::EthSpec>>(
                     id,
                     peer_id,
                     resp,
                     &mut self.network,
-                )
-        } else {
-            debug!(
-                self.log,
-                "RPC error for blob lookup has no associated entry in network context, ungraceful disconnect";
-                "peer_id" => %peer_id,
-                "request_id" => ?id,
-            );
+                ),
+            RpcResponseResult::RequestNotFound => {
+                debug!(
+                    self.log,
+                    "RPC error for blob lookup has no associated entry in network context, ungraceful disconnect";
+                    "peer_id" => %peer_id,
+                    "request_id" => ?id,
+                );
+            }
+            RpcResponseResult::NoOp | RpcResponseResult::StreamTermination => {}
         }
     }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -402,7 +402,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         // Note: the order is important here, we should only remove the requests
         // from network context's maps after we have initiated the retries for
         // the associated batches/lookups
-        self.network.peer_disconnected(peer_id.clone());
+        self.network.peer_disconnected(peer_id);
         self.update_sync_state();
     }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -381,7 +381,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         self.range_sync.peer_disconnect(&mut self.network, peer_id);
         self.block_lookups.peer_disconnected(peer_id);
         // Regardless of the outcome, we update the sync status.
-        let _ = self.backfill_sync.peer_disconnected(peer_id);
+        let _ = self
+            .backfill_sync
+            .peer_disconnected(peer_id, &mut self.network);
         self.update_sync_state();
     }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -177,7 +177,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         }
     }
 
-    /// Returns all ids that were requested to the given peer_id
+    /// Returns the ids of all the requests made to the given peer_id.
     pub fn peer_disconnected(&mut self, peer_id: &PeerId) -> Vec<SyncRequestId> {
         let failed_range_ids =
             self.range_blocks_and_blobs_requests

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -183,13 +183,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     }
 
     /// Remove all active requests associated with the peer.
-    pub fn peer_disconnected(&mut self, peer_id: PeerId) {
+    pub fn peer_disconnected(&mut self, peer_id: &PeerId) {
         self.blocks_by_root_requests
-            .retain(|_, request| request.peer_id != peer_id);
+            .retain(|_, request| request.peer_id != *peer_id);
         self.blobs_by_root_requests
-            .retain(|_, request| request.peer_id != peer_id);
+            .retain(|_, request| request.peer_id != *peer_id);
         self.range_blocks_and_blobs_requests
-            .retain(|_, request| request.1.peer_id != peer_id);
+            .retain(|_, request| request.1.peer_id != *peer_id);
     }
 
     pub fn network_globals(&self) -> &NetworkGlobals<T::EthSpec> {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -184,7 +184,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 .iter()
                 .filter_map(|(id, request)| {
                     if request.1.peer_id == *peer_id {
-                        Some(SyncRequestId::RangeBlockAndBlobs { id: id.clone() })
+                        Some(SyncRequestId::RangeBlockAndBlobs { id: *id })
                     } else {
                         None
                     }
@@ -195,7 +195,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .iter()
             .filter_map(|(id, request)| {
                 if request.peer_id == *peer_id {
-                    Some(SyncRequestId::SingleBlock { id: id.clone() })
+                    Some(SyncRequestId::SingleBlock { id: *id })
                 } else {
                     None
                 }
@@ -205,7 +205,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .iter()
             .filter_map(|(id, request)| {
                 if request.peer_id == *peer_id {
-                    Some(SyncRequestId::SingleBlob { id: id.clone() })
+                    Some(SyncRequestId::SingleBlob { id: *id })
                 } else {
                     None
                 }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -52,12 +52,7 @@ pub enum RpcEvent<T> {
     RPCError(RPCError),
 }
 
-pub enum RpcResponseResult<T> {
-    Response(Result<(T, Duration), RpcResponseError>),
-    StreamTermination,
-    RequestNotFound,
-    NoOp,
-}
+pub type RpcResponseResult<T> = Result<(T, Duration), RpcResponseError>;
 
 pub enum RpcResponseError {
     RpcError(RPCError),
@@ -617,36 +612,36 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         request_id: SingleLookupReqId,
         peer_id: PeerId,
         block: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
-    ) -> RpcResponseResult<Arc<SignedBeaconBlock<T::EthSpec>>> {
+    ) -> Option<RpcResponseResult<Arc<SignedBeaconBlock<T::EthSpec>>>> {
         let Entry::Occupied(mut request) = self.blocks_by_root_requests.entry(request_id) else {
-            return RpcResponseResult::RequestNotFound;
+            return None;
         };
 
         let resp = match block {
             RpcEvent::Response(block, seen_timestamp) => {
                 match request.get_mut().add_response(block) {
-                    Ok(block) => RpcResponseResult::Response(Ok((block, seen_timestamp))),
+                    Ok(block) => Ok((block, seen_timestamp)),
                     Err(e) => {
                         // The request must be dropped after receiving an error.
                         request.remove();
-                        RpcResponseResult::Response(Err(e.into()))
+                        Err(e.into())
                     }
                 }
             }
             RpcEvent::StreamTermination => match request.remove().terminate() {
-                Ok(_) => return RpcResponseResult::StreamTermination,
-                Err(e) => RpcResponseResult::Response(Err(e.into())),
+                Ok(_) => return None,
+                Err(e) => Err(e.into()),
             },
             RpcEvent::RPCError(e) => {
                 request.remove();
-                RpcResponseResult::Response(Err(e.into()))
+                Err(e.into())
             }
         };
 
-        if let RpcResponseResult::Response(Err(RpcResponseError::VerifyError(e))) = &resp {
+        if let Err(RpcResponseError::VerifyError(e)) = &resp {
             self.report_peer(peer_id, PeerAction::LowToleranceError, e.into());
         }
-        resp
+        Some(resp)
     }
 
     pub fn on_single_blob_response(
@@ -654,9 +649,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         request_id: SingleLookupReqId,
         peer_id: PeerId,
         blob: RpcEvent<Arc<BlobSidecar<T::EthSpec>>>,
-    ) -> RpcResponseResult<FixedBlobSidecarList<T::EthSpec>> {
+    ) -> Option<RpcResponseResult<FixedBlobSidecarList<T::EthSpec>>> {
         let Entry::Occupied(mut request) = self.blobs_by_root_requests.entry(request_id) else {
-            return RpcResponseResult::RequestNotFound;
+            return None;
         };
 
         let resp = match blob {
@@ -666,12 +661,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     Ok(Some(blobs)) => to_fixed_blob_sidecar_list(blobs)
                         .map(|blobs| (blobs, seen_timestamp))
                         .map_err(|e| (e.into(), request.resolve())),
-                    Ok(None) => return RpcResponseResult::NoOp,
+                    Ok(None) => return None,
                     Err(e) => Err((e.into(), request.resolve())),
                 }
             }
             RpcEvent::StreamTermination => match request.remove().terminate() {
-                Ok(_) => return RpcResponseResult::StreamTermination,
+                Ok(_) => return None,
                 // (err, false = not resolved) because terminate returns Ok() if resolved
                 Err(e) => Err((e.into(), false)),
             },
@@ -679,7 +674,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         };
 
         match resp {
-            Ok(resp) => RpcResponseResult::Response(Ok(resp)),
+            Ok(resp) => Some(Ok(resp)),
             // Track if this request has already returned some value downstream. Ensure that
             // downstream code only receives a single Result per request. If the serving peer does
             // multiple penalizable actions per request, downscore and return None. This allows to
@@ -690,9 +685,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     self.report_peer(peer_id, PeerAction::LowToleranceError, e.into());
                 }
                 if resolved {
-                    RpcResponseResult::NoOp
+                    None
                 } else {
-                    RpcResponseResult::Response(Err(e))
+                    Some(Err(e))
                 }
             }
         }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -388,7 +388,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             // Block is known are currently processing, expect a future event with the result of
             // processing.
             BlockProcessStatus::NotValidated { .. } => {
-                return Ok(LookupRequestResult::Pending("block in processing cache"))
+                // Lookup sync event safety: If the block is currently in the processing cache, we
+                // are guaranteed to receive a `SyncMessage::GossipBlockProcessResult` that will
+                // make progress on this lookup
+                return Ok(LookupRequestResult::Pending("block in processing cache"));
             }
             // Block is fully validated. If it's not yet imported it's waiting for missing block
             // components. Consider this request completed and do nothing.
@@ -411,6 +414,12 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         let request = BlocksByRootSingleRequest(block_root);
 
+        // Lookup sync event safety: If network_send.send() returns Ok(_) we are guaranteed that
+        // eventually at least one this 3 events will be received:
+        // - StreamTermination(request_id): handled by `Self::on_single_block_response`
+        // - RPCError(request_id): handled by `Self::on_single_block_response`
+        // - Disconnect(peer_id) handled by `Self::peer_disconnected``which converts it to a
+        // ` RPCError(request_id)`event handled by the above method
         self.network_send
             .send(NetworkMessage::SendRequest {
                 peer_id,
@@ -453,6 +462,13 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             // latter handle the case where if the peer sent no blobs, penalize.
             // - if `downloaded_block_expected_blobs` is Some = block is downloading or processing.
             // - if `num_expected_blobs` returns Some = block is processed.
+            //
+            // Lookup sync event safety: Reaching this code means that a block is not in any pre-import
+            // cache nor in the request state of this lookup. Therefore, the block must either: (1) not
+            // be downloaded yet or (2) the block is already imported into the fork-choice.
+            // In case (1) the lookup must either successfully download the block or get dropped.
+            // In case (2) the block will be downloaded, processed, reach `BlockIsAlreadyKnown` and
+            // get dropped as completed.
             return Ok(LookupRequestResult::Pending("waiting for block download"));
         };
 
@@ -489,6 +505,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             indices,
         };
 
+        // Lookup sync event safety: Refer to `Self::block_lookup_request` `network_send.send` call
         self.network_send
             .send(NetworkMessage::SendRequest {
                 peer_id,
@@ -705,6 +722,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .ok_or(SendErrorProcessor::ProcessorNotAvailable)?;
 
         debug!(self.log, "Sending block for processing"; "block" => ?block_root, "id" => id);
+        // Lookup sync event safety: If `beacon_processor.send_rpc_beacon_block` returns Ok() sync
+        // must receive a single `SyncMessage::BlockComponentProcessed` with this process type
         beacon_processor
             .send_rpc_beacon_block(
                 block_root,
@@ -734,6 +753,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .ok_or(SendErrorProcessor::ProcessorNotAvailable)?;
 
         debug!(self.log, "Sending blobs for processing"; "block" => ?block_root, "id" => id);
+        // Lookup sync event safety: If `beacon_processor.send_rpc_blobs` returns Ok() sync
+        // must receive a single `SyncMessage::BlockComponentProcessed` event with this process type
         beacon_processor
             .send_rpc_blobs(
                 block_root,

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -1,5 +1,8 @@
 use beacon_chain::get_block_root;
-use lighthouse_network::rpc::{methods::BlobsByRootRequest, BlocksByRootRequest};
+use lighthouse_network::{
+    rpc::{methods::BlobsByRootRequest, BlocksByRootRequest},
+    PeerId,
+};
 use std::sync::Arc;
 use strum::IntoStaticStr;
 use types::{
@@ -20,13 +23,15 @@ pub enum LookupVerifyError {
 pub struct ActiveBlocksByRootRequest {
     request: BlocksByRootSingleRequest,
     resolved: bool,
+    pub(crate) peer_id: PeerId,
 }
 
 impl ActiveBlocksByRootRequest {
-    pub fn new(request: BlocksByRootSingleRequest) -> Self {
+    pub fn new(request: BlocksByRootSingleRequest, peer_id: PeerId) -> Self {
         Self {
             request,
             resolved: false,
+            peer_id,
         }
     }
 
@@ -94,14 +99,16 @@ pub struct ActiveBlobsByRootRequest<E: EthSpec> {
     request: BlobsByRootSingleBlockRequest,
     blobs: Vec<Arc<BlobSidecar<E>>>,
     resolved: bool,
+    pub(crate) peer_id: PeerId,
 }
 
 impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
-    pub fn new(request: BlobsByRootSingleBlockRequest) -> Self {
+    pub fn new(request: BlobsByRootSingleBlockRequest, peer_id: PeerId) -> Self {
         Self {
             request,
             blobs: vec![],
             resolved: false,
+            peer_id,
         }
     }
 

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -174,8 +174,30 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// Removes a peer from the chain.
     /// If the peer has active batches, those are considered failed and re-requested.
-    pub fn remove_peer(&mut self, peer_id: &PeerId) -> ProcessingResult {
-        self.peers.remove(peer_id);
+    pub fn remove_peer(
+        &mut self,
+        peer_id: &PeerId,
+        network: &mut SyncNetworkContext<T>,
+    ) -> ProcessingResult {
+        if let Some(batch_ids) = self.peers.remove(peer_id) {
+            // fail the batches
+            for id in batch_ids {
+                if let Some(batch) = self.batches.get_mut(&id) {
+                    if let BatchOperationOutcome::Failed { blacklist } =
+                        batch.download_failed(true)?
+                    {
+                        return Err(RemoveChain::ChainFailed {
+                            blacklist,
+                            failing_batch: id,
+                        });
+                    }
+                    self.retry_batch_download(network, id)?;
+                } else {
+                    debug!(self.log, "Batch not found while removing peer";
+                        "peer" => %peer_id, "batch" => id)
+                }
+            }
+        }
 
         if self.peers.is_empty() {
             Err(RemoveChain::EmptyPeerPool)

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -180,7 +180,7 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         network: &mut SyncNetworkContext<T>,
     ) -> ProcessingResult {
         if let Some(batch_ids) = self.peers.remove(peer_id) {
-            // fail the batches
+            // fail the batches.
             for id in batch_ids {
                 if let Some(batch) = self.batches.get_mut(&id) {
                     if let BatchOperationOutcome::Failed { blacklist } =

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -278,8 +278,9 @@ where
     /// for this peer. If so we mark the batch as failed. The batch may then hit it's maximum
     /// retries. In this case, we need to remove the chain.
     fn remove_peer(&mut self, network: &mut SyncNetworkContext<T>, peer_id: &PeerId) {
-        for (removed_chain, sync_type, remove_reason) in
-            self.chains.call_all(|chain| chain.remove_peer(peer_id))
+        for (removed_chain, sync_type, remove_reason) in self
+            .chains
+            .call_all(|chain| chain.remove_peer(peer_id, network))
         {
             self.on_chain_removed(
                 removed_chain,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

In https://github.com/sigp/lighthouse/pull/5680 , we decoupled a peer disconnect from an rpc error to simplify the logic in sync a bit. 
The peer disconnect message from the network was responsible for removing the peer from all the sync data structures.
The rpc error was responsible for re-requesting the failed batch/lookup.

We assumed that an rpc error would always go together with a peer disconnect, however we learned the hard way that there are many edge cases where the rpc error never gets generated when the peer disconnects. e.g. the peer manager disconnects a peer that has its rpc response mid-flight, peer disconnects before a rpc request reaches the network etc. There are many other cases we may not know about.
This leads to multiple bugs in sync where sync stalls because a batch/lookup never gets re-requested on peer disconnects.

https://github.com/sigp/lighthouse/pull/5967 was an attempt at adding timeouts to the rpc requests sent from sync that trigger re-requests when the timer elapses. However, as @AgeManning noted, this would lead to many more edge cases.

This PR triggers re-request of batches/lookups on peer disconnects partially reverting #5680 . This isn't the cleanest but considering that we cannot always rely on `lighthouse_network` to generate rpc errors to go with peer disconnects, this seems the best option.

I intend to test this extensively on mainnet before merging