### PR TITLE
Broadcast validator registration to all synced beacon nodes

### DIFF
--- a/validator_client/src/preparation_service.rs
+++ b/validator_client/src/preparation_service.rs
@@ -478,7 +478,7 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                 match self
                     .beacon_nodes
                     .broadcast(
-                        RequireSynced::Yes,
+                        RequireSynced::No,
                         OfflineOnFailure::No,
                         |beacon_node| async move {
                             beacon_node.post_validator_register_validator(batch).await

--- a/validator_client/src/preparation_service.rs
+++ b/validator_client/src/preparation_service.rs
@@ -477,8 +477,8 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
             for batch in signed.chunks(self.validator_registration_batch_size) {
                 match self
                     .beacon_nodes
-                    .first_success(
-                        RequireSynced::No,
+                    .broadcast(
+                        RequireSynced::Yes,
                         OfflineOnFailure::No,
                         |beacon_node| async move {
                             beacon_node.post_validator_register_validator(batch).await


### PR DESCRIPTION
## Issue Addressed

The validator client currently publish validator registrations to its first beacon node, and it doesn't require the beacon node to be synced. This could potentially result in registration not being sent to all builders beacon nodes are connected to, because:
- Beacon nodes may be connected to different relays, and only sending it to the first one means registrations may not be sent to all relays.
- Beacon nodes read validator data from the chain, and only send registration for active validators. However if the node is out of sync, it could either be missing the validator or have an outdated status of the validator, resulting in registration for the active validator to be missed.

https://github.com/sigp/lighthouse/blob/b4556a3d621c39cb28ef10df9daec4ee935909b6/validator_client/src/preparation_service.rs#L478-L487

## Proposed Changes

To ensure registrations for all active validators are sent to all relays, we publish validator registration to **all synced** beacon nodes.
