### PR TITLE
Release v5.2.1 (final branch)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
             - uses: KyleMayes/install-llvm-action@v1
               if: env.SELF_HOSTED_RUNNERS == 'false' && startsWith(matrix.arch, 'x86_64-windows')
               with:
-                version: "16.0"
+                version: "17.0"
                 directory: ${{ runner.temp }}/llvm
             - name: Set LIBCLANG_PATH
               if: startsWith(matrix.arch, 'x86_64-windows')

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,7 +41,7 @@ jobs:
          LABELS: ${{ toJson(github.event.pull_request.labels) }}
        run: |
          SKIP_CI="false"
-         if [ -z "${LABELS}" ]; then
+         if [ -z "${LABELS}" ]  || [ "${LABELS}" = "null" ]; then
            LABELS="none";
          else
            LABELS=$(echo ${LABELS} | jq -r '.[].name')
@@ -52,7 +52,7 @@ jobs:
              break
            fi
          done
-         echo "::set-output name=skip_ci::$SKIP_CI"
+         echo "skip_ci=$SKIP_CI" >> $GITHUB_OUTPUT
 
   target-branch-check:
     name: target-branch-check

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -112,11 +112,6 @@ jobs:
     - name: Install make
       if: env.SELF_HOSTED_RUNNERS == 'false'
       run: choco install -y make
-#    - uses: KyleMayes/install-llvm-action@v1
-#         if: env.SELF_HOSTED_RUNNERS == 'false'
-#      with:
-#        version: "16.0"
-#        directory: ${{ runner.temp }}/llvm
     - name: Set LIBCLANG_PATH
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - name: Run tests in release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,16 +1716,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms 3.4.0",
  "rustc_version 0.4.0",
  "subtle",
  "zeroize",
@@ -6145,12 +6144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
 
 [[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
-
-[[package]]
 name = "plotters"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6456,7 +6449,7 @@ dependencies = [
  "nix 0.24.3",
  "num_cpus",
  "once_cell",
- "platforms 2.0.0",
+ "platforms",
  "thiserror",
  "unescape",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4964,6 +4964,7 @@ dependencies = [
  "libp2p-mplex",
  "lighthouse_metrics",
  "lighthouse_version",
+ "logging",
  "lru",
  "lru_cache",
  "parking_lot 0.12.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "beacon_chain",
  "clap",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "beacon_node",
  "clap",
@@ -4322,7 +4322,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "5.2.0"
+version = "5.2.1"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/FUNDING.json
+++ b/FUNDING.json
@@ -1,0 +1,7 @@
+{
+    "drips": {
+        "ethereum": {
+            "ownedBy": "0x25c4a76E7d118705e7Ea2e9b7d8C59930d8aCD3b"
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ lint:
 		-D clippy::manual_let_else \
 		-D warnings \
 		-A clippy::derive_partial_eq_without_eq \
-		-A clippy::from-over-into \
 		-A clippy::upper-case-acronyms \
 		-A clippy::vec-init-then-push \
 		-A clippy::question-mark \

--- a/account_manager/src/lib.rs
+++ b/account_manager/src/lib.rs
@@ -18,7 +18,7 @@ pub const WALLETS_DIR_FLAG: &str = "wallets-dir";
 
 pub fn cli_app() -> Command {
     Command::new(CMD)
-        .visible_aliases(["a", "am", "account", CMD])
+        .visible_aliases(["a", "am", "account"])
         .about("Utilities for generating and managing Ethereum 2.0 accounts.")
         .display_order(0)
         .arg(

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "5.2.0"
+version = "5.2.1"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
+++ b/beacon_node/beacon_chain/src/beacon_fork_choice_store.rs
@@ -389,35 +389,35 @@ pub struct PersistedForkChoiceStore {
     pub equivocating_indices: BTreeSet<u64>,
 }
 
-impl Into<PersistedForkChoiceStore> for PersistedForkChoiceStoreV11 {
-    fn into(self) -> PersistedForkChoiceStore {
+impl From<PersistedForkChoiceStoreV11> for PersistedForkChoiceStore {
+    fn from(from: PersistedForkChoiceStoreV11) -> PersistedForkChoiceStore {
         PersistedForkChoiceStore {
-            balances_cache: self.balances_cache,
-            time: self.time,
-            finalized_checkpoint: self.finalized_checkpoint,
-            justified_checkpoint: self.justified_checkpoint,
-            justified_balances: self.justified_balances,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
-            proposer_boost_root: self.proposer_boost_root,
-            equivocating_indices: self.equivocating_indices,
+            balances_cache: from.balances_cache,
+            time: from.time,
+            finalized_checkpoint: from.finalized_checkpoint,
+            justified_checkpoint: from.justified_checkpoint,
+            justified_balances: from.justified_balances,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
+            proposer_boost_root: from.proposer_boost_root,
+            equivocating_indices: from.equivocating_indices,
         }
     }
 }
 
-impl Into<PersistedForkChoiceStoreV11> for PersistedForkChoiceStore {
-    fn into(self) -> PersistedForkChoiceStoreV11 {
+impl From<PersistedForkChoiceStore> for PersistedForkChoiceStoreV11 {
+    fn from(from: PersistedForkChoiceStore) -> PersistedForkChoiceStoreV11 {
         PersistedForkChoiceStoreV11 {
-            balances_cache: self.balances_cache,
-            time: self.time,
-            finalized_checkpoint: self.finalized_checkpoint,
-            justified_checkpoint: self.justified_checkpoint,
-            justified_balances: self.justified_balances,
+            balances_cache: from.balances_cache,
+            time: from.time,
+            finalized_checkpoint: from.finalized_checkpoint,
+            justified_checkpoint: from.justified_checkpoint,
+            justified_balances: from.justified_balances,
             best_justified_checkpoint: JUNK_BEST_JUSTIFIED_CHECKPOINT,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
-            proposer_boost_root: self.proposer_boost_root,
-            equivocating_indices: self.equivocating_indices,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
+            proposer_boost_root: from.proposer_boost_root,
+            equivocating_indices: from.equivocating_indices,
         }
     }
 }

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -10,7 +10,6 @@ use crate::block_verification::{
 use crate::kzg_utils::{validate_blob, validate_blobs};
 use crate::{metrics, BeaconChainError};
 use kzg::{Error as KzgError, Kzg, KzgCommitment};
-use merkle_proof::MerkleTreeError;
 use slog::debug;
 use ssz_derive::{Decode, Encode};
 use ssz_types::VariableList;
@@ -127,13 +126,6 @@ pub enum GossipBlobError<E: EthSpec> {
     ///
     /// The blob sidecar is invalid and the peer is faulty.
     KzgError(kzg::Error),
-
-    /// The kzg commitment inclusion proof failed.
-    ///
-    /// ## Peer scoring
-    ///
-    /// The blob sidecar is invalid
-    InclusionProof(MerkleTreeError),
 
     /// The pubkey cache timed out.
     ///
@@ -459,10 +451,7 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes>(
 
     // Verify the inclusion proof in the sidecar
     let _timer = metrics::start_timer(&metrics::BLOB_SIDECAR_INCLUSION_PROOF_VERIFICATION);
-    if !blob_sidecar
-        .verify_blob_sidecar_inclusion_proof()
-        .map_err(GossipBlobError::InclusionProof)?
-    {
+    if !blob_sidecar.verify_blob_sidecar_inclusion_proof() {
         return Err(GossipBlobError::InvalidInclusionProof);
     }
     drop(_timer);

--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -685,7 +685,7 @@ mod test {
     fn get_eth1_data(i: u64) -> Eth1Data {
         Eth1Data {
             block_hash: Hash256::from_low_u64_be(i),
-            deposit_root: Hash256::from_low_u64_be(u64::max_value() - i),
+            deposit_root: Hash256::from_low_u64_be(u64::MAX - i),
             deposit_count: i,
         }
     }

--- a/beacon_node/beacon_chain/src/persisted_fork_choice.rs
+++ b/beacon_node/beacon_chain/src/persisted_fork_choice.rs
@@ -20,20 +20,20 @@ pub struct PersistedForkChoice {
     pub fork_choice_store: PersistedForkChoiceStoreV17,
 }
 
-impl Into<PersistedForkChoice> for PersistedForkChoiceV11 {
-    fn into(self) -> PersistedForkChoice {
+impl From<PersistedForkChoiceV11> for PersistedForkChoice {
+    fn from(from: PersistedForkChoiceV11) -> PersistedForkChoice {
         PersistedForkChoice {
-            fork_choice: self.fork_choice,
-            fork_choice_store: self.fork_choice_store.into(),
+            fork_choice: from.fork_choice,
+            fork_choice_store: from.fork_choice_store.into(),
         }
     }
 }
 
-impl Into<PersistedForkChoiceV11> for PersistedForkChoice {
-    fn into(self) -> PersistedForkChoiceV11 {
+impl From<PersistedForkChoice> for PersistedForkChoiceV11 {
+    fn from(from: PersistedForkChoice) -> PersistedForkChoiceV11 {
         PersistedForkChoiceV11 {
-            fork_choice: self.fork_choice,
-            fork_choice_store: self.fork_choice_store.into(),
+            fork_choice: from.fork_choice,
+            fork_choice_store: from.fork_choice_store.into(),
         }
     }
 }

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -2068,7 +2068,7 @@ pub fn timestamp_now() -> Duration {
 }
 
 fn u64_to_i64(n: impl Into<u64>) -> i64 {
-    i64::try_from(n.into()).unwrap_or(i64::max_value())
+    i64::try_from(n.into()).unwrap_or(i64::MAX)
 }
 
 /// Returns the delay between the start of `block.slot` and `seen_timestamp`.

--- a/beacon_node/client/src/lib.rs
+++ b/beacon_node/client/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate slog;
-
 mod compute_light_client_updates;
 pub mod config;
 mod metrics;

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -721,10 +721,10 @@ fn eth1_logging<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>, log: &Logger
     }
 }
 
-/// Returns the peer count, returning something helpful if it's `usize::max_value` (effectively a
+/// Returns the peer count, returning something helpful if it's `usize::MAX` (effectively a
 /// `None` value).
 fn peer_count_pretty(peer_count: usize) -> String {
-    if peer_count == usize::max_value() {
+    if peer_count == usize::MAX {
         String::from("--")
     } else {
         format!("{}", peer_count)
@@ -824,7 +824,7 @@ impl Speedo {
 
     /// Returns the average of the speeds between each observation.
     ///
-    /// Does not gracefully handle slots that are above `u32::max_value()`.
+    /// Does not gracefully handle slots that are above `u32::MAX`.
     pub fn slots_per_second(&self) -> Option<f64> {
         let speeds = self
             .0

--- a/beacon_node/eth1/src/lib.rs
+++ b/beacon_node/eth1/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod block_cache;
 mod deposit_cache;
 mod inner;

--- a/beacon_node/eth1/src/metrics.rs
+++ b/beacon_node/eth1/src/metrics.rs
@@ -1,5 +1,7 @@
 pub use lighthouse_metrics::*;
 
+use lazy_static::lazy_static;
+
 lazy_static! {
     /*
      * Eth1 blocks

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -853,7 +853,7 @@ impl Service {
         let max_log_requests_per_update = self
             .config()
             .max_log_requests_per_update
-            .unwrap_or_else(usize::max_value);
+            .unwrap_or(usize::MAX);
 
         let range = {
             match new_block_numbers {
@@ -996,10 +996,7 @@ impl Service {
     ) -> Result<BlockCacheUpdateOutcome, Error> {
         let client = self.client();
         let block_cache_truncation = self.config().block_cache_truncation;
-        let max_blocks_per_update = self
-            .config()
-            .max_blocks_per_update
-            .unwrap_or_else(usize::max_value);
+        let max_blocks_per_update = self.config().max_blocks_per_update.unwrap_or(usize::MAX);
 
         let range = {
             match new_block_numbers {
@@ -1025,7 +1022,7 @@ impl Service {
                 let range_size = range.end() - range.start();
                 let max_size = block_cache_truncation
                     .map(|n| n as u64)
-                    .unwrap_or_else(u64::max_value);
+                    .unwrap_or_else(|| u64::MAX);
                 if range_size > max_size {
                     // If the range of required blocks is larger than `max_size`, drop all
                     // existing blocks and download `max_size` count of blocks.

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -412,7 +412,7 @@ pub mod deposit_methods {
                     .ok_or("Block number was not string")?,
             )?;
 
-            if number <= usize::max_value() as u64 {
+            if number <= usize::MAX as u64 {
                 Ok(Block {
                     hash,
                     timestamp,

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -257,9 +257,9 @@ pub mod deposit_methods {
         Latest,
     }
 
-    impl Into<u64> for Eth1Id {
-        fn into(self) -> u64 {
-            match self {
+    impl From<Eth1Id> for u64 {
+        fn from(from: Eth1Id) -> u64 {
+            match from {
                 Eth1Id::Mainnet => 1,
                 Eth1Id::Custom(id) => id,
             }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1985,39 +1985,10 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     excess_blob_gas: deneb_block.excess_blob_gas,
                 })
             }
-            ExecutionBlockWithTransactions::Electra(electra_block) => {
-                let withdrawals = VariableList::new(
-                    electra_block
-                        .withdrawals
-                        .into_iter()
-                        .map(Into::into)
-                        .collect(),
-                )
-                .map_err(ApiError::DeserializeWithdrawals)?;
-                ExecutionPayload::Electra(ExecutionPayloadElectra {
-                    parent_hash: electra_block.parent_hash,
-                    fee_recipient: electra_block.fee_recipient,
-                    state_root: electra_block.state_root,
-                    receipts_root: electra_block.receipts_root,
-                    logs_bloom: electra_block.logs_bloom,
-                    prev_randao: electra_block.prev_randao,
-                    block_number: electra_block.block_number,
-                    gas_limit: electra_block.gas_limit,
-                    gas_used: electra_block.gas_used,
-                    timestamp: electra_block.timestamp,
-                    extra_data: electra_block.extra_data,
-                    base_fee_per_gas: electra_block.base_fee_per_gas,
-                    block_hash: electra_block.block_hash,
-                    transactions: convert_transactions(electra_block.transactions)?,
-                    withdrawals,
-                    blob_gas_used: electra_block.blob_gas_used,
-                    excess_blob_gas: electra_block.excess_blob_gas,
-                    // TODO(electra)
-                    // deposit_receipts: electra_block.deposit_receipts,
-                    // withdrawal_requests: electra_block.withdrawal_requests,
-                    deposit_receipts: <_>::default(),
-                    withdrawal_requests: <_>::default(),
-                })
+            ExecutionBlockWithTransactions::Electra(_) => {
+                return Err(ApiError::UnsupportedForkVariant(format!(
+                    "legacy payload construction for {fork} is not implemented"
+                )));
             }
         };
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2178,7 +2178,7 @@ fn verify_builder_bid<E: EthSpec>(
 
     // Avoid logging values that we can't represent with our Prometheus library.
     let payload_value_gwei = bid.data.message.value() / 1_000_000_000;
-    if payload_value_gwei <= Uint256::from(i64::max_value()) {
+    if payload_value_gwei <= Uint256::from(i64::MAX) {
         metrics::set_gauge_vec(
             &metrics::EXECUTION_LAYER_PAYLOAD_BIDS,
             &[metrics::BUILDER],

--- a/beacon_node/execution_layer/src/metrics.rs
+++ b/beacon_node/execution_layer/src/metrics.rs
@@ -81,7 +81,7 @@ lazy_static::lazy_static! {
     );
     pub static ref EXECUTION_LAYER_PAYLOAD_BIDS: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "execution_layer_payload_bids",
-        "The gwei bid value of payloads received by local EEs or builders. Only shows values up to i64::max_value.",
+        "The gwei bid value of payloads received by local EEs or builders. Only shows values up to i64::MAX.",
         &["source"]
     );
 }

--- a/beacon_node/execution_layer/src/versioned_hashes.rs
+++ b/beacon_node/execution_layer/src/versioned_hashes.rs
@@ -1,5 +1,3 @@
-extern crate alloy_consensus;
-extern crate alloy_rlp;
 use alloy_consensus::TxEnvelope;
 use alloy_rlp::Decodable;
 use types::{EthSpec, ExecutionPayloadRef, Hash256, Unsigned, VersionedHash};

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -2266,9 +2266,9 @@ impl ApiTester {
             vec![validator_count],
             vec![validator_count, 1],
             vec![validator_count, 1, 3],
-            vec![u64::max_value()],
-            vec![u64::max_value(), 1],
-            vec![u64::max_value(), 1, 3],
+            vec![u64::MAX],
+            vec![u64::MAX, 1],
+            vec![u64::MAX, 1, 3],
         ];
 
         interesting.push((0..validator_count).collect());

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -60,6 +60,7 @@ tempfile = { workspace = true }
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
 async-channel = { workspace = true }
+logging = { workspace = true }
 
 [features]
 libp2p-websocket = []

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -561,8 +561,8 @@ impl<E: EthSpec> Discovery<E> {
     /// Updates the `eth2` field of our local ENR.
     pub fn update_eth2_enr(&mut self, enr_fork_id: EnrForkId) {
         // to avoid having a reference to the spec constant, for the logging we assume
-        // FAR_FUTURE_EPOCH is u64::max_value()
-        let next_fork_epoch_log = if enr_fork_id.next_fork_epoch == u64::max_value() {
+        // FAR_FUTURE_EPOCH is u64::MAX
+        let next_fork_epoch_log = if enr_fork_id.next_fork_epoch == u64::MAX {
             String::from("No other fork")
         } else {
             format!("{:?}", enr_fork_id.next_fork_epoch)

--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -2,9 +2,6 @@
 /// all required libp2p functionality.
 ///
 /// This crate builds and manages the libp2p services required by the beacon node.
-#[macro_use]
-extern crate lazy_static;
-
 mod config;
 pub mod service;
 

--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -1,5 +1,7 @@
 pub use lighthouse_metrics::*;
 
+use lazy_static::lazy_static;
+
 lazy_static! {
     pub static ref NAT_OPEN: Result<IntGaugeVec> = try_create_int_gauge_vec(
         "nat_open",

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/score.rs
@@ -6,6 +6,7 @@
 //!
 //! The scoring algorithms are currently experimental.
 use crate::service::gossipsub_scoring_parameters::GREYLIST_THRESHOLD as GOSSIPSUB_GREYLIST_THRESHOLD;
+use lazy_static::lazy_static;
 use serde::Serialize;
 use std::time::Instant;
 use strum::AsRefStr;

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -374,6 +374,12 @@ where
                 id: outbound_info.req_id,
             })));
         }
+
+        // Also handle any events that are awaiting to be sent to the behaviour
+        if !self.events_out.is_empty() {
+            return Poll::Ready(Some(self.events_out.remove(0)));
+        }
+
         Poll::Ready(None)
     }
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -3,6 +3,7 @@ use crate::rpc::codec::{base::BaseInboundCodec, ssz_snappy::SSZSnappyInboundCode
 use futures::future::BoxFuture;
 use futures::prelude::{AsyncRead, AsyncWrite};
 use futures::{FutureExt, StreamExt};
+use lazy_static::lazy_static;
 use libp2p::core::{InboundUpgrade, UpgradeInfo};
 use ssz::Encode;
 use ssz_types::VariableList;

--- a/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
@@ -147,7 +147,7 @@ impl<Id: ReqId, E: EthSpec> SelfRateLimiter<Id, E> {
                     Err((rate_limited_req, wait_time)) => {
                         let key = (peer_id, protocol);
                         self.next_peer_request.insert(key, wait_time);
-                        queued_requests.push_back(rate_limited_req);
+                        queued_requests.push_front(rate_limited_req);
                         // If one fails just wait for the next window that allows sending requests.
                         return;
                     }
@@ -203,5 +203,74 @@ impl<Id: ReqId, E: EthSpec> SelfRateLimiter<Id, E> {
         }
 
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rpc::config::{OutboundRateLimiterConfig, RateLimiterConfig};
+    use crate::rpc::rate_limiter::Quota;
+    use crate::rpc::self_limiter::SelfRateLimiter;
+    use crate::rpc::{OutboundRequest, Ping, Protocol};
+    use crate::service::api_types::RequestId;
+    use libp2p::PeerId;
+    use std::time::Duration;
+    use types::MainnetEthSpec;
+
+    /// Test that `next_peer_request_ready` correctly maintains the queue.
+    #[tokio::test]
+    async fn test_next_peer_request_ready() {
+        let log = logging::test_logger();
+        let config = OutboundRateLimiterConfig(RateLimiterConfig {
+            ping_quota: Quota::n_every(1, 2),
+            ..Default::default()
+        });
+        let mut limiter: SelfRateLimiter<RequestId<u64>, MainnetEthSpec> =
+            SelfRateLimiter::new(config, log).unwrap();
+        let peer_id = PeerId::random();
+
+        for i in 1..=5 {
+            let _ = limiter.allows(
+                peer_id,
+                RequestId::Application(i),
+                OutboundRequest::Ping(Ping { data: i }),
+            );
+        }
+
+        {
+            let queue = limiter
+                .delayed_requests
+                .get(&(peer_id, Protocol::Ping))
+                .unwrap();
+            assert_eq!(4, queue.len());
+
+            // Check that requests in the queue are ordered in the sequence 2, 3, 4, 5.
+            let mut iter = queue.iter();
+            for i in 2..=5 {
+                assert_eq!(iter.next().unwrap().request_id, RequestId::Application(i));
+            }
+
+            assert_eq!(limiter.ready_requests.len(), 0);
+        }
+
+        // Wait until the tokens have been regenerated, then run `next_peer_request_ready`.
+        tokio::time::sleep(Duration::from_secs(3)).await;
+        limiter.next_peer_request_ready(peer_id, Protocol::Ping);
+
+        {
+            let queue = limiter
+                .delayed_requests
+                .get(&(peer_id, Protocol::Ping))
+                .unwrap();
+            assert_eq!(3, queue.len());
+
+            // Check that requests in the queue are ordered in the sequence 3, 4, 5.
+            let mut iter = queue.iter();
+            for i in 3..=5 {
+                assert_eq!(iter.next().unwrap().request_id, RequestId::Application(i));
+            }
+
+            assert_eq!(limiter.ready_requests.len(), 1);
+        }
     }
 }

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::Protocol;
-use lighthouse_network::rpc::{methods::*, RPCError};
+use lighthouse_network::rpc::methods::*;
 use lighthouse_network::{rpc::max_rpc_size, NetworkEvent, ReportSource, Request, Response};
 use slog::{debug, warn, Level};
 use ssz::Encode;
@@ -998,98 +998,6 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                         // stop sending messages
                         return;
                     }
-                }
-            }
-        };
-
-        tokio::select! {
-            _ = sender_future => {}
-            _ = receiver_future => {}
-            _ = sleep(Duration::from_secs(30)) => {
-                panic!("Future timed out");
-            }
-        }
-    })
-}
-
-#[test]
-fn test_disconnect_triggers_rpc_error() {
-    // set up the logging. The level and enabled logging or not
-    let log_level = Level::Debug;
-    let enable_logging = false;
-
-    let log = common::build_log(log_level, enable_logging);
-    let spec = E::default_spec();
-
-    let rt = Arc::new(Runtime::new().unwrap());
-    // get sender/receiver
-    rt.block_on(async {
-        let (mut sender, mut receiver) = common::build_node_pair(
-            Arc::downgrade(&rt),
-            &log,
-            ForkName::Base,
-            &spec,
-            Protocol::Tcp,
-        )
-        .await;
-
-        // BlocksByRoot Request
-        let rpc_request = Request::BlocksByRoot(BlocksByRootRequest::new(
-            // Must have at least one root for the request to create a stream
-            vec![Hash256::from_low_u64_be(0)],
-            &spec,
-        ));
-
-        // build the sender future
-        let sender_future = async {
-            loop {
-                match sender.next_event().await {
-                    NetworkEvent::PeerConnectedOutgoing(peer_id) => {
-                        // Send a STATUS message
-                        debug!(log, "Sending RPC");
-                        sender
-                            .send_request(peer_id, 42, rpc_request.clone())
-                            .unwrap();
-                    }
-                    NetworkEvent::RPCFailed { error, id: 42, .. } => match error {
-                        RPCError::Disconnected => return,
-                        other => panic!("received unexpected error {:?}", other),
-                    },
-                    other => {
-                        warn!(log, "Ignoring other event {:?}", other);
-                    }
-                }
-            }
-        };
-
-        // determine messages to send (PeerId, RequestId). If some, indicates we still need to send
-        // messages
-        let mut sending_peer = None;
-        let receiver_future = async {
-            loop {
-                // this future either drives the sending/receiving or times out allowing messages to be
-                // sent in the timeout
-                match futures::future::select(
-                    Box::pin(receiver.next_event()),
-                    Box::pin(tokio::time::sleep(Duration::from_secs(1))),
-                )
-                .await
-                {
-                    futures::future::Either::Left((ev, _)) => match ev {
-                        NetworkEvent::RequestReceived { peer_id, .. } => {
-                            sending_peer = Some(peer_id);
-                        }
-                        other => {
-                            warn!(log, "Ignoring other event {:?}", other);
-                        }
-                    },
-                    futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
-                }
-
-                // if we need to send messages send them here. This will happen after a delay
-                if let Some(peer_id) = sending_peer.take() {
-                    warn!(log, "Receiver got request, disconnecting peer");
-                    receiver.__hard_disconnect_testing_only(peer_id);
                 }
             }
         };

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 /// This crate provides the network server for Lighthouse.
 pub mod error;
 #[allow(clippy::mutable_key_type)] // PeerId in hashmaps are no longer permitted by clippy

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -5,6 +5,7 @@ use beacon_chain::{
     sync_committee_verification::Error as SyncCommitteeError,
 };
 use fnv::FnvHashMap;
+use lazy_static::lazy_static;
 pub use lighthouse_metrics::*;
 use lighthouse_network::{
     peer_manager::peerdb::client::ClientKind, types::GossipKind, GossipTopic, Gossipsub,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -700,7 +700,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             "index" => %index,
                             "commitment" => %commitment,
                         );
-                        // Prevent recurring behaviour by penalizing the peer slightly.
+                        // Prevent recurring behaviour by penalizing the peer.
                         self.gossip_penalize_peer(
                             peer_id,
                             PeerAction::LowToleranceError,
@@ -712,10 +712,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             MessageAcceptance::Reject,
                         );
                     }
-                    GossipBlobError::FutureSlot { .. }
-                    | GossipBlobError::RepeatBlob { .. }
-                    | GossipBlobError::PastFinalizedSlot { .. } => {
-                        warn!(
+                    GossipBlobError::FutureSlot { .. } | GossipBlobError::RepeatBlob { .. } => {
+                        debug!(
                             self.log,
                             "Could not verify blob sidecar for gossip. Ignoring the blob sidecar";
                             "error" => ?err,
@@ -729,6 +727,30 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             peer_id,
                             PeerAction::HighToleranceError,
                             "gossip_blob_high",
+                        );
+                        self.propagate_validation_result(
+                            message_id,
+                            peer_id,
+                            MessageAcceptance::Ignore,
+                        );
+                    }
+                    GossipBlobError::PastFinalizedSlot { .. } => {
+                        debug!(
+                            self.log,
+                            "Could not verify blob sidecar for gossip. Ignoring the blob sidecar";
+                            "error" => ?err,
+                            "slot" => %slot,
+                            "root" => %root,
+                            "index" => %index,
+                            "commitment" => %commitment,
+                        );
+                        // Prevent recurring behaviour by penalizing the peer. A low-tolerance
+                        // error is fine because there's no reason for peers to be propagating old
+                        // blobs on gossip, even if their view of finality is lagging.
+                        self.gossip_penalize_peer(
+                            peer_id,
+                            PeerAction::LowToleranceError,
+                            "gossip_blob_low",
                         );
                         self.propagate_validation_result(
                             message_id,

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -690,7 +690,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     | GossipBlobError::InvalidSubnet { .. }
                     | GossipBlobError::InvalidInclusionProof
                     | GossipBlobError::KzgError(_)
-                    | GossipBlobError::InclusionProof(_)
                     | GossipBlobError::NotFinalizedDescendant { .. } => {
                         warn!(
                             self.log,

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -793,9 +793,7 @@ async fn aggregate_attestation_to_unknown_block(import_method: BlockImportMethod
     let mut rig = TestRig::new(SMALL_CHAIN).await;
 
     // Empty the op pool.
-    rig.chain
-        .op_pool
-        .prune_attestations(u64::max_value().into());
+    rig.chain.op_pool.prune_attestations(u64::MAX.into());
     assert_eq!(rig.chain.op_pool.num_attestations(), 0);
 
     // Send the attestation but not the block, and check that it was not imported.

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -291,7 +291,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 }
             }
 
-            if let Err(e) = self.add_peers_to_lookup_and_ancestors(lookup_id, peers) {
+            if let Err(e) = self.add_peers_to_lookup_and_ancestors(lookup_id, peers, cx) {
                 warn!(self.log, "Error adding peers to ancestor lookup"; "error" => ?e);
             }
 
@@ -844,14 +844,17 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         lookup_id: SingleLookupId,
         peers: &[PeerId],
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), String> {
         let lookup = self
             .single_block_lookups
             .get_mut(&lookup_id)
             .ok_or(format!("Unknown lookup for id {lookup_id}"))?;
 
+        let mut added_some_peer = false;
         for peer in peers {
             if lookup.add_peer(*peer) {
+                added_some_peer = true;
                 debug!(self.log, "Adding peer to existing single block lookup";
                     "block_root" => ?lookup.block_root(),
                     "peer" => ?peer
@@ -859,22 +862,25 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             }
         }
 
-        // We may choose to attempt to continue a lookup here. It is possible that a lookup had zero
-        // peers and after adding this set of peers it can make progress again. Note that this
-        // recursive function iterates from child to parent, so continuing the child first is weird.
-        // However, we choose to not attempt to continue the lookup for simplicity. It's not
-        // strictly required and just and optimization for a rare corner case.
-
         if let Some(parent_root) = lookup.awaiting_parent() {
             if let Some((&child_id, _)) = self
                 .single_block_lookups
                 .iter()
                 .find(|(_, l)| l.block_root() == parent_root)
             {
-                self.add_peers_to_lookup_and_ancestors(child_id, peers)
+                self.add_peers_to_lookup_and_ancestors(child_id, peers, cx)
             } else {
                 Err(format!("Lookup references unknown parent {parent_root:?}"))
             }
+        } else if added_some_peer {
+            // If this lookup is not awaiting a parent and we added at least one peer, attempt to
+            // make progress. It is possible that a lookup is created with zero peers, attempted to
+            // make progress, and then receives peers. After that time the lookup will never be
+            // pruned with `drop_lookups_without_peers` because it has peers. This is rare corner
+            // case, but it can result in stuck lookups.
+            let result = lookup.continue_requests(cx);
+            self.on_lookup_result(lookup_id, result, "add_peers", cx);
+            Ok(())
         } else {
             Ok(())
         }

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -197,21 +197,36 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             }
 
             let Some(peer_id) = self.use_rand_available_peer() else {
-                // Allow lookup to not have any peers. In that case do nothing. If the lookup does
-                // not have peers for some time, it will be dropped.
+                // Allow lookup to not have any peers and do nothing. This is an optimization to not
+                // lose progress of lookups created from a block with unknown parent before we receive
+                // attestations for said block.
+                // Lookup sync event safety: If a lookup requires peers to make progress, and does
+                // not receive any new peers for some time it will be dropped. If it receives a new
+                // peer it must attempt to make progress.
+                R::request_state_mut(self)
+                    .get_state_mut()
+                    .update_awaiting_download_status("no peers");
                 return Ok(());
             };
 
             let request = R::request_state_mut(self);
             match request.make_request(id, peer_id, downloaded_block_expected_blobs, cx)? {
                 LookupRequestResult::RequestSent(req_id) => {
+                    // Lookup sync event safety: If make_request returns `RequestSent`, we are
+                    // guaranteed that `BlockLookups::on_download_response` will be called exactly
+                    // with this `req_id`.
                     request.get_state_mut().on_download_start(req_id)?
                 }
                 LookupRequestResult::NoRequestNeeded => {
+                    // Lookup sync event safety: Advances this request to the terminal `Processed`
+                    // state. If all requests reach this state, the request is marked as completed
+                    // in `Self::continue_requests`.
                     request.get_state_mut().on_completed_request()?
                 }
                 // Sync will receive a future event to make progress on the request, do nothing now
                 LookupRequestResult::Pending(reason) => {
+                    // Lookup sync event safety: Refer to the code paths constructing
+                    // `LookupRequestResult::Pending`
                     request
                         .get_state_mut()
                         .update_awaiting_download_status(reason);
@@ -222,15 +237,27 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         // Otherwise, attempt to progress awaiting processing
         // If this request is awaiting a parent lookup to be processed, do not send for processing.
         // The request will be rejected with unknown parent error.
+        //
+        // TODO: The condition `block_is_processed || Block` can be dropped after checking for
+        // unknown parent root when import RPC blobs
         } else if !awaiting_parent
             && (block_is_processed || matches!(R::response_type(), ResponseType::Block))
         {
             // maybe_start_processing returns Some if state == AwaitingProcess. This pattern is
             // useful to conditionally access the result data.
             if let Some(result) = request.get_state_mut().maybe_start_processing() {
+                // Lookup sync event safety: If `send_for_processing` returns Ok() we are guaranteed
+                // that `BlockLookups::on_processing_result` will be called exactly once with this
+                // lookup_id
                 return R::send_for_processing(id, result, cx);
             }
+            // Lookup sync event safety: If the request is not in `AwaitingDownload` or
+            // `AwaitingProcessing` state it is guaranteed to receive some event to make progress.
         }
+
+        // Lookup sync event safety: If a lookup is awaiting a parent we are guaranteed to either:
+        // (1) attempt to make progress with `BlockLookups::continue_child_lookups` if the parent
+        // lookup completes, or (2) get dropped if the parent fails and is dropped.
 
         Ok(())
     }
@@ -246,10 +273,9 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.peers.insert(peer_id)
     }
 
-    /// Remove peer from available peers. Return true if there are no more available peers and all
-    /// requests are not expecting any future event (AwaitingDownload).
-    pub fn remove_peer(&mut self, peer_id: &PeerId) -> bool {
-        self.peers.remove(peer_id)
+    /// Remove peer from available peers.
+    pub fn remove_peer(&mut self, peer_id: &PeerId) {
+        self.peers.remove(peer_id);
     }
 
     /// Returns true if this lookup has zero peers

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -290,6 +290,7 @@ impl TestRig {
             .0
     }
 
+    #[track_caller]
     fn expect_no_active_single_lookups(&self) {
         assert!(
             self.active_single_lookups().is_empty(),
@@ -298,6 +299,7 @@ impl TestRig {
         );
     }
 
+    #[track_caller]
     fn expect_no_active_lookups(&self) {
         self.expect_no_active_single_lookups();
     }
@@ -539,10 +541,6 @@ impl TestRig {
         })
     }
 
-    fn peer_disconnected(&mut self, disconnected_peer_id: PeerId) {
-        self.send_sync_message(SyncMessage::Disconnect(disconnected_peer_id));
-    }
-
     /// Return RPCErrors for all active requests of peer
     fn rpc_error_all_active_requests(&mut self, disconnected_peer_id: PeerId) {
         self.drain_network_rx();
@@ -560,6 +558,10 @@ impl TestRig {
                 error: RPCError::Disconnected,
             });
         }
+    }
+
+    fn peer_disconnected(&mut self, peer_id: PeerId) {
+        self.send_sync_message(SyncMessage::Disconnect(peer_id));
     }
 
     fn drain_network_rx(&mut self) {
@@ -1027,6 +1029,28 @@ fn test_single_block_lookup_failure() {
 }
 
 #[test]
+fn test_single_block_lookup_peer_disconnected_then_rpc_error() {
+    let mut rig = TestRig::test_setup();
+
+    let block_hash = Hash256::random();
+    let peer_id = rig.new_connected_peer();
+
+    // Trigger the request.
+    rig.trigger_unknown_block_from_attestation(block_hash, peer_id);
+    let id = rig.expect_block_lookup_request(block_hash);
+
+    // The peer disconnect event reaches sync before the rpc error.
+    rig.peer_disconnected(peer_id);
+    // The lookup is not removed as it can still potentially make progress.
+    rig.assert_single_lookups_count(1);
+    // The request fails.
+    rig.single_lookup_failed(id, peer_id, RPCError::Disconnected);
+    rig.expect_block_lookup_request(block_hash);
+    // The request should be removed from the network context on disconnection.
+    rig.expect_empty_network();
+}
+
+#[test]
 fn test_single_block_lookup_becomes_parent_request() {
     let mut rig = TestRig::test_setup();
 
@@ -1289,19 +1313,9 @@ fn test_lookup_peer_disconnected_no_peers_left_while_request() {
     rig.trigger_unknown_parent_block(peer_id, trigger_block.into());
     rig.peer_disconnected(peer_id);
     rig.rpc_error_all_active_requests(peer_id);
-    rig.expect_no_active_lookups();
-}
-
-#[test]
-fn test_lookup_peer_disconnected_no_peers_left_not_while_request() {
-    let mut rig = TestRig::test_setup();
-    let peer_id = rig.new_connected_peer();
-    let trigger_block = rig.rand_block();
-    rig.trigger_unknown_parent_block(peer_id, trigger_block.into());
-    rig.peer_disconnected(peer_id);
-    // Note: this test case may be removed in the future. It's not strictly necessary to drop a
-    // lookup if there are no peers left. Lookup should only be dropped if it can not make progress
-    rig.expect_no_active_lookups();
+    // Erroring all rpc requests and disconnecting the peer shouldn't remove the requests
+    // from the lookups map as they can still progress.
+    rig.assert_single_lookups_count(2);
 }
 
 #[test]

--- a/beacon_node/network/src/sync/block_sidecar_coupling.rs
+++ b/beacon_node/network/src/sync/block_sidecar_coupling.rs
@@ -1,4 +1,5 @@
 use beacon_chain::block_verification_types::RpcBlock;
+use lighthouse_network::PeerId;
 use ssz_types::VariableList;
 use std::{collections::VecDeque, sync::Arc};
 use types::{BlobSidecar, EthSpec, SignedBeaconBlock};
@@ -17,16 +18,19 @@ pub struct BlocksAndBlobsRequestInfo<E: EthSpec> {
     is_sidecars_stream_terminated: bool,
     /// Used to determine if this accumulator should wait for a sidecars stream termination
     request_type: ByRangeRequestType,
+    /// The peer the request was made to.
+    pub(crate) peer_id: PeerId,
 }
 
 impl<E: EthSpec> BlocksAndBlobsRequestInfo<E> {
-    pub fn new(request_type: ByRangeRequestType) -> Self {
+    pub fn new(request_type: ByRangeRequestType, peer_id: PeerId) -> Self {
         Self {
             accumulated_blocks: <_>::default(),
             accumulated_sidecars: <_>::default(),
             is_blocks_stream_terminated: <_>::default(),
             is_sidecars_stream_terminated: <_>::default(),
             request_type,
+            peer_id,
         }
     }
 
@@ -109,12 +113,14 @@ mod tests {
     use super::BlocksAndBlobsRequestInfo;
     use crate::sync::range_sync::ByRangeRequestType;
     use beacon_chain::test_utils::{generate_rand_block_and_blobs, NumBlobs};
+    use lighthouse_network::PeerId;
     use rand::SeedableRng;
     use types::{test_utils::XorShiftRng, ForkName, MinimalEthSpec as E};
 
     #[test]
     fn no_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::Blocks);
+        let peer_id = PeerId::random();
+        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::Blocks, peer_id);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| generate_rand_block_and_blobs::<E>(ForkName::Base, NumBlobs::None, &mut rng).0)
@@ -133,7 +139,9 @@ mod tests {
 
     #[test]
     fn empty_blobs_into_responses() {
-        let mut info = BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::BlocksAndBlobs);
+        let peer_id = PeerId::random();
+        let mut info =
+            BlocksAndBlobsRequestInfo::<E>::new(ByRangeRequestType::BlocksAndBlobs, peer_id);
         let mut rng = XorShiftRng::from_seed([42; 16]);
         let blocks = (0..4)
             .map(|_| {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -372,16 +372,39 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                             Err(_) => self.update_sync_state(),
                         },
                     }
+                } else {
+                    debug!(
+                        self.log,
+                        "RPC error for range request has no associated entry in network context, ungraceful disconnect";
+                        "peer_id" => %peer_id,
+                        "request_id" => %id,
+                        "error" => ?error,
+                    );
                 }
             }
         }
     }
 
+    /// Handles a peer disconnect.
+    ///
+    /// It is important that a peer disconnect retries all the batches/lookups as
+    /// there is no way to guarantee that libp2p always emits a error along with
+    /// the disconnect.
     fn peer_disconnect(&mut self, peer_id: &PeerId) {
+        // Inject a Disconnected error on all requests associated with the disconnected peer
+        // to retry all batches/lookups
+        for request_id in self.network.peer_disconnected(peer_id) {
+            self.inject_error(*peer_id, request_id, RPCError::Disconnected);
+        }
+
+        // Remove peer from all data structures
         self.range_sync.peer_disconnect(&mut self.network, peer_id);
+        let _ = self
+            .backfill_sync
+            .peer_disconnected(peer_id, &mut self.network);
         self.block_lookups.peer_disconnected(peer_id);
+
         // Regardless of the outcome, we update the sync status.
-        let _ = self.backfill_sync.peer_disconnected(peer_id);
         self.update_sync_state();
     }
 
@@ -951,7 +974,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                     self.network.insert_range_blocks_and_blobs_request(
                         id,
                         resp.sender_id,
-                        BlocksAndBlobsRequestInfo::new(resp.request_type),
+                        BlocksAndBlobsRequestInfo::new(resp.request_type, peer_id),
                     );
                     // inform range that the request needs to be treated as failed
                     // With time we will want to downgrade this log

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -1,5 +1,8 @@
 use beacon_chain::get_block_root;
-use lighthouse_network::rpc::{methods::BlobsByRootRequest, BlocksByRootRequest};
+use lighthouse_network::{
+    rpc::{methods::BlobsByRootRequest, BlocksByRootRequest},
+    PeerId,
+};
 use std::sync::Arc;
 use strum::IntoStaticStr;
 use types::{
@@ -20,13 +23,15 @@ pub enum LookupVerifyError {
 pub struct ActiveBlocksByRootRequest {
     request: BlocksByRootSingleRequest,
     resolved: bool,
+    pub(crate) peer_id: PeerId,
 }
 
 impl ActiveBlocksByRootRequest {
-    pub fn new(request: BlocksByRootSingleRequest) -> Self {
+    pub fn new(request: BlocksByRootSingleRequest, peer_id: PeerId) -> Self {
         Self {
             request,
             resolved: false,
+            peer_id,
         }
     }
 
@@ -94,14 +99,16 @@ pub struct ActiveBlobsByRootRequest<E: EthSpec> {
     request: BlobsByRootSingleBlockRequest,
     blobs: Vec<Arc<BlobSidecar<E>>>,
     resolved: bool,
+    pub(crate) peer_id: PeerId,
 }
 
 impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
-    pub fn new(request: BlobsByRootSingleBlockRequest) -> Self {
+    pub fn new(request: BlobsByRootSingleBlockRequest, peer_id: PeerId) -> Self {
         Self {
             request,
             blobs: vec![],
             resolved: false,
+            peer_id,
         }
     }
 

--- a/beacon_node/network/src/sync/network_context/requests.rs
+++ b/beacon_node/network/src/sync/network_context/requests.rs
@@ -120,7 +120,7 @@ impl<E: EthSpec> ActiveBlobsByRootRequest<E> {
         if self.request.block_root != block_root {
             return Err(LookupVerifyError::UnrequestedBlockRoot(block_root));
         }
-        if !blob.verify_blob_sidecar_inclusion_proof().unwrap_or(false) {
+        if !blob.verify_blob_sidecar_inclusion_proof() {
             return Err(LookupVerifyError::InvalidInclusionProof);
         }
         if !self.request.indices.contains(&blob.index) {

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -174,8 +174,30 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
 
     /// Removes a peer from the chain.
     /// If the peer has active batches, those are considered failed and re-requested.
-    pub fn remove_peer(&mut self, peer_id: &PeerId) -> ProcessingResult {
-        self.peers.remove(peer_id);
+    pub fn remove_peer(
+        &mut self,
+        peer_id: &PeerId,
+        network: &mut SyncNetworkContext<T>,
+    ) -> ProcessingResult {
+        if let Some(batch_ids) = self.peers.remove(peer_id) {
+            // fail the batches.
+            for id in batch_ids {
+                if let Some(batch) = self.batches.get_mut(&id) {
+                    if let BatchOperationOutcome::Failed { blacklist } =
+                        batch.download_failed(true)?
+                    {
+                        return Err(RemoveChain::ChainFailed {
+                            blacklist,
+                            failing_batch: id,
+                        });
+                    }
+                    self.retry_batch_download(network, id)?;
+                } else {
+                    debug!(self.log, "Batch not found while removing peer";
+                        "peer" => %peer_id, "batch" => id)
+                }
+            }
+        }
 
         if self.peers.is_empty() {
             Err(RemoveChain::EmptyPeerPool)

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -278,8 +278,9 @@ where
     /// for this peer. If so we mark the batch as failed. The batch may then hit it's maximum
     /// retries. In this case, we need to remove the chain.
     fn remove_peer(&mut self, network: &mut SyncNetworkContext<T>, peer_id: &PeerId) {
-        for (removed_chain, sync_type, remove_reason) in
-            self.chains.call_all(|chain| chain.remove_peer(peer_id))
+        for (removed_chain, sync_type, remove_reason) in self
+            .chains
+            .call_all(|chain| chain.remove_peer(peer_id, network))
         {
             self.on_chain_removed(
                 removed_chain,

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -602,7 +602,7 @@ impl<E: EthSpec> OperationPool<E> {
                         })
             },
             |address_change| address_change.as_inner().clone(),
-            usize::max_value(),
+            usize::MAX,
         );
         changes.shuffle(&mut thread_rng());
         changes
@@ -1343,7 +1343,7 @@ mod release_tests {
         // Set of indices covered by previous attestations in `best_attestations`.
         let mut seen_indices = BTreeSet::<u64>::new();
         // Used for asserting that rewards are in decreasing order.
-        let mut prev_reward = u64::max_value();
+        let mut prev_reward = u64::MAX;
 
         let mut reward_cache = RewardCache::default();
         reward_cache.update(&state).unwrap();

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate clap;
-
 mod cli;
 mod config;
 

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -7,9 +7,6 @@
 //!
 //! Provides a simple API for storing/retrieving all types that sometimes needs type-hints. See
 //! tests for implementation examples.
-#[macro_use]
-extern crate lazy_static;
-
 mod chunk_writer;
 pub mod chunked_iter;
 pub mod chunked_vector;

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -1,6 +1,7 @@
 pub use lighthouse_metrics::{set_gauge, try_create_int_gauge, *};
 
 use directory::size_of_dir;
+use lazy_static::lazy_static;
 use std::path::Path;
 
 lazy_static! {

--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -133,7 +133,6 @@ where
     #[superstruct(only(Electra))]
     pub earliest_consolidation_epoch: Epoch,
 
-    // TODO(electra) should these be optional?
     #[superstruct(only(Electra))]
     pub pending_balance_deposits: List<PendingBalanceDeposit, E::PendingBalanceDepositsLimit>,
     #[superstruct(only(Electra))]

--- a/book/src/checkpoint-sync.md
+++ b/book/src/checkpoint-sync.md
@@ -146,8 +146,19 @@ For more information on historic state storage see the
 
 To manually specify a checkpoint use the following two flags:
 
-* `--checkpoint-state`: accepts an SSZ-encoded `BeaconState` blob
-* `--checkpoint-block`: accepts an SSZ-encoded `SignedBeaconBlock` blob
+* `--checkpoint-state`: accepts an SSZ-encoded `BeaconState` file
+* `--checkpoint-block`: accepts an SSZ-encoded `SignedBeaconBlock` file
+* `--checkpoint-blobs`: accepts an SSZ-encoded `Blobs` file
+
+The command is as following:
+
+```bash
+curl -H "Accept: application/octet-stream" "http://localhost:5052/eth/v2/debug/beacon/states/$SLOT" > state.ssz
+curl -H "Accept: application/octet-stream" "http://localhost:5052/eth/v2/beacon/blocks/$SLOT" > block.ssz
+curl -H "Accept: application/octet-stream" "http://localhost:5052/eth/v1/beacon/blob_sidecars/$SLOT" > blobs.ssz
+```
+
+where `$SLOT` is the slot number. It can be specified as `head` or `finalized` as well.
 
 _Both_ the state and block must be provided and the state **must** match the block. The
 state may be from the same slot as the block (unadvanced), or advanced to an epoch boundary,

--- a/book/src/database-migrations.md
+++ b/book/src/database-migrations.md
@@ -16,6 +16,7 @@ validator client or the slasher**.
 
 | Lighthouse version | Release date | Schema version | Downgrade available? |
 |--------------------|--------------|----------------|----------------------|
+| v5.2.0             | Jun 2024     | v19            | yes before Deneb     |
 | v5.1.0             | Mar 2024     | v19            | yes before Deneb     |
 | v5.0.0             | Feb 2024     | v19            | yes before Deneb     |
 | v4.6.0             | Dec 2023     | v19            | yes before Deneb     |

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -9,7 +9,7 @@ Usage: lighthouse [OPTIONS] [COMMAND]
 Commands:
   account_manager
           Utilities for generating and managing Ethereum 2.0 accounts. [aliases:
-          a, am, account, account_manager]
+          a, am, account]
   beacon_node
           The primary component which connects to the Ethereum 2.0 P2P network
           and downloads, verifies and stores blocks. Provides a HTTP API for
@@ -30,7 +30,7 @@ Commands:
           validator]
   validator_manager
           Utilities for managing a Lighthouse validator client via the HTTP API.
-          [aliases: vm, validator-manager, validator_manager]
+          [aliases: vm, validator-manager]
   help
           Print this message or the help of the given subcommand(s)
 

--- a/book/src/slasher.md
+++ b/book/src/slasher.md
@@ -114,13 +114,13 @@ changed after initialization.
 
 * Flag: `--slasher-max-db-size GIGABYTES`
 * Argument: maximum size of the database in gigabytes
-* Default: 256 GB
+* Default: 512 GB
 
 Both database backends LMDB and MDBX place a hard limit on the size of the database
 file. You can use the `--slasher-max-db-size` flag to set this limit. It can be adjusted after
 initialization if the limit is reached.
 
-By default the limit is set to accommodate the default history length and around 600K validators (with about 30% headroom) but
+By default the limit is set to accommodate the default history length and around 1 million validators but
 you can set it lower if running with a reduced history length. The space required scales
 approximately linearly in validator count and history length, i.e. if you halve either you can halve
 the space required.

--- a/book/src/slashing-protection.md
+++ b/book/src/slashing-protection.md
@@ -75,7 +75,7 @@ Once you have the slashing protection database from your existing client, you ca
 using this command:
 
 ```bash
-lighthouse account validator slashing-protection import <my_interchange.json>
+lighthouse account validator slashing-protection import filename.json
 ```
 
 When importing an interchange file, you still need to import the validator keystores themselves
@@ -86,7 +86,7 @@ separately, using the instructions for [import validator keys](./mainnet-validat
 You can export Lighthouse's database for use with another client with this command:
 
 ```
-lighthouse account validator slashing-protection export <lighthouse_interchange.json>
+lighthouse account validator slashing-protection export filename.json
 ```
 
 The validator client needs to be stopped in order to export, to guarantee that the data exported is

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "5.2.0"
+version = "5.2.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/compare_fields_derive/src/lib.rs
+++ b/common/compare_fields_derive/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/common/deposit_contract/src/lib.rs
+++ b/common/deposit_contract/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
         let mut deposit_data = DepositData {
             pubkey: keypair.pk.into(),
             withdrawal_credentials: Hash256::from_slice(&[42; 32]),
-            amount: u64::max_value(),
+            amount: u64::MAX,
             signature: Signature::empty().into(),
         };
         deposit_data.signature = deposit_data.create_signature(&keypair.sk, spec);

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -1700,11 +1700,11 @@ impl<E: EthSpec> ForkVersionDeserialize for FullBlockContents<E> {
     }
 }
 
-impl<E: EthSpec> Into<BeaconBlock<E>> for FullBlockContents<E> {
-    fn into(self) -> BeaconBlock<E> {
-        match self {
-            Self::BlockContents(block_and_sidecars) => block_and_sidecars.block,
-            Self::Block(block) => block,
+impl<E: EthSpec> From<FullBlockContents<E>> for BeaconBlock<E> {
+    fn from(from: FullBlockContents<E>) -> BeaconBlock<E> {
+        match from {
+            FullBlockContents::<E>::BlockContents(block_and_sidecars) => block_and_sidecars.block,
+            FullBlockContents::<E>::Block(block) => block,
         }
     }
 }

--- a/common/eth2_interop_keypairs/src/lib.rs
+++ b/common/eth2_interop_keypairs/src/lib.rs
@@ -16,11 +16,9 @@
 //!
 //! This implementation passes the [reference implementation
 //! tests](https://github.com/ethereum/eth2.0-pm/blob/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start/keygen_test_vector.yaml).
-#[macro_use]
-extern crate lazy_static;
-
 use bls::{Keypair, PublicKey, SecretKey};
 use ethereum_hashing::hash;
+use lazy_static::lazy_static;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use std::fs::File;

--- a/common/lighthouse_metrics/src/lib.rs
+++ b/common/lighthouse_metrics/src/lib.rs
@@ -20,8 +20,7 @@
 //! ## Example
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate lazy_static;
+//! use lazy_static::lazy_static;
 //! use lighthouse_metrics::*;
 //!
 //! // These metrics are "magically" linked to the global registry defined in `lighthouse_metrics`.

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v5.2.0-",
-    fallback = "Lighthouse/v5.2.0"
+    prefix = "Lighthouse/v5.2.1-",
+    fallback = "Lighthouse/v5.2.1"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/common/logging/src/async_record.rs
+++ b/common/logging/src/async_record.rs
@@ -123,12 +123,10 @@ impl Serializer for ToSendSerializer {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())
     }
-    #[cfg(integer128)]
     fn emit_u128(&mut self, key: Key, val: u128) -> slog::Result {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())
     }
-    #[cfg(integer128)]
     fn emit_i128(&mut self, key: Key, val: i128) -> slog::Result {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate lazy_static;
-
+use lazy_static::lazy_static;
 use lighthouse_metrics::{
     inc_counter, try_create_int_counter, IntCounter, Result as MetricsResult,
 };

--- a/common/logging/src/tracing_metrics_layer.rs
+++ b/common/logging/src/tracing_metrics_layer.rs
@@ -1,5 +1,6 @@
 //! Exposes [`MetricsLayer`]: A tracing layer that registers metrics of logging events.
 
+use lazy_static::lazy_static;
 use lighthouse_metrics as metrics;
 use tracing_log::NormalizeEvent;
 

--- a/common/slot_clock/src/lib.rs
+++ b/common/slot_clock/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-
 mod manual_slot_clock;
 mod metrics;
 mod system_time_slot_clock;

--- a/common/slot_clock/src/metrics.rs
+++ b/common/slot_clock/src/metrics.rs
@@ -1,4 +1,5 @@
 use crate::SlotClock;
+use lazy_static::lazy_static;
 pub use lighthouse_metrics::*;
 use types::{EthSpec, Slot};
 

--- a/common/test_random_derive/src/lib.rs
+++ b/common/test_random_derive/src/lib.rs
@@ -1,6 +1,4 @@
-extern crate proc_macro;
-
-use crate::proc_macro::TokenStream;
+use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 

--- a/common/validator_dir/src/validator_dir.rs
+++ b/common/validator_dir/src/validator_dir.rs
@@ -39,8 +39,6 @@ pub enum Error {
     /// generally caused by supplying an `amount` at deposit-time that is different to the one used
     /// at generation-time.
     Eth1DepositRootMismatch,
-    #[cfg(feature = "unencrypted_keys")]
-    SszKeypairError(String),
 }
 
 /// Information required to submit a deposit to the Eth1 deposit contract.

--- a/consensus/proto_array/src/fork_choice_test_definition.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition.rs
@@ -285,17 +285,17 @@ impl ForkChoiceTestDefinition {
     }
 }
 
-/// Gives a root that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a root that is not the zero hash (unless i is `usize::MAX)`.
 fn get_root(i: u64) -> Hash256 {
     Hash256::from_low_u64_be(i + 1)
 }
 
-/// Gives a hash that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a hash that is not the zero hash (unless i is `usize::MAX)`.
 fn get_hash(i: u64) -> ExecutionBlockHash {
     ExecutionBlockHash::from_root(get_root(i))
 }
 
-/// Gives a checkpoint with a root that is not the zero hash (unless i is `usize::max_value)`.
+/// Gives a checkpoint with a root that is not the zero hash (unless i is `usize::MAX)`.
 /// `Epoch` will always equal `i`.
 fn get_checkpoint(i: u64) -> Checkpoint {
     Checkpoint {

--- a/consensus/proto_array/src/fork_choice_test_definition/votes.rs
+++ b/consensus/proto_array/src/fork_choice_test_definition/votes.rs
@@ -738,7 +738,7 @@ pub fn get_votes_test_definition() -> ForkChoiceTestDefinition {
     // Ensure that pruning below the prune threshold does not prune.
     ops.push(Operation::Prune {
         finalized_root: get_root(5),
-        prune_threshold: usize::max_value(),
+        prune_threshold: usize::MAX,
         expected_len: 11,
     });
 

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -145,24 +145,24 @@ impl TryInto<ProtoNode> for ProtoNodeV16 {
     }
 }
 
-impl Into<ProtoNodeV16> for ProtoNode {
-    fn into(self) -> ProtoNodeV16 {
+impl From<ProtoNode> for ProtoNodeV16 {
+    fn from(from: ProtoNode) -> ProtoNodeV16 {
         ProtoNodeV16 {
-            slot: self.slot,
-            state_root: self.state_root,
-            target_root: self.target_root,
-            current_epoch_shuffling_id: self.current_epoch_shuffling_id,
-            next_epoch_shuffling_id: self.next_epoch_shuffling_id,
-            root: self.root,
-            parent: self.parent,
-            justified_checkpoint: Some(self.justified_checkpoint),
-            finalized_checkpoint: Some(self.finalized_checkpoint),
-            weight: self.weight,
-            best_child: self.best_child,
-            best_descendant: self.best_descendant,
-            execution_status: self.execution_status,
-            unrealized_justified_checkpoint: self.unrealized_justified_checkpoint,
-            unrealized_finalized_checkpoint: self.unrealized_finalized_checkpoint,
+            slot: from.slot,
+            state_root: from.state_root,
+            target_root: from.target_root,
+            current_epoch_shuffling_id: from.current_epoch_shuffling_id,
+            next_epoch_shuffling_id: from.next_epoch_shuffling_id,
+            root: from.root,
+            parent: from.parent,
+            justified_checkpoint: Some(from.justified_checkpoint),
+            finalized_checkpoint: Some(from.finalized_checkpoint),
+            weight: from.weight,
+            best_child: from.best_child,
+            best_descendant: from.best_descendant,
+            execution_status: from.execution_status,
+            unrealized_justified_checkpoint: from.unrealized_justified_checkpoint,
+            unrealized_finalized_checkpoint: from.unrealized_finalized_checkpoint,
         }
     }
 }

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -995,7 +995,7 @@ mod test_compute_deltas {
     use super::*;
     use types::MainnetEthSpec;
 
-    /// Gives a hash that is not the zero hash (unless i is `usize::max_value)`.
+    /// Gives a hash that is not the zero hash (unless i is `usize::MAX)`.
     fn hash_from_index(i: usize) -> Hash256 {
         Hash256::from_low_u64_be(i as u64 + 1)
     }

--- a/consensus/proto_array/src/ssz_container.rs
+++ b/consensus/proto_array/src/ssz_container.rs
@@ -55,19 +55,19 @@ impl TryInto<SszContainer> for SszContainerV16 {
     }
 }
 
-impl Into<SszContainerV16> for SszContainer {
-    fn into(self) -> SszContainerV16 {
-        let nodes = self.nodes.into_iter().map(Into::into).collect();
+impl From<SszContainer> for SszContainerV16 {
+    fn from(from: SszContainer) -> SszContainerV16 {
+        let nodes = from.nodes.into_iter().map(Into::into).collect();
 
         SszContainerV16 {
-            votes: self.votes,
-            balances: self.balances,
-            prune_threshold: self.prune_threshold,
-            justified_checkpoint: self.justified_checkpoint,
-            finalized_checkpoint: self.finalized_checkpoint,
+            votes: from.votes,
+            balances: from.balances,
+            prune_threshold: from.prune_threshold,
+            justified_checkpoint: from.justified_checkpoint,
+            finalized_checkpoint: from.finalized_checkpoint,
             nodes,
-            indices: self.indices,
-            previous_proposer_boost: self.previous_proposer_boost,
+            indices: from.indices,
+            previous_proposer_boost: from.previous_proposer_boost,
         }
     }
 }

--- a/consensus/safe_arith/src/lib.rs
+++ b/consensus/safe_arith/src/lib.rs
@@ -155,12 +155,12 @@ mod test {
 
     #[test]
     fn errors() {
-        assert!(u32::max_value().safe_add(1).is_err());
-        assert!(u32::min_value().safe_sub(1).is_err());
-        assert!(u32::max_value().safe_mul(2).is_err());
-        assert!(u32::max_value().safe_div(0).is_err());
-        assert!(u32::max_value().safe_rem(0).is_err());
-        assert!(u32::max_value().safe_shl(32).is_err());
-        assert!(u32::max_value().safe_shr(32).is_err());
+        assert!(u32::MAX.safe_add(1).is_err());
+        assert!(u32::MIN.safe_sub(1).is_err());
+        assert!(u32::MAX.safe_mul(2).is_err());
+        assert!(u32::MAX.safe_div(0).is_err());
+        assert!(u32::MAX.safe_rem(0).is_err());
+        assert!(u32::MAX.safe_shl(32).is_err());
+        assert!(u32::MAX.safe_shr(32).is_err());
     }
 }

--- a/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
+++ b/consensus/state_processing/src/per_epoch_processing/base/validator_statuses.rs
@@ -30,7 +30,7 @@ impl Default for InclusionInfo {
     /// Defaults to `delay` at its maximum value and `proposer_index` at zero.
     fn default() -> Self {
         Self {
-            delay: u64::max_value(),
+            delay: u64::MAX,
             proposer_index: 0,
         }
     }

--- a/consensus/swap_or_not_shuffle/src/compute_shuffled_index.rs
+++ b/consensus/swap_or_not_shuffle/src/compute_shuffled_index.rs
@@ -17,7 +17,7 @@ use std::cmp::max;
 ///  - `list_size == 0`
 ///  - `index >= list_size`
 ///  - `list_size > 2**24`
-///  - `list_size > usize::max_value() / 2`
+///  - `list_size > usize::MAX / 2`
 pub fn compute_shuffled_index(
     index: usize,
     list_size: usize,
@@ -26,7 +26,7 @@ pub fn compute_shuffled_index(
 ) -> Option<usize> {
     if list_size == 0
         || index >= list_size
-        || list_size > usize::max_value() / 2
+        || list_size > usize::MAX / 2
         || list_size > 2_usize.pow(24)
     {
         return None;
@@ -140,7 +140,7 @@ mod tests {
     fn returns_none_for_too_large_list() {
         assert_eq!(
             None,
-            compute_shuffled_index(100, usize::max_value() / 2, &[42, 42], 90)
+            compute_shuffled_index(100, usize::MAX / 2, &[42, 42], 90)
         );
     }
 }

--- a/consensus/swap_or_not_shuffle/src/shuffle_list.rs
+++ b/consensus/swap_or_not_shuffle/src/shuffle_list.rs
@@ -75,7 +75,7 @@ impl Buf {
 /// Returns `None` under any of the following conditions:
 ///  - `list_size == 0`
 ///  - `list_size > 2**24`
-///  - `list_size > usize::max_value() / 2`
+///  - `list_size > usize::MAX / 2`
 pub fn shuffle_list(
     mut input: Vec<usize>,
     rounds: u8,
@@ -84,10 +84,7 @@ pub fn shuffle_list(
 ) -> Option<Vec<usize>> {
     let list_size = input.len();
 
-    if input.is_empty()
-        || list_size > usize::max_value() / 2
-        || list_size > 2_usize.pow(24)
-        || rounds == 0
+    if input.is_empty() || list_size > usize::MAX / 2 || list_size > 2_usize.pow(24) || rounds == 0
     {
         return None;
     }

--- a/consensus/types/benches/benches.rs
+++ b/consensus/types/benches/benches.rs
@@ -36,8 +36,8 @@ fn get_state<E: EthSpec>(validator_count: usize) -> BeaconState<E> {
                 slashed: false,
                 activation_eligibility_epoch: Epoch::new(0),
                 activation_epoch: Epoch::new(0),
-                exit_epoch: Epoch::from(u64::max_value()),
-                withdrawable_epoch: Epoch::from(u64::max_value()),
+                exit_epoch: Epoch::from(u64::MAX),
+                withdrawable_epoch: Epoch::from(u64::MAX),
             })
             .collect(),
     )

--- a/consensus/types/src/beacon_state/committee_cache.rs
+++ b/consensus/types/src/beacon_state/committee_cache.rs
@@ -86,7 +86,7 @@ impl CommitteeCache {
         }
 
         // The use of `NonZeroUsize` reduces the maximum number of possible validators by one.
-        if state.validators().len() == usize::max_value() {
+        if state.validators().len() == usize::MAX {
             return Err(Error::TooManyValidators);
         }
 

--- a/consensus/types/src/beacon_state/committee_cache/tests.rs
+++ b/consensus/types/src/beacon_state/committee_cache/tests.rs
@@ -2,6 +2,7 @@
 use crate::test_utils::*;
 use beacon_chain::test_utils::{BeaconChainHarness, EphemeralHarnessType};
 use beacon_chain::types::*;
+use lazy_static::lazy_static;
 use swap_or_not_shuffle::shuffle_list;
 
 pub const VALIDATOR_COUNT: usize = 16;

--- a/consensus/types/src/beacon_state/tests.rs
+++ b/consensus/types/src/beacon_state/tests.rs
@@ -6,6 +6,7 @@ use beacon_chain::types::{
     ChainSpec, Domain, Epoch, EthSpec, Hash256, Keypair, MainnetEthSpec, MinimalEthSpec,
     RelativeEpoch, Slot, Vector,
 };
+use lazy_static::lazy_static;
 use ssz::Encode;
 use std::ops::Mul;
 use swap_or_not_shuffle::compute_shuffled_index;

--- a/consensus/types/src/blob_sidecar.rs
+++ b/consensus/types/src/blob_sidecar.rs
@@ -6,10 +6,7 @@ use crate::{
 use crate::{KzgProofs, SignedBeaconBlock};
 use bls::Signature;
 use derivative::Derivative;
-use kzg::{
-    Blob as KzgBlob, Kzg, KzgCommitment, KzgProof, BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT,
-    FIELD_ELEMENTS_PER_BLOB,
-};
+use kzg::{Blob as KzgBlob, Kzg, KzgCommitment, KzgProof, BYTES_PER_BLOB, BYTES_PER_FIELD_ELEMENT};
 use merkle_proof::{merkle_root_from_branch, verify_merkle_proof, MerkleTreeError};
 use rand::Rng;
 use safe_arith::ArithError;
@@ -221,13 +218,7 @@ impl<E: EthSpec> BlobSidecar<E> {
         rng.fill_bytes(&mut blob_bytes);
         // Ensure that the blob is canonical by ensuring that
         // each field element contained in the blob is < BLS_MODULUS
-        for i in 0..FIELD_ELEMENTS_PER_BLOB {
-            let Some(byte) = blob_bytes.get_mut(
-                i.checked_mul(BYTES_PER_FIELD_ELEMENT)
-                    .ok_or("overflow".to_string())?,
-            ) else {
-                return Err(format!("blob byte index out of bounds: {:?}", i));
-            };
+        for byte in blob_bytes.iter_mut().step_by(BYTES_PER_FIELD_ELEMENT) {
             *byte = 0;
         }
 

--- a/consensus/types/src/execution_payload_header.rs
+++ b/consensus/types/src/execution_payload_header.rs
@@ -120,7 +120,6 @@ impl<E: EthSpec> ExecutionPayloadHeader<E> {
     #[allow(clippy::arithmetic_side_effects)]
     pub fn ssz_max_var_len_for_fork(fork_name: ForkName) -> usize {
         // Matching here in case variable fields are added in future forks.
-        // TODO(electra): review electra changes
         match fork_name {
             ForkName::Base
             | ForkName::Altair

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -37,9 +37,9 @@ impl From<[u8; GRAFFITI_BYTES_LEN]> for Graffiti {
     }
 }
 
-impl Into<[u8; GRAFFITI_BYTES_LEN]> for Graffiti {
-    fn into(self) -> [u8; GRAFFITI_BYTES_LEN] {
-        self.0
+impl From<Graffiti> for [u8; GRAFFITI_BYTES_LEN] {
+    fn from(from: Graffiti) -> [u8; GRAFFITI_BYTES_LEN] {
+        from.0
     }
 }
 
@@ -77,9 +77,9 @@ impl<'de> Deserialize<'de> for GraffitiString {
     }
 }
 
-impl Into<Graffiti> for GraffitiString {
-    fn into(self) -> Graffiti {
-        let graffiti_bytes = self.0.as_bytes();
+impl From<GraffitiString> for Graffiti {
+    fn from(from: GraffitiString) -> Graffiti {
+        let graffiti_bytes = from.0.as_bytes();
         let mut graffiti = [0; GRAFFITI_BYTES_LEN];
 
         let graffiti_len = std::cmp::min(graffiti_bytes.len(), GRAFFITI_BYTES_LEN);

--- a/consensus/types/src/lib.rs
+++ b/consensus/types/src/lib.rs
@@ -10,8 +10,6 @@
 )]
 
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 pub mod test_utils;
 
 pub mod aggregate_and_proof;

--- a/consensus/types/src/selection_proof.rs
+++ b/consensus/types/src/selection_proof.rs
@@ -77,9 +77,9 @@ impl SelectionProof {
     }
 }
 
-impl Into<Signature> for SelectionProof {
-    fn into(self) -> Signature {
-        self.0
+impl From<SelectionProof> for Signature {
+    fn from(from: SelectionProof) -> Signature {
+        from.0
     }
 }
 

--- a/consensus/types/src/slot_epoch.rs
+++ b/consensus/types/src/slot_epoch.rs
@@ -70,7 +70,7 @@ impl Slot {
     }
 
     pub fn max_value() -> Slot {
-        Slot(u64::max_value())
+        Slot(u64::MAX)
     }
 }
 
@@ -80,7 +80,7 @@ impl Epoch {
     }
 
     pub fn max_value() -> Epoch {
-        Epoch(u64::max_value())
+        Epoch(u64::MAX)
     }
 
     /// The first slot in the epoch.
@@ -176,10 +176,10 @@ mod epoch_tests {
         let slots_per_epoch = 32;
 
         // The last epoch which can be represented by u64.
-        let epoch = Epoch::new(u64::max_value() / slots_per_epoch);
+        let epoch = Epoch::new(u64::MAX / slots_per_epoch);
 
         // A slot number on the epoch should be equal to u64::max_value.
-        assert_eq!(epoch.end_slot(slots_per_epoch), Slot::new(u64::max_value()));
+        assert_eq!(epoch.end_slot(slots_per_epoch), Slot::new(u64::MAX));
     }
 
     #[test]

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -352,7 +352,7 @@ macro_rules! new_tests {
         fn new() {
             assert_eq!($type(0), $type::new(0));
             assert_eq!($type(3), $type::new(3));
-            assert_eq!($type(u64::max_value()), $type::new(u64::max_value()));
+            assert_eq!($type(u64::MAX), $type::new(u64::MAX));
         }
     };
 }
@@ -368,17 +368,17 @@ macro_rules! from_into_tests {
             let x: $other = $type(3).into();
             assert_eq!(x, 3);
 
-            let x: $other = $type(u64::max_value()).into();
+            let x: $other = $type(u64::MAX).into();
             // Note: this will fail on 32 bit systems. This is expected as we don't have a proper
             // 32-bit system strategy in place.
-            assert_eq!(x, $other::max_value());
+            assert_eq!(x, $other::MAX);
         }
 
         #[test]
         fn from() {
             assert_eq!($type(0), $type::from(0_u64));
             assert_eq!($type(3), $type::from(3_u64));
-            assert_eq!($type(u64::max_value()), $type::from($other::max_value()));
+            assert_eq!($type(u64::MAX), $type::from($other::MAX));
         }
     };
 }
@@ -396,8 +396,8 @@ macro_rules! math_between_tests {
 
             assert_partial_ord(1, Ordering::Less, 2);
             assert_partial_ord(2, Ordering::Greater, 1);
-            assert_partial_ord(0, Ordering::Less, u64::max_value());
-            assert_partial_ord(u64::max_value(), Ordering::Greater, 0);
+            assert_partial_ord(0, Ordering::Less, u64::MAX);
+            assert_partial_ord(u64::MAX, Ordering::Greater, 0);
         }
 
         #[test]
@@ -412,9 +412,9 @@ macro_rules! math_between_tests {
             assert_partial_eq(1, 0, false);
             assert_partial_eq(1, 1, true);
 
-            assert_partial_eq(u64::max_value(), u64::max_value(), true);
-            assert_partial_eq(0, u64::max_value(), false);
-            assert_partial_eq(u64::max_value(), 0, false);
+            assert_partial_eq(u64::MAX, u64::MAX, true);
+            assert_partial_eq(0, u64::MAX, false);
+            assert_partial_eq(u64::MAX, 0, false);
         }
 
         #[test]
@@ -436,8 +436,8 @@ macro_rules! math_between_tests {
             assert_add(7, 7, 14);
 
             // Addition should be saturating.
-            assert_add(u64::max_value(), 1, u64::max_value());
-            assert_add(u64::max_value(), u64::max_value(), u64::max_value());
+            assert_add(u64::MAX, 1, u64::MAX);
+            assert_add(u64::MAX, u64::MAX, u64::MAX);
         }
 
         #[test]
@@ -455,8 +455,8 @@ macro_rules! math_between_tests {
             assert_sub(1, 0, 1);
             assert_sub(2, 1, 1);
             assert_sub(14, 7, 7);
-            assert_sub(u64::max_value(), 1, u64::max_value() - 1);
-            assert_sub(u64::max_value(), u64::max_value(), 0);
+            assert_sub(u64::MAX, 1, u64::MAX - 1);
+            assert_sub(u64::MAX, u64::MAX, 0);
 
             // Subtraction should be saturating
             assert_sub(0, 1, 0);
@@ -480,7 +480,7 @@ macro_rules! math_between_tests {
             assert_mul(0, 2, 0);
 
             // Multiplication should be saturating.
-            assert_mul(u64::max_value(), 2, u64::max_value());
+            assert_mul(u64::MAX, 2, u64::MAX);
         }
 
         #[test]
@@ -499,7 +499,7 @@ macro_rules! math_between_tests {
             assert_div(2, 2, 1);
             assert_div(100, 50, 2);
             assert_div(128, 2, 64);
-            assert_div(u64::max_value(), 2, 2_u64.pow(63) - 1);
+            assert_div(u64::MAX, 2, 2_u64.pow(63) - 1);
         }
 
         #[test]
@@ -544,8 +544,8 @@ macro_rules! math_tests {
             assert_saturating_sub(1, 0, 1);
             assert_saturating_sub(2, 1, 1);
             assert_saturating_sub(14, 7, 7);
-            assert_saturating_sub(u64::max_value(), 1, u64::max_value() - 1);
-            assert_saturating_sub(u64::max_value(), u64::max_value(), 0);
+            assert_saturating_sub(u64::MAX, 1, u64::MAX - 1);
+            assert_saturating_sub(u64::MAX, u64::MAX, 0);
 
             // Subtraction should be saturating
             assert_saturating_sub(0, 1, 0);
@@ -565,8 +565,8 @@ macro_rules! math_tests {
             assert_saturating_add(7, 7, 14);
 
             // Addition should be saturating.
-            assert_saturating_add(u64::max_value(), 1, u64::max_value());
-            assert_saturating_add(u64::max_value(), u64::max_value(), u64::max_value());
+            assert_saturating_add(u64::MAX, 1, u64::MAX);
+            assert_saturating_add(u64::MAX, u64::MAX, u64::MAX);
         }
 
         #[test]
@@ -581,11 +581,11 @@ macro_rules! math_tests {
             assert_checked_div(2, 2, Some(1));
             assert_checked_div(100, 50, Some(2));
             assert_checked_div(128, 2, Some(64));
-            assert_checked_div(u64::max_value(), 2, Some(2_u64.pow(63) - 1));
+            assert_checked_div(u64::MAX, 2, Some(2_u64.pow(63) - 1));
 
             assert_checked_div(2, 0, None);
             assert_checked_div(0, 0, None);
-            assert_checked_div(u64::max_value(), 0, None);
+            assert_checked_div(u64::MAX, 0, None);
         }
 
         #[test]
@@ -607,7 +607,7 @@ macro_rules! math_tests {
             assert_is_power_of_two(4, true);
 
             assert_is_power_of_two(2_u64.pow(4), true);
-            assert_is_power_of_two(u64::max_value(), false);
+            assert_is_power_of_two(u64::MAX, false);
         }
 
         #[test]
@@ -619,8 +619,8 @@ macro_rules! math_tests {
 
             assert_ord(1, Ordering::Less, 2);
             assert_ord(2, Ordering::Greater, 1);
-            assert_ord(0, Ordering::Less, u64::max_value());
-            assert_ord(u64::max_value(), Ordering::Greater, 0);
+            assert_ord(0, Ordering::Less, u64::MAX);
+            assert_ord(u64::MAX, Ordering::Greater, 0);
         }
     };
 }
@@ -647,8 +647,8 @@ macro_rules! all_tests {
                 let x = $type(3).as_u64();
                 assert_eq!(x, 3);
 
-                let x = $type(u64::max_value()).as_u64();
-                assert_eq!(x, u64::max_value());
+                let x = $type(u64::MAX).as_u64();
+                assert_eq!(x, u64::MAX);
             }
         }
 
@@ -665,8 +665,8 @@ macro_rules! all_tests {
                 let x = $type(3).as_usize();
                 assert_eq!(x, 3);
 
-                let x = $type(u64::max_value()).as_usize();
-                assert_eq!(x, usize::max_value());
+                let x = $type(u64::MAX).as_usize();
+                assert_eq!(x, usize::MAX);
             }
         }
     };

--- a/consensus/types/src/slot_epoch_macros.rs
+++ b/consensus/types/src/slot_epoch_macros.rs
@@ -6,9 +6,9 @@ macro_rules! impl_from_into_u64 {
             }
         }
 
-        impl Into<u64> for $main {
-            fn into(self) -> u64 {
-                self.0
+        impl From<$main> for u64 {
+            fn from(from: $main) -> u64 {
+                from.0
             }
         }
 
@@ -28,9 +28,9 @@ macro_rules! impl_from_into_usize {
             }
         }
 
-        impl Into<usize> for $main {
-            fn into(self) -> usize {
-                self.0 as usize
+        impl From<$main> for usize {
+            fn from(from: $main) -> usize {
+                from.0 as usize
             }
         }
 

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -1,5 +1,6 @@
 //! Identifies each shard by an integer identifier.
 use crate::{AttestationData, ChainSpec, CommitteeIndex, Epoch, EthSpec, Slot};
+use lazy_static::lazy_static;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use std::ops::{Deref, DerefMut};

--- a/consensus/types/src/subnet_id.rs
+++ b/consensus/types/src/subnet_id.rs
@@ -150,15 +150,15 @@ impl From<u64> for SubnetId {
     }
 }
 
-impl Into<u64> for SubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<SubnetId> for u64 {
+    fn from(from: SubnetId) -> u64 {
+        from.0
     }
 }
 
-impl Into<u64> for &SubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<&SubnetId> for u64 {
+    fn from(from: &SubnetId) -> u64 {
+        from.0
     }
 }
 

--- a/consensus/types/src/sync_selection_proof.rs
+++ b/consensus/types/src/sync_selection_proof.rs
@@ -90,9 +90,9 @@ impl SyncSelectionProof {
     }
 }
 
-impl Into<Signature> for SyncSelectionProof {
-    fn into(self) -> Signature {
-        self.0
+impl From<SyncSelectionProof> for Signature {
+    fn from(from: SyncSelectionProof) -> Signature {
+        from.0
     }
 }
 

--- a/consensus/types/src/sync_subnet_id.rs
+++ b/consensus/types/src/sync_subnet_id.rs
@@ -1,6 +1,7 @@
 //! Identifies each sync committee subnet by an integer identifier.
 use crate::consts::altair::SYNC_COMMITTEE_SUBNET_COUNT;
 use crate::EthSpec;
+use lazy_static::lazy_static;
 use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz_types::typenum::Unsigned;

--- a/consensus/types/src/sync_subnet_id.rs
+++ b/consensus/types/src/sync_subnet_id.rs
@@ -78,15 +78,15 @@ impl From<u64> for SyncSubnetId {
     }
 }
 
-impl Into<u64> for SyncSubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<SyncSubnetId> for u64 {
+    fn from(from: SyncSubnetId) -> u64 {
+        from.0
     }
 }
 
-impl Into<u64> for &SyncSubnetId {
-    fn into(self) -> u64 {
-        self.0
+impl From<&SyncSubnetId> for u64 {
+    fn from(from: &SyncSubnetId) -> u64 {
+        from.0
     }
 }
 

--- a/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
+++ b/consensus/types/src/test_utils/generate_random_block_and_blobs.rs
@@ -1,0 +1,96 @@
+use rand::Rng;
+
+use kzg::{KzgCommitment, KzgProof};
+
+use crate::beacon_block_body::KzgCommitments;
+use crate::*;
+
+use super::*;
+
+type BlobsBundle<E> = (KzgCommitments<E>, KzgProofs<E>, BlobsList<E>);
+
+pub fn generate_rand_block_and_blobs<E: EthSpec>(
+    fork_name: ForkName,
+    num_blobs: usize,
+    rng: &mut impl Rng,
+) -> (SignedBeaconBlock<E, FullPayload<E>>, Vec<BlobSidecar<E>>) {
+    let inner = map_fork_name!(fork_name, BeaconBlock, <_>::random_for_test(rng));
+    let mut block = SignedBeaconBlock::from_block(inner, Signature::random_for_test(rng));
+    let mut blob_sidecars = vec![];
+
+    if block.fork_name_unchecked() < ForkName::Deneb {
+        return (block, blob_sidecars);
+    }
+
+    let (commitments, proofs, blobs) = generate_blobs::<E>(num_blobs).unwrap();
+    *block
+        .message_mut()
+        .body_mut()
+        .blob_kzg_commitments_mut()
+        .expect("kzg commitment expected from Deneb") = commitments.clone();
+
+    for (index, ((blob, kzg_commitment), kzg_proof)) in blobs
+        .into_iter()
+        .zip(commitments.into_iter())
+        .zip(proofs.into_iter())
+        .enumerate()
+    {
+        blob_sidecars.push(BlobSidecar {
+            index: index as u64,
+            blob: blob.clone(),
+            kzg_commitment,
+            kzg_proof,
+            signed_block_header: block.signed_block_header(),
+            kzg_commitment_inclusion_proof: block
+                .message()
+                .body()
+                .kzg_commitment_merkle_proof(index)
+                .unwrap(),
+        });
+    }
+    (block, blob_sidecars)
+}
+
+pub fn generate_blobs<E: EthSpec>(n_blobs: usize) -> Result<BlobsBundle<E>, String> {
+    let (mut commitments, mut proofs, mut blobs) = BlobsBundle::<E>::default();
+
+    for blob_index in 0..n_blobs {
+        blobs
+            .push(Blob::<E>::default())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+        commitments
+            .push(KzgCommitment::empty_for_testing())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+        proofs
+            .push(KzgProof::empty())
+            .map_err(|_| format!("blobs are full, blob index: {:?}", blob_index))?;
+    }
+
+    Ok((commitments, proofs, blobs))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rand::thread_rng;
+
+    #[test]
+    fn test_verify_blob_inclusion_proof() {
+        let (_block, blobs) =
+            generate_rand_block_and_blobs::<MainnetEthSpec>(ForkName::Deneb, 6, &mut thread_rng());
+        for blob in blobs {
+            assert!(blob.verify_blob_sidecar_inclusion_proof());
+        }
+    }
+
+    #[test]
+    fn test_verify_blob_inclusion_proof_invalid() {
+        let (_block, blobs) =
+            generate_rand_block_and_blobs::<MainnetEthSpec>(ForkName::Deneb, 6, &mut thread_rng());
+
+        for mut blob in blobs {
+            blob.kzg_commitment_inclusion_proof = FixedVector::random_for_test(&mut thread_rng());
+            assert!(!blob.verify_blob_sidecar_inclusion_proof());
+        }
+    }
+}

--- a/consensus/types/src/test_utils/mod.rs
+++ b/consensus/types/src/test_utils/mod.rs
@@ -15,6 +15,8 @@ use tree_hash::TreeHash;
 #[macro_use]
 mod macros;
 mod generate_deterministic_keypairs;
+#[cfg(test)]
+mod generate_random_block_and_blobs;
 mod test_random;
 
 pub fn test_ssz_tree_hash_pair<T, U>(v1: &T, v2: &U)

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -254,12 +254,12 @@ impl Default for Validator {
         Self {
             pubkey: PublicKeyBytes::empty(),
             withdrawal_credentials: Hash256::default(),
-            activation_eligibility_epoch: Epoch::from(std::u64::MAX),
-            activation_epoch: Epoch::from(std::u64::MAX),
-            exit_epoch: Epoch::from(std::u64::MAX),
-            withdrawable_epoch: Epoch::from(std::u64::MAX),
+            activation_eligibility_epoch: Epoch::from(u64::MAX),
+            activation_epoch: Epoch::from(u64::MAX),
+            exit_epoch: Epoch::from(u64::MAX),
+            withdrawable_epoch: Epoch::from(u64::MAX),
             slashed: false,
-            effective_balance: std::u64::MAX,
+            effective_balance: u64::MAX,
         }
     }
 }

--- a/crypto/eth2_key_derivation/tests/tests.rs
+++ b/crypto/eth2_key_derivation/tests/tests.rs
@@ -22,7 +22,7 @@ fn deterministic() {
 fn children_deterministic() {
     let master = DerivedKey::from_seed(&[42]).unwrap();
     assert_eq!(
-        master.child(u32::max_value()).secret(),
-        master.child(u32::max_value()).secret(),
+        master.child(u32::MAX).secret(),
+        master.child(u32::MAX).secret(),
     )
 }

--- a/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/checksum_module.rs
@@ -14,9 +14,9 @@ pub enum ChecksumFunction {
     Sha256,
 }
 
-impl Into<String> for ChecksumFunction {
-    fn into(self) -> String {
-        match self {
+impl From<ChecksumFunction> for String {
+    fn from(from: ChecksumFunction) -> String {
+        match from {
             ChecksumFunction::Sha256 => "sha256".into(),
         }
     }
@@ -38,8 +38,8 @@ impl TryFrom<String> for ChecksumFunction {
 #[serde(try_from = "Value", into = "Value")]
 pub struct EmptyMap;
 
-impl Into<Value> for EmptyMap {
-    fn into(self) -> Value {
+impl From<EmptyMap> for Value {
+    fn from(_from: EmptyMap) -> Value {
         Value::Object(Map::default())
     }
 }

--- a/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/cipher_module.rs
@@ -13,9 +13,9 @@ pub enum CipherFunction {
     Aes128Ctr,
 }
 
-impl Into<String> for CipherFunction {
-    fn into(self) -> String {
-        match self {
+impl From<CipherFunction> for String {
+    fn from(from: CipherFunction) -> String {
+        match from {
             CipherFunction::Aes128Ctr => "aes-128-ctr".into(),
         }
     }

--- a/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
+++ b/crypto/eth2_keystore/src/json_keystore/hex_bytes.rs
@@ -25,9 +25,9 @@ impl From<Vec<u8>> for HexBytes {
     }
 }
 
-impl Into<String> for HexBytes {
-    fn into(self) -> String {
-        hex::encode(self.0)
+impl From<HexBytes> for String {
+    fn from(from: HexBytes) -> String {
+        hex::encode(from.0)
     }
 }
 

--- a/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
+++ b/crypto/eth2_keystore/src/json_keystore/kdf_module.rs
@@ -23,8 +23,8 @@ pub struct KdfModule {
 #[serde(try_from = "String", into = "String")]
 pub struct EmptyString;
 
-impl Into<String> for EmptyString {
-    fn into(self) -> String {
+impl From<EmptyString> for String {
+    fn from(_from: EmptyString) -> String {
         "".into()
     }
 }
@@ -91,9 +91,9 @@ pub enum KdfFunction {
     Pbkdf2,
 }
 
-impl Into<String> for KdfFunction {
-    fn into(self) -> String {
-        match self {
+impl From<KdfFunction> for String {
+    fn from(from: KdfFunction) -> String {
+        match from {
             KdfFunction::Scrypt => "scrypt".into(),
             KdfFunction::Pbkdf2 => "pbkdf2".into(),
         }

--- a/crypto/eth2_wallet/src/json_wallet/mod.rs
+++ b/crypto/eth2_wallet/src/json_wallet/mod.rs
@@ -39,9 +39,9 @@ pub enum TypeField {
     Hd,
 }
 
-impl Into<String> for TypeField {
-    fn into(self) -> String {
-        match self {
+impl From<TypeField> for String {
+    fn from(from: TypeField) -> String {
+        match from {
             TypeField::Hd => "hierarchical deterministic".into(),
         }
     }

--- a/crypto/eth2_wallet/src/wallet.rs
+++ b/crypto/eth2_wallet/src/wallet.rs
@@ -179,7 +179,7 @@ impl Wallet {
     ///
     /// - If `wallet_password` is unable to decrypt `self`.
     /// - If `keystore_password.is_empty()`.
-    /// - If `self.nextaccount == u32::max_value()`.
+    /// - If `self.nextaccount == u32::MAX`.
     pub fn next_validator(
         &mut self,
         wallet_password: &[u8],

--- a/crypto/kzg/src/kzg_proof.rs
+++ b/crypto/kzg/src/kzg_proof.rs
@@ -38,9 +38,9 @@ impl From<[u8; BYTES_PER_PROOF]> for KzgProof {
     }
 }
 
-impl Into<[u8; BYTES_PER_PROOF]> for KzgProof {
-    fn into(self) -> [u8; BYTES_PER_PROOF] {
-        self.0
+impl From<KzgProof> for [u8; BYTES_PER_PROOF] {
+    fn from(from: KzgProof) -> [u8; BYTES_PER_PROOF] {
+        from.0
     }
 }
 

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "5.2.0"
+version = "5.2.1"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lcli/src/block_root.rs
+++ b/lcli/src/block_root.rs
@@ -32,6 +32,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::BlockId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use types::{EthSpec, FullPayload, SignedBeaconBlock};

--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate log;
 mod block_root;
 mod check_deposit_data;
 mod generate_bootnode_enr;

--- a/lcli/src/parse_ssz.rs
+++ b/lcli/src/parse_ssz.rs
@@ -1,6 +1,7 @@
 use clap::ArgMatches;
 use clap_utils::parse_required;
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use serde::Serialize;
 use snap::raw::Decoder;
 use ssz::Decode;

--- a/lcli/src/skip_slots.rs
+++ b/lcli/src/skip_slots.rs
@@ -50,6 +50,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use ssz::Encode;
 use state_processing::state_advance::{complete_state_advance, partial_state_advance};
 use state_processing::AllCaches;

--- a/lcli/src/state_root.rs
+++ b/lcli/src/state_root.rs
@@ -4,6 +4,7 @@ use clap_utils::{parse_optional, parse_required};
 use environment::Environment;
 use eth2::{types::StateId, BeaconNodeHttpClient, SensitiveUrl, Timeouts};
 use eth2_network_config::Eth2NetworkConfig;
+use log::info;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 use types::{BeaconState, EthSpec};

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -72,6 +72,7 @@ use eth2::{
     BeaconNodeHttpClient, SensitiveUrl, Timeouts,
 };
 use eth2_network_config::Eth2NetworkConfig;
+use log::{debug, info};
 use ssz::Encode;
 use state_processing::state_advance::complete_state_advance;
 use state_processing::{

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "5.2.0"
+version = "5.2.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false

--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -1,201 +1,85 @@
 # Simple Local Testnet
 
-These scripts allow for running a small local testnet with multiple beacon nodes and validator clients and a geth execution client.
+These scripts allow for running a small local testnet with a default of 4 beacon nodes, 4 validator clients and 4 geth execution clients using Kurtosis.
 This setup can be useful for testing and development.
 
-## Requirements
+## Installation
 
-The scripts require `lcli`, `lighthouse`, `geth`, `bootnode` to be installed on `PATH` (run `echo $PATH` to view all `PATH` directories).
+1. Install [Docker](https://docs.docker.com/get-docker/). Verify that Docker has been successfully installed by running `sudo docker run hello-world`. 
 
+1. Install [Kurtosis](https://docs.kurtosis.com/install/). Verify that Kurtosis has been successfully installed by running `kurtosis version` which should display the version.
 
-MacOS users need to install GNU `sed` and GNU `grep`, and add them both to `PATH` as well.
-
-The first step is to install Rust and dependencies. Refer to the [Lighthouse Book](https://lighthouse-book.sigmaprime.io/installation-source.html#dependencies) for installation. We will also need [jq](https://jqlang.github.io/jq/), which can be installed with `sudo apt install jq`.
-
-Then, we clone the Lighthouse repository:
-```bash
-cd ~
-git clone https://github.com/sigp/lighthouse.git
-cd lighthouse
-```
-We are now ready to build Lighthouse. Run the command:
-
-```bash
-make
-make install-lcli
-```
-
-This will build `lighthouse` and `lcli`. For `geth` and `bootnode`, go to [geth website](https://geth.ethereum.org/downloads) and download the `Geth & Tools`. For example, to download and extract `Geth & Tools 1.13.1`:
-
-```bash
-cd ~
-curl -LO https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.13.1-3f40e65c.tar.gz
-tar xvf geth-alltools-linux-amd64-1.13.1-3f40e65c.tar.gz
-```
-
-After extraction, copy `geth` and `bootnode` to the `PATH`. A typical directory is `/usr/local/bin`.
-
-```bash
-cd geth-alltools-linux-amd64-1.13.1-3f40e65c
-sudo cp geth bootnode /usr/local/bin
-```
-
-After that We can remove the downloaded files:
-
-```bash
-cd ~
-rm -r geth-alltools-linux-amd64-1.13.1-3f40e65c geth-alltools-linux-amd64-1.13.1-3f40e65c.tar.gz
-```
-
-We are now ready to start a local testnet.
+1. Install [yq](https://github.com/mikefarah/yq). If you are on Ubuntu, you can install `yq` by running `sudo apt install yq -y`.
 
 ## Starting the testnet
 
-To start a testnet using the predetermined settings:
+To start a testnet, from the Lighthouse root repository:
 
 ```bash
-cd ~
-cd ./lighthouse/scripts/local_testnet
-./start_local_testnet.sh genesis.json
+cd ./scripts/local_testnet
+./start_local_testnet.sh
 ```
 
-This will execute the script and if the testnet setup is successful, you will see "Started!" at the end. 
+It will build a Lighthouse docker image from the root of the directory and will take an approximately 12 minutes to complete. Once built, the testing will be started automatically. You will see a list of services running and "Started!" at the end. 
+You can also select your own Lighthouse docker image to use by specifying it in `network_params.yml` under the `cl_image` key.
+Full configuration reference for kurtosis is specified [here](https://github.com/ethpandaops/ethereum-package?tab=readme-ov-file#configuration).
 
-The testnet starts with a post-merge genesis state. 
-The testnet starts a consensus layer and execution layer boot node along with `BN_COUNT`
-(the number of beacon nodes) each connected to a geth execution client and `VC_COUNT` (the number of validator clients). By default, `BN_COUNT=4`, `VC_COUNT=4`. 
-
-The `start_local_testnet.sh` script takes four options `-v VC_COUNT`, `-d DEBUG_LEVEL`, `-p` to enable builder proposals and `-h` for help. It also takes a mandatory `GENESIS_FILE` for initialising geth's state.
-A sample `genesis.json` is provided in this directory.
-
-The options may be in any order or absent in which case they take the default value specified.
-- VC_COUNT: the number of validator clients to create, default: `BN_COUNT`
-- DEBUG_LEVEL: one of { error, warn, info, debug, trace }, default: `info`
-
-The `ETH1_BLOCK_HASH` environment variable is set to the block_hash of the genesis execution layer block which depends on the contents of `genesis.json`. Users of these scripts need to ensure that the `ETH1_BLOCK_HASH` variable is updated if genesis file is modified.
-
-To view the beacon, validator client and geth logs:
+To view all running services:
 
 ```bash
-tail -f ~/.lighthouse/local-testnet/testnet/beacon_node_1.log
-tail -f ~/.lighthouse/local-testnet/testnet/validator_node_1.log
-tail -f ~/.lighthouse/local-testnet/testnet/geth_1.log
+kurtosis enclave inspect local-testnet
 ```
 
-where `beacon_node_1` can be changed to `beacon_node_2`, `beacon_node_3` or `beacon_node_4` to view logs for different beacon nodes. The same applies to validator clients and geth nodes. 
+To view the logs:
+
+```bash
+kurtosis service logs local-testnet $SERVICE_NAME
+```
+
+where `$SERVICE_NAME` is obtained by inspecting the running services above. For example, to view the logs of the first beacon node, validator client and geth:
+
+```bash
+kurtosis service logs local-testnet -f cl-1-lighthouse-geth 
+kurtosis service logs local-testnet -f vc-1-geth-lighthouse
+kurtosis service logs local-testnet -f el-1-geth-lighthouse
+```
+
+If you would like to save the logs, use the command:
+
+```bash
+kurtosis dump $OUTPUT_DIRECTORY
+```
+
+This will create a folder named `$OUTPUT_DIRECTORY` in the present working directory that contains all logs and other information. If you want the logs for a particular service and saved to a file named `logs.txt`:
+
+```bash
+kurtosis service logs local-testnet $SERVICE_NAME -a > logs.txt
+```
+where `$SERVICE_NAME` can be viewed by running `kurtosis enclave inspect local-testnet`.
+
+Kurtosis comes with a Dora explorer which can be opened with:
+
+```bash
+open $(kurtosis port print local-testnet dora http)
+```
+
+Some testnet parameters can be varied by modifying the `network_params.yaml` file. Kurtosis also comes with a web UI which can be open with `kurtosis web`.
 
 ## Stopping the testnet
 
-To stop the testnet, navigate to the directory `cd ~/lighthouse/scripts/local_testnet`, then run the command:
+To stop the testnet, from the Lighthouse root repository:
 
 ```bash
+cd ./scripts/local_testnet
 ./stop_local_testnet.sh
 ```
 
-Once a testnet is stopped, it cannot be continued from where it left off. When the start local testnet command is run, it will start a new local testnet.
+You will see "Local testnet stopped." at the end. 
 
-## Manual creation of local testnet
+## CLI options
 
-In [Starting the testnet](./README.md#starting-the-testnet), the testnet is started automatically with predetermined parameters (database directory, ports used etc).  This section describes some modifications of the local testnet settings, e.g., changing the database directory, or changing the ports used. 
-
-
-The testnet also contains parameters that are specified in `vars.env`, such as the slot time `SECONDS_PER_SLOT=3` (instead of 12 seconds on mainnet). You may change these parameters to suit your testing purposes. After that, in the `local_testnet` directory, run the following command to create genesis state with embedded validators and validator keys, and also to update the time in `genesis.json`:
+The script comes with some CLI options, which can be viewed with `./start_local_testnet.sh --help`. One of the CLI options is to avoid rebuilding Lighthouse each time the testnet starts, which can be configured with the command:
 
 ```bash
-./setup.sh
-./setup_time.sh genesis.json
+./start_local_testnet.sh -b false
 ```
-
-Note: The generated genesis validators are embedded into the genesis state as genesis validators and hence do not require manual deposits to activate.
-
-Generate bootnode enr and start an EL and CL bootnode so that multiple nodes can find each other
-```bash
-./bootnode.sh
-./el_bootnode.sh
-```
-
-Start a geth node:
-```bash
-./geth.sh <DATADIR> <NETWORK-PORT> <HTTP-PORT> <AUTH-HTTP-PORT> <GENESIS_FILE>
-```
-e.g.
-```bash
-./geth.sh $HOME/.lighthouse/local-testnet/geth_1 7001 6001 5001 genesis.json
-```
-
-Start a beacon node:
-
-```bash
-./beacon_node.sh <DATADIR> <NETWORK-PORT> <QUIC-PORT> <HTTP-PORT> <EXECUTION-ENDPOINT> <EXECUTION-JWT-PATH> <OPTIONAL-DEBUG-LEVEL>
-```
-e.g.
-```bash
-./beacon_node.sh $HOME/.lighthouse/local-testnet/node_1 9001 9101 8001 http://localhost:5001 ~/.lighthouse/local-testnet/geth_1/geth/jwtsecret
-```
-
-In a new terminal, start the validator client which will attach to the first
-beacon node:
-
-```bash
-./validator_client.sh <DATADIR> <BEACON-NODE-HTTP> <OPTIONAL-DEBUG-LEVEL>
-```
-e.g. to attach to the above created beacon node
-```bash
-./validator_client.sh $HOME/.lighthouse/local-testnet/node_1 http://localhost:8001
-```
-
-You can create additional geth, beacon node and validator client instances by changing the ports, e.g., for a second geth, beacon node and validator client:
-
-```bash
-./geth.sh $HOME/.lighthouse/local-testnet/geth_2 7002 6002 5002 genesis.json
-./beacon_node.sh $HOME/.lighthouse/local-testnet/node_2 9002 9102 8002 http://localhost:5002 ~/.lighthouse/local-testnet/geth_2/geth/jwtsecret
-./validator_client.sh $HOME/.lighthouse/local-testnet/node_2 http://localhost:8002
-```
-
-## Additional Info
-
-### Adjusting number and distribution of validators
-The `VALIDATOR_COUNT` parameter is used to specify the number of insecure validator keystores to generate and make deposits for.
-The `BN_COUNT` parameter is used to adjust the division of these generated keys among separate validator client instances.
-For e.g. for `VALIDATOR_COUNT=80` and `BN_COUNT=4`, the validator keys are distributed over 4 datadirs with 20 keystores per datadir. The datadirs are located in `$DATADIR/node_{i}` which can be passed to separate validator client
-instances using the `--datadir` parameter.
-
-### Starting fresh
-
-You can delete the current testnet and all related files using the following command. Alternatively, if you wish to start another testnet, doing the steps [Starting the testnet](./README.md#starting-the-testnet) will automatically delete the files and start a fresh local testnet. 
-
-```bash
-./clean.sh
-```
-
-### Updating the genesis time of the beacon state
-
-If it's been a while since you ran `./setup` then the genesis time of the
-genesis state will be far in the future, causing lots of skip slots.
-
-Update the genesis time to now using:
-
-```bash
-./reset_genesis_time.sh
-```
-
-> Note: you probably want to just rerun `./start_local_testnet.sh` to start over
-> but this is another option.
-
-### Testing builder flow
-
-1. Add builder URL to `BN_ARGS` in `./vars.env`, e.g. `--builder http://localhost:8650`. Some mock builder server options: 
-    - [`mock-relay`](https://github.com/realbigsean/mock-relay)
-    - [`dummy-builder`](https://github.com/michaelsproul/dummy_builder)
-2. The above mock builders do not support non-mainnet presets as of now, and will require setting `SECONDS_PER_SLOT` and `SECONDS_PER_ETH1_BLOCK` to `12` in `./vars.env`. 
-3. Start the testnet with the following command (the `-p` flag enables the validator client `--builder-proposals` flag):
-    ```bash
-    ./start_local_testnet.sh -p genesis.json
-    ```
-4. Block production using builder flow will start at epoch 4.
-
-### Testing sending a transaction
-
-Some addresses in the local testnet are seeded with testnet ETH, allowing users to carry out transactions. To send a transaction, we first add the address to a wallet, such as [Metamask](https://metamask.io/). The private keys for the addresses are listed [here](https://github.com/sigp/lighthouse/blob/441fc1691b69f9edc4bbdc6665f3efab16265c9b/testing/execution_engine_integration/src/execution_engine.rs#L13-L14).
-
-Next, we add the local testnet to Metamask, a brief guide can be found [here](https://support.metamask.io/hc/en-us/articles/360043227612-How-to-add-a-custom-network-RPC). If you start the local testnet with default settings, the network RPC is: http://localhost:6001 and the `Chain ID` is `4242`, as defined in [`vars.env`](https://github.com/sigp/lighthouse/blob/441fc1691b69f9edc4bbdc6665f3efab16265c9b/scripts/local_testnet/vars.env#L42). Once the network and account are added, you should see that the account contains testnet ETH which allow us to carry out transactions. 

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -78,6 +78,6 @@ fi
 # Stop local testnet
 kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/kurtosis-tech/ethereum-package --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"

--- a/scripts/tests/network_params.yaml
+++ b/scripts/tests/network_params.yaml
@@ -1,4 +1,4 @@
-# Full configuration reference [here](https://github.com/kurtosis-tech/ethereum-package?tab=readme-ov-file#configuration).
+# Full configuration reference [here](https://github.com/ethpandaops/ethereum-package?tab=readme-ov-file#configuration).
 participants:
   - el_type: geth
     el_image: ethereum/client-go:latest

--- a/slasher/src/config.rs
+++ b/slasher/src/config.rs
@@ -11,7 +11,7 @@ pub const DEFAULT_VALIDATOR_CHUNK_SIZE: usize = 256;
 pub const DEFAULT_HISTORY_LENGTH: usize = 4096;
 pub const DEFAULT_UPDATE_PERIOD: u64 = 12;
 pub const DEFAULT_SLOT_OFFSET: f64 = 10.5;
-pub const DEFAULT_MAX_DB_SIZE: usize = 256 * 1024; // 256 GiB
+pub const DEFAULT_MAX_DB_SIZE: usize = 512 * 1024; // 512 GiB
 pub const DEFAULT_ATTESTATION_ROOT_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(100_000);
 pub const DEFAULT_BROADCAST: bool = false;
 

--- a/testing/execution_engine_integration/src/nethermind.rs
+++ b/testing/execution_engine_integration/src/nethermind.rs
@@ -11,7 +11,7 @@ use unused_port::unused_tcp4_port;
 /// We've pinned the Nethermind version since our method of using the `master` branch to
 /// find the latest tag isn't working. It appears Nethermind don't always tag on `master`.
 /// We should fix this so we always pull the latest version of Nethermind.
-const NETHERMIND_BRANCH: &str = "release/1.21.0";
+const NETHERMIND_BRANCH: &str = "release/1.27.0";
 const NETHERMIND_REPO_URL: &str = "https://github.com/NethermindEth/nethermind";
 
 fn build_result(repo_dir: &Path) -> Output {
@@ -70,11 +70,10 @@ impl NethermindEngine {
             .join("nethermind")
             .join("src")
             .join("Nethermind")
-            .join("Nethermind.Runner")
+            .join("artifacts")
             .join("bin")
-            .join("Release")
-            .join("net7.0")
-            .join("linux-x64")
+            .join("Nethermind.Runner")
+            .join("release")
             .join("nethermind")
     }
 }

--- a/testing/simulator/src/main.rs
+++ b/testing/simulator/src/main.rs
@@ -10,9 +10,6 @@
 //! simulation uses `println` to communicate some info. It might be nice if the nodes logged to
 //! easy-to-find files and stdout only contained info from the simulation.
 //!
-
-extern crate clap;
-
 mod basic_sim;
 mod checks;
 mod cli;

--- a/validator_client/slashing_protection/src/interchange.rs
+++ b/validator_client/slashing_protection/src/interchange.rs
@@ -7,7 +7,7 @@ use types::{Epoch, Hash256, PublicKeyBytes, Slot};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct InterchangeMetadata {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub interchange_format_version: u64,
@@ -16,7 +16,7 @@ pub struct InterchangeMetadata {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct InterchangeData {
     pub pubkey: PublicKeyBytes,
     pub signed_blocks: Vec<SignedBlock>,
@@ -25,7 +25,7 @@ pub struct InterchangeData {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct SignedBlock {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub slot: Slot,
@@ -35,7 +35,7 @@ pub struct SignedBlock {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct SignedAttestation {
     #[serde(with = "serde_utils::quoted_u64::require_quotes")]
     pub source_epoch: Epoch,
@@ -46,7 +46,7 @@ pub struct SignedAttestation {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct Interchange {
     pub metadata: InterchangeMetadata,
     pub data: Vec<InterchangeData>,

--- a/validator_client/slashing_protection/src/interchange_test.rs
+++ b/validator_client/slashing_protection/src/interchange_test.rs
@@ -9,7 +9,7 @@ use tempfile::tempdir;
 use types::{Epoch, Hash256, PublicKeyBytes, Slot};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct MultiTestCase {
     pub name: String,
     pub genesis_validators_root: Hash256,
@@ -17,7 +17,7 @@ pub struct MultiTestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestCase {
     pub should_succeed: bool,
     pub contains_slashable_data: bool,
@@ -27,7 +27,7 @@ pub struct TestCase {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestBlock {
     pub pubkey: PublicKeyBytes,
     pub slot: Slot,
@@ -37,7 +37,7 @@ pub struct TestBlock {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary-fuzz", derive(arbitrary::Arbitrary))]
 pub struct TestAttestation {
     pub pubkey: PublicKeyBytes,
     pub source_epoch: Epoch,

--- a/validator_client/slashing_protection/src/lib.rs
+++ b/validator_client/slashing_protection/src/lib.rs
@@ -67,9 +67,9 @@ impl From<Hash256> for SigningRoot {
     }
 }
 
-impl Into<Hash256> for SigningRoot {
-    fn into(self) -> Hash256 {
-        self.0
+impl From<SigningRoot> for Hash256 {
+    fn from(from: SigningRoot) -> Hash256 {
+        from.0
     }
 }
 

--- a/validator_client/src/doppelganger_service.rs
+++ b/validator_client/src/doppelganger_service.rs
@@ -1115,7 +1115,7 @@ mod test {
             )
             // All validators should still be disabled.
             .assert_all_disabled()
-            // The states of all validators should be jammed with `u64::max_value()`.
+            // The states of all validators should be jammed with `u64:MAX`.
             .assert_all_states(&DoppelgangerState {
                 next_check_epoch: starting_epoch + 1,
                 remaining_epochs: u64::MAX,
@@ -1347,7 +1347,7 @@ mod test {
             )
             .assert_all_states(&DoppelgangerState {
                 next_check_epoch: initial_epoch + 1,
-                remaining_epochs: u64::max_value(),
+                remaining_epochs: u64::MAX,
             });
     }
 

--- a/validator_manager/src/lib.rs
+++ b/validator_manager/src/lib.rs
@@ -40,7 +40,7 @@ impl DumpConfig {
 
 pub fn cli_app() -> Command {
     Command::new(CMD)
-        .visible_aliases(["vm", "validator-manager", CMD])
+        .visible_aliases(["vm", "validator-manager"])
         .display_order(0)
         .styles(get_color_style())
         .about("Utilities for managing a Lighthouse validator client via the HTTP API.")

--- a/watch/src/blockprint/database.rs
+++ b/watch/src/blockprint/database.rs
@@ -33,6 +33,7 @@ pub struct WatchBlockprint {
 }
 
 #[derive(Debug, QueryableByName, diesel::FromSqlRow)]
+#[allow(dead_code)]
 pub struct WatchValidatorBlockprint {
     #[diesel(sql_type = Integer)]
     pub proposer_index: i32,

--- a/watch/src/blockprint/mod.rs
+++ b/watch/src/blockprint/mod.rs
@@ -24,6 +24,7 @@ pub use server::blockprint_routes;
 const TIMEOUT: Duration = Duration::from_secs(50);
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     Reqwest(reqwest::Error),
     Url(url::ParseError),

--- a/watch/src/server/error.rs
+++ b/watch/src/server/error.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 use std::io::Error as IoError;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     Axum(AxumError),
     Hyper(HyperError),

--- a/watch/src/updater/error.rs
+++ b/watch/src/updater/error.rs
@@ -5,6 +5,7 @@ use eth2::{Error as Eth2Error, SensitiveError};
 use std::fmt;
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum Error {
     BeaconChain(BeaconChainError),
     Eth2(Eth2Error),

--- a/watch/src/updater/handler.rs
+++ b/watch/src/updater/handler.rs
@@ -9,6 +9,7 @@ use eth2::{
 };
 use log::{debug, error, info, warn};
 use std::collections::HashSet;
+use std::marker::PhantomData;
 use types::{BeaconBlockHeader, EthSpec, Hash256, SignedBeaconBlock, Slot};
 
 use crate::updater::{get_beacon_block, get_header, get_validators};
@@ -47,7 +48,7 @@ pub struct UpdateHandler<E: EthSpec> {
     pub blockprint: Option<WatchBlockprintClient>,
     pub config: Config,
     pub slots_per_epoch: u64,
-    pub spec: WatchSpec<E>,
+    pub _phantom: PhantomData<E>,
 }
 
 impl<E: EthSpec> UpdateHandler<E> {
@@ -84,7 +85,7 @@ impl<E: EthSpec> UpdateHandler<E> {
             blockprint,
             config: config.updater,
             slots_per_epoch: spec.slots_per_epoch(),
-            spec,
+            _phantom: PhantomData,
         })
     }
 


### PR DESCRIPTION
## Proposed Changes

This is a _release branch_ for v5.2.1 that will be merged to `stable` without going via `unstable`.

This is a break from our usual release process which always used fast-forward merges from `unstable` to `stable`. The advantage is that we can continue developing breaking changes on `unstable` while waiting for `v5.2.1`.

## How to include a PR

- Use `release-v5.2.1` as the target branch for any pull request targeting v5.2.1.
- Label it with the `v5.2.1` label.
- Test and review as normal, then squash merge into this PR (you *should* use Mergify).

I'm also considering making _another_ `test-v5.2.1` PR that can contain squashed PRs for testing, prior to their final merge. Lets try to keep the history on this branch clean (no force pushes) so that it can be back-merged to `unstable` without creating problems.