### PR TITLE
Avoid rayon in lighthouse block verification

### DIFF
--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -4,7 +4,6 @@ use super::signature_sets::{Error as SignatureSetError, *};
 use crate::per_block_processing::errors::{AttestationInvalid, BlockOperationError};
 use crate::{ConsensusContext, ContextError};
 use bls::{verify_signature_sets, PublicKey, PublicKeyBytes, SignatureSet};
-use rayon::prelude::*;
 use std::borrow::Cow;
 use types::{
     AbstractExecPayload, BeaconState, BeaconStateError, ChainSpec, EthSpec, Hash256,
@@ -389,15 +388,10 @@ impl<'a> ParallelSignatureSets<'a> {
     /// It is not possible to know exactly _which_ signature is invalid here, just that
     /// _at least one_ was invalid.
     ///
-    /// Uses `rayon` to do a map-reduce of Vitalik's method across multiple cores.
+    /// Blst library spreads the signature verification work across multiple available cores, so
+    /// this function is already parallelized.
     #[must_use]
     pub fn verify(self) -> bool {
-        let num_sets = self.sets.len();
-        let num_chunks = std::cmp::max(1, num_sets / rayon::current_num_threads());
-        self.sets
-            .into_par_iter()
-            .chunks(num_chunks)
-            .map(|chunk| verify_signature_sets(chunk.iter()))
-            .reduce(|| true, |current, this| current && this)
+        verify_signature_sets(self.sets.iter())
     }
 }


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The blst library's `verify_multiple_aggregate_signatures` function [already](https://github.com/supranational/blst/blob/afd60c5f689ef11863852353dd394265a0c37863/bindings/rust/src/lib.rs#L1234-L1239) spreads the verification across multiple cores, we are doing redundant parallelization in lighthouse. 
This PR just calls the blst function directly without doing any additional parralelization. 

I'm guessing we did this when we were also using milagro bls as it presumably didn't parallelize, but now that we exclusively use blst, this is not needed anymore.

## Additional info

This PR need not necessarily be in 5.2.1, we can get some additional long term testing for this to check it doesn't result in performance degradation somehow.