### PR TITLE
Attempt to continue lookups after adding peers

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -269,7 +269,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 }
             }
 
-            if let Err(e) = self.add_peers_to_lookup_and_ancestors(lookup_id, peers) {
+            if let Err(e) = self.add_peers_to_lookup_and_ancestors(lookup_id, peers, cx) {
                 warn!(self.log, "Error adding peers to ancestor lookup"; "error" => ?e);
             }
 
@@ -834,14 +834,17 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
         &mut self,
         lookup_id: SingleLookupId,
         peers: &[PeerId],
+        cx: &mut SyncNetworkContext<T>,
     ) -> Result<(), String> {
         let lookup = self
             .single_block_lookups
             .get_mut(&lookup_id)
             .ok_or(format!("Unknown lookup for id {lookup_id}"))?;
 
+        let mut added_some_peer = false;
         for peer in peers {
             if lookup.add_peer(*peer) {
+                added_some_peer = true;
                 debug!(self.log, "Adding peer to existing single block lookup";
                     "block_root" => ?lookup.block_root(),
                     "peer" => ?peer
@@ -849,22 +852,25 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
             }
         }
 
-        // We may choose to attempt to continue a lookup here. It is possible that a lookup had zero
-        // peers and after adding this set of peers it can make progress again. Note that this
-        // recursive function iterates from child to parent, so continuing the child first is weird.
-        // However, we choose to not attempt to continue the lookup for simplicity. It's not
-        // strictly required and just and optimization for a rare corner case.
-
         if let Some(parent_root) = lookup.awaiting_parent() {
             if let Some((&child_id, _)) = self
                 .single_block_lookups
                 .iter()
                 .find(|(_, l)| l.block_root() == parent_root)
             {
-                self.add_peers_to_lookup_and_ancestors(child_id, peers)
+                self.add_peers_to_lookup_and_ancestors(child_id, peers, cx)
             } else {
                 Err(format!("Lookup references unknown parent {parent_root:?}"))
             }
+        } else if added_some_peer {
+            // If this lookup is not awaiting a parent and we added at least one peer, attempt to
+            // make progress. It is possible that a lookup is created with zero peers, attempted to
+            // make progress, and then receives peers. After that time the lookup will never be
+            // pruned with `drop_lookups_without_peers` because it has peers. This is rare corner
+            // case, but it can result in stuck lookups.
+            let result = lookup.continue_requests(cx);
+            self.on_lookup_result(lookup_id, result, "add_peers", cx);
+            Ok(())
         } else {
             Ok(())
         }


### PR DESCRIPTION
## Issue Addressed

Testing v5.2.1 a node hit a corner case of lookup sync causing a lookup to get stuck:

The lookup was originally created from an unknown parent block event with a block as child components. Therefore the original state of each request was:
- block: AwaitingProcess
- blobs: AwaitingDownload

When the parent imported successfully, it got called lookup `continue_request`. For each request:
- block: request is in AwaitingProcess so the block was sent to processing
- blobs: request is AwaitingDownload but the lookup has 0 peers so it doesn't make progress

https://github.com/sigp/lighthouse/blob/f1d88ba4b1256e084d3a2a547e0ce574b896246c/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs#L202

When the block completes processing and it gets the MissingComponents, `continue_request` is called again, but the lookup still has 0 peers. So no progress is made.

Then immediately after that attempt at `continue_request` the lookup gets peers. When the `drop_lookups_without_peers` function runs, the lookup has peers but nothing is trying to make progress on it.

It appears the comment below is too optmistic. Yes this situation is a rare case but it results in lookups getting stuck. We should attempt to make progress on lookups when adding peers

https://github.com/sigp/lighthouse/blob/f1d88ba4b1256e084d3a2a547e0ce574b896246c/beacon_node/network/src/sync/block_lookups/mod.rs#L852-L856

## Proposed Changes

Attempt to make progress on existing lookups that are not awaiting parent and got new peers


