### PR TITLE
Enable jemalloc by default on non windows targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,6 @@ BUILD_PATH_AARCH64 = "target/$(AARCH64_TAG)/release"
 PINNED_NIGHTLY ?= nightly
 CLIPPY_PINNED_NIGHTLY=nightly-2022-05-19
 
-# List of features to use when building natively. Can be overridden via the environment.
-# No jemalloc on Windows
-ifeq ($(OS),Windows_NT)
-    FEATURES?=
-else
-    FEATURES?=jemalloc
-endif
-
 # List of features to use when cross-compiling. Can be overridden via the environment.
 CROSS_FEATURES ?= gnosis,slasher-lmdb,slasher-mdbx,jemalloc
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -22,8 +22,14 @@ gnosis = []
 slasher-mdbx = ["slasher/mdbx"]
 # Support slasher LMDB backend.
 slasher-lmdb = ["slasher/lmdb"]
-# Use jemalloc.
-jemalloc = ["malloc_utils/jemalloc"]
+# Deprecated. This is now enabled by default on non windows targets.
+jemalloc = []
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+malloc_utils = { workspace = true, features = ["jemalloc"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+malloc_utils = { workspace = true }
 
 [dependencies]
 beacon_node = { workspace = true }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -51,10 +51,10 @@ fn bls_library_name() -> &'static str {
 }
 
 fn allocator_name() -> &'static str {
-    if cfg!(feature = "jemalloc") {
-        "jemalloc"
-    } else {
+    if cfg!(target_os = "windows") {
         "system"
+    } else {
+        "jemalloc"
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

A few discord users that build Lighthouse from source has reported high RAM usage since v5.2.0. @michaelsproul and @chong-he [have found](https://github.com/sigp/lighthouse/issues/5970#issuecomment-2190216812) that this is due to `jemalloc` feature being disabled. This is now necessary (on linux) with the introduction of `tree-states` and should always be enabled.

The Dockerfile doesn't have a default for `FEATURES`:
https://github.com/sigp/lighthouse/blob/f1d88ba4b1256e084d3a2a547e0ce574b896246c/Dockerfile#L4-L7

From @michaelsproul 
> it sets it as an _argument_, which I think means if you don't do `--arg FEATURES=jemalloc` it will build with `FEATURES=""`

This PR removes the feature flag and enables jemalloc by default on non windows targets, even when it's not specified via `FEATURES` environment variable. 