### PR TITLE
Add metrics for beacon processor status queue size

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -1345,6 +1345,10 @@ impl<E: EthSpec> BeaconProcessor<E> {
                     gossip_bls_to_execution_change_queue.len() as i64,
                 );
                 metrics::set_gauge(
+                    &metrics::BEACON_PROCESSOR_STATUS_QUEUE_TOTAL,
+                    status_queue.len() as i64,
+                );
+                metrics::set_gauge(
                     &metrics::BEACON_PROCESSOR_API_REQUEST_P0_QUEUE_TOTAL,
                     api_request_p0_queue.len() as i64,
                 );

--- a/beacon_node/beacon_processor/src/metrics.rs
+++ b/beacon_node/beacon_processor/src/metrics.rs
@@ -110,6 +110,11 @@ lazy_static::lazy_static! {
         "beacon_processor_sync_contribution_queue_total",
         "Count of sync committee contributions waiting to be processed."
     );
+    // Status messages.
+    pub static ref BEACON_PROCESSOR_STATUS_QUEUE_TOTAL: Result<IntGauge> = try_create_int_gauge(
+        "beacon_processor_status_queue_total",
+        "Count of status messages waiting to be processed."
+    );
     // HTTP API requests.
     pub static ref BEACON_PROCESSOR_API_REQUEST_P0_QUEUE_TOTAL: Result<IntGauge> = try_create_int_gauge(
         "beacon_processor_api_request_p0_queue_total",


### PR DESCRIPTION
## Issue Addressed

Add metrics for beacon processor status queue size.