### PR TITLE
chore: add `proof` parameter to `recover_cells_and_kzg_proofs`

### DIFF
--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -215,6 +215,7 @@ impl<E: EthSpec> DataColumnSidecar<E> {
             .map(|row_index| {
                 let mut cells: Vec<KzgCell> = vec![];
                 let mut cell_ids: Vec<u64> = vec![];
+                let mut proofs = vec![];
                 for data_column in data_columns {
                     let cell = data_column.column.get(row_index).ok_or(
                         KzgError::InconsistentArrayLength(format!(
@@ -224,8 +225,13 @@ impl<E: EthSpec> DataColumnSidecar<E> {
 
                     cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
                     cell_ids.push(data_column.index);
+                    proofs.push(*data_column.kzg_proofs.get(row_index).ok_or(
+                    KzgError::InconsistentArrayLength(format!(
+                        "Missing data column proof at index {row_index}"
+                    )),
+                    )?);
                 }
-                kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells)
+                kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells, proofs.as_slice())
             })
             .collect::<Result<Vec<_>, KzgError>>()?;
 

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -226,9 +226,9 @@ impl<E: EthSpec> DataColumnSidecar<E> {
                     cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
                     cell_ids.push(data_column.index);
                     proofs.push(*data_column.kzg_proofs.get(row_index).ok_or(
-                    KzgError::InconsistentArrayLength(format!(
-                        "Missing data column proof at index {row_index}"
-                    )),
+                        KzgError::InconsistentArrayLength(format!(
+                            "Missing data column proof at index {row_index}"
+                        )),
                     )?);
                 }
                 kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells, proofs.as_slice())

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -199,7 +199,7 @@ impl Kzg {
         &self,
         cell_ids: &[u64],
         cells: &[Cell],
-        _kzg_proofs : &[KzgProof],
+        _kzg_proofs: &[KzgProof],
     ) -> Result<CellsAndKzgProofs, Error> {
         let all_cells = c_kzg::Cell::recover_all_cells(cell_ids, cells, &self.trusted_setup)?;
         let blob = self.cells_to_blob(&all_cells)?;

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -199,6 +199,7 @@ impl Kzg {
         &self,
         cell_ids: &[u64],
         cells: &[Cell],
+        _kzg_proofs : &[KzgProof],
     ) -> Result<CellsAndKzgProofs, Error> {
         let all_cells = c_kzg::Cell::recover_all_cells(cell_ids, cells, &self.trusted_setup)?;
         let blob = self.cells_to_blob(&all_cells)?;

--- a/testing/ef_tests/src/cases/kzg_recover_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_recover_cells_and_kzg_proofs.rs
@@ -62,6 +62,7 @@ impl<E: EthSpec> Case for KZGRecoverCellsAndKZGProofs<E> {
                     .recover_cells_and_compute_kzg_proofs(
                         cell_indices.as_slice(),
                         input_cells.as_slice(),
+                        input_proofs.as_slice(),
                     )
                     .map_err(|e| {
                         Error::InternalError(format!(


### PR DESCRIPTION
## Issue Addressed

To recover the cells and proofs, we do not need the proofs that correspond to the cells we already have. As of now the DAS branch recovers_cells_and_proofs using three methods `recover_cells`, `cells_to_blob`, `compute_cells_and_proofs`. 

The consensus-specs has introduced a new method which encapsulates all three of these methods, called `recover_cells_and_proofs`. This method takes in a proof parameter and there are additional checks that libraries that implement that function will perform. This means that the `proofs` parameter cannot be missing or empty. As an example, libraries will check that the number of proofs is equal to the number of cells.

We will eventually remove the proof parameter here: https://github.com/ethereum/consensus-specs/pull/3819 but until then it is needed.

## Proposed Changes

In reconstruct, we also fetch the proof for the given cell. 

The specs do it by forming an ExtendedMatrix, however most codebases seem to just have PartialDataColumnSideCars instead, so was not able to corroborate with the specs

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
