### PR TITLE
Downgrade duplication log of attestation to Debug

### DIFF
--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1384,16 +1384,16 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                 let is_first_inclusion = validator
                     .get_from_epoch_summary(epoch, |summary_opt| {
                         if let Some(summary) = summary_opt {
-                            Some(summary.attestation_aggregate_inclusions == 0)
+                            Some(summary.attestation_aggregate_inclusions == 1)
                         } else {
                             // No data for this validator: no inclusion.
-                            Some(true)
+                            Some(false)
                         }
                     })
                     .unwrap();
 
                 if self.individual_tracking() {
-                    if is_first_inclusion {
+                    if is_first_inclusion == false {
                         info!(
                             self.log,
                             "Attestation included in aggregate";

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1390,7 +1390,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             Some(true)
                         }
                     })
-                    .unwrap();
+                    .unwrap_or(true);
 
                 if self.individual_tracking() {
                     if is_first_inclusion {

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1390,7 +1390,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             Some(true)
                         }
                     })
-                    .unwrap_or(true);
+                    .unwrap();
 
                 if self.individual_tracking() {
                     if is_first_inclusion {

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1393,7 +1393,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                     .unwrap_or(true);
 
                 if self.individual_tracking() {
-                    if is_first_inclusion == true {
+                    if is_first_inclusion {
                         info!(
                             self.log,
                             "Attestation included in aggregate";
@@ -1413,8 +1413,6 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             "Attestation included in aggregate";
                             "index" => %data.index,
                             "delay_ms" => %delay.as_millis(),
-                            "epoch" => %epoch,
-                            "slot" => %data.slot,
                             "slot" => %data.slot,
                             "src" => src,
                         )

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1381,18 +1381,18 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                     );
                 });
 
-                let is_first_inclusion_aggregate = validator
-                    .get_from_epoch_summary(epoch, |summary_opt| {
-                        if let Some(summary) = summary_opt {
-                            Some(summary.attestation_aggregate_inclusions == 0)
-                        } else {
-                            // No data for this validator: no inclusion.
-                            Some(true)
-                        }
-                    })
-                    .unwrap_or(true);
-
                 if self.individual_tracking() {
+                    let is_first_inclusion_aggregate = validator
+                        .get_from_epoch_summary(epoch, |summary_opt| {
+                            if let Some(summary) = summary_opt {
+                                Some(summary.attestation_aggregate_inclusions == 0)
+                            } else {
+                                // No data for this validator: no inclusion.
+                                Some(true)
+                            }
+                        })
+                        .unwrap_or(true);
+
                     if is_first_inclusion_aggregate {
                         info!(
                             self.log,
@@ -1405,8 +1405,8 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             "src" => src,
                             "validator" => %id,
                         );
-                        // Downgrade to Debug for second and onwards of logging to reduce verbosity
                     } else {
+                        // Downgrade to Debug for second and onwards of logging to reduce verbosity
                         debug!(
                             self.log,
                             "Attestation included in aggregate";
@@ -1459,24 +1459,23 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                         &["block", label],
                     );
                 });
-
-                let is_first_inclusion_block = validator
-                    .get_from_epoch_summary(epoch, |summary_opt| {
-                        if let Some(summary) = summary_opt {
-                            Some(summary.attestation_block_inclusions == 0)
-                        } else {
-                            // No data for this validator: no inclusion.
-                            Some(true)
-                        }
-                    })
-                    .unwrap_or(true);
-
                 if self.individual_tracking() {
                     metrics::set_int_gauge(
                         &metrics::VALIDATOR_MONITOR_ATTESTATION_IN_BLOCK_DELAY_SLOTS,
                         &["block", id],
                         delay.as_u64() as i64,
                     );
+
+                    let is_first_inclusion_block = validator
+                        .get_from_epoch_summary(epoch, |summary_opt| {
+                            if let Some(summary) = summary_opt {
+                                Some(summary.attestation_block_inclusions == 0)
+                            } else {
+                                // No data for this validator: no inclusion.
+                                Some(true)
+                            }
+                        })
+                        .unwrap_or(true);
 
                     if is_first_inclusion_block {
                         info!(
@@ -1490,6 +1489,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             "validator" => %id,
                         );
                     } else {
+                        // Downgrade to Debug for second and onwards of logging to reduce verbosity
                         debug!(
                             self.log,
                             "Attestation included in block";

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1393,7 +1393,7 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                     .unwrap();
 
                 if self.individual_tracking() {
-                    if is_first_inclusion == false {
+                    if is_first_inclusion {
                         info!(
                             self.log,
                             "Attestation included in aggregate";

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1405,9 +1405,9 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             "src" => src,
                             "validator" => %id,
                         );
-                        // Will be downgrade to debug once tested working
+                        // Downgrade to Debug for second and onwards of logging to reduce verbosity
                     } else {
-                        warn!(
+                        debug!(
                             self.log,
                             "Attestation included in aggregate";
                             "head" => ?data.beacon_block_root,

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1384,10 +1384,10 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                 let is_first_inclusion = validator
                     .get_from_epoch_summary(epoch, |summary_opt| {
                         if let Some(summary) = summary_opt {
-                            Some(summary.attestation_aggregate_inclusions == 1)
+                            Some(summary.attestation_aggregate_inclusions == 0)
                         } else {
                             // No data for this validator: no inclusion.
-                            Some(false)
+                            Some(true)
                         }
                     })
                     .unwrap();
@@ -1405,16 +1405,18 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                             "src" => src,
                             "validator" => %id,
                         );
-                    // As a first step, reduce the logging to make sure that it works, because completely remove it may not be obvious that it works
-                    // (e.g., when there is only 1 inclusion)
+                        // Will be downgrade to debug once tested working
                     } else {
-                        info!(
+                        warn!(
                             self.log,
                             "Attestation included in aggregate";
+                            "head" => ?data.beacon_block_root,
                             "index" => %data.index,
                             "delay_ms" => %delay.as_millis(),
+                            "epoch" => %epoch,
                             "slot" => %data.slot,
                             "src" => src,
+                            "validator" => %id,
                         )
                     };
                 }

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1382,8 +1382,8 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                 });
 
                 let is_first_inclusion = validator
-                    .get_from_epoch_summary(epoch, |opt_summary| {
-                        if let Some(summary) = opt_summary {
+                    .get_from_epoch_summary(epoch, |summary_opt| {
+                        if let Some(summary) = summary_opt {
                             Some(summary.attestation_aggregate_inclusions == 0)
                         } else {
                             // No data for this validator: no inclusion.

--- a/beacon_node/beacon_chain/src/validator_monitor.rs
+++ b/beacon_node/beacon_chain/src/validator_monitor.rs
@@ -1381,18 +1381,44 @@ impl<E: EthSpec> ValidatorMonitor<E> {
                     );
                 });
 
+                let is_first_inclusion = validator
+                    .get_from_epoch_summary(epoch, |opt_summary| {
+                        if let Some(summary) = opt_summary {
+                            Some(summary.attestation_aggregate_inclusions == 0)
+                        } else {
+                            // No data for this validator: no inclusion.
+                            Some(true)
+                        }
+                    })
+                    .unwrap_or(true);
+
                 if self.individual_tracking() {
-                    info!(
-                        self.log,
-                        "Attestation included in aggregate";
-                        "head" => ?data.beacon_block_root,
-                        "index" => %data.index,
-                        "delay_ms" => %delay.as_millis(),
-                        "epoch" => %epoch,
-                        "slot" => %data.slot,
-                        "src" => src,
-                        "validator" => %id,
-                    );
+                    if is_first_inclusion == true {
+                        info!(
+                            self.log,
+                            "Attestation included in aggregate";
+                            "head" => ?data.beacon_block_root,
+                            "index" => %data.index,
+                            "delay_ms" => %delay.as_millis(),
+                            "epoch" => %epoch,
+                            "slot" => %data.slot,
+                            "src" => src,
+                            "validator" => %id,
+                        );
+                    // As a first step, reduce the logging to make sure that it works, because completely remove it may not be obvious that it works
+                    // (e.g., when there is only 1 inclusion)
+                    } else {
+                        info!(
+                            self.log,
+                            "Attestation included in aggregate";
+                            "index" => %data.index,
+                            "delay_ms" => %delay.as_millis(),
+                            "epoch" => %epoch,
+                            "slot" => %data.slot,
+                            "slot" => %data.slot,
+                            "src" => src,
+                        )
+                    };
                 }
 
                 validator.with_epoch_summary(epoch, |summary| {


### PR DESCRIPTION
## Issue Addressed

* #2732 

## Proposed Changes

Only display the first log of `Attestation included in aggregate` and `Attestation included in block` as `INFO` and downgrade subsequent logs to `DEBG`. This will reduce verbosity of the logs when `validator-monitor-auto` is turned on. 

## Additional Info

For `Attestation included in aggregate`:

Before:
```
Jun 23 13:04:44.195 INFO Attestation included in aggregate, validator: x, src: gossip, slot: 1937123, epoch: 60535, delay_ms: 187, index: 25, head: 0x423bdb9a0376d74a5315454610527f30c1d943098df501d69ff38b1512e81c19, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1385
Jun 23 13:04:44.317 INFO Attestation included in aggregate, validator: x, src: gossip, slot: 1937123, epoch: 60535, delay_ms: 272, index: 25, head: 0x423bdb9a0376d74a5315454610527f30c1d943098df501d69ff38b1512e81c19, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1385
Jun 23 13:04:44.380 INFO Attestation included in aggregate, validator: x, src: gossip, slot: 1937123, epoch: 60535, delay_ms: 310, index: 25, head: 0x423bdb9a0376d74a5315454610527f30c1d943098df501d69ff38b1512e81c19, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1385
```

After:
```
Jun 27 01:34:32.246 INFO Attestation included in aggregate, validator: x, src: gossip, slot: 1962472, epoch: 61327, delay_ms: 208, index: 17, head: 0xeb08a01a9ee36448c9b7313a5df4834bdcf3d5b576851c87e46ed91aa499b625, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1397
Jun 27 01:34:32.306 DEBG Attestation included in aggregate, validator: x, src: gossip, slot: 1962472, epoch: 61327, delay_ms: 301, index: 17, head: 0xeb08a01a9ee36448c9b7313a5df4834bdcf3d5b576851c87e46ed91aa499b625, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1410
Jun 27 01:34:32.386 DEBG Attestation included in aggregate, validator: x, src: gossip, slot: 1962472, epoch: 61327, delay_ms: 373, index: 17, head: 0xeb08a01a9ee36448c9b7313a5df4834bdcf3d5b576851c87e46ed91aa499b625, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1410
```

For `Attestation included in block`:

Before:
```
Jun 26 12:16:50.029 INFO Attestation included in block, validator: x, slot: 1958483, epoch: 61202, inclusion_lag: 0 slot(s), index: 35, head: 0xe4e89134dc9aa0c1ca7c75c16c3d4f94ce3ec5054d33a800ab3e735b858ee301, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1470
Jun 26 12:16:50.041 INFO Attestation included in block, validator: x, slot: 1958483, epoch: 61202, inclusion_lag: 0 slot(s), index: 35, head: 0xe4e89134dc9aa0c1ca7c75c16c3d4f94ce3ec5054d33a800ab3e735b858ee301, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1470
```

After:
```
Jun 27 01:34:37.504 INFO Attestation included in block, validator: x, slot: 1962472, epoch: 61327, inclusion_lag: 0 slot(s), index: 17, head: 0xeb08a01a9ee36448c9b7313a5df4834bdcf3d5b576851c87e46ed91aa499b625, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1482
Jun 27 01:34:50.587 DEBG Attestation included in block, validator: x, slot: 1962472, epoch: 61327, inclusion_lag: 1 slot(s), index: 17, head: 0xeb08a01a9ee36448c9b7313a5df4834bdcf3d5b576851c87e46ed91aa499b625, service: val_mon, service: beacon, module: beacon_chain::validator_monitor:1493
```
