### PR TITLE
Prevent connections from peers with a banned ip history

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -14,7 +14,6 @@ use slog::{debug, error, trace};
 use types::EthSpec;
 
 use crate::discovery::enr_ext::EnrExt;
-use crate::peer_manager::peerdb::BanResult;
 use crate::rpc::GoodbyeReason;
 use crate::types::SyncState;
 use crate::{metrics, ClearDialError};

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -201,7 +201,7 @@ impl<E: EthSpec> NetworkBehaviour for PeerManager<E> {
     ) -> Result<libp2p::swarm::THandler<Self>, ConnectionDenied> {
         trace!(self.log, "Inbound connection"; "peer_id" => %peer_id, "multiaddr" => %remote_addr);
         // We already checked if the peer was banned on `handle_pending_inbound_connection`.
-        if let Some(BanResult::BadScore) = self.ban_status(&peer_id) {
+        if self.ban_status(&peer_id).is_some() {
             return Err(ConnectionDenied::new(
                 "Connection to peer rejected: peer has a bad score",
             ));


### PR DESCRIPTION
This synchronizes the logic we have between what peers we allow to connect to us and what think are connecting to us. 

Specifically, peers that have a history of connecting to us via an IP address that is currently banned (i.e has a number of peers currently banned associated with this IP) we prevent their connection, even if they are connecting on a new IP address. 

This should resolve some potential error logs also. 