### PR TITLE
Drop skip too large condition for liveness safety

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -114,7 +114,7 @@ use std::collections::HashSet;
 use std::io::prelude::*;
 use std::marker::PhantomData;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use store::iter::{BlockRootsIterator, ParentRootBlockIterator, StateRootsIterator};
 use store::{
     DatabaseBlock, Error as DBError, HotColdDB, KeyValueStore, KeyValueStoreOp, StoreItem, StoreOp,
@@ -1410,10 +1410,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     )
                 }
 
-                let start_slot = head_state.slot();
-                let task_start = Instant::now();
-                let max_task_runtime = Duration::from_secs(self.spec.seconds_per_slot);
-
                 let head_state_slot = head_state.slot();
                 let mut state = head_state;
 
@@ -1423,18 +1419,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 };
 
                 while state.slot() < slot {
-                    // Do not allow and forward state skip that takes longer than the maximum task duration.
-                    //
-                    // This is a protection against nodes doing too much work when they're not synced
-                    // to a chain.
-                    if task_start + max_task_runtime < Instant::now() {
-                        return Err(Error::StateSkipTooLarge {
-                            start_slot,
-                            requested_slot: slot,
-                            max_task_runtime,
-                        });
-                    }
-
                     // Note: supplying some `state_root` when it is known would be a cheap and easy
                     // optimization.
                     match per_slot_processing(&mut state, skip_state_root, &self.spec) {

--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -28,7 +28,6 @@ use state_processing::{
     state_advance::Error as StateAdvanceError,
     BlockProcessingError, BlockReplayError, EpochProcessingError, SlotProcessingError,
 };
-use std::time::Duration;
 use task_executor::ShutdownReason;
 use tokio::task::JoinError;
 use types::milhouse::Error as MilhouseError;
@@ -77,11 +76,6 @@ pub enum BeaconChainError {
     ProposerSlashingValidationError(ProposerSlashingValidationError),
     AttesterSlashingValidationError(AttesterSlashingValidationError),
     BlsExecutionChangeValidationError(BlsExecutionChangeValidationError),
-    StateSkipTooLarge {
-        start_slot: Slot,
-        requested_slot: Slot,
-        max_task_runtime: Duration,
-    },
     MissingFinalizedStateRoot(Slot),
     /// Returned when an internal check fails, indicating corrupt data.
     InvariantViolated(String),


### PR DESCRIPTION
## Issue Addressed

Chating with @michaelsproul he noted that Lighthouse still includes a condition that could jeopardize the liveness of the chain under extreme circumstances.

If some codepath (for example block production) needs to advance a state multiple epochs such that the total runtime of that advance is larger than `seconds_per_slot`, it will just error. If this condition happens the node will be stuck, unable to propose blocks on the chain and making the problem worse. If enough nodes follow this rule, the network will never progress and stall. The motivation for this error is to protect the node against very expensive state advance requests, but these are necessary for liveness.

For context, the condition was introduced in this PR
- https://github.com/sigp/lighthouse/pull/618

I believe we should drop the condition now as is. In the future, we may choose to harden the node against corner cases where the network is in a problematic state, such as having no head in the last N epochs.

## Proposed Changes

Drop skip too large condition for liveness safety
