### PR TITLE
Fix incorrect inbound request count causing rate limiting.

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -308,9 +308,7 @@ pub struct DataColumnsByRangeRequest {
 
 impl DataColumnsByRangeRequest {
     pub fn max_requested<E: EthSpec>(&self) -> u64 {
-        self.count
-            .saturating_mul(E::max_blobs_per_block() as u64)
-            .saturating_mul(self.columns.len() as u64)
+        self.count.saturating_mul(self.columns.len() as u64)
     }
 
     pub fn ssz_min_len() -> usize {

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -366,8 +366,10 @@ where
                                 protocol,
                                 Protocol::BlocksByRange
                                     | Protocol::BlobsByRange
+                                    | Protocol::DataColumnsByRange
                                     | Protocol::BlocksByRoot
                                     | Protocol::BlobsByRoot
+                                    | Protocol::DataColumnsByRoot
                             ) {
                                 debug!(self.log, "Request too large to process"; "request" => %req, "protocol" => %protocol);
                             } else {


### PR DESCRIPTION
## Issue Addressed

Fix incorrect inbound request count causing rate limiting.

This result in all max data column by range being rejected, as the required response count is incorrectly computed to `32 * 6 * 128 = 24,576` column sidecars instead of `32 * 128 = 4096`.

The max allowed size is `40 * 128 = 5,120` column sidecars per 10 seconds for each peer (or 60mb)

The default rate limit is configured to `5120/10` here:
https://github.com/sigp/lighthouse/blob/aa8095086c43745faac9efce2b1d3eb7aeb7e886/beacon_node/lighthouse_network/src/rpc/config.rs#L112 

