### PR TITLE
Delete duplicated serde code

### DIFF
--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -53,10 +53,10 @@ use tree_hash_derive::TreeHash;
 pub struct IndexedAttestation<E: EthSpec> {
     /// Lists validator registry indices, not committee indices.
     #[superstruct(only(Base), partial_getter(rename = "attesting_indices_base"))]
-    #[serde(with = "quoted_variable_list_u64")]
+    #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     pub attesting_indices: VariableList<u64, E::MaxValidatorsPerCommittee>,
     #[superstruct(only(Electra), partial_getter(rename = "attesting_indices_electra"))]
-    #[serde(with = "quoted_variable_list_u64")]
+    #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     pub attesting_indices: VariableList<u64, E::MaxValidatorsPerSlot>,
     pub data: AttestationData,
     pub signature: AggregateSignature,
@@ -200,43 +200,6 @@ impl<E: EthSpec> Hash for IndexedAttestation<E> {
         };
         self.data().hash(state);
         self.signature().as_ssz_bytes().hash(state);
-    }
-}
-
-/// Serialize a variable list of `u64` such that each int is quoted. Deserialize a variable
-/// list supporting both quoted and un-quoted ints.
-///
-/// E.g.,`["0", "1", "2"]`
-mod quoted_variable_list_u64 {
-    use super::*;
-    use crate::Unsigned;
-    use serde::ser::SerializeSeq;
-    use serde::{Deserializer, Serializer};
-    use serde_utils::quoted_u64_vec::{QuotedIntVecVisitor, QuotedIntWrapper};
-
-    pub fn serialize<S, T>(value: &VariableList<u64, T>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-        T: Unsigned,
-    {
-        let mut seq = serializer.serialize_seq(Some(value.len()))?;
-        for &int in value.iter() {
-            seq.serialize_element(&QuotedIntWrapper { int })?;
-        }
-        seq.end()
-    }
-
-    pub fn deserialize<'de, D, T>(deserializer: D) -> Result<VariableList<u64, T>, D::Error>
-    where
-        D: Deserializer<'de>,
-        T: Unsigned,
-    {
-        deserializer
-            .deserialize_any(QuotedIntVecVisitor)
-            .and_then(|vec| {
-                VariableList::new(vec)
-                    .map_err(|e| serde::de::Error::custom(format!("invalid length: {:?}", e)))
-            })
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

Found some serde code for `IndexedAttestation` that is just copy-pasta of stuff we already have in `ethereum_serde_utils`. I think it actually predates that module though, and the duplication just never got cleaned up (until now).

The new code also supports omitting quotes during deserialisation, so there is no breaking change here: https://docs.rs/ssz_types/latest/ssz_types/serde_utils/quoted_u64_var_list/index.html
