### PR TITLE
Fix SigVerifiedOp SSZ implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7824,6 +7824,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "arbitrary",
+]
 
 [[package]]
 name = "snap"
@@ -7942,10 +7945,12 @@ dependencies = [
  "lazy_static",
  "lighthouse_metrics",
  "merkle_proof",
+ "rand",
  "rayon",
  "safe_arith",
  "smallvec",
  "ssz_types",
+ "test_random_derive",
  "tokio",
  "tree_hash",
  "types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ slog = { version = "2", features = ["max_level_trace", "release_max_level_trace"
 slog-async = "2"
 slog-term = "2"
 sloggers = { version = "2", features = ["json"] }
-smallvec = "1.11.2"
+smallvec = { version = "1.11.2", features = ["arbitrary"] }
 snap = "1"
 ssz_types = "0.6"
 strum = { version = "0.24", features = ["derive"] }

--- a/consensus/state_processing/Cargo.toml
+++ b/consensus/state_processing/Cargo.toml
@@ -28,6 +28,8 @@ arbitrary = { workspace = true }
 lighthouse_metrics = { workspace = true }
 lazy_static = { workspace = true }
 derivative = { workspace = true }
+test_random_derive = { path = "../../common/test_random_derive" }
+rand = { workspace = true }
 
 [features]
 default = ["legacy-arith"]

--- a/consensus/types/src/attester_slashing.rs
+++ b/consensus/types/src/attester_slashing.rs
@@ -3,6 +3,7 @@ use crate::indexed_attestation::{
 };
 use crate::{test_utils::TestRandom, EthSpec};
 use derivative::Derivative;
+use rand::{Rng, RngCore};
 use serde::{Deserialize, Serialize};
 use ssz_derive::{Decode, Encode};
 use superstruct::superstruct;
@@ -156,6 +157,16 @@ impl<E: EthSpec> AttesterSlashing<E> {
             AttesterSlashing::Electra(attester_slashing) => {
                 IndexedAttestationRef::Electra(&attester_slashing.attestation_2)
             }
+        }
+    }
+}
+
+impl<E: EthSpec> TestRandom for AttesterSlashing<E> {
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        if rng.gen_bool(0.5) {
+            AttesterSlashing::Base(AttesterSlashingBase::random_for_test(rng))
+        } else {
+            AttesterSlashing::Electra(AttesterSlashingElectra::random_for_test(rng))
         }
     }
 }

--- a/consensus/types/src/test_utils/test_random.rs
+++ b/consensus/types/src/test_utils/test_random.rs
@@ -2,6 +2,7 @@ use crate::*;
 use rand::RngCore;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
+use smallvec::{smallvec, SmallVec};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
@@ -115,6 +116,21 @@ where
         }
 
         output.into()
+    }
+}
+
+impl<U, const N: usize> TestRandom for SmallVec<[U; N]>
+where
+    U: TestRandom,
+{
+    fn random_for_test(rng: &mut impl RngCore) -> Self {
+        let mut output = smallvec![];
+
+        for _ in 0..(usize::random_for_test(rng) % 4) {
+            output.push(<U>::random_for_test(rng));
+        }
+
+        output
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

The schema v20 migration was liable to fail and brick the database due to a discrepency in the `Encode` and `Decode` implementations for `SigVerifiedOp`. This was identified while testing the v21 schema migration: https://github.com/sigp/lighthouse/pull/5897#issuecomment-2196266245.

## Proposed Changes

Rather than trying to tweak the hand-written implementation I've replaced it with a more obviously correct implementation that translates to and from `SigVerifiedOp{Encode,Decode}` types. IMO this is much easier to check the correctness of, because the `Decode` and `Encode` implementations are just mappings.

I've also added some roundtrip tests which pass on the new impl and fail on the old.

## Additional Info

Manual testing of the migration didn't catch this because the error only occurs sometimes: when there are `SigVerifiedOp`s in the op pool.
