### PR TITLE
Show `blst` hardware support in `lighthouse --version`

### DIFF
--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -53,15 +53,12 @@ fn bls_library_name() -> &'static str {
 }
 
 #[inline(always)]
-#[allow(unreachable_code)]
 fn bls_hardware_acceleration() -> bool {
-    #[cfg(feature = "portable")]
-    return false;
-
     #[cfg(target_arch = "x86_64")]
     return std::is_x86_feature_detected!("adx");
 
-    false
+    #[cfg(target_arch = "aarch64")]
+    return std::arch::is_aarch64_feature_detected!("neon");
 }
 
 fn allocator_name() -> &'static str {

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -52,8 +52,14 @@ fn bls_library_name() -> &'static str {
     }
 }
 
+#[inline(always)]
+#[allow(unreachable_code)]
 fn bls_hardware_acceleration() -> bool {
-    !cfg!(feature = "portable")
+    #[cfg(feature = "portable")]
+    return false;
+
+    #[cfg(target_arch = "x86_64")]
+    return std::is_x86_feature_detected!("adx");
 }
 
 fn allocator_name() -> &'static str {

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -26,12 +26,14 @@ lazy_static! {
     pub static ref LONG_VERSION: String = format!(
         "{}\n\
          BLS library: {}\n\
+         BLS hardware acceleration: {}\n\
          SHA256 hardware acceleration: {}\n\
          Allocator: {}\n\
          Profile: {}\n\
          Specs: mainnet (true), minimal ({}), gnosis ({})",
         SHORT_VERSION.as_str(),
         bls_library_name(),
+        bls_hardware_acceleration(),
         have_sha_extensions(),
         allocator_name(),
         build_profile_name(),
@@ -48,6 +50,10 @@ fn bls_library_name() -> &'static str {
     } else {
         "blst"
     }
+}
+
+fn bls_hardware_acceleration() -> bool {
+    !cfg!(feature = "portable")
 }
 
 fn allocator_name() -> &'static str {

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -60,6 +60,8 @@ fn bls_hardware_acceleration() -> bool {
 
     #[cfg(target_arch = "x86_64")]
     return std::is_x86_feature_detected!("adx");
+
+    false
 }
 
 fn allocator_name() -> &'static str {


### PR DESCRIPTION
Show `blst` hardware support in `lighthouse --version`:

```
$ ./target/debug/lighthouse --version
Lighthouse v5.2.1
BLS library: blst-portable
BLS hardware acceleration: false
SHA256 hardware acceleration: true
Allocator: system
Profile: debug
Specs: mainnet (true), minimal (false), gnosis (false)
```


Will close #5918