### PR TITLE
Drop unused store metrics

### DIFF
--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -55,14 +55,6 @@ lazy_static! {
         "store_beacon_state_hot_get_total",
         "Total number of hot beacon states requested from the store (cache or DB)"
     );
-    pub static ref BEACON_STATE_CACHE_HIT_COUNT: Result<IntCounter> = try_create_int_counter(
-        "store_beacon_state_cache_hit_total",
-        "Number of hits to the store's state cache"
-    );
-    pub static ref BEACON_STATE_CACHE_CLONE_TIME: Result<Histogram> = try_create_histogram(
-        "store_beacon_state_cache_clone_time",
-        "Time to load a beacon block from the block cache"
-    );
     pub static ref BEACON_STATE_READ_TIMES: Result<Histogram> = try_create_histogram(
         "store_beacon_state_read_seconds",
         "Total time required to read a BeaconState from the database"
@@ -105,30 +97,6 @@ lazy_static! {
     pub static ref BEACON_BLOBS_CACHE_HIT_COUNT: Result<IntCounter> = try_create_int_counter(
         "store_beacon_blobs_cache_hit_total",
         "Number of hits to the store's blob cache"
-    );
-    pub static ref BEACON_BLOCK_READ_TIMES: Result<Histogram> = try_create_histogram(
-        "store_beacon_block_read_overhead_seconds",
-        "Overhead on reading a beacon block from the DB (e.g., decoding)"
-    );
-    pub static ref BEACON_BLOCK_READ_COUNT: Result<IntCounter> = try_create_int_counter(
-        "store_beacon_block_read_total",
-        "Total number of beacon block reads from the DB"
-    );
-    pub static ref BEACON_BLOCK_READ_BYTES: Result<IntCounter> = try_create_int_counter(
-        "store_beacon_block_read_bytes_total",
-        "Total number of beacon block bytes read from the DB"
-    );
-    pub static ref BEACON_BLOCK_WRITE_TIMES: Result<Histogram> = try_create_histogram(
-        "store_beacon_block_write_overhead_seconds",
-        "Overhead on writing a beacon block to the DB (e.g., encoding)"
-    );
-    pub static ref BEACON_BLOCK_WRITE_COUNT: Result<IntCounter> = try_create_int_counter(
-        "store_beacon_block_write_total",
-        "Total number of beacon block writes the DB"
-    );
-    pub static ref BEACON_BLOCK_WRITE_BYTES: Result<IntCounter> = try_create_int_counter(
-        "store_beacon_block_write_bytes_total",
-        "Total number of beacon block bytes written to the DB"
     );
 }
 


### PR DESCRIPTION
## Issue Addressed

Is there a way for the linter to caught these unused static refs? I changed them to pub(crate) and still did not raise a warn

## Proposed Changes

Drop unused store metrics
