### PR TITLE
Record `BEACON_BLOCK_DELAY_GOSSIP` metric only after a bock is verified

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -907,16 +907,18 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             get_block_delay_ms(seen_duration, block.message(), &self.chain.slot_clock);
         // Log metrics to track delay from other nodes on the network.
 
-        metrics::set_gauge(
-            &metrics::BEACON_BLOCK_DELAY_GOSSIP,
-            block_delay.as_millis() as i64,
-        );
-
         let verification_result = self
             .chain
             .clone()
             .verify_block_for_gossip(block.clone())
             .await;
+
+        if verification_result.is_ok() {
+            metrics::set_gauge(
+                &metrics::BEACON_BLOCK_DELAY_GOSSIP,
+                block_delay.as_millis() as i64,
+            );
+        }
 
         let block_root = if let Ok(verified_block) = &verification_result {
             verified_block.block_root


### PR DESCRIPTION
@michaelsproul found that the `BEACON_BLOCK_DELAY_GOSSIP` metric is recorded before the block is verified:

https://github.com/sigp/lighthouse/blob/d84e3e391e336a5819b8734a3cf285f8821204a7/beacon_node/network/src/network_beacon_processor/gossip_methods.rs#L910-L919

This causes the metric could record a time in the range minutes-hours if an old block is received, see https://discord.com/channels/605577013327167508/746918775919738893/1255734712971038810

This PR fixes it so that the metric is only recorded after the block is verified.

Thanks @michaelsproul !