### PR TITLE
Increase penalty for old block gossip spam

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1010,16 +1010,36 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return None;
             }
-            Err(e @ BlockError::FutureSlot { .. })
-            | Err(e @ BlockError::WouldRevertFinalizedSlot { .. })
-            | Err(e @ BlockError::NotFinalizedDescendant { .. }) => {
-                debug!(self.log, "Could not verify block for gossip. Ignoring the block";
-                            "error" => %e);
+            Err(e @ BlockError::FutureSlot { .. }) => {
+                debug!(
+                    self.log,
+                    "Could not verify block for gossip. Ignoring the block";
+                    "error" => %e
+                );
                 // Prevent recurring behaviour by penalizing the peer slightly.
                 self.gossip_penalize_peer(
                     peer_id,
                     PeerAction::HighToleranceError,
                     "gossip_block_high",
+                );
+                self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
+                return None;
+            }
+            Err(e @ BlockError::WouldRevertFinalizedSlot { .. })
+            | Err(e @ BlockError::NotFinalizedDescendant { .. }) => {
+                debug!(
+                    self.log,
+                    "Could not verify block for gossip. Ignoring the block";
+                    "error" => %e
+                );
+                // The spec says we must IGNORE these blocks but there's no reason for an honest
+                // and non-buggy client to be gossiping blocks that blatantly conflict with
+                // finalization. Old versions of Erigon/Caplin are known to gossip pre-finalization
+                // blocks and we want to isolate them to encourage an update.
+                self.gossip_penalize_peer(
+                    peer_id,
+                    PeerAction::LowToleranceError,
+                    "gossip_block_low",
                 );
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
                 return None;


### PR DESCRIPTION
## Issue Addressed

Simplified and streamlined version of:

- https://github.com/sigp/lighthouse/pull/4277

## Proposed Changes

We're still seeing a lot of stale pre-finalization blocks being gossiped by Erigon/Caplin. To encourage users to update to a non-buggy version, this PR increases the peer penalty which will result in more frequent bans.

As far as I can tell there are no cases where honest peers should be gossiping blocks prior to finalization. If a peer is syncing, they should not be broadcasting the blocks they're syncing on gossip. In case of a consensus fault and chain split, it's somewhat irrelevant whether the two sides of the split remain connected to each other, as the damage has already been done by finalizing and nodes will need to be manually resynced to the correct chain. E.g. if Lighthouse-Geth finalizes an invalid checkpoint, then it will view the (valid) minority chain as conflicting with its view of finalization. There is no way it will continue importing blocks from the valid chain until its DB is blown away to revert the faulty finalization. Most attached validators (ones that attested to the invalid finalization) will also be lost at this point (leaked out to 0).

## Additional Info

Related to:

- https://github.com/sigp/lighthouse/pull/6046
