### PR TITLE
Add an option to keep existing enclave when starting local testnet

### DIFF
--- a/scripts/local_testnet/network_params.yaml
+++ b/scripts/local_testnet/network_params.yaml
@@ -12,3 +12,6 @@ network_params:
   seconds_per_slot: 3
 global_log_level: debug
 snooper_enabled: false
+additional_services:
+  - dora
+  - prometheus_grafana

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -33,6 +33,7 @@ while getopts "e:b:n:phck" flag; do
         echo "   -n: kurtosis network params file path           default: $NETWORK_PARAMS_FILE"
         echo "   -p: enable builder proposals"
         echo "   -c: CI mode, run without other additional services like Grafana and Dora explorer"
+        echo "   -k: keeping enclave to allow starting the testnet without destroying the existing one"
         echo "   -h: this help"
         exit
         ;;

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -11,15 +11,17 @@ NETWORK_PARAMS_FILE=$SCRIPT_DIR/network_params.yaml
 BUILD_IMAGE=true
 BUILDER_PROPOSALS=false
 CI=false
+KEEP_ENCLAVE=false
 
 # Get options
-while getopts "e:b:n:phc" flag; do
+while getopts "e:b:n:phck" flag; do
   case "${flag}" in
     e) ENCLAVE_NAME=${OPTARG};;
     b) BUILD_IMAGE=${OPTARG};;
     n) NETWORK_PARAMS_FILE=${OPTARG};;
     p) BUILDER_PROPOSALS=true;;
     c) CI=true;;
+    k) KEEP_ENCLAVE=true;;
     h)
         echo "Start a local testnet with kurtosis."
         echo
@@ -62,9 +64,6 @@ if [ "$CI" = true ]; then
   # TODO: run assertoor tests
   yq eval '.additional_services = []' -i $NETWORK_PARAMS_FILE
   echo "Running without additional services (CI mode)."
-else
-  yq eval '.additional_services = ["dora", "prometheus_grafana"]' -i $NETWORK_PARAMS_FILE
-  echo "Additional services dora and prometheus_grafana added to network_params.yaml"
 fi
 
 if [ "$BUILD_IMAGE" = true ]; then
@@ -75,9 +74,11 @@ else
     echo "Not rebuilding Lighthouse Docker image."
 fi
 
-# Stop local testnet
-kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
+if [ "$KEEP_ENCLAVE" = false ]; then
+  # Stop local testnet
+  kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
+fi
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --image-download always --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"

--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -75,11 +75,14 @@ else
     echo "Not rebuilding Lighthouse Docker image."
 fi
 
+IMAGE_DOWNLOAD_FLAG=""
+
 if [ "$KEEP_ENCLAVE" = false ]; then
   # Stop local testnet
   kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
+  IMAGE_DOWNLOAD_FLAG="--image-download always"
 fi
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --image-download always --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package $IMAGE_DOWNLOAD_FLAG --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"


### PR DESCRIPTION
## Issue Addressed

This PR contains the following improvements to local testnet scripts:
1. Add a `-k` (`KEEP_ENCLAVE`) option to allow starting the testnet without destroying the existing one. This allows ~~starting from the existing db with an updated image.~~ modifying log levels, add additional services and re-run the testnet without having to destroy and start from scratch, using the `-k` option of this script. Note that updating image will cause the container to be recreated, and causes the node to lose its state. If all nodes lose their state, the network will stall.

2. Move the `additional_services` back into the `network_params.yaml`. Dynamically modifying the network_params file (other than CI) is quite a confusing behaviour, because user's manually added services would get overridden.
3. Add `--image-download always` to the kurtosis run command to make sure we're not testing against outdated images.