### PR TITLE
Fix builds with `slasher-redb`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,8 +174,9 @@ test-network-%:
 # Run the tests in the `slasher` crate for all supported database backends.
 test-slasher:
 	cargo nextest run --release -p slasher --features "lmdb,$(TEST_FEATURES)"
+	cargo nextest run --release -p slasher --no-default-features --features "redb,$(TEST_FEATURES)"
 	cargo nextest run --release -p slasher --no-default-features --features "mdbx,$(TEST_FEATURES)"
-	cargo nextest run --release -p slasher --features "lmdb,mdbx,$(TEST_FEATURES)" # both backends enabled
+	cargo nextest run --release -p slasher --features "lmdb,mdbx,redb,$(TEST_FEATURES)" # all backends enabled
 
 # Runs only the tests/state_transition_vectors tests.
 run-state-transition-tests:

--- a/slasher/src/database/redb_impl.rs
+++ b/slasher/src/database/redb_impl.rs
@@ -91,7 +91,7 @@ impl Environment {
     }
 
     pub fn filenames(&self, config: &Config) -> Vec<PathBuf> {
-        vec![config.database_path.join(BASE_DB)]
+        vec![config.database_path.join(REDB_DATA_FILENAME)]
     }
 
     pub fn begin_rw_txn(&self) -> Result<RwTransaction, Error> {

--- a/slasher/tests/backend.rs
+++ b/slasher/tests/backend.rs
@@ -1,4 +1,4 @@
-#![cfg(any(feature = "lmdb", feature = "redb"))]
+#![cfg(feature = "lmdb")]
 
 use slasher::{config::MDBX_DATA_FILENAME, Config, DatabaseBackend, DatabaseBackendOverride};
 use std::fs::File;
@@ -41,7 +41,7 @@ fn no_override_with_existing_mdbx_db() {
 }
 
 #[test]
-#[cfg(all(not(feature = "mdbx"), feature = "lmdb", not(feature = "redb")))]
+#[cfg(all(not(feature = "mdbx"), feature = "lmdb"))]
 fn failed_override_with_existing_mdbx_db() {
     let tempdir = tempdir().unwrap();
     let mut config = Config::new(tempdir.path().into());

--- a/slasher/tests/backend.rs
+++ b/slasher/tests/backend.rs
@@ -55,19 +55,3 @@ fn failed_override_with_existing_mdbx_db() {
     );
     assert_eq!(config.backend, DatabaseBackend::Lmdb);
 }
-
-#[test]
-#[cfg(feature = "redb")]
-fn failed_override_with_existing_mdbx_db() {
-    let tempdir = tempdir().unwrap();
-    let mut config = Config::new(tempdir.path().into());
-
-    let filename = config.database_path.join(MDBX_DATA_FILENAME);
-    File::create(&filename).unwrap();
-
-    assert_eq!(
-        config.override_backend(),
-        DatabaseBackendOverride::Failure(filename)
-    );
-    assert_eq!(config.backend, DatabaseBackend::Redb);
-}


### PR DESCRIPTION
## Issue Addressed

Currently `unstable` fails to build with the `slasher-redb` feature due to a last-minute tweak I made to the `redb` impl prior to merging.

## Proposed Changes

- Correct the compilation error
- Run the tests for the `redb` slasher on CI (would have caught this issue)
