### PR TITLE
Add requires `suggested-fee-recipient` flag when `always-prepare-payload` is set

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1333,6 +1333,7 @@ pub fn cli_app() -> Command {
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
+                .requires("suggested-fee-recipient")
         )
         .arg(
             Arg::new("fork-choice-before-proposal-timeout")

--- a/book/src/api-bn.md
+++ b/book/src/api-bn.md
@@ -128,7 +128,7 @@ You can replace `1` in the above command with the validator index that you would
 
 ### Events API
 
-The [events API](https://ethereum.github.io/beacon-APIs/#/Events/eventstream) provides information such as the payload attributes that are of interest to block builders and relays. To query the payload attributes, it is necessary to run Lighthouse beacon node with the flag `--always-prepare-payload`. It is also recommended to add the flag `--prepare-payload-lookahead 8000` which configures the payload attributes to be sent at 4s into each slot (or 8s from the start of the next slot). An example of the command is:
+The [events API](https://ethereum.github.io/beacon-APIs/#/Events/eventstream) provides information such as the payload attributes that are of interest to block builders and relays. To query the payload attributes, it is necessary to run Lighthouse beacon node with the flag `--always-prepare-payload`. With the flag `--always-prepare-payload`, it is mandatory to also have the flag `--suggested-fee-recipient` set on the beacon node. You could pass a dummy fee recipient and have it override with the intended fee recipient of the proposer during the actual block proposal. It is also recommended to add the flag `--prepare-payload-lookahead 8000` which configures the payload attributes to be sent at 4s into each slot (or 8s from the start of the next slot). An example of the command is:
 
 ```bash
 curl -X 'GET' \

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -269,15 +269,12 @@ fn always_prepare_payload_default() {
 fn always_prepare_payload_override() {
     CommandLineTest::new()
         .flag("always-prepare-payload", None)
+        .flag(
+            "suggested-fee-recipient",
+            "0x00000000219ab540356cbb839cbe05303d7705fa",
+        )
         .run_with_zero_port()
-        .with_config(|config| {
-            assert!(config.chain.always_prepare_payload);
-            let config = config.execution_layer.as_ref().unwrap();
-            assert_eq!(
-                config.suggested_fee_recipient,
-                Some(Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap())
-            )
-        });
+        .with_config(|config| assert!(config.chain.always_prepare_payload));
 }
 
 #[test]

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -271,7 +271,7 @@ fn always_prepare_payload_override() {
         .flag("always-prepare-payload", None)
         .flag(
             "suggested-fee-recipient",
-            "0x00000000219ab540356cbb839cbe05303d7705fa",
+            Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -273,6 +273,7 @@ fn always_prepare_payload_override() {
             "suggested-fee-recipient",
             Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
+        .flag("execution-endpoint", Some("http://localhost:8551/"))
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -267,6 +267,7 @@ fn always_prepare_payload_default() {
 
 #[test]
 fn always_prepare_payload_override() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
     CommandLineTest::new()
         .flag("always-prepare-payload", None)
         .flag(
@@ -274,7 +275,10 @@ fn always_prepare_payload_override() {
             Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
         .flag("execution-endpoint", Some("http://localhost:8551/"))
-        .flag("execution-jwt-secret-key", Some(jwt_secret_key))
+        .flag(
+            "execution-jwt",
+            dir.path().join("jwt-file").as_os_str().to_str(),
+        )
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -270,7 +270,14 @@ fn always_prepare_payload_override() {
     CommandLineTest::new()
         .flag("always-prepare-payload", None)
         .run_with_zero_port()
-        .with_config(|config| assert!(config.chain.always_prepare_payload));
+        .with_config(|config| {
+            assert!(config.chain.always_prepare_payload);
+            let config = config.execution_layer.as_ref().unwrap();
+            assert_eq!(
+                config.suggested_fee_recipient,
+                Some(Address::from_str("0x00000000219ab540356cbb839cbe05303d7705fa").unwrap())
+            )
+        });
 }
 
 #[test]

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -274,6 +274,7 @@ fn always_prepare_payload_override() {
             Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
         .flag("execution-endpoint", Some("http://localhost:8551/"))
+        .flag("execution-jwt", Some(&jwts_arg))
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -274,7 +274,10 @@ fn always_prepare_payload_override() {
             Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
         .flag("execution-endpoint", Some("http://localhost:8551/"))
-        .flag("execution-jwt", Some(&jwts_arg))
+        .flag(
+            "execution-jwt",
+            dir.path().join("jwt-file").as_os_str().to_str(),
+        )
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));
 }

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -274,10 +274,7 @@ fn always_prepare_payload_override() {
             Some("0x00000000219ab540356cbb839cbe05303d7705fa"),
         )
         .flag("execution-endpoint", Some("http://localhost:8551/"))
-        .flag(
-            "execution-jwt",
-            dir.path().join("jwt-file").as_os_str().to_str(),
-        )
+        .flag("execution-jwt-secret-key", Some(jwt_secret_key))
         .run_with_zero_port()
         .with_config(|config| assert!(config.chain.always_prepare_payload));
 }


### PR DESCRIPTION
Currently, when the flag `--always-prepare-payload` is set and a fee recipient is not set in the beacon node, the beacon node will print the log:

`CRIT Fee recipient unknown                   proposer_index: 368409, msg: the suggested_fee_recipient was unknown during block production. a junk address was used, rewards were lost! check the --suggested-fee-recipient flag and VC configuration., service: exec`

which can be noisy and not desirable. This PR changes it so that the flag ` --suggested-fee-recipient` must always be set when `--always-prepare-payload` is set. The documentation is also updated to reflect this change.

Thanks to the discussion raised by @just_in_time and @michaelsproul in Discord

























































