### PR TITLE
Bump default `logfile-max-number` to 10

### DIFF
--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -241,7 +241,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -70,7 +70,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -86,7 +86,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -62,7 +62,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -74,7 +74,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -43,7 +43,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -63,7 +63,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-          background file logging is disabled. [default: 5]
+§          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -63,7 +63,7 @@ Options:
           [possible values: DEFAULT, JSON]
       --logfile-max-number <COUNT>
           The maximum number of log files that will be stored. If set to 0,
-§          background file logging is disabled. [default: 10]
+          background file logging is disabled. [default: 10]
       --logfile-max-size <SIZE>
           The maximum size (in MB) each log file can grow to before rotating. If
           set to 0, background file logging is disabled. [default: 200]

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -169,7 +169,7 @@ fn main() {
                     "The maximum number of log files that will be stored. If set to 0, \
                     background file logging is disabled.")
                 .action(ArgAction::Set)
-                .default_value("5")
+                .default_value("10")
                 .global(true)
                 .display_order(0)
         )


### PR DESCRIPTION
## Issue Addressed

This PR bumps the default `logfile-max-number` from `5` to `10`.

When the beacon node has a large number of validators attached to it, the log file gets filled up and sometimes gets rotated very quickly. This gets a bit worse if the node is overwhelmed / behind. It would be better if the debug logs can stay on the machine for at least 2~3 days, so that we have enough time to respond when an issue occurs. There's been multiple instances where we request logs from user and the old logs just got rotated out.

The current default limits the total logs stored on disk to 1Gb, this change would increase it to 2Gb, which isn't too bad.