### PR TITLE
Enable the outbound rate limiter by default, and update blobs method quotas

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -103,8 +103,13 @@ impl RateLimiterConfig {
     pub const DEFAULT_GOODBYE_QUOTA: Quota = Quota::one_every(10);
     pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota = Quota::n_every(1024, 10);
     pub const DEFAULT_BLOCKS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
-    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(768, 10);
-    pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
+    // `BlocksByRange` and `BlobsByRange` are sent together during range sync.
+    // It makes sense for blocks and blobs quotas to be equivalent in terms of the number of blocks:
+    // 1024 blocks * 6 max blobs per block.
+    // This doesn't necessarily mean that we are sending this many blobs, because the quotas are
+    // measured against the maximum request size.
+    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(6144, 10);
+    pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(768, 10);
     pub const DEFAULT_LIGHT_CLIENT_BOOTSTRAP_QUOTA: Quota = Quota::one_every(10);
     pub const DEFAULT_LIGHT_CLIENT_OPTIMISTIC_UPDATE_QUOTA: Quota = Quota::one_every(10);
     pub const DEFAULT_LIGHT_CLIENT_FINALITY_UPDATE_QUOTA: Quota = Quota::one_every(10);

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -372,16 +372,21 @@ pub fn cli_app() -> Command {
         .arg(
             Arg::new("self-limiter")
             .long("self-limiter")
-            .help(
-                "Enables the outbound rate limiter (requests made by this node). \
-                Use the self-limiter-protocol flag to set per protocol configurations. \
-                If the self rate limiter is enabled and a protocol is not \
-                present in the configuration, the quotas used for the inbound rate limiter will be \
-                used."
-            )
+            .help("This flag is deprecated and has no effect.")
+            .hide(true)
             .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
             .display_order(0)
+        )
+        .arg(
+            Arg::new("disable-self-limiter")
+                .long("disable-self-limiter")
+                .help(
+                    "Disables the outbound rate limiter (requests sent by this node)."
+                )
+                .action(ArgAction::SetTrue)
+                .help_heading(FLAG_HEADER)
+                .display_order(0)
         )
         .arg(
             Arg::new("self-limiter-protocols")
@@ -397,7 +402,7 @@ pub fn cli_app() -> Command {
             )
             .action(ArgAction::Append)
             .value_delimiter(';')
-            .requires("self-limiter")
+            .conflicts_with("disable-self-limiter")
             .display_order(0)
         )
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1420,12 +1420,10 @@ pub fn set_network_config(
     // the default params will be used.
     config.outbound_rate_limiter_config = if parse_flag(cli_args, "disable-self-limiter") {
         None
+    } else if let Some(protocols) = cli_args.get_one::<String>("self-limiter-protocols") {
+        Some(protocols.parse()?)
     } else {
-        if let Some(protocols) = cli_args.get_one::<String>("self-limiter-protocols") {
-            Some(protocols.parse()?)
-        } else {
-            Some(Default::default())
-        }
+        Some(Default::default())
     };
 
     // Proposer-only mode overrides a number of previous configuration parameters.

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1416,16 +1416,17 @@ pub fn set_network_config(
     // Light client server config.
     config.enable_light_client_server = parse_flag(cli_args, "light-client-server");
 
-    // The self limiter is disabled by default. If the `self-limiter` flag is provided
-    // without the `self-limiter-protocols` flag, the default params will be used.
-    if parse_flag(cli_args, "self-limiter") {
-        config.outbound_rate_limiter_config =
-            if let Some(protocols) = cli_args.get_one::<String>("self-limiter-protocols") {
-                Some(protocols.parse()?)
-            } else {
-                Some(Default::default())
-            };
-    }
+    // The self limiter is enabled by default. If the `self-limiter-protocols` flag is not provided,
+    // the default params will be used.
+    config.outbound_rate_limiter_config = if parse_flag(cli_args, "disable-self-limiter") {
+        None
+    } else {
+        if let Some(protocols) = cli_args.get_one::<String>("self-limiter-protocols") {
+            Some(protocols.parse()?)
+        } else {
+            Some(Default::default())
+        }
+    };
 
     // Proposer-only mode overrides a number of previous configuration parameters.
     // Specifically, we avoid subscribing to long-lived subnets and wish to maintain a minimal set

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -505,6 +505,8 @@ Flags:
       --disable-quic
           Disables the quic transport. The node will rely solely on the TCP
           transport for libp2p connections.
+      --disable-self-limiter
+          Disables the outbound rate limiter (requests sent by this node).
       --disable-upnp
           Disables UPnP support. Setting this will prevent Lighthouse from
           attempting to automatically establish external port mappings.
@@ -575,12 +577,6 @@ Flags:
           When present, Lighthouse will forget the payload statuses of any
           already-imported blocks. This can assist in the recovery from a
           consensus failure caused by the execution layer.
-      --self-limiter
-          Enables the outbound rate limiter (requests made by this node). Use
-          the self-limiter-protocol flag to set per protocol configurations. If
-          the self rate limiter is enabled and a protocol is not present in the
-          configuration, the quotas used for the inbound rate limiter will be
-          used.
       --shutdown-after-sync
           Shutdown beacon node as soon as sync is completed. Backfill sync will
           not be performed before shutdown.


### PR DESCRIPTION
## Issue Addressed

Enable outbound rate limiter by default to prevent sending execessive amount of requests the peers in case of bugs.

There are **no known issues** on the `stable` branch that would require this change. However, such issues have occurred on some feature branches, and it makes sense to enable the rate limiter by default. This is also important in preparation for PeerDAS, to moderate the speed at which nodes perform sampling during sync.
