### PR TITLE
Fix bug on engine api with consolidations

### DIFF
--- a/beacon_node/execution_layer/src/engine_api.rs
+++ b/beacon_node/execution_layer/src/engine_api.rs
@@ -43,7 +43,7 @@ pub use new_payload_request::{
     NewPayloadRequestDeneb, NewPayloadRequestElectra,
 };
 
-use self::json_structures::{JsonDepositRequest, JsonWithdrawalRequest};
+use self::json_structures::{JsonConsolidationRequest, JsonDepositRequest, JsonWithdrawalRequest};
 
 pub const LATEST_TAG: &str = "latest";
 
@@ -210,8 +210,7 @@ pub struct ExecutionBlockWithTransactions<E: EthSpec> {
     #[superstruct(only(Electra))]
     pub withdrawal_requests: Vec<JsonWithdrawalRequest>,
     #[superstruct(only(Electra))]
-    // TODO(electra): I don't think we need a JsonConsolidationRequest here because the bytes should be little-endian but we need to confirm
-    pub consolidation_requests: Vec<ConsolidationRequest>,
+    pub consolidation_requests: Vec<JsonConsolidationRequest>,
 }
 
 impl<E: EthSpec> TryFrom<ExecutionPayload<E>> for ExecutionBlockWithTransactions<E> {
@@ -329,7 +328,11 @@ impl<E: EthSpec> TryFrom<ExecutionPayload<E>> for ExecutionBlockWithTransactions
                         .into_iter()
                         .map(|withdrawal| withdrawal.into())
                         .collect(),
-                    consolidation_requests: block.consolidation_requests.to_vec(),
+                    consolidation_requests: block
+                        .consolidation_requests
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
                 })
             }
         };

--- a/beacon_node/execution_layer/src/engine_api/json_structures.rs
+++ b/beacon_node/execution_layer/src/engine_api/json_structures.rs
@@ -108,7 +108,7 @@ pub struct JsonExecutionPayload<E: EthSpec> {
         VariableList<JsonWithdrawalRequest, E::MaxWithdrawalRequestsPerPayload>,
     #[superstruct(only(V4))]
     pub consolidation_requests:
-        VariableList<ConsolidationRequest, E::MaxConsolidationRequestsPerPayload>,
+        VariableList<JsonConsolidationRequest, E::MaxConsolidationRequestsPerPayload>,
 }
 
 impl<E: EthSpec> From<ExecutionPayloadBellatrix<E>> for JsonExecutionPayloadV1<E> {
@@ -223,7 +223,12 @@ impl<E: EthSpec> From<ExecutionPayloadElectra<E>> for JsonExecutionPayloadV4<E> 
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),
-            consolidation_requests: payload.consolidation_requests,
+            consolidation_requests: payload
+                .consolidation_requests
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+                .into(),
         }
     }
 }
@@ -352,7 +357,12 @@ impl<E: EthSpec> From<JsonExecutionPayloadV4<E>> for ExecutionPayloadElectra<E> 
                 .map(Into::into)
                 .collect::<Vec<_>>()
                 .into(),
-            consolidation_requests: payload.consolidation_requests,
+            consolidation_requests: payload
+                .consolidation_requests
+                .into_iter()
+                .map(Into::into)
+                .collect::<Vec<_>>()
+                .into(),
         }
     }
 }
@@ -924,6 +934,34 @@ impl From<JsonWithdrawalRequest> for WithdrawalRequest {
             source_address: json_withdrawal_request.source_address,
             validator_pubkey: json_withdrawal_request.validator_pubkey,
             amount: json_withdrawal_request.amount,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct JsonConsolidationRequest {
+    pub source_address: Address,
+    pub source_pubkey: PublicKeyBytes,
+    pub target_pubkey: PublicKeyBytes,
+}
+
+impl From<ConsolidationRequest> for JsonConsolidationRequest {
+    fn from(consolidation_request: ConsolidationRequest) -> Self {
+        Self {
+            source_address: consolidation_request.source_address,
+            source_pubkey: consolidation_request.source_pubkey,
+            target_pubkey: consolidation_request.target_pubkey,
+        }
+    }
+}
+
+impl From<JsonConsolidationRequest> for ConsolidationRequest {
+    fn from(json_consolidation_request: JsonConsolidationRequest) -> Self {
+        Self {
+            source_address: json_consolidation_request.source_address,
+            source_pubkey: json_consolidation_request.source_pubkey,
+            target_pubkey: json_consolidation_request.target_pubkey,
         }
     }
 }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2011,9 +2011,14 @@ impl<E: EthSpec> ExecutionLayer<E> {
                 )
                 .map_err(ApiError::DeserializeWithdrawalRequests)?;
                 let n_consolidations = electra_block.consolidation_requests.len();
-                let consolidation_requests =
-                    VariableList::new(electra_block.consolidation_requests)
-                        .map_err(|_| ApiError::TooManyConsolidationRequests(n_consolidations))?;
+                let consolidation_requests = VariableList::new(
+                    electra_block
+                        .consolidation_requests
+                        .into_iter()
+                        .map(Into::into)
+                        .collect::<Vec<_>>(),
+                )
+                .map_err(|_| ApiError::TooManyConsolidationRequests(n_consolidations))?;
                 ExecutionPayload::Electra(ExecutionPayloadElectra {
                     parent_hash: electra_block.parent_hash,
                     fee_recipient: electra_block.fee_recipient,

--- a/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
+++ b/beacon_node/execution_layer/src/test_utils/handle_rpc.rs
@@ -658,7 +658,13 @@ pub async fn handle_rpc<E: EthSpec>(
                             ),
                             consolidation_requests: block.consolidation_requests().ok().map(
                                 |consolidation_requests| {
-                                    VariableList::from(consolidation_requests.clone())
+                                    VariableList::from(
+                                        consolidation_requests
+                                            .clone()
+                                            .into_iter()
+                                            .map(Into::into)
+                                            .collect::<Vec<_>>(),
+                                    )
                                 },
                             ),
                         }));


### PR DESCRIPTION
## Issue Addressed

Needed a `JsonConsolidationRequest` object just to make the names `camelCase` :/
