### PR TITLE
Remove trace logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ serde_json = "1"
 serde_repr = "0.1"
 serde_yaml = "0.9"
 sha2 = "0.9"
-slog = { version = "2", features = ["max_level_trace", "release_max_level_trace", "nested-values"] }
+slog = { version = "2", features = ["max_level_debug", "release_max_level_debug", "nested-values"] }
 slog-async = "2"
 slog-term = "2"
 sloggers = { version = "2", features = ["json"] }


### PR DESCRIPTION
In practice I do not use trace logging and I don't know if anyone else does. 

The way slog works is it passes these logs into its own task and then filters based on the log level. We are currently compiling with trace logging, which I would imagine has a non-negligible performance hit by producing all the trace logging then filtering them out. 

Even when we are debugging we rarely use trace-level logging (to my knowledge). Even if we wanted to use them, we would have to restart the client as most default configurations favour debug-level. 

For those really wanting trace-level logging, I propose they re-compile lighthouse to enable it, to spare everyone else not using tracing from generating and filtering the logs.
