### PR TITLE
Disable slasher default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ pretty_reqwest_error = { path = "common/pretty_reqwest_error" }
 proto_array = { path = "consensus/proto_array" }
 safe_arith = { path = "consensus/safe_arith" }
 sensitive_url = { path = "common/sensitive_url" }
-slasher = { path = "slasher" }
+slasher = { path = "slasher", default-features = false }
 slashing_protection = { path = "validator_client/slashing_protection" }
 slot_clock = { path = "common/slot_clock" }
 state_processing = { path = "consensus/state_processing" }


### PR DESCRIPTION
## Issue Addressed

Because slasher had lmdb as a default feature, it was impossible to have a pure mdbx build of lighthouse.

## Proposed Changes

This commit sets `default-features = false` for slasher so lighthouse can actually choose one or the other.