### PR TITLE
Fix payload_bodies bug in engine_api

### DIFF
--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -1791,7 +1791,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
             .request(|engine: &Engine| async move {
                 engine
                     .api
-                    .get_payload_bodies_by_range_v1(start, count)
+                    .get_payload_bodies_by_range(start, count)
                     .await
             })
             .await


### PR DESCRIPTION
## Issue Addressed

Lighthouse was using the wrong method for `get_payload_bodies_by_range()`
