### PR TITLE
chore: update peerdas-kzg library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_bls12_381"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
 dependencies = [
  "blst",
  "blstrs",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_erasure_codes"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_polynomial",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_polynomial"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
 ]
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_kzg_multi_open_fk20"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_polynomial",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "eip7594"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_erasure_codes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,8 +4421,10 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "c-kzg",
+ "criterion",
  "derivative",
  "eip7594",
+ "eth2_network_config",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
@@ -4430,6 +4432,7 @@ dependencies = [
  "hex",
  "mockall",
  "serde",
+ "serde_json",
  "tree_hash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_bls12_381"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=bb8295011cf27dc663699539c7f9a17fe273e896#bb8295011cf27dc663699539c7f9a17fe273e896"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
 dependencies = [
  "blst",
  "blstrs",
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_erasure_codes"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=bb8295011cf27dc663699539c7f9a17fe273e896#bb8295011cf27dc663699539c7f9a17fe273e896"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_polynomial",
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_internal_peerdas_polynomial"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=bb8295011cf27dc663699539c7f9a17fe273e896#bb8295011cf27dc663699539c7f9a17fe273e896"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
 ]
@@ -1588,7 +1588,7 @@ dependencies = [
 [[package]]
 name = "crate_crypto_kzg_multi_open_fk20"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=bb8295011cf27dc663699539c7f9a17fe273e896#bb8295011cf27dc663699539c7f9a17fe273e896"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_polynomial",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "eip7594"
 version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=bb8295011cf27dc663699539c7f9a17fe273e896#bb8295011cf27dc663699539c7f9a17fe273e896"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=cbe41bf98379f038af3766032279d2185e7a1c5a#cbe41bf98379f038af3766032279d2185e7a1c5a"
 dependencies = [
  "crate_crypto_internal_peerdas_bls12_381",
  "crate_crypto_internal_peerdas_erasure_codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ delay_map = "0.3"
 derivative = "2"
 dirs = "3"
 either = "1.9"
-peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "bb8295011cf27dc663699539c7f9a17fe273e896", package = "eip7594" }
+peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "cbe41bf98379f038af3766032279d2185e7a1c5a", package = "eip7594" }
 discv5 = { version = "0.4.1", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ delay_map = "0.3"
 derivative = "2"
 dirs = "3"
 either = "1.9"
-peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "cbe41bf98379f038af3766032279d2185e7a1c5a", package = "eip7594" }
+peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "55ae9e9011d792a2998d242c2a71d822ba909fa9", package = "eip7594" }
 discv5 = { version = "0.4.1", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -19,3 +19,12 @@ ethereum_hashing = { workspace = true }
 c-kzg = { workspace = true }
 peerdas-kzg = { workspace = true }
 mockall = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+serde_json = { workspace = true }
+eth2_network_config = { workspace = true }
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -1,0 +1,27 @@
+use c_kzg::KzgSettings;
+use criterion::{criterion_group, criterion_main, Criterion};
+use eth2_network_config::TRUSTED_SETUP_BYTES;
+use kzg::TrustedSetup;
+use peerdas_kzg::{PeerDASContext, TrustedSetup as PeerDASTrustedSetup};
+
+pub fn bench_init_context(c: &mut Criterion) {
+    c.bench_function(&format!("Initialize context peerdas-kzg"), |b| {
+        b.iter(|| {
+            const NUM_THREADS: usize = 1;
+            let trusted_setup = PeerDASTrustedSetup::default();
+            PeerDASContext::with_threads(&trusted_setup, NUM_THREADS)
+        })
+    });
+    c.bench_function(&format!("Initialize context c-kzg (4844)"), |b| {
+        b.iter(|| {
+            let trusted_setup: TrustedSetup = serde_json::from_reader(TRUSTED_SETUP_BYTES)
+                .map_err(|e| format!("Unable to read trusted setup file: {}", e))
+                .expect("should have trusted setup");
+            KzgSettings::load_trusted_setup(&trusted_setup.g1_points(), &trusted_setup.g2_points())
+                .unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, bench_init_context);
+criterion_main!(benches);

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -17,7 +17,7 @@ use mockall::automock;
 
 pub use peerdas_kzg::{
     constants::{BYTES_PER_CELL, CELLS_PER_EXT_BLOB},
-    Cell, CellID, CellRef, TrustedSetup as PeerDASTrustedSetup,
+    Cell, CellIndex as CellID, CellRef, TrustedSetup as PeerDASTrustedSetup,
 };
 use peerdas_kzg::{prover::ProverError, verifier::VerifierError, PeerDASContext};
 pub type CellsAndKzgProofs = ([Cell; CELLS_PER_EXT_BLOB], [KzgProof; CELLS_PER_EXT_BLOB]);
@@ -181,7 +181,6 @@ impl Kzg {
 
         let (cells, proofs) = self
             .context
-            .prover_ctx()
             .compute_cells_and_kzg_proofs(blob_bytes)
             .map_err(Error::ProverKZG)?;
 
@@ -212,7 +211,7 @@ impl Kzg {
             .iter()
             .map(|commitment| commitment.as_ref())
             .collect();
-        let verification_result = self.context.verifier_ctx().verify_cell_kzg_proof_batch(
+        let verification_result = self.context.verify_cell_kzg_proof_batch(
             commitments.to_vec(),
             rows,
             columns,
@@ -236,7 +235,6 @@ impl Kzg {
     ) -> Result<CellsAndKzgProofs, Error> {
         let (cells, proofs) = self
             .context
-            .prover_ctx()
             .recover_cells_and_proofs(cell_ids.to_vec(), cells.to_vec())
             .map_err(Error::ProverKZG)?;
 


### PR DESCRIPTION
## Issue Addressed

This adds the following changes from upstream:

- Removed the need to call `prover_context` and `verifier_context` when accessing methods
- [Replaced rust-embed with include_str!](https://github.com/crate-crypto/peerdas-kzg/pull/77) due to an issue in devnet
- Removed subgroup checks that were being done on the trusted setup. Its safer to have them, though you really only need to do it once, if your input is constant.

I've added a benchmark for initializing the context for peerdas-kzg and c-kzg (I can remove the benchmark, was just incase you wanted it) -- though note that it benchmarks c-kzg (4844) which does a lot less things than the peerdas variant. 

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
