### PR TITLE
Fix `proposer-nodes` cli flag name

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -2,6 +2,7 @@ use validator_client::{config::DEFAULT_WEB3SIGNER_KEEP_ALIVE, ApiTopic, Config};
 
 use crate::exec::CommandLineTestExec;
 use bls::{Keypair, PublicKeyBytes};
+use sensitive_url::SensitiveUrl;
 use std::fs::File;
 use std::io::Write;
 use std::net::IpAddr;
@@ -669,6 +670,29 @@ fn validator_web3_signer_keep_alive_override() {
             assert_eq!(
                 config.web3_signer_keep_alive_timeout,
                 Some(Duration::from_secs(1))
+            );
+        });
+}
+
+#[test]
+fn validator_proposer_nodes_default_empty() {
+    CommandLineTest::new().run().with_config(|config| {
+        assert_eq!(config.proposer_nodes, vec![]);
+    });
+}
+
+#[test]
+fn validator_proposer_nodes() {
+    CommandLineTest::new()
+        .flag("proposer-nodes", Some("http://bn-1:5052,http://bn-2:5052"))
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.proposer_nodes,
+                vec![
+                    SensitiveUrl::parse("http://bn-1:5052").unwrap(),
+                    SensitiveUrl::parse("http://bn-2:5052").unwrap()
+                ]
             );
         });
 }

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -187,7 +187,7 @@ impl Config {
                 .collect::<Result<_, _>>()
                 .map_err(|e| format!("Unable to parse beacon node URL: {:?}", e))?;
         }
-        if let Some(proposer_nodes) = parse_optional::<String>(cli_args, "proposer_nodes")? {
+        if let Some(proposer_nodes) = parse_optional::<String>(cli_args, "proposer-nodes")? {
             config.proposer_nodes = proposer_nodes
                 .split(',')
                 .map(SensitiveUrl::parse)


### PR DESCRIPTION
## Issue Addressed

Getting this error while trying to run validator client locally (with a custom built docker image) and it shuts down immediately with:
```
Unable to initialize validator config: Unable to parse proposer_nodes: Unknown argument or group id.  Make sure you are using the argument id and not the short or long flags
```

This PR fixes the `--proposer-node` flag parsing to use the correct arg name.

https://github.com/sigp/lighthouse/blob/947e2e8db1646ce56b5fdf9e04cd2b80d5b564ff/validator_client/src/cli.rs#L33-L35