### PR TITLE
Return syncing on HTTP when sync is stalled

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2888,7 +2888,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 .map_err(warp_utils::reject::beacon_chain_error)?;
 
                             let syncing_data = api_types::SyncingData {
-                                is_syncing: network_globals.sync_state.read().is_syncing(),
+                                is_syncing: !network_globals.sync_state.read().is_synced(),
                                 is_optimistic: Some(is_optimistic),
                                 el_offline: Some(el_offline),
                                 head_slot,

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -23,7 +23,7 @@ use http_api::{
     test_utils::{create_api_server, ApiServer},
     BlockId, StateId,
 };
-use lighthouse_network::{Enr, EnrExt, PeerId};
+use lighthouse_network::{types::SyncState, Enr, EnrExt, PeerId};
 use network::NetworkReceivers;
 use proto_array::ExecutionStatus;
 use sensitive_url::SensitiveUrl;
@@ -62,6 +62,7 @@ const SKIPPED_SLOTS: &[u64] = &[
 ];
 
 struct ApiTester {
+    ctx: Arc<http_api::Context<EphemeralHarnessType<E>>>,
     harness: Arc<BeaconChainHarness<EphemeralHarnessType<E>>>,
     chain: Arc<BeaconChain<EphemeralHarnessType<E>>>,
     client: BeaconNodeHttpClient,
@@ -253,7 +254,7 @@ impl ApiTester {
         let log = null_logger().unwrap();
 
         let ApiServer {
-            ctx: _,
+            ctx,
             server,
             listening_socket,
             network_rx,
@@ -284,6 +285,7 @@ impl ApiTester {
         );
 
         Self {
+            ctx,
             harness: Arc::new(harness),
             chain,
             client,
@@ -350,7 +352,7 @@ impl ApiTester {
         let log = null_logger().unwrap();
 
         let ApiServer {
-            ctx: _,
+            ctx,
             server,
             listening_socket,
             network_rx,
@@ -371,6 +373,7 @@ impl ApiTester {
         );
 
         Self {
+            ctx,
             harness,
             chain,
             client,
@@ -2164,6 +2167,37 @@ impl ApiTester {
         };
 
         assert_eq!(result, expected);
+
+        self
+    }
+
+    pub async fn test_get_node_syncing_stalled(self) -> Self {
+        // Set sync status to stalled.
+        *self
+            .ctx
+            .network_globals
+            .as_ref()
+            .unwrap()
+            .sync_state
+            .write() = SyncState::Stalled;
+
+        let is_syncing = self
+            .client
+            .get_node_syncing()
+            .await
+            .unwrap()
+            .data
+            .is_syncing;
+        assert_eq!(is_syncing, true);
+
+        // Reset sync state.
+        *self
+            .ctx
+            .network_globals
+            .as_ref()
+            .unwrap()
+            .sync_state
+            .write() = SyncState::Synced;
 
         self
     }
@@ -6122,6 +6156,8 @@ async fn node_get() {
         .test_get_node_version()
         .await
         .test_get_node_syncing()
+        .await
+        .test_get_node_syncing_stalled()
         .await
         .test_get_node_identity()
         .await


### PR DESCRIPTION
## Issue Addressed

Closes #6121:

- https://github.com/sigp/lighthouse/issues/6121

## Proposed Changes

The `syncing` field of `/eth/v1/node/syncing` would be `false` when sync is stalled (e.g. due to 0 peers). I think the intention of the API is to show `syncing: false` only when the node is fully synced, so it is better if we return `syncing: true` for a stall.

In terms of liveness (e.g. a network where _all_ BNs are stalled), the validator client will try requests even if its BN indicates that it is stalled. It might just try those BNs less preferentially. 

## Additional Info

Related liveness risk:

- https://github.com/sigp/lighthouse/pull/6014
