### PR TITLE
Delete `--builder-profit-threshold` flag

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1408,14 +1408,6 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
-            Arg::new("builder-profit-threshold")
-                .long("builder-profit-threshold")
-                .value_name("WEI_VALUE")
-                .help("This flag is deprecated and has no effect.")
-                .action(ArgAction::Set)
-                .display_order(0)
-        )
-        .arg(
             Arg::new("builder-user-agent")
                 .long("builder-user-agent")
                 .value_name("STRING")

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -335,13 +335,6 @@ pub fn get_config<E: EthSpec>(
                     .map(Duration::from_millis);
         }
 
-        if parse_flag(cli_args, "builder-profit-threshold") {
-            warn!(
-                log,
-                "Ignoring --builder-profit-threshold";
-                "info" => "this flag is deprecated and will be removed"
-            );
-        }
         if cli_args.get_flag("always-prefer-builder-payload") {
             warn!(
                 log,

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -46,8 +46,6 @@ Options:
       --builder-header-timeout <MILLISECONDS>
           Defines a timeout value (in milliseconds) to use when fetching a block
           header from the builder API. [default: 1000]
-      --builder-profit-threshold <WEI_VALUE>
-          This flag is deprecated and has no effect.
       --builder-user-agent <STRING>
           The HTTP user agent to send alongside requests to the builder URL. The
           default is Lighthouse's version string.


### PR DESCRIPTION
There is a bug when using the deprecated flag `--builder-profit-threshold` in Lighthouse 5.2.0 and above, reported by @CouzDelCouzzz on Discord: https://discord.com/channels/605577013327167508/605577013331361793/1262698540358963261

To reproduce, run Lighthouse with the flag, e.g.:

`./lighthouse bn --checkpoint-sync-url https://mainnet.checkpoint.sigp.io --builder-profit-threshold 100 --execution-endpoint http://localhost:8551 --execution-jwt /home/hi/.ethereum/geth/jwtsecret`

@michaelsproul mentioned that this is due to the `parse_flag` should only be used when the flag does not take an argument (i.e., the flag is a boolean, such as the `--metrics` flag): https://github.com/sigp/lighthouse/blob/9e12c21f268c80a3f002ae0ca27477f9f512eb6f/beacon_node/src/config.rs#L1379-L1381

This is not the case for `--builder-profit-threshold` which takes an argument:
https://github.com/sigp/lighthouse/blob/9e12c21f268c80a3f002ae0ca27477f9f512eb6f/beacon_node/src/config.rs#L338-L344

This PR deletes the `--builder-profit-threshold` flag so that the panic is not possible to manifest.