### PR TITLE
Attempt to fix flaky basic sim test

### DIFF
--- a/testing/simulator/src/basic_sim.rs
+++ b/testing/simulator/src/basic_sim.rs
@@ -37,6 +37,8 @@ pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
         .unwrap_or(&String::from("0"))
         .parse::<usize>()
         .unwrap_or(0);
+    // extra beacon node added with delay
+    let extra_nodes: usize = 1;
     println!("PROPOSER-NODES: {}", proposer_nodes);
     let validators_per_node = matches
         .get_one::<String>("validators-per-node")
@@ -133,6 +135,7 @@ pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
                 LocalNetworkParams {
                     validator_count: total_validator_count,
                     node_count,
+                    extra_nodes,
                     proposer_nodes,
                     genesis_delay,
                 },

--- a/testing/simulator/src/fallback_sim.rs
+++ b/testing/simulator/src/fallback_sim.rs
@@ -143,6 +143,7 @@ pub fn run_fallback_sim(matches: &ArgMatches) -> Result<(), String> {
                 LocalNetworkParams {
                     validator_count: total_validator_count,
                     node_count,
+                    extra_nodes: 0,
                     proposer_nodes: 0,
                     genesis_delay,
                 },

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -27,6 +27,7 @@ pub struct LocalNetworkParams {
     pub validator_count: usize,
     pub node_count: usize,
     pub proposer_nodes: usize,
+    pub extra_nodes: usize,
     pub genesis_delay: u64,
 }
 
@@ -38,7 +39,7 @@ fn default_client_config(network_params: LocalNetworkParams, genesis_time: u64) 
         genesis_time,
     };
     beacon_config.network.target_peers =
-        network_params.node_count + network_params.proposer_nodes - 1;
+        network_params.node_count + network_params.proposer_nodes + network_params.extra_nodes - 1;
     beacon_config.network.enr_address = (Some(Ipv4Addr::LOCALHOST), None);
     beacon_config.network.enable_light_client_server = true;
     beacon_config.network.discv5_config.enable_packet_filter = false;


### PR DESCRIPTION
## Issue Addressed

Fix `target_peer` config for basic_sim, so a node doesn't disconnected by peers because of `TooManyPeers`.

I think the test fails when enough nodes disconnect one of the nodes and messages from that node don't get propagated to the network correctly.
