### PR TITLE
Upgrade `openssl` to address cargo audit issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5773,9 +5773,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -5814,9 +5814,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Issue Addressed

Update `openssl` to address [cargo audit failure](https://github.com/sigp/lighthouse/actions/runs/10033598026/job/27726944372).

 [RUSTSEC-2024-0357](https://rustsec.org/advisories/RUSTSEC-2024-0357)