### PR TITLE
chore: Add regression test for stackoverflow when calling compute_cells_and_proofs in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4431,6 +4431,7 @@ dependencies = [
  "ethereum_ssz_derive",
  "hex",
  "mockall",
+ "rayon",
  "serde",
  "serde_json",
  "tree_hash",

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -24,6 +24,7 @@ mockall = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }
 eth2_network_config = { workspace = true }
+rayon = { workspace = true }
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
## Issue Addressed

This PR currently only adds a regression test to show the stackoverflow happening. A solution will be added and the PR title changed in the future.

(Can also close this and put a test in the cryptography library instead)

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
