### PR TITLE
Show correct total validator count during validator recovery

### DIFF
--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -147,7 +147,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
 
         println!(
             "{}/{}\tIndex: {}\t0x{}",
-            index - first_index,
+            index - first_index + 1,
             count,
             index,
             voting_pubkey

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -148,7 +148,7 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
         println!(
             "{}/{}\tIndex: {}\t0x{}",
             index - first_index,
-            count - first_index,
+            count,
             index,
             voting_pubkey
         );


### PR DESCRIPTION
## Issue Addressed

A small one I found just now: The progress indicator displayed during `lighthouse account validator recover` would show something like `0/4294967276 Index: 40` when `count < first_index`.

## Proposed Changes

Simply display the count there instead of subtracting the first index.

## Additional Info

None.
