### PR TITLE
Prevent continuous searches for low-peer networks

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -885,6 +885,11 @@ impl<E: EthSpec> PeerManager<E> {
                 self.max_peers().saturating_sub(dialing_peers) - peer_count
             } else if outbound_only_peer_count < self.min_outbound_only_peers()
                 && peer_count < self.max_outbound_dialing_peers()
+                && self.target_peers > 10
+            // This condition is to attempt to exclude testnets without
+            // an explicit CLI flag. For networks with low peer counts, we don't want to do
+            // repetitive searches for outbound peers, when we may be already connected to every
+            // peer on the testnet
             {
                 self.max_outbound_dialing_peers()
                     .saturating_sub(dialing_peers)


### PR DESCRIPTION
We have logic to try and maintain a healthy amount of outbound connections. 

For testnets and low-networks it could be the case that we have connected to every node on the network and there are no more nodes to establish outbound connections to. In these cases, we do repetitive loops of discovery requests. 

I didn't want to add yet another flag to the CLI, so I added heuristic, that removes the logic to try and find more outbound peers if we set the target peers to <= 10. 

It should at the very least help with the kurtosis local testnet scripts. 
