### PR TITLE
Revert --image-download always flag to avoid CI getting rate limited

### DIFF
--- a/scripts/local_testnet/start_local_testnet.sh
+++ b/scripts/local_testnet/start_local_testnet.sh
@@ -75,14 +75,11 @@ else
     echo "Not rebuilding Lighthouse Docker image."
 fi
 
-IMAGE_DOWNLOAD_FLAG=""
-
 if [ "$KEEP_ENCLAVE" = false ]; then
   # Stop local testnet
   kurtosis enclave rm -f $ENCLAVE_NAME 2>/dev/null || true
-  IMAGE_DOWNLOAD_FLAG="--image-download always"
 fi
 
-kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package $IMAGE_DOWNLOAD_FLAG --args-file $NETWORK_PARAMS_FILE
+kurtosis run --enclave $ENCLAVE_NAME github.com/ethpandaops/ethereum-package --args-file $NETWORK_PARAMS_FILE
 
 echo "Started!"


### PR DESCRIPTION
## Issue Addressed

Partially #6161. 

This PR reverts `--image-download=always` flag to avoid CI getting rate limited by Docker Hub. It looks like the Kurtosis tests are now pulling all images every job, whereas it wasn't doing this before the flag was added.

