### PR TITLE
Use `then` instead of `then_some` when checking `upnp_enabled` to avoid useless UPnP query

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -385,7 +385,7 @@ impl<E: EthSpec> Network<E> {
         let upnp = Toggle::from(
             config
                 .upnp_enabled
-                .then_some(libp2p::upnp::tokio::Behaviour::default()),
+                .then(libp2p::upnp::tokio::Behaviour::default),
         );
         let behaviour = {
             Behaviour {


### PR DESCRIPTION
## Issue Addressed

I noticed that Lighthouse sends to UPnP's multicast address `239.255.255.250` even though I passed `--disable-upnp`. After some investigation, I found out that `libp2p_upnp`'s `Behaviour::default` immediately starts the search for the gateway. As we use `bool::then_some` to transform `upnp_enabled` into an `Option<Behaviour>`, we have to call `Behaviour::default` eagerly to pass it, triggering the search even if `upnp_enabled` is `false`.

## Proposed Changes

Use `bool::then` instead, passing `Behaviour::default` as function reference so that it is called lazily (only when `upnp_enabled` is `true`).

## Additional Info

In my opinion, starting the search immediately when `Behaviour::default` is invoked is bad design (as usually `default` only returns "some data"), so an alternative fix is to try and improve the API upstream.
