### PR TITLE
chore: Use MultiPoint trait for aggregating public keys

### DIFF
--- a/crypto/bls/Cargo.toml
+++ b/crypto/bls/Cargo.toml
@@ -15,7 +15,7 @@ ethereum_hashing = { workspace = true }
 ethereum-types = { workspace = true }
 arbitrary = { workspace = true }
 zeroize = { workspace = true }
-blst = { version = "0.3.3", optional = true }
+blst = { version = "0.3.13", optional = true }
 
 [features]
 arbitrary = []
@@ -24,3 +24,12 @@ fake_crypto = []
 supranational = ["blst"]
 supranational-portable = ["supranational", "blst/portable"]
 supranational-force-adx = ["supranational", "blst/force-adx"]
+
+
+[dev-dependencies]
+criterion = "0.5.1"
+rand = "0.8.4"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/crypto/bls/benches/benchmark.rs
+++ b/crypto/bls/benches/benchmark.rs
@@ -1,0 +1,53 @@
+use std::borrow::Cow;
+
+use bls::{verify_signature_sets, Hash256, PublicKey, SecretKey, SignatureSet};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+pub fn bench_verify_signature_set(c: &mut Criterion) {
+    let private_keys: Vec<_> = (0..16384).map(|_| SecretKey::random()).collect();
+    let public_keys: Vec<Cow<PublicKey>> = private_keys
+        .iter()
+        .map(|sk| Cow::Owned(sk.public_key()))
+        .collect();
+    let num_signature_sets = 1;
+    let msgs = (0..num_signature_sets)
+        .map(|_| Hash256::random())
+        .collect::<Vec<_>>();
+
+    // For each message, we want the private key to sign over them
+    let set_of_signatures: Vec<Vec<_>> = msgs
+        .iter()
+        .map(|msg| {
+            private_keys
+                .iter()
+                .map(|sk| sk.sign(*msg))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    let num_signatures = [32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768];
+
+    for num_sig in num_signatures.iter() {
+        let mut signature_sets = Vec::new();
+        for i in 0..num_signature_sets {
+            let msg = msgs[i];
+            let public_keys: Vec<_> = public_keys.iter().cloned().take(*num_sig).collect();
+            signature_sets.push(SignatureSet::multiple_pubkeys(
+                &set_of_signatures[i][0],
+                public_keys,
+                msg,
+            ));
+        }
+
+        c.bench_function(
+            &format!(
+                "num signatures {}, sig_sets {}",
+                num_sig, num_signature_sets
+            ),
+            |b| b.iter(|| verify_signature_sets(signature_sets.iter())),
+        );
+    }
+}
+
+criterion_group!(benches, bench_verify_signature_set,);
+criterion_main!(benches);


### PR DESCRIPTION
## Issue Addressed

This uses a more optimized algorithm in blst for aggregating multiple public keys. This can also be used to optimize signature aggregation though because we do not have all of the signatures at any particular point in time, it would require more changes.

## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
