### PR TITLE
Update database migration docs for 5.3

### DIFF
--- a/book/src/database-migrations.md
+++ b/book/src/database-migrations.md
@@ -16,7 +16,7 @@ validator client or the slasher**.
 
 | Lighthouse version | Release date | Schema version | Downgrade available? |
 |--------------------|--------------|----------------|----------------------|
-| v5.3.0             | Aug 2024 TBD | v22 TBD        | no (TBD)             |
+| v5.3.0             | Aug 2024     | v21            | yes                  |
 | v5.2.0             | Jun 2024     | v19            | no                   |
 | v5.1.0             | Mar 2024     | v19            | no                   |
 | v5.0.0             | Feb 2024     | v19            | no                   |
@@ -208,6 +208,7 @@ Here are the steps to prune historic states:
 
 | Lighthouse version | Release date | Schema version | Downgrade available?                |
 |--------------------|--------------|----------------|-------------------------------------|
+| v5.3.0             | Aug 2024     | v21            | yes                                 |
 | v5.2.0             | Jun 2024     | v19            | yes before Deneb using <= v5.2.1    |
 | v5.1.0             | Mar 2024     | v19            | yes before Deneb using <= v5.2.1    |
 | v5.0.0             | Feb 2024     | v19            | yes before Deneb using <= v5.2.1    |


### PR DESCRIPTION
## Proposed Changes

Update the book with the correct schema version (v21) for v5.3.0 and information on the available downgrade.

## Additional Info

We could wait to merge this to see whether v5.3.0 falls in July or August, or we could just YOLO and assume the release happens on Thursday or later
