### PR TITLE
Avoid acquiring another read lock while holding one to avoid potential deadlock

### DIFF
--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -1129,7 +1129,7 @@ impl Service {
 
         Ok(BlockCacheUpdateOutcome {
             blocks_imported,
-            head_block_number: self.inner.block_cache.read().highest_block_number(),
+            head_block_number: block_cache.highest_block_number(),
         })
     }
 }


### PR DESCRIPTION
## Issue Addressed

While testing PeerDAS I ran into a scenario that looked like a deadlock. The Lighthouse process was still live but stopped responding and logging anything.

The backtrace shows that one of the thread is waiting for a read lock
```
(gdb) bt
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x0000556ea43cf66d in parking_lot::raw_rwlock::RawRwLock::lock_shared_slow ()
#2  0x0000556ea5cbb969 in eth1::service::Service::earliest_block_timestamp ()
#3  0x0000556ea54fc61e in beacon_chain::eth1_chain::Eth1Chain<T,E>::eth1_data_for_block_production ()
```
while another one is waiting for a write lock, potentially [here](https://github.com/sigp/lighthouse/blob/fc0a8b5532818406061933ef156397901f781848/beacon_node/eth1/src/service.rs#L651)

```
(gdb) bt
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x0000556ea6ffc92d in parking_lot::raw_rwlock::RawRwLock::wait_for_readers ()
#2  0x0000556ea43cedf0 in parking_lot::raw_rwlock::RawRwLock::lock_exclusive_slow ()
#3  0x0000556ea5cbf35f in <futures_util::future::maybe_done::MaybeDone<Fut> as core::future::future::Future>::poll ()
#4  0x0000556ea5cb643b in <futures_util::future::poll_fn::PollFn<F> as core::future::future::Future>::poll ()
#5  0x0000556ea5ccb06d in eth1::service::Service::do_update::{{closure}} ()
```

I'm not sure if I've got to the bottom of the problem yet, but I'm suspecting that the code here is causing the deadlock, as it tries to acquire a read lock while we already hold one in scope. If `do_update` attempts to acquire a write lock when the deposit cache read lock is in place, then it will wait for the read lock to release. However the code below attempts to acquire the read lock again while the old read lock is still in scope, causing the write lock to be stuck and a dead lock in this function:

https://github.com/sigp/lighthouse/blob/19b3ab39ee2d131abe3226ab58aeaaa73b7f99fb/beacon_node/eth1/src/service.rs#L1132

This part of the code hasn't changed in ages though, so I could be wrong or running into an edge case.