### PR TITLE
Use blinded blocks for light client proofs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -6766,12 +6766,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         block_root: &Hash256,
     ) -> Result<Option<(LightClientBootstrap<T::EthSpec>, ForkName)>, Error> {
-        let handle = self
-            .task_executor
-            .handle()
-            .ok_or(BeaconChainError::RuntimeShutdown)?;
-
-        let Some(block) = handle.block_on(async { self.get_block(block_root).await })? else {
+        let Some(block) = self.get_blinded_block(block_root)? else {
             return Ok(None);
         };
 

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -84,13 +84,12 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         let signature_slot = block_slot;
         let attested_block_root = block_parent_root;
 
-        let attested_block =
-            store
-                .get_full_block(attested_block_root)?
-                .ok_or(BeaconChainError::DBInconsistent(format!(
-                    "Block not available {:?}",
-                    attested_block_root
-                )))?;
+        let attested_block = store.get_blinded_block(attested_block_root)?.ok_or(
+            BeaconChainError::DBInconsistent(format!(
+                "Block not available {:?}",
+                attested_block_root
+            )),
+        )?;
 
         let cached_parts = self.get_or_compute_prev_block_cache(
             store.clone(),
@@ -130,7 +129,7 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         if is_latest_finality & !cached_parts.finalized_block_root.is_zero() {
             // Immediately after checkpoint sync the finalized block may not be available yet.
             if let Some(finalized_block) =
-                store.get_full_block(&cached_parts.finalized_block_root)?
+                store.get_blinded_block(&cached_parts.finalized_block_root)?
             {
                 *self.latest_finality_update.write() = Some(LightClientFinalityUpdate::new(
                     &attested_block,

--- a/consensus/types/src/light_client_bootstrap.rs
+++ b/consensus/types/src/light_client_bootstrap.rs
@@ -1,8 +1,8 @@
 use crate::{
     light_client_update::*, test_utils::TestRandom, BeaconState, ChainSpec, EthSpec, FixedVector,
     ForkName, ForkVersionDeserialize, Hash256, LightClientHeader, LightClientHeaderAltair,
-    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra, SignedBeaconBlock,
-    Slot, SyncCommittee,
+    LightClientHeaderCapella, LightClientHeaderDeneb, LightClientHeaderElectra,
+    SignedBlindedBeaconBlock, Slot, SyncCommittee,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -114,7 +114,7 @@ impl<E: EthSpec> LightClientBootstrap<E> {
 
     pub fn from_beacon_state(
         beacon_state: &mut BeaconState<E>,
-        block: &SignedBeaconBlock<E>,
+        block: &SignedBlindedBeaconBlock<E>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, Error> {
         let mut header = beacon_state.latest_block_header().clone();

--- a/consensus/types/src/light_client_finality_update.rs
+++ b/consensus/types/src/light_client_finality_update.rs
@@ -3,7 +3,7 @@ use crate::ChainSpec;
 use crate::{
     light_client_update::*, test_utils::TestRandom, ForkName, ForkVersionDeserialize,
     LightClientHeaderAltair, LightClientHeaderCapella, LightClientHeaderDeneb,
-    LightClientHeaderElectra, SignedBeaconBlock,
+    LightClientHeaderElectra, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -73,8 +73,8 @@ pub struct LightClientFinalityUpdate<E: EthSpec> {
 
 impl<E: EthSpec> LightClientFinalityUpdate<E> {
     pub fn new(
-        attested_block: &SignedBeaconBlock<E>,
-        finalized_block: &SignedBeaconBlock<E>,
+        attested_block: &SignedBlindedBeaconBlock<E>,
+        finalized_block: &SignedBlindedBeaconBlock<E>,
         finality_branch: FixedVector<Hash256, FinalizedRootProofLen>,
         sync_aggregate: SyncAggregate<E>,
         signature_slot: Slot,

--- a/consensus/types/src/light_client_optimistic_update.rs
+++ b/consensus/types/src/light_client_optimistic_update.rs
@@ -2,7 +2,7 @@ use super::{EthSpec, ForkName, ForkVersionDeserialize, LightClientHeader, Slot, 
 use crate::test_utils::TestRandom;
 use crate::{
     light_client_update::*, ChainSpec, LightClientHeaderAltair, LightClientHeaderCapella,
-    LightClientHeaderDeneb, LightClientHeaderElectra, SignedBeaconBlock,
+    LightClientHeaderDeneb, LightClientHeaderElectra, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -63,7 +63,7 @@ pub struct LightClientOptimisticUpdate<E: EthSpec> {
 
 impl<E: EthSpec> LightClientOptimisticUpdate<E> {
     pub fn new(
-        attested_block: &SignedBeaconBlock<E>,
+        attested_block: &SignedBlindedBeaconBlock<E>,
         sync_aggregate: SyncAggregate<E>,
         signature_slot: Slot,
         chain_spec: &ChainSpec,

--- a/consensus/types/src/light_client_update.rs
+++ b/consensus/types/src/light_client_update.rs
@@ -3,7 +3,7 @@ use crate::light_client_header::LightClientHeaderElectra;
 use crate::{
     beacon_state, test_utils::TestRandom, BeaconBlock, BeaconBlockHeader, BeaconState, ChainSpec,
     ForkName, ForkVersionDeserialize, LightClientHeaderAltair, LightClientHeaderCapella,
-    LightClientHeaderDeneb, SignedBeaconBlock,
+    LightClientHeaderDeneb, SignedBlindedBeaconBlock,
 };
 use derivative::Derivative;
 use safe_arith::ArithError;
@@ -156,8 +156,8 @@ impl<E: EthSpec> LightClientUpdate<E> {
         beacon_state: BeaconState<E>,
         block: BeaconBlock<E>,
         attested_state: &mut BeaconState<E>,
-        attested_block: &SignedBeaconBlock<E>,
-        finalized_block: &SignedBeaconBlock<E>,
+        attested_block: &SignedBlindedBeaconBlock<E>,
+        finalized_block: &SignedBlindedBeaconBlock<E>,
         chain_spec: &ChainSpec,
     ) -> Result<Self, Error> {
         let sync_aggregate = block.body().sync_aggregate()?;


### PR DESCRIPTION
## Issue Addressed

A user on Discord reported the following error when running with the light client server enabled:

> Jul 29 23:30:22.614 ERRO error computing light_client updates DBError(HotColdDBError(MissingFullBlockExecutionPayloadPruned(0x86d1262c063c06cfe49a36bcfda8f606e33aca2821a10b33f9332e98ef761507, Slot(2199359)))), service: lc_update

This is due to the light client logic trying to load a full block from the database when the execution payload has been pruned (which is the default if the slot is finalized).

## Proposed Changes

Use blinded blocks in all light client logic. There's no need to have the full execution payload at present, and I don't foresee us needing it in future.

This also enabled a few simplifications.
