### PR TITLE
Swap finalized chains based on processed batches

### DIFF
--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -111,9 +111,6 @@ pub struct SyncingChain<T: BeaconChainTypes> {
     /// The current processing batch, if any.
     current_processing_batch: Option<BatchId>,
 
-    /// Batches validated by this chain.
-    validated_batches: u64,
-
     /// The chain's log.
     log: slog::Logger,
 }
@@ -161,7 +158,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             attempted_optimistic_starts: HashSet::default(),
             state: ChainSyncingState::Stopped,
             current_processing_batch: None,
-            validated_batches: 0,
             log: log.new(o!("chain" => id)),
         }
     }
@@ -182,8 +178,10 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
     }
 
     /// Progress in epochs made by the chain
-    pub fn validated_epochs(&self) -> u64 {
-        self.validated_batches * EPOCHS_PER_BATCH
+    pub fn processed_epochs(&self) -> u64 {
+        self.processing_target
+            .saturating_sub(self.start_epoch)
+            .into()
     }
 
     /// Returns the total count of pending blocks in all the batches of this chain
@@ -654,7 +652,6 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
         let removed_batches = std::mem::replace(&mut self.batches, remaining_batches);
 
         for (id, batch) in removed_batches.into_iter() {
-            self.validated_batches = self.validated_batches.saturating_add(1);
             // only for batches awaiting validation can we be sure the last attempt is
             // right, and thus, that any different attempt is wrong
             match batch.state() {
@@ -1166,7 +1163,6 @@ impl<T: BeaconChainTypes> slog::KV for SyncingChain<T> {
         )?;
         serializer.emit_usize("batches", self.batches.len())?;
         serializer.emit_usize("peers", self.peers.len())?;
-        serializer.emit_u64("validated_batches", self.validated_batches)?;
         serializer.emit_arguments("state", &format_args!("{:?}", self.state))?;
         slog::Result::Ok(())
     }

--- a/beacon_node/network/src/sync/range_sync/chain_collection.rs
+++ b/beacon_node/network/src/sync/range_sync/chain_collection.rs
@@ -24,7 +24,7 @@ use types::{Epoch, Hash256, Slot};
 const PARALLEL_HEAD_CHAINS: usize = 2;
 
 /// Minimum work we require a finalized chain to do before picking a chain with more peers.
-const MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS: u64 = 10;
+const MIN_FINALIZED_CHAIN_PROCESSED_EPOCHS: u64 = 10;
 
 /// The state of the long range/batch sync.
 #[derive(Clone)]
@@ -273,8 +273,8 @@ impl<T: BeaconChainTypes, C: BlockStorage> ChainCollection<T, C> {
                     // chains are different, check that they don't have the same number of peers
                     if let Some(syncing_chain) = self.finalized_chains.get_mut(&syncing_id) {
                         if max_peers > syncing_chain.available_peers()
-                            && syncing_chain.validated_epochs()
-                                > MIN_FINALIZED_CHAIN_VALIDATED_EPOCHS
+                            && syncing_chain.processed_epochs()
+                                > MIN_FINALIZED_CHAIN_PROCESSED_EPOCHS
                         {
                             syncing_chain.stop_syncing();
                             old_id = Some(Some(syncing_id));


### PR DESCRIPTION
## Issue Addressed

Previously we decided whether to swap finalized chains based on validated patches. It is a more robust approach to make this decision based on processed batches. 

This PR shifts the switch to use processed batches rather than validated.
