### PR TITLE
Add metrics inside fork-choice crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3099,6 +3099,7 @@ dependencies = [
  "beacon_chain",
  "ethereum_ssz",
  "ethereum_ssz_derive",
+ "lighthouse_metrics",
  "proto_array",
  "slog",
  "state_processing",

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2148,8 +2148,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         &self,
         verified: &impl VerifiedAttestation<T>,
     ) -> Result<(), Error> {
-        let _timer = metrics::start_timer(&metrics::FORK_CHOICE_PROCESS_ATTESTATION_TIMES);
-
         self.canonical_head
             .fork_choice_write_lock()
             .on_attestation(
@@ -3516,8 +3514,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Register the new block with the fork choice service.
         {
-            let _fork_choice_block_timer =
-                metrics::start_timer(&metrics::FORK_CHOICE_PROCESS_BLOCK_TIMES);
             let block_delay = self
                 .slot_clock
                 .seconds_from_current_slot_start()

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1666,9 +1666,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
 
         // Register each attestation in the block with fork choice.
         for (i, attestation) in block.message().body().attestations().enumerate() {
-            let _fork_choice_attestation_timer =
-                metrics::start_timer(&metrics::FORK_CHOICE_PROCESS_ATTESTATION_TIMES);
-
             let indexed_attestation = consensus_context
                 .get_indexed_attestation(&state, attestation)
                 .map_err(|e| BlockError::PerBlockProcessingError(e.into_with_index(i)))?;

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -569,19 +569,6 @@ pub static FORK_CHOICE_AFTER_FINALIZATION_TIMES: LazyLock<Result<Histogram>> =
             exponential_buckets(1e-3, 2.0, 10),
         )
     });
-pub static FORK_CHOICE_PROCESS_BLOCK_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
-    try_create_histogram(
-        "beacon_fork_choice_process_block_seconds",
-        "Time taken to add a block and all attestations to fork choice",
-    )
-});
-pub static FORK_CHOICE_PROCESS_ATTESTATION_TIMES: LazyLock<Result<Histogram>> =
-    LazyLock::new(|| {
-        try_create_histogram(
-            "beacon_fork_choice_process_attestation_seconds",
-            "Time taken to add an attestation to fork choice",
-        )
-    });
 pub static FORK_CHOICE_SET_HEAD_LAG_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "beacon_fork_choice_set_head_lag_times",
@@ -1928,6 +1915,11 @@ pub fn scrape_for_metrics<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) {
         .validator_monitor
         .read()
         .scrape_metrics(&beacon_chain.slot_clock, &beacon_chain.spec);
+
+    beacon_chain
+        .canonical_head
+        .fork_choice_read_lock()
+        .scrape_for_metrics();
 }
 
 /// Scrape the given `state` assuming it's the head state, updating the `DEFAULT_REGISTRY`.

--- a/consensus/fork_choice/Cargo.toml
+++ b/consensus/fork_choice/Cargo.toml
@@ -12,6 +12,7 @@ state_processing = { workspace = true }
 proto_array = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
+lighthouse_metrics = { workspace = true }
 slog = { workspace = true }
 
 [dev-dependencies]

--- a/consensus/fork_choice/src/lib.rs
+++ b/consensus/fork_choice/src/lib.rs
@@ -1,5 +1,6 @@
 mod fork_choice;
 mod fork_choice_store;
+mod metrics;
 
 pub use crate::fork_choice::{
     AttestationFromBlock, Error, ForkChoice, ForkChoiceView, ForkchoiceUpdateParameters,

--- a/consensus/fork_choice/src/metrics.rs
+++ b/consensus/fork_choice/src/metrics.rs
@@ -1,0 +1,62 @@
+pub use lighthouse_metrics::*;
+use std::sync::LazyLock;
+use types::EthSpec;
+
+use crate::{ForkChoice, ForkChoiceStore};
+
+pub static FORK_CHOICE_QUEUED_ATTESTATIONS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "fork_choice_queued_attestations",
+        "Current count of queued attestations",
+    )
+});
+pub static FORK_CHOICE_NODES: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge("fork_choice_nodes", "Current count of proto array nodes")
+});
+pub static FORK_CHOICE_INDICES: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "fork_choice_indices",
+        "Current count of proto array indices",
+    )
+});
+pub static FORK_CHOICE_DEQUEUED_ATTESTATIONS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "fork_choice_dequeued_attestations_total",
+        "Total count of dequeued attestations",
+    )
+});
+pub static FORK_CHOICE_ON_BLOCK_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "beacon_fork_choice_process_block_seconds",
+        "The duration in seconds of on_block runs",
+    )
+});
+pub static FORK_CHOICE_ON_ATTESTATION_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "beacon_fork_choice_process_attestation_seconds",
+        "The duration in seconds of on_attestation runs",
+    )
+});
+pub static FORK_CHOICE_ON_ATTESTER_SLASHING_TIMES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "beacon_fork_choice_on_attester_slashing_seconds",
+            "The duration in seconds on on_attester_slashing runs",
+        )
+    });
+
+/// Update the global metrics `DEFAULT_REGISTRY` with info from the fork choice.
+pub fn scrape_for_metrics<T: ForkChoiceStore<E>, E: EthSpec>(fork_choice: &ForkChoice<T, E>) {
+    set_gauge(
+        &FORK_CHOICE_QUEUED_ATTESTATIONS,
+        fork_choice.queued_attestations().len() as i64,
+    );
+    set_gauge(
+        &FORK_CHOICE_NODES,
+        fork_choice.proto_array().core_proto_array().nodes.len() as i64,
+    );
+    set_gauge(
+        &FORK_CHOICE_INDICES,
+        fork_choice.proto_array().core_proto_array().indices.len() as i64,
+    );
+}


### PR DESCRIPTION
## Issue Addressed

Debugging an unrelated issue, I noted that the metric `beacon_fork_choice_process_attestation_seconds` is imprecise because it measures two distinct spans:
- in gossip processing = lock acquire time + attestation process time
- in block processing = attestation process time

Instead, we can move the timer calls inside the fork-choice crate and always measure the same thing.

## Proposed Changes

- Consistent timing measures for fork-choice calls
- Add metrics for fork-choice data structures

## Notes

I have maintained the same metrics names as they were in the beacon_chain crate. 
- Is it okay to break the metric names for consistency?
- Should the metric names be prefixed by `beacon_fork_choice` or just `fork_choice`?