### PR TITLE
Skip recursive discovery query if no useful ENRs

### DIFF
--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -77,6 +77,12 @@ pub static DISCOVERY_SESSIONS: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
         "The number of active discovery sessions with peers",
     )
 });
+pub static DISCOVERY_NO_USEFUL_ENRS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "discovery_no_useful_enrs_found",
+        "Total number of counts a query returned no useful ENRs to dial",
+    )
+});
 
 pub static PEERS_PER_CLIENT: LazyLock<Result<IntGaugeVec>> = LazyLock::new(|| {
     try_create_int_gauge_vec(

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -323,6 +323,7 @@ impl<E: EthSpec> PeerManager<E> {
     #[allow(clippy::mutable_key_type)]
     pub fn peers_discovered(&mut self, results: HashMap<Enr, Option<Instant>>) {
         let mut to_dial_peers = 0;
+        let results_count = results.len();
         let connected_or_dialing = self.network_globals.connected_or_dialing_peers();
         for (enr, min_ttl) in results {
             // There are two conditions in deciding whether to dial this peer.
@@ -354,8 +355,19 @@ impl<E: EthSpec> PeerManager<E> {
             }
         }
 
-        // Queue another discovery if we need to
-        self.maintain_peer_count(to_dial_peers);
+        // The heartbeat will attempt new discovery queries every N seconds if the node needs more
+        // peers. As an optimization, this function can recursively trigger new discovery queries
+        // immediatelly if we don't fulfill our peers needs after completing a query. This
+        // recursiveness results in an infinite loop in networks where there not enough peers to
+        // reach out target. To prevent the infinite loop, if a query returns no useful peers, we
+        // will cancel the recursiveness and wait for the heartbeat to trigger another query latter.
+        if results_count > 0 && to_dial_peers == 0 {
+            debug!(self.log, "Skipping recursive discovery query after finding no useful results"; "results" => results_count);
+            metrics::inc_counter(&metrics::DISCOVERY_NO_USEFUL_ENRS);
+        } else {
+            // Queue another discovery if we need to
+            self.maintain_peer_count(to_dial_peers);
+        }
     }
 
     /// A STATUS message has been received from a peer. This resets the status timer.


### PR DESCRIPTION
## Issue Addressed

Lighthouse's basic simulator logs are completely un-usable because of the spam from the sequence of logs:
```
2024-07-30T08:50:55.2102984Z Jul 30 08:50:55.160 DEBG Starting a new peer discovery query     wanted: 6, outbound: 1, target: 6, connected: 1, service: libp2p, service: node_1
2024-07-30T08:50:55.2104783Z Jul 30 08:50:55.160 DEBG Starting a peer discovery request       target_peers: 6, service: libp2p, service: node_1
2024-07-30T08:50:55.2106299Z Jul 30 08:50:55.160 DEBG Discovery query completed               peers_found: 1, service: libp2p, service: node_1
2024-07-30T08:50:55.2108037Z Jul 30 08:50:55.160 DEBG Starting a new peer discovery query     wanted: 6, outbound: 1, target: 6, connected: 1, service: libp2p, service: node_1
2024-07-30T08:50:55.2109828Z Jul 30 08:50:55.160 DEBG Starting a peer discovery request       target_peers: 6, service: libp2p, service: node_1
2024-07-30T08:50:55.2111755Z Jul 30 08:50:55.160 DEBG Discovery query completed               peers_found: 1, service: libp2p, service: node_1
```

The root cause is that there are not enough peers in the network ever to satisfy the needs of the peer manager.

The peer manager enters an infinite loop of discovery queries that never yield new useful peers.

@AgeManning Tried to fix the issue with this PR but it doesn't work. The first condition of current_count < target is never met, so the spam still happens even with https://github.com/sigp/lighthouse/pull/6162
- https://github.com/sigp/lighthouse/pull/6162

Note that this infinite loop can theoretically happen in Mainnet too, if somehow the pool of ENRs shrinks to less than our target, or someone tries to run lighthouse with `--target-peers 10000`. 

## Proposed Changes

IMO the recursiveness is an optimization that we can safely skip under certain circumstances to prevent the infinite loop. This PR implements the heuristic that if:
- A query includes > 0 results
- None of those results is diable

Then we have likely exhausted the discv5 table and should stop the recursive query. Note that if there are false positives the heartbeat will trigger queries latter anyway.

I have tested this PR locally with `cargo run --release --bin simulator basic-sim` and there is no more spam of the logs above and the node still reaches the expected 5 target peers quickly.
