### PR TITLE
Work around UB in LMDB bindings

### DIFF
--- a/slasher/tests/random.rs
+++ b/slasher/tests/random.rs
@@ -235,3 +235,8 @@ fn no_crash_blocks_example1() {
         },
     );
 }
+
+#[test]
+fn no_crash_aug_24() {
+    random_test(13519442335106054152, TestConfig::default())
+}


### PR DESCRIPTION
## Issue Addressed

Fix a crazy memory corruption bug in the LMDB slasher impl.

## Proposed Changes

Copy the contents of the cursor's `value` prior to returning it, so that LMDB can't mutate the data being pointed to when `.delete_current()` is called.

## Additional Info

This possibly explains the strange behaviour seen on some slasher nodes:

- https://github.com/sigp/lighthouse/issues/6206

The bug had existed latently for a long time, but only now became executable with the refactor in:

- https://github.com/sigp/lighthouse/pull/4529