### PR TITLE
Peerdas kzg test

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -7,6 +7,7 @@ on:
       - staging
       - trying
       - 'pr/*'
+      - peerdas-kzg-test
   pull_request:
   merge_group:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "blstrs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a8a8ed6fefbeef4a8c7b460e4110e12c5e22a5b7cf32621aae6ad650c4dcf29"
+dependencies = [
+ "blst",
+ "byte-slice-cast",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing",
+ "rand_core",
+ "serde",
+ "subtle",
+]
+
+[[package]]
 name = "bollard-stubs"
 version = "1.42.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,6 +1528,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_bls12_381"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+dependencies = [
+ "blst",
+ "blstrs",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing",
+ "rayon",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_erasure_codes"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_polynomial",
+]
+
+[[package]]
+name = "crate_crypto_internal_peerdas_polynomial"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+]
+
+[[package]]
+name = "crate_crypto_kzg_multi_open_fk20"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_polynomial",
+ "hex",
+ "rayon",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2233,6 +2291,21 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
+]
+
+[[package]]
+name = "eip7594"
+version = "0.3.0"
+source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+dependencies = [
+ "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_peerdas_erasure_codes",
+ "crate_crypto_kzg_multi_open_fk20",
+ "hex",
+ "rayon",
+ "rust-embed",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3001,6 +3074,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
+ "bitvec 1.0.1",
  "rand_core",
  "subtle",
 ]
@@ -3431,7 +3505,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
+ "rand",
  "rand_core",
+ "rand_xorshift",
  "subtle",
 ]
 
@@ -4083,6 +4159,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
+dependencies = [
+ "include-flate-codegen",
+ "lazy_static",
+ "libflate",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
+dependencies = [
+ "libflate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,13 +4441,17 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "c-kzg",
+ "criterion",
  "derivative",
+ "eip7594",
+ "eth2_network_config",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
  "serde",
+ "serde_json",
  "tree_hash",
 ]
 
@@ -5898,6 +6001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7013,6 +7125,41 @@ dependencies = [
  "hashlink 0.8.4",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+dependencies = [
+ "include-flate",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.72",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+dependencies = [
+ "sha2 0.10.8",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,9 +1531,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crate_crypto_internal_peerdas_bls12_381"
-version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+name = "crate_crypto_internal_eth_kzg_bls12_381"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56bfd17086d959b4a54151a453be7cbe2b25002c29e1808fec4feb9d61dd766a"
 dependencies = [
  "blst",
  "blstrs",
@@ -1544,29 +1545,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "crate_crypto_internal_peerdas_erasure_codes"
-version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+name = "crate_crypto_internal_eth_kzg_erasure_codes"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d10bd21c929288745124ba171a6a7a9b9a02775f5b258e67e3bc9fa5a83c53"
 dependencies = [
- "crate_crypto_internal_peerdas_bls12_381",
- "crate_crypto_internal_peerdas_polynomial",
+ "crate_crypto_internal_eth_kzg_bls12_381",
+ "crate_crypto_internal_eth_kzg_polynomial",
 ]
 
 [[package]]
-name = "crate_crypto_internal_peerdas_polynomial"
-version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+name = "crate_crypto_internal_eth_kzg_polynomial"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3e4a2aae6a74a33f443cedf93474243e6ff288d14b71ceb7ad3f64112ae76b"
 dependencies = [
- "crate_crypto_internal_peerdas_bls12_381",
+ "crate_crypto_internal_eth_kzg_bls12_381",
 ]
 
 [[package]]
 name = "crate_crypto_kzg_multi_open_fk20"
-version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e186422e6af37e2c58aad943024f740309b05a8d80fd42d9c6a066fe246481"
 dependencies = [
- "crate_crypto_internal_peerdas_bls12_381",
- "crate_crypto_internal_peerdas_polynomial",
+ "crate_crypto_internal_eth_kzg_bls12_381",
+ "crate_crypto_internal_eth_kzg_polynomial",
  "hex",
  "rayon",
  "sha2 0.10.8",
@@ -2291,21 +2295,6 @@ dependencies = [
  "tree_hash",
  "tree_hash_derive",
  "types",
-]
-
-[[package]]
-name = "eip7594"
-version = "0.3.0"
-source = "git+https://github.com/crate-crypto/peerdas-kzg?rev=55ae9e9011d792a2998d242c2a71d822ba909fa9#55ae9e9011d792a2998d242c2a71d822ba909fa9"
-dependencies = [
- "crate_crypto_internal_peerdas_bls12_381",
- "crate_crypto_internal_peerdas_erasure_codes",
- "crate_crypto_kzg_multi_open_fk20",
- "hex",
- "rayon",
- "rust-embed",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4159,29 +4148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
-dependencies = [
- "include-flate-codegen",
- "lazy_static",
- "libflate",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
-dependencies = [
- "libflate",
- "proc-macro2",
- "quote",
- "syn 2.0.72",
-]
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,13 +4409,13 @@ dependencies = [
  "c-kzg",
  "criterion",
  "derivative",
- "eip7594",
  "eth2_network_config",
  "ethereum_hashing",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "hex",
+ "rust_eth_kzg",
  "serde",
  "serde_json",
  "tree_hash",
@@ -7128,38 +7094,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.5.0"
+name = "rust_eth_kzg"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+checksum = "32a65028eb4212d9d88161d3aa8059be8c6bd71f2e92d61c633be86e4d25d364"
 dependencies = [
- "include-flate",
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.72",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
-dependencies = [
- "sha2 0.10.8",
- "walkdir",
+ "crate_crypto_internal_eth_kzg_bls12_381",
+ "crate_crypto_internal_eth_kzg_erasure_codes",
+ "crate_crypto_kzg_multi_open_fk20",
+ "hex",
+ "rayon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ delay_map = "0.3"
 derivative = "2"
 dirs = "3"
 either = "1.9"
+peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "55ae9e9011d792a2998d242c2a71d822ba909fa9", package = "eip7594" }
 discv5 = { version = "0.4.1", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ delay_map = "0.3"
 derivative = "2"
 dirs = "3"
 either = "1.9"
-peerdas-kzg = { git = "https://github.com/crate-crypto/peerdas-kzg", rev = "55ae9e9011d792a2998d242c2a71d822ba909fa9", package = "eip7594" }
+rust_eth_kzg = "0.3.2"
 discv5 = { version = "0.4.1", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -2,7 +2,8 @@ use crate::block_verification::{
     cheap_state_advance_to_obtain_committees, get_validator_pubkey_cache, process_block_slash_info,
     BlockSlashInfo,
 };
-use crate::{BeaconChain, BeaconChainError, BeaconChainTypes};
+use crate::kzg_utils::validate_data_columns;
+use crate::{metrics, BeaconChain, BeaconChainError, BeaconChainTypes};
 use derivative::Derivative;
 use fork_choice::ProtoBlock;
 use kzg::{Error as KzgError, Kzg};
@@ -11,6 +12,7 @@ use slasher::test_utils::E;
 use slog::debug;
 use slot_clock::SlotClock;
 use ssz_derive::{Decode, Encode};
+use std::iter;
 use std::sync::Arc;
 use types::data_column_sidecar::{ColumnIndex, DataColumnIdentifier};
 use types::{
@@ -236,9 +238,10 @@ impl<E: EthSpec> KzgVerifiedCustodyDataColumn<E> {
 /// Returns an error if the kzg verification check fails.
 pub fn verify_kzg_for_data_column<E: EthSpec>(
     data_column: Arc<DataColumnSidecar<E>>,
-    _kzg: &Kzg,
+    kzg: &Kzg,
 ) -> Result<KzgVerifiedDataColumn<E>, KzgError> {
-    // TODO(das): KZG verification to be implemented
+    let _timer = metrics::start_timer(&metrics::KZG_VERIFICATION_DATA_COLUMN_SINGLE_TIMES);
+    validate_data_columns(kzg, iter::once(&data_column))?;
     Ok(KzgVerifiedDataColumn { data: data_column })
 }
 
@@ -248,13 +251,14 @@ pub fn verify_kzg_for_data_column<E: EthSpec>(
 /// Note: This function should be preferred over calling `verify_kzg_for_data_column`
 /// in a loop since this function kzg verifies a list of data columns more efficiently.
 pub fn verify_kzg_for_data_column_list<'a, E: EthSpec, I>(
-    _data_column_iter: I,
-    _kzg: &'a Kzg,
+    data_column_iter: I,
+    kzg: &'a Kzg,
 ) -> Result<(), KzgError>
 where
     I: Iterator<Item = &'a Arc<DataColumnSidecar<E>>> + Clone,
 {
-    // TODO(das): implement KZG verification
+    let _timer = metrics::start_timer(&metrics::KZG_VERIFICATION_DATA_COLUMN_BATCH_TIMES);
+    validate_data_columns(kzg, data_column_iter)?;
     Ok(())
 }
 

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -3,8 +3,8 @@ use rayon::prelude::*;
 use std::sync::Arc;
 use types::data_column_sidecar::{Cell, DataColumn, DataColumnSidecarError};
 use types::{
-    Blob, BlobsList, ChainSpec, DataColumnSidecar, DataColumnSidecarList, EthSpec, Hash256,
-    KzgCommitment, KzgProof, KzgProofs, SignedBeaconBlock,
+    Blob, BlobsList, ChainSpec, ColumnIndex, DataColumnSidecar, DataColumnSidecarList, EthSpec,
+    Hash256, KzgCommitment, KzgProof, KzgProofs, SignedBeaconBlock,
 };
 
 /// Converts a blob ssz List object to an array to be used with the kzg
@@ -57,13 +57,13 @@ where
         })
         .collect::<Vec<_>>();
 
-    let coordinates = data_column_iter
+    let column_indices = data_column_iter
         .clone()
         .flat_map(|data_column| {
             let col_index = data_column.index;
-            (0..data_column.column.len()).map(move |row| (row as u64, col_index))
+            (0..data_column.column.len()).map(move |_| col_index)
         })
-        .collect::<Vec<(u64, u64)>>();
+        .collect::<Vec<ColumnIndex>>();
 
     let commitments = data_column_iter
         .clone()
@@ -75,7 +75,7 @@ where
         })
         .collect::<Vec<_>>();
 
-    kzg.verify_cell_proof_batch(&cells, &proofs, &coordinates, &commitments)
+    kzg.verify_cell_proof_batch(&cells, &proofs, column_indices, &commitments)
 }
 
 /// Validate a batch of blob-commitment-proof triplets from multiple `BlobSidecars`.

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -1,10 +1,25 @@
-use kzg::{Blob as KzgBlob, Error as KzgError, Kzg};
-use types::{Blob, EthSpec, Hash256, KzgCommitment, KzgProof};
+use kzg::{Blob as KzgBlob, Bytes48, CellRef as KzgCellRef, Error as KzgError, Kzg};
+use rayon::prelude::*;
+use std::sync::Arc;
+use types::data_column_sidecar::{Cell, DataColumn, DataColumnSidecarError};
+use types::{
+    Blob, BlobsList, ChainSpec, DataColumnSidecar, DataColumnSidecarList, EthSpec, Hash256,
+    KzgCommitment, KzgProof, KzgProofs, SignedBeaconBlock,
+};
 
 /// Converts a blob ssz List object to an array to be used with the kzg
 /// crypto library.
 fn ssz_blob_to_crypto_blob<E: EthSpec>(blob: &Blob<E>) -> Result<KzgBlob, KzgError> {
     KzgBlob::from_bytes(blob.as_ref()).map_err(Into::into)
+}
+
+/// Converts a cell ssz List object to an array to be used with the kzg
+/// crypto library.
+fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCellRef, KzgError> {
+    let cell_bytes: &[u8] = cell.as_ref();
+    Ok(cell_bytes
+        .try_into()
+        .expect("expected cell to have size {BYTES_PER_CELL}. This should be guaranteed by the `FixedVector type"))
 }
 
 /// Validate a single blob-commitment-proof triplet from a `BlobSidecar`.
@@ -17,6 +32,50 @@ pub fn validate_blob<E: EthSpec>(
     let _timer = crate::metrics::start_timer(&crate::metrics::KZG_VERIFICATION_SINGLE_TIMES);
     let kzg_blob = ssz_blob_to_crypto_blob::<E>(blob)?;
     kzg.verify_blob_kzg_proof(&kzg_blob, kzg_commitment, kzg_proof)
+}
+
+/// Validate a batch of `DataColumnSidecar`.
+pub fn validate_data_columns<'a, E: EthSpec, I>(
+    kzg: &Kzg,
+    data_column_iter: I,
+) -> Result<(), KzgError>
+where
+    I: Iterator<Item = &'a Arc<DataColumnSidecar<E>>> + Clone,
+{
+    let cells = data_column_iter
+        .clone()
+        .flat_map(|data_column| data_column.column.iter().map(ssz_cell_to_crypto_cell::<E>))
+        .collect::<Result<Vec<_>, KzgError>>()?;
+
+    let proofs = data_column_iter
+        .clone()
+        .flat_map(|data_column| {
+            data_column
+                .kzg_proofs
+                .iter()
+                .map(|&proof| Bytes48::from(proof))
+        })
+        .collect::<Vec<_>>();
+
+    let coordinates = data_column_iter
+        .clone()
+        .flat_map(|data_column| {
+            let col_index = data_column.index;
+            (0..data_column.column.len()).map(move |row| (row as u64, col_index))
+        })
+        .collect::<Vec<(u64, u64)>>();
+
+    let commitments = data_column_iter
+        .clone()
+        .flat_map(|data_column| {
+            data_column
+                .kzg_commitments
+                .iter()
+                .map(|&commitment| Bytes48::from(commitment))
+        })
+        .collect::<Vec<_>>();
+
+    kzg.verify_cell_proof_batch(&cells, &proofs, &coordinates, &commitments)
 }
 
 /// Validate a batch of blob-commitment-proof triplets from multiple `BlobSidecars`.
@@ -75,4 +134,300 @@ pub fn verify_kzg_proof<E: EthSpec>(
     y: Hash256,
 ) -> Result<bool, KzgError> {
     kzg.verify_kzg_proof(kzg_commitment, &z.0.into(), &y.0.into(), kzg_proof)
+}
+
+/// Build data column sidecars from a signed beacon block and its blobs.
+pub fn build_data_column_sidecars<E: EthSpec>(
+    blobs: &BlobsList<E>,
+    block: &SignedBeaconBlock<E>,
+    kzg: &Kzg,
+    spec: &ChainSpec,
+) -> Result<DataColumnSidecarList<E>, DataColumnSidecarError> {
+    let number_of_columns = spec.number_of_columns;
+    if blobs.is_empty() {
+        return Ok(vec![]);
+    }
+    let kzg_commitments = block
+        .message()
+        .body()
+        .blob_kzg_commitments()
+        .map_err(|_err| DataColumnSidecarError::PreDeneb)?;
+    let kzg_commitments_inclusion_proof = block.message().body().kzg_commitments_merkle_proof()?;
+    let signed_block_header = block.signed_block_header();
+
+    let mut columns = vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
+    let mut column_kzg_proofs =
+        vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
+
+    // NOTE: assumes blob sidecars are ordered by index
+    let blob_cells_and_proofs_vec = blobs
+        .into_par_iter()
+        .map(|blob| {
+            let blob = blob
+                .as_ref()
+                .try_into()
+                .expect("blob should have a guaranteed size due to FixedVector");
+            kzg.compute_cells_and_proofs(blob)
+        })
+        .collect::<Result<Vec<_>, KzgError>>()?;
+
+    for (blob_cells, blob_cell_proofs) in blob_cells_and_proofs_vec {
+        // we iterate over each column, and we construct the column from "top to bottom",
+        // pushing on the cell and the corresponding proof at each column index. we do this for
+        // each blob (i.e. the outer loop).
+        for col in 0..number_of_columns {
+            let cell =
+                blob_cells
+                    .get(col)
+                    .ok_or(DataColumnSidecarError::InconsistentArrayLength(format!(
+                        "Missing blob cell at index {col}"
+                    )))?;
+            let cell: Vec<u8> = cell.to_vec();
+            let cell = Cell::<E>::from(cell);
+
+            let proof = blob_cell_proofs.get(col).ok_or(
+                DataColumnSidecarError::InconsistentArrayLength(format!(
+                    "Missing blob cell KZG proof at index {col}"
+                )),
+            )?;
+
+            let column =
+                columns
+                    .get_mut(col)
+                    .ok_or(DataColumnSidecarError::InconsistentArrayLength(format!(
+                        "Missing data column at index {col}"
+                    )))?;
+            let column_proofs = column_kzg_proofs.get_mut(col).ok_or(
+                DataColumnSidecarError::InconsistentArrayLength(format!(
+                    "Missing data column proofs at index {col}"
+                )),
+            )?;
+
+            column.push(cell);
+            column_proofs.push(*proof);
+        }
+    }
+
+    let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
+        .into_iter()
+        .zip(column_kzg_proofs)
+        .enumerate()
+        .map(|(index, (col, proofs))| {
+            Arc::new(DataColumnSidecar {
+                index: index as u64,
+                column: DataColumn::<E>::from(col),
+                kzg_commitments: kzg_commitments.clone(),
+                kzg_proofs: KzgProofs::<E>::from(proofs),
+                signed_block_header: signed_block_header.clone(),
+                kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
+            })
+        })
+        .collect();
+
+    Ok(sidecars)
+}
+
+/// Reconstruct all data columns from a subset of data column sidecars (requires at least 50%).
+pub fn reconstruct_data_columns<E: EthSpec>(
+    kzg: &Kzg,
+    data_columns: &[Arc<DataColumnSidecar<E>>],
+    spec: &ChainSpec,
+) -> Result<Vec<Arc<DataColumnSidecar<E>>>, KzgError> {
+    let number_of_columns = spec.number_of_columns;
+    let mut columns = vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
+    let mut column_kzg_proofs =
+        vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
+
+    let first_data_column = data_columns
+        .first()
+        .ok_or(KzgError::InconsistentArrayLength(
+            "data_columns should have at least one element".to_string(),
+        ))?;
+    let num_of_blobs = first_data_column.kzg_commitments.len();
+
+    let blob_cells_and_proofs_vec =
+        (0..num_of_blobs)
+            .into_par_iter()
+            .map(|row_index| {
+                let mut cells: Vec<KzgCellRef> = vec![];
+                let mut cell_ids: Vec<u64> = vec![];
+                for data_column in data_columns {
+                    let cell = data_column.column.get(row_index).ok_or(
+                        KzgError::InconsistentArrayLength(format!(
+                            "Missing data column at index {row_index}"
+                        )),
+                    )?;
+
+                    cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
+                    cell_ids.push(data_column.index);
+                }
+                kzg.recover_cells_and_compute_kzg_proofs(&cell_ids, &cells)
+            })
+            .collect::<Result<Vec<_>, KzgError>>()?;
+
+    for (blob_cells, blob_cell_proofs) in blob_cells_and_proofs_vec {
+        // we iterate over each column, and we construct the column from "top to bottom",
+        // pushing on the cell and the corresponding proof at each column index. we do this for
+        // each blob (i.e. the outer loop).
+        for col in 0..number_of_columns {
+            let cell = blob_cells
+                .get(col)
+                .ok_or(KzgError::InconsistentArrayLength(format!(
+                    "Missing blob cell at index {col}"
+                )))?;
+            let cell: Vec<u8> = cell.to_vec();
+            let cell = Cell::<E>::from(cell);
+
+            let proof = blob_cell_proofs
+                .get(col)
+                .ok_or(KzgError::InconsistentArrayLength(format!(
+                    "Missing blob cell KZG proof at index {col}"
+                )))?;
+
+            let column = columns
+                .get_mut(col)
+                .ok_or(KzgError::InconsistentArrayLength(format!(
+                    "Missing data column at index {col}"
+                )))?;
+            let column_proofs =
+                column_kzg_proofs
+                    .get_mut(col)
+                    .ok_or(KzgError::InconsistentArrayLength(format!(
+                        "Missing data column proofs at index {col}"
+                    )))?;
+
+            column.push(cell);
+            column_proofs.push(*proof);
+        }
+    }
+
+    // Clone sidecar elements from existing data column, no need to re-compute
+    let kzg_commitments = &first_data_column.kzg_commitments;
+    let signed_block_header = &first_data_column.signed_block_header;
+    let kzg_commitments_inclusion_proof = &first_data_column.kzg_commitments_inclusion_proof;
+
+    let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
+        .into_iter()
+        .zip(column_kzg_proofs)
+        .enumerate()
+        .map(|(index, (col, proofs))| {
+            Arc::new(DataColumnSidecar {
+                index: index as u64,
+                column: DataColumn::<E>::from(col),
+                kzg_commitments: kzg_commitments.clone(),
+                kzg_proofs: KzgProofs::<E>::from(proofs),
+                signed_block_header: signed_block_header.clone(),
+                kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
+            })
+        })
+        .collect();
+    Ok(sidecars)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::kzg_utils::{build_data_column_sidecars, reconstruct_data_columns};
+    use crate::test_utils::KZG;
+    use bls::Signature;
+    use kzg::KzgCommitment;
+    use types::{
+        beacon_block_body::KzgCommitments, BeaconBlock, BeaconBlockDeneb, Blob, BlobsList,
+        ChainSpec, EmptyBlock, EthSpec, MainnetEthSpec, SignedBeaconBlock,
+    };
+
+    #[test]
+    fn test_build_sidecars_empty() {
+        type E = MainnetEthSpec;
+        let num_of_blobs = 0;
+        let spec = E::default_spec();
+        let (signed_block, blob_sidecars) = create_test_block_and_blobs::<E>(num_of_blobs, &spec);
+
+        let column_sidecars =
+            build_data_column_sidecars(&blob_sidecars, &signed_block, &KZG, &spec).unwrap();
+
+        assert!(column_sidecars.is_empty());
+    }
+
+    #[test]
+    fn test_build_sidecars() {
+        type E = MainnetEthSpec;
+        let num_of_blobs = 6;
+        let spec = E::default_spec();
+        let (signed_block, blob_sidecars) = create_test_block_and_blobs::<E>(num_of_blobs, &spec);
+
+        let column_sidecars =
+            build_data_column_sidecars(&blob_sidecars, &signed_block, &KZG, &spec).unwrap();
+
+        let block_kzg_commitments = signed_block
+            .message()
+            .body()
+            .blob_kzg_commitments()
+            .unwrap()
+            .clone();
+        let block_kzg_commitments_inclusion_proof = signed_block
+            .message()
+            .body()
+            .kzg_commitments_merkle_proof()
+            .unwrap();
+
+        assert_eq!(column_sidecars.len(), spec.number_of_columns);
+        for (idx, col_sidecar) in column_sidecars.iter().enumerate() {
+            assert_eq!(col_sidecar.index, idx as u64);
+
+            assert_eq!(col_sidecar.kzg_commitments.len(), num_of_blobs);
+            assert_eq!(col_sidecar.column.len(), num_of_blobs);
+            assert_eq!(col_sidecar.kzg_proofs.len(), num_of_blobs);
+
+            assert_eq!(col_sidecar.kzg_commitments, block_kzg_commitments);
+            assert_eq!(
+                col_sidecar.kzg_commitments_inclusion_proof,
+                block_kzg_commitments_inclusion_proof
+            );
+            assert!(col_sidecar.verify_inclusion_proof());
+        }
+    }
+
+    #[test]
+    fn build_and_reconstruct() {
+        type E = MainnetEthSpec;
+        let num_of_blobs = 6;
+        let spec = E::default_spec();
+        let (signed_block, blob_sidecars) = create_test_block_and_blobs::<E>(num_of_blobs, &spec);
+
+        let column_sidecars =
+            build_data_column_sidecars(&blob_sidecars, &signed_block, &KZG, &spec).unwrap();
+
+        // Now reconstruct
+        let reconstructed_columns = reconstruct_data_columns(
+            &KZG,
+            &column_sidecars.iter().as_slice()[0..column_sidecars.len() / 2],
+            &spec,
+        )
+        .unwrap();
+
+        for i in 0..spec.number_of_columns {
+            assert_eq!(reconstructed_columns.get(i), column_sidecars.get(i), "{i}");
+        }
+    }
+
+    fn create_test_block_and_blobs<E: EthSpec>(
+        num_of_blobs: usize,
+        spec: &ChainSpec,
+    ) -> (SignedBeaconBlock<E>, BlobsList<E>) {
+        let mut block = BeaconBlock::Deneb(BeaconBlockDeneb::empty(spec));
+        let mut body = block.body_mut();
+        let blob_kzg_commitments = body.blob_kzg_commitments_mut().unwrap();
+        *blob_kzg_commitments =
+            KzgCommitments::<E>::new(vec![KzgCommitment::empty_for_testing(); num_of_blobs])
+                .unwrap();
+
+        let signed_block = SignedBeaconBlock::from_block(block, Signature::empty());
+
+        let blobs = (0..num_of_blobs)
+            .map(|_| Blob::<E>::default())
+            .collect::<Vec<_>>()
+            .into();
+
+        (signed_block, blobs)
+    }
 }

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1645,6 +1645,12 @@ pub static BLOB_SIDECAR_INCLUSION_PROOF_COMPUTATION: LazyLock<Result<Histogram>>
             "Time taken to compute blob sidecar inclusion proof",
         )
     });
+pub static DATA_COLUMN_SIDECAR_COMPUTATION: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "data_column_sidecar_computation_seconds",
+        "Time taken to compute data column sidecar, including cells, proofs and inclusion proof",
+    )
+});
 pub static DATA_COLUMN_SIDECAR_PROCESSING_REQUESTS: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {
         try_create_int_counter(
@@ -1785,6 +1791,20 @@ pub static KZG_VERIFICATION_BATCH_TIMES: LazyLock<Result<Histogram>> = LazyLock:
         "Runtime of batched kzg verification",
     )
 });
+pub static KZG_VERIFICATION_DATA_COLUMN_SINGLE_TIMES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "kzg_verification_data_column_single_seconds",
+            "Runtime of single data column kzg verification",
+        )
+    });
+pub static KZG_VERIFICATION_DATA_COLUMN_BATCH_TIMES: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "kzg_verification_data_column_batch_seconds",
+            "Runtime of batched data column kzg verification",
+        )
+    });
 
 pub static BLOCK_PRODUCTION_BLOBS_VERIFICATION_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(
     || {

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1646,9 +1646,10 @@ pub static BLOB_SIDECAR_INCLUSION_PROOF_COMPUTATION: LazyLock<Result<Histogram>>
         )
     });
 pub static DATA_COLUMN_SIDECAR_COMPUTATION: LazyLock<Result<Histogram>> = LazyLock::new(|| {
-    try_create_histogram(
+    try_create_histogram_with_buckets(
         "data_column_sidecar_computation_seconds",
         "Time taken to compute data column sidecar, including cells, proofs and inclusion proof",
+        Ok(vec![0.04, 0.05, 0.1, 0.2, 0.3, 0.5, 0.7, 1.0]),
     )
 });
 pub static DATA_COLUMN_SIDECAR_PROCESSING_REQUESTS: LazyLock<Result<IntCounter>> =
@@ -1793,16 +1794,22 @@ pub static KZG_VERIFICATION_BATCH_TIMES: LazyLock<Result<Histogram>> = LazyLock:
 });
 pub static KZG_VERIFICATION_DATA_COLUMN_SINGLE_TIMES: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
-        try_create_histogram(
+        try_create_histogram_with_buckets(
             "kzg_verification_data_column_single_seconds",
             "Runtime of single data column kzg verification",
+            Ok(vec![
+                0.0005, 0.001, 0.0015, 0.002, 0.003, 0.004, 0.005, 0.007, 0.01, 0.02, 0.05,
+            ]),
         )
     });
 pub static KZG_VERIFICATION_DATA_COLUMN_BATCH_TIMES: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
-        try_create_histogram(
+        try_create_histogram_with_buckets(
             "kzg_verification_data_column_batch_seconds",
             "Runtime of batched data column kzg verification",
+            Ok(vec![
+                0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.015, 0.02, 0.03, 0.05, 0.07,
+            ]),
         )
     });
 

--- a/consensus/types/src/data_column_sidecar.rs
+++ b/consensus/types/src/data_column_sidecar.rs
@@ -1,17 +1,12 @@
 use crate::beacon_block_body::{KzgCommitments, BLOB_KZG_COMMITMENTS_INDEX};
 use crate::test_utils::TestRandom;
-use crate::{
-    BeaconBlockHeader, ChainSpec, EthSpec, Hash256, KzgProofs, SignedBeaconBlock,
-    SignedBeaconBlockHeader, Slot,
-};
-use crate::{BeaconStateError, BlobsList};
+use crate::BeaconStateError;
+use crate::{BeaconBlockHeader, EthSpec, Hash256, KzgProofs, SignedBeaconBlockHeader, Slot};
 use bls::Signature;
 use derivative::Derivative;
-use kzg::Kzg;
-use kzg::{Blob as KzgBlob, Cell as KzgCell, Error as KzgError};
+use kzg::Error as KzgError;
 use kzg::{KzgCommitment, KzgProof};
 use merkle_proof::verify_merkle_proof;
-use rayon::prelude::*;
 use safe_arith::ArithError;
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
@@ -60,7 +55,7 @@ pub struct DataColumnSidecar<E: EthSpec> {
     pub index: ColumnIndex,
     #[serde(with = "ssz_types::serde_utils::list_of_hex_fixed_vec")]
     pub column: DataColumn<E>,
-    /// All of the KZG commitments and proofs associated with the block, used for verifying sample cells.
+    /// All the KZG commitments and proofs associated with the block, used for verifying sample cells.
     pub kzg_commitments: KzgCommitments<E>,
     pub kzg_proofs: KzgProofs<E>,
     pub signed_block_header: SignedBeaconBlockHeader,
@@ -96,197 +91,6 @@ impl<E: EthSpec> DataColumnSidecar<E> {
             BLOB_KZG_COMMITMENTS_INDEX,
             self.signed_block_header.message.body_root,
         )
-    }
-
-    pub fn build_sidecars(
-        blobs: &BlobsList<E>,
-        block: &SignedBeaconBlock<E>,
-        kzg: &Kzg,
-        spec: &ChainSpec,
-    ) -> Result<DataColumnSidecarList<E>, DataColumnSidecarError> {
-        let number_of_columns = spec.number_of_columns;
-        if blobs.is_empty() {
-            return Ok(vec![]);
-        }
-        let kzg_commitments = block
-            .message()
-            .body()
-            .blob_kzg_commitments()
-            .map_err(|_err| DataColumnSidecarError::PreDeneb)?;
-        let kzg_commitments_inclusion_proof =
-            block.message().body().kzg_commitments_merkle_proof()?;
-        let signed_block_header = block.signed_block_header();
-
-        let mut columns = vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
-        let mut column_kzg_proofs =
-            vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
-
-        // NOTE: assumes blob sidecars are ordered by index
-        let blob_cells_and_proofs_vec = blobs
-            .into_par_iter()
-            .map(|blob| {
-                let blob = KzgBlob::from_bytes(blob).map_err(KzgError::from)?;
-                kzg.compute_cells_and_proofs(&blob)
-            })
-            .collect::<Result<Vec<_>, KzgError>>()?;
-
-        for (blob_cells, blob_cell_proofs) in blob_cells_and_proofs_vec {
-            // we iterate over each column, and we construct the column from "top to bottom",
-            // pushing on the cell and the corresponding proof at each column index. we do this for
-            // each blob (i.e. the outer loop).
-            for col in 0..number_of_columns {
-                let cell =
-                    blob_cells
-                        .get(col)
-                        .ok_or(DataColumnSidecarError::InconsistentArrayLength(format!(
-                            "Missing blob cell at index {col}"
-                        )))?;
-                let cell: Vec<u8> = cell.into_inner().into_iter().collect();
-                let cell = Cell::<E>::from(cell);
-
-                let proof = blob_cell_proofs.get(col).ok_or(
-                    DataColumnSidecarError::InconsistentArrayLength(format!(
-                        "Missing blob cell KZG proof at index {col}"
-                    )),
-                )?;
-
-                let column =
-                    columns
-                        .get_mut(col)
-                        .ok_or(DataColumnSidecarError::InconsistentArrayLength(format!(
-                            "Missing data column at index {col}"
-                        )))?;
-                let column_proofs = column_kzg_proofs.get_mut(col).ok_or(
-                    DataColumnSidecarError::InconsistentArrayLength(format!(
-                        "Missing data column proofs at index {col}"
-                    )),
-                )?;
-
-                column.push(cell);
-                column_proofs.push(*proof);
-            }
-        }
-
-        let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
-            .into_iter()
-            .zip(column_kzg_proofs)
-            .enumerate()
-            .map(|(index, (col, proofs))| {
-                Arc::new(DataColumnSidecar {
-                    index: index as u64,
-                    column: DataColumn::<E>::from(col),
-                    kzg_commitments: kzg_commitments.clone(),
-                    kzg_proofs: KzgProofs::<E>::from(proofs),
-                    signed_block_header: signed_block_header.clone(),
-                    kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
-                })
-            })
-            .collect();
-
-        Ok(sidecars)
-    }
-
-    pub fn reconstruct(
-        kzg: &Kzg,
-        data_columns: &[Arc<Self>],
-        spec: &ChainSpec,
-    ) -> Result<Vec<Arc<Self>>, KzgError> {
-        let number_of_columns = spec.number_of_columns;
-        let mut columns = vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
-        let mut column_kzg_proofs =
-            vec![Vec::with_capacity(E::max_blobs_per_block()); number_of_columns];
-
-        let first_data_column = data_columns
-            .first()
-            .ok_or(KzgError::InconsistentArrayLength(
-                "data_columns should have at least one element".to_string(),
-            ))?;
-        let num_of_blobs = first_data_column.kzg_commitments.len();
-
-        let blob_cells_and_proofs_vec = (0..num_of_blobs)
-            .into_par_iter()
-            .map(|row_index| {
-                let mut cells: Vec<KzgCell> = vec![];
-                let mut cell_ids: Vec<u64> = vec![];
-                for data_column in data_columns {
-                    let cell = data_column.column.get(row_index).ok_or(
-                        KzgError::InconsistentArrayLength(format!(
-                            "Missing data column at index {row_index}"
-                        )),
-                    )?;
-
-                    cells.push(ssz_cell_to_crypto_cell::<E>(cell)?);
-                    cell_ids.push(data_column.index);
-                }
-                // recover_all_cells does not expect sorted
-                let all_cells = kzg.recover_all_cells(&cell_ids, &cells)?;
-                let blob = kzg.cells_to_blob(&all_cells)?;
-
-                // Note: This function computes all cells and proofs. According to Justin this is okay,
-                // computing a partial set may be more expensive and requires code paths that don't exist.
-                // Computing the blobs cells is technically unnecessary but very cheap. It's done here again
-                // for simplicity.
-                kzg.compute_cells_and_proofs(&blob)
-            })
-            .collect::<Result<Vec<_>, KzgError>>()?;
-
-        for (blob_cells, blob_cell_proofs) in blob_cells_and_proofs_vec {
-            // we iterate over each column, and we construct the column from "top to bottom",
-            // pushing on the cell and the corresponding proof at each column index. we do this for
-            // each blob (i.e. the outer loop).
-            for col in 0..number_of_columns {
-                let cell = blob_cells
-                    .get(col)
-                    .ok_or(KzgError::InconsistentArrayLength(format!(
-                        "Missing blob cell at index {col}"
-                    )))?;
-                let cell: Vec<u8> = cell.into_inner().into_iter().collect();
-                let cell = Cell::<E>::from(cell);
-
-                let proof = blob_cell_proofs
-                    .get(col)
-                    .ok_or(KzgError::InconsistentArrayLength(format!(
-                        "Missing blob cell KZG proof at index {col}"
-                    )))?;
-
-                let column = columns
-                    .get_mut(col)
-                    .ok_or(KzgError::InconsistentArrayLength(format!(
-                        "Missing data column at index {col}"
-                    )))?;
-                let column_proofs =
-                    column_kzg_proofs
-                        .get_mut(col)
-                        .ok_or(KzgError::InconsistentArrayLength(format!(
-                            "Missing data column proofs at index {col}"
-                        )))?;
-
-                column.push(cell);
-                column_proofs.push(*proof);
-            }
-        }
-
-        // Clone sidecar elements from existing data column, no need to re-compute
-        let kzg_commitments = &first_data_column.kzg_commitments;
-        let signed_block_header = &first_data_column.signed_block_header;
-        let kzg_commitments_inclusion_proof = &first_data_column.kzg_commitments_inclusion_proof;
-
-        let sidecars: Vec<Arc<DataColumnSidecar<E>>> = columns
-            .into_iter()
-            .zip(column_kzg_proofs)
-            .enumerate()
-            .map(|(index, (col, proofs))| {
-                Arc::new(DataColumnSidecar {
-                    index: index as u64,
-                    column: DataColumn::<E>::from(col),
-                    kzg_commitments: kzg_commitments.clone(),
-                    kzg_proofs: KzgProofs::<E>::from(proofs),
-                    signed_block_header: signed_block_header.clone(),
-                    kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof.clone(),
-                })
-            })
-            .collect();
-        Ok(sidecars)
     }
 
     pub fn min_size() -> usize {
@@ -385,10 +189,4 @@ impl From<SszError> for DataColumnSidecarError {
     fn from(e: SszError) -> Self {
         Self::SszError(e)
     }
-}
-
-/// Converts a cell ssz List object to an array to be used with the kzg
-/// crypto library.
-fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCell, KzgError> {
-    KzgCell::from_bytes(cell.as_ref()).map_err(Into::into)
 }

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,3 +17,13 @@ ethereum_serde_utils = { workspace = true }
 hex = { workspace = true }
 ethereum_hashing = { workspace = true }
 c-kzg = { workspace = true }
+peerdas-kzg = { workspace = true }
+
+[dev-dependencies]
+criterion = { workspace = true }
+serde_json = { workspace = true }
+eth2_network_config = { workspace = true }
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -17,7 +17,7 @@ ethereum_serde_utils = { workspace = true }
 hex = { workspace = true }
 ethereum_hashing = { workspace = true }
 c-kzg = { workspace = true }
-peerdas-kzg = { workspace = true }
+rust_eth_kzg = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -1,0 +1,27 @@
+use c_kzg::KzgSettings;
+use criterion::{criterion_group, criterion_main, Criterion};
+use eth2_network_config::TRUSTED_SETUP_BYTES;
+use kzg::TrustedSetup;
+use peerdas_kzg::{PeerDASContext, TrustedSetup as PeerDASTrustedSetup};
+
+pub fn bench_init_context(c: &mut Criterion) {
+    c.bench_function(&format!("Initialize context peerdas-kzg"), |b| {
+        b.iter(|| {
+            const NUM_THREADS: usize = 1;
+            let trusted_setup = PeerDASTrustedSetup::default();
+            PeerDASContext::with_threads(&trusted_setup, NUM_THREADS)
+        })
+    });
+    c.bench_function(&format!("Initialize context c-kzg (4844)"), |b| {
+        b.iter(|| {
+            let trusted_setup: TrustedSetup = serde_json::from_reader(TRUSTED_SETUP_BYTES)
+                .map_err(|e| format!("Unable to read trusted setup file: {}", e))
+                .expect("should have trusted setup");
+            KzgSettings::load_trusted_setup(&trusted_setup.g1_points(), &trusted_setup.g2_points())
+                .unwrap()
+        })
+    });
+}
+
+criterion_group!(benches, bench_init_context);
+criterion_main!(benches);

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -2,14 +2,14 @@ use c_kzg::KzgSettings;
 use criterion::{criterion_group, criterion_main, Criterion};
 use eth2_network_config::TRUSTED_SETUP_BYTES;
 use kzg::TrustedSetup;
-use peerdas_kzg::{PeerDASContext, TrustedSetup as PeerDASTrustedSetup};
+use rust_eth_kzg::{DASContext, TrustedSetup as PeerDASTrustedSetup};
 
 pub fn bench_init_context(c: &mut Criterion) {
-    c.bench_function(&format!("Initialize context peerdas-kzg"), |b| {
+    c.bench_function(&format!("Initialize context rust_eth_kzg"), |b| {
         b.iter(|| {
             const NUM_THREADS: usize = 1;
             let trusted_setup = PeerDASTrustedSetup::default();
-            PeerDASContext::with_threads(&trusted_setup, NUM_THREADS)
+            DASContext::with_threads(&trusted_setup, NUM_THREADS)
         })
     });
     c.bench_function(&format!("Initialize context c-kzg (4844)"), |b| {

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -57,7 +57,7 @@ impl Kzg {
         //
         // Note: One can also use `from_json` to initialize it from the consensus-specs
         // json string.
-        let peerdas_trusted_setup = PeerDASTrustedSetup::default();
+        let peerdas_trusted_setup = PeerDASTrustedSetup::from(&trusted_setup);
         // Set the number of threads to be used
         //
         // we set it to 1 to match the c-kzg performance

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -2,7 +2,7 @@ mod kzg_commitment;
 mod kzg_proof;
 mod trusted_setup;
 
-use peerdas_kzg::{prover::ProverError, verifier::VerifierError, PeerDASContext};
+use rust_eth_kzg::{CellIndex, DASContext};
 use std::fmt::Debug;
 
 pub use crate::{
@@ -16,7 +16,7 @@ pub use c_kzg::{
     BYTES_PER_FIELD_ELEMENT, BYTES_PER_PROOF, FIELD_ELEMENTS_PER_BLOB,
 };
 
-pub use peerdas_kzg::{
+pub use rust_eth_kzg::{
     constants::{BYTES_PER_CELL, CELLS_PER_EXT_BLOB},
     Cell, CellIndex as CellID, CellRef, TrustedSetup as PeerDASTrustedSetup,
 };
@@ -29,10 +29,8 @@ pub type KzgBlobRef<'a> = &'a [u8; BYTES_PER_BLOB];
 pub enum Error {
     /// An error from the underlying kzg library.
     Kzg(c_kzg::Error),
-    /// A prover error from the PeerdasKZG library
-    ProverKZG(ProverError),
-    /// A verifier error from the PeerdasKZG library
-    VerifierKZG(VerifierError),
+    /// A prover/verifier error from the rust-eth-kzg library.
+    PeerDASKZG(rust_eth_kzg::Error),
     /// The kzg verification failed
     KzgVerificationFailed,
     /// Misc indexing error
@@ -49,7 +47,7 @@ impl From<c_kzg::Error> for Error {
 #[derive(Debug)]
 pub struct Kzg {
     trusted_setup: KzgSettings,
-    context: PeerDASContext,
+    context: DASContext,
 }
 
 impl Kzg {
@@ -65,7 +63,7 @@ impl Kzg {
         // we set it to 1 to match the c-kzg performance
         const NUM_THREADS: usize = 1;
 
-        let context = PeerDASContext::with_threads(&peerdas_trusted_setup, NUM_THREADS);
+        let context = DASContext::with_threads(&peerdas_trusted_setup, NUM_THREADS);
 
         Ok(Self {
             trusted_setup: KzgSettings::load_trusted_setup(
@@ -183,7 +181,7 @@ impl Kzg {
         let (cells, proofs) = self
             .context
             .compute_cells_and_kzg_proofs(blob)
-            .map_err(Error::ProverKZG)?;
+            .map_err(Error::PeerDASKZG)?;
 
         // Convert the proof type to a c-kzg proof type
         let c_kzg_proof = proofs.map(KzgProof);
@@ -200,13 +198,9 @@ impl Kzg {
         &self,
         cells: &[CellRef<'a>],
         kzg_proofs: &[Bytes48],
-        coordinates: &[(u64, u64)],
+        columns: Vec<CellIndex>,
         kzg_commitments: &[Bytes48],
     ) -> Result<(), Error> {
-        let (rows, columns): (Vec<u64>, Vec<u64>) = coordinates.iter().cloned().unzip();
-        // The result of this is either an Ok indicating the proof passed, or an Err indicating
-        // the proof failed or something else went wrong.
-
         let proofs: Vec<_> = kzg_proofs.iter().map(|proof| proof.as_ref()).collect();
         let commitments: Vec<_> = kzg_commitments
             .iter()
@@ -214,7 +208,6 @@ impl Kzg {
             .collect();
         let verification_result = self.context.verify_cell_kzg_proof_batch(
             commitments.to_vec(),
-            rows,
             columns,
             cells.to_vec(),
             proofs.to_vec(),
@@ -223,8 +216,8 @@ impl Kzg {
         // Modify the result so it matches roughly what the previous method was doing.
         match verification_result {
             Ok(_) => Ok(()),
-            Err(VerifierError::InvalidProof) => Err(Error::KzgVerificationFailed),
-            Err(e) => Err(Error::VerifierKZG(e)),
+            Err(e) if e.invalid_proof() => Err(Error::KzgVerificationFailed),
+            Err(e) => Err(Error::PeerDASKZG(e)),
         }
     }
 
@@ -237,7 +230,7 @@ impl Kzg {
         let (cells, proofs) = self
             .context
             .recover_cells_and_proofs(cell_ids.to_vec(), cells.to_vec())
-            .map_err(Error::ProverKZG)?;
+            .map_err(Error::PeerDASKZG)?;
 
         // Convert the proof type to a c-kzg proof type
         let c_kzg_proof = proofs.map(KzgProof);

--- a/crypto/kzg/src/trusted_setup.rs
+++ b/crypto/kzg/src/trusted_setup.rs
@@ -1,3 +1,4 @@
+use crate::PeerDASTrustedSetup;
 use c_kzg::{BYTES_PER_G1_POINT, BYTES_PER_G2_POINT};
 use serde::{
     de::{self, Deserializer, Visitor},
@@ -40,6 +41,28 @@ impl TrustedSetup {
 
     pub fn g1_len(&self) -> usize {
         self.g1_points.len()
+    }
+}
+
+impl From<&TrustedSetup> for PeerDASTrustedSetup {
+    fn from(trusted_setup: &TrustedSetup) -> Self {
+        Self {
+            g1_monomial: trusted_setup
+                .g1_monomial_points
+                .iter()
+                .map(|g1_point| format!("0x{}", hex::encode(g1_point.0)))
+                .collect::<Vec<_>>(),
+            g1_lagrange: trusted_setup
+                .g1_points
+                .iter()
+                .map(|g1_point| format!("0x{}", hex::encode(g1_point.0)))
+                .collect::<Vec<_>>(),
+            g2_monomial: trusted_setup
+                .g2_points
+                .iter()
+                .map(|g2_point| format!("0x{}", hex::encode(g2_point.0)))
+                .collect::<Vec<_>>(),
+        }
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

Part of #6072. 

Add plumbing for peerdas supernodes (#5050, #5409, #5570, #5966)
- add cli option `--subscribe-to-all-data-columns`
- add custody subnet count to ENR, only if PeerDAS is scheduled
- subscribe to data column topics, only if PeerDAS is scheduled

Upstream PRs:
- #5050
- #5409 (Thanks @jacobkaufmann ❤️ )
- #5570
- #5966
