### PR TITLE
Store computed custody subnets in PeerDB and fix custody lookup test

### DIFF
--- a/beacon_node/http_api/src/publish_blocks.rs
+++ b/beacon_node/http_api/src/publish_blocks.rs
@@ -273,7 +273,7 @@ pub async fn publish_block<T: BeaconChainTypes, B: IntoGossipVerifiedBlockConten
     }
 
     if let Some(gossip_verified_data_columns) = gossip_verified_data_columns {
-        let custody_columns_indices = network_globals.custody_columns(block.epoch(), &chain.spec);
+        let custody_columns_indices = network_globals.custody_columns(block.epoch());
 
         let custody_columns = gossip_verified_data_columns
             .into_iter()

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -151,6 +151,7 @@ pub async fn create_api_server<T: BeaconChainTypes>(
         vec![],
         false,
         &log,
+        chain.spec.clone(),
     ));
 
     // Only a peer manager can add peers, so we create a dummy manager.

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -1232,6 +1232,7 @@ mod tests {
             vec![],
             false,
             &log,
+            spec.clone(),
         );
         let keypair = keypair.into();
         Discovery::new(keypair, &config, Arc::new(globals), &log, &spec)

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -1383,7 +1383,8 @@ mod tests {
             ..Default::default()
         };
         let log = build_log(slog::Level::Debug, false);
-        let globals = NetworkGlobals::new_test_globals(vec![], &log);
+        let spec = E::default_spec();
+        let globals = NetworkGlobals::new_test_globals(vec![], &log, spec);
         PeerManager::new(config, Arc::new(globals), &log).unwrap()
     }
 
@@ -1397,7 +1398,8 @@ mod tests {
             ..Default::default()
         };
         let log = build_log(slog::Level::Debug, false);
-        let globals = NetworkGlobals::new_test_globals(trusted_peers, &log);
+        let spec = E::default_spec();
+        let globals = NetworkGlobals::new_test_globals(trusted_peers, &log, spec);
         PeerManager::new(config, Arc::new(globals), &log).unwrap()
     }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1,7 +1,8 @@
 use crate::discovery::enr::PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY;
 use crate::discovery::CombinedKey;
-use crate::rpc::{MetaData, MetaDataV2};
-use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub, PeerId};
+use crate::{
+    metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Eth2Enr, Gossipsub, PeerId,
+};
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
 use rand::seq::SliceRandom;
 use score::{PeerAction, ReportSource, Score, ScoreState};
@@ -46,10 +47,16 @@ pub struct PeerDB<E: EthSpec> {
     disable_peer_scoring: bool,
     /// PeerDB's logger
     log: slog::Logger,
+    spec: ChainSpec,
 }
 
 impl<E: EthSpec> PeerDB<E> {
-    pub fn new(trusted_peers: Vec<PeerId>, disable_peer_scoring: bool, log: &slog::Logger) -> Self {
+    pub fn new(
+        trusted_peers: Vec<PeerId>,
+        disable_peer_scoring: bool,
+        log: &slog::Logger,
+        spec: ChainSpec,
+    ) -> Self {
         // Initialize the peers hashmap with trusted peers
         let peers = trusted_peers
             .into_iter()
@@ -61,6 +68,7 @@ impl<E: EthSpec> PeerDB<E> {
             banned_peers_count: BannedPeersCount::default(),
             disable_peer_scoring,
             peers,
+            spec,
         }
     }
 
@@ -244,6 +252,27 @@ impl<E: EthSpec> PeerDB<E> {
                     && info.on_subnet_metadata(&subnet)
                     && info.on_subnet_gossipsub(&subnet)
                     && info.is_good_gossipsub_peer()
+            })
+            .map(|(peer_id, _)| peer_id)
+    }
+
+    pub fn good_custody_subnet_peer(
+        &self,
+        subnet: DataColumnSubnetId,
+    ) -> impl Iterator<Item = &PeerId> {
+        self.peers
+            .iter()
+            .filter(move |(_, info)| {
+                // TODO(das): we currently consider peer to be a subnet peer if the peer is *either*
+                // subscribed to the subnet or assigned to the subnet.
+                // The first condition is currently required as we don't have custody count in
+                // metadata implemented yet, and therefore unable to reliably determine custody
+                // subnet count (ENR is not always available).
+                // This condition can be removed later so that we can identify peers that are not
+                // serving custody columns and penalise accordingly.
+                let is_custody_subnet_peer = info.on_subnet_gossipsub(&Subnet::DataColumn(subnet))
+                    || info.is_assigned_to_custody_subnet(&subnet);
+                info.is_connected() && info.is_good_gossipsub_peer() && is_custody_subnet_peer
             })
             .map(|(peer_id, _)| peer_id)
     }
@@ -683,7 +712,6 @@ impl<E: EthSpec> PeerDB<E> {
         let enr_key = CombinedKey::generate_secp256k1();
         let mut enr = Enr::builder().build(&enr_key).unwrap();
         let peer_id = enr.peer_id();
-        let node_id = enr.node_id();
 
         if supernode {
             enr.insert(
@@ -702,31 +730,6 @@ impl<E: EthSpec> PeerDB<E> {
                 direction: ConnectionDirection::Outgoing,
             },
         );
-
-        let custody_subnet_count = if supernode {
-            spec.data_column_sidecar_subnet_count
-        } else {
-            spec.custody_requirement
-        };
-
-        // add subnet subscription
-        for subnet in DataColumnSubnetId::compute_custody_subnets::<E>(
-            node_id.raw().into(),
-            custody_subnet_count,
-            spec,
-        ) {
-            self.add_subscription(&peer_id, Subnet::DataColumn(subnet));
-        }
-
-        // add metadata
-        let metadata = MetaDataV2 {
-            seq_number: 0,
-            attnets: Default::default(),
-            syncnets: Default::default(),
-        };
-        self.peer_info_mut(&peer_id)
-            .unwrap()
-            .set_meta_data(MetaData::V2(metadata));
 
         peer_id
     }
@@ -791,8 +794,17 @@ impl<E: EthSpec> PeerDB<E> {
                     seen_address,
                 },
             ) => {
-                // Update the ENR if one exists
+                // Update the ENR if one exists, and compute the custody subnets
                 if let Some(enr) = enr {
+                    let node_id = enr.node_id().raw().into();
+                    let custody_subnet_count = enr.custody_subnet_count::<E>(&self.spec);
+                    let custody_subnets = DataColumnSubnetId::compute_custody_subnets::<E>(
+                        node_id,
+                        custody_subnet_count,
+                        &self.spec,
+                    )
+                    .collect::<HashSet<_>>();
+                    info.set_custody_subnets(custody_subnets);
                     info.set_enr(enr);
                 }
 
@@ -1343,7 +1355,8 @@ mod tests {
 
     fn get_db() -> PeerDB<M> {
         let log = build_log(slog::Level::Debug, false);
-        PeerDB::new(vec![], false, &log)
+        let spec = M::default_spec();
+        PeerDB::new(vec![], false, &log, spec)
     }
 
     #[test]
@@ -2042,7 +2055,8 @@ mod tests {
     fn test_trusted_peers_score() {
         let trusted_peer = PeerId::random();
         let log = build_log(slog::Level::Debug, false);
-        let mut pdb: PeerDB<M> = PeerDB::new(vec![trusted_peer], false, &log);
+        let spec = M::default_spec();
+        let mut pdb: PeerDB<M> = PeerDB::new(vec![trusted_peer], false, &log, spec);
 
         pdb.connect_ingoing(&trusted_peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 
@@ -2066,7 +2080,8 @@ mod tests {
     fn test_disable_peer_scoring() {
         let peer = PeerId::random();
         let log = build_log(slog::Level::Debug, false);
-        let mut pdb: PeerDB<M> = PeerDB::new(vec![], true, &log);
+        let spec = M::default_spec();
+        let mut pdb: PeerDB<M> = PeerDB::new(vec![], true, &log, spec);
 
         pdb.connect_ingoing(&peer, "/ip4/0.0.0.0".parse().unwrap(), None);
 

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -172,6 +172,7 @@ impl<E: EthSpec> Network<E> {
                 trusted_peers,
                 config.disable_peer_scoring,
                 &log,
+                ctx.chain_spec.clone(),
             );
             Arc::new(globals)
         };

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -93,7 +93,7 @@ impl TestRig {
         spec.shard_committee_period = 2;
 
         let harness = BeaconChainHarness::builder(MainnetEthSpec)
-            .spec(spec)
+            .spec(spec.clone())
             .deterministic_keypairs(VALIDATOR_COUNT)
             .fresh_ephemeral_store()
             .mock_execution_layer()
@@ -204,7 +204,14 @@ impl TestRig {
         });
         let enr_key = CombinedKey::generate_secp256k1();
         let enr = enr::Enr::builder().build(&enr_key).unwrap();
-        let network_globals = Arc::new(NetworkGlobals::new(enr, meta_data, vec![], false, &log));
+        let network_globals = Arc::new(NetworkGlobals::new(
+            enr,
+            meta_data,
+            vec![],
+            false,
+            &log,
+            spec,
+        ));
 
         let executor = harness.runtime.task_executor.clone();
 

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -385,21 +385,17 @@ impl TestRig {
     }
 
     fn new_connected_peer(&mut self) -> PeerId {
-        let peer_id = PeerId::random();
         self.network_globals
             .peers
             .write()
-            .__add_connected_peer_testing_only(&peer_id, false, &self.harness.spec);
-        peer_id
+            .__add_connected_peer_testing_only(false, &self.harness.spec)
     }
 
     fn new_connected_supernode_peer(&mut self) -> PeerId {
-        let peer_id = PeerId::random();
         self.network_globals
             .peers
             .write()
-            .__add_connected_peer_testing_only(&peer_id, true, &self.harness.spec);
-        peer_id
+            .__add_connected_peer_testing_only(true, &self.harness.spec)
     }
 
     fn new_connected_peers_for_peerdas(&mut self) {
@@ -972,8 +968,8 @@ impl TestRig {
         .unwrap_or_else(|e| panic!("Expected blob parent request for {for_block:?}: {e}"))
     }
 
-    /// Retrieves an unknown number of requests for data columns of `block_root`. Because peer enrs
-    /// are random, and peer selection is random the total number of batches requests in unknown.
+    /// Retrieves an unknown number of requests for data columns of `block_root`. Because peer ENRs
+    /// are random, and peer selection is random, the total number of batched requests is unknown.
     fn expect_data_columns_by_root_requests(
         &mut self,
         block_root: Hash256,

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -132,7 +132,11 @@ impl TestRig {
         let (network_tx, network_rx) = mpsc::unbounded_channel();
         // TODO(das): make the generation of the ENR use the deterministic rng to have consistent
         // column assignments
-        let globals = Arc::new(NetworkGlobals::new_test_globals(Vec::new(), &log));
+        let globals = Arc::new(NetworkGlobals::new_test_globals(
+            Vec::new(),
+            &log,
+            chain.spec.clone(),
+        ));
         let (beacon_processor, beacon_processor_rx) = NetworkBeaconProcessor::null_for_testing(
             globals,
             chain.clone(),

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -276,7 +276,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     // TODO(das): epoch argument left here in case custody rotation is implemented
     pub fn get_custodial_peers(&self, _epoch: Epoch, column_index: ColumnIndex) -> Vec<PeerId> {
         self.network_globals()
-            .custody_peers_for_column(column_index, &self.chain.spec)
+            .custody_peers_for_column(column_index)
     }
 
     pub fn get_random_custodial_peer(
@@ -382,9 +382,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         let expects_custody_columns = if matches!(batch_type, ByRangeRequestType::BlocksAndColumns)
         {
-            let custody_indexes = self
-                .network_globals()
-                .custody_columns(epoch, &self.chain.spec);
+            let custody_indexes = self.network_globals().custody_columns(epoch);
 
             for (peer_id, columns_by_range_request) in
                 self.make_columns_by_range_requests(epoch, request, &custody_indexes)?
@@ -755,9 +753,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
         // TODO(das): figure out how to pass block.slot if we end up doing rotation
         let block_epoch = Epoch::new(0);
-        let custody_indexes_duty = self
-            .network_globals()
-            .custody_columns(block_epoch, &self.chain.spec);
+        let custody_indexes_duty = self.network_globals().custody_columns(block_epoch);
 
         // Include only the blob indexes not yet imported (received through gossip)
         let custody_indexes_to_fetch = custody_indexes_duty

--- a/beacon_node/network/src/sync/range_sync/range.rs
+++ b/beacon_node/network/src/sync/range_sync/range.rs
@@ -689,7 +689,11 @@ mod tests {
             log.new(o!("component" => "range")),
         );
         let (network_tx, network_rx) = mpsc::unbounded_channel();
-        let globals = Arc::new(NetworkGlobals::new_test_globals(Vec::new(), &log));
+        let globals = Arc::new(NetworkGlobals::new_test_globals(
+            Vec::new(),
+            &log,
+            chain.spec.clone(),
+        ));
         let (network_beacon_processor, beacon_processor_rx) =
             NetworkBeaconProcessor::null_for_testing(
                 globals.clone(),


### PR DESCRIPTION
## Issue Addressed

This PR stores the computed custody subnets in `PeerDB`, so that we don't have to compute it every time we do a data column query.

Additionally it contains a fix to the failing custody lookup test - the `peer_id` was previously randomly generated and didn't match the ENR generated in [`__add_connected_peer_testing_only`](https://github.com/sigp/lighthouse/blob/abeb795cb16d2e0de0813539a1b1cff60afb67d6/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs#L707), and we were therefore not finding peers in the `PeerDB`.

