### PR TITLE
Downgrade re-org log to INFO

### DIFF
--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -48,7 +48,7 @@ use fork_choice::{
 };
 use itertools::process_results;
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use slog::{crit, debug, error, warn, Logger};
+use slog::{crit, debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
 use state_processing::AllCaches;
 use std::sync::Arc;
@@ -1212,7 +1212,7 @@ fn detect_reorg<E: EthSpec>(
             &metrics::FORK_CHOICE_REORG_DISTANCE,
             reorg_distance.as_u64() as i64,
         );
-        warn!(
+        info!(
             log,
             "Beacon chain re-org";
             "previous_head" => ?old_block_root,

--- a/book/src/late-block-re-orgs.md
+++ b/book/src/late-block-re-orgs.md
@@ -53,7 +53,7 @@ A pair of messages at `INFO` level will be logged if a re-org opportunity is det
 This should be followed shortly after by a `WARN` log indicating that a re-org occurred. This is
 expected and normal:
 
-> WARN Beacon chain re-org                     reorg_distance: 1, new_slot: 1105320, new_head: 0x72791549e4ca792f91053bc7cf1e55c6fbe745f78ce7a16fc3acb6f09161becd, previous_slot: 1105319, previous_head: 0xf64f8e5ed617dc18c1e759dab5d008369767c3678416dac2fe1d389562842b49
+> INFO Beacon chain re-org                     reorg_distance: 1, new_slot: 1105320, new_head: 0x72791549e4ca792f91053bc7cf1e55c6fbe745f78ce7a16fc3acb6f09161becd, previous_slot: 1105319, previous_head: 0xf64f8e5ed617dc18c1e759dab5d008369767c3678416dac2fe1d389562842b49
 
 In case a re-org is not viable (which should be most of the time), Lighthouse will just propose a
 block as normal and log the reason the re-org was not attempted at debug level:

--- a/book/src/late-block-re-orgs.md
+++ b/book/src/late-block-re-orgs.md
@@ -50,7 +50,7 @@ A pair of messages at `INFO` level will be logged if a re-org opportunity is det
 
 > INFO Proposing block to re-org current head  head_to_reorg: 0xf64f…2b49, slot: 1105320
 
-This should be followed shortly after by a `WARN` log indicating that a re-org occurred. This is
+This should be followed shortly after by a `INFO` log indicating that a re-org occurred. This is
 expected and normal:
 
 > INFO Beacon chain re-org                     reorg_distance: 1, new_slot: 1105320, new_head: 0x72791549e4ca792f91053bc7cf1e55c6fbe745f78ce7a16fc3acb6f09161becd, previous_slot: 1105319, previous_head: 0xf64f8e5ed617dc18c1e759dab5d008369767c3678416dac2fe1d389562842b49


### PR DESCRIPTION
## Proposed Changes

Downgrade the `WARN Beacon chain re-org` log to `INFO` level.

Re-orgs are a normal part of node operation and completely unactionable by the node operator. Removing this warning is long overdue.
