### PR TITLE
Don't expect DAS config in HTTP spec response

### DIFF
--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1365,10 +1365,13 @@ pub struct Config {
     #[serde(with = "serde_utils::quoted_u64")]
     max_per_epoch_activation_exit_churn_limit: u64,
 
+    #[serde(default = "default_custody_requirement")]
     #[serde(with = "serde_utils::quoted_u64")]
     custody_requirement: u64,
+    #[serde(default = "default_data_column_sidecar_subnet_count")]
     #[serde(with = "serde_utils::quoted_u64")]
     data_column_sidecar_subnet_count: u64,
+    #[serde(default = "default_number_of_columns")]
     #[serde(with = "serde_utils::quoted_u64")]
     number_of_columns: u64,
 }
@@ -1507,6 +1510,18 @@ const fn default_attestation_propagation_slot_range() -> u64 {
 
 const fn default_maximum_gossip_clock_disparity_millis() -> u64 {
     500
+}
+
+const fn default_custody_requirement() -> u64 {
+    1
+}
+
+const fn default_data_column_sidecar_subnet_count() -> u64 {
+    32
+}
+
+const fn default_number_of_columns() -> u64 {
+    128
 }
 
 fn max_blocks_by_root_request_common(max_request_blocks: u64) -> usize {


### PR DESCRIPTION
## Issue Addressed

Lighthouse v5.3.0 RC validator clients unintentionally broke backwards compatibility with prior BNs due to some peer DAS fields that were considered mandatory in the `/eth/v1/config/spec` response:

> ERRO Unable to read spec from beacon node endpoint: https://localhost:5052/, error: HttpClient(, kind: decode, detail: missing field `CUSTODY_REQUIREMENT` at line 1 column 4281)

## Proposed Changes

- Add `default` annotations for the peer DAS fields of `Config` so the VC doesn't fail to decode responses that lack these fields. This is not necessarily a great approach, but it's what we've done for every fork so far. It might be nice to clean this up in future.

## Additional Info

In future we could also remove the `default`s for past forks.
