### PR TITLE
Deprecate mplex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,25 +4671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-mplex"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e895765e27e30217b25f7cb7ac4686dad1ff80bf2fdeffd1d898566900a924"
-dependencies = [
- "asynchronous-codec 0.6.2",
- "bytes",
- "futures",
- "libp2p-core",
- "libp2p-identity",
- "nohash-hasher",
- "parking_lot 0.12.3",
- "rand",
- "smallvec",
- "tracing",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
 name = "libp2p-noise"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5006,7 +4987,6 @@ dependencies = [
  "hex",
  "itertools 0.10.5",
  "libp2p",
- "libp2p-mplex",
  "lighthouse_metrics",
  "lighthouse_version",
  "logging",

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -46,7 +46,6 @@ itertools = { workspace = true }
 
 # Local dependencies
 void = "1.0.2"
-libp2p-mplex = "0.41"
 
 [dependencies.libp2p]
 version = "0.53"

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -401,7 +401,7 @@ impl<E: EthSpec> Network<E> {
             }
         };
 
-        // Set up the transport - tcp/quic with noise and mplex
+        // Set up the transport - tcp/quic with noise and yamux
         let transport = build_transport(local_keypair.clone(), !config.disable_quic_support)
             .map_err(|e| format!("Failed to build transport: {:?}", e))?;
 

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -38,26 +38,18 @@ pub struct Context<'a> {
 type BoxedTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
 /// The implementation supports TCP/IP, QUIC (experimental) over UDP, noise as the encryption layer, and
-/// mplex/yamux as the multiplexing layer (when using TCP).
+/// yamux as the multiplexing layer (when using TCP).
 pub fn build_transport(
     local_private_key: Keypair,
     quic_support: bool,
 ) -> std::io::Result<BoxedTransport> {
-    // mplex config
-    let mut mplex_config = libp2p_mplex::MplexConfig::new();
-    mplex_config.set_max_buffer_size(256);
-    mplex_config.set_max_buffer_behaviour(libp2p_mplex::MaxBufferBehaviour::Block);
-
     // yamux config
     let yamux_config = yamux::Config::default();
     // Creates the TCP transport layer
     let tcp = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default().nodelay(true))
         .upgrade(core::upgrade::Version::V1)
         .authenticate(generate_noise_config(&local_private_key))
-        .multiplex(core::upgrade::SelectUpgrade::new(
-            yamux_config,
-            mplex_config,
-        ))
+        .multiplex(yamux_config)
         .timeout(Duration::from_secs(10));
     let transport = if quic_support {
         // Enables Quic


### PR DESCRIPTION
Mplex is deprecated and is becoming a liability. 

We currently support two better alternatives, yamux (for TCP) and QUIC (which has its own multiplexer) over UDP. 

The issue is that other clients may still depend solely on mplex. This PR should not be merged until it has been brought to the attention of all the client teams.

Relevant spec change: https://github.com/ethereum/consensus-specs/pull/3866