### PR TITLE
Add PeerDAS RPC import boilerplate

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -23,9 +23,7 @@ use crate::chain_config::ChainConfig;
 use crate::data_availability_checker::{
     Availability, AvailabilityCheckError, AvailableBlock, DataAvailabilityChecker,
 };
-use crate::data_column_verification::{
-    DataColumnsSameBlock, GossipDataColumnError, GossipVerifiedDataColumn,
-};
+use crate::data_column_verification::{GossipDataColumnError, GossipVerifiedDataColumn};
 use crate::early_attester_cache::EarlyAttesterCache;
 use crate::errors::{BeaconChainError as Error, BlockProductionError};
 use crate::eth1_chain::{Eth1Chain, Eth1ChainBackend};
@@ -2970,13 +2968,23 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
     /// Cache the data columns in the processing cache, process it, then evict it from the cache if it was
     /// imported or errors.
-    pub async fn process_gossip_data_column(
+    pub async fn process_gossip_data_columns(
         self: &Arc<Self>,
-        data_column: GossipVerifiedDataColumn<T>,
+        data_columns: Vec<GossipVerifiedDataColumn<T>>,
     ) -> Result<AvailabilityProcessingStatus, BlockError<T::EthSpec>> {
+        let Ok((slot, block_root)) = data_columns
+            .iter()
+            .map(|c| (c.slot(), c.block_root()))
+            .unique()
+            .exactly_one()
+        else {
+            return Err(BlockError::InternalError(
+                "Columns should be from the same block".to_string(),
+            ));
+        };
+
         // If this block has already been imported to forkchoice it must have been available, so
         // we don't need to process its samples again.
-        let block_root = data_column.block_root();
         if self
             .canonical_head
             .fork_choice_read_lock()
@@ -2986,7 +2994,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         let r = self
-            .check_gossip_data_columns_availability_and_import(data_column)
+            .check_gossip_data_columns_availability_and_import(slot, block_root, data_columns)
             .await;
         self.remove_notified_custody_columns(&block_root, r)
     }
@@ -3029,11 +3037,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// imported or errors.
     pub async fn process_rpc_custody_columns(
         self: &Arc<Self>,
-        custody_columns: DataColumnsSameBlock<T::EthSpec>,
+        custody_columns: DataColumnSidecarList<T::EthSpec>,
     ) -> Result<AvailabilityProcessingStatus, BlockError<T::EthSpec>> {
+        let Ok((slot, block_root)) = custody_columns
+            .iter()
+            .map(|c| (c.slot(), c.block_root()))
+            .unique()
+            .exactly_one()
+        else {
+            return Err(BlockError::InternalError(
+                "Columns should be from the same block".to_string(),
+            ));
+        };
+
         // If this block has already been imported to forkchoice it must have been available, so
         // we don't need to process its columns again.
-        let block_root = custody_columns.block_root();
         if self
             .canonical_head
             .fork_choice_read_lock()
@@ -3045,7 +3063,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         // TODO(das): custody column SSE event
 
         let r = self
-            .check_rpc_custody_columns_availability_and_import(custody_columns)
+            .check_rpc_custody_columns_availability_and_import(slot, block_root, custody_columns)
             .await;
         self.remove_notified(&block_root, r)
     }
@@ -3328,16 +3346,21 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// if so, otherwise caches the data column in the data availability checker.
     async fn check_gossip_data_columns_availability_and_import(
         self: &Arc<Self>,
-        data_column: GossipVerifiedDataColumn<T>,
+        slot: Slot,
+        block_root: Hash256,
+        data_columns: Vec<GossipVerifiedDataColumn<T>>,
     ) -> Result<AvailabilityProcessingStatus, BlockError<T::EthSpec>> {
         if let Some(slasher) = self.slasher.as_ref() {
-            slasher.accept_block_header(data_column.signed_block_header());
+            for data_colum in &data_columns {
+                slasher.accept_block_header(data_colum.signed_block_header());
+            }
         }
 
-        let slot = data_column.slot();
-        let availability = self
-            .data_availability_checker
-            .put_gossip_data_column(data_column)?;
+        let availability = self.data_availability_checker.put_gossip_data_columns(
+            slot,
+            block_root,
+            data_columns,
+        )?;
 
         self.process_availability(slot, availability).await
     }
@@ -3385,34 +3408,39 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     /// if so, otherwise caches the columns in the data availability checker.
     async fn check_rpc_custody_columns_availability_and_import(
         self: &Arc<Self>,
-        custody_columns: DataColumnsSameBlock<T::EthSpec>,
+        slot: Slot,
+        block_root: Hash256,
+        custody_columns: DataColumnSidecarList<T::EthSpec>,
     ) -> Result<AvailabilityProcessingStatus, BlockError<T::EthSpec>> {
         // Need to scope this to ensure the lock is dropped before calling `process_availability`
         // Even an explicit drop is not enough to convince the borrow checker.
         {
             let mut slashable_cache = self.observed_slashable.write();
-            let header = custody_columns.signed_block_header();
-            let block_root = custody_columns.block_root();
-            if verify_header_signature::<T, BlockError<T::EthSpec>>(self, header).is_ok() {
-                slashable_cache
-                    .observe_slashable(
-                        header.message.slot,
-                        header.message.proposer_index,
-                        block_root,
-                    )
-                    .map_err(|e| BlockError::BeaconChainError(e.into()))?;
-                if let Some(slasher) = self.slasher.as_ref() {
-                    slasher.accept_block_header(header.clone());
+            // Assumes all items in custody_columns are for the same block_root
+            if let Some(column) = custody_columns.first() {
+                let header = &column.signed_block_header;
+                if verify_header_signature::<T, BlockError<T::EthSpec>>(self, header).is_ok() {
+                    slashable_cache
+                        .observe_slashable(
+                            header.message.slot,
+                            header.message.proposer_index,
+                            block_root,
+                        )
+                        .map_err(|e| BlockError::BeaconChainError(e.into()))?;
+                    if let Some(slasher) = self.slasher.as_ref() {
+                        slasher.accept_block_header(header.clone());
+                    }
                 }
             }
         }
 
         // This slot value is purely informative for the consumers of
         // `AvailabilityProcessingStatus::MissingComponents` to log an error with a slot.
-        let slot = custody_columns.slot();
-        let availability = self
-            .data_availability_checker
-            .put_rpc_custody_columns(custody_columns)?;
+        let availability = self.data_availability_checker.put_rpc_custody_columns(
+            block_root,
+            slot.epoch(T::EthSpec::slots_per_epoch()),
+            custody_columns,
+        )?;
 
         self.process_availability(slot, availability).await
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -185,7 +185,6 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
 
     /// Put a list of custody columns received via RPC into the availability cache. This performs KZG
     /// verification on the blobs in the list.
-    #[allow(clippy::type_complexity)]
     pub fn put_rpc_custody_columns(
         &self,
         block_root: Hash256,

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -14,10 +14,11 @@ use slot_clock::SlotClock;
 use ssz_derive::{Decode, Encode};
 use std::iter;
 use std::sync::Arc;
+use tree_hash::TreeHash;
 use types::data_column_sidecar::{ColumnIndex, DataColumnIdentifier};
 use types::{
-    BeaconStateError, ChainSpec, DataColumnSidecar, DataColumnSubnetId, EthSpec, Hash256,
-    RuntimeVariableList, SignedBeaconBlockHeader, Slot,
+    BeaconStateError, ChainSpec, DataColumnSidecar, DataColumnSidecarList, DataColumnSubnetId,
+    EthSpec, Hash256, RuntimeVariableList, SignedBeaconBlockHeader, Slot,
 };
 
 /// An error occurred while validating a gossip data column.
@@ -177,7 +178,7 @@ impl<T: BeaconChainTypes> GossipVerifiedDataColumn<T> {
     pub fn id(&self) -> DataColumnIdentifier {
         DataColumnIdentifier {
             block_root: self.block_root,
-            index: self.data_column.data_column_index(),
+            index: self.data_column.index(),
         }
     }
 
@@ -221,34 +222,91 @@ impl<E: EthSpec> KzgVerifiedDataColumn<E> {
         self.data.clone()
     }
 
-    pub fn data_column_index(&self) -> u64 {
-        self.data.index
-    }
-}
-
-/// Data column that we must custody and has completed kzg verification
-#[derive(Debug, Derivative, Clone, Encode, Decode)]
-#[derivative(PartialEq, Eq)]
-#[ssz(struct_behaviour = "transparent")]
-pub struct KzgVerifiedCustodyDataColumn<E: EthSpec> {
-    data: Arc<DataColumnSidecar<E>>,
-}
-
-impl<E: EthSpec> KzgVerifiedCustodyDataColumn<E> {
-    /// Mark a column as custody column. Caller must ensure that our current custody requirements
-    /// include this column
-    pub fn from_asserted_custody(kzg_verified: KzgVerifiedDataColumn<E>) -> Self {
-        Self {
-            data: kzg_verified.to_data_column(),
-        }
-    }
-
     pub fn index(&self) -> ColumnIndex {
         self.data.index
     }
+}
 
-    pub fn into_inner(self) -> Arc<DataColumnSidecar<E>> {
-        self.data
+/// Collection of data columns for the same block root
+pub struct DataColumnsSameBlock<E: EthSpec> {
+    block_root: Hash256,
+    signed_block_header: SignedBeaconBlockHeader,
+    columns: DataColumnSidecarList<E>,
+}
+
+impl<E: EthSpec> DataColumnsSameBlock<E> {
+    pub fn new(columns: DataColumnSidecarList<E>) -> Result<Self, &'static str> {
+        let first_column = columns.first().ok_or("empty columns")?;
+        let signed_block_header = first_column.signed_block_header.clone();
+        for column in columns.iter().skip(1) {
+            if column.signed_block_header != signed_block_header {
+                return Err("no same block");
+            }
+        }
+        Ok(Self {
+            block_root: signed_block_header.message.tree_hash_root(),
+            signed_block_header,
+            columns,
+        })
+    }
+
+    pub fn verify(self, kzg: &Kzg) -> Result<KzgVerifiedDataColumnsSameBlock<E>, KzgError> {
+        Ok(KzgVerifiedDataColumnsSameBlock {
+            block_root: self.block_root,
+            signed_block_header: self.signed_block_header,
+            columns: self
+                .columns
+                .into_iter()
+                .map(|column| KzgVerifiedDataColumn::new(column, kzg))
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+
+    pub fn block_root(&self) -> Hash256 {
+        self.block_root
+    }
+    pub fn slot(&self) -> Slot {
+        self.signed_block_header.message.slot
+    }
+    pub fn signed_block_header(&self) -> &SignedBeaconBlockHeader {
+        &self.signed_block_header
+    }
+    pub fn columns(&self) -> &DataColumnSidecarList<E> {
+        &self.columns
+    }
+}
+
+/// Collection of KZG verified data columns for the same block root
+pub struct KzgVerifiedDataColumnsSameBlock<E: EthSpec> {
+    block_root: Hash256,
+    signed_block_header: SignedBeaconBlockHeader,
+    columns: Vec<KzgVerifiedDataColumn<E>>,
+}
+
+impl<E: EthSpec> KzgVerifiedDataColumnsSameBlock<E> {
+    pub fn new(columns: Vec<KzgVerifiedDataColumn<E>>) -> Result<Self, &'static str> {
+        let first_column = columns.first().ok_or("empty columns")?;
+        let signed_block_header = first_column.as_data_column().signed_block_header.clone();
+        for column in columns.iter().skip(1) {
+            if column.as_data_column().signed_block_header != signed_block_header {
+                return Err("no same block");
+            }
+        }
+        Ok(Self {
+            block_root: signed_block_header.message.tree_hash_root(),
+            signed_block_header,
+            columns,
+        })
+    }
+
+    pub fn block_root(&self) -> Hash256 {
+        self.block_root
+    }
+    pub fn slot(&self) -> Slot {
+        self.signed_block_header.message.slot
+    }
+    pub fn columns(&self) -> &[KzgVerifiedDataColumn<E>] {
+        &self.columns
     }
 }
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -988,7 +988,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         match self
             .chain
-            .process_gossip_data_columns(vec![verified_data_column])
+            .process_gossip_data_column(verified_data_column)
             .await
         {
             Ok(availability) => {

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -988,7 +988,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
         match self
             .chain
-            .process_gossip_data_column(verified_data_column)
+            .process_gossip_data_columns(vec![verified_data_column])
             .await
         {
             Ok(availability) => {

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -1,7 +1,6 @@
 use crate::sync::manager::BlockProcessType;
 use crate::{service::NetworkMessage, sync::manager::SyncMessage};
 use beacon_chain::block_verification_types::RpcBlock;
-use beacon_chain::data_column_verification::DataColumnsSameBlock;
 use beacon_chain::{builder::Witness, eth1_chain::CachingEth1Backend, BeaconChain};
 use beacon_chain::{BeaconChainTypes, NotifyExecutionLayer};
 use beacon_processor::{
@@ -481,7 +480,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /// the result back to sync.
     pub fn send_rpc_custody_columns(
         self: &Arc<Self>,
-        custody_columns: DataColumnsSameBlock<T::EthSpec>,
+        block_root: Hash256,
+        custody_columns: DataColumnSidecarList<T::EthSpec>,
         seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) -> Result<(), Error<T::EthSpec>> {
@@ -489,8 +489,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::RpcCustodyColumn(Box::pin(async move {
-                s.process_rpc_custody_columns(custody_columns, seen_timestamp, process_type)
-                    .await;
+                s.process_rpc_custody_columns(
+                    block_root,
+                    custody_columns,
+                    seen_timestamp,
+                    process_type,
+                )
+                .await;
             })),
         })
     }

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -1,6 +1,7 @@
 use crate::sync::manager::BlockProcessType;
 use crate::{service::NetworkMessage, sync::manager::SyncMessage};
 use beacon_chain::block_verification_types::RpcBlock;
+use beacon_chain::data_column_verification::DataColumnsSameBlock;
 use beacon_chain::{builder::Witness, eth1_chain::CachingEth1Backend, BeaconChain};
 use beacon_chain::{BeaconChainTypes, NotifyExecutionLayer};
 use beacon_processor::{
@@ -473,6 +474,24 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
             work: Work::RpcBlobs { process_fn },
+        })
+    }
+
+    /// Create a new `Work` event for some custody columns. `process_rpc_custody_columns` reports
+    /// the result back to sync.
+    pub fn send_rpc_custody_columns(
+        self: &Arc<Self>,
+        custody_columns: DataColumnsSameBlock<T::EthSpec>,
+        seen_timestamp: Duration,
+        process_type: BlockProcessType,
+    ) -> Result<(), Error<T::EthSpec>> {
+        let s = self.clone();
+        self.try_send(BeaconWorkEvent {
+            drop_during_sync: false,
+            work: Work::RpcCustodyColumn(Box::pin(async move {
+                s.process_rpc_custody_columns(custody_columns, seen_timestamp, process_type)
+                    .await;
+            })),
         })
     }
 

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -8,7 +8,6 @@ use crate::sync::{
 use beacon_chain::block_verification_types::{AsBlock, RpcBlock};
 use beacon_chain::data_availability_checker::AvailabilityCheckError;
 use beacon_chain::data_availability_checker::MaybeAvailableBlock;
-use beacon_chain::data_column_verification::DataColumnsSameBlock;
 use beacon_chain::{
     validator_monitor::get_slot_delay_ms, AvailabilityProcessingStatus, BeaconChainError,
     BeaconChainTypes, BlockError, ChainSegmentResult, HistoricalBlockError, NotifyExecutionLayer,
@@ -25,7 +24,7 @@ use store::KzgCommitment;
 use tokio::sync::mpsc;
 use types::beacon_block_body::format_kzg_commitments;
 use types::blob_sidecar::FixedBlobSidecarList;
-use types::BlockImportSource;
+use types::{BlockImportSource, DataColumnSidecarList};
 use types::{Epoch, Hash256};
 
 /// Id associated to a batch processing request, either a sync batch or a parent lookup.
@@ -310,11 +309,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
     pub async fn process_rpc_custody_columns(
         self: Arc<NetworkBeaconProcessor<T>>,
-        custody_columns: DataColumnsSameBlock<T::EthSpec>,
+        block_root: Hash256,
+        custody_columns: DataColumnSidecarList<T::EthSpec>,
         _seen_timestamp: Duration,
         process_type: BlockProcessType,
     ) {
-        let block_root = custody_columns.block_root();
         let result = self
             .chain
             .process_rpc_custody_columns(custody_columns)


### PR DESCRIPTION
## Issue Addressed

Continue porting network changes of `das` branch. Extends https://github.com/sigp/lighthouse/pull/6224

Part of 
- https://github.com/sigp/lighthouse/issues/4983

## Proposed Changes

- Add a new `Work:: RpcCustodyColumn` event
- Wire process function with importing columns into da_checker
- Introduce new type `DataColumnsSameBlock` as downstream code assumes that all submitted columns are in the same block. The implementation in `das` just assumes this to be the case, but this PR makes this assumption explicit via a new type. I changed the gossip import method from accepting N columns to exactly 1, so we can assert that the single column is always part of the same block.