### PR TITLE
Enables TCP port reuse

### DIFF
--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -51,14 +51,18 @@ pub fn build_transport(
     // yamux config
     let yamux_config = yamux::Config::default();
     // Creates the TCP transport layer
-    let tcp = libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::default().nodelay(true))
-        .upgrade(core::upgrade::Version::V1)
-        .authenticate(generate_noise_config(&local_private_key))
-        .multiplex(core::upgrade::SelectUpgrade::new(
-            yamux_config,
-            mplex_config,
-        ))
-        .timeout(Duration::from_secs(10));
+    let tcp = libp2p::tcp::tokio::Transport::new(
+        libp2p::tcp::Config::default()
+            .nodelay(true)
+            .port_reuse(true),
+    )
+    .upgrade(core::upgrade::Version::V1)
+    .authenticate(generate_noise_config(&local_private_key))
+    .multiplex(core::upgrade::SelectUpgrade::new(
+        yamux_config,
+        mplex_config,
+    ))
+    .timeout(Duration::from_secs(10));
     let transport = if quic_support {
         // Enables Quic
         // The default quic configuration suits us for now.


### PR DESCRIPTION
This is a temporary PR as this flag has been deprecated in the latest libp2p release. 


We need to ugprade to the latest libp2p version and change this flag to be used in the DialOpts when dialing. However this may be useful for the time being.