### PR TITLE
Fix compilation of LCLI

### DIFF
--- a/common/malloc_utils/src/glibc.rs
+++ b/common/malloc_utils/src/glibc.rs
@@ -9,6 +9,7 @@ use parking_lot::Mutex;
 use std::env;
 use std::os::raw::c_int;
 use std::result::Result;
+use std::sync::LazyLock;
 
 /// The optimal mmap threshold for Lighthouse seems to be around 128KB.
 ///


### PR DESCRIPTION
I think https://github.com/sigp/lighthouse/pull/5922 broke the compilation of LCLI. 

Seems like no one has compiled it in a few months. 

I think this PR fixes it.