### PR TITLE
Implement hierarchical state diffs config migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8213,6 +8213,7 @@ dependencies = [
  "smallvec",
  "state_processing",
  "strum",
+ "superstruct",
  "tempfile",
  "types",
  "xdelta3",

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -15,6 +15,7 @@ parking_lot = { workspace = true }
 itertools = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
+superstruct = { workspace = true }
 types = { workspace = true }
 state_processing = { workspace = true }
 slog = { workspace = true }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -322,13 +322,15 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
                 .check_compatibility(&disk_config, &split, anchor.as_ref())?;
 
             // Inform user if hierarchy config is changing.
-            if db.config.hierarchy_config != disk_config.hierarchy_config {
-                info!(
-                    db.log,
-                    "Updating historic state config";
-                    "previous_config" => ?disk_config.hierarchy_config,
-                    "new_config" => ?db.config.hierarchy_config,
-                );
+            if let Ok(hierarchy_config) = disk_config.hierarchy_config() {
+                if &db.config.hierarchy_config != hierarchy_config {
+                    info!(
+                        db.log,
+                        "Updating historic state config";
+                        "previous_config" => ?hierarchy_config,
+                        "new_config" => ?db.config.hierarchy_config,
+                    );
+                }
             }
         }
         db.store_config()?;


### PR DESCRIPTION
## Issue Addressed

Extends the migration PR to include handling the changing DB config
- https://github.com/sigp/lighthouse/pull/6193

## Proposed Changes

Superstruct the on disk DB config and start prefixing the serialization starting from V1.

**NOTE!**: When downgrading, the previous lighthouse version will be unable to deserialize the on disk config as it expects an SZZ `u64`. However, it should be fine as the on_disk config is only there to ensure compatibility.

@michaelsproul please confirm that this is ok, LH will just ignore a badly encoded on disk config
