### PR TITLE
Prevent fd leak in random slasher tests

### DIFF
--- a/slasher/src/database.rs
+++ b/slasher/src/database.rs
@@ -848,7 +848,7 @@ impl<E: EthSpec> SlasherDB<E> {
     }
 
     fn reset_db(&self, txn: &mut RwTransaction<'_>, db: &Database<'static>) -> Result<(), Error> {
-        let mut cursor = txn.cursor(&db)?;
+        let mut cursor = txn.cursor(db)?;
         if cursor.first_key()?.is_none() {
             return Ok(());
         }

--- a/slasher/src/database.rs
+++ b/slasher/src/database.rs
@@ -4,8 +4,8 @@ mod mdbx_impl;
 mod redb_impl;
 
 use crate::{
-    metrics, AttesterRecord, AttesterSlashingStatus, CompactAttesterRecord, Config, Error,
-    ProposerSlashingStatus,
+    metrics, AttesterRecord, AttesterSlashingStatus, CompactAttesterRecord, Config, Database,
+    Error, ProposerSlashingStatus,
 };
 use byteorder::{BigEndian, ByteOrder};
 use interface::{Environment, OpenDatabases, RwTransaction};
@@ -348,6 +348,18 @@ impl<E: EthSpec> SlasherDB<E> {
             &bincode::serialize(&CURRENT_SCHEMA_VERSION)?,
         )?;
         Ok(())
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.config
+    }
+
+    /// TESTING ONLY.
+    ///
+    /// Replace the config for this database. This is only a sane thing to do if the database
+    /// is empty (has been `reset`).
+    pub fn update_config(&mut self, config: Arc<Config>) {
+        self.config = config;
     }
 
     /// Load a config from disk.
@@ -797,6 +809,50 @@ impl<E: EthSpec> SlasherDB<E> {
         }
         self.delete_attestation_data_roots(indexed_attestation_ids);
 
+        Ok(())
+    }
+
+    /// Delete all data from the database, essentially re-initialising it.
+    ///
+    /// We use this reset pattern in tests instead of leaking tonnes of file descriptors and
+    /// exhausting our allocation by creating (and leaking) databases.
+    ///
+    /// THIS FUNCTION SHOULD ONLY BE USED IN TESTS.
+    pub fn reset(&self) -> Result<(), Error> {
+        // Clear the cache(s) first.
+        self.attestation_root_cache.lock().clear();
+
+        // Pattern match to avoid missing any database.
+        let OpenDatabases {
+            indexed_attestation_db,
+            indexed_attestation_id_db,
+            attesters_db,
+            attesters_max_targets_db,
+            min_targets_db,
+            max_targets_db,
+            current_epochs_db,
+            proposers_db,
+            metadata_db,
+        } = &self.databases;
+        let mut txn = self.begin_rw_txn()?;
+        self.reset_db(&mut txn, indexed_attestation_db)?;
+        self.reset_db(&mut txn, indexed_attestation_id_db)?;
+        self.reset_db(&mut txn, attesters_db)?;
+        self.reset_db(&mut txn, attesters_max_targets_db)?;
+        self.reset_db(&mut txn, min_targets_db)?;
+        self.reset_db(&mut txn, max_targets_db)?;
+        self.reset_db(&mut txn, current_epochs_db)?;
+        self.reset_db(&mut txn, proposers_db)?;
+        self.reset_db(&mut txn, metadata_db)?;
+        txn.commit()
+    }
+
+    fn reset_db(&self, txn: &mut RwTransaction<'_>, db: &Database<'static>) -> Result<(), Error> {
+        let mut cursor = txn.cursor(&db)?;
+        if cursor.first_key()?.is_none() {
+            return Ok(());
+        }
+        cursor.delete_while(|_| Ok(true))?;
         Ok(())
     }
 }

--- a/slasher/src/slasher.rs
+++ b/slasher/src/slasher.rs
@@ -33,6 +33,19 @@ impl<E: EthSpec> Slasher<E> {
         config.validate()?;
         let config = Arc::new(config);
         let db = SlasherDB::open(config.clone(), spec, log.clone())?;
+        Self::from_config_and_db(config, db, log)
+    }
+
+    /// TESTING ONLY.
+    ///
+    /// Initialise a slasher database from an existing `db`. The caller must ensure that the
+    /// database's config matches the one provided.
+    pub fn from_config_and_db(
+        config: Arc<Config>,
+        db: SlasherDB<E>,
+        log: Logger,
+    ) -> Result<Self, Error> {
+        config.validate()?;
         let attester_slashings = Mutex::new(HashSet::new());
         let proposer_slashings = Mutex::new(HashSet::new());
         let attestation_queue = AttestationQueue::default();
@@ -46,6 +59,11 @@ impl<E: EthSpec> Slasher<E> {
             config,
             log,
         })
+    }
+
+    pub fn into_reset_db(self) -> Result<SlasherDB<E>, Error> {
+        self.db.reset()?;
+        Ok(self.db)
     }
 
     /// Harvest all attester slashings found, removing them from the slasher.


### PR DESCRIPTION
## Issue Addressed

Presently the random slasher tests crash after a few thousand iterations with an error about file descriptor exhaustion. The reason for this is that we use `Box::leak` to give the slasher database a `'static` lifetime. As a result, if more than 1 `SlasherDB` is ever created, its destructor will not run and the open files will never be closed. Even though the `tempdir` will delete the DB directory containing the files, this does not free the

## Proposed Changes

Reuse the same database for each test rather than creating a new one. The contents of the database are deleted completely between iterations. Some refactoring to allow changing the `config` between iterations was required.

## Additional Info

You can reproduce the crash after a few minutes running this command on `unstable`:

```
cargo test -p slasher --release --test random -- --ignored no_crash --nocapture
```

After this PR, it can run indefinitely.
