### PR TITLE
Fix PeerDAS stuck range sync when multiple columns are batched in a single request

### DIFF
--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -1161,6 +1161,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
                         RangeBlockComponentsRequest::new(
                             resp.expects_blobs,
                             resp.expects_custody_columns,
+                            None,
                             vec![],
                         ),
                     );


### PR DESCRIPTION
Currently the PeerDAS range sync never evaluate range requests as finished, causing it to get stuck.

In #6004 we finally got range sync working, but one of the later commit in the PR (batching multiple columns in range sync requests) broke it again. 

It turned out that range sync assumes that each data column request only contains 1 column index, hence expecting `custody_column_indices.len()` number of stream terminations, and in this case we only have 1 stream termination from a single request (multiple columns batched), so the request was never completed. 

I've tested this locally on a devnet and it's able to sync to head.

For details of the investigation:
https://hackmd.io/@jimmygchen/H1TDSKPqR

Note that this is a short term fix to make range sync work, and we're expecting an overhaul of the custody range sync logic, see #6258.
