### PR TITLE
Increase priority for validator HTTP requests

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -714,7 +714,14 @@ pub fn serve<T: BeaconChainTypes>(
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              query_res: Result<api_types::ValidatorsQuery, warp::Rejection>| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
+                // Prioritise requests for validators at the head. These should be fast to service
+                // and could be required by the validator client.
+                let priority = if let StateId(eth2::types::StateId::Head) = state_id {
+                    Priority::P0
+                } else {
+                    Priority::P1
+                };
+                task_spawner.blocking_json_task(priority, move || {
                     let query = query_res?;
                     crate::validators::get_beacon_state_validators(
                         state_id,
@@ -737,7 +744,14 @@ pub fn serve<T: BeaconChainTypes>(
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              query: ValidatorsRequestBody| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
+                // Prioritise requests for validators at the head. These should be fast to service
+                // and could be required by the validator client.
+                let priority = if let StateId(eth2::types::StateId::Head) = state_id {
+                    Priority::P0
+                } else {
+                    Priority::P1
+                };
+                task_spawner.blocking_json_task(priority, move || {
                     crate::validators::get_beacon_state_validators(
                         state_id,
                         chain,
@@ -763,7 +777,14 @@ pub fn serve<T: BeaconChainTypes>(
              task_spawner: TaskSpawner<T::EthSpec>,
              chain: Arc<BeaconChain<T>>,
              validator_id: ValidatorId| {
-                task_spawner.blocking_json_task(Priority::P1, move || {
+                // Prioritise requests for validators at the head. These should be fast to service
+                // and could be required by the validator client.
+                let priority = if let StateId(eth2::types::StateId::Head) = state_id {
+                    Priority::P0
+                } else {
+                    Priority::P1
+                };
+                task_spawner.blocking_json_task(priority, move || {
                     let (data, execution_optimistic, finalized) = state_id
                         .map_state_and_execution_optimistic_and_finalized(
                             &chain,


### PR DESCRIPTION
## Issue Addressed

Address an issue reported by Stakely during Obol testing (for Lido) whereby [`charon`](https://github.com/ObolNetwork/charon) gets stuck in a timeout loop trying to request the details of inactive validators from Lighthouse.

The error from Charon is:

> 14:51:30.489 ERRO vapi       Validator api 5xx response: fetching non-cached validators from BN: beacon api validators: http request timeout: context deadline exceeded {"status_code": 500, "message": "Internal server error", "duration": "2.001067392s", "label": "validators", "url": "http://beaconnode:5051/eth/v1/beacon/states/head/validators?id=XXX", "method": "Get", "vapi_endpoint": "get_validator"}
        app/eth2wrap/eth2wrap.go:206 .wrapError
        app/eth2wrap/eth2wrap_gen.go:648 .Validators
        core/validatorapi/validatorapi.go:1021 .Validators
       core/validatorapi/router.go:1372 .getValidatorsByID
       core/validatorapi/router.go:388 .func7
       core/validatorapi/router.go:311 .func1
        app/app.go:954 .func2

## Proposed Changes

This PR increases the priority for validator info requests from P1 to P0, until we can do the hard work of overhauling the priority system:

- https://github.com/sigp/lighthouse/issues/6291

This is a low-risk change, but will require a new LH release before it can be used in production by Obol users. I will try to get Stakely to run it on testnets.

## Additional Info

There is a workaround that achieves a similar effect: `--http-enable-beacon-processor false`. However this comes with the downside of opening Lighthouse's HTTP API up to accidental DoS. With no limit to the number of concurrent requests, it is easy to overwhelm Lighthouse with requests and cause OOMs and other slowness.
