### PR TITLE
Update jsonwebtoken version to enable RISC-V builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4334,13 +4334,14 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "8.3.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
+ "js-sys",
+ "pem",
+ "ring 0.17.8",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -6123,15 +6124,6 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
@@ -6785,7 +6777,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.4",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",

--- a/beacon_node/execution_layer/Cargo.toml
+++ b/beacon_node/execution_layer/Cargo.toml
@@ -17,7 +17,7 @@ ethereum_serde_utils = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 warp = { workspace = true }
-jsonwebtoken = "8"
+jsonwebtoken = "9"
 bytes = { workspace = true }
 task_executor = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
## Issue Addressed
As described in issue https://github.com/sigp/lighthouse/issues/6297 bumping the version of jsonwebtoken is one of the changes necessary to be able to build lighthouse on RISC-V boards

## Proposed Changes

Bumping jsonwebtoken version from 8 to 9

## Additional Info

See the issue https://github.com/sigp/lighthouse/issues/6297 as a reference.

We did not see any issues from this change on our self built lighthouse 5.2.1 and it has been running a node reliably on testnet and mainnet.
