### PR TITLE
Implement Electra spec v1.5.0-alpha.5

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.5.0-alpha.3
+TESTS_TAG := v1.5.0-alpha.5
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -26,15 +26,15 @@ excluded_paths = [
     "tests/.*/.*/ssz_static/Eth1Block/",
     "tests/.*/.*/ssz_static/PowBlock/",
     # light_client
-    # "tests/.*/.*/light_client",
     "tests/.*/.*/light_client/single_merkle_proof",
     "tests/.*/.*/light_client/sync",
+    "tests/.*/electra/light_client/update_ranking",
     # LightClientStore
     "tests/.*/.*/ssz_static/LightClientStore",
     # LightClientSnapshot
     "tests/.*/.*/ssz_static/LightClientSnapshot",
     # One of the EF researchers likes to pack the tarballs on a Mac
-    ".*\.DS_Store.*",
+    ".*\\.DS_Store.*",
     # More Mac weirdness.
     "tests/mainnet/bellatrix/operations/deposit/pyspec_tests/deposit_with_previous_fork_version__valid_ineffective/._meta.yaml",
     # bls tests are moved to bls12-381-tests directory
@@ -49,7 +49,8 @@ excluded_paths = [
     # TODO(electra) re-enable once https://github.com/sigp/lighthouse/issues/6002 is resolved
     "tests/.*/electra/ssz_static/LightClientUpdate",
     "tests/.*/electra/ssz_static/LightClientFinalityUpdate",
-    "tests/.*/electra/ssz_static/LightClientBootstrap"
+    "tests/.*/electra/ssz_static/LightClientBootstrap",
+    "tests/.*/electra/merkle_proof",
 ]
 
 


### PR DESCRIPTION
## Proposed Changes

Implement the Electra spec changes for [v1.5.0-alpha.5](https://github.com/ethereum/consensus-specs/releases/tag/v1.5.0-alpha.5). As far as I can tell the only substantive change was from `v1.5.0-alpha.4`:

- https://github.com/ethereum/consensus-specs/pull/3868

I have made no attempt to update for the PeerDAS changes. That can happen in another PR once this one is merged:

- https://github.com/sigp/lighthouse/pull/5683

I started on trying to update the Electra types, but it got quite involved quite quickly, so I've just commented out those tests for now. We can handle updating them as part of:

- https://github.com/sigp/lighthouse/issues/6002