### PR TITLE
Bump diesel for CVE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf97ee7261bb708fa3402fa9c17a54b70e90e3cb98afb3dc8999d5512cb03f94"
+checksum = "65e13bab2796f412722112327f3e575601a3e9cdcbe426f0d30dbf43f3f5dc71"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
@@ -2044,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ff2be1e7312c858b2ef974f5c7089833ae57b5311b334b30923af58e5718d8"
+checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,6 @@ AARCH64_TAG = "aarch64-unknown-linux-gnu"
 BUILD_PATH_AARCH64 = "target/$(AARCH64_TAG)/release"
 
 PINNED_NIGHTLY ?= nightly
-CLIPPY_PINNED_NIGHTLY=nightly-2022-05-19
 
 # List of features to use when cross-compiling. Can be overridden via the environment.
 CROSS_FEATURES ?= gnosis,slasher-lmdb,slasher-mdbx,slasher-redb,jemalloc
@@ -221,13 +220,6 @@ lint:
 # Lints the code using Clippy and automatically fix some simple compiler warnings.
 lint-fix:
 	EXTRA_CLIPPY_OPTS="--fix --allow-staged --allow-dirty" $(MAKE) lint
-
-nightly-lint:
-	cp .github/custom/clippy.toml .
-	cargo +$(CLIPPY_PINNED_NIGHTLY) clippy --workspace --tests --release -- \
-		-A clippy::all \
-		-D clippy::disallowed_from_async
-	rm clippy.toml
 
 # Runs the makefile in the `ef_tests` repo.
 #


### PR DESCRIPTION
## Issue Addressed

Fix `cargo audit` failure for diesel (used by `watch`).

https://rustsec.org/advisories/RUSTSEC-2024-0365

## Proposed Changes

Bump diesel to the patched 2.2.3 version. This has no impact on regular LH code (related: we could consider spinning `watch` out in a separate repo).

I also removed some `PINNED_NIGHTLY` stuff which is unused since my async Clippy lint was removed.
