### PR TITLE
chore!: Update rust_eth_kzg to v0.5.1 (formally known as peerdas-kzg)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,47 +1533,53 @@ dependencies = [
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_bls12_381"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8761b04feb6031ffaf93933c955a0c91a2f3ce15dcac6b9586d2487fe55abf0b"
+checksum = "a23be5253f1bd7fd411721a58712308c4747d0a41d040bbf8ebb78d52909a480"
 dependencies = [
  "blst",
  "blstrs",
  "ff 0.13.0",
  "group 0.13.0",
  "pairing",
- "rayon",
+ "subtle",
 ]
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_erasure_codes"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca410dff79524a2babe8a0d9ab5fdce21b16808f8189eb8b6da6159681f8de2"
+checksum = "f2067ce20ef380ff33a93ce0af62bea22d35531b7f3586224d8d5176ec6cf578"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
  "crate_crypto_internal_eth_kzg_polynomial",
 ]
 
 [[package]]
-name = "crate_crypto_internal_eth_kzg_polynomial"
-version = "0.3.4"
+name = "crate_crypto_internal_eth_kzg_maybe_rayon"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68be1a5f16bc1c09254dec5209e22278d7d395284443576886a5890e7131234f"
+checksum = "558f50324ff016e5fe93113c78a72776d790d52f244ae9602a8013a67a189b66"
+
+[[package]]
+name = "crate_crypto_internal_eth_kzg_polynomial"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e051c4f5aa5696bd7c504930485436ec62bf14f30a4c2d78504f3f8ec6a3daf"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
 ]
 
 [[package]]
 name = "crate_crypto_kzg_multi_open_fk20"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fe5b687fe8c5a46851b8bc624ad49603a339dc93c920d4f7e61592c201ee8"
+checksum = "66ed6bf8993d9f3b361da4ed38f067503e08c0b948af0d6f4bb941dd647c0f2c"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
+ "crate_crypto_internal_eth_kzg_maybe_rayon",
  "crate_crypto_internal_eth_kzg_polynomial",
  "hex",
- "rayon",
  "sha2 0.10.8",
 ]
 
@@ -7090,15 +7096,14 @@ dependencies = [
 
 [[package]]
 name = "rust_eth_kzg"
-version = "0.3.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "013a850c7e131a8f9651ffbb151dc33240234f21dd357b692bd5ff4cdc84bf9a"
+checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
  "crate_crypto_internal_eth_kzg_erasure_codes",
  "crate_crypto_kzg_multi_open_fk20",
  "hex",
- "rayon",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ delay_map = "0.3"
 derivative = "2"
 dirs = "3"
 either = "1.9"
-rust_eth_kzg = "0.3.4"
+rust_eth_kzg = "0.5.1"
 discv5 = { version = "0.4.1", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -11,9 +11,13 @@ pub fn bench_init_context(c: &mut Criterion) {
 
     c.bench_function(&format!("Initialize context rust_eth_kzg"), |b| {
         b.iter(|| {
-            const NUM_THREADS: usize = 1;
             let trusted_setup = PeerDASTrustedSetup::from(&trusted_setup);
-            DASContext::with_threads(&trusted_setup, NUM_THREADS)
+            DASContext::new(
+                &trusted_setup,
+                rust_eth_kzg::UsePrecomp::Yes {
+                    width: rust_eth_kzg::constants::RECOMMENDED_PRECOMP_WIDTH,
+                },
+            )
         })
     });
     c.bench_function(&format!("Initialize context c-kzg (4844)"), |b| {

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -73,6 +73,9 @@ impl Kzg {
         // json string.
         let peerdas_trusted_setup = PeerDASTrustedSetup::from(&trusted_setup);
 
+        // It's not recommended to change the config parameter for precomputation as storage
+        // grows exponentially, but the speedup is exponential - after a while the speedup
+        // starts to become sublinear.
         let context = DASContext::new(
             &peerdas_trusted_setup,
             rust_eth_kzg::UsePrecomp::Yes {

--- a/crypto/kzg/src/lib.rs
+++ b/crypto/kzg/src/lib.rs
@@ -72,12 +72,13 @@ impl Kzg {
         // Note: One can also use `from_json` to initialize it from the consensus-specs
         // json string.
         let peerdas_trusted_setup = PeerDASTrustedSetup::from(&trusted_setup);
-        // Set the number of threads to be used
-        //
-        // we set it to 1 to match the c-kzg performance
-        const NUM_THREADS: usize = 1;
 
-        let context = DASContext::with_threads(&peerdas_trusted_setup, NUM_THREADS);
+        let context = DASContext::new(
+            &peerdas_trusted_setup,
+            rust_eth_kzg::UsePrecomp::Yes {
+                width: rust_eth_kzg::constants::RECOMMENDED_PRECOMP_WIDTH,
+            },
+        );
 
         Ok(Self {
             trusted_setup: KzgSettings::load_trusted_setup(
@@ -244,7 +245,7 @@ impl Kzg {
     ) -> Result<CellsAndKzgProofs, Error> {
         let (cells, proofs) = self
             .context()?
-            .recover_cells_and_proofs(cell_ids.to_vec(), cells.to_vec())
+            .recover_cells_and_kzg_proofs(cell_ids.to_vec(), cells.to_vec())
             .map_err(Error::PeerDASKZG)?;
 
         // Convert the proof type to a c-kzg proof type


### PR DESCRIPTION
## Issue Addressed

v0.5.0 was published with the following changes: https://github.com/crate-crypto/rust-eth-kzg/pull/161

From the list of breaking changes in that link, the ones relevant to downstream rust users are:

- Rename recover_cells_and_proofs -> recover_cells_and_kzg_proofs
- Add a ThreadCount enum for specifying the number of threads to use 
- Allow downstream users to avoid the precomputations
- Add compile time flags to disable rayon

Which issue # does this PR address?

## Proposed Changes

- The library by default runs on a single thread, so one no longer specifies the threadcount.
- update `recover_cells_and_kzg_proofs`

## Additional Info

Rayon's global threadpool and local threadpool seems to have issues -- if we were to enable multithreading it would be using the global threadpool. 

In a future PR, I think we would want to re-enable multithreading as we are experimenting with a branch which allows us to parallelize across blobs. As a corollary, it reduces the precomputation by 50x and is faster on a single thread (the speedup numbers are still being looked into, currently it seems to be ~20%)