### PR TITLE
chore: Lazy initialize the KZG struct when running tests

### DIFF
--- a/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
+++ b/testing/ef_tests/src/cases/kzg_blob_to_kzg_commitment.rs
@@ -36,7 +36,7 @@ impl<E: EthSpec> Case for KZGBlobToKZGCommitment<E> {
     }
 
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let commitment = parse_blob::<E>(&self.input.blob).and_then(|blob| {
             blob_to_kzg_commitment::<E>(&kzg, &blob).map_err(|e| {
                 Error::InternalError(format!("Failed to compute kzg commitment: {:?}", e))

--- a/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_blob_kzg_proof.rs
@@ -43,7 +43,7 @@ impl<E: EthSpec> Case for KZGComputeBlobKZGProof<E> {
             Ok((blob, commitment))
         };
 
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let proof = parse_input(&self.input).and_then(|(blob, commitment)| {
             compute_blob_kzg_proof::<E>(&kzg, &blob, commitment)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))

--- a/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_cells_and_kzg_proofs.rs
@@ -35,7 +35,7 @@ impl<E: EthSpec> Case for KZGComputeCellsAndKZGProofs<E> {
             let blob = blob.as_ref().try_into().map_err(|e| {
                 Error::InternalError(format!("Failed to convert blob to kzg blob: {e:?}"))
             })?;
-            let kzg = get_kzg()?;
+            let kzg = get_kzg();
             kzg.compute_cells_and_proofs(blob).map_err(|e| {
                 Error::InternalError(format!("Failed to compute cells and kzg proofs: {e:?}"))
             })

--- a/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_compute_kzg_proof.rs
@@ -50,7 +50,7 @@ impl<E: EthSpec> Case for KZGComputeKZGProof<E> {
             Ok((blob, z))
         };
 
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let proof = parse_input(&self.input).and_then(|(blob, z)| {
             compute_kzg_proof::<E>(&kzg, &blob, z)
                 .map_err(|e| Error::InternalError(format!("Failed to compute kzg proof: {:?}", e)))

--- a/testing/ef_tests/src/cases/kzg_recover_cells_and_kzg_proofs.rs
+++ b/testing/ef_tests/src/cases/kzg_recover_cells_and_kzg_proofs.rs
@@ -59,7 +59,7 @@ impl<E: EthSpec> Case for KZGRecoverCellsAndKZGProofs<E> {
         let result =
             parse_input(&self.input).and_then(|(input_proofs, input_cells, cell_indices)| {
                 let input_cells_ref: Vec<_> = input_cells.iter().map(|cell| &**cell).collect();
-                let kzg = get_kzg()?;
+                let kzg = get_kzg();
                 let (cells, proofs) = kzg
                     .recover_cells_and_compute_kzg_proofs(
                         cell_indices.as_slice(),

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -17,8 +17,8 @@ static KZG: LazyLock<Arc<Kzg>> = LazyLock::new(|| {
     Arc::new(kzg)
 });
 
-pub fn get_kzg() -> Result<Arc<Kzg>, Error> {
-    Ok(Arc::clone(&KZG))
+pub fn get_kzg() -> Arc<Kzg> {
+    Arc::clone(&KZG)
 }
 
 pub fn parse_cells_and_proofs(
@@ -126,7 +126,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProof<E> {
             Ok((blob, commitment, proof))
         };
 
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let result = parse_input(&self.input).and_then(|(blob, commitment, proof)| {
             match validate_blob::<E>(&kzg, &blob, commitment, proof) {
                 Ok(_) => Ok(true),

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof.rs
@@ -10,10 +10,13 @@ use std::sync::LazyLock;
 use types::Blob;
 
 static KZG: LazyLock<Arc<Kzg>> = LazyLock::new(|| {
-    let trusted_setup: TrustedSetup =
-        serde_json::from_reader(TRUSTED_SETUP_BYTES).expect("failed to initialize kzg");
+    let trusted_setup: TrustedSetup = serde_json::from_reader(TRUSTED_SETUP_BYTES)
+        .map_err(|e| Error::InternalError(format!("Failed to initialize trusted setup: {:?}", e)))
+        .expect("failed to initialize trusted setup");
     // TODO(das): need to enable these tests when rayon issues in rust_eth_kzg are fixed
-    let kzg = Kzg::new_from_trusted_setup(trusted_setup).expect("failed to initialize kzg");
+    let kzg = Kzg::new_from_trusted_setup(trusted_setup)
+        .map_err(|e| Error::InternalError(format!("Failed to initialize kzg: {:?}", e)))
+        .expect("failed to initialize kzg");
     Arc::new(kzg)
 });
 

--- a/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_blob_kzg_proof_batch.rs
@@ -57,7 +57,7 @@ impl<E: EthSpec> Case for KZGVerifyBlobKZGProofBatch<E> {
             Ok((commitments, blobs, proofs))
         };
 
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let result =
             parse_input(&self.input).and_then(
                 |(commitments, blobs, proofs)| match validate_blobs::<E>(

--- a/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
@@ -37,32 +37,37 @@ impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGVerifyCellKZGProofBatchInput| -> Result<_, Error> {
             let (cells, proofs) = parse_cells_and_proofs(&input.cells, &input.proofs)?;
+            // TODO: We are not pulling in the latest consensus-specs
+            // TODO: whereas the kzg libraries are using the new API, so
+            // TODO: we need to update this code to work for the new API.
             let row_commitments = input
                 .row_commitments
                 .iter()
                 .map(|s| parse_commitment(s))
                 .collect::<Result<Vec<_>, _>>()?;
-            let coordinates = input
+            // The new API requires the duplicated commitments
+            let commitments: Vec<_> = input
                 .row_indices
                 .iter()
-                .zip(&input.column_indices)
-                .map(|(&row, &col)| (row as u64, col as u64))
+                .filter_map(|row_index| row_commitments.get(*row_index).cloned())
+                .collect();
+            // The new API only requires the cell indices
+            let cell_indices = input
+                .column_indices
+                .iter()
+                .map(|&col| col as u64)
                 .collect::<Vec<_>>();
 
-            Ok((cells, proofs, coordinates, row_commitments))
+            Ok((cells, proofs, cell_indices, commitments))
         };
 
         let result =
-            parse_input(&self.input).and_then(|(cells, proofs, coordinates, commitments)| {
+            parse_input(&self.input).and_then(|(cells, proofs, cell_indices, commitments)| {
                 let proofs: Vec<Bytes48> = proofs.iter().map(|&proof| proof.into()).collect();
                 let commitments: Vec<Bytes48> = commitments.iter().map(|&c| c.into()).collect();
                 let cells = cells.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
-                let column_indices = coordinates
-                    .into_iter()
-                    .map(|(_row, col)| col)
-                    .collect::<Vec<_>>();
-                let kzg = get_kzg()?;
-                match kzg.verify_cell_proof_batch(&cells, &proofs, column_indices, &commitments) {
+                let kzg = get_kzg();
+                match kzg.verify_cell_proof_batch(&cells, &proofs, cell_indices, &commitments) {
                     Ok(_) => Ok(true),
                     Err(KzgError::KzgVerificationFailed) => Ok(false),
                     Err(e) => Err(Error::InternalError(format!(

--- a/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_cell_kzg_proof_batch.rs
@@ -37,37 +37,32 @@ impl<E: EthSpec> Case for KZGVerifyCellKZGProofBatch<E> {
     fn result(&self, _case_index: usize, _fork_name: ForkName) -> Result<(), Error> {
         let parse_input = |input: &KZGVerifyCellKZGProofBatchInput| -> Result<_, Error> {
             let (cells, proofs) = parse_cells_and_proofs(&input.cells, &input.proofs)?;
-            // TODO: We are not pulling in the latest consensus-specs
-            // TODO: whereas the kzg libraries are using the new API, so
-            // TODO: we need to update this code to work for the new API.
             let row_commitments = input
                 .row_commitments
                 .iter()
                 .map(|s| parse_commitment(s))
                 .collect::<Result<Vec<_>, _>>()?;
-            // The new API requires the duplicated commitments
-            let commitments: Vec<_> = input
+            let coordinates = input
                 .row_indices
                 .iter()
-                .filter_map(|row_index| row_commitments.get(*row_index).cloned())
-                .collect();
-            // The new API only requires the cell indices
-            let cell_indices = input
-                .column_indices
-                .iter()
-                .map(|&col| col as u64)
+                .zip(&input.column_indices)
+                .map(|(&row, &col)| (row as u64, col as u64))
                 .collect::<Vec<_>>();
 
-            Ok((cells, proofs, cell_indices, commitments))
+            Ok((cells, proofs, coordinates, row_commitments))
         };
 
         let result =
-            parse_input(&self.input).and_then(|(cells, proofs, cell_indices, commitments)| {
+            parse_input(&self.input).and_then(|(cells, proofs, coordinates, commitments)| {
                 let proofs: Vec<Bytes48> = proofs.iter().map(|&proof| proof.into()).collect();
                 let commitments: Vec<Bytes48> = commitments.iter().map(|&c| c.into()).collect();
                 let cells = cells.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
+                let column_indices = coordinates
+                    .into_iter()
+                    .map(|(_row, col)| col)
+                    .collect::<Vec<_>>();
                 let kzg = get_kzg();
-                match kzg.verify_cell_proof_batch(&cells, &proofs, cell_indices, &commitments) {
+                match kzg.verify_cell_proof_batch(&cells, &proofs, column_indices, &commitments) {
                     Ok(_) => Ok(true),
                     Err(KzgError::KzgVerificationFailed) => Ok(false),
                     Err(e) => Err(Error::InternalError(format!(

--- a/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
+++ b/testing/ef_tests/src/cases/kzg_verify_kzg_proof.rs
@@ -46,7 +46,7 @@ impl<E: EthSpec> Case for KZGVerifyKZGProof<E> {
             Ok((commitment, z, y, proof))
         };
 
-        let kzg = get_kzg()?;
+        let kzg = get_kzg();
         let result = parse_input(&self.input).and_then(|(commitment, z, y, proof)| {
             verify_kzg_proof::<E>(&kzg, commitment, proof, z, y)
                 .map_err(|e| Error::InternalError(format!("Failed to validate proof: {:?}", e)))


### PR DESCRIPTION
## Issue Addressed

get_kzg creates a new KZG struct each time its called, which can slow down tests since each test case will call get_kzg. 

## Proposed Changes

This PR uses LazyLock to instantiate it once using LazyLock and then other tests will just take a thread-safe reference to it. 

## Additional Info

There is another get_kzg that has been defined in kzg_utils -- That only calls get_kzg once, so its not an issue. Longer term, it might make sense to put a get_kzg method with LazyLock in crypto/get_kzg.rs, so that tests all over the workspace can access it. The main issue I see with this, is that the trusted_setup file is not in crypto/kzg.rs, so the solution won't be as clean as what it looks like in the tests modules.
