### PR TITLE
Encode DataColumn responses with Electra context bytes

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -3122,8 +3122,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             return Err(BlockError::BlockIsAlreadyKnown(block_root));
         }
 
-        // TODO(das): custody column SSE event
-
         let r = self
             .check_rpc_custody_columns_availability_and_import(slot, block_root, custody_columns)
             .await;

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -422,8 +422,7 @@ fn context_bytes<E: EthSpec>(
                 RPCResponse::BlobsByRange(_) | RPCResponse::BlobsByRoot(_) => {
                     return fork_context.to_context_bytes(ForkName::Deneb);
                 }
-                RPCResponse::DataColumnsByRoot(data_column)
-                | RPCResponse::DataColumnsByRange(data_column) => {
+                RPCResponse::DataColumnsByRoot(_) | RPCResponse::DataColumnsByRange(_) => {
                     // TODO(das): Remove deneb fork after `peerdas-devnet-2`.
                     return if fork_context.spec.eip7594_fork_epoch
                         == fork_context.spec.deneb_fork_epoch

--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -419,13 +419,19 @@ fn context_bytes<E: EthSpec>(
                         }
                     };
                 }
-                RPCResponse::BlobsByRange(_)
-                | RPCResponse::BlobsByRoot(_)
-                | RPCResponse::DataColumnsByRoot(_)
-                | RPCResponse::DataColumnsByRange(_) => {
-                    // TODO(das): If DataColumnSidecar is defined as an Electra type, update the
-                    // context bytes to point to ForkName::Electra
+                RPCResponse::BlobsByRange(_) | RPCResponse::BlobsByRoot(_) => {
                     return fork_context.to_context_bytes(ForkName::Deneb);
+                }
+                RPCResponse::DataColumnsByRoot(data_column)
+                | RPCResponse::DataColumnsByRange(data_column) => {
+                    // TODO(das): Remove deneb fork after `peerdas-devnet-2`.
+                    return if fork_context.spec.eip7594_fork_epoch
+                        == fork_context.spec.deneb_fork_epoch
+                    {
+                        fork_context.to_context_bytes(ForkName::Deneb)
+                    } else {
+                        fork_context.to_context_bytes(ForkName::Electra)
+                    };
                 }
                 RPCResponse::LightClientBootstrap(lc_bootstrap) => {
                     return lc_bootstrap

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -766,7 +766,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .imported_custody_column_indexes(&block_root)
             .unwrap_or_default();
 
-        // TODO(das): figure out how to pass block.slot if we end up doing rotation
         let custody_indexes_duty = self.network_globals().custody_columns();
 
         // Include only the blob indexes not yet imported (received through gossip)


### PR DESCRIPTION
## Issue Addressed

Encode DataColumn responses with Electra context bytes and remove some outdated `das` TODOs.

The current response returns Deneb context bytes as we've been testing PeerDAS with Deneb. From the `peerdas-devnet-3` onwards, we'll be testing it with Electra, so it would be good to get this change in to start testing. 

Once we're comfortable with testing on Electra, the Deneb fork conditions can be removed.
