### PR TITLE
Remove duplicate should_fetch_blobs check in sync lookup

### DIFF
--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -28,7 +28,6 @@ use rand::thread_rng;
 use requests::ActiveDataColumnsByRootRequest;
 pub use requests::LookupVerifyError;
 use slog::{debug, error, warn};
-use slot_clock::SlotClock;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -595,21 +594,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         block_root: Hash256,
         downloaded_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
-        // Check if we are into deneb, and before peerdas
-        if !self
-            .chain
-            .data_availability_checker
-            .blobs_required_for_epoch(
-                // TODO(das): use the block's slot
-                self.chain
-                    .slot_clock
-                    .now_or_genesis()
-                    .ok_or(RpcRequestSendError::SlotClockError)?
-                    .epoch(T::EthSpec::slots_per_epoch()),
-            )
-        {
-            return Ok(LookupRequestResult::NoRequestNeeded);
-        }
         let Some(block) = downloaded_block.or_else(|| {
             // If the block is already being processed or fully validated, retrieve how many blobs
             // it expects. Consider any stage of the block. If the block root has been validated, we
@@ -637,7 +621,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let expected_blobs = block.num_expected_blobs();
         let block_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
 
-        // Check if we are into peerdas
+        // Check if we are in deneb, before peerdas and inside da window
         if !self.chain.should_fetch_blobs(block_epoch) {
             return Ok(LookupRequestResult::NoRequestNeeded);
         }
@@ -750,7 +734,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let expected_blobs = block.num_expected_blobs();
         let block_epoch = block.slot().epoch(T::EthSpec::slots_per_epoch());
 
-        // Check if we are into peerdas
+        // Check if we are into peerdas and inside da window
         if !self.chain.should_fetch_custody_columns(block_epoch) {
             return Ok(LookupRequestResult::NoRequestNeeded);
         }


### PR DESCRIPTION
## Issue Addressed

The function `blob_lookup_request` now includes two checks if a block is in the da window:
- First: check if clock slot is in da_window
- Second: check if block's slot is in da_window

https://github.com/sigp/lighthouse/blob/5a966874da03cd987fef1629f732898a2859ce87/beacon_node/network/src/sync/network_context.rs#L641-L643

The first check has been there since pre-deneb, and is incorrect da_window-inclusiveness should be computed on the block  slot not the clock.

## Proposed Changes

Remove the first check

