### PR TITLE
Run network tests with test_logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-network: $(patsubst %,test-network-%,$(FORKS))
 
 test-network-%:
 	env FORK_NAME=$* cargo nextest run --release \
-		--features "fork_from_env,$(TEST_FEATURES)" \
+		--features "fork_from_env,test_logger,$(TEST_FEATURES)" \
 		-p network
 
 # Run the tests in the `slasher` crate for all supported database backends.


### PR DESCRIPTION
## Issue Addressed

When debugging network test errors in CI I miss having access to the logs if the test fail. There should be no significant downside to enabling the logger, capturing the logs and dropping them on failure.

## Proposed Changes

Enable test logger by default on network tests CI run
