### PR TITLE
Switch custody_subnet_count from u64 to u8

### DIFF
--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -67,8 +67,10 @@ impl Eth2Enr for Enr {
     /// if the custody value is non-existent in the ENR, then we assume the minimum custody value
     /// defined in the spec.
     fn custody_subnet_count<E: EthSpec>(&self, spec: &ChainSpec) -> u64 {
-        self.get_decodable::<u64>(PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY)
+        // Decode as a u8
+        self.get_decodable::<u8>(PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY)
             .and_then(|r| r.ok())
+            .map(|r| r as u64)
             // If value supplied in ENR is invalid, fallback to `custody_requirement`
             .filter(|csc| csc <= &spec.data_column_sidecar_subnet_count)
             .unwrap_or(spec.custody_requirement)

--- a/beacon_node/lighthouse_network/src/discovery/enr.rs
+++ b/beacon_node/lighthouse_network/src/discovery/enr.rs
@@ -247,7 +247,10 @@ pub fn build_enr<E: EthSpec>(
         } else {
             spec.custody_requirement
         };
-        builder.add_value(PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY, &custody_subnet_count);
+        let csc: u8 = custody_subnet_count
+            .try_into()
+            .map_err(|_| "custody_subnet_count cannot exceed u8::MAX".to_string())?;
+        builder.add_value(PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY, &csc);
     }
 
     builder

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -375,7 +375,10 @@ impl<E: EthSpec> PeerInfo<E> {
             if let Ok(custody_subnet_count) = meta_data.custody_subnet_count() {
                 let custody_subnets = DataColumnSubnetId::compute_custody_subnets::<E>(
                     node_id.raw().into(),
-                    std::cmp::min(*custody_subnet_count, spec.data_column_sidecar_subnet_count),
+                    std::cmp::min(
+                        *custody_subnet_count as u64,
+                        spec.data_column_sidecar_subnet_count,
+                    ),
                     spec,
                 )
                 .collect::<HashSet<_>>();

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -136,7 +136,7 @@ pub struct MetaData<E: EthSpec> {
     #[superstruct(only(V2, V3))]
     pub syncnets: EnrSyncCommitteeBitfield<E>,
     #[superstruct(only(V3))]
-    pub custody_subnet_count: u64,
+    pub custody_subnet_count: u8,
 }
 
 impl<E: EthSpec> MetaData<E> {
@@ -179,13 +179,19 @@ impl<E: EthSpec> MetaData<E> {
                 seq_number: metadata.seq_number,
                 attnets: metadata.attnets.clone(),
                 syncnets: Default::default(),
-                custody_subnet_count: spec.custody_requirement,
+                custody_subnet_count: spec
+                    .custody_requirement
+                    .try_into()
+                    .expect("config value should fit within a u8"),
             }),
             MetaData::V2(metadata) => MetaData::V3(MetaDataV3 {
                 seq_number: metadata.seq_number,
                 attnets: metadata.attnets.clone(),
                 syncnets: metadata.syncnets.clone(),
-                custody_subnet_count: spec.custody_requirement,
+                custody_subnet_count: spec
+                    .custody_requirement
+                    .try_into()
+                    .expect("config value should fit within a u8"),
             }),
             md @ MetaData::V3(_) => md.clone(),
         }

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -225,7 +225,9 @@ pub fn load_or_build_metadata<E: EthSpec>(
             attnets: meta_data.attnets,
             seq_number: meta_data.seq_number,
             syncnets: meta_data.syncnets,
-            custody_subnet_count: custody_count,
+            custody_subnet_count: custody_count
+                .try_into()
+                .expect("config value must fit in a u8"),
         })
     } else {
         MetaData::V2(meta_data)

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -166,7 +166,10 @@ impl<E: EthSpec> NetworkGlobals<E> {
                 seq_number: 0,
                 attnets: Default::default(),
                 syncnets: Default::default(),
-                custody_subnet_count: spec.data_column_sidecar_subnet_count,
+                custody_subnet_count: spec
+                    .data_column_sidecar_subnet_count
+                    .try_into()
+                    .expect("config value should fit within a u8"),
             }),
             trusted_peers,
             false,


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/pull/3897/

## Proposed Changes

Change metadata and enr fields to take a u8 instead of a u64. 

I have chosen not to change the config and chainspec params to u8 as well since they permeate throughout the codebase and we'll have to do a bunch of unnecessary `u8 as u64` sort of conversions. Instead, I made apply_to_chainspec fallible in case the parameters in the config exceed u8::MAX.
