### PR TITLE
Fix context bytes logic for DataColumn RPC responses

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec/ssz_snappy.rs
@@ -426,11 +426,12 @@ fn context_bytes<E: EthSpec>(
                 RPCResponse::BlobsByRange(_) | RPCResponse::BlobsByRoot(_) => {
                     return fork_context.to_context_bytes(ForkName::Deneb);
                 }
-                RPCResponse::DataColumnsByRoot(_) | RPCResponse::DataColumnsByRange(_) => {
+                RPCResponse::DataColumnsByRoot(d) | RPCResponse::DataColumnsByRange(d) => {
                     // TODO(das): Remove deneb fork after `peerdas-devnet-2`.
-                    return if fork_context.spec.eip7594_fork_epoch
-                        == fork_context.spec.deneb_fork_epoch
-                    {
+                    return if matches!(
+                        fork_context.spec.fork_name_at_slot::<E>(d.slot()),
+                        ForkName::Deneb
+                    ) {
                         fork_context.to_context_bytes(ForkName::Deneb)
                     } else {
                         fork_context.to_context_bytes(ForkName::Electra)


### PR DESCRIPTION
## Issue Addressed

The data column context bytes logic implemented in #6313 won't work if we start Electra and PeerDAS at genesis, see @pawanjay176 's comment here:
https://github.com/sigp/lighthouse/pull/6313#discussion_r1735112366

This PR fixes the issue, and eventually we should delete this logic altogether once Deneb testing is over. 