### PR TITLE
Ignore flaky sampling test

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1967,6 +1967,7 @@ fn sampling_happy_path() {
 }
 
 #[test]
+#[ignore] // Ignoring due to flakiness https://github.com/sigp/lighthouse/issues/6319
 fn sampling_with_retries() {
     let Some(mut r) = TestRig::test_setup_after_peerdas() else {
         return;


### PR DESCRIPTION
## Issue Addressed

The test `network sync::block_lookups::tests::sampling_with_retries` has been failing quite regularly on CI,.

This PR ignores the test, as it is slowing down our checks and merges. Sampling is currently disabled by default anyway and is probably not worth slowing down other higher priority work.

Issue raised for this: https://github.com/sigp/lighthouse/issues/6319