### PR TITLE
Enable `large_stack_frames` lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ lint:
 	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D clippy::manual_let_else \
+		-D clippy::large_stack_frames \
 		-D warnings \
 		-A clippy::derive_partial_eq_without_eq \
 		-A clippy::upper-case-acronyms \

--- a/beacon_node/beacon_chain/src/kzg_utils.rs
+++ b/beacon_node/beacon_chain/src/kzg_utils.rs
@@ -17,6 +17,10 @@ fn ssz_blob_to_crypto_blob<E: EthSpec>(blob: &Blob<E>) -> Result<KzgBlob, KzgErr
     KzgBlob::from_bytes(blob.as_ref()).map_err(Into::into)
 }
 
+fn ssz_blob_to_crypto_blob_boxed<E: EthSpec>(blob: &Blob<E>) -> Result<Box<KzgBlob>, KzgError> {
+    ssz_blob_to_crypto_blob::<E>(blob).map(Box::new)
+}
+
 /// Converts a cell ssz List object to an array to be used with the kzg
 /// crypto library.
 fn ssz_cell_to_crypto_cell<E: EthSpec>(cell: &Cell<E>) -> Result<KzgCellRef, KzgError> {
@@ -34,7 +38,7 @@ pub fn validate_blob<E: EthSpec>(
     kzg_proof: KzgProof,
 ) -> Result<(), KzgError> {
     let _timer = crate::metrics::start_timer(&crate::metrics::KZG_VERIFICATION_SINGLE_TIMES);
-    let kzg_blob = ssz_blob_to_crypto_blob::<E>(blob)?;
+    let kzg_blob = ssz_blob_to_crypto_blob_boxed::<E>(blob)?;
     kzg.verify_blob_kzg_proof(&kzg_blob, kzg_commitment, kzg_proof)
 }
 
@@ -104,7 +108,7 @@ pub fn compute_blob_kzg_proof<E: EthSpec>(
     blob: &Blob<E>,
     kzg_commitment: KzgCommitment,
 ) -> Result<KzgProof, KzgError> {
-    let kzg_blob = ssz_blob_to_crypto_blob::<E>(blob)?;
+    let kzg_blob = ssz_blob_to_crypto_blob_boxed::<E>(blob)?;
     kzg.compute_blob_kzg_proof(&kzg_blob, kzg_commitment)
 }
 
@@ -113,7 +117,7 @@ pub fn blob_to_kzg_commitment<E: EthSpec>(
     kzg: &Kzg,
     blob: &Blob<E>,
 ) -> Result<KzgCommitment, KzgError> {
-    let kzg_blob = ssz_blob_to_crypto_blob::<E>(blob)?;
+    let kzg_blob = ssz_blob_to_crypto_blob_boxed::<E>(blob)?;
     kzg.blob_to_kzg_commitment(&kzg_blob)
 }
 
@@ -124,7 +128,7 @@ pub fn compute_kzg_proof<E: EthSpec>(
     z: Hash256,
 ) -> Result<(KzgProof, Hash256), KzgError> {
     let z = z.0.into();
-    let kzg_blob = ssz_blob_to_crypto_blob::<E>(blob)?;
+    let kzg_blob = ssz_blob_to_crypto_blob_boxed::<E>(blob)?;
     kzg.compute_kzg_proof(&kzg_blob, &z)
         .map(|(proof, z)| (proof, Hash256::from_slice(&z.to_vec())))
 }

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -954,6 +954,7 @@ mod test {
         let kzg = load_kzg()?;
         let (kzg_commitment, kzg_proof, blob) = load_test_blobs_bundle::<E>()?;
         let kzg_blob = kzg::Blob::from_bytes(blob.as_ref())
+            .map(Box::new)
             .map_err(|e| format!("Error converting blob to kzg blob: {e:?}"))?;
         kzg.verify_blob_kzg_proof(&kzg_blob, kzg_commitment, kzg_proof)
             .map_err(|e| format!("Invalid blobs bundle: {e:?}"))

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -4,6 +4,7 @@ use clap::{builder::ArgPredicate, crate_version, Arg, ArgAction, ArgGroup, Comma
 use clap_utils::{get_color_style, FLAG_HEADER};
 use strum::VariantNames;
 
+#[allow(clippy::large_stack_frames)]
 pub fn cli_app() -> Command {
     Command::new("beacon_node")
         .display_order(0)

--- a/testing/simulator/src/basic_sim.rs
+++ b/testing/simulator/src/basic_sim.rs
@@ -26,6 +26,7 @@ const DENEB_FORK_EPOCH: u64 = 2;
 const SUGGESTED_FEE_RECIPIENT: [u8; 20] =
     [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1];
 
+#[allow(clippy::large_stack_frames)]
 pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
     let node_count = matches
         .get_one::<String>("nodes")

--- a/testing/state_transition_vectors/src/macros.rs
+++ b/testing/state_transition_vectors/src/macros.rs
@@ -4,6 +4,7 @@
 /// - `mod tests`: runs all the test vectors locally.
 macro_rules! vectors_and_tests {
     ($($name: ident, $test: expr),*) => {
+        #[allow(clippy::large_stack_frames)]
         pub async fn vectors() -> Vec<TestVector> {
             let mut vec = vec![];
 

--- a/watch/tests/tests.rs
+++ b/watch/tests/tests.rs
@@ -852,6 +852,7 @@ async fn chain_grows() {
 
 #[cfg(unix)]
 #[tokio::test]
+#[allow(clippy::large_stack_frames)]
 async fn chain_grows_with_metadata() {
     let builder = TesterBuilder::new().await;
 
@@ -959,6 +960,7 @@ async fn chain_grows_with_metadata() {
 
 #[cfg(unix)]
 #[tokio::test]
+#[allow(clippy::large_stack_frames)]
 async fn chain_grows_with_metadata_and_multiple_skip_slots() {
     let builder = TesterBuilder::new().await;
 


### PR DESCRIPTION
## Proposed Changes

Enable the `large_stack_frames` lint and fix some existing failures while allowing others.

Using `Box::new` in the KZG utils prevents some stack growth, because even though the blob is (probably) still copied on the stack when it is passed as an argument to `Box::new`, by avoiding _returning_ `Blob` or assigning it to a stack variable, we avoid it contributing to the size of the stack frame for the calling function.

For other places that the lint tripped, like in tests and for the CLI app, I've opted to just ignore the lint for now. These failures are low impact and harder to fix because they involve lots of nested futures. I couldn't figure out why the `watch` tests were blowing out the stack so much.

## Additional Info

The clap failure might be resolved by moving the BN over to clap derive:

- https://github.com/sigp/lighthouse/issues/5900