### PR TITLE
Remove beta tag from gossipsub 1.2

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/CHANGELOG.md
+++ b/beacon_node/lighthouse_network/gossipsub/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.5 Sigma Prime fork
+- Remove the beta tag from the v1.2 upgrade.
+  See [PR 6344](https://github.com/sigp/lighthouse/pull/6344)
 
 - Implement IDONTWANT messages as per [spec](https://github.com/libp2p/specs/pull/548).
   See [PR 5422](https://github.com/sigp/lighthouse/pull/5422)

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -2716,7 +2716,7 @@ where
             };
 
             // Only gossipsub 1.2 peers support IDONTWANT.
-            if peer.kind != PeerKind::Gossipsubv1_2_beta {
+            if peer.kind != PeerKind::Gossipsubv1_2 {
                 continue;
             }
 

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -5259,7 +5259,7 @@ fn sends_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2_beta)
+        .peer_kind(PeerKind::Gossipsubv1_2)
         .create_network();
 
     let local_id = PeerId::random();
@@ -5344,7 +5344,7 @@ fn doesnt_forward_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2_beta)
+        .peer_kind(PeerKind::Gossipsubv1_2)
         .create_network();
 
     let local_id = PeerId::random();
@@ -5393,7 +5393,7 @@ fn parses_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2_beta)
+        .peer_kind(PeerKind::Gossipsubv1_2)
         .create_network();
 
     let message_id = MessageId::new(&[0, 1, 2, 3]);
@@ -5425,7 +5425,7 @@ fn clear_stale_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2_beta)
+        .peer_kind(PeerKind::Gossipsubv1_2)
         .create_network();
 
     let peer = gs.connected_peers.get_mut(&peers[2]).unwrap();

--- a/beacon_node/lighthouse_network/gossipsub/src/protocol.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/protocol.rs
@@ -40,9 +40,9 @@ use void::Void;
 
 pub(crate) const SIGNING_PREFIX: &[u8] = b"libp2p-pubsub:";
 
-pub(crate) const GOSSIPSUB_1_2_0_BETA_PROTOCOL: ProtocolId = ProtocolId {
+pub(crate) const GOSSIPSUB_1_2_0_PROTOCOL: ProtocolId = ProtocolId {
     protocol: StreamProtocol::new("/meshsub/1.2.0"),
-    kind: PeerKind::Gossipsubv1_2_beta,
+    kind: PeerKind::Gossipsubv1_2,
 };
 pub(crate) const GOSSIPSUB_1_1_0_PROTOCOL: ProtocolId = ProtocolId {
     protocol: StreamProtocol::new("/meshsub/1.1.0"),
@@ -74,7 +74,7 @@ impl Default for ProtocolConfig {
             max_transmit_size: 65536,
             validation_mode: ValidationMode::Strict,
             protocol_ids: vec![
-                GOSSIPSUB_1_2_0_BETA_PROTOCOL,
+                GOSSIPSUB_1_2_0_PROTOCOL,
                 GOSSIPSUB_1_1_0_PROTOCOL,
                 GOSSIPSUB_1_0_0_PROTOCOL,
             ],

--- a/beacon_node/lighthouse_network/gossipsub/src/types.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/types.rs
@@ -132,7 +132,7 @@ pub(crate) struct PeerConnections {
 #[allow(non_camel_case_types)]
 pub enum PeerKind {
     /// A gossipsub 1.2 peer.
-    Gossipsubv1_2_beta,
+    Gossipsubv1_2,
     /// A gossipsub 1.1 peer.
     Gossipsubv1_1,
     /// A gossipsub 1.0 peer.
@@ -148,7 +148,7 @@ impl PeerKind {
     pub(crate) fn is_gossipsub(&self) -> bool {
         matches!(
             self,
-            Self::Gossipsubv1_2_beta | Self::Gossipsubv1_1 | Self::Gossipsub
+            Self::Gossipsubv1_2 | Self::Gossipsubv1_1 | Self::Gossipsub
         )
     }
 }
@@ -623,7 +623,7 @@ impl PeerKind {
             Self::Floodsub => "Floodsub",
             Self::Gossipsub => "Gossipsub v1.0",
             Self::Gossipsubv1_1 => "Gossipsub v1.1",
-            Self::Gossipsubv1_2_beta => "Gossipsub v1.2-beta",
+            Self::Gossipsubv1_2 => "Gossipsub v1.2",
         }
     }
 }


### PR DESCRIPTION
I was watching the network metrics to see how many nodes on mainnet had upgraded and are using gossipsub 1.2. 

I noticed the metrics still identify as 1.2-beta. This is not the actual protocol id just a naming. This PR removes the beta naming, to clean up the metrics. 