### PR TITLE
Ignore Rust 1.82 warnings about void patterns

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/handler.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/handler.rs
@@ -520,6 +520,7 @@ impl ConnectionHandler for Handler {
                         ..
                     }) => match protocol {
                         Either::Left(protocol) => handler.on_fully_negotiated_inbound(protocol),
+                        #[allow(unreachable_patterns)]
                         Either::Right(v) => void::unreachable(v),
                     },
                     ConnectionEvent::FullyNegotiatedOutbound(fully_negotiated_outbound) => {
@@ -531,6 +532,9 @@ impl ConnectionHandler for Handler {
                     }) => {
                         tracing::debug!("Dial upgrade error: Protocol negotiation timeout");
                     }
+                    // This pattern is unreachable as of Rust 1.82, we can remove it once the
+                    // MSRV is increased past that version.
+                    #[allow(unreachable_patterns)]
                     ConnectionEvent::DialUpgradeError(DialUpgradeError {
                         error: StreamUpgradeError::Apply(e),
                         ..

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1809,6 +1809,7 @@ impl<E: EthSpec> Network<E> {
                         self.inject_upnp_event(e);
                         None
                     }
+                    #[allow(unreachable_patterns)]
                     BehaviourEvent::ConnectionLimits(le) => void::unreachable(le),
                 },
                 SwarmEvent::ConnectionEstablished { .. } => None,

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -265,6 +265,8 @@ pub async fn convert_rejection<T: Reply>(res: Result<T, warp::Rejection>) -> Res
         Ok(response) => response.into_response(),
         Err(e) => match handle_rejection(e).await {
             Ok(reply) => reply.into_response(),
+            // We can simplify this once Rust 1.82 is MSRV
+            #[allow(unreachable_patterns)]
             Err(_) => warp::reply::with_status(
                 warp::reply::json(&"unhandled error"),
                 eth2::StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## Proposed Changes

Fix compilation with Rust 1.82 beta, which now runs on CI.

We cannot remove these patterns entirely yet, because we still need to be able to compile with older versions of Rust. I've opened an issue to track their eventual removal:

- https://github.com/sigp/lighthouse/issues/6356
