### PR TITLE
Add more granularity to data column proof computation metric

### DIFF
--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1651,7 +1651,7 @@ pub static DATA_COLUMN_SIDECAR_COMPUTATION: LazyLock<Result<HistogramVec>> = Laz
     try_create_histogram_vec_with_buckets(
         "data_column_sidecar_computation_seconds",
         "Time taken to compute data column sidecar, including cells, proofs and inclusion proof",
-        Ok(vec![0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]),
+        Ok(vec![0.1, 0.15, 0.25, 0.35, 0.5, 0.7, 1.0, 2.5, 5.0, 10.0]),
         &["blob_count"],
     )
 });


### PR DESCRIPTION
## Issue Addressed

Add more granularity to data column proof computation metric to capture more variations between 0.25 and 1 second.

We currently get a lot of data point at 500ms and some at 1s, would be good to get more granularity there on computation time. 
