### PR TITLE
add PeerDAS metric 'Number of bytes received from each topic (deduplicated)'

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -1837,7 +1837,7 @@ where
 
         // Record the received message with the metrics
         if let Some(metrics) = self.metrics.as_mut() {
-            metrics.msg_recvd(&message.topic);
+            metrics.msg_recvd(&message.topic, message.get_size());
         }
 
         // Consider the message as delivered for gossip promises.

--- a/beacon_node/lighthouse_network/gossipsub/src/topic.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/topic.rs
@@ -82,6 +82,10 @@ impl TopicHash {
     pub fn as_str(&self) -> &str {
         &self.hash
     }
+
+    pub fn hash_byte_len(&self) -> usize {
+        self.hash.as_bytes().len()
+    }
 }
 
 /// A gossipsub topic.

--- a/beacon_node/lighthouse_network/gossipsub/src/types.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/types.rs
@@ -30,6 +30,7 @@ use libp2p::identity::PeerId;
 use libp2p::swarm::ConnectionId;
 use prometheus_client::encoding::EncodeLabelValue;
 use quick_protobuf::MessageWrite;
+use quick_protobuf::sizeofs::*;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -234,6 +235,22 @@ impl fmt::Debug for Message {
             .field("sequence_number", &self.sequence_number)
             .field("topic", &self.topic)
             .finish()
+    }
+}
+
+/// The byte size of a message
+impl Message {
+    pub(crate) fn get_size(&self) -> usize {
+        0 + self
+            .source
+            .as_ref()
+            .map_or(0, |m| 1 + sizeof_len(m.to_bytes().len()))
+            + sizeof_len(self.data.len())
+            + self
+                .sequence_number
+                .as_ref()
+                .map_or(0, |m| 1 + sizeof_varint(*(m) as u64))
+            + sizeof_len(self.topic.hash_byte_len())
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

This PR addresses issue #6018, the list of the additional PeerDAS metrics.

## Proposed Changes

- Changed `topic_msg_recv_bytes` metric into `topic_msg_recv_bytes_unfiltered`. This can be a critical change, but needed to put metrics in order. 
- Implemented `topic_msg_recv_bytes` as deduplicated.

