### PR TITLE
Set custody subnets on tests

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1,5 +1,5 @@
 use crate::discovery::enr::PEERDAS_CUSTODY_SUBNET_COUNT_ENR_KEY;
-use crate::discovery::CombinedKey;
+use crate::discovery::{peer_id_to_node_id, CombinedKey};
 use crate::{metrics, multiaddr::Multiaddr, types::Subnet, Enr, EnrExt, Gossipsub, PeerId};
 use peer_info::{ConnectionDirection, PeerConnectionStatus, PeerInfo};
 use rand::seq::SliceRandom;
@@ -723,6 +723,17 @@ impl<E: EthSpec> PeerDB<E> {
                 .map(|csc| csc.into())
                 .collect();
             peer_info.set_custody_subnets(all_subnets);
+        } else {
+            let peer_info = self.peers.get_mut(&peer_id).expect("peer exists");
+            let node_id = peer_id_to_node_id(&peer_id).expect("convert peer_id to node_id");
+            let subnets = DataColumnSubnetId::compute_custody_subnets::<E>(
+                node_id.raw(),
+                spec.custody_requirement + 4,
+                spec,
+            )
+            .expect("should compute custody subnets")
+            .collect();
+            peer_info.set_custody_subnets(subnets);
         }
 
         peer_id

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -728,7 +728,7 @@ impl<E: EthSpec> PeerDB<E> {
             let node_id = peer_id_to_node_id(&peer_id).expect("convert peer_id to node_id");
             let subnets = DataColumnSubnetId::compute_custody_subnets::<E>(
                 node_id.raw(),
-                spec.custody_requirement + 4,
+                spec.custody_requirement,
                 spec,
             )
             .expect("should compute custody subnets")

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1977,6 +1977,8 @@ fn sampling_with_retries() {
         return;
     };
     r.new_connected_peers_for_peerdas();
+    // Add another supernode to ensure that the node can retry.
+    r.new_connected_supernode_peer();
     let (block, data_columns) = r.rand_block_and_data_columns();
     let block_root = block.canonical_root();
     r.trigger_sample_block(block_root, block.slot());

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1972,7 +1972,6 @@ fn sampling_happy_path() {
 }
 
 #[test]
-#[ignore] // Ignoring due to flakiness https://github.com/sigp/lighthouse/issues/6319
 fn sampling_with_retries() {
     let Some(mut r) = TestRig::test_setup_after_peerdas() else {
         return;


### PR DESCRIPTION
## Issue Addressed

Closes https://github.com/sigp/lighthouse/issues/6319

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

1. Update the `__add_connected_peer_testing_only` to set custody subnets
2. Add an additional supernode in the `sampling_with_retries` test to ensure that the node can retry

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->