### PR TITLE
Include compiler version in `lighthouse --version`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5035,6 +5035,7 @@ dependencies = [
  "lighthouse_version",
  "logging",
  "malloc_utils",
+ "rustc_version 0.4.1",
  "sensitive_url",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ reqwest = { version = "0.11", default-features = false, features = ["blocking", 
 ring = "0.16"
 rpds = "0.11"
 rusqlite = { version = "0.28", features = ["bundled"] }
+rustc_version = "0.4.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_repr = "0.1"

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -61,6 +61,7 @@ database_manager = { path = "../database_manager" }
 slasher = { workspace = true }
 validator_manager = { path = "../validator_manager" }
 logging = { workspace = true }
+rustc_version = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -35,6 +35,7 @@ pub static LONG_VERSION: LazyLock<String> = LazyLock::new(|| {
          SHA256 hardware acceleration: {}\n\
          Allocator: {}\n\
          Profile: {}\n\
+         Compiler: {}\n\
          Specs: mainnet (true), minimal ({}), gnosis ({})",
         SHORT_VERSION.as_str(),
         bls_library_name(),
@@ -42,6 +43,7 @@ pub static LONG_VERSION: LazyLock<String> = LazyLock::new(|| {
         have_sha_extensions(),
         allocator_name(),
         build_profile_name(),
+        compiler_version(),
         cfg!(feature = "spec-minimal"),
         cfg!(feature = "gnosis"),
     )
@@ -83,6 +85,29 @@ fn build_profile_name() -> String {
         .nth_back(3)
         .unwrap_or_else(|| "unknown")
         .to_string()
+}
+
+fn compiler_version() -> String {
+    let version = rustc_version::version_meta().expect("should be able to fetch compiler version");
+    let commit_hash_chars = 7;
+    format!(
+        "Rust v{} {} ({})",
+        version.semver,
+        compiler_channel(&version.channel),
+        version
+            .commit_hash
+            .map_or("??".to_string(), |hash| hash[..commit_hash_chars]
+                .to_string()),
+    )
+}
+
+fn compiler_channel(channel: &rustc_version::Channel) -> &'static str {
+    match channel {
+        rustc_version::Channel::Stable => "stable",
+        rustc_version::Channel::Beta => "beta",
+        rustc_version::Channel::Nightly => "nightly",
+        rustc_version::Channel::Dev => "dev",
+    }
 }
 
 fn main() {


### PR DESCRIPTION
## Proposed Changes

In aid of making builds easier to reproduce, include the compiler's version information in `lighthouse --version`.

Initial testing for reproducible builds shows that Lighthouse can't (yet) be built bit-identically by `make build-x86_64` for the same commit hash & compiler version :(

See:

- https://github.com/sigp/lighthouse/issues/6393