### PR TITLE
Simplify database anchor

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -905,9 +905,6 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
 
         let block_root = get_block_header_root(block_header);
 
-        // Disallow blocks that conflict with the anchor (weak subjectivity checkpoint), if any.
-        check_block_against_anchor_slot(block.message(), chain)?;
-
         // Do not gossip a block from a finalized slot.
         check_block_against_finalized_slot(block.message(), block_root, chain)?;
 
@@ -1137,9 +1134,6 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
             .as_block()
             .fork_name(&chain.spec)
             .map_err(BlockError::InconsistentFork)?;
-
-        // Check the anchor slot before loading the parent, to avoid spurious lookups.
-        check_block_against_anchor_slot(block.message(), chain)?;
 
         let (mut parent, block) = load_parent(block, chain)?;
 
@@ -1773,19 +1767,6 @@ impl<T: BeaconChainTypes> ExecutionPendingBlock<T> {
             payload_verification_handle,
         })
     }
-}
-
-/// Returns `Ok(())` if the block's slot is greater than the anchor block's slot (if any).
-fn check_block_against_anchor_slot<T: BeaconChainTypes>(
-    block: BeaconBlockRef<'_, T::EthSpec>,
-    chain: &BeaconChain<T>,
-) -> Result<(), BlockError> {
-    if let Some(anchor_slot) = chain.store.get_anchor_slot() {
-        if block.slot() <= anchor_slot {
-            return Err(BlockError::WeakSubjectivityConflict);
-        }
-    }
-    Ok(())
 }
 
 /// Returns `Ok(())` if the block is later than the finalized slot on `chain`.

--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -216,7 +216,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> BackgroundMigrator<E, Ho
                 // Schedule another reconstruction batch if required and we have access to the
                 // channel for requeueing.
                 if let Some(tx) = opt_tx {
-                    if db.get_anchor_info().is_some() {
+                    if !db.get_anchor_info().all_historic_states_stored() {
                         if let Err(e) = tx.send(Notification::Reconstruction) {
                             error!(
                                 log,

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -72,7 +72,7 @@ impl<E: EthSpec> NetworkGlobals<E> {
             peers: RwLock::new(PeerDB::new(trusted_peers, disable_peer_scoring, log)),
             gossipsub_subscriptions: RwLock::new(HashSet::new()),
             sync_state: RwLock::new(SyncState::Stalled),
-            backfill_state: RwLock::new(BackFillState::NotRequired),
+            backfill_state: RwLock::new(BackFillState::Paused),
             custody_subnets,
             custody_columns,
             spec,

--- a/beacon_node/lighthouse_network/src/types/sync_state.rs
+++ b/beacon_node/lighthouse_network/src/types/sync_state.rs
@@ -35,8 +35,6 @@ pub enum BackFillState {
     Syncing,
     /// A backfill sync has completed.
     Completed,
-    /// A backfill sync is not required.
-    NotRequired,
     /// Too many failed attempts at backfilling. Consider it failed.
     Failed,
 }

--- a/beacon_node/network/src/network_beacon_processor/sync_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/sync_methods.rs
@@ -656,16 +656,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                                 peer_action: None,
                             }
                         }
-                        HistoricalBlockError::NoAnchorInfo => {
-                            warn!(self.log, "Backfill not required");
-
-                            ChainSegmentFailed {
-                                message: String::from("no_anchor_info"),
-                                // There is no need to do a historical sync, this is not a fault of
-                                // the peer.
-                                peer_action: None,
-                            }
-                        }
                         HistoricalBlockError::IndexOutOfBounds => {
                             error!(
                                 self.log,

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -124,12 +124,10 @@ impl StoreConfig {
         &self,
         on_disk_config: &OnDiskStoreConfig,
         split: &Split,
-        anchor: Option<&AnchorInfo>,
+        anchor: &AnchorInfo,
     ) -> Result<(), StoreConfigError> {
         // Allow changing the hierarchy exponents if no historic states are stored.
-        // anchor == None implies full archive node thus all historic states
-        let no_historic_states_stored =
-            anchor.map_or(false, |anchor| anchor.no_historic_states_stored(split.slot));
+        let no_historic_states_stored = anchor.no_historic_states_stored(split.slot);
         let hierarchy_config_changed =
             if let Ok(on_disk_hierarchy_config) = on_disk_config.hierarchy_config() {
                 *on_disk_hierarchy_config != self.hierarchy_config
@@ -247,7 +245,10 @@ impl StoreItem for OnDiskStoreConfig {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{metadata::STATE_UPPER_LIMIT_NO_RETAIN, AnchorInfo, Split};
+    use crate::{
+        metadata::{ANCHOR_UNINITIALIZED, STATE_UPPER_LIMIT_NO_RETAIN},
+        AnchorInfo, Split,
+    };
     use ssz::DecodeError;
     use types::{Hash256, Slot};
 
@@ -261,7 +262,7 @@ mod test {
         ));
         let split = Split::default();
         assert!(store_config
-            .check_compatibility(&on_disk_config, &split, None)
+            .check_compatibility(&on_disk_config, &split, &ANCHOR_UNINITIALIZED)
             .is_ok());
     }
 
@@ -275,7 +276,7 @@ mod test {
         });
         let split = Split::default();
         assert!(store_config
-            .check_compatibility(&on_disk_config, &split, None)
+            .check_compatibility(&on_disk_config, &split, &ANCHOR_UNINITIALIZED)
             .is_ok());
     }
 
@@ -289,7 +290,7 @@ mod test {
         }));
         let split = Split::default();
         assert!(store_config
-            .check_compatibility(&on_disk_config, &split, None)
+            .check_compatibility(&on_disk_config, &split, &ANCHOR_UNINITIALIZED)
             .is_err());
     }
 
@@ -310,7 +311,7 @@ mod test {
             state_lower_limit: Slot::new(0),
         };
         assert!(store_config
-            .check_compatibility(&on_disk_config, &split, Some(&anchor))
+            .check_compatibility(&on_disk_config, &split, &anchor)
             .is_ok());
     }
 

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -246,7 +246,7 @@ impl StoreItem for OnDiskStoreConfig {
 mod test {
     use super::*;
     use crate::{
-        metadata::{ANCHOR_UNINITIALIZED, STATE_UPPER_LIMIT_NO_RETAIN},
+        metadata::{ANCHOR_FOR_ARCHIVE_NODE, ANCHOR_UNINITIALIZED, STATE_UPPER_LIMIT_NO_RETAIN},
         AnchorInfo, Split,
     };
     use ssz::DecodeError;
@@ -282,15 +282,16 @@ mod test {
 
     #[test]
     fn check_compatibility_hierarchy_config_incompatible() {
-        let store_config = StoreConfig {
-            ..Default::default()
-        };
+        let store_config = StoreConfig::default();
         let on_disk_config = OnDiskStoreConfig::V22(OnDiskStoreConfigV22::new(HierarchyConfig {
             exponents: vec![5, 8, 11, 13, 16, 18, 21],
         }));
-        let split = Split::default();
+        let split = Split {
+            slot: Slot::new(32),
+            ..Default::default()
+        };
         assert!(store_config
-            .check_compatibility(&on_disk_config, &split, &ANCHOR_UNINITIALIZED)
+            .check_compatibility(&on_disk_config, &split, &ANCHOR_FOR_ARCHIVE_NODE)
             .is_err());
     }
 

--- a/beacon_node/store/src/forwards_iter.rs
+++ b/beacon_node/store/src/forwards_iter.rs
@@ -99,27 +99,19 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
     fn freezer_upper_bound_for_state_roots(&self, start_slot: Slot) -> Option<Slot> {
         let split_slot = self.get_split_slot();
-        let anchor_info = self.get_anchor_info();
+        let anchor = self.get_anchor_info();
 
-        match anchor_info {
-            Some(anchor) => {
-                if start_slot <= anchor.state_lower_limit {
-                    // Starting slot is prior to lower limit, so that's the upper limit. We can't
-                    // iterate past the lower limit into the gap. The +1 accounts for exclusivity.
-                    Some(anchor.state_lower_limit + 1)
-                } else if start_slot >= anchor.state_upper_limit {
-                    // Starting slot is after the upper limit, so the split is the upper limit.
-                    // The split state's root is not available in the freezer so this is exclusive.
-                    Some(split_slot)
-                } else {
-                    // In the gap, nothing is available.
-                    None
-                }
-            }
-            None => {
-                // No anchor indicates that all state roots up to the split slot are available.
-                Some(split_slot)
-            }
+        if start_slot >= anchor.state_upper_limit {
+            // Starting slot is after the upper limit, so the split is the upper limit.
+            // The split state's root is not available in the freezer so this is exclusive.
+            Some(split_slot)
+        } else if start_slot <= anchor.state_lower_limit {
+            // Starting slot is prior to lower limit, so that's the upper limit. We can't
+            // iterate past the lower limit into the gap. The +1 accounts for exclusivity.
+            Some(anchor.state_lower_limit + 1)
+        } else {
+            // In the gap, nothing is available.
+            None
         }
     }
 }

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2126,7 +2126,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
     /// Load the anchor info from disk.
     fn load_anchor_info(hot_db: &Hot) -> Result<AnchorInfo, Error> {
-        // FIXME(sproul): add migration
         Ok(hot_db
             .get(&ANCHOR_INFO_KEY)?
             .unwrap_or(ANCHOR_UNINITIALIZED))

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -1,5 +1,6 @@
 //! Implementation of historic state reconstruction (given complete block history).
 use crate::hot_cold_store::{HotColdDB, HotColdDBError};
+use crate::metadata::ANCHOR_FOR_ARCHIVE_NODE;
 use crate::metrics;
 use crate::{Error, ItemStore};
 use itertools::{process_results, Itertools};
@@ -21,10 +22,12 @@ where
         self: &Arc<Self>,
         num_blocks: Option<usize>,
     ) -> Result<(), Error> {
-        let Some(mut anchor) = self.get_anchor_info() else {
-            // Nothing to do, history is complete.
+        let mut anchor = self.get_anchor_info();
+
+        // Nothing to do, history is complete.
+        if anchor.state_upper_limit == anchor.state_lower_limit {
             return Ok(());
-        };
+        }
 
         // Check that all historic blocks are known.
         if anchor.oldest_block_slot != 0 {
@@ -132,7 +135,7 @@ where
                     self.cold_db.do_atomically(std::mem::take(&mut io_batch))?;
 
                     // Update anchor.
-                    let old_anchor = Some(anchor.clone());
+                    let old_anchor = anchor.clone();
 
                     if reconstruction_complete {
                         // The two limits have met in the middle! We're done!
@@ -146,17 +149,17 @@ where
                             });
                         }
 
-                        self.compare_and_set_anchor_info_with_write(old_anchor, None)?;
+                        self.compare_and_set_anchor_info_with_write(
+                            old_anchor,
+                            ANCHOR_FOR_ARCHIVE_NODE,
+                        )?;
 
                         return Ok(());
                     } else {
                         // The lower limit has been raised, store it.
                         anchor.state_lower_limit = slot;
 
-                        self.compare_and_set_anchor_info_with_write(
-                            old_anchor,
-                            Some(anchor.clone()),
-                        )?;
+                        self.compare_and_set_anchor_info_with_write(old_anchor, anchor.clone())?;
                     }
 
                     // If this is the end of the batch, return Ok. The caller will run another

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -25,7 +25,7 @@ where
         let mut anchor = self.get_anchor_info();
 
         // Nothing to do, history is complete.
-        if anchor.state_upper_limit == anchor.state_lower_limit {
+        if anchor.all_historic_states_stored() {
             return Ok(());
         }
 

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -361,7 +361,7 @@ pub struct DatabaseInfo {
     pub schema_version: u64,
     pub config: StoreConfig,
     pub split: Split,
-    pub anchor: Option<AnchorInfo>,
+    pub anchor: AnchorInfo,
     pub blob_info: BlobInfo,
 }
 

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -16,7 +16,6 @@ use slog::{info, warn, Logger};
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
-use store::metadata::STATE_UPPER_LIMIT_NO_RETAIN;
 use store::{
     errors::Error,
     metadata::{SchemaVersion, CURRENT_SCHEMA_VERSION},
@@ -433,18 +432,12 @@ pub fn prune_states<E: EthSpec>(
 
     // Check that the user has confirmed they want to proceed.
     if !prune_config.confirm {
-        match db.get_anchor_info() {
-            Some(anchor_info)
-                if anchor_info.state_lower_limit == 0
-                    && anchor_info.state_upper_limit == STATE_UPPER_LIMIT_NO_RETAIN =>
-            {
-                info!(log, "States have already been pruned");
-                return Ok(());
-            }
-            _ => {
-                info!(log, "Ready to prune states");
-            }
+        if db.get_anchor_info().full_state_pruning_enabled() {
+            info!(log, "States have already been pruned");
+            return Ok(());
         }
+
+        info!(log, "Ready to prune states");
         warn!(
             log,
             "Pruning states is irreversible";


### PR DESCRIPTION
## Proposed Changes

Based on a suggestion from @dapplion, simplify the database's anchor by making it non-optional.

Rippling this change through the codebase also allowed for some other simplifications including deleting the `BackFillState::NotRequired` enum variant, which was redundant. Previously there were two checks for a backfill sync having already completed: checking if the anchor was `None` (the `BackFillState::NotRequired` case) and checking if all desired blocks had been downloaded based on the anchor's `oldest_block_slot` (the `BackFillState::Complete` case). I see no need to handle these cases differently, so I've deleted the `NotRequired` variant in the process of deleting the code that handled `anchor == None` which is no longer a possible state.
