### PR TITLE
Fix deadlock on block cache.

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -475,10 +475,10 @@ impl<E: EthSpec> Eth1ChainBackend<E> for CachingEth1Backend<E> {
             voting_period_start_slot,
         );
 
-        let blocks = self.core.blocks().read();
-
-        let votes_to_consider =
-            get_votes_to_consider(blocks.iter(), voting_period_start_seconds, spec);
+        let votes_to_consider = {
+            let blocks = self.core.blocks().read();
+            get_votes_to_consider(blocks.iter(), voting_period_start_seconds, spec)
+        };
 
         trace!(
             self.log,


### PR DESCRIPTION
## Issue Addressed

I ran into another deadlock scenario again today during testing. 

On thread A, read lock (1) for `block_cache` is acquired here:
https://github.com/sigp/lighthouse/blob/99e53b88c3bd2e3af5aefe2e86bb0804556d8d8c/beacon_node/beacon_chain/src/eth1_chain.rs#L478
https://github.com/sigp/lighthouse/blob/9b3b73015925a84fbb004f63516d28e45da675ce/beacon_node/eth1/src/service.rs#L477-L479

On thread B, a write lock (2) for `block_cache` is acquired in `prune_blocks`, so it waits for (1) to release the lock
https://github.com/sigp/lighthouse/blob/c824142a6dad50c4c05cb17a5718ec79a66d4aaf/beacon_node/eth1/src/inner.rs#L63

On thread A, a read lock (3) for `block_cache` is acquired again, now this is waiting on (2), but (1) may not have release the lock before this, so we're in a deadlock.
https://github.com/sigp/lighthouse/blob/99e53b88c3bd2e3af5aefe2e86bb0804556d8d8c/beacon_node/beacon_chain/src/eth1_chain.rs#L516
https://github.com/sigp/lighthouse/blob/9b3b73015925a84fbb004f63516d28e45da675ce/beacon_node/eth1/src/service.rs#L499-L501

Strangely it's on code that hasn't been touched for ages, maybe it's more easily reproducible when resources are very constrained (I'm running a kurtosis devnet).

## Proposed Changes

Drop the `block_cache` at (1) after using, and before it gets acquired again.
