### PR TITLE
Update blog reference to new combined blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An open-source Ethereum consensus client, written in Rust and maintained by Sigm
 
 [Chat Badge]: https://img.shields.io/badge/chat-discord-%237289da
 [Chat Link]: https://discord.gg/cyAszAh
-[Book Status]:https://img.shields.io/badge/user--docs-unstable-informational
+[Book Status]:https://img.shields.io/badge/user--docs-stable-informational
 [Book Link]: https://lighthouse-book.sigmaprime.io
 [stable]: https://github.com/sigp/lighthouse/tree/stable
 [unstable]: https://github.com/sigp/lighthouse/tree/unstable
@@ -41,7 +41,7 @@ as the canonical staking deposit contract address.
 The [Lighthouse Book](https://lighthouse-book.sigmaprime.io) contains information for users and
 developers.
 
-The Lighthouse team maintains a blog at [lighthouse-blog.sigmaprime.io][blog] which contains periodic
+The Lighthouse team maintains a blog at [https://blog.sigmaprime.io/tag/lighthouse][blog] which contains periodic
 progress updates, roadmap insights and interesting findings.
 
 ## Branches

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An open-source Ethereum consensus client, written in Rust and maintained by Sigm
 
 [Chat Badge]: https://img.shields.io/badge/chat-discord-%237289da
 [Chat Link]: https://discord.gg/cyAszAh
-[Book Status]:https://img.shields.io/badge/user--docs-stable-informational
+[Book Status]:https://img.shields.io/badge/user--docs-unstable-informational
 [Book Link]: https://lighthouse-book.sigmaprime.io
 [stable]: https://github.com/sigp/lighthouse/tree/stable
 [unstable]: https://github.com/sigp/lighthouse/tree/unstable


### PR DESCRIPTION
Update the blog reference to point at our new consolidate blog URL. The old lighthouse url is currently deprecated. 

This also changes the badge of our book to be stable
