### PR TITLE
estimate the total inbound bandwidth of IDONTWANT messages in bytes

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -3348,6 +3348,8 @@ where
                             };
                             if let Some(metrics) = self.metrics.as_mut() {
                                 metrics.register_idontwant(message_ids.len());
+                                let idontwant_size = message_ids.iter().map(|id| id.0.len()).sum();
+                                metrics.register_idontwant_bytes(idontwant_size);
                             }
                             for message_id in message_ids {
                                 peer.dont_send.insert(message_id, Instant::now());

--- a/beacon_node/lighthouse_network/gossipsub/src/metrics.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/metrics.rs
@@ -185,6 +185,9 @@ pub(crate) struct Metrics {
     /// The number of msg_id's we have received in every IDONTWANT control message.
     idontwant_msgs_ids: Counter,
 
+    /// The number of bytes we have received in every IDONTWANT control message.
+    idontwant_bytes: Counter,
+
     /// The size of the priority queue.
     priority_queue_size: Histogram,
     /// The size of the non-priority queue.
@@ -338,6 +341,16 @@ impl Metrics {
             metric
         };
 
+        let idontwant_bytes = {
+            let metric = Counter::default();
+            registry.register(
+                "idontwant_bytes",
+                "The total bytes we have received an IDONTWANT control messages",
+                metric.clone(),
+            );
+            metric
+        };
+
         let memcache_misses = {
             let metric = Counter::default();
             registry.register(
@@ -390,6 +403,7 @@ impl Metrics {
             memcache_misses,
             topic_iwant_msgs,
             idontwant_msgs,
+            idontwant_bytes,
             idontwant_msgs_ids,
             priority_queue_size,
             non_priority_queue_size,
@@ -587,6 +601,11 @@ impl Metrics {
         if self.register_topic(topic).is_ok() {
             self.topic_iwant_msgs.get_or_create(topic).inc();
         }
+    }
+
+    /// Register receiving the total bytes of an IDONTWANT control message.
+    pub(crate) fn register_idontwant_bytes(&mut self, bytes: usize) {
+        self.idontwant_bytes.inc_by(bytes as u64);
     }
 
     /// Register receiving an IDONTWANT msg for this topic.


### PR DESCRIPTION
## Issue Addressed

While trying to understand a report from a user which its inbound bandwidth increased considerably I noticed that in general we don't have a way to estimate what is the length in bytes of each IDONTWANT message as it depends on the message id.
This PR addresses that