### PR TITLE
Prevent Kurtosis container pollution

### DIFF
--- a/scripts/local_testnet/stop_local_testnet.sh
+++ b/scripts/local_testnet/stop_local_testnet.sh
@@ -12,4 +12,5 @@ kurtosis enclave dump $ENCLAVE_NAME $LOGS_SUBDIR
 echo "Local testnet logs stored to $LOGS_SUBDIR."
 
 kurtosis enclave rm -f $ENCLAVE_NAME
+kurtosis engine stop
 echo "Local testnet stopped."


### PR DESCRIPTION
## Issue Addressed

After using the kurtosis testnet scripts I was left with autostarting Docker containers for `traefik` and `timberio/vector`. Given that `traefik` can open tunnels and expose ports to the internet I would prefer that it doesn't randomly auto start on my machine.

## Proposed Changes

Add `kurtosis engine stop` to `stop_local_testnet.sh` so that all Kurtosis-related containers are stopped when the script ends.

This may be a bit aggressive, as some users may want to run multiple testnets in parallel. I'm open to stopping the engine by default and having a flag to avoid stopping it, if that would be useful?

## Additional Info

Discussion on Kurtosis discord: https://discord.com/channels/783719264308953108/1131048810861314169/1289051346947018846
