### PR TITLE
add a unique integer id to Rpc requests

### DIFF
--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -122,6 +122,6 @@ pub use peer_manager::{
     ConnectionDirection, PeerConnectionStatus, PeerInfo, PeerManager, SyncInfo, SyncStatus,
 };
 // pub use service::{load_private_key, Context, Libp2pEvent, Service, NETWORK_KEY_FILENAME};
-pub use service::api_types::{PeerRequestId, Request, Response};
+pub use service::api_types::{PeerRequestId, Response};
 pub use service::utils::*;
 pub use service::{Gossipsub, NetworkEvent};

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::discovery::enr_ext::EnrExt;
 use crate::discovery::peer_id_to_node_id;
-use crate::rpc::{GoodbyeReason, MetaData, Protocol, RPCError, RPCResponseErrorCode};
+use crate::rpc::{GoodbyeReason, MetaData, Protocol, RPCError, RpcErrorResponse};
 use crate::service::TARGET_SUBNET_PEERS;
 use crate::{error, metrics, Gossipsub, NetworkGlobals, PeerId, Subnet, SubnetDiscovery};
 use delay_map::HashSetDelay;
@@ -526,8 +526,8 @@ impl<E: EthSpec> PeerManager<E> {
                 PeerAction::HighToleranceError
             }
             RPCError::ErrorResponse(code, _) => match code {
-                RPCResponseErrorCode::Unknown => PeerAction::HighToleranceError,
-                RPCResponseErrorCode::ResourceUnavailable => {
+                RpcErrorResponse::Unknown => PeerAction::HighToleranceError,
+                RpcErrorResponse::ResourceUnavailable => {
                     // Don't ban on this because we want to retry with a block by root request.
                     if matches!(
                         protocol,
@@ -558,9 +558,9 @@ impl<E: EthSpec> PeerManager<E> {
                         ConnectionDirection::Incoming => return,
                     }
                 }
-                RPCResponseErrorCode::ServerError => PeerAction::MidToleranceError,
-                RPCResponseErrorCode::InvalidRequest => PeerAction::LowToleranceError,
-                RPCResponseErrorCode::RateLimited => match protocol {
+                RpcErrorResponse::ServerError => PeerAction::MidToleranceError,
+                RpcErrorResponse::InvalidRequest => PeerAction::LowToleranceError,
+                RpcErrorResponse::RateLimited => match protocol {
                     Protocol::Ping => PeerAction::MidToleranceError,
                     Protocol::BlocksByRange => PeerAction::MidToleranceError,
                     Protocol::BlocksByRoot => PeerAction::MidToleranceError,
@@ -577,7 +577,7 @@ impl<E: EthSpec> PeerManager<E> {
                     Protocol::MetaData => PeerAction::LowToleranceError,
                     Protocol::Status => PeerAction::LowToleranceError,
                 },
-                RPCResponseErrorCode::BlobsNotFoundForBlock => PeerAction::LowToleranceError,
+                RpcErrorResponse::BlobsNotFoundForBlock => PeerAction::LowToleranceError,
             },
             RPCError::SSZDecodeError(_) => PeerAction::Fatal,
             RPCError::UnsupportedProtocol => {

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -4,7 +4,7 @@
 use super::methods::{GoodbyeReason, RPCCodedResponse, RPCResponseErrorCode};
 use super::outbound::OutboundRequestContainer;
 use super::protocol::{InboundOutput, InboundRequest, Protocol, RPCError, RPCProtocol};
-use super::{RPCReceived, RPCSend, ReqId};
+use super::{RPCReceived, RPCSend, ReqId, Request, RequestId};
 use crate::rpc::outbound::{OutboundFramed, OutboundRequest};
 use crate::rpc::protocol::InboundFramed;
 use fnv::FnvHashMap;
@@ -892,10 +892,12 @@ where
             self.shutdown(None);
         }
 
-        self.events_out.push(HandlerEvent::Ok(RPCReceived::Request(
-            self.current_inbound_substream_id,
-            req,
-        )));
+        self.events_out
+            .push(HandlerEvent::Ok(RPCReceived::Request(Request {
+                id: RequestId::next(),
+                substream_id: self.current_inbound_substream_id,
+                r#type: req,
+            })));
         self.current_inbound_substream_id.0 += 1;
     }
 

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -481,7 +481,7 @@ impl DataColumnsByRootRequest {
 // Collection of enums and structs used by the Codecs to encode/decode RPC messages
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum RPCResponse<E: EthSpec> {
+pub enum RpcSuccessResponse<E: EthSpec> {
     /// A HELLO message.
     Status(StatusMessage),
 
@@ -545,11 +545,11 @@ pub enum ResponseTermination {
 /// The structured response containing a result/code indicating success or failure
 /// and the contents of the response
 #[derive(Debug, Clone)]
-pub enum RPCCodedResponse<E: EthSpec> {
+pub enum RpcResponse<E: EthSpec> {
     /// The response is a successful.
-    Success(RPCResponse<E>),
+    Success(RpcSuccessResponse<E>),
 
-    Error(RPCResponseErrorCode, ErrorType),
+    Error(RpcErrorResponse, ErrorType),
 
     /// Received a stream termination indicating which response is being terminated.
     StreamTermination(ResponseTermination),
@@ -564,7 +564,7 @@ pub struct LightClientBootstrapRequest {
 /// The code assigned to an erroneous `RPCResponse`.
 #[derive(Debug, Clone, Copy, PartialEq, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
-pub enum RPCResponseErrorCode {
+pub enum RpcErrorResponse {
     RateLimited,
     BlobsNotFoundForBlock,
     InvalidRequest,
@@ -574,13 +574,13 @@ pub enum RPCResponseErrorCode {
     Unknown,
 }
 
-impl<E: EthSpec> RPCCodedResponse<E> {
+impl<E: EthSpec> RpcResponse<E> {
     /// Used to encode the response in the codec.
     pub fn as_u8(&self) -> Option<u8> {
         match self {
-            RPCCodedResponse::Success(_) => Some(0),
-            RPCCodedResponse::Error(code, _) => Some(code.as_u8()),
-            RPCCodedResponse::StreamTermination(_) => None,
+            RpcResponse::Success(_) => Some(0),
+            RpcResponse::Error(code, _) => Some(code.as_u8()),
+            RpcResponse::StreamTermination(_) => None,
         }
     }
 
@@ -592,64 +592,66 @@ impl<E: EthSpec> RPCCodedResponse<E> {
     /// Builds an RPCCodedResponse from a response code and an ErrorMessage
     pub fn from_error(response_code: u8, err: ErrorType) -> Self {
         let code = match response_code {
-            1 => RPCResponseErrorCode::InvalidRequest,
-            2 => RPCResponseErrorCode::ServerError,
-            3 => RPCResponseErrorCode::ResourceUnavailable,
-            139 => RPCResponseErrorCode::RateLimited,
-            140 => RPCResponseErrorCode::BlobsNotFoundForBlock,
-            _ => RPCResponseErrorCode::Unknown,
+            1 => RpcErrorResponse::InvalidRequest,
+            2 => RpcErrorResponse::ServerError,
+            3 => RpcErrorResponse::ResourceUnavailable,
+            139 => RpcErrorResponse::RateLimited,
+            140 => RpcErrorResponse::BlobsNotFoundForBlock,
+            _ => RpcErrorResponse::Unknown,
         };
-        RPCCodedResponse::Error(code, err)
+        RpcResponse::Error(code, err)
     }
 
     /// Returns true if this response always terminates the stream.
     pub fn close_after(&self) -> bool {
-        !matches!(self, RPCCodedResponse::Success(_))
+        !matches!(self, RpcResponse::Success(_))
     }
 }
 
-impl RPCResponseErrorCode {
+impl RpcErrorResponse {
     fn as_u8(&self) -> u8 {
         match self {
-            RPCResponseErrorCode::InvalidRequest => 1,
-            RPCResponseErrorCode::ServerError => 2,
-            RPCResponseErrorCode::ResourceUnavailable => 3,
-            RPCResponseErrorCode::Unknown => 255,
-            RPCResponseErrorCode::RateLimited => 139,
-            RPCResponseErrorCode::BlobsNotFoundForBlock => 140,
+            RpcErrorResponse::InvalidRequest => 1,
+            RpcErrorResponse::ServerError => 2,
+            RpcErrorResponse::ResourceUnavailable => 3,
+            RpcErrorResponse::Unknown => 255,
+            RpcErrorResponse::RateLimited => 139,
+            RpcErrorResponse::BlobsNotFoundForBlock => 140,
         }
     }
 }
 
 use super::Protocol;
-impl<E: EthSpec> RPCResponse<E> {
+impl<E: EthSpec> RpcSuccessResponse<E> {
     pub fn protocol(&self) -> Protocol {
         match self {
-            RPCResponse::Status(_) => Protocol::Status,
-            RPCResponse::BlocksByRange(_) => Protocol::BlocksByRange,
-            RPCResponse::BlocksByRoot(_) => Protocol::BlocksByRoot,
-            RPCResponse::BlobsByRange(_) => Protocol::BlobsByRange,
-            RPCResponse::BlobsByRoot(_) => Protocol::BlobsByRoot,
-            RPCResponse::DataColumnsByRoot(_) => Protocol::DataColumnsByRoot,
-            RPCResponse::DataColumnsByRange(_) => Protocol::DataColumnsByRange,
-            RPCResponse::Pong(_) => Protocol::Ping,
-            RPCResponse::MetaData(_) => Protocol::MetaData,
-            RPCResponse::LightClientBootstrap(_) => Protocol::LightClientBootstrap,
-            RPCResponse::LightClientOptimisticUpdate(_) => Protocol::LightClientOptimisticUpdate,
-            RPCResponse::LightClientFinalityUpdate(_) => Protocol::LightClientFinalityUpdate,
+            RpcSuccessResponse::Status(_) => Protocol::Status,
+            RpcSuccessResponse::BlocksByRange(_) => Protocol::BlocksByRange,
+            RpcSuccessResponse::BlocksByRoot(_) => Protocol::BlocksByRoot,
+            RpcSuccessResponse::BlobsByRange(_) => Protocol::BlobsByRange,
+            RpcSuccessResponse::BlobsByRoot(_) => Protocol::BlobsByRoot,
+            RpcSuccessResponse::DataColumnsByRoot(_) => Protocol::DataColumnsByRoot,
+            RpcSuccessResponse::DataColumnsByRange(_) => Protocol::DataColumnsByRange,
+            RpcSuccessResponse::Pong(_) => Protocol::Ping,
+            RpcSuccessResponse::MetaData(_) => Protocol::MetaData,
+            RpcSuccessResponse::LightClientBootstrap(_) => Protocol::LightClientBootstrap,
+            RpcSuccessResponse::LightClientOptimisticUpdate(_) => {
+                Protocol::LightClientOptimisticUpdate
+            }
+            RpcSuccessResponse::LightClientFinalityUpdate(_) => Protocol::LightClientFinalityUpdate,
         }
     }
 }
 
-impl std::fmt::Display for RPCResponseErrorCode {
+impl std::fmt::Display for RpcErrorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let repr = match self {
-            RPCResponseErrorCode::InvalidRequest => "The request was invalid",
-            RPCResponseErrorCode::ResourceUnavailable => "Resource unavailable",
-            RPCResponseErrorCode::ServerError => "Server error occurred",
-            RPCResponseErrorCode::Unknown => "Unknown error occurred",
-            RPCResponseErrorCode::RateLimited => "Rate limited",
-            RPCResponseErrorCode::BlobsNotFoundForBlock => "No blobs for the given root",
+            RpcErrorResponse::InvalidRequest => "The request was invalid",
+            RpcErrorResponse::ResourceUnavailable => "Resource unavailable",
+            RpcErrorResponse::ServerError => "Server error occurred",
+            RpcErrorResponse::Unknown => "Unknown error occurred",
+            RpcErrorResponse::RateLimited => "Rate limited",
+            RpcErrorResponse::BlobsNotFoundForBlock => "No blobs for the given root",
         };
         f.write_str(repr)
     }
@@ -661,45 +663,47 @@ impl std::fmt::Display for StatusMessage {
     }
 }
 
-impl<E: EthSpec> std::fmt::Display for RPCResponse<E> {
+impl<E: EthSpec> std::fmt::Display for RpcSuccessResponse<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RPCResponse::Status(status) => write!(f, "{}", status),
-            RPCResponse::BlocksByRange(block) => {
+            RpcSuccessResponse::Status(status) => write!(f, "{}", status),
+            RpcSuccessResponse::BlocksByRange(block) => {
                 write!(f, "BlocksByRange: Block slot: {}", block.slot())
             }
-            RPCResponse::BlocksByRoot(block) => {
+            RpcSuccessResponse::BlocksByRoot(block) => {
                 write!(f, "BlocksByRoot: Block slot: {}", block.slot())
             }
-            RPCResponse::BlobsByRange(blob) => {
+            RpcSuccessResponse::BlobsByRange(blob) => {
                 write!(f, "BlobsByRange: Blob slot: {}", blob.slot())
             }
-            RPCResponse::BlobsByRoot(sidecar) => {
+            RpcSuccessResponse::BlobsByRoot(sidecar) => {
                 write!(f, "BlobsByRoot: Blob slot: {}", sidecar.slot())
             }
-            RPCResponse::DataColumnsByRoot(sidecar) => {
+            RpcSuccessResponse::DataColumnsByRoot(sidecar) => {
                 write!(f, "DataColumnsByRoot: Data column slot: {}", sidecar.slot())
             }
-            RPCResponse::DataColumnsByRange(sidecar) => {
+            RpcSuccessResponse::DataColumnsByRange(sidecar) => {
                 write!(
                     f,
                     "DataColumnsByRange: Data column slot: {}",
                     sidecar.slot()
                 )
             }
-            RPCResponse::Pong(ping) => write!(f, "Pong: {}", ping.data),
-            RPCResponse::MetaData(metadata) => write!(f, "Metadata: {}", metadata.seq_number()),
-            RPCResponse::LightClientBootstrap(bootstrap) => {
+            RpcSuccessResponse::Pong(ping) => write!(f, "Pong: {}", ping.data),
+            RpcSuccessResponse::MetaData(metadata) => {
+                write!(f, "Metadata: {}", metadata.seq_number())
+            }
+            RpcSuccessResponse::LightClientBootstrap(bootstrap) => {
                 write!(f, "LightClientBootstrap Slot: {}", bootstrap.get_slot())
             }
-            RPCResponse::LightClientOptimisticUpdate(update) => {
+            RpcSuccessResponse::LightClientOptimisticUpdate(update) => {
                 write!(
                     f,
                     "LightClientOptimisticUpdate Slot: {}",
                     update.signature_slot()
                 )
             }
-            RPCResponse::LightClientFinalityUpdate(update) => {
+            RpcSuccessResponse::LightClientFinalityUpdate(update) => {
                 write!(
                     f,
                     "LightClientFinalityUpdate Slot: {}",
@@ -710,12 +714,12 @@ impl<E: EthSpec> std::fmt::Display for RPCResponse<E> {
     }
 }
 
-impl<E: EthSpec> std::fmt::Display for RPCCodedResponse<E> {
+impl<E: EthSpec> std::fmt::Display for RpcResponse<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            RPCCodedResponse::Success(res) => write!(f, "{}", res),
-            RPCCodedResponse::Error(code, err) => write!(f, "{}: {}", code, err),
-            RPCCodedResponse::StreamTermination(_) => write!(f, "Stream Termination"),
+            RpcResponse::Success(res) => write!(f, "{}", res),
+            RpcResponse::Error(code, err) => write!(f, "{}: {}", code, err),
+            RpcResponse::StreamTermination(_) => write!(f, "Stream Termination"),
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -208,6 +208,7 @@ impl<Id: ReqId, E: EthSpec> RPC<Id, E> {
         &mut self,
         peer_id: PeerId,
         id: (ConnectionId, SubstreamId),
+        _request_id: RequestId,
         event: RpcResponse<E>,
     ) {
         self.events.push(ToSwarm::NotifyHandler {
@@ -429,6 +430,7 @@ where
                             self.send_response(
                                 peer_id,
                                 (conn_id, substream_id),
+                                id,
                                 RpcResponse::Error(
                                     RpcErrorResponse::RateLimited,
                                     "Rate limited. Request too large".into(),
@@ -444,6 +446,7 @@ where
                             self.send_response(
                                 peer_id,
                                 (conn_id, substream_id),
+                                id,
                                 RpcResponse::Error(
                                     RpcErrorResponse::RateLimited,
                                     format!("Wait {:?}", wait_time).into(),
@@ -462,6 +465,7 @@ where
                     self.send_response(
                         peer_id,
                         (conn_id, substream_id),
+                        id,
                         RpcResponse::Success(RpcSuccessResponse::Pong(Ping {
                             data: self.seq_number,
                         })),

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -1,7 +1,6 @@
-use super::methods::*;
 use super::protocol::ProtocolId;
-use super::protocol::SupportedProtocol;
 use super::RPCError;
+use super::RequestType;
 use crate::rpc::codec::SSZSnappyOutboundCodec;
 use crate::rpc::protocol::Encoding;
 use futures::future::BoxFuture;
@@ -21,23 +20,9 @@ use types::{EthSpec, ForkContext};
 
 #[derive(Debug, Clone)]
 pub struct OutboundRequestContainer<E: EthSpec> {
-    pub req: OutboundRequest<E>,
+    pub req: RequestType<E>,
     pub fork_context: Arc<ForkContext>,
     pub max_rpc_size: usize,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum OutboundRequest<E: EthSpec> {
-    Status(StatusMessage),
-    Goodbye(GoodbyeReason),
-    BlocksByRange(OldBlocksByRangeRequest),
-    BlocksByRoot(BlocksByRootRequest),
-    BlobsByRange(BlobsByRangeRequest),
-    BlobsByRoot(BlobsByRootRequest),
-    DataColumnsByRoot(DataColumnsByRootRequest),
-    DataColumnsByRange(DataColumnsByRangeRequest),
-    Ping(Ping),
-    MetaData(MetadataRequest<E>),
 }
 
 impl<E: EthSpec> UpgradeInfo for OutboundRequestContainer<E> {
@@ -47,133 +32,6 @@ impl<E: EthSpec> UpgradeInfo for OutboundRequestContainer<E> {
     // add further protocols as we support more encodings/versions
     fn protocol_info(&self) -> Self::InfoIter {
         self.req.supported_protocols()
-    }
-}
-
-/// Implements the encoding per supported protocol for `RPCRequest`.
-impl<E: EthSpec> OutboundRequest<E> {
-    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
-        match self {
-            // add more protocols when versions/encodings are supported
-            OutboundRequest::Status(_) => vec![ProtocolId::new(
-                SupportedProtocol::StatusV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::Goodbye(_) => vec![ProtocolId::new(
-                SupportedProtocol::GoodbyeV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::BlocksByRange(_) => vec![
-                ProtocolId::new(SupportedProtocol::BlocksByRangeV2, Encoding::SSZSnappy),
-                ProtocolId::new(SupportedProtocol::BlocksByRangeV1, Encoding::SSZSnappy),
-            ],
-            OutboundRequest::BlocksByRoot(_) => vec![
-                ProtocolId::new(SupportedProtocol::BlocksByRootV2, Encoding::SSZSnappy),
-                ProtocolId::new(SupportedProtocol::BlocksByRootV1, Encoding::SSZSnappy),
-            ],
-            OutboundRequest::BlobsByRange(_) => vec![ProtocolId::new(
-                SupportedProtocol::BlobsByRangeV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::BlobsByRoot(_) => vec![ProtocolId::new(
-                SupportedProtocol::BlobsByRootV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::DataColumnsByRoot(_) => vec![ProtocolId::new(
-                SupportedProtocol::DataColumnsByRootV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::DataColumnsByRange(_) => vec![ProtocolId::new(
-                SupportedProtocol::DataColumnsByRangeV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::Ping(_) => vec![ProtocolId::new(
-                SupportedProtocol::PingV1,
-                Encoding::SSZSnappy,
-            )],
-            OutboundRequest::MetaData(_) => vec![
-                ProtocolId::new(SupportedProtocol::MetaDataV3, Encoding::SSZSnappy),
-                ProtocolId::new(SupportedProtocol::MetaDataV2, Encoding::SSZSnappy),
-                ProtocolId::new(SupportedProtocol::MetaDataV1, Encoding::SSZSnappy),
-            ],
-        }
-    }
-    /* These functions are used in the handler for stream management */
-
-    /// Maximum number of responses expected for this request.
-    pub fn max_responses(&self) -> u64 {
-        match self {
-            OutboundRequest::Status(_) => 1,
-            OutboundRequest::Goodbye(_) => 0,
-            OutboundRequest::BlocksByRange(req) => *req.count(),
-            OutboundRequest::BlocksByRoot(req) => req.block_roots().len() as u64,
-            OutboundRequest::BlobsByRange(req) => req.max_blobs_requested::<E>(),
-            OutboundRequest::BlobsByRoot(req) => req.blob_ids.len() as u64,
-            OutboundRequest::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
-            OutboundRequest::DataColumnsByRange(req) => req.max_requested::<E>(),
-            OutboundRequest::Ping(_) => 1,
-            OutboundRequest::MetaData(_) => 1,
-        }
-    }
-
-    pub fn expect_exactly_one_response(&self) -> bool {
-        match self {
-            OutboundRequest::Status(_) => true,
-            OutboundRequest::Goodbye(_) => false,
-            OutboundRequest::BlocksByRange(_) => false,
-            OutboundRequest::BlocksByRoot(_) => false,
-            OutboundRequest::BlobsByRange(_) => false,
-            OutboundRequest::BlobsByRoot(_) => false,
-            OutboundRequest::DataColumnsByRoot(_) => false,
-            OutboundRequest::DataColumnsByRange(_) => false,
-            OutboundRequest::Ping(_) => true,
-            OutboundRequest::MetaData(_) => true,
-        }
-    }
-
-    /// Gives the corresponding `SupportedProtocol` to this request.
-    pub fn versioned_protocol(&self) -> SupportedProtocol {
-        match self {
-            OutboundRequest::Status(_) => SupportedProtocol::StatusV1,
-            OutboundRequest::Goodbye(_) => SupportedProtocol::GoodbyeV1,
-            OutboundRequest::BlocksByRange(req) => match req {
-                OldBlocksByRangeRequest::V1(_) => SupportedProtocol::BlocksByRangeV1,
-                OldBlocksByRangeRequest::V2(_) => SupportedProtocol::BlocksByRangeV2,
-            },
-            OutboundRequest::BlocksByRoot(req) => match req {
-                BlocksByRootRequest::V1(_) => SupportedProtocol::BlocksByRootV1,
-                BlocksByRootRequest::V2(_) => SupportedProtocol::BlocksByRootV2,
-            },
-            OutboundRequest::BlobsByRange(_) => SupportedProtocol::BlobsByRangeV1,
-            OutboundRequest::BlobsByRoot(_) => SupportedProtocol::BlobsByRootV1,
-            OutboundRequest::DataColumnsByRoot(_) => SupportedProtocol::DataColumnsByRootV1,
-            OutboundRequest::DataColumnsByRange(_) => SupportedProtocol::DataColumnsByRangeV1,
-            OutboundRequest::Ping(_) => SupportedProtocol::PingV1,
-            OutboundRequest::MetaData(req) => match req {
-                MetadataRequest::V1(_) => SupportedProtocol::MetaDataV1,
-                MetadataRequest::V2(_) => SupportedProtocol::MetaDataV2,
-                MetadataRequest::V3(_) => SupportedProtocol::MetaDataV3,
-            },
-        }
-    }
-
-    /// Returns the `ResponseTermination` type associated with the request if a stream gets
-    /// terminated.
-    pub fn stream_termination(&self) -> ResponseTermination {
-        match self {
-            // this only gets called after `multiple_responses()` returns true. Therefore, only
-            // variants that have `multiple_responses()` can have values.
-            OutboundRequest::BlocksByRange(_) => ResponseTermination::BlocksByRange,
-            OutboundRequest::BlocksByRoot(_) => ResponseTermination::BlocksByRoot,
-            OutboundRequest::BlobsByRange(_) => ResponseTermination::BlobsByRange,
-            OutboundRequest::BlobsByRoot(_) => ResponseTermination::BlobsByRoot,
-            OutboundRequest::DataColumnsByRoot(_) => ResponseTermination::DataColumnsByRoot,
-            OutboundRequest::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
-            OutboundRequest::Status(_) => unreachable!(),
-            OutboundRequest::Goodbye(_) => unreachable!(),
-            OutboundRequest::Ping(_) => unreachable!(),
-            OutboundRequest::MetaData(_) => unreachable!(),
-        }
     }
 }
 
@@ -209,24 +67,5 @@ where
             Ok(socket)
         }
         .boxed()
-    }
-}
-
-impl<E: EthSpec> std::fmt::Display for OutboundRequest<E> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OutboundRequest::Status(status) => write!(f, "Status Message: {}", status),
-            OutboundRequest::Goodbye(reason) => write!(f, "Goodbye: {}", reason),
-            OutboundRequest::BlocksByRange(req) => write!(f, "Blocks by range: {}", req),
-            OutboundRequest::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
-            OutboundRequest::BlobsByRange(req) => write!(f, "Blobs by range: {:?}", req),
-            OutboundRequest::BlobsByRoot(req) => write!(f, "Blobs by root: {:?}", req),
-            OutboundRequest::DataColumnsByRoot(req) => write!(f, "Data columns by root: {:?}", req),
-            OutboundRequest::DataColumnsByRange(req) => {
-                write!(f, "Data columns by range: {:?}", req)
-            }
-            OutboundRequest::Ping(ping) => write!(f, "Ping: {}", ping.data),
-            OutboundRequest::MetaData(_) => write!(f, "MetaData request"),
-        }
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -645,7 +645,7 @@ pub fn rpc_data_column_limits<E: EthSpec>() -> RpcLimits {
 // The inbound protocol reads the request, decodes it and returns the stream to the protocol
 // handler to respond to once ready.
 
-pub type InboundOutput<TSocket, E> = (InboundRequest<E>, InboundFramed<TSocket, E>);
+pub type InboundOutput<TSocket, E> = (RequestType<E>, InboundFramed<TSocket, E>);
 pub type InboundFramed<TSocket, E> =
     Framed<std::pin::Pin<Box<TimeoutStream<Compat<TSocket>>>>, SSZSnappyInboundCodec<E>>;
 
@@ -679,19 +679,19 @@ where
             // MetaData requests should be empty, return the stream
             match versioned_protocol {
                 SupportedProtocol::MetaDataV1 => {
-                    Ok((InboundRequest::MetaData(MetadataRequest::new_v1()), socket))
+                    Ok((RequestType::MetaData(MetadataRequest::new_v1()), socket))
                 }
                 SupportedProtocol::MetaDataV2 => {
-                    Ok((InboundRequest::MetaData(MetadataRequest::new_v2()), socket))
+                    Ok((RequestType::MetaData(MetadataRequest::new_v2()), socket))
                 }
                 SupportedProtocol::MetaDataV3 => {
-                    Ok((InboundRequest::MetaData(MetadataRequest::new_v3()), socket))
+                    Ok((RequestType::MetaData(MetadataRequest::new_v3()), socket))
                 }
                 SupportedProtocol::LightClientOptimisticUpdateV1 => {
-                    Ok((InboundRequest::LightClientOptimisticUpdate, socket))
+                    Ok((RequestType::LightClientOptimisticUpdate, socket))
                 }
                 SupportedProtocol::LightClientFinalityUpdateV1 => {
-                    Ok((InboundRequest::LightClientFinalityUpdate, socket))
+                    Ok((RequestType::LightClientFinalityUpdate, socket))
                 }
                 _ => {
                     match tokio::time::timeout(
@@ -713,7 +713,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum InboundRequest<E: EthSpec> {
+pub enum RequestType<E: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),
     BlocksByRange(OldBlocksByRangeRequest),
@@ -730,56 +730,56 @@ pub enum InboundRequest<E: EthSpec> {
 }
 
 /// Implements the encoding per supported protocol for `RPCRequest`.
-impl<E: EthSpec> InboundRequest<E> {
+impl<E: EthSpec> RequestType<E> {
     /* These functions are used in the handler for stream management */
 
     /// Maximum number of responses expected for this request.
     pub fn max_responses(&self) -> u64 {
         match self {
-            InboundRequest::Status(_) => 1,
-            InboundRequest::Goodbye(_) => 0,
-            InboundRequest::BlocksByRange(req) => *req.count(),
-            InboundRequest::BlocksByRoot(req) => req.block_roots().len() as u64,
-            InboundRequest::BlobsByRange(req) => req.max_blobs_requested::<E>(),
-            InboundRequest::BlobsByRoot(req) => req.blob_ids.len() as u64,
-            InboundRequest::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
-            InboundRequest::DataColumnsByRange(req) => req.max_requested::<E>(),
-            InboundRequest::Ping(_) => 1,
-            InboundRequest::MetaData(_) => 1,
-            InboundRequest::LightClientBootstrap(_) => 1,
-            InboundRequest::LightClientOptimisticUpdate => 1,
-            InboundRequest::LightClientFinalityUpdate => 1,
+            RequestType::Status(_) => 1,
+            RequestType::Goodbye(_) => 0,
+            RequestType::BlocksByRange(req) => *req.count(),
+            RequestType::BlocksByRoot(req) => req.block_roots().len() as u64,
+            RequestType::BlobsByRange(req) => req.max_blobs_requested::<E>(),
+            RequestType::BlobsByRoot(req) => req.blob_ids.len() as u64,
+            RequestType::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
+            RequestType::DataColumnsByRange(req) => req.max_requested::<E>(),
+            RequestType::Ping(_) => 1,
+            RequestType::MetaData(_) => 1,
+            RequestType::LightClientBootstrap(_) => 1,
+            RequestType::LightClientOptimisticUpdate => 1,
+            RequestType::LightClientFinalityUpdate => 1,
         }
     }
 
     /// Gives the corresponding `SupportedProtocol` to this request.
     pub fn versioned_protocol(&self) -> SupportedProtocol {
         match self {
-            InboundRequest::Status(_) => SupportedProtocol::StatusV1,
-            InboundRequest::Goodbye(_) => SupportedProtocol::GoodbyeV1,
-            InboundRequest::BlocksByRange(req) => match req {
+            RequestType::Status(_) => SupportedProtocol::StatusV1,
+            RequestType::Goodbye(_) => SupportedProtocol::GoodbyeV1,
+            RequestType::BlocksByRange(req) => match req {
                 OldBlocksByRangeRequest::V1(_) => SupportedProtocol::BlocksByRangeV1,
                 OldBlocksByRangeRequest::V2(_) => SupportedProtocol::BlocksByRangeV2,
             },
-            InboundRequest::BlocksByRoot(req) => match req {
+            RequestType::BlocksByRoot(req) => match req {
                 BlocksByRootRequest::V1(_) => SupportedProtocol::BlocksByRootV1,
                 BlocksByRootRequest::V2(_) => SupportedProtocol::BlocksByRootV2,
             },
-            InboundRequest::BlobsByRange(_) => SupportedProtocol::BlobsByRangeV1,
-            InboundRequest::BlobsByRoot(_) => SupportedProtocol::BlobsByRootV1,
-            InboundRequest::DataColumnsByRoot(_) => SupportedProtocol::DataColumnsByRootV1,
-            InboundRequest::DataColumnsByRange(_) => SupportedProtocol::DataColumnsByRangeV1,
-            InboundRequest::Ping(_) => SupportedProtocol::PingV1,
-            InboundRequest::MetaData(req) => match req {
+            RequestType::BlobsByRange(_) => SupportedProtocol::BlobsByRangeV1,
+            RequestType::BlobsByRoot(_) => SupportedProtocol::BlobsByRootV1,
+            RequestType::DataColumnsByRoot(_) => SupportedProtocol::DataColumnsByRootV1,
+            RequestType::DataColumnsByRange(_) => SupportedProtocol::DataColumnsByRangeV1,
+            RequestType::Ping(_) => SupportedProtocol::PingV1,
+            RequestType::MetaData(req) => match req {
                 MetadataRequest::V1(_) => SupportedProtocol::MetaDataV1,
                 MetadataRequest::V2(_) => SupportedProtocol::MetaDataV2,
                 MetadataRequest::V3(_) => SupportedProtocol::MetaDataV3,
             },
-            InboundRequest::LightClientBootstrap(_) => SupportedProtocol::LightClientBootstrapV1,
-            InboundRequest::LightClientOptimisticUpdate => {
+            RequestType::LightClientBootstrap(_) => SupportedProtocol::LightClientBootstrapV1,
+            RequestType::LightClientOptimisticUpdate => {
                 SupportedProtocol::LightClientOptimisticUpdateV1
             }
-            InboundRequest::LightClientFinalityUpdate => {
+            RequestType::LightClientFinalityUpdate => {
                 SupportedProtocol::LightClientFinalityUpdateV1
             }
         }
@@ -791,19 +791,96 @@ impl<E: EthSpec> InboundRequest<E> {
         match self {
             // this only gets called after `multiple_responses()` returns true. Therefore, only
             // variants that have `multiple_responses()` can have values.
-            InboundRequest::BlocksByRange(_) => ResponseTermination::BlocksByRange,
-            InboundRequest::BlocksByRoot(_) => ResponseTermination::BlocksByRoot,
-            InboundRequest::BlobsByRange(_) => ResponseTermination::BlobsByRange,
-            InboundRequest::BlobsByRoot(_) => ResponseTermination::BlobsByRoot,
-            InboundRequest::DataColumnsByRoot(_) => ResponseTermination::DataColumnsByRoot,
-            InboundRequest::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
-            InboundRequest::Status(_) => unreachable!(),
-            InboundRequest::Goodbye(_) => unreachable!(),
-            InboundRequest::Ping(_) => unreachable!(),
-            InboundRequest::MetaData(_) => unreachable!(),
-            InboundRequest::LightClientBootstrap(_) => unreachable!(),
-            InboundRequest::LightClientFinalityUpdate => unreachable!(),
-            InboundRequest::LightClientOptimisticUpdate => unreachable!(),
+            RequestType::BlocksByRange(_) => ResponseTermination::BlocksByRange,
+            RequestType::BlocksByRoot(_) => ResponseTermination::BlocksByRoot,
+            RequestType::BlobsByRange(_) => ResponseTermination::BlobsByRange,
+            RequestType::BlobsByRoot(_) => ResponseTermination::BlobsByRoot,
+            RequestType::DataColumnsByRoot(_) => ResponseTermination::DataColumnsByRoot,
+            RequestType::DataColumnsByRange(_) => ResponseTermination::DataColumnsByRange,
+            RequestType::Status(_) => unreachable!(),
+            RequestType::Goodbye(_) => unreachable!(),
+            RequestType::Ping(_) => unreachable!(),
+            RequestType::MetaData(_) => unreachable!(),
+            RequestType::LightClientBootstrap(_) => unreachable!(),
+            RequestType::LightClientFinalityUpdate => unreachable!(),
+            RequestType::LightClientOptimisticUpdate => unreachable!(),
+        }
+    }
+
+    pub fn supported_protocols(&self) -> Vec<ProtocolId> {
+        match self {
+            // add more protocols when versions/encodings are supported
+            RequestType::Status(_) => vec![ProtocolId::new(
+                SupportedProtocol::StatusV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::Goodbye(_) => vec![ProtocolId::new(
+                SupportedProtocol::GoodbyeV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::BlocksByRange(_) => vec![
+                ProtocolId::new(SupportedProtocol::BlocksByRangeV2, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::BlocksByRangeV1, Encoding::SSZSnappy),
+            ],
+            RequestType::BlocksByRoot(_) => vec![
+                ProtocolId::new(SupportedProtocol::BlocksByRootV2, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::BlocksByRootV1, Encoding::SSZSnappy),
+            ],
+            RequestType::BlobsByRange(_) => vec![ProtocolId::new(
+                SupportedProtocol::BlobsByRangeV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::BlobsByRoot(_) => vec![ProtocolId::new(
+                SupportedProtocol::BlobsByRootV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::DataColumnsByRoot(_) => vec![ProtocolId::new(
+                SupportedProtocol::DataColumnsByRootV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::DataColumnsByRange(_) => vec![ProtocolId::new(
+                SupportedProtocol::DataColumnsByRangeV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::Ping(_) => vec![ProtocolId::new(
+                SupportedProtocol::PingV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::MetaData(_) => vec![
+                ProtocolId::new(SupportedProtocol::MetaDataV3, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::MetaDataV2, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::MetaDataV1, Encoding::SSZSnappy),
+            ],
+            RequestType::LightClientBootstrap(_) => vec![ProtocolId::new(
+                SupportedProtocol::LightClientBootstrapV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::LightClientOptimisticUpdate => vec![ProtocolId::new(
+                SupportedProtocol::LightClientOptimisticUpdateV1,
+                Encoding::SSZSnappy,
+            )],
+            RequestType::LightClientFinalityUpdate => vec![ProtocolId::new(
+                SupportedProtocol::LightClientFinalityUpdateV1,
+                Encoding::SSZSnappy,
+            )],
+        }
+    }
+
+    pub fn expect_exactly_one_response(&self) -> bool {
+        match self {
+            RequestType::Status(_) => true,
+            RequestType::Goodbye(_) => false,
+            RequestType::BlocksByRange(_) => false,
+            RequestType::BlocksByRoot(_) => false,
+            RequestType::BlobsByRange(_) => false,
+            RequestType::BlobsByRoot(_) => false,
+            RequestType::DataColumnsByRoot(_) => false,
+            RequestType::DataColumnsByRange(_) => false,
+            RequestType::Ping(_) => true,
+            RequestType::MetaData(_) => true,
+            RequestType::LightClientBootstrap(_) => true,
+            RequestType::LightClientOptimisticUpdate => true,
+            RequestType::LightClientFinalityUpdate => true,
         }
     }
 }
@@ -898,28 +975,28 @@ impl std::error::Error for RPCError {
     }
 }
 
-impl<E: EthSpec> std::fmt::Display for InboundRequest<E> {
+impl<E: EthSpec> std::fmt::Display for RequestType<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InboundRequest::Status(status) => write!(f, "Status Message: {}", status),
-            InboundRequest::Goodbye(reason) => write!(f, "Goodbye: {}", reason),
-            InboundRequest::BlocksByRange(req) => write!(f, "Blocks by range: {}", req),
-            InboundRequest::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
-            InboundRequest::BlobsByRange(req) => write!(f, "Blobs by range: {:?}", req),
-            InboundRequest::BlobsByRoot(req) => write!(f, "Blobs by root: {:?}", req),
-            InboundRequest::DataColumnsByRoot(req) => write!(f, "Data columns by root: {:?}", req),
-            InboundRequest::DataColumnsByRange(req) => {
+            RequestType::Status(status) => write!(f, "Status Message: {}", status),
+            RequestType::Goodbye(reason) => write!(f, "Goodbye: {}", reason),
+            RequestType::BlocksByRange(req) => write!(f, "Blocks by range: {}", req),
+            RequestType::BlocksByRoot(req) => write!(f, "Blocks by root: {:?}", req),
+            RequestType::BlobsByRange(req) => write!(f, "Blobs by range: {:?}", req),
+            RequestType::BlobsByRoot(req) => write!(f, "Blobs by root: {:?}", req),
+            RequestType::DataColumnsByRoot(req) => write!(f, "Data columns by root: {:?}", req),
+            RequestType::DataColumnsByRange(req) => {
                 write!(f, "Data columns by range: {:?}", req)
             }
-            InboundRequest::Ping(ping) => write!(f, "Ping: {}", ping.data),
-            InboundRequest::MetaData(_) => write!(f, "MetaData request"),
-            InboundRequest::LightClientBootstrap(bootstrap) => {
+            RequestType::Ping(ping) => write!(f, "Ping: {}", ping.data),
+            RequestType::MetaData(_) => write!(f, "MetaData request"),
+            RequestType::LightClientBootstrap(bootstrap) => {
                 write!(f, "Light client boostrap: {}", bootstrap.root)
             }
-            InboundRequest::LightClientOptimisticUpdate => {
+            RequestType::LightClientOptimisticUpdate => {
                 write!(f, "Light client optimistic update request")
             }
-            InboundRequest::LightClientFinalityUpdate => {
+            RequestType::LightClientFinalityUpdate => {
                 write!(f, "Light client finality update request")
             }
         }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -819,7 +819,7 @@ pub enum RPCError {
     /// IO Error.
     IoError(String),
     /// The peer returned a valid response but the response indicated an error.
-    ErrorResponse(RPCResponseErrorCode, String),
+    ErrorResponse(RpcErrorResponse, String),
     /// Timed out waiting for a response.
     StreamTimeout,
     /// Peer does not support the protocol.

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -252,7 +252,7 @@ pub trait RateLimiterItem {
     fn max_responses(&self) -> u64;
 }
 
-impl<E: EthSpec> RateLimiterItem for super::InboundRequest<E> {
+impl<E: EthSpec> RateLimiterItem for super::RequestType<E> {
     fn protocol(&self) -> Protocol {
         self.versioned_protocol().protocol()
     }
@@ -262,15 +262,6 @@ impl<E: EthSpec> RateLimiterItem for super::InboundRequest<E> {
     }
 }
 
-impl<E: EthSpec> RateLimiterItem for super::OutboundRequest<E> {
-    fn protocol(&self) -> Protocol {
-        self.versioned_protocol().protocol()
-    }
-
-    fn max_responses(&self) -> u64 {
-        self.max_responses()
-    }
-}
 impl RPCRateLimiter {
     pub fn new_with_config(config: RateLimiterConfig) -> Result<Self, &'static str> {
         // Destructure to make sure every configuration value is used.

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -13,7 +13,7 @@ use crate::rpc::{
     methods::{
         BlocksByRangeRequest, BlocksByRootRequest, LightClientBootstrapRequest,
         OldBlocksByRangeRequest, OldBlocksByRangeRequestV1, OldBlocksByRangeRequestV2,
-        RPCCodedResponse, RPCResponse, ResponseTermination, StatusMessage,
+        ResponseTermination, RpcResponse, RpcSuccessResponse, StatusMessage,
     },
     OutboundRequest, SubstreamId,
 };
@@ -186,44 +186,42 @@ pub enum Response<E: EthSpec> {
     LightClientFinalityUpdate(Arc<LightClientFinalityUpdate<E>>),
 }
 
-impl<E: EthSpec> std::convert::From<Response<E>> for RPCCodedResponse<E> {
-    fn from(resp: Response<E>) -> RPCCodedResponse<E> {
+impl<E: EthSpec> std::convert::From<Response<E>> for RpcResponse<E> {
+    fn from(resp: Response<E>) -> RpcResponse<E> {
         match resp {
             Response::BlocksByRoot(r) => match r {
-                Some(b) => RPCCodedResponse::Success(RPCResponse::BlocksByRoot(b)),
-                None => RPCCodedResponse::StreamTermination(ResponseTermination::BlocksByRoot),
+                Some(b) => RpcResponse::Success(RpcSuccessResponse::BlocksByRoot(b)),
+                None => RpcResponse::StreamTermination(ResponseTermination::BlocksByRoot),
             },
             Response::BlocksByRange(r) => match r {
-                Some(b) => RPCCodedResponse::Success(RPCResponse::BlocksByRange(b)),
-                None => RPCCodedResponse::StreamTermination(ResponseTermination::BlocksByRange),
+                Some(b) => RpcResponse::Success(RpcSuccessResponse::BlocksByRange(b)),
+                None => RpcResponse::StreamTermination(ResponseTermination::BlocksByRange),
             },
             Response::BlobsByRoot(r) => match r {
-                Some(b) => RPCCodedResponse::Success(RPCResponse::BlobsByRoot(b)),
-                None => RPCCodedResponse::StreamTermination(ResponseTermination::BlobsByRoot),
+                Some(b) => RpcResponse::Success(RpcSuccessResponse::BlobsByRoot(b)),
+                None => RpcResponse::StreamTermination(ResponseTermination::BlobsByRoot),
             },
             Response::BlobsByRange(r) => match r {
-                Some(b) => RPCCodedResponse::Success(RPCResponse::BlobsByRange(b)),
-                None => RPCCodedResponse::StreamTermination(ResponseTermination::BlobsByRange),
+                Some(b) => RpcResponse::Success(RpcSuccessResponse::BlobsByRange(b)),
+                None => RpcResponse::StreamTermination(ResponseTermination::BlobsByRange),
             },
             Response::DataColumnsByRoot(r) => match r {
-                Some(d) => RPCCodedResponse::Success(RPCResponse::DataColumnsByRoot(d)),
-                None => RPCCodedResponse::StreamTermination(ResponseTermination::DataColumnsByRoot),
+                Some(d) => RpcResponse::Success(RpcSuccessResponse::DataColumnsByRoot(d)),
+                None => RpcResponse::StreamTermination(ResponseTermination::DataColumnsByRoot),
             },
             Response::DataColumnsByRange(r) => match r {
-                Some(d) => RPCCodedResponse::Success(RPCResponse::DataColumnsByRange(d)),
-                None => {
-                    RPCCodedResponse::StreamTermination(ResponseTermination::DataColumnsByRange)
-                }
+                Some(d) => RpcResponse::Success(RpcSuccessResponse::DataColumnsByRange(d)),
+                None => RpcResponse::StreamTermination(ResponseTermination::DataColumnsByRange),
             },
-            Response::Status(s) => RPCCodedResponse::Success(RPCResponse::Status(s)),
+            Response::Status(s) => RpcResponse::Success(RpcSuccessResponse::Status(s)),
             Response::LightClientBootstrap(b) => {
-                RPCCodedResponse::Success(RPCResponse::LightClientBootstrap(b))
+                RpcResponse::Success(RpcSuccessResponse::LightClientBootstrap(b))
             }
             Response::LightClientOptimisticUpdate(o) => {
-                RPCCodedResponse::Success(RPCResponse::LightClientOptimisticUpdate(o))
+                RpcResponse::Success(RpcSuccessResponse::LightClientOptimisticUpdate(o))
             }
             Response::LightClientFinalityUpdate(f) => {
-                RPCCodedResponse::Success(RPCResponse::LightClientFinalityUpdate(f))
+                RpcResponse::Success(RpcSuccessResponse::LightClientFinalityUpdate(f))
             }
         }
     }

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -6,16 +6,9 @@ use types::{
     LightClientFinalityUpdate, LightClientOptimisticUpdate, SignedBeaconBlock,
 };
 
-use crate::rpc::methods::{
-    BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRangeRequest, DataColumnsByRootRequest,
-};
 use crate::rpc::{
-    methods::{
-        BlocksByRangeRequest, BlocksByRootRequest, LightClientBootstrapRequest,
-        OldBlocksByRangeRequest, OldBlocksByRangeRequestV1, OldBlocksByRangeRequestV2,
-        ResponseTermination, RpcResponse, RpcSuccessResponse, StatusMessage,
-    },
-    OutboundRequest, SubstreamId,
+    methods::{ResponseTermination, RpcResponse, RpcSuccessResponse, StatusMessage},
+    SubstreamId,
 };
 
 /// Identifier of requests sent by a peer.
@@ -91,69 +84,6 @@ pub enum AppRequestId {
 pub enum RequestId {
     Application(AppRequestId),
     Internal,
-}
-
-/// The type of RPC requests the Behaviour informs it has received and allows for sending.
-///
-// NOTE: This is an application-level wrapper over the lower network level requests that can be
-//       sent. The main difference is the absence of the Ping, Metadata and Goodbye protocols, which don't
-//       leave the Behaviour. For all protocols managed by RPC see `RPCRequest`.
-#[derive(Debug, Clone, PartialEq)]
-pub enum Request {
-    /// A Status message.
-    Status(StatusMessage),
-    /// A blocks by range request.
-    BlocksByRange(BlocksByRangeRequest),
-    /// A blobs by range request.
-    BlobsByRange(BlobsByRangeRequest),
-    /// A request blocks root request.
-    BlocksByRoot(BlocksByRootRequest),
-    // light client bootstrap request
-    LightClientBootstrap(LightClientBootstrapRequest),
-    // light client optimistic update request
-    LightClientOptimisticUpdate,
-    // light client finality update request
-    LightClientFinalityUpdate,
-    /// A request blobs root request.
-    BlobsByRoot(BlobsByRootRequest),
-    /// A request data columns root request.
-    DataColumnsByRoot(DataColumnsByRootRequest),
-    /// A request data columns by range request.
-    DataColumnsByRange(DataColumnsByRangeRequest),
-}
-
-impl<E: EthSpec> std::convert::From<Request> for OutboundRequest<E> {
-    fn from(req: Request) -> OutboundRequest<E> {
-        match req {
-            Request::BlocksByRoot(r) => OutboundRequest::BlocksByRoot(r),
-            Request::BlocksByRange(r) => match r {
-                BlocksByRangeRequest::V1(req) => OutboundRequest::BlocksByRange(
-                    OldBlocksByRangeRequest::V1(OldBlocksByRangeRequestV1 {
-                        start_slot: req.start_slot,
-                        count: req.count,
-                        step: 1,
-                    }),
-                ),
-                BlocksByRangeRequest::V2(req) => OutboundRequest::BlocksByRange(
-                    OldBlocksByRangeRequest::V2(OldBlocksByRangeRequestV2 {
-                        start_slot: req.start_slot,
-                        count: req.count,
-                        step: 1,
-                    }),
-                ),
-            },
-            Request::LightClientBootstrap(_)
-            | Request::LightClientOptimisticUpdate
-            | Request::LightClientFinalityUpdate => {
-                unreachable!("Lighthouse never makes an outbound light client request")
-            }
-            Request::BlobsByRange(r) => OutboundRequest::BlobsByRange(r),
-            Request::BlobsByRoot(r) => OutboundRequest::BlobsByRoot(r),
-            Request::DataColumnsByRoot(r) => OutboundRequest::DataColumnsByRoot(r),
-            Request::DataColumnsByRange(r) => OutboundRequest::DataColumnsByRange(r),
-            Request::Status(s) => OutboundRequest::Status(s),
-        }
-    }
 }
 
 /// The type of RPC responses the Behaviour informs it has received, and allows for sending.

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -131,7 +131,7 @@ fn test_tcp_status_rpc() {
                         if request.r#type == rpc_request {
                             // send the response
                             debug!(log, "Receiver Received");
-                            receiver.send_response(peer_id, id, rpc_response.clone());
+                            receiver.send_response(peer_id, id, request.id, rpc_response.clone());
                         }
                     }
                     _ => {} // Ignore other events
@@ -265,10 +265,20 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
                                 } else {
                                     rpc_response_bellatrix_small.clone()
                                 };
-                                receiver.send_response(peer_id, id, rpc_response.clone());
+                                receiver.send_response(
+                                    peer_id,
+                                    id,
+                                    request.id,
+                                    rpc_response.clone(),
+                                );
                             }
                             // send the stream termination
-                            receiver.send_response(peer_id, id, Response::BlocksByRange(None));
+                            receiver.send_response(
+                                peer_id,
+                                id,
+                                request.id,
+                                Response::BlocksByRange(None),
+                            );
                         }
                     }
                     _ => {} // Ignore other events
@@ -378,10 +388,20 @@ fn test_blobs_by_range_chunked_rpc() {
                             for _ in 0..messages_to_send {
                                 // Send first third of responses as base blocks,
                                 // second as altair and third as bellatrix.
-                                receiver.send_response(peer_id, id, rpc_response.clone());
+                                receiver.send_response(
+                                    peer_id,
+                                    id,
+                                    request.id,
+                                    rpc_response.clone(),
+                                );
                             }
                             // send the stream termination
-                            receiver.send_response(peer_id, id, Response::BlobsByRange(None));
+                            receiver.send_response(
+                                peer_id,
+                                id,
+                                request.id,
+                                Response::BlobsByRange(None),
+                            );
                         }
                     }
                     _ => {} // Ignore other events
@@ -475,10 +495,20 @@ fn test_tcp_blocks_by_range_over_limit() {
                             warn!(log, "Receiver got request");
                             for _ in 0..messages_to_send {
                                 let rpc_response = rpc_response_bellatrix_large.clone();
-                                receiver.send_response(peer_id, id, rpc_response.clone());
+                                receiver.send_response(
+                                    peer_id,
+                                    id,
+                                    request.id,
+                                    rpc_response.clone(),
+                                );
                             }
                             // send the stream termination
-                            receiver.send_response(peer_id, id, Response::BlocksByRange(None));
+                            receiver.send_response(
+                                peer_id,
+                                id,
+                                request.id,
+                                Response::BlocksByRange(None),
+                            );
                         }
                     }
                     _ => {} // Ignore other events
@@ -601,7 +631,7 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
                         if request.r#type == rpc_request {
                             // send the response
                             warn!(log, "Receiver got request");
-                            message_info = Some((peer_id, id));
+                            message_info = Some((peer_id, id, request.id));
                         }
                     }
                     futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
@@ -611,8 +641,8 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
                 // if we need to send messages send them here. This will happen after a delay
                 if message_info.is_some() {
                     messages_sent += 1;
-                    let (peer_id, stream_id) = message_info.as_ref().unwrap();
-                    receiver.send_response(*peer_id, *stream_id, rpc_response.clone());
+                    let (peer_id, stream_id, request_id) = message_info.as_ref().unwrap();
+                    receiver.send_response(*peer_id, *stream_id, *request_id, rpc_response.clone());
                     debug!(log, "Sending message {}", messages_sent);
                     if messages_sent == messages_to_send + extra_messages_to_send {
                         // stop sending messages
@@ -721,10 +751,20 @@ fn test_tcp_blocks_by_range_single_empty_rpc() {
                             warn!(log, "Receiver got request");
 
                             for _ in 1..=messages_to_send {
-                                receiver.send_response(peer_id, id, rpc_response.clone());
+                                receiver.send_response(
+                                    peer_id,
+                                    id,
+                                    request.id,
+                                    rpc_response.clone(),
+                                );
                             }
                             // send the stream termination
-                            receiver.send_response(peer_id, id, Response::BlocksByRange(None));
+                            receiver.send_response(
+                                peer_id,
+                                id,
+                                request.id,
+                                Response::BlocksByRange(None),
+                            );
                         }
                     }
                     _ => {} // Ignore other events
@@ -860,11 +900,16 @@ fn test_tcp_blocks_by_root_chunked_rpc() {
                                 } else {
                                     rpc_response_bellatrix_small.clone()
                                 };
-                                receiver.send_response(peer_id, id, rpc_response);
+                                receiver.send_response(peer_id, id, request.id, rpc_response);
                                 debug!(log, "Sending message");
                             }
                             // send the stream termination
-                            receiver.send_response(peer_id, id, Response::BlocksByRange(None));
+                            receiver.send_response(
+                                peer_id,
+                                id,
+                                request.id,
+                                Response::BlocksByRange(None),
+                            );
                             debug!(log, "Send stream term");
                         }
                     }
@@ -994,7 +1039,7 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                         if request.r#type == rpc_request {
                             // send the response
                             warn!(log, "Receiver got request");
-                            message_info = Some((peer_id, id));
+                            message_info = Some((peer_id, id, request.id));
                         }
                     }
                     futures::future::Either::Right((_, _)) => {} // The timeout hit, send messages if required
@@ -1004,8 +1049,8 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                 // if we need to send messages send them here. This will happen after a delay
                 if message_info.is_some() {
                     messages_sent += 1;
-                    let (peer_id, stream_id) = message_info.as_ref().unwrap();
-                    receiver.send_response(*peer_id, *stream_id, rpc_response.clone());
+                    let (peer_id, stream_id, request_id) = message_info.as_ref().unwrap();
+                    receiver.send_response(*peer_id, *stream_id, *request_id, rpc_response.clone());
                     debug!(log, "Sending message {}", messages_sent);
                     if messages_sent == messages_to_send + extra_messages_to_send {
                         // stop sending messages

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -9,12 +9,14 @@ use beacon_processor::{
     DuplicateCache, GossipAggregatePackage, GossipAttestationPackage, Work,
     WorkEvent as BeaconWorkEvent,
 };
+use lighthouse_network::discovery::ConnectionId;
 use lighthouse_network::rpc::methods::{
     BlobsByRangeRequest, BlobsByRootRequest, DataColumnsByRangeRequest, DataColumnsByRootRequest,
 };
+use lighthouse_network::rpc::{RequestId, SubstreamId};
 use lighthouse_network::{
     rpc::{BlocksByRangeRequest, BlocksByRootRequest, LightClientBootstrapRequest, StatusMessage},
-    Client, MessageId, NetworkGlobals, PeerId, PeerRequestId,
+    Client, MessageId, NetworkGlobals, PeerId,
 };
 use slog::{debug, Logger};
 use slot_clock::ManualSlotClock;
@@ -596,13 +598,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_blocks_by_range_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: BlocksByRangeRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
         let process_fn = async move {
             processor
-                .handle_blocks_by_range_request(peer_id, request_id, request)
+                .handle_blocks_by_range_request(
+                    peer_id,
+                    connection_id,
+                    substream_id,
+                    request_id,
+                    request,
+                )
                 .await;
         };
 
@@ -616,13 +626,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_blocks_by_roots_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: BlocksByRootRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
         let process_fn = async move {
             processor
-                .handle_blocks_by_root_request(peer_id, request_id, request)
+                .handle_blocks_by_root_request(
+                    peer_id,
+                    connection_id,
+                    substream_id,
+                    request_id,
+                    request,
+                )
                 .await;
         };
 
@@ -636,12 +654,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_blobs_by_range_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: BlobsByRangeRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_blobs_by_range_request(peer_id, request_id, request);
+        let process_fn = move || {
+            processor.handle_blobs_by_range_request(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+                request,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
@@ -653,12 +680,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_blobs_by_roots_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: BlobsByRootRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_blobs_by_root_request(peer_id, request_id, request);
+        let process_fn = move || {
+            processor.handle_blobs_by_root_request(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+                request,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
@@ -670,12 +706,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_data_columns_by_roots_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: DataColumnsByRootRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_data_columns_by_root_request(peer_id, request_id, request);
+        let process_fn = move || {
+            processor.handle_data_columns_by_root_request(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+                request,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
@@ -687,12 +732,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_data_columns_by_range_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: DataColumnsByRangeRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_data_columns_by_range_request(peer_id, request_id, request);
+        let process_fn = move || {
+            processor.handle_data_columns_by_range_request(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+                request,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: false,
@@ -704,12 +758,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_light_client_bootstrap_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
         request: LightClientBootstrapRequest,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_light_client_bootstrap(peer_id, request_id, request);
+        let process_fn = move || {
+            processor.handle_light_client_bootstrap(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+                request,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: true,
@@ -721,11 +784,19 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_light_client_optimistic_update_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn =
-            move || processor.handle_light_client_optimistic_update(peer_id, request_id);
+        let process_fn = move || {
+            processor.handle_light_client_optimistic_update(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: true,
@@ -737,10 +808,19 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_light_client_finality_update_request(
         self: &Arc<Self>,
         peer_id: PeerId,
-        request_id: PeerRequestId,
+        connection_id: ConnectionId,
+        substream_id: SubstreamId,
+        request_id: RequestId,
     ) -> Result<(), Error<T::EthSpec>> {
         let processor = self.clone();
-        let process_fn = move || processor.handle_light_client_finality_update(peer_id, request_id);
+        let process_fn = move || {
+            processor.handle_light_client_finality_update(
+                peer_id,
+                connection_id,
+                substream_id,
+                request_id,
+            )
+        };
 
         self.try_send(BeaconWorkEvent {
             drop_during_sync: true,

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -45,7 +45,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     pub fn send_error_response(
         &self,
         peer_id: PeerId,
-        error: RPCResponseErrorCode,
+        error: RpcErrorResponse,
         reason: String,
         id: PeerRequestId,
     ) {
@@ -150,7 +150,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         request: BlocksByRootRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let log_results = |peer_id, requested_blocks, send_block_count| {
             debug!(
                 self.log,
@@ -169,10 +169,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Ok(block_stream) => block_stream,
             Err(e) => {
                 error!(self.log, "Error getting block stream"; "error" => ?e);
-                return Err((
-                    RPCResponseErrorCode::ServerError,
-                    "Error getting block stream",
-                ));
+                return Err((RpcErrorResponse::ServerError, "Error getting block stream"));
             }
         };
         // Fetching blocks is async because it may have to hit the execution layer for payloads.
@@ -204,7 +201,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     );
                     log_results(peer_id, requested_blocks, send_block_count);
                     return Err((
-                        RPCResponseErrorCode::ResourceUnavailable,
+                        RpcErrorResponse::ResourceUnavailable,
                         "Execution layer not synced",
                     ));
                 }
@@ -245,7 +242,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         request: BlobsByRootRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let Some(requested_root) = request.blob_ids.as_slice().first().map(|id| id.block_root)
         else {
             // No blob ids requested.
@@ -337,7 +334,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         request: DataColumnsByRootRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let mut send_data_column_count = 0;
 
         for data_column_id in request.data_column_ids.as_slice() {
@@ -361,10 +358,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "error" => ?e
                     );
-                    return Err((
-                        RPCResponseErrorCode::ServerError,
-                        "Error getting data column",
-                    ));
+                    return Err((RpcErrorResponse::ServerError, "Error getting data column"));
                 }
             }
         }
@@ -393,7 +387,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             match self.chain.get_light_client_bootstrap(&request.root) {
                 Ok(Some((bootstrap, _))) => Ok(Arc::new(bootstrap)),
                 Ok(None) => Err((
-                    RPCResponseErrorCode::ResourceUnavailable,
+                    RpcErrorResponse::ResourceUnavailable,
                     "Bootstrap not available".to_string(),
                 )),
                 Err(e) => {
@@ -402,10 +396,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "error" => ?e
                     );
-                    Err((
-                        RPCResponseErrorCode::ResourceUnavailable,
-                        format!("{:?}", e),
-                    ))
+                    Err((RpcErrorResponse::ResourceUnavailable, format!("{:?}", e)))
                 }
             },
             Response::LightClientBootstrap,
@@ -428,7 +419,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             {
                 Some(update) => Ok(Arc::new(update)),
                 None => Err((
-                    RPCResponseErrorCode::ResourceUnavailable,
+                    RpcErrorResponse::ResourceUnavailable,
                     "Latest optimistic update not available".to_string(),
                 )),
             },
@@ -452,7 +443,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             {
                 Some(update) => Ok(Arc::new(update)),
                 None => Err((
-                    RPCResponseErrorCode::ResourceUnavailable,
+                    RpcErrorResponse::ResourceUnavailable,
                     "Latest finality update not available".to_string(),
                 )),
             },
@@ -483,7 +474,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         req: BlocksByRangeRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         debug!(self.log, "Received BlocksByRange Request";
             "peer_id" => %peer_id,
             "count" => req.count(),
@@ -507,7 +498,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 });
         if *req.count() > max_request_size {
             return Err((
-                RPCResponseErrorCode::InvalidRequest,
+                RpcErrorResponse::InvalidRequest,
                 "Request exceeded max size",
             ));
         }
@@ -527,7 +518,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "requested_slot" => slot,
                     "oldest_known_slot" => oldest_block_slot
                 );
-                return Err((RPCResponseErrorCode::ResourceUnavailable, "Backfilling"));
+                return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
             }
             Err(e) => {
                 error!(self.log, "Unable to obtain root iter";
@@ -535,7 +526,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "peer" => %peer_id,
                     "error" => ?e
                 );
-                return Err((RPCResponseErrorCode::ServerError, "Database error"));
+                return Err((RpcErrorResponse::ServerError, "Database error"));
             }
         };
 
@@ -566,7 +557,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "peer" => %peer_id,
                     "error" => ?e
                 );
-                return Err((RPCResponseErrorCode::ServerError, "Iteration error"));
+                return Err((RpcErrorResponse::ServerError, "Iteration error"));
             }
         };
 
@@ -607,7 +598,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Ok(block_stream) => block_stream,
             Err(e) => {
                 error!(self.log, "Error getting block stream"; "error" => ?e);
-                return Err((RPCResponseErrorCode::ServerError, "Iterator error"));
+                return Err((RpcErrorResponse::ServerError, "Iterator error"));
             }
         };
 
@@ -638,7 +629,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "request_root" => ?root
                     );
                     log_results(req, peer_id, blocks_sent);
-                    return Err((RPCResponseErrorCode::ServerError, "Database inconsistency"));
+                    return Err((RpcErrorResponse::ServerError, "Database inconsistency"));
                 }
                 Err(BeaconChainError::BlockHashMissingFromExecutionLayer(_)) => {
                     debug!(
@@ -650,7 +641,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     log_results(req, peer_id, blocks_sent);
                     // send the stream terminator
                     return Err((
-                        RPCResponseErrorCode::ResourceUnavailable,
+                        RpcErrorResponse::ResourceUnavailable,
                         "Execution layer not synced",
                     ));
                 }
@@ -677,7 +668,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     }
                     log_results(req, peer_id, blocks_sent);
                     // send the stream terminator
-                    return Err((RPCResponseErrorCode::ServerError, "Failed fetching blocks"));
+                    return Err((RpcErrorResponse::ServerError, "Failed fetching blocks"));
                 }
             }
         }
@@ -707,7 +698,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         req: BlobsByRangeRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         debug!(self.log, "Received BlobsByRange Request";
             "peer_id" => %peer_id,
             "count" => req.count,
@@ -717,7 +708,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // Should not send more than max request blocks
         if req.max_blobs_requested::<T::EthSpec>() > self.chain.spec.max_request_blob_sidecars {
             return Err((
-                RPCResponseErrorCode::InvalidRequest,
+                RpcErrorResponse::InvalidRequest,
                 "Request exceeded `MAX_REQUEST_BLOBS_SIDECARS`",
             ));
         }
@@ -728,10 +719,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
             None => {
                 debug!(self.log, "Deneb fork is disabled");
-                return Err((
-                    RPCResponseErrorCode::InvalidRequest,
-                    "Deneb fork is disabled",
-                ));
+                return Err((RpcErrorResponse::InvalidRequest, "Deneb fork is disabled"));
             }
         };
 
@@ -752,12 +740,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
             return if data_availability_boundary_slot < oldest_blob_slot {
                 Err((
-                    RPCResponseErrorCode::ResourceUnavailable,
+                    RpcErrorResponse::ResourceUnavailable,
                     "blobs pruned within boundary",
                 ))
             } else {
                 Err((
-                    RPCResponseErrorCode::InvalidRequest,
+                    RpcErrorResponse::InvalidRequest,
                     "Req outside availability period",
                 ))
             };
@@ -776,7 +764,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "requested_slot" => slot,
                         "oldest_known_slot" => oldest_block_slot
                     );
-                    return Err((RPCResponseErrorCode::ResourceUnavailable, "Backfilling"));
+                    return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
                 }
                 Err(e) => {
                     error!(self.log, "Unable to obtain root iter";
@@ -784,7 +772,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "error" => ?e
                     );
-                    return Err((RPCResponseErrorCode::ServerError, "Database error"));
+                    return Err((RpcErrorResponse::ServerError, "Database error"));
                 }
             };
 
@@ -821,7 +809,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "peer" => %peer_id,
                     "error" => ?e
                 );
-                return Err((RPCResponseErrorCode::ServerError, "Database error"));
+                return Err((RpcErrorResponse::ServerError, "Database error"));
             }
         };
 
@@ -870,7 +858,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     log_results(peer_id, req, blobs_sent);
 
                     return Err((
-                        RPCResponseErrorCode::ServerError,
+                        RpcErrorResponse::ServerError,
                         "No blobs and failed fetching corresponding block",
                     ));
                 }
@@ -902,7 +890,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         peer_id: PeerId,
         request_id: PeerRequestId,
         req: DataColumnsByRangeRequest,
-    ) -> Result<(), (RPCResponseErrorCode, &'static str)> {
+    ) -> Result<(), (RpcErrorResponse, &'static str)> {
         debug!(self.log, "Received DataColumnsByRange Request";
             "peer_id" => %peer_id,
             "count" => req.count,
@@ -912,7 +900,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         // Should not send more than max request data columns
         if req.max_requested::<T::EthSpec>() > self.chain.spec.max_request_data_column_sidecars {
             return Err((
-                RPCResponseErrorCode::InvalidRequest,
+                RpcErrorResponse::InvalidRequest,
                 "Request exceeded `MAX_REQUEST_BLOBS_SIDECARS`",
             ));
         }
@@ -923,10 +911,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
             None => {
                 debug!(self.log, "Deneb fork is disabled");
-                return Err((
-                    RPCResponseErrorCode::InvalidRequest,
-                    "Deneb fork is disabled",
-                ));
+                return Err((RpcErrorResponse::InvalidRequest, "Deneb fork is disabled"));
             }
         };
 
@@ -948,12 +933,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
             return if data_availability_boundary_slot < oldest_data_column_slot {
                 Err((
-                    RPCResponseErrorCode::ResourceUnavailable,
+                    RpcErrorResponse::ResourceUnavailable,
                     "blobs pruned within boundary",
                 ))
             } else {
                 Err((
-                    RPCResponseErrorCode::InvalidRequest,
+                    RpcErrorResponse::InvalidRequest,
                     "Req outside availability period",
                 ))
             };
@@ -972,7 +957,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "requested_slot" => slot,
                         "oldest_known_slot" => oldest_block_slot
                     );
-                    return Err((RPCResponseErrorCode::ResourceUnavailable, "Backfilling"));
+                    return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
                 }
                 Err(e) => {
                     error!(self.log, "Unable to obtain root iter";
@@ -980,7 +965,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "error" => ?e
                     );
-                    return Err((RPCResponseErrorCode::ServerError, "Database error"));
+                    return Err((RpcErrorResponse::ServerError, "Database error"));
                 }
             };
 
@@ -1017,7 +1002,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     "peer" => %peer_id,
                     "error" => ?e
                 );
-                return Err((RPCResponseErrorCode::ServerError, "Database error"));
+                return Err((RpcErrorResponse::ServerError, "Database error"));
             }
         };
 
@@ -1049,7 +1034,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             "error" => ?e
                         );
                         return Err((
-                            RPCResponseErrorCode::ServerError,
+                            RpcErrorResponse::ServerError,
                             "No data columns and failed fetching corresponding block",
                         ));
                     }
@@ -1081,7 +1066,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         &self,
         peer_id: PeerId,
         request_id: PeerRequestId,
-        result: Result<R, (RPCResponseErrorCode, String)>,
+        result: Result<R, (RpcErrorResponse, String)>,
         into_response: F,
     ) {
         match result {
@@ -1107,7 +1092,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         &self,
         peer_id: PeerId,
         request_id: PeerRequestId,
-        result: Result<(), (RPCResponseErrorCode, &'static str)>,
+        result: Result<(), (RpcErrorResponse, &'static str)>,
         into_response: F,
     ) {
         match result {

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -16,7 +16,7 @@ use beacon_chain::{BeaconChain, WhenSlotSkipped};
 use beacon_processor::{work_reprocessing_queue::*, *};
 use lighthouse_network::discovery::ConnectionId;
 use lighthouse_network::rpc::methods::BlobsByRangeRequest;
-use lighthouse_network::rpc::SubstreamId;
+use lighthouse_network::rpc::{RequestId, SubstreamId};
 use lighthouse_network::{
     discv5::enr::{self, CombinedKey},
     rpc::methods::{MetaData, MetaDataV2},
@@ -360,7 +360,9 @@ impl TestRig {
         self.network_beacon_processor
             .send_blobs_by_range_request(
                 PeerId::random(),
-                (ConnectionId::new_unchecked(42), SubstreamId::new(24)),
+                ConnectionId::new_unchecked(42),
+                SubstreamId::new(24),
+                RequestId::new_unchecked(0),
                 BlobsByRangeRequest {
                     start_slot: 0,
                     count,
@@ -1137,6 +1139,7 @@ async fn test_blobs_by_range() {
             peer_id: _,
             response: Response::BlobsByRange(blob),
             id: _,
+            request_id: _,
         } = next
         {
             if blob.is_some() {

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -14,12 +14,13 @@ use futures::channel::mpsc::Sender;
 use futures::future::OptionFuture;
 use futures::prelude::*;
 use futures::StreamExt;
+use lighthouse_network::rpc::RequestType;
 use lighthouse_network::service::Network;
 use lighthouse_network::types::GossipKind;
 use lighthouse_network::{prometheus_client::registry::Registry, MessageAcceptance};
 use lighthouse_network::{
     rpc::{GoodbyeReason, RpcErrorResponse},
-    Context, PeerAction, PeerRequestId, PubsubMessage, ReportSource, Request, Response, Subnet,
+    Context, PeerAction, PeerRequestId, PubsubMessage, ReportSource, Response, Subnet,
 };
 use lighthouse_network::{
     service::api_types::AppRequestId,
@@ -61,7 +62,7 @@ pub enum NetworkMessage<E: EthSpec> {
     /// Send an RPC request to the libp2p service.
     SendRequest {
         peer_id: PeerId,
-        request: Request,
+        request: RequestType<E>,
         request_id: AppRequestId,
     },
     /// Send a successful Response to the libp2p service.

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -18,7 +18,7 @@ use lighthouse_network::service::Network;
 use lighthouse_network::types::GossipKind;
 use lighthouse_network::{prometheus_client::registry::Registry, MessageAcceptance};
 use lighthouse_network::{
-    rpc::{GoodbyeReason, RPCResponseErrorCode},
+    rpc::{GoodbyeReason, RpcErrorResponse},
     Context, PeerAction, PeerRequestId, PubsubMessage, ReportSource, Request, Response, Subnet,
 };
 use lighthouse_network::{
@@ -73,7 +73,7 @@ pub enum NetworkMessage<E: EthSpec> {
     /// Sends an error response to an RPC request.
     SendErrorResponse {
         peer_id: PeerId,
-        error: RPCResponseErrorCode,
+        error: RpcErrorResponse,
         reason: String,
         id: PeerRequestId,
     },

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -22,7 +22,7 @@ use beacon_chain::{
     AvailabilityPendingExecutedBlock, PayloadVerificationOutcome, PayloadVerificationStatus,
 };
 use beacon_processor::WorkEvent;
-use lighthouse_network::rpc::{RPCError, RPCResponseErrorCode};
+use lighthouse_network::rpc::{RPCError, RpcErrorResponse};
 use lighthouse_network::service::api_types::{
     AppRequestId, DataColumnsByRootRequester, Id, SamplingRequester, SingleLookupReqId,
     SyncRequestId,
@@ -618,7 +618,7 @@ impl TestRig {
             id,
             peer_id,
             RPCError::ErrorResponse(
-                RPCResponseErrorCode::ResourceUnavailable,
+                RpcErrorResponse::ResourceUnavailable,
                 "older than deneb".into(),
             ),
         );

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -28,6 +28,7 @@ use lighthouse_network::service::api_types::{
     SyncRequestId,
 };
 use lighthouse_network::types::SyncState;
+use lighthouse_network::NetworkConfig;
 use lighthouse_network::NetworkGlobals;
 use slog::info;
 use slot_clock::{ManualSlotClock, SlotClock, TestingSlotClock};

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -22,13 +22,13 @@ use beacon_chain::{
     AvailabilityPendingExecutedBlock, PayloadVerificationOutcome, PayloadVerificationStatus,
 };
 use beacon_processor::WorkEvent;
-use lighthouse_network::rpc::{RPCError, RpcErrorResponse};
+use lighthouse_network::rpc::{RPCError, RequestType, RpcErrorResponse};
 use lighthouse_network::service::api_types::{
     AppRequestId, DataColumnsByRootRequester, Id, SamplingRequester, SingleLookupReqId,
     SyncRequestId,
 };
 use lighthouse_network::types::SyncState;
-use lighthouse_network::{NetworkConfig, NetworkGlobals, Request};
+use lighthouse_network::NetworkGlobals;
 use slog::info;
 use slot_clock::{ManualSlotClock, SlotClock, TestingSlotClock};
 use store::MemoryStore;
@@ -894,7 +894,7 @@ impl TestRig {
         self.pop_received_network_event(|ev| match ev {
             NetworkMessage::SendRequest {
                 peer_id: _,
-                request: Request::BlocksByRoot(request),
+                request: RequestType::BlocksByRoot(request),
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
             } if request.block_roots().to_vec().contains(&for_block) => Some(*id),
             _ => None,
@@ -914,7 +914,7 @@ impl TestRig {
         self.pop_received_network_event(|ev| match ev {
             NetworkMessage::SendRequest {
                 peer_id: _,
-                request: Request::BlobsByRoot(request),
+                request: RequestType::BlobsByRoot(request),
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
             } if request
                 .blob_ids
@@ -939,7 +939,7 @@ impl TestRig {
         self.pop_received_network_event(|ev| match ev {
             NetworkMessage::SendRequest {
                 peer_id: _,
-                request: Request::BlocksByRoot(request),
+                request: RequestType::BlocksByRoot(request),
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
             } if request.block_roots().to_vec().contains(&for_block) => Some(*id),
             _ => None,
@@ -961,7 +961,7 @@ impl TestRig {
         self.pop_received_network_event(|ev| match ev {
             NetworkMessage::SendRequest {
                 peer_id: _,
-                request: Request::BlobsByRoot(request),
+                request: RequestType::BlobsByRoot(request),
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
             } if request
                 .blob_ids
@@ -989,7 +989,7 @@ impl TestRig {
                 .pop_received_network_event(|ev| match ev {
                     NetworkMessage::SendRequest {
                         peer_id: _,
-                        request: Request::DataColumnsByRoot(request),
+                        request: RequestType::DataColumnsByRoot(request),
                         request_id: AppRequestId::Sync(id @ SyncRequestId::DataColumnsByRoot { .. }),
                     } if request
                         .data_column_ids


### PR DESCRIPTION
## Issue Addressed

This PR aims to replace the `(ConnectionId, SubstreamId)` identification method for the Rpc to a simple integer value that is unique for each request. This solves two main issues:
- avoids passing the `(ConnectionId, SubstreamId)` combination into the consensus land 
- allows the Rpc `Behaviour` to match a response to a request and potentially simplify a lot https://github.com/sigp/lighthouse/pull/5923 so that the `Handler` and `Behaviour` don't need to share a `Mutex`

review by commit is suggested
