### PR TITLE
Filter out BlsToExecutionChange messages for 0x02 validators

### DIFF
--- a/beacon_node/operation_pool/src/bls_to_execution_changes.rs
+++ b/beacon_node/operation_pool/src/bls_to_execution_changes.rs
@@ -113,7 +113,7 @@ impl<E: EthSpec> BlsToExecutionChanges<E> {
                 .validators()
                 .get(validator_index as usize)
                 .map_or(true, |validator| {
-                    let prune = validator.has_execution_withdrawal_credential(&spec)
+                    let prune = validator.has_execution_withdrawal_credential(spec)
                         && head_block
                             .message()
                             .body()

--- a/beacon_node/operation_pool/src/bls_to_execution_changes.rs
+++ b/beacon_node/operation_pool/src/bls_to_execution_changes.rs
@@ -113,7 +113,7 @@ impl<E: EthSpec> BlsToExecutionChanges<E> {
                 .validators()
                 .get(validator_index as usize)
                 .map_or(true, |validator| {
-                    let prune = validator.has_eth1_withdrawal_credential(spec)
+                    let prune = validator.has_execution_withdrawal_credential(&spec)
                         && head_block
                             .message()
                             .body()

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -585,7 +585,7 @@ impl<E: EthSpec> OperationPool<E> {
                     && state
                         .get_validator(address_change.as_inner().message.validator_index as usize)
                         .map_or(false, |validator| {
-                            !validator.has_eth1_withdrawal_credential(spec)
+                            !validator.has_execution_withdrawal_credential(spec)
                         })
             },
             |address_change| address_change.as_inner().clone(),


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Thanks @pk910 for finding the issue on electra devnet-3.

When producing a block, we get all the messages from our op pool filtering only for messages that have validators which already have an `eth1_withdrawal_credential`. 

With electra, we can have the following sequence of events:
1. We get a valid `SignedBlsToExecutionMessage` `b` for validator `v` and add it to our op pool
2.  The next proposer includes the message `b` in its block and the validator goes from 0x00 to 0x01
3. We get another block with a `DepositRequest/ConsolidationRequest` that changes the withdrawal credential for `v` from 0x01 to 0x02
4. We are the block proposer for the next slot and end up including the message `b` because its still in our op pool and the prefix is not 0x00 (its 0x02)
5. The block proposal fails when we try to verify the block we just produced e.g. 
```
Oct 03 14:04:36.044 ERRO Error whilst producing block            info: block v3 proposal failed, this error may or may not result in a missed block, block_slot: Slot(158868), error: "Some endpoints failed, num_failed: 1 http://beacon:5052/ => RequestFailed(Recoverable(\"Error from beacon node when producing block: Recoverable(\\\"Error from beacon node when producing block: ServerMessage(ErrorMessage { code: 400, message: \\\\\\\"BAD_REQUEST: failed to fetch a block: BlockProcessingError(BlsExecutionChangeInvalid { index: 0, reason: NonBlsWithdrawalCredentials })\\\\\\\", stacktraces: [] })\\\")\"))", service: block
```

This PR checks that the prefix is not 0x01 **and** 0x02 before getting it from the op pool. We also need to change the pruning routine to do the same.

### TODO

- [ ] Add a test for this scenario
 