### PR TITLE
Bound min size of dynamic processor queues

### DIFF
--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -1697,3 +1697,21 @@ impl Drop for SendOnDrop {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use types::{BeaconState, ChainSpec, Eth1Data, ForkName, MainnetEthSpec};
+
+    #[test]
+    fn min_queue_len() {
+        // State with no validators.
+        let spec = ForkName::latest().make_genesis_spec(ChainSpec::mainnet());
+        let genesis_time = 0;
+        let state = BeaconState::<MainnetEthSpec>::new(genesis_time, Eth1Data::default(), &spec);
+        assert_eq!(state.validators().len(), 0);
+        let queue_lengths = BeaconProcessorQueueLengths::from_state(&state, &spec).unwrap();
+        assert_eq!(queue_lengths.attestation_queue, MIN_QUEUE_LEN);
+        assert_eq!(queue_lengths.unknown_block_attestation_queue, MIN_QUEUE_LEN);
+    }
+}

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -160,12 +160,12 @@ impl BeaconProcessorQueueLengths {
             aggregate_queue: 4096,
             unknown_block_aggregate_queue: 1024,
             // Capacity for a full slot's worth of attestations if subscribed to all subnets
-            attestation_queue: std::cmp::min(
+            attestation_queue: std::cmp::max(
                 active_validator_count / slots_per_epoch,
                 MIN_QUEUE_LEN,
             ),
             // Capacity for a full slot's worth of attestations if subscribed to all subnets
-            unknown_block_attestation_queue: std::cmp::min(
+            unknown_block_attestation_queue: std::cmp::max(
                 active_validator_count / slots_per_epoch,
                 MIN_QUEUE_LEN,
             ),


### PR DESCRIPTION
## Issue Addressed

A discord user notes that in networks of < SLOTS_PER_EPOCH the beacon node did not process attestations. 

- #6463

It's due to integer division here

https://github.com/sigp/lighthouse/blob/35ac9f4602a7c68d258f039f93828fe604f37ab3/beacon_node/beacon_processor/src/lib.rs#L149-L152



## Proposed Changes

Min against a const

Closes #6463