### PR TITLE
Use snap install yq in local_testnet

### DIFF
--- a/scripts/local_testnet/README.md
+++ b/scripts/local_testnet/README.md
@@ -9,7 +9,7 @@ This setup can be useful for testing and development.
 
 1. Install [Kurtosis](https://docs.kurtosis.com/install/). Verify that Kurtosis has been successfully installed by running `kurtosis version` which should display the version.
 
-1. Install [yq](https://github.com/mikefarah/yq). If you are on Ubuntu, you can install `yq` by running `sudo apt install yq -y`.
+1. Install [yq](https://github.com/mikefarah/yq). If you are on Ubuntu, you can install `yq` by running `snap install yq`.
 
 ## Starting the testnet
 


### PR DESCRIPTION
snap is better than apt since it's recommended in yq doc

## Issue Addressed

I installed yq using apt and my version was v0.0.0. I don't know why.

## Proposed Changes

Use snap to install yq instead of apt since it's a recommended method in yq doc. See https://github.com/mikefarah/yq/?tab=readme-ov-file#linux-via-snap

## Additional Info