### PR TITLE
Match block and blobs after validating execution

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -15,6 +15,7 @@ pub enum Error {
     SszTypes(ssz_types::Error),
     MissingBlobs,
     MissingCustodyColumns,
+    MissingCustodyColumn(ColumnIndex),
     BlobIndexInvalid(u64),
     DataColumnIndexInvalid(u64),
     StoreError(store::Error),
@@ -52,6 +53,7 @@ impl Error {
             | Error::ReconstructColumnsError { .. }
             | Error::BlobIndexInvalid(_)
             | Error::DataColumnIndexInvalid(_)
+            | Error::MissingCustodyColumn(_)
             | Error::KzgCommitmentMismatch { .. } => ErrorCategory::Malicious,
         }
     }

--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -5,6 +5,7 @@ use types::{BeaconStateError, ColumnIndex, Hash256};
 pub enum Error {
     InvalidBlobs(KzgError),
     InvalidColumn(ColumnIndex, KzgError),
+    InvalidInclusionProof,
     ReconstructColumnsError(KzgError),
     KzgCommitmentMismatch {
         blob_commitment: KzgCommitment,
@@ -50,6 +51,7 @@ impl Error {
             | Error::SlotClockError => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }
             | Error::InvalidColumn { .. }
+            | Error::InvalidInclusionProof
             | Error::ReconstructColumnsError { .. }
             | Error::BlobIndexInvalid(_)
             | Error::DataColumnIndexInvalid(_)


### PR DESCRIPTION
## Issue Addressed

After PeerDAS we request block and data to different peers. Consider the following scenario when doing a by range sync:
- Block at slot N contains no data
- Peer serving the block at slot N forges the block adding KZG commitments
- The peers serving data columns do not return any data columns for slot N

Current unstable will attempt to match block and columns and consider the entire RpcBlock invalid. A similar scenario can occur where the block peer is honest and the column peer is dishonest.

We need to make the code more aware of **who** is at fault, and specifically do not attempt to match columns before validating the block.

Part of
- https://github.com/sigp/lighthouse/issues/6258

**Note: this PR touches code on the mainnet path, not only PeerDAS**

## Proposed Changes

Relax RpcBlock construction with `new_unchecked` and perform matching in `verify_kzg_for_rpc_block` after the block is execution validated.

This PR does not include a fix for peer scoring. This will be tackled latter as part of https://github.com/sigp/lighthouse/issues/6258
