### PR TITLE
Add lockbud task to CI

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,7 +66,7 @@ jobs:
         run: apt update && apt install -y cmake
       - name: Generate code coverage
         run: |
-          cargo lockbud -k deadlock
+          cargo lockbud -k deadlock -b -l tokio_util
 
   target-branch-check:
     name: target-branch-check
@@ -447,6 +447,7 @@ jobs:
       'cargo-udeps',
       'compile-with-beta-compiler',
       'cli-check',
+      'lockbud',
     ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -54,6 +54,20 @@ jobs:
          done
          echo "skip_ci=$SKIP_CI" >> $GITHUB_OUTPUT
 
+  lockbud:
+    name: lockbud
+    runs-on: ubuntu-latest
+    container:
+      image: eserilev/lockbud:latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: apt update && apt install -y cmake
+      - name: Generate code coverage
+        run: |
+          cargo lockbud -k deadlock
+
   target-branch-check:
     name: target-branch-check
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -58,7 +58,7 @@ jobs:
     name: lockbud
     runs-on: ubuntu-latest
     container:
-      image: eserilev/lockbud:latest
+      image: sigmaprime/lockbud:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -549,10 +549,11 @@ impl Service {
 
     /// Returns the number of deposits with valid signatures that have been observed.
     pub fn get_valid_signature_count(&self) -> Option<usize> {
+        let highest_safe_block = self.highest_safe_block()?;
         self.deposits()
             .read()
             .cache
-            .get_valid_signature_count(self.highest_safe_block()?)
+            .get_valid_signature_count(highest_safe_block)
     }
 
     /// Returns the number of deposits with valid signatures that have been observed, without

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -147,6 +147,7 @@ impl<E: EthSpec> ConsensusContext<E> {
         }
     }
 
+    #[allow(elided_named_lifetimes)]
     pub fn get_indexed_attestation<'a>(
         &'a mut self,
         state: &BeaconState<E>,

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -147,6 +147,7 @@ impl<E: EthSpec> ConsensusContext<E> {
         }
     }
 
+    #[allow(unknown_lints)]
     #[allow(elided_named_lifetimes)]
     pub fn get_indexed_attestation<'a>(
         &'a mut self,


### PR DESCRIPTION
## Issue Addressed

Closes #6413

## Proposed Changes

Add lockbud to CI

## Additional Info

Lockbud was pinned to 2024-05-20 Rust nightly. This conflicted with lazy_lock as it used to be an unstable feature. I've opened a PR here to pin it to the current latest Rust nightly (2024-10-05). I'm not sure if my changes have introduced any regressions, hopefully the author will review it soon and give some feedback.

https://github.com/BurtonQin/lockbud/pull/70

Currently the new CI step uses a docker image hosted on my account

Steps to generate the docker image:

- Checkout https://github.com/eserilev/lockbud `docker-instance` branch
- Run `docker build --platform linux/amd64 -t [namespace]/[repository]  -f Dockerfile .  `
- Push the resulting image to docker hub

