### PR TITLE
Better assert message in lookup sampling test

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1303,14 +1303,30 @@ impl TestRig {
         });
     }
 
-    fn assert_sampling_request_status(
-        &self,
-        block_root: Hash256,
-        ongoing: &Vec<ColumnIndex>,
-        no_peers: &Vec<ColumnIndex>,
-    ) {
-        self.sync_manager
-            .assert_sampling_request_status(block_root, ongoing, no_peers)
+    fn assert_sampling_request_ongoing(&self, block_root: Hash256, indices: &Vec<ColumnIndex>) {
+        for index in indices {
+            let status = self
+                .sync_manager
+                .get_sampling_request_status(block_root, index)
+                .unwrap_or_else(|| panic!("No request state for {index}"));
+            assert_eq!(
+                status, "Sampling",
+                "expected {block_root} {index} request to be ongoing"
+            );
+        }
+    }
+
+    fn assert_sampling_request_nopeers(&self, block_root: Hash256, indices: &Vec<ColumnIndex>) {
+        for index in indices {
+            let status = self
+                .sync_manager
+                .get_sampling_request_status(block_root, index)
+                .unwrap_or_else(|| panic!("No request state for {index}"));
+            assert_eq!(
+                status, "NoPeers",
+                "expected {block_root} {index} request to be nopeers"
+            );
+        }
     }
 }
 
@@ -2061,7 +2077,7 @@ fn sampling_batch_requests() {
         .pop()
         .unwrap();
     assert_eq!(column_indexes.len(), SAMPLING_REQUIRED_SUCCESSES);
-    r.assert_sampling_request_status(block_root, &column_indexes, &vec![]);
+    r.assert_sampling_request_ongoing(block_root, &column_indexes);
 
     // Resolve the request.
     r.complete_valid_sampling_column_requests(
@@ -2089,7 +2105,7 @@ fn sampling_batch_requests_not_enough_responses_returned() {
     assert_eq!(column_indexes.len(), SAMPLING_REQUIRED_SUCCESSES);
 
     // The request status should be set to Sampling.
-    r.assert_sampling_request_status(block_root, &column_indexes, &vec![]);
+    r.assert_sampling_request_ongoing(block_root, &column_indexes);
 
     // Split the indexes to simulate the case where the supernode doesn't have the requested column.
     let (_column_indexes_supernode_does_not_have, column_indexes_to_complete) =
@@ -2107,7 +2123,7 @@ fn sampling_batch_requests_not_enough_responses_returned() {
     );
 
     // The request status should be set to NoPeers since the supernode, the only peer, returned not enough responses.
-    r.assert_sampling_request_status(block_root, &vec![], &column_indexes);
+    r.assert_sampling_request_nopeers(block_root, &column_indexes);
 
     // The sampling request stalls.
     r.expect_empty_network();

--- a/beacon_node/network/src/sync/block_lookups/tests.rs
+++ b/beacon_node/network/src/sync/block_lookups/tests.rs
@@ -1309,10 +1309,9 @@ impl TestRig {
                 .sync_manager
                 .get_sampling_request_status(block_root, index)
                 .unwrap_or_else(|| panic!("No request state for {index}"));
-            assert_eq!(
-                status, "Sampling",
-                "expected {block_root} {index} request to be ongoing"
-            );
+            if !matches!(status, crate::sync::peer_sampling::Status::Sampling { .. }) {
+                panic!("expected {block_root} {index} request to be on going: {status:?}");
+            }
         }
     }
 
@@ -1322,10 +1321,9 @@ impl TestRig {
                 .sync_manager
                 .get_sampling_request_status(block_root, index)
                 .unwrap_or_else(|| panic!("No request state for {index}"));
-            assert_eq!(
-                status, "NoPeers",
-                "expected {block_root} {index} request to be nopeers"
-            );
+            if !matches!(status, crate::sync::peer_sampling::Status::NoPeers { .. }) {
+                panic!("expected {block_root} {index} request to be no peers: {status:?}");
+            }
         }
     }
 }

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -338,14 +338,12 @@ impl<T: BeaconChainTypes> SyncManager<T> {
     }
 
     #[cfg(test)]
-    pub(crate) fn assert_sampling_request_status(
+    pub(crate) fn get_sampling_request_status(
         &self,
         block_root: Hash256,
-        ongoing: &Vec<ColumnIndex>,
-        no_peers: &Vec<ColumnIndex>,
-    ) {
-        self.sampling
-            .assert_sampling_request_status(block_root, ongoing, no_peers);
+        index: &ColumnIndex,
+    ) -> Option<&'static str> {
+        self.sampling.get_request_status(block_root, index)
     }
 
     fn network_globals(&self) -> &NetworkGlobals<T::EthSpec> {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -342,7 +342,7 @@ impl<T: BeaconChainTypes> SyncManager<T> {
         &self,
         block_root: Hash256,
         index: &ColumnIndex,
-    ) -> Option<&'static str> {
+    ) -> Option<super::peer_sampling::Status> {
         self.sampling.get_request_status(block_root, index)
     }
 

--- a/beacon_node/network/src/sync/peer_sampling.rs
+++ b/beacon_node/network/src/sync/peer_sampling.rs
@@ -567,7 +567,6 @@ mod request {
     use rand::seq::SliceRandom;
     use rand::thread_rng;
     use std::collections::HashSet;
-    use strum::IntoStaticStr;
     use types::data_column_sidecar::ColumnIndex;
 
     pub(crate) struct ActiveColumnSampleRequest {
@@ -578,7 +577,7 @@ mod request {
     }
 
     // Exposed only for testing assertions in lookup tests
-    #[derive(Debug, Clone, IntoStaticStr)]
+    #[derive(Debug, Clone)]
     pub(crate) enum Status {
         NoPeers,
         NotStarted,


### PR DESCRIPTION
## Issue Addressed

Debugging a sampling failed test in https://github.com/sigp/lighthouse/pull/6398 it is hard to identify which specific column and request had the wrong state since there's an `assert!` statement without more metadata.

## Proposed Changes

Log which specific sampling request and column has an unexpected state

