### PR TITLE
Rust nightly lints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,7 +214,8 @@ lint:
 		-A clippy::vec-init-then-push \
 		-A clippy::question-mark \
 		-A clippy::uninlined-format-args \
-		-A clippy::enum_variant_names
+		-A clippy::enum_variant_names \
+		-A clippy::too_long_first_doc_paragraph
 
 # Lints the code using Clippy and automatically fix some simple compiler warnings.
 lint-fix:

--- a/consensus/state_processing/src/consensus_context.rs
+++ b/consensus/state_processing/src/consensus_context.rs
@@ -151,7 +151,7 @@ impl<E: EthSpec> ConsensusContext<E> {
         &'a mut self,
         state: &BeaconState<E>,
         attestation: AttestationRef<'a, E>,
-    ) -> Result<IndexedAttestationRef<E>, BlockOperationError<AttestationInvalid>> {
+    ) -> Result<IndexedAttestationRef<'a, E>, BlockOperationError<AttestationInvalid>> {
         let key = attestation.tree_hash_root();
         match attestation {
             AttestationRef::Base(attn) => match self.indexed_attestations.entry(key) {


### PR DESCRIPTION
Latest rust nightly introduces two lints
- `elided_named_lifetimes`
- `too_long_first_doc_paragraph`

I've gone ahead and updated `make lint` to ignore `too_long_first_doc_paragraph` as it seems like an unnecessary lint.
