### PR TITLE
New historic state cache

### DIFF
--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1992,6 +1992,8 @@ pub fn scrape_for_metrics<T: BeaconChainTypes>(beacon_chain: &BeaconChain<T>) {
         .canonical_head
         .fork_choice_read_lock()
         .scrape_for_metrics();
+
+    beacon_chain.store.register_metrics();
 }
 
 /// Scrape the given `state` assuming it's the head state, updating the `DEFAULT_REGISTRY`.

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2696,12 +2696,14 @@ pub fn serve<T: BeaconChainTypes>(
         .and(warp::header::optional::<api_types::Accept>("accept"))
         .and(task_spawner_filter.clone())
         .and(chain_filter.clone())
+        .and(log_filter.clone())
         .then(
             |endpoint_version: EndpointVersion,
              state_id: StateId,
              accept_header: Option<api_types::Accept>,
              task_spawner: TaskSpawner<T::EthSpec>,
-             chain: Arc<BeaconChain<T>>| {
+             chain: Arc<BeaconChain<T>>,
+             log: Logger| {
                 task_spawner.blocking_response_task(Priority::P1, move || match accept_header {
                     Some(api_types::Accept::Ssz) => {
                         // We can ignore the optimistic status for the "fork" since it's a
@@ -2716,7 +2718,7 @@ pub fn serve<T: BeaconChainTypes>(
                         let response_bytes = state.as_ssz_bytes();
                         drop(timer);
                         debug!(
-                            self.log,
+                            log,
                             "HTTP state load";
                             "load_time_ms" => t.elapsed().as_millis(),
                             "target_slot" => state.slot()

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -2707,6 +2707,7 @@ pub fn serve<T: BeaconChainTypes>(
                         // We can ignore the optimistic status for the "fork" since it's a
                         // specification constant that doesn't change across competing heads of the
                         // beacon chain.
+                        let t = std::time::Instant::now();
                         let (state, _execution_optimistic, _finalized) = state_id.state(&chain)?;
                         let fork_name = state
                             .fork_name(&chain.spec)
@@ -2714,6 +2715,13 @@ pub fn serve<T: BeaconChainTypes>(
                         let timer = metrics::start_timer(&metrics::HTTP_API_STATE_SSZ_ENCODE_TIMES);
                         let response_bytes = state.as_ssz_bytes();
                         drop(timer);
+                        debug!(
+                            self.log,
+                            "HTTP state load";
+                            "load_time_ms" => t.elapsed().as_millis(),
+                            "target_slot" => state.slot()
+                        );
+
                         Response::builder()
                             .status(200)
                             .body(response_bytes.into())

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -803,7 +803,8 @@ pub fn cli_app() -> Command {
             Arg::new("historic-state-cache-size")
                 .long("historic-state-cache-size")
                 .value_name("SIZE")
-                .help("This cache is currently inactive. Please use hdiff-buffer-cache-size instead.")
+                .help("Specifies how many states from the freezer database should be cached in \
+                       memory")
                 .default_value("1")
                 .action(ArgAction::Set)
                 .display_order(0)

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -436,15 +436,10 @@ pub fn get_config<E: EthSpec>(
             .map_err(|_| "state-cache-size is not a valid integer".to_string())?;
     }
 
-    if cli_args
-        .get_one::<String>("historic-state-cache-size")
-        .is_some()
+    if let Some(historic_state_cache_size) =
+        clap_utils::parse_optional(cli_args, "historic-state-cache-size")?
     {
-        warn!(
-            log,
-            "Historic state cache is currently disabled. \
-             Please use hdiff-buffer-cache-size instead"
-        );
+        client_config.store.historic_state_cache_size = historic_state_cache_size;
     }
 
     if let Some(hdiff_buffer_cache_size) =

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -15,6 +15,7 @@ pub const DEFAULT_EPOCHS_PER_STATE_DIFF: u64 = 8;
 pub const DEFAULT_BLOCK_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(64);
 pub const DEFAULT_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(128);
 pub const DEFAULT_COMPRESSION_LEVEL: i32 = 1;
+pub const DEFAULT_HISTORIC_STATE_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(1);
 pub const DEFAULT_HDIFF_BUFFER_CACHE_SIZE: NonZeroUsize = new_non_zero_usize(16);
 const EST_COMPRESSION_FACTOR: usize = 2;
 pub const DEFAULT_EPOCHS_PER_BLOB_PRUNE: u64 = 1;
@@ -31,6 +32,8 @@ pub struct StoreConfig {
     pub state_cache_size: NonZeroUsize,
     /// Compression level for blocks, state diffs and other compressed values.
     pub compression_level: i32,
+    /// Maximum number of historic states to store in the in-memory historic state cache.
+    pub historic_state_cache_size: NonZeroUsize,
     /// Maximum number of `HDiffBuffer`s to store in memory.
     pub hdiff_buffer_cache_size: NonZeroUsize,
     /// Whether to compact the database on initialization.
@@ -102,6 +105,7 @@ impl Default for StoreConfig {
             epochs_per_state_diff: DEFAULT_EPOCHS_PER_STATE_DIFF,
             block_cache_size: DEFAULT_BLOCK_CACHE_SIZE,
             state_cache_size: DEFAULT_STATE_CACHE_SIZE,
+            historic_state_cache_size: DEFAULT_HISTORIC_STATE_CACHE_SIZE,
             hdiff_buffer_cache_size: DEFAULT_HDIFF_BUFFER_CACHE_SIZE,
             compression_level: DEFAULT_COMPRESSION_LEVEL,
             compact_on_init: false,

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -79,8 +79,8 @@ pub enum StorageStrategy {
 /// Hierarchical diff output and working buffer.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct HDiffBuffer {
-    pub state: Vec<u8>,
-    pub balances: Vec<u64>,
+    state: Vec<u8>,
+    balances: Vec<u64>,
 }
 
 /// Hierarchical state diff.

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
 use std::io::{Read, Write};
+use std::ops::RangeInclusive;
 use std::str::FromStr;
 use types::{BeaconState, ChainSpec, EthSpec, List, Slot};
 use zstd::{Decoder, Encoder};
@@ -354,6 +355,35 @@ impl HierarchyModuli {
             || Ok(slot == self.next_snapshot_slot(slot)?),
             |second_layer_moduli| Ok(slot % *second_layer_moduli == 0),
         )
+    }
+}
+
+impl StorageStrategy {
+    /// For the state stored with this `StorageStrategy` at `slot`, return the range of slots which
+    /// should be checked for ancestor states in the historic state cache.
+    ///
+    /// The idea is that for states which need to be built by replaying blocks we should scan
+    /// for any viable ancestor state between their `from` slot and `slot`. If we find such a
+    /// state it will save us from the slow reconstruction of the `from` state using diffs.
+    ///
+    /// Similarly for `DiffFrom` and `Snapshot` states, loading the prior state and replaying 1
+    /// block is often going to be faster than loading and applying diffs/snapshots, so we may as
+    /// well check the cache for that 1 slot prior (in case the caller is iterating sequentially).
+    pub fn replay_from_range(
+        &self,
+        slot: Slot,
+    ) -> std::iter::Map<RangeInclusive<u64>, fn(u64) -> Slot> {
+        match self {
+            Self::ReplayFrom(from) => from.as_u64()..=slot.as_u64(),
+            Self::Snapshot | Self::DiffFrom(_) => {
+                if slot > 0 {
+                    (slot - 1).as_u64()..=slot.as_u64()
+                } else {
+                    slot.as_u64()..=slot.as_u64()
+                }
+            }
+        }
+        .map(Slot::from)
     }
 }
 

--- a/beacon_node/store/src/historic_state_cache.rs
+++ b/beacon_node/store/src/historic_state_cache.rs
@@ -1,0 +1,95 @@
+use crate::hdiff::{Error, HDiffBuffer};
+use lru::LruCache;
+use std::num::NonZeroUsize;
+use types::{BeaconState, ChainSpec, EthSpec, Slot};
+
+/// Empty HDiffBuffer used to replace a real buffer temporarily during mutation.
+const EMPTY_HDIFF_BUFFER: HDiffBuffer = HDiffBuffer {
+    state: Vec::new(),
+    balances: Vec::new(),
+};
+
+#[derive(Debug)]
+pub enum HistoricState<E: EthSpec> {
+    State(BeaconState<E>),
+    HDiff(HDiffBuffer),
+    Both(BeaconState<E>, HDiffBuffer),
+}
+
+#[derive(Debug)]
+pub struct HistoricStateCache<E: EthSpec> {
+    cache: LruCache<Slot, HistoricState<E>>,
+}
+
+impl<E: EthSpec> HistoricState<E> {
+    fn as_hdiff_buffer(&mut self) -> HDiffBuffer {
+        match self {
+            HistoricState::State(state) => {
+                let buffer = HDiffBuffer::from_state(state.clone());
+                *self = HistoricState::Both(state.clone(), buffer.clone());
+                buffer
+            }
+            HistoricState::HDiff(buffer) | HistoricState::Both(_, buffer) => buffer.clone(),
+        }
+    }
+
+    fn as_state(&mut self, spec: &ChainSpec) -> Result<BeaconState<E>, Error> {
+        match self {
+            HistoricState::HDiff(buffer) => {
+                let state = buffer.as_state(spec)?;
+                let buffer = std::mem::replace(buffer, EMPTY_HDIFF_BUFFER);
+                *self = HistoricState::Both(state.clone(), buffer);
+                Ok(state)
+            }
+            HistoricState::State(state) | HistoricState::Both(state, _) => Ok(state.clone()),
+        }
+    }
+}
+
+impl<E: EthSpec> HistoricStateCache<E> {
+    pub fn new(cache_size: NonZeroUsize) -> Self {
+        Self {
+            cache: LruCache::new(cache_size),
+        }
+    }
+
+    pub fn get_hdiff_buffer(&mut self, slot: Slot) -> Option<HDiffBuffer> {
+        self.cache
+            .get_mut(&slot)
+            .map(HistoricState::as_hdiff_buffer)
+    }
+
+    pub fn get_state(
+        &mut self,
+        slot: Slot,
+        spec: &ChainSpec,
+    ) -> Result<Option<BeaconState<E>>, Error> {
+        self.cache
+            .get_mut(&slot)
+            .map(|entry| entry.as_state(spec))
+            .transpose()
+    }
+
+    pub fn put_state(&mut self, slot: Slot, state: BeaconState<E>) {
+        let cache_entry = self
+            .cache
+            .get_or_insert_mut(slot, || HistoricState::State(state.clone()));
+        if let HistoricState::HDiff(buffer) = cache_entry {
+            let buffer = std::mem::replace(buffer, EMPTY_HDIFF_BUFFER);
+            *cache_entry = HistoricState::Both(state, buffer);
+        }
+    }
+
+    pub fn put_hdiff_buffer(&mut self, slot: Slot, buffer: HDiffBuffer) {
+        let cache_entry = self
+            .cache
+            .get_or_insert_mut(slot, || HistoricState::HDiff(buffer.clone()));
+        if let HistoricState::State(state) = cache_entry {
+            *cache_entry = HistoricState::Both(state.clone(), buffer);
+        }
+    }
+
+    pub fn put_both(&mut self, slot: Slot, state: BeaconState<E>, buffer: HDiffBuffer) {
+        self.cache.put(slot, HistoricState::Both(state, buffer));
+    }
+}

--- a/beacon_node/store/src/historic_state_cache.rs
+++ b/beacon_node/store/src/historic_state_cache.rs
@@ -4,6 +4,13 @@ use lru::LruCache;
 use std::num::NonZeroUsize;
 use types::{BeaconState, ChainSpec, EthSpec, Slot};
 
+/// Holds a combination of finalized states in two formats:
+/// - `hdiff_buffers`: Format close to an SSZ serialized state for rapid application of diffs on top
+///   of it
+/// - `states`: Deserialized states for direct use or for rapid application of blocks (replay)
+///
+/// An example use: when requesting state data for consecutive slots, this cache allows the node to
+/// apply diffs once on the first request, and latter just apply blocks one at a time.
 #[derive(Debug)]
 pub struct HistoricStateCache<E: EthSpec> {
     hdiff_buffers: LruCache<Slot, HDiffBuffer>,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -217,8 +217,9 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
             hot_db: MemoryStore::open(),
             block_cache: Mutex::new(BlockCache::new(config.block_cache_size)),
             state_cache: Mutex::new(StateCache::new(config.state_cache_size)),
-            // FIXME(sproul): rename
+            // FIXME(sproul): plumbing
             historic_state_cache: Mutex::new(HistoricStateCache::new(
+                config.hdiff_buffer_cache_size,
                 config.hdiff_buffer_cache_size,
             )),
             config,
@@ -263,7 +264,9 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
             hot_db,
             block_cache: Mutex::new(BlockCache::new(config.block_cache_size)),
             state_cache: Mutex::new(StateCache::new(config.state_cache_size)),
+            // FIXME(sproul): plumb
             historic_state_cache: Mutex::new(HistoricStateCache::new(
+                config.hdiff_buffer_cache_size,
                 config.hdiff_buffer_cache_size,
             )),
             config,
@@ -458,16 +461,6 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         metrics::set_gauge(
             &metrics::STORE_BEACON_STATE_CACHE_SIZE,
             self.state_cache.lock().len() as i64,
-        );
-        metrics::set_int_gauge(
-            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
-            &["total"],
-            hsc_metrics.num_total as i64,
-        );
-        metrics::set_int_gauge(
-            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
-            &["both"],
-            hsc_metrics.num_both as i64,
         );
         metrics::set_int_gauge(
             &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -445,17 +445,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
     }
 
     pub fn register_metrics(&self) {
-        /* FIXME(sproul): think about how best to update metrics
-        let historic_state_cache = self.historic_state_cache.lock();
-        let historic_state_cache_byte_size = historic_state_cache
-            .iter()
-            .map(|(_, diff)| diff.size())
-            .sum::<usize>();
-        let historic_state_cache_len = historic_state_cache.len();
-        drop(historic_state_cache);
-        */
-        let historic_state_cache_byte_size = 0;
-        let historic_state_cache_len = 0;
+        let hsc_metrics = self.historic_state_cache.lock().metrics();
 
         metrics::set_gauge(
             &metrics::STORE_BEACON_BLOCK_CACHE_SIZE,
@@ -469,13 +459,29 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             &metrics::STORE_BEACON_STATE_CACHE_SIZE,
             self.state_cache.lock().len() as i64,
         );
-        metrics::set_gauge(
-            &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE,
-            historic_state_cache_len as i64,
+        metrics::set_int_gauge(
+            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
+            &["total"],
+            hsc_metrics.num_total as i64,
+        );
+        metrics::set_int_gauge(
+            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
+            &["both"],
+            hsc_metrics.num_both as i64,
+        );
+        metrics::set_int_gauge(
+            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
+            &["hdiff"],
+            hsc_metrics.num_hdiff as i64,
+        );
+        metrics::set_int_gauge(
+            &metrics::STORE_BEACON_HISTORIC_STATE_CACHE_SIZE,
+            &["state"],
+            hsc_metrics.num_state as i64,
         );
         metrics::set_gauge(
             &metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE,
-            historic_state_cache_byte_size as i64,
+            hsc_metrics.hdiff_byte_size as i64,
         );
 
         let anchor_info = self.get_anchor_info();

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -1771,9 +1771,11 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             .lock()
             .get_state(slot, &self.spec)?
         {
-            // FIXME(sproul): metric here
+            metrics::inc_counter(&metrics::STORE_BEACON_HISTORIC_STATE_CACHE_HIT);
             return Ok(state);
         }
+
+        metrics::inc_counter(&metrics::STORE_BEACON_HISTORIC_STATE_CACHE_MISS);
 
         // Load using the diff hierarchy. For states that require replay we recurse into this
         // function so that we can try to get their pre-state *as a state* rather than an hdiff
@@ -1841,9 +1843,8 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             );
             metrics::inc_counter(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_HIT);
             return Ok((slot, buffer.clone()));
-        } else {
-            metrics::inc_counter(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS);
         }
+        metrics::inc_counter(&metrics::STORE_BEACON_HDIFF_BUFFER_CACHE_MISS);
 
         // Load buffer for the previous state.
         // This amount of recursion (<10 levels) should be OK.

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -217,10 +217,9 @@ impl<E: EthSpec> HotColdDB<E, MemoryStore<E>, MemoryStore<E>> {
             hot_db: MemoryStore::open(),
             block_cache: Mutex::new(BlockCache::new(config.block_cache_size)),
             state_cache: Mutex::new(StateCache::new(config.state_cache_size)),
-            // FIXME(sproul): plumbing
             historic_state_cache: Mutex::new(HistoricStateCache::new(
                 config.hdiff_buffer_cache_size,
-                config.hdiff_buffer_cache_size,
+                config.historic_state_cache_size,
             )),
             config,
             hierarchy,
@@ -264,10 +263,9 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
             hot_db,
             block_cache: Mutex::new(BlockCache::new(config.block_cache_size)),
             state_cache: Mutex::new(StateCache::new(config.state_cache_size)),
-            // FIXME(sproul): plumb
             historic_state_cache: Mutex::new(HistoricStateCache::new(
                 config.hdiff_buffer_cache_size,
-                config.hdiff_buffer_cache_size,
+                config.historic_state_cache_size,
             )),
             config,
             hierarchy,

--- a/beacon_node/store/src/lib.rs
+++ b/beacon_node/store/src/lib.rs
@@ -15,6 +15,7 @@ pub mod errors;
 mod forwards_iter;
 mod garbage_collection;
 pub mod hdiff;
+pub mod historic_state_cache;
 pub mod hot_cold_store;
 mod impls;
 mod leveldb_store;

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -262,6 +262,20 @@ pub static STORE_BEACON_HDIFF_BUFFER_LOAD_FOR_STORE_TIME: LazyLock<Result<Histog
             "Time taken to load an hdiff buffer to store another hdiff",
         )
     });
+pub static STORE_BEACON_HISTORIC_STATE_CACHE_HIT: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "store_beacon_historic_state_cache_hit_total",
+            "Total count of historic state cache hits for full states",
+        )
+    });
+pub static STORE_BEACON_HISTORIC_STATE_CACHE_MISS: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "store_beacon_hdiff_buffer_cache_miss_total",
+            "Total count of historic state cache misses for full states",
+        )
+    });
 pub static STORE_BEACON_HDIFF_BUFFER_CACHE_HIT: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {
         try_create_int_counter(

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -163,6 +163,12 @@ pub static BEACON_HDIFF_DECODE_TIMES: LazyLock<Result<Histogram>> = LazyLock::ne
         "Time required to decode hierarchical diff bytes",
     )
 });
+pub static BEACON_HDIFF_BUFFER_CLONE_TIMES: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "store_hdiff_buffer_clone_seconds",
+        "Time required to clone hierarchical diff buffer bytes",
+    )
+});
 /*
  * Beacon Block
  */

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -316,6 +316,20 @@ pub static STORE_BEACON_REPLAYED_BLOCKS: LazyLock<Result<IntCounter>> = LazyLock
         "Total count of replayed blocks",
     )
 });
+pub static STORE_BEACON_COLD_REPLAY_BLOCKS_TIME: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "store_beacon_cold_replay_blocks_time",
+            "Time spent replaying blocks for historic states",
+        )
+    });
+pub static STORE_BEACON_HOT_REPLAY_BLOCKS_TIME: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "store_beacon_cold_replay_blocks_time",
+            "Time spent replaying blocks for historic states",
+        )
+    });
 pub static STORE_BEACON_RECONSTRUCTION_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "store_beacon_reconstruction_time_seconds",

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -272,7 +272,7 @@ pub static STORE_BEACON_HISTORIC_STATE_CACHE_HIT: LazyLock<Result<IntCounter>> =
 pub static STORE_BEACON_HISTORIC_STATE_CACHE_MISS: LazyLock<Result<IntCounter>> =
     LazyLock::new(|| {
         try_create_int_counter(
-            "store_beacon_hdiff_buffer_cache_miss_total",
+            "store_beacon_historic_state_cache_miss_total",
             "Total count of historic state cache misses for full states",
         )
     });

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -212,19 +212,24 @@ pub static STORE_BEACON_STATE_CACHE_SIZE: LazyLock<Result<IntGauge>> = LazyLock:
         "Current count of items in beacon store state cache",
     )
 });
-pub static STORE_BEACON_HISTORIC_STATE_CACHE_SIZE: LazyLock<Result<IntGaugeVec>> =
+pub static STORE_BEACON_HISTORIC_STATE_CACHE_SIZE: LazyLock<Result<IntGauge>> =
     LazyLock::new(|| {
-        try_create_int_gauge_vec(
+        try_create_int_gauge(
             "store_beacon_historic_state_cache_size",
-            "Current count of items in the historic state cache",
-            &["type"],
+            "Current count of states in the historic state cache",
         )
     });
+pub static STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
+    try_create_int_gauge(
+        "store_beacon_hdiff_buffer_cache_size",
+        "Current count of hdiff buffers in the historic state cache",
+    )
+});
 pub static STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE: LazyLock<Result<IntGauge>> =
     LazyLock::new(|| {
         try_create_int_gauge(
-            "store_beacon_historic_state_cache_hdiff_byte_size",
-            "Current byte size sum of all hdiff buffers in beacon store hdiff buffer cache",
+            "store_beacon_hdiff_buffer_cache_byte_size",
+            "Memory consumed by hdiff buffers in the historic state cache",
         )
     });
 pub static STORE_BEACON_STATE_FREEZER_COMPRESS_TIME: LazyLock<Result<Histogram>> =
@@ -316,20 +321,38 @@ pub static STORE_BEACON_REPLAYED_BLOCKS: LazyLock<Result<IntCounter>> = LazyLock
         "Total count of replayed blocks",
     )
 });
-pub static STORE_BEACON_COLD_REPLAY_BLOCKS_TIME: LazyLock<Result<IntCounter>> =
+pub static STORE_BEACON_LOAD_COLD_BLOCKS_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "store_beacon_load_cold_blocks_time",
+        "Time spent loading blocks to replay for historic states",
+    )
+});
+pub static STORE_BEACON_LOAD_HOT_BLOCKS_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "store_beacon_load_hot_blocks_time",
+        "Time spent loading blocks to replay for hot states",
+    )
+});
+pub static STORE_BEACON_REPLAY_COLD_BLOCKS_TIME: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
-        try_create_int_counter(
-            "store_beacon_cold_replay_blocks_time",
+        try_create_histogram(
+            "store_beacon_replay_cold_blocks_time",
             "Time spent replaying blocks for historic states",
         )
     });
-pub static STORE_BEACON_HOT_REPLAY_BLOCKS_TIME: LazyLock<Result<IntCounter>> =
+pub static STORE_BEACON_COLD_BUILD_BEACON_CACHES_TIME: LazyLock<Result<Histogram>> =
     LazyLock::new(|| {
-        try_create_int_counter(
-            "store_beacon_cold_replay_blocks_time",
-            "Time spent replaying blocks for historic states",
+        try_create_histogram(
+            "store_beacon_cold_build_beacon_caches_time",
+            "Time spent building caches on historic states",
         )
     });
+pub static STORE_BEACON_REPLAY_HOT_BLOCKS_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "store_beacon_replay_hot_blocks_time",
+        "Time spent replaying blocks for hot states",
+    )
+});
 pub static STORE_BEACON_RECONSTRUCTION_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
     try_create_histogram(
         "store_beacon_reconstruction_time_seconds",

--- a/beacon_node/store/src/metrics.rs
+++ b/beacon_node/store/src/metrics.rs
@@ -206,24 +206,19 @@ pub static STORE_BEACON_STATE_CACHE_SIZE: LazyLock<Result<IntGauge>> = LazyLock:
         "Current count of items in beacon store state cache",
     )
 });
-pub static STORE_BEACON_HISTORIC_STATE_CACHE_SIZE: LazyLock<Result<IntGauge>> =
+pub static STORE_BEACON_HISTORIC_STATE_CACHE_SIZE: LazyLock<Result<IntGaugeVec>> =
     LazyLock::new(|| {
-        try_create_int_gauge(
+        try_create_int_gauge_vec(
             "store_beacon_historic_state_cache_size",
-            "Current count of items in beacon store historic state cache",
+            "Current count of items in the historic state cache",
+            &["type"],
         )
     });
-pub static STORE_BEACON_HDIFF_BUFFER_CACHE_SIZE: LazyLock<Result<IntGauge>> = LazyLock::new(|| {
-    try_create_int_gauge(
-        "store_beacon_hdiff_buffer_cache_size",
-        "Current count of items in beacon store hdiff buffer cache",
-    )
-});
 pub static STORE_BEACON_HDIFF_BUFFER_CACHE_BYTE_SIZE: LazyLock<Result<IntGauge>> =
     LazyLock::new(|| {
         try_create_int_gauge(
-            "store_beacon_hdiff_buffer_cache_byte_size",
-            "Current byte size sum of all elements in beacon store hdiff buffer cache",
+            "store_beacon_historic_state_cache_hdiff_byte_size",
+            "Current byte size sum of all hdiff buffers in beacon store hdiff buffer cache",
         )
     });
 pub static STORE_BEACON_STATE_FREEZER_COMPRESS_TIME: LazyLock<Result<Histogram>> =

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -59,9 +59,7 @@ where
             .take(num_blocks.map_or(usize::MAX, |n| n + 1));
 
         // The state to be advanced.
-        let mut state = self
-            .load_cold_state_by_slot(lower_limit_slot)?
-            .ok_or(HotColdDBError::MissingLowerLimitState(lower_limit_slot))?;
+        let mut state = self.load_cold_state_by_slot(lower_limit_slot)?;
 
         state.build_caches(&self.spec)?;
 

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -181,8 +181,8 @@ Options:
           slots, and second-level diffs every 16 (2^4) slots. Cannot be changed
           after initialization. [default: 5,9,11,13,16,18,21]
       --historic-state-cache-size <SIZE>
-          This cache is currently inactive. Please use hdiff-buffer-cache-size
-          instead. [default: 1]
+          Specifies how many states from the freezer database should be cached
+          in memory [default: 1]
       --http-address <ADDRESS>
           Set the listen address for the RESTful HTTP API server.
       --http-allow-origin <ORIGIN>

--- a/common/lighthouse_metrics/src/lib.rs
+++ b/common/lighthouse_metrics/src/lib.rs
@@ -283,6 +283,14 @@ pub fn stop_timer(timer: Option<HistogramTimer>) {
     }
 }
 
+/// Stops a timer created with `start_timer(..)`.
+///
+/// Return the duration that the timer was running for, or 0.0 if it was `None` due to incorrect
+/// initialisation.
+pub fn stop_timer_with_duration(timer: Option<HistogramTimer>) -> Duration {
+    Duration::from_secs_f64(timer.map_or(0.0, |t| t.stop_and_record()))
+}
+
 pub fn observe_vec(vec: &Result<HistogramVec>, name: &[&str], value: f64) {
     if let Some(h) = get_histogram(vec, name) {
         h.observe(value)

--- a/consensus/state_processing/src/common/update_progressive_balances_cache.rs
+++ b/consensus/state_processing/src/common/update_progressive_balances_cache.rs
@@ -1,6 +1,6 @@
 /// A collection of all functions that mutates the `ProgressiveBalancesCache`.
 use crate::metrics::{
-    PARTICIPATION_CURR_EPOCH_TARGET_ATTESTING_GWEI_PROGRESSIVE_TOTAL,
+    self, PARTICIPATION_CURR_EPOCH_TARGET_ATTESTING_GWEI_PROGRESSIVE_TOTAL,
     PARTICIPATION_PREV_EPOCH_TARGET_ATTESTING_GWEI_PROGRESSIVE_TOTAL,
 };
 use crate::{BlockProcessingError, EpochProcessingError};
@@ -20,6 +20,8 @@ pub fn initialize_progressive_balances_cache<E: EthSpec>(
     {
         return Ok(());
     }
+
+    let _timer = metrics::start_timer(&metrics::BUILD_PROGRESSIVE_BALANCES_CACHE_TIME);
 
     // Calculate the total flag balances for previous & current epoch in a single iteration.
     // This calculates `get_total_balance(unslashed_participating_indices(..))` for each flag in

--- a/consensus/state_processing/src/epoch_cache.rs
+++ b/consensus/state_processing/src/epoch_cache.rs
@@ -1,6 +1,7 @@
 use crate::common::altair::BaseRewardPerIncrement;
 use crate::common::base::SqrtTotalActiveBalance;
 use crate::common::{altair, base};
+use crate::metrics;
 use safe_arith::SafeArith;
 use types::epoch_cache::{EpochCache, EpochCacheError, EpochCacheKey};
 use types::{
@@ -137,6 +138,8 @@ pub fn initialize_epoch_cache<E: EthSpec>(
         // `EpochCache` has already been initialized and is valid, no need to initialize.
         return Ok(());
     }
+
+    let _timer = metrics::start_timer(&metrics::BUILD_EPOCH_CACHE_TIME);
 
     let current_epoch = state.current_epoch();
     let next_epoch = state.next_epoch().map_err(EpochCacheError::BeaconState)?;

--- a/consensus/state_processing/src/metrics.rs
+++ b/consensus/state_processing/src/metrics.rs
@@ -41,6 +41,20 @@ pub static PROCESS_EPOCH_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
         "Time required for process_epoch",
     )
 });
+pub static BUILD_EPOCH_CACHE_TIME: LazyLock<Result<Histogram>> = LazyLock::new(|| {
+    try_create_histogram(
+        "beacon_state_processing_epoch_cache",
+        "Time required to build the epoch cache",
+    )
+});
+pub static BUILD_PROGRESSIVE_BALANCES_CACHE_TIME: LazyLock<Result<Histogram>> =
+    LazyLock::new(|| {
+        try_create_histogram(
+            "beacon_state_processing_progressive_balances_cache",
+            "Time required to build the progressive balances cache",
+        )
+    });
+
 /*
  * Participation Metrics (progressive balances)
  */

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -420,8 +420,7 @@ pub fn prune_states<E: EthSpec>(
     // correct network, and that we don't end up storing the wrong genesis state.
     let genesis_from_db = db
         .load_cold_state_by_slot(Slot::new(0))
-        .map_err(|e| format!("Error reading genesis state: {e:?}"))?
-        .ok_or("Error: genesis state missing from database. Check schema version.")?;
+        .map_err(|e| format!("Error reading genesis state: {e:?}"))?;
 
     if genesis_from_db.genesis_validators_root() != genesis_state.genesis_validators_root() {
         return Err(format!(

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1886,12 +1886,29 @@ fn state_cache_size_flag() {
         .run_with_zero_port()
         .with_config(|config| assert_eq!(config.store.state_cache_size, new_non_zero_usize(64)));
 }
-// This flag is deprecated but should not cause a crash.
 #[test]
 fn historic_state_cache_size_flag() {
     CommandLineTest::new()
         .flag("historic-state-cache-size", Some("4"))
-        .run_with_zero_port();
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.store.historic_state_cache_size,
+                new_non_zero_usize(4)
+            )
+        });
+}
+#[test]
+fn historic_state_cache_size_default() {
+    use beacon_node::beacon_chain::store::config::DEFAULT_HISTORIC_STATE_CACHE_SIZE;
+    CommandLineTest::new()
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(
+                config.store.historic_state_cache_size,
+                DEFAULT_HISTORIC_STATE_CACHE_SIZE
+            );
+        });
 }
 #[test]
 fn hdiff_buffer_cache_size_flag() {


### PR DESCRIPTION
## Proposed Changes

Attempt to unify the new HDiffBuffer cache with the old "historic state cache" by creating a cache that holds either or both kinds of states, and lazily converts between the formats as required.

## Additional Info

Performance testing on mainnet with `--hierarchy-exponents 5,7,11` shows much improved performance for sequential queries. Most queries after the first are served in 400-700ms.
