### PR TITLE
Optimization to Redb slasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6797,9 +6797,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.1.2"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58323dc32ea52a8ae105ff94bc0460c5d906307533ba3401aa63db3cbe491fe5"
+checksum = "074373f3e7e5d27d8741d19512232adb47be8622d3daef3a45bcae72050c3d2a"
 dependencies = [
  "libc",
 ]

--- a/slasher/Cargo.toml
+++ b/slasher/Cargo.toml
@@ -37,7 +37,7 @@ mdbx = { package = "libmdbx", git = "https://github.com/sigp/libmdbx-rs", rev = 
 lmdb-rkv = { git = "https://github.com/sigp/lmdb-rs", rev = "f33845c6469b94265319aac0ed5085597862c27e", optional = true }
 lmdb-rkv-sys = { git = "https://github.com/sigp/lmdb-rs", rev = "f33845c6469b94265319aac0ed5085597862c27e", optional = true }
 
-redb = { version = "2.1", optional = true }
+redb = { version = "2.1.4", optional = true }
 
 [dev-dependencies]
 maplit = { workspace = true }

--- a/slasher/src/database/redb_impl.rs
+++ b/slasher/src/database/redb_impl.rs
@@ -165,12 +165,10 @@ impl<'env> Cursor<'env> {
             TableDefinition::new(&self.db.table_name);
         let table = self.txn.open_table(table_definition)?;
         let first = table
-            .iter()?
-            .next()
-            .map(|x| x.map(|(key, _)| key.value().to_vec()));
+            .first()?
+            .map(|(key, _)|  key.value().to_vec());
 
         if let Some(owned_key) = first {
-            let owned_key = owned_key?;
             self.current_key = Some(Cow::from(owned_key));
             Ok(self.current_key.clone())
         } else {
@@ -183,12 +181,10 @@ impl<'env> Cursor<'env> {
             TableDefinition::new(&self.db.table_name);
         let table = self.txn.open_table(table_definition)?;
         let last = table
-            .iter()?
-            .next_back()
-            .map(|x| x.map(|(key, _)| key.value().to_vec()));
+            .last()?
+            .map(|(key, _)| key.value().to_vec());
 
         if let Some(owned_key) = last {
-            let owned_key = owned_key?;
             self.current_key = Some(Cow::from(owned_key));
             return Ok(self.current_key.clone());
         }

--- a/slasher/src/database/redb_impl.rs
+++ b/slasher/src/database/redb_impl.rs
@@ -164,9 +164,7 @@ impl<'env> Cursor<'env> {
         let table_definition: TableDefinition<'_, &[u8], &[u8]> =
             TableDefinition::new(&self.db.table_name);
         let table = self.txn.open_table(table_definition)?;
-        let first = table
-            .first()?
-            .map(|(key, _)|  key.value().to_vec());
+        let first = table.first()?.map(|(key, _)| key.value().to_vec());
 
         if let Some(owned_key) = first {
             self.current_key = Some(Cow::from(owned_key));
@@ -180,9 +178,7 @@ impl<'env> Cursor<'env> {
         let table_definition: TableDefinition<'_, &[u8], &[u8]> =
             TableDefinition::new(&self.db.table_name);
         let table = self.txn.open_table(table_definition)?;
-        let last = table
-            .last()?
-            .map(|(key, _)| key.value().to_vec());
+        let last = table.last()?.map(|(key, _)| key.value().to_vec());
 
         if let Some(owned_key) = last {
             self.current_key = Some(Cow::from(owned_key));


### PR DESCRIPTION
Upgraded to redb 2.1.4 which introduces optimizations to `first()` and `last()`

https://github.com/cberner/redb/releases/tag/v2.1.4

Updated the redb slasher to use those methods instead of using `iter().next()` and `iter().next_back()`