### PR TITLE
Simplify hashing in shuffling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
-alloy-primitives = "0.8"
+alloy-primitives = { version = "0.8", features = ["rlp", "getrandom"] }
 alloy-rlp = "0.3.4"
 alloy-consensus = "0.3.0"
 anyhow = "1"

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-full: cargo-fmt test-release test-debug test-ef test-exec-engine
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	cargo clippy --workspace --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
+	cargo clippy --workspace --benches --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D clippy::manual_let_else \
 		-D clippy::large_stack_frames \

--- a/consensus/swap_or_not_shuffle/Cargo.toml
+++ b/consensus/swap_or_not_shuffle/Cargo.toml
@@ -18,4 +18,3 @@ fixed_bytes = { workspace = true }
 
 [features]
 arbitrary = ["alloy-primitives/arbitrary"]
-getrandom = ["alloy-primitives/getrandom"]

--- a/consensus/swap_or_not_shuffle/src/shuffle_list.rs
+++ b/consensus/swap_or_not_shuffle/src/shuffle_list.rs
@@ -45,7 +45,7 @@ impl Buf {
 
     /// Hash the entire buffer.
     fn hash(&self) -> Hash256 {
-        Hash256::from_slice(&hash_fixed(&self.0))
+        Hash256::from(hash_fixed(&self.0))
     }
 }
 

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -9,7 +9,7 @@ name = "benches"
 harness = false
 
 [dependencies]
-alloy-primitives = { workspace = true, features = ["rlp", "getrandom"] }
+alloy-primitives = { workspace = true }
 merkle_proof = { workspace = true }
 bls = { workspace = true, features = ["arbitrary"] }
 kzg = { workspace = true }

--- a/consensus/types/benches/benches.rs
+++ b/consensus/types/benches/benches.rs
@@ -78,7 +78,7 @@ fn all_benches(c: &mut Criterion) {
                 || (bytes.clone(), spec.clone()),
                 |(bytes, spec)| {
                     let state: BeaconState<MainnetEthSpec> =
-                        BeaconState::from_ssz_bytes(&bytes, &spec).expect("should decode");
+                        BeaconState::from_ssz_bytes(bytes, spec).expect("should decode");
                     black_box(state)
                 },
                 BatchSize::SmallInput,

--- a/crypto/kzg/benches/benchmark.rs
+++ b/crypto/kzg/benches/benchmark.rs
@@ -8,7 +8,7 @@ pub fn bench_init_context(c: &mut Criterion) {
         .map_err(|e| format!("Unable to read trusted setup file: {}", e))
         .expect("should have trusted setup");
 
-    c.bench_function(&format!("Initialize context rust_eth_kzg"), |b| {
+    c.bench_function("Initialize context rust_eth_kzg", |b| {
         b.iter(|| {
             let trusted_setup = PeerDASTrustedSetup::from(&trusted_setup);
             DASContext::new(
@@ -19,7 +19,7 @@ pub fn bench_init_context(c: &mut Criterion) {
             )
         })
     });
-    c.bench_function(&format!("Initialize context c-kzg (4844)"), |b| {
+    c.bench_function("Initialize context c-kzg (4844)", |b| {
         b.iter(|| {
             let trusted_setup: TrustedSetup =
                 serde_json::from_reader(get_trusted_setup().as_slice())


### PR DESCRIPTION
## Proposed Changes

Remove some bounds checks from `swap_or_not_shuffle` by using the infallible method `Hash256::from` rather than `Hash256::from_slice` which does runtime checks and can panic.

This didn't seem to make a difference to the benchmarks, but I think it's a nice cleanup regardless.
