### PR TITLE
Trigger sampling after gossip block is execution valid

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -1460,20 +1460,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let block = verified_block.block.block_cloned();
         let block_root = verified_block.block_root;
 
-        // TODO(das) Might be too early to issue a request here. We haven't checked that the block
-        // actually includes blob transactions and thus has data. A peer could send a block is
-        // garbage commitments, and make us trigger sampling for a block that does not have data.
-        if block.num_expected_blobs() > 0 {
-            // Trigger sampling for block not yet execution valid. At this point column custodials are
-            // unlikely to have received their columns. Triggering sampling so early is only viable with
-            // either:
-            // - Sync delaying sampling until some latter window
-            // - Re-processing early sampling requests: https://github.com/sigp/lighthouse/pull/5569
-            if self.chain.should_sample_slot(block.slot()) {
-                self.send_sync_message(SyncMessage::SampleBlock(block_root, block.slot()));
-            }
-        }
-
         let result = self
             .chain
             .process_block_with_early_caching(
@@ -1483,6 +1469,22 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 NotifyExecutionLayer::Yes,
             )
             .await;
+
+        // Block imported or block is execution valid and waiting for components
+        if result.is_ok() {
+            // Issue sampling request here and not before to ensure that the block is correct and
+            // actually has data. A peer could send a block is garbage commitments, and make us
+            // trigger sampling for a block that does not have data.
+            if block.num_expected_blobs() > 0 {
+                // At this point column custodials are unlikely to have received their columns.
+                // Triggering sampling so early is only viable with either:
+                // - Sync delaying sampling until some latter window
+                // - Re-processing early sampling requests: https://github.com/sigp/lighthouse/pull/5569
+                if self.chain.should_sample_slot(block.slot()) {
+                    self.send_sync_message(SyncMessage::SampleBlock(block_root, block.slot()));
+                }
+            }
+        }
 
         match &result {
             Ok(AvailabilityProcessingStatus::Imported(block_root)) => {


### PR DESCRIPTION
## Issue Addressed

Resolve a PeerDAS todo

## Proposed Changes

Wait for a gossip block to be execution valid before triggering sampling. Otherwise, the block might have invalid transactions and trigger us to ask peers for data that does not exist. However, a proposer could still include valid blob transactions and withhold data, causing the same situation. Since gossip blocks are proposer signature valid, we have some DOS protection.

I'm 50/50 on this change being necessary, thoughts?


