### PR TITLE
Strict match of errors in backfill sync

### DIFF
--- a/beacon_node/beacon_chain/src/errors.rs
+++ b/beacon_node/beacon_chain/src/errors.rs
@@ -4,7 +4,6 @@ use crate::beacon_chain::ForkChoiceError;
 use crate::beacon_fork_choice_store::Error as ForkChoiceStoreError;
 use crate::data_availability_checker::AvailabilityCheckError;
 use crate::eth1_chain::Error as Eth1ChainError;
-use crate::historical_blocks::HistoricalBlockError;
 use crate::migrate::PruningError;
 use crate::naive_aggregation_pool::Error as NaiveAggregationError;
 use crate::observed_aggregates::Error as ObservedAttestationsError;
@@ -123,7 +122,11 @@ pub enum BeaconChainError {
         block_slot: Slot,
         state_slot: Slot,
     },
-    HistoricalBlockError(HistoricalBlockError),
+    /// Block is not available (only returned when fetching historic blocks).
+    HistoricalBlockOutOfRange {
+        slot: Slot,
+        oldest_block_slot: Slot,
+    },
     InvalidStateForShuffling {
         state_epoch: Epoch,
         shuffling_epoch: Epoch,
@@ -245,7 +248,6 @@ easy_from_to!(BlockSignatureVerifierError, BeaconChainError);
 easy_from_to!(PruningError, BeaconChainError);
 easy_from_to!(ArithError, BeaconChainError);
 easy_from_to!(ForkChoiceStoreError, BeaconChainError);
-easy_from_to!(HistoricalBlockError, BeaconChainError);
 easy_from_to!(StateAdvanceError, BeaconChainError);
 easy_from_to!(BlockReplayError, BeaconChainError);
 easy_from_to!(InconsistentFork, BeaconChainError);

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -2830,9 +2830,7 @@ async fn weak_subjectivity_sync_test(slots: Vec<Slot>, checkpoint_slot: Slot) {
     // Forwards iterator from 0 should fail as we lack blocks.
     assert!(matches!(
         beacon_chain.forwards_iter_block_roots(Slot::new(0)),
-        Err(BeaconChainError::HistoricalBlockError(
-            HistoricalBlockError::BlockOutOfRange { .. }
-        ))
+        Err(BeaconChainError::HistoricalBlockOutOfRange { .. })
     ));
 
     // Simulate processing of a `StatusMessage` with an older finalized epoch by calling
@@ -2900,7 +2898,7 @@ async fn weak_subjectivity_sync_test(slots: Vec<Slot>, checkpoint_slot: Slot) {
         beacon_chain
             .import_historical_block_batch(batch_with_invalid_first_block)
             .unwrap_err(),
-        BeaconChainError::HistoricalBlockError(HistoricalBlockError::InvalidSignature)
+        HistoricalBlockError::InvalidSignature
     ));
 
     // Importing the batch with valid signatures should succeed.

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -2,7 +2,7 @@ use crate::network_beacon_processor::{NetworkBeaconProcessor, FUTURE_SLOT_TOLERA
 use crate::service::NetworkMessage;
 use crate::status::ToStatusMessage;
 use crate::sync::SyncMessage;
-use beacon_chain::{BeaconChainError, BeaconChainTypes, HistoricalBlockError, WhenSlotSkipped};
+use beacon_chain::{BeaconChainError, BeaconChainTypes, WhenSlotSkipped};
 use itertools::process_results;
 use lighthouse_network::discovery::ConnectionId;
 use lighthouse_network::rpc::methods::{
@@ -682,12 +682,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .forwards_iter_block_roots(Slot::from(*req.start_slot()))
         {
             Ok(iter) => iter,
-            Err(BeaconChainError::HistoricalBlockError(
-                HistoricalBlockError::BlockOutOfRange {
-                    slot,
-                    oldest_block_slot,
-                },
-            )) => {
+            Err(BeaconChainError::HistoricalBlockOutOfRange {
+                slot,
+                oldest_block_slot,
+            }) => {
                 debug!(self.log, "Range request failed during backfill";
                     "requested_slot" => slot,
                     "oldest_known_slot" => oldest_block_slot
@@ -941,12 +939,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let forwards_block_root_iter =
             match self.chain.forwards_iter_block_roots(request_start_slot) {
                 Ok(iter) => iter,
-                Err(BeaconChainError::HistoricalBlockError(
-                    HistoricalBlockError::BlockOutOfRange {
-                        slot,
-                        oldest_block_slot,
-                    },
-                )) => {
+                Err(BeaconChainError::HistoricalBlockOutOfRange {
+                    slot,
+                    oldest_block_slot,
+                }) => {
                     debug!(self.log, "Range request failed during backfill";
                         "requested_slot" => slot,
                         "oldest_known_slot" => oldest_block_slot
@@ -1147,12 +1143,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         let forwards_block_root_iter =
             match self.chain.forwards_iter_block_roots(request_start_slot) {
                 Ok(iter) => iter,
-                Err(BeaconChainError::HistoricalBlockError(
-                    HistoricalBlockError::BlockOutOfRange {
-                        slot,
-                        oldest_block_slot,
-                    },
-                )) => {
+                Err(BeaconChainError::HistoricalBlockOutOfRange {
+                    slot,
+                    oldest_block_slot,
+                }) => {
                     debug!(self.log, "Range request failed during backfill";
                         "requested_slot" => slot,
                         "oldest_known_slot" => oldest_block_slot


### PR DESCRIPTION
## Issue Addressed

Same spirit as
- https://github.com/sigp/lighthouse/pull/6321

Handling errors in sync with a fallback match is not great. In the case of backfill sync it's very easy to fix! =D 

> (tangent) Noting a chat with @pawanjay176 in https://github.com/sigp/lighthouse/pull/6321 `BeaconChainError` actually includes errors that are not internal. In this case it was some of the variants of `HistoricalBlockError`.. I'll review `BeaconChainError` to double check there's no other hidden scorable variants.

## Proposed Changes

Turns out that its processing returns almost only variants of `HistoricalBlockError`, so I changed `import_historical_block_batch` to return `HistoricalBlockError` instead of `BeaconChainError`.

All logic is the same, just made the match on network beacon processor cleaner a bit cleaner.
