### PR TITLE
Strict match of errors in range sync

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -10,7 +10,6 @@ pub enum Error {
         blob_commitment: KzgCommitment,
         block_commitment: KzgCommitment,
     },
-    UnableToDetermineImportRequirement,
     Unexpected,
     SszTypes(ssz_types::Error),
     MissingBlobs,
@@ -44,7 +43,6 @@ impl Error {
             | Error::Unexpected
             | Error::ParentStateMissing(_)
             | Error::BlockReplayError(_)
-            | Error::UnableToDetermineImportRequirement
             | Error::RebuildingStateCaches(_)
             | Error::SlotClockError => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }


### PR DESCRIPTION
## Issue Addressed

Same spirit as
- https://github.com/sigp/lighthouse/pull/6321

Handling errors in sync with a fallback match is not great. Range sync requires a big match like lookup sync.

## Proposed Changes

Explicitly match all variants of `BlockError` in range sync. 

Marked as draft to gather feedback on the correctness of my assumptions on what to match each variant to.
