### PR TITLE
VC: use block publication v2 SSZ API

### DIFF
--- a/validator_client/src/block_service.rs
+++ b/validator_client/src/block_service.rs
@@ -525,7 +525,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                     &[metrics::BEACON_BLOCK_HTTP_POST],
                 );
                 beacon_node
-                    .post_beacon_blocks(signed_block)
+                    .post_beacon_blocks_v2_ssz(signed_block, None)
                     .await
                     .or_else(|e| handle_block_post_error(e, slot, log))?
             }
@@ -535,7 +535,7 @@ impl<T: SlotClock + 'static, E: EthSpec> BlockService<T, E> {
                     &[metrics::BLINDED_BEACON_BLOCK_HTTP_POST],
                 );
                 beacon_node
-                    .post_beacon_blinded_blocks(signed_block)
+                    .post_beacon_blinded_blocks_v2_ssz(signed_block, None)
                     .await
                     .or_else(|e| handle_block_post_error(e, slot, log))?
             }


### PR DESCRIPTION
## Issue Addressed

Prepare for the removal of the v1 block publishing API:

- https://github.com/ethereum/beacon-APIs/pull/467

## Proposed Changes

Switch the VC over to using the v2 version of the block publication API, with the default `broadcast_validation=gossip` (equivalent to current behaviour).

While making the change, I think we should also switch to sending SSZ rather than JSON. This should be slightly quicker for the BN to decode.

## Testing

The simulator tests cover the interaction between current versions of the Lighthouse VC and BN. We can conduct further testing as part of the v6.0.0 release rollout on testnet infra.

## Additional Info

We _could_ guard the use of SSZ behind a new flag, but this feels somewhat unnecessary. Lighthouse BN has no issue with SSZ, and other clients have also supported it on this endpoint for a long time. This change is somewhat overdue.