### PR TITLE
Penalize peer if missing blobs

### DIFF
--- a/beacon_node/beacon_chain/src/data_availability_checker/error.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/error.rs
@@ -37,8 +37,6 @@ impl Error {
     pub fn category(&self) -> ErrorCategory {
         match self {
             Error::SszTypes(_)
-            | Error::MissingBlobs
-            | Error::MissingCustodyColumns
             | Error::StoreError(_)
             | Error::DecodeError(_)
             | Error::Unexpected
@@ -49,6 +47,8 @@ impl Error {
             | Error::SlotClockError => ErrorCategory::Internal,
             Error::InvalidBlobs { .. }
             | Error::InvalidColumn { .. }
+            | Error::MissingBlobs
+            | Error::MissingCustodyColumns
             | Error::ReconstructColumnsError { .. }
             | Error::BlobIndexInvalid(_)
             | Error::DataColumnIndexInvalid(_)


### PR DESCRIPTION
## Issue Addressed

During range sync, if a peer replies with empty blobs we do not downscore that peer. We should.

## Proposed Changes

Downscore peer if we can't match block and data when constructing an RpcBlock

The PRs below also move these two variants into not being internal
- https://github.com/sigp/lighthouse/pull/6521
- https://github.com/sigp/lighthouse/pull/6321


