### PR TITLE
Fix BlobsByRange by reverting PR6462

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -28,7 +28,7 @@ const CONTEXT_BYTES_LEN: usize = 4;
 
 /* Inbound Codec */
 
-pub struct SSZSnappyInboundCodec<E> {
+pub struct SSZSnappyInboundCodec<E: EthSpec> {
     protocol: ProtocolId,
     inner: Uvi<usize>,
     len: Option<usize>,
@@ -143,7 +143,7 @@ impl<E: EthSpec> Encoder<RpcResponse<E>> for SSZSnappyInboundCodec<E> {
 
 // Decoder for inbound streams: Decodes RPC requests from peers
 impl<E: EthSpec> Decoder for SSZSnappyInboundCodec<E> {
-    type Item = RequestType;
+    type Item = RequestType<E>;
     type Error = RPCError;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
@@ -195,7 +195,7 @@ impl<E: EthSpec> Decoder for SSZSnappyInboundCodec<E> {
 }
 
 /* Outbound Codec: Codec for initiating RPC requests */
-pub struct SSZSnappyOutboundCodec<E> {
+pub struct SSZSnappyOutboundCodec<E: EthSpec> {
     inner: Uvi<usize>,
     len: Option<usize>,
     protocol: ProtocolId,
@@ -322,10 +322,10 @@ impl<E: EthSpec> SSZSnappyOutboundCodec<E> {
 }
 
 // Encoder for outbound streams: Encodes RPC Requests to peers
-impl<E: EthSpec> Encoder<RequestType> for SSZSnappyOutboundCodec<E> {
+impl<E: EthSpec> Encoder<RequestType<E>> for SSZSnappyOutboundCodec<E> {
     type Error = RPCError;
 
-    fn encode(&mut self, item: RequestType, dst: &mut BytesMut) -> Result<(), Self::Error> {
+    fn encode(&mut self, item: RequestType<E>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         let bytes = match item {
             RequestType::Status(req) => req.as_ssz_bytes(),
             RequestType::Goodbye(req) => req.as_ssz_bytes(),
@@ -549,11 +549,11 @@ fn handle_length(
 /// Decodes an `InboundRequest` from the byte stream.
 /// `decoded_buffer` should be an ssz-encoded bytestream with
 // length = length-prefix received in the beginning of the stream.
-fn handle_rpc_request(
+fn handle_rpc_request<E: EthSpec>(
     versioned_protocol: SupportedProtocol,
     decoded_buffer: &[u8],
     spec: &ChainSpec,
-) -> Result<Option<RequestType>, RPCError> {
+) -> Result<Option<RequestType<E>>, RPCError> {
     match versioned_protocol {
         SupportedProtocol::StatusV1 => Ok(Some(RequestType::Status(
             StatusMessage::from_ssz_bytes(decoded_buffer)?,
@@ -1035,7 +1035,6 @@ mod tests {
         BlobsByRangeRequest {
             start_slot: 0,
             count: 10,
-            max_blobs_per_block: Spec::max_blobs_per_block(),
         }
     }
 
@@ -1181,7 +1180,7 @@ mod tests {
     }
 
     /// Verifies that requests we send are encoded in a way that we would correctly decode too.
-    fn encode_then_decode_request(req: RequestType, fork_name: ForkName, spec: &ChainSpec) {
+    fn encode_then_decode_request(req: RequestType<Spec>, fork_name: ForkName, spec: &ChainSpec) {
         let fork_context = Arc::new(fork_context(fork_name));
         let max_packet_size = max_rpc_size(&fork_context, spec.max_chunk_size as usize);
         let protocol = ProtocolId::new(req.versioned_protocol(), Encoding::SSZSnappy);
@@ -1778,7 +1777,7 @@ mod tests {
     fn test_encode_then_decode_request() {
         let chain_spec = Spec::default_spec();
 
-        let requests: &[RequestType] = &[
+        let requests: &[RequestType<Spec>] = &[
             RequestType::Ping(ping_message()),
             RequestType::Status(status_message()),
             RequestType::Goodbye(GoodbyeReason::Fault),

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -8,6 +8,7 @@ use ssz_derive::{Decode, Encode};
 use ssz_types::{typenum::U256, VariableList};
 use std::collections::BTreeMap;
 use std::fmt::Display;
+use std::marker::PhantomData;
 use std::ops::Deref;
 use std::sync::Arc;
 use strum::IntoStaticStr;
@@ -93,19 +94,27 @@ pub struct Ping {
     variant_attributes(derive(Clone, Debug, PartialEq, Serialize),)
 )]
 #[derive(Clone, Debug, PartialEq)]
-pub struct MetadataRequest;
+pub struct MetadataRequest<E: EthSpec> {
+    _phantom_data: PhantomData<E>,
+}
 
-impl MetadataRequest {
+impl<E: EthSpec> MetadataRequest<E> {
     pub fn new_v1() -> Self {
-        Self::V1(MetadataRequestV1 {})
+        Self::V1(MetadataRequestV1 {
+            _phantom_data: PhantomData,
+        })
     }
 
     pub fn new_v2() -> Self {
-        Self::V2(MetadataRequestV2 {})
+        Self::V2(MetadataRequestV2 {
+            _phantom_data: PhantomData,
+        })
     }
 
     pub fn new_v3() -> Self {
-        Self::V3(MetadataRequestV3 {})
+        Self::V3(MetadataRequestV3 {
+            _phantom_data: PhantomData,
+        })
     }
 }
 
@@ -315,14 +324,11 @@ pub struct BlobsByRangeRequest {
 
     /// The number of slots from the start slot.
     pub count: u64,
-
-    /// maximum number of blobs in a single block.
-    pub max_blobs_per_block: usize,
 }
 
 impl BlobsByRangeRequest {
-    pub fn max_blobs_requested(&self) -> u64 {
-        self.count.saturating_mul(self.max_blobs_per_block as u64)
+    pub fn max_blobs_requested<E: EthSpec>(&self) -> u64 {
+        self.count.saturating_mul(E::max_blobs_per_block() as u64)
     }
 }
 
@@ -338,7 +344,7 @@ pub struct DataColumnsByRangeRequest {
 }
 
 impl DataColumnsByRangeRequest {
-    pub fn max_requested(&self) -> u64 {
+    pub fn max_requested<E: EthSpec>(&self) -> u64 {
         self.count.saturating_mul(self.columns.len() as u64)
     }
 

--- a/beacon_node/lighthouse_network/src/rpc/mod.rs
+++ b/beacon_node/lighthouse_network/src/rpc/mod.rs
@@ -61,7 +61,7 @@ pub enum RPCSend<Id, E: EthSpec> {
     ///
     /// The `Id` is given by the application making the request. These
     /// go over *outbound* connections.
-    Request(Id, RequestType),
+    Request(Id, RequestType<E>),
     /// A response sent from Lighthouse.
     ///
     /// The `SubstreamId` must correspond to the RPC-given ID of the original request received from the
@@ -79,7 +79,7 @@ pub enum RPCReceived<Id, E: EthSpec> {
     ///
     /// The `SubstreamId` is given by the `RPCHandler` as it identifies this request with the
     /// *inbound* substream over which it is managed.
-    Request(Request),
+    Request(Request<E>),
     /// A response received from the outside.
     ///
     /// The `Id` corresponds to the application given ID of the original request sent to the
@@ -113,10 +113,10 @@ impl RequestId {
 
 /// An Rpc Request.
 #[derive(Debug, Clone)]
-pub struct Request {
+pub struct Request<E: EthSpec> {
     pub id: RequestId,
     pub substream_id: SubstreamId,
-    pub r#type: RequestType,
+    pub r#type: RequestType<E>,
 }
 
 impl<E: EthSpec, Id: std::fmt::Debug> std::fmt::Display for RPCSend<Id, E> {
@@ -221,7 +221,7 @@ impl<Id: ReqId, E: EthSpec> RPC<Id, E> {
     /// Submits an RPC request.
     ///
     /// The peer must be connected for this to succeed.
-    pub fn send_request(&mut self, peer_id: PeerId, request_id: Id, req: RequestType) {
+    pub fn send_request(&mut self, peer_id: PeerId, request_id: Id, req: RequestType<E>) {
         let event = if let Some(self_limiter) = self.self_limiter.as_mut() {
             match self_limiter.allows(peer_id, request_id, req) {
                 Ok(event) => event,

--- a/beacon_node/lighthouse_network/src/rpc/outbound.rs
+++ b/beacon_node/lighthouse_network/src/rpc/outbound.rs
@@ -7,7 +7,6 @@ use futures::future::BoxFuture;
 use futures::prelude::{AsyncRead, AsyncWrite};
 use futures::{FutureExt, SinkExt};
 use libp2p::core::{OutboundUpgrade, UpgradeInfo};
-use std::marker::PhantomData;
 use std::sync::Arc;
 use tokio_util::{
     codec::Framed,
@@ -20,14 +19,13 @@ use types::{EthSpec, ForkContext};
 // `OutboundUpgrade`
 
 #[derive(Debug, Clone)]
-pub struct OutboundRequestContainer<E> {
-    pub req: RequestType,
+pub struct OutboundRequestContainer<E: EthSpec> {
+    pub req: RequestType<E>,
     pub fork_context: Arc<ForkContext>,
     pub max_rpc_size: usize,
-    pub phantom: PhantomData<E>,
 }
 
-impl<E> UpgradeInfo for OutboundRequestContainer<E> {
+impl<E: EthSpec> UpgradeInfo for OutboundRequestContainer<E> {
     type Info = ProtocolId;
     type InfoIter = Vec<Self::Info>;
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -686,7 +686,7 @@ pub fn rpc_data_column_limits<E: EthSpec>() -> RpcLimits {
 // The inbound protocol reads the request, decodes it and returns the stream to the protocol
 // handler to respond to once ready.
 
-pub type InboundOutput<TSocket, E> = (RequestType, InboundFramed<TSocket, E>);
+pub type InboundOutput<TSocket, E> = (RequestType<E>, InboundFramed<TSocket, E>);
 pub type InboundFramed<TSocket, E> =
     Framed<std::pin::Pin<Box<TimeoutStream<Compat<TSocket>>>>, SSZSnappyInboundCodec<E>>;
 
@@ -754,7 +754,7 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum RequestType {
+pub enum RequestType<E: EthSpec> {
     Status(StatusMessage),
     Goodbye(GoodbyeReason),
     BlocksByRange(OldBlocksByRangeRequest),
@@ -768,11 +768,11 @@ pub enum RequestType {
     LightClientFinalityUpdate,
     LightClientUpdatesByRange(LightClientUpdatesByRangeRequest),
     Ping(Ping),
-    MetaData(MetadataRequest),
+    MetaData(MetadataRequest<E>),
 }
 
 /// Implements the encoding per supported protocol for `RPCRequest`.
-impl RequestType {
+impl<E: EthSpec> RequestType<E> {
     /* These functions are used in the handler for stream management */
 
     /// Maximum number of responses expected for this request.
@@ -782,10 +782,10 @@ impl RequestType {
             RequestType::Goodbye(_) => 0,
             RequestType::BlocksByRange(req) => *req.count(),
             RequestType::BlocksByRoot(req) => req.block_roots().len() as u64,
-            RequestType::BlobsByRange(req) => req.max_blobs_requested(),
+            RequestType::BlobsByRange(req) => req.max_blobs_requested::<E>(),
             RequestType::BlobsByRoot(req) => req.blob_ids.len() as u64,
             RequestType::DataColumnsByRoot(req) => req.data_column_ids.len() as u64,
-            RequestType::DataColumnsByRange(req) => req.max_requested(),
+            RequestType::DataColumnsByRange(req) => req.max_requested::<E>(),
             RequestType::Ping(_) => 1,
             RequestType::MetaData(_) => 1,
             RequestType::LightClientBootstrap(_) => 1,
@@ -1027,7 +1027,7 @@ impl std::error::Error for RPCError {
     }
 }
 
-impl std::fmt::Display for RequestType {
+impl<E: EthSpec> std::fmt::Display for RequestType<E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             RequestType::Status(status) => write!(f, "Status Message: {}", status),

--- a/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/rate_limiter.rs
@@ -9,6 +9,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tokio::time::Interval;
+use types::EthSpec;
 
 /// Nanoseconds since a given time.
 // Maintained as u64 to reduce footprint
@@ -261,7 +262,7 @@ pub trait RateLimiterItem {
     fn max_responses(&self) -> u64;
 }
 
-impl RateLimiterItem for super::RequestType {
+impl<E: EthSpec> RateLimiterItem for super::RequestType<E> {
     fn protocol(&self) -> Protocol {
         self.versioned_protocol().protocol()
     }

--- a/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
@@ -19,8 +19,8 @@ use super::{
 
 /// A request that was rate limited or waiting on rate limited requests for the same peer and
 /// protocol.
-struct QueuedRequest<Id: ReqId> {
-    req: RequestType,
+struct QueuedRequest<Id: ReqId, E: EthSpec> {
+    req: RequestType<E>,
     request_id: Id,
 }
 
@@ -28,7 +28,7 @@ pub(crate) struct SelfRateLimiter<Id: ReqId, E: EthSpec> {
     /// Requests queued for sending per peer. This requests are stored when the self rate
     /// limiter rejects them. Rate limiting is based on a Peer and Protocol basis, therefore
     /// are stored in the same way.
-    delayed_requests: HashMap<(PeerId, Protocol), VecDeque<QueuedRequest<Id>>>,
+    delayed_requests: HashMap<(PeerId, Protocol), VecDeque<QueuedRequest<Id, E>>>,
     /// The delay required to allow a peer's outbound request per protocol.
     next_peer_request: DelayQueue<(PeerId, Protocol)>,
     /// Rate limiter for our own requests.
@@ -70,7 +70,7 @@ impl<Id: ReqId, E: EthSpec> SelfRateLimiter<Id, E> {
         &mut self,
         peer_id: PeerId,
         request_id: Id,
-        req: RequestType,
+        req: RequestType<E>,
     ) -> Result<BehaviourAction<Id, E>, Error> {
         let protocol = req.versioned_protocol().protocol();
         // First check that there are not already other requests waiting to be sent.
@@ -101,9 +101,9 @@ impl<Id: ReqId, E: EthSpec> SelfRateLimiter<Id, E> {
         limiter: &mut RateLimiter,
         peer_id: PeerId,
         request_id: Id,
-        req: RequestType,
+        req: RequestType<E>,
         log: &Logger,
-    ) -> Result<BehaviourAction<Id, E>, (QueuedRequest<Id>, Duration)> {
+    ) -> Result<BehaviourAction<Id, E>, (QueuedRequest<Id, E>, Duration)> {
         match limiter.allows(&peer_id, &req) {
             Ok(()) => Ok(BehaviourAction::NotifyHandler {
                 peer_id,

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -80,7 +80,7 @@ pub enum NetworkEvent<E: EthSpec> {
         /// Identifier of the request. All responses to this request must use this id.
         id: PeerRequestId,
         /// Request the peer sent.
-        request: rpc::Request,
+        request: rpc::Request<E>,
     },
     ResponseReceived {
         /// Peer that sent the response.
@@ -966,7 +966,7 @@ impl<E: EthSpec> Network<E> {
         &mut self,
         peer_id: PeerId,
         request_id: AppRequestId,
-        request: RequestType,
+        request: RequestType<E>,
     ) -> Result<(), (AppRequestId, RPCError)> {
         // Check if the peer is connected before sending an RPC request
         if !self.swarm.is_connected(&peer_id) {
@@ -1179,7 +1179,7 @@ impl<E: EthSpec> Network<E> {
     /// Sends a METADATA response to a peer.
     fn send_meta_data_response(
         &mut self,
-        _req: MetadataRequest,
+        _req: MetadataRequest<E>,
         id: PeerRequestId,
         request_id: rpc::RequestId,
         peer_id: PeerId,

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -327,7 +327,6 @@ fn test_blobs_by_range_chunked_rpc() {
         let rpc_request = RequestType::BlobsByRange(BlobsByRangeRequest {
             start_slot: 0,
             count: slot_count,
-            max_blobs_per_block: E::max_blobs_per_block(),
         });
 
         // BlocksByRange Response

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -893,7 +893,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         );
 
         // Should not send more than max request blocks
-        if req.max_blobs_requested() > self.chain.spec.max_request_blob_sidecars {
+        if req.max_blobs_requested::<T::EthSpec>() > self.chain.spec.max_request_blob_sidecars {
             return Err((
                 RpcErrorResponse::InvalidRequest,
                 "Request exceeded `MAX_REQUEST_BLOBS_SIDECARS`",
@@ -1098,7 +1098,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         );
 
         // Should not send more than max request data columns
-        if req.max_requested() > self.chain.spec.max_request_data_column_sidecars {
+        if req.max_requested::<T::EthSpec>() > self.chain.spec.max_request_data_column_sidecars {
             return Err((
                 RpcErrorResponse::InvalidRequest,
                 "Request exceeded `MAX_REQUEST_BLOBS_SIDECARS`",

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -30,9 +30,9 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use types::blob_sidecar::FixedBlobSidecarList;
 use types::{
-    Attestation, AttesterSlashing, BlobSidecar, BlobSidecarList, Epoch, EthSpec, Hash256,
-    MainnetEthSpec, ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock,
-    SignedVoluntaryExit, Slot, SubnetId,
+    Attestation, AttesterSlashing, BlobSidecar, BlobSidecarList, Epoch, Hash256, MainnetEthSpec,
+    ProposerSlashing, SignedAggregateAndProof, SignedBeaconBlock, SignedVoluntaryExit, Slot,
+    SubnetId,
 };
 
 type E = MainnetEthSpec;
@@ -366,7 +366,6 @@ impl TestRig {
                 BlobsByRangeRequest {
                     start_slot: 0,
                     count,
-                    max_blobs_per_block: E::max_blobs_per_block(),
                 },
             )
             .unwrap();

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -58,7 +58,7 @@ pub enum RouterMessage<E: EthSpec> {
     RPCRequestReceived {
         peer_id: PeerId,
         id: PeerRequestId,
-        request: rpc::Request,
+        request: rpc::Request<E>,
     },
     /// An RPC response has been received.
     RPCResponseReceived {
@@ -193,11 +193,11 @@ impl<T: BeaconChainTypes> Router<T> {
     /* RPC - Related functionality */
 
     /// A new RPC request has been received from the network.
-    fn handle_rpc_request(
+    fn handle_rpc_request<E: EthSpec>(
         &mut self,
         peer_id: PeerId,
         request_id: PeerRequestId,
-        rpc_request: rpc::Request,
+        rpc_request: rpc::Request<E>,
     ) {
         if !self.network_globals.peers.read().is_connected(&peer_id) {
             debug!(self.log, "Dropping request of disconnected peer"; "peer_id" => %peer_id, "request" => ?rpc_request);
@@ -836,7 +836,7 @@ impl<E: EthSpec> HandlerNetworkContext<E> {
     }
 
     /// Sends a request to the network task.
-    pub fn send_processor_request(&mut self, peer_id: PeerId, request: RequestType) {
+    pub fn send_processor_request(&mut self, peer_id: PeerId, request: RequestType<E>) {
         self.inform_network(NetworkMessage::SendRequest {
             peer_id,
             request_id: AppRequestId::Router,

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -62,7 +62,7 @@ pub enum NetworkMessage<E: EthSpec> {
     /// Send an RPC request to the libp2p service.
     SendRequest {
         peer_id: PeerId,
-        request: RequestType,
+        request: RequestType<E>,
         request_id: AppRequestId,
     },
     /// Send a successful Response to the libp2p service.

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -401,7 +401,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                     request: RequestType::BlobsByRange(BlobsByRangeRequest {
                         start_slot: *request.start_slot(),
                         count: *request.count(),
-                        max_blobs_per_block: T::EthSpec::max_blobs_per_block(),
                     }),
                     request_id: AppRequestId::Sync(SyncRequestId::RangeBlockAndBlobs { id }),
                 })


### PR DESCRIPTION
## Issue Addressed

This reverts PR:

- #6462

That PR accidentally broke `BlobsByRange` requests by adding a non-standard field to the SSZ representation (sent over the network). The result is that peers would not respond to Lighthouse's `BlobsByRange` requests and Lighthouse would be unable to sync.
