### PR TITLE
Use `make cli-local` in CI test suite to remove redundant docker

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -420,7 +420,7 @@ jobs:
         channel: stable
         cache-target: release
     - name: Run Makefile to trigger the bash script
-      run: make cli
+      run: make cli-local
   # This job succeeds ONLY IF all others succeed. It is used by the merge queue to determine whether
   # a PR is safe to merge. New jobs should be added here.
   test-suite-success:

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,9 @@ test-exec-engine:
 # test vectors.
 test: test-release
 
-# Updates the CLI help text pages in the Lighthouse book, building with Docker.
-cli:
-	docker run --rm --user=root \
-	-v ${PWD}:/home/runner/actions-runner/lighthouse sigmaprime/github-runner \
-	bash -c 'cd lighthouse && make && ./scripts/cli.sh'
-
 # Updates the CLI help text pages in the Lighthouse book, building using local
 # `cargo`.
-cli-local:
+cli:
 	make && ./scripts/cli.sh
 
 # Check for markdown files

--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,15 @@ test-exec-engine:
 # test vectors.
 test: test-release
 
+# Updates the CLI help text pages in the Lighthouse book, building with Docker (primarily for window users).
+cli:
+	docker run --rm --user=root \
+	-v ${PWD}:/home/runner/actions-runner/lighthouse sigmaprime/github-runner \
+	bash -c 'cd lighthouse && make && ./scripts/cli.sh'
+
 # Updates the CLI help text pages in the Lighthouse book, building using local
 # `cargo`.
-cli:
+cli-local:
 	make && ./scripts/cli.sh
 
 # Check for markdown files

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ test-exec-engine:
 # test vectors.
 test: test-release
 
-# Updates the CLI help text pages in the Lighthouse book, building with Docker (primarily for window users).
+# Updates the CLI help text pages in the Lighthouse book, building with Docker (primarily for Windows users).
 cli:
 	docker run --rm --user=root \
 	-v ${PWD}:/home/runner/actions-runner/lighthouse sigmaprime/github-runner \

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -2,7 +2,7 @@
 
 # IMPORTANT
 # This script should NOT be run directly.
-# Run `make cli` from the root of the repository instead.
+# Run `make cli` or `make cli-local` from the root of the repository instead.
 
 set -e
 
@@ -90,7 +90,7 @@ rm -f help_general.md help_bn.md help_vc.md help_am.md help_vm.md help_vm_create
 
 # only exit at the very end
 if [[ $changes == true ]]; then
-    echo "Exiting with error to indicate changes occurred. To fix, run 'make cli' and commit the changes."
+    echo "Exiting with error to indicate changes occurred. To fix, run 'make cli-local' or 'make cli' and commit the changes."
     exit 1
 else
     echo "CLI help texts are up to date."

--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -2,7 +2,7 @@
 
 # IMPORTANT
 # This script should NOT be run directly.
-# Run `make cli` or `make cli-local` from the root of the repository instead.
+# Run `make cli` from the root of the repository instead.
 
 set -e
 
@@ -90,7 +90,7 @@ rm -f help_general.md help_bn.md help_vc.md help_am.md help_vm.md help_vm_create
 
 # only exit at the very end
 if [[ $changes == true ]]; then
-    echo "Exiting with error to indicate changes occurred. To fix, run 'make cli-local' or 'make cli' and commit the changes."
+    echo "Exiting with error to indicate changes occurred. To fix, run 'make cli' and commit the changes."
     exit 1
 else
     echo "CLI help texts are up to date."


### PR DESCRIPTION
## Issue Addressed

I noticed that our `cli` job sometimes take quite a while and take a few `docker pull` retries before it completes. This is because it attempts to pull the 2.2 GB `github-runner` image to run the the cli script in a docker container.

I think we can safely replace the `cli` command to run with `cargo` directly instead of running it with a `github-runner` image, as the job runs in a container running the `github-runner` image, so this is a bit redundant and slow. 