### PR TITLE
RequestType::max_responses for LightClientUpdatesByRange

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -791,7 +791,7 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::LightClientBootstrap(_) => 1,
             RequestType::LightClientOptimisticUpdate => 1,
             RequestType::LightClientFinalityUpdate => 1,
-            RequestType::LightClientUpdatesByRange(req) => req.max_requested(),
+            RequestType::LightClientUpdatesByRange(req) => req.count,
         }
     }
 


### PR DESCRIPTION
## Issue Addressed

<!-- Which issue # does this PR address? -->

In case of `RequestType::LightClientUpdatesByRange`, `RequestType::max_responses()` returns  the number that  [`LightClientUpdatesByRangeRequest::max_requested()`](https://github.com/sigp/lighthouse/blob/9aefb5539baff637d68deb3dd386ff45312f3573/beacon_node/lighthouse_network/src/rpc/methods.rs#L491-L493) returns, which is a constant value representing [the maximum number of LightClientUpdate instances in a single request](https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/light-client/p2p-interface.md#configuration). I think it should return the actual number of instances the request requires, instead of the constant value defined in the spec.

<!--
## Proposed Changes

Please list or describe the changes introduced by this PR.

## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->