### PR TITLE
Track beacon processor import result metrics

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -92,6 +92,7 @@ use std::fs;
 use std::io::Write;
 use std::sync::Arc;
 use store::{Error as DBError, HotStateSummary, KeyValueStore, StoreOp};
+use strum::AsRefStr;
 use task_executor::JoinHandle;
 use types::{
     data_column_sidecar::DataColumnSidecarError, BeaconBlockRef, BeaconState, BeaconStateError,
@@ -137,7 +138,7 @@ const WRITE_BLOCK_PROCESSING_SSZ: bool = cfg!(feature = "write_ssz_files");
 ///
 /// - The block is malformed/invalid (indicated by all results other than `BeaconChainError`.
 /// - We encountered an error whilst trying to verify the block (a `BeaconChainError`).
-#[derive(Debug)]
+#[derive(Debug, AsRefStr)]
 pub enum BlockError {
     /// The parent block was unknown.
     ///

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -2,7 +2,8 @@ use beacon_chain::{
     attestation_verification::Error as AttnError,
     light_client_finality_update_verification::Error as LightClientFinalityUpdateError,
     light_client_optimistic_update_verification::Error as LightClientOptimisticUpdateError,
-    sync_committee_verification::Error as SyncCommitteeError,
+    sync_committee_verification::Error as SyncCommitteeError, AvailabilityProcessingStatus,
+    BlockError,
 };
 use fnv::FnvHashMap;
 use lighthouse_network::{
@@ -11,11 +12,18 @@ use lighthouse_network::{
 };
 pub use metrics::*;
 use std::sync::{Arc, LazyLock};
+use strum::AsRefStr;
 use strum::IntoEnumIterator;
 use types::EthSpec;
 
 pub const SUCCESS: &str = "SUCCESS";
 pub const FAILURE: &str = "FAILURE";
+
+#[derive(Debug, AsRefStr)]
+pub(crate) enum BlockSource {
+    Gossip,
+    Rpc,
+}
 
 pub static BEACON_BLOCK_MESH_PEERS_PER_CLIENT: LazyLock<Result<IntGaugeVec>> =
     LazyLock::new(|| {
@@ -56,6 +64,27 @@ pub static SYNC_COMMITTEE_SUBSCRIPTION_REQUESTS: LazyLock<Result<IntCounter>> =
         try_create_int_counter(
             "validator_sync_committee_subnet_subscriptions_total",
             "Count of validator sync committee subscription requests.",
+        )
+    });
+
+/*
+ * Beacon processor
+ */
+pub static BEACON_PROCESSOR_MISSING_COMPONENTS: LazyLock<Result<IntCounterVec>> = LazyLock::new(
+    || {
+        try_create_int_counter_vec(
+            "beacon_processor_missing_components_total",
+            "Total number of imported individual block components that resulted in missing components",
+            &["source", "component"],
+        )
+    },
+);
+pub static BEACON_PROCESSOR_IMPORT_ERRORS_PER_TYPE: LazyLock<Result<IntCounterVec>> =
+    LazyLock::new(|| {
+        try_create_int_counter_vec(
+            "beacon_processor_import_errors_total",
+            "Total number of block components verified",
+            &["source", "component", "type"],
         )
     });
 
@@ -604,6 +633,37 @@ pub fn register_attestation_error(error: &AttnError) {
 
 pub fn register_sync_committee_error(error: &SyncCommitteeError) {
     inc_counter_vec(&GOSSIP_SYNC_COMMITTEE_ERRORS_PER_TYPE, &[error.as_ref()]);
+}
+
+pub(crate) fn register_process_result_metrics(
+    result: &std::result::Result<AvailabilityProcessingStatus, BlockError>,
+    source: BlockSource,
+    block_component: &'static str,
+) {
+    match result {
+        Ok(status) => match status {
+            AvailabilityProcessingStatus::Imported { .. } => match source {
+                BlockSource::Gossip => {
+                    inc_counter(&BEACON_PROCESSOR_GOSSIP_BLOCK_IMPORTED_TOTAL);
+                }
+                BlockSource::Rpc => {
+                    inc_counter(&BEACON_PROCESSOR_RPC_BLOCK_IMPORTED_TOTAL);
+                }
+            },
+            AvailabilityProcessingStatus::MissingComponents { .. } => {
+                inc_counter_vec(
+                    &BEACON_PROCESSOR_MISSING_COMPONENTS,
+                    &[source.as_ref(), block_component],
+                );
+            }
+        },
+        Err(error) => {
+            inc_counter_vec(
+                &BEACON_PROCESSOR_IMPORT_ERRORS_PER_TYPE,
+                &[source.as_ref(), block_component, error.as_ref()],
+            );
+        }
+    }
 }
 
 pub fn from_result<T, E>(result: &std::result::Result<T, E>) -> &str {

--- a/beacon_node/network/src/metrics.rs
+++ b/beacon_node/network/src/metrics.rs
@@ -83,7 +83,7 @@ pub static BEACON_PROCESSOR_IMPORT_ERRORS_PER_TYPE: LazyLock<Result<IntCounterVe
     LazyLock::new(|| {
         try_create_int_counter_vec(
             "beacon_processor_import_errors_total",
-            "Total number of block components verified",
+            "Total number of block components that were not verified",
             &["source", "component", "type"],
         )
     });


### PR DESCRIPTION
## Issue Addressed

Our current metrics to track the result of block imports are incomplete. A block import can be triggered by any block component, both from gossip and RPC. We should metric the `AvailabilityProcessingStatus` of block, blob, and custody column import to count all possible import events.

Also, I would like to track all errors that can occur during import. For example `BlockError::DuplicateFullyImported`, which show the efficiency of sync.

## Proposed Changes

Track the return of all `process_*` functions with the same helper `register_process_result_metrics`. Track the result `FullyImported` / `MissingComponents` / `Error` labeled by block component and provenance. 

## Additional Info

This PR has no breaking changes w.r.t. current metrics. However, it fixes the following metric:
- `beacon_processor_rpc_block_imported_total`: This metric is incorrect. Blocks with blobs synced by lookup sync are never tracked, as the block is always imported first and blobs second.
