### PR TITLE
lower ListenerError log level

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -1897,16 +1897,7 @@ impl<E: EthSpec> Network<E> {
                     }
                 }
                 SwarmEvent::ListenerError { error, .. } => {
-                    // Ignore quic accept and close errors.
-                    if let Some(error) = error
-                        .get_ref()
-                        .and_then(|err| err.downcast_ref::<libp2p::quic::Error>())
-                        .filter(|err| matches!(err, libp2p::quic::Error::Connection(_)))
-                    {
-                        debug!(self.log, "Listener closed quic connection"; "reason" => ?error);
-                    } else {
-                        warn!(self.log, "Listener error"; "error" => ?error);
-                    }
+                    debug!(self.log, "Listener closed connection attempt"; "reason" => ?error);
                     None
                 }
                 _ => {


### PR DESCRIPTION
these are non fatal, so no need to `warn`