### PR TITLE
Compute diff of validators list manually

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8282,6 +8282,7 @@ version = "0.2.0"
 dependencies = [
  "beacon_chain",
  "bls",
+ "criterion",
  "db-key",
  "directory",
  "ethereum_ssz",
@@ -8292,6 +8293,7 @@ dependencies = [
  "lru",
  "metrics",
  "parking_lot 0.12.3",
+ "rand 0.8.5",
  "safe_arith",
  "serde",
  "slog",

--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -7,6 +7,8 @@ edition = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 beacon_chain = { workspace = true }
+criterion = { workspace = true }
+rand = { workspace = true }
 
 [dependencies]
 db-key = "0.0.5"
@@ -31,3 +33,7 @@ zstd = { workspace = true }
 bls = { workspace = true }
 smallvec = { workspace = true }
 logging = { workspace = true }
+
+[[bench]]
+name = "hdiff"
+harness = false

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -25,6 +25,24 @@ pub fn all_benches(c: &mut Criterion) {
             "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
             &spec,
         );
+        bench_against_disk_states(
+            c,
+            "/Users/lion/code/sigp/lighthouse/state_10268064.ssz",
+            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
+            &spec,
+        );
+        bench_against_disk_states(
+            c,
+            "/Users/lion/code/sigp/lighthouse/state_9980064.ssz",
+            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
+            &spec,
+        );
+        bench_against_disk_states(
+            c,
+            "/Users/lion/code/sigp/lighthouse/state_7100064.ssz",
+            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
+            &spec,
+        );
         return;
     }
 
@@ -70,6 +88,7 @@ fn bench_against_disk_states(
         BeaconState::<E>::from_ssz_bytes(&fs::read(source_state_path).unwrap(), spec).unwrap();
     let target_state =
         BeaconState::<E>::from_ssz_bytes(&fs::read(target_state_path).unwrap(), spec).unwrap();
+
     bench_against_states(
         c,
         source_state,
@@ -84,11 +103,15 @@ fn bench_against_states(
     target_state: BeaconState<E>,
     id: &str,
 ) {
+    let slot_diff = target_state.slot() - source_state.slot();
     let config = StoreConfig::default();
     let source = HDiffBuffer::from_state(source_state);
     let target = HDiffBuffer::from_state(target_state);
     let diff = HDiff::compute(&source, &target, &config).unwrap();
-    println!("diff size {id} {}", diff.size());
+    println!(
+        "state slot diff {slot_diff} - diff size {id} {}",
+        diff.size()
+    );
 
     c.bench_function(&format!("compute hdiff {id}"), |b| {
         b.iter(|| {

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -49,25 +49,6 @@ pub fn all_benches(c: &mut Criterion) {
     }
 }
 
-fn bench_against_disk_states(
-    c: &mut Criterion,
-    source_state_path: &str,
-    target_state_path: &str,
-    spec: &ChainSpec,
-) {
-    let source_state =
-        BeaconState::<E>::from_ssz_bytes(&fs::read(source_state_path).unwrap(), spec).unwrap();
-    let target_state =
-        BeaconState::<E>::from_ssz_bytes(&fs::read(target_state_path).unwrap(), spec).unwrap();
-
-    bench_against_states(
-        c,
-        source_state,
-        target_state,
-        &format!("{source_state_path} - {target_state_path}"),
-    );
-}
-
 fn bench_against_states(
     c: &mut Criterion,
     source_state: BeaconState<E>,

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -2,21 +2,31 @@ use bls::PublicKeyBytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 use ssz::Decode;
+use std::fs;
 use store::{
     hdiff::{HDiff, HDiffBuffer},
     StoreConfig,
 };
-use types::{BeaconState, Epoch, Eth1Data, EthSpec, ForkName, MainnetEthSpec as E, Validator};
+use types::{BeaconState, ChainSpec, Epoch, Eth1Data, EthSpec, MainnetEthSpec as E, Validator};
 
 pub fn all_benches(c: &mut Criterion) {
-    let fork = ForkName::Base;
-    let spec = fork.make_genesis_spec(E::default_spec());
+    let spec = E::default_spec();
     let genesis_time = 0;
     let eth1_data = Eth1Data::default();
-    let config = StoreConfig::default();
     let mut rng = rand::thread_rng();
     let validator_mutations = 1000;
     let validator_additions = 100;
+
+    // TODO: Temp
+    if std::path::Path::new("/Users/lion/code/sigp/lighthouse/state_10300000.ssz").exists() {
+        bench_against_disk_states(
+            c,
+            "/Users/lion/code/sigp/lighthouse/state_10300000.ssz",
+            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
+            &spec,
+        );
+        return;
+    }
 
     for n in [1_000_000, 1_500_000, 2_000_000] {
         let mut source_state = BeaconState::<E>::new(genesis_time, eth1_data.clone(), &spec);
@@ -41,21 +51,56 @@ pub fn all_benches(c: &mut Criterion) {
             append_validator(&mut target_state, &mut rng);
         }
 
-        let source = HDiffBuffer::from_state(source_state);
-        let target = HDiffBuffer::from_state(target_state);
-        let diff = HDiff::compute(&source, &target, &config).unwrap();
-
-        c.bench_function(
-            &format!("apply hdiff n={n} v_mut={validator_mutations} v_add={validator_additions}"),
-            |b| {
-                let mut source = source.clone();
-                b.iter(|| {
-                    diff.apply(&mut source, &config).unwrap();
-                    println!("diff size {}", diff.size());
-                })
-            },
+        bench_against_states(
+            c,
+            source_state,
+            target_state,
+            &format!("n={n} v_mut={validator_mutations} v_add={validator_additions}"),
         );
     }
+}
+
+fn bench_against_disk_states(
+    c: &mut Criterion,
+    source_state_path: &str,
+    target_state_path: &str,
+    spec: &ChainSpec,
+) {
+    let source_state =
+        BeaconState::<E>::from_ssz_bytes(&fs::read(source_state_path).unwrap(), spec).unwrap();
+    let target_state =
+        BeaconState::<E>::from_ssz_bytes(&fs::read(target_state_path).unwrap(), spec).unwrap();
+    bench_against_states(
+        c,
+        source_state,
+        target_state,
+        &format!("{source_state_path} - {target_state_path}"),
+    );
+}
+
+fn bench_against_states(
+    c: &mut Criterion,
+    source_state: BeaconState<E>,
+    target_state: BeaconState<E>,
+    id: &str,
+) {
+    let config = StoreConfig::default();
+    let source = HDiffBuffer::from_state(source_state);
+    let target = HDiffBuffer::from_state(target_state);
+    let diff = HDiff::compute(&source, &target, &config).unwrap();
+    println!("diff size {id} {}", diff.size());
+
+    c.bench_function(&format!("compute hdiff {id}"), |b| {
+        b.iter(|| {
+            HDiff::compute(&source, &target, &config).unwrap();
+        })
+    });
+    c.bench_function(&format!("apply hdiff {id}"), |b| {
+        let mut source = source.clone();
+        b.iter(|| {
+            diff.apply(&mut source, &config).unwrap();
+        })
+    });
 }
 
 fn rand_validator(mut rng: impl Rng) -> Validator {

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -1,0 +1,97 @@
+use bls::PublicKeyBytes;
+use criterion::{criterion_group, criterion_main, Criterion};
+use rand::Rng;
+use ssz::Decode;
+use store::{
+    hdiff::{HDiff, HDiffBuffer},
+    StoreConfig,
+};
+use types::{BeaconState, Epoch, Eth1Data, EthSpec, ForkName, MainnetEthSpec as E, Validator};
+
+pub fn all_benches(c: &mut Criterion) {
+    let fork = ForkName::Base;
+    let spec = fork.make_genesis_spec(E::default_spec());
+    let genesis_time = 0;
+    let eth1_data = Eth1Data::default();
+    let config = StoreConfig::default();
+    let mut rng = rand::thread_rng();
+    let validator_mutations = 1000;
+    let validator_additions = 100;
+
+    for n in [1_000_000, 1_500_000, 2_000_000] {
+        let mut source_state = BeaconState::<E>::new(genesis_time, eth1_data.clone(), &spec);
+
+        for _ in 0..n {
+            append_validator(&mut source_state, &mut rng);
+        }
+
+        let mut target_state = source_state.clone();
+        // Change all balances
+        for i in 0..n {
+            let balance = target_state.balances_mut().get_mut(i).unwrap();
+            *balance += rng.gen_range(1..=1_000_000);
+        }
+        // And some validator records
+        for _ in 0..validator_mutations {
+            let index = rng.gen_range(1..n);
+            // TODO: Only change a few things, and not the pubkey
+            *target_state.validators_mut().get_mut(index).unwrap() = rand_validator(&mut rng);
+        }
+        for _ in 0..validator_additions {
+            append_validator(&mut target_state, &mut rng);
+        }
+
+        let source = HDiffBuffer::from_state(source_state);
+        let target = HDiffBuffer::from_state(target_state);
+        let diff = HDiff::compute(&source, &target, &config).unwrap();
+
+        c.bench_function(
+            &format!("apply hdiff n={n} v_mut={validator_mutations} v_add={validator_additions}"),
+            |b| {
+                let mut source = source.clone();
+                b.iter(|| {
+                    diff.apply(&mut source, &config).unwrap();
+                    println!("diff size {}", diff.size());
+                })
+            },
+        );
+    }
+}
+
+fn rand_validator(mut rng: impl Rng) -> Validator {
+    let mut pubkey = [0u8; 48];
+    rng.fill_bytes(&mut pubkey);
+    let withdrawal_credentials: [u8; 32] = rng.gen();
+
+    Validator {
+        pubkey: PublicKeyBytes::from_ssz_bytes(&pubkey).unwrap(),
+        withdrawal_credentials: withdrawal_credentials.into(),
+        slashed: false,
+        effective_balance: 32_000_000_000,
+        activation_eligibility_epoch: Epoch::max_value(),
+        activation_epoch: Epoch::max_value(),
+        exit_epoch: Epoch::max_value(),
+        withdrawable_epoch: Epoch::max_value(),
+    }
+}
+
+fn append_validator(state: &mut BeaconState<E>, mut rng: impl Rng) {
+    state
+        .balances_mut()
+        .push(32_000_000_000 + rng.gen_range(1..=1_000_000_000))
+        .unwrap();
+    if let Ok(inactivity_scores) = state.inactivity_scores_mut() {
+        inactivity_scores.push(0).unwrap();
+    }
+    state
+        .validators_mut()
+        .push(rand_validator(&mut rng))
+        .unwrap();
+}
+
+criterion_group! {
+  name = benches;
+  config = Criterion::default().sample_size(10);
+  targets = all_benches
+}
+criterion_main!(benches);

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -17,35 +17,6 @@ pub fn all_benches(c: &mut Criterion) {
     let validator_mutations = 1000;
     let validator_additions = 100;
 
-    // TODO: Temp
-    if std::path::Path::new("/Users/lion/code/sigp/lighthouse/state_10300000.ssz").exists() {
-        bench_against_disk_states(
-            c,
-            "/Users/lion/code/sigp/lighthouse/state_10300000.ssz",
-            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
-            &spec,
-        );
-        bench_against_disk_states(
-            c,
-            "/Users/lion/code/sigp/lighthouse/state_10268064.ssz",
-            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
-            &spec,
-        );
-        bench_against_disk_states(
-            c,
-            "/Users/lion/code/sigp/lighthouse/state_9980064.ssz",
-            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
-            &spec,
-        );
-        bench_against_disk_states(
-            c,
-            "/Users/lion/code/sigp/lighthouse/state_7100064.ssz",
-            "/Users/lion/code/sigp/lighthouse/state_10300064.ssz",
-            &spec,
-        );
-        return;
-    }
-
     for n in [1_000_000, 1_500_000, 2_000_000] {
         let mut source_state = BeaconState::<E>::new(genesis_time, eth1_data.clone(), &spec);
 

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -119,8 +119,8 @@ fn bench_against_states(
         })
     });
     c.bench_function(&format!("apply hdiff {id}"), |b| {
-        let mut source = source.clone();
         b.iter(|| {
+            let mut source = source.clone();
             diff.apply(&mut source, &config).unwrap();
         })
     });

--- a/beacon_node/store/benches/hdiff.rs
+++ b/beacon_node/store/benches/hdiff.rs
@@ -2,12 +2,11 @@ use bls::PublicKeyBytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 use rand::Rng;
 use ssz::Decode;
-use std::fs;
 use store::{
     hdiff::{HDiff, HDiffBuffer},
     StoreConfig,
 };
-use types::{BeaconState, ChainSpec, Epoch, Eth1Data, EthSpec, MainnetEthSpec as E, Validator};
+use types::{BeaconState, Epoch, Eth1Data, EthSpec, MainnetEthSpec as E, Validator};
 
 pub fn all_benches(c: &mut Criterion) {
     let spec = E::default_spec();

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -1,5 +1,6 @@
 //! Hierarchical diff implementation.
 use crate::{metrics, DBColumn, StoreConfig, StoreItem};
+use bls::PublicKeyBytes;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
@@ -7,7 +8,7 @@ use ssz_derive::{Decode, Encode};
 use std::io::{Read, Write};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
-use types::{BeaconState, ChainSpec, EthSpec, List, Slot};
+use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, List, Slot, Validator};
 use zstd::{Decoder, Encoder};
 
 #[derive(Debug)]
@@ -81,6 +82,8 @@ pub enum StorageStrategy {
 pub struct HDiffBuffer {
     state: Vec<u8>,
     balances: Vec<u64>,
+    inactivity_scores: Vec<u64>,
+    validators: Vec<Validator>,
 }
 
 /// Hierarchical state diff.
@@ -101,6 +104,8 @@ pub struct HDiffBuffer {
 pub struct HDiff {
     state_diff: BytesDiff,
     balances_diff: CompressedU64Diff,
+    inactivity_scores_diff: CompressedU64Diff,
+    validators_diff: ValidatorsDiff,
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -113,30 +118,57 @@ pub struct CompressedU64Diff {
     bytes: Vec<u8>,
 }
 
+#[derive(Debug, Encode, Decode)]
+pub struct ValidatorsDiff {
+    bytes: Vec<u8>,
+}
+
 impl HDiffBuffer {
     pub fn from_state<E: EthSpec>(mut beacon_state: BeaconState<E>) -> Self {
         let _t = metrics::start_timer(&metrics::STORE_BEACON_HDIFF_BUFFER_FROM_STATE_TIME);
         // Set state.balances to empty list, and then serialize state as ssz
         let balances_list = std::mem::take(beacon_state.balances_mut());
+        let inactivity_scores = if let Ok(inactivity_scores) = beacon_state.inactivity_scores_mut()
+        {
+            std::mem::take(inactivity_scores).to_vec()
+        } else {
+            // TODO: What to set the diff list before altair?
+            vec![]
+        };
+        let validators = std::mem::take(beacon_state.validators_mut()).to_vec();
 
         let state = beacon_state.as_ssz_bytes();
         let balances = balances_list.to_vec();
 
-        HDiffBuffer { state, balances }
+        HDiffBuffer {
+            state,
+            balances,
+            inactivity_scores,
+            validators,
+        }
     }
 
     pub fn as_state<E: EthSpec>(&self, spec: &ChainSpec) -> Result<BeaconState<E>, Error> {
         let _t = metrics::start_timer(&metrics::STORE_BEACON_HDIFF_BUFFER_INTO_STATE_TIME);
         let mut state =
             BeaconState::from_ssz_bytes(&self.state, spec).map_err(Error::InvalidSszState)?;
+
         *state.balances_mut() = List::try_from_iter(self.balances.iter().copied())
             .map_err(|_| Error::InvalidBalancesLength)?;
+        if let Ok(inactivity_scores) = state.inactivity_scores_mut() {
+            *inactivity_scores = List::try_from_iter(self.inactivity_scores.iter().copied())
+                .map_err(|_| Error::InvalidBalancesLength)?;
+        }
+
         Ok(state)
     }
 
     /// Byte size of this instance
     pub fn size(&self) -> usize {
-        self.state.len() + self.balances.len() * std::mem::size_of::<u64>()
+        self.state.len()
+            + self.balances.len() * std::mem::size_of::<u64>()
+            + self.inactivity_scores.len() * std::mem::size_of::<u64>()
+            + self.validators.len() * std::mem::size_of::<Validator>()
     }
 }
 
@@ -148,27 +180,39 @@ impl HDiff {
     ) -> Result<Self, Error> {
         let state_diff = BytesDiff::compute(&source.state, &target.state)?;
         let balances_diff = CompressedU64Diff::compute(&source.balances, &target.balances, config)?;
+        let inactivity_scores_diff = CompressedU64Diff::compute(
+            &source.inactivity_scores,
+            &target.inactivity_scores,
+            config,
+        )?;
+        let validators_diff =
+            ValidatorsDiff::compute(&source.validators, &target.validators, config)?;
 
         Ok(Self {
             state_diff,
             balances_diff,
+            inactivity_scores_diff,
+            validators_diff,
         })
     }
 
     pub fn apply(&self, source: &mut HDiffBuffer, config: &StoreConfig) -> Result<(), Error> {
         let source_state = std::mem::take(&mut source.state);
         self.state_diff.apply(&source_state, &mut source.state)?;
-
         self.balances_diff.apply(&mut source.balances, config)?;
+        self.inactivity_scores_diff
+            .apply(&mut source.inactivity_scores, config)?;
+        self.validators_diff.apply(&mut source.validators, config)?;
+
         Ok(())
     }
 
-    pub fn state_diff_len(&self) -> usize {
-        self.state_diff.bytes.len()
-    }
-
-    pub fn balances_diff_len(&self) -> usize {
-        self.balances_diff.bytes.len()
+    /// Byte size of this instance
+    pub fn size(&self) -> usize {
+        self.state_diff.size()
+            + self.balances_diff.size()
+            + self.inactivity_scores_diff.size()
+            + self.validators_diff.size()
     }
 }
 
@@ -205,6 +249,11 @@ impl BytesDiff {
         *target = xdelta3::decode(&self.bytes, source).ok_or(Error::UnableToApplyDiff)?;
         Ok(())
     }
+
+    /// Byte size of this instance
+    pub fn size(&self) -> usize {
+        self.bytes.len()
+    }
 }
 
 impl CompressedU64Diff {
@@ -223,29 +272,14 @@ impl CompressedU64Diff {
             })
             .collect();
 
-        let compression_level = config.compression_level;
-        let mut compressed_bytes =
-            Vec::with_capacity(config.estimate_compressed_size(uncompressed_bytes.len()));
-        let mut encoder =
-            Encoder::new(&mut compressed_bytes, compression_level).map_err(Error::Compression)?;
-        encoder
-            .write_all(&uncompressed_bytes)
-            .map_err(Error::Compression)?;
-        encoder.finish().map_err(Error::Compression)?;
-
         Ok(CompressedU64Diff {
-            bytes: compressed_bytes,
+            bytes: compress_bytes(&uncompressed_bytes, config)?,
         })
     }
 
     pub fn apply(&self, xs: &mut Vec<u64>, config: &StoreConfig) -> Result<(), Error> {
         // Decompress balances diff.
-        let mut balances_diff_bytes =
-            Vec::with_capacity(config.estimate_decompressed_size(self.bytes.len()));
-        let mut decoder = Decoder::new(&*self.bytes).map_err(Error::Compression)?;
-        decoder
-            .read_to_end(&mut balances_diff_bytes)
-            .map_err(Error::Compression)?;
+        let balances_diff_bytes = uncompress_bytes(&self.bytes, config)?;
 
         for (i, diff_bytes) in balances_diff_bytes
             .chunks(u64::BITS as usize / 8)
@@ -265,6 +299,184 @@ impl CompressedU64Diff {
 
         Ok(())
     }
+
+    /// Byte size of this instance
+    pub fn size(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+fn compress_bytes(input: &[u8], config: &StoreConfig) -> Result<Vec<u8>, Error> {
+    let compression_level = config.compression_level;
+    let mut out = Vec::with_capacity(config.estimate_compressed_size(input.len()));
+    let mut encoder = Encoder::new(&mut out, compression_level).map_err(Error::Compression)?;
+    encoder.write_all(input).map_err(Error::Compression)?;
+    encoder.finish().map_err(Error::Compression)?;
+    Ok(out)
+}
+
+fn uncompress_bytes(input: &[u8], config: &StoreConfig) -> Result<Vec<u8>, Error> {
+    // Decompress balances diff.
+    let mut out = Vec::with_capacity(config.estimate_decompressed_size(input.len()));
+    let mut decoder = Decoder::new(input).map_err(Error::Compression)?;
+    decoder.read_to_end(&mut out).map_err(Error::Compression)?;
+    Ok(out)
+}
+
+impl ValidatorsDiff {
+    pub fn compute(
+        xs: &[Validator],
+        ys: &[Validator],
+        config: &StoreConfig,
+    ) -> Result<Self, Error> {
+        if xs.len() > ys.len() {
+            return Err(Error::U64DiffDeletionsNotSupported);
+        }
+
+        let uncompressed_bytes = ys
+            .iter()
+            .enumerate()
+            .filter_map(|(i, y)| {
+                let validator_diff = if let Some(x) = xs.get(i) {
+                    // How expensive are comparisions?
+                    // TODO: Is it worth it to optimize the comparision and do them only once here?
+                    if y == x {
+                        return None;
+                    } else {
+                        let pubkey_changed = y.pubkey != x.pubkey;
+                        // Note: If researchers attempt to change the Validator container, go quickly to
+                        // All Core Devs and push hard to add another List in the BeaconState instead.
+                        Validator {
+                            // The pubkey can be changed on index re-use
+                            pubkey: if pubkey_changed {
+                                y.pubkey
+                            } else {
+                                PublicKeyBytes::empty()
+                            },
+                            // withdrawal_credentials can be set to zero initially but can never be
+                            // changed INTO zero. On index re-use it can be set to zero, but in that
+                            // case the pubkey will also change.
+                            withdrawal_credentials: if pubkey_changed
+                                || y.withdrawal_credentials != x.withdrawal_credentials
+                            {
+                                y.withdrawal_credentials
+                            } else {
+                                Hash256::ZERO
+                            },
+                            // effective_balance can increase and decrease
+                            effective_balance: y.effective_balance - x.effective_balance,
+                            // slashed can only change from false into true. In an index re-use it can
+                            // switch back to false, but in that case the pubkey will also change.
+                            slashed: y.slashed,
+                            // activation_eligibility_epoch can never be zero under any case. It's
+                            // set to either FAR_FUTURE_EPOCH or get_current_epoch(state) + 1
+                            activation_eligibility_epoch: if y.activation_eligibility_epoch
+                                != x.activation_eligibility_epoch
+                            {
+                                y.activation_eligibility_epoch
+                            } else {
+                                Epoch::new(0)
+                            },
+                            // activation_epoch can never be zero under any case. It's
+                            // set to either FAR_FUTURE_EPOCH or epoch + 1 + MAX_SEED_LOOKAHEAD
+                            activation_epoch: if y.activation_epoch != x.activation_epoch {
+                                y.activation_epoch
+                            } else {
+                                Epoch::new(0)
+                            },
+                            // exit_epoch can never be zero under any case. It's set to either
+                            // FAR_FUTURE_EPOCH or > epoch + 1 + MAX_SEED_LOOKAHEAD
+                            exit_epoch: if y.exit_epoch != x.exit_epoch {
+                                y.exit_epoch
+                            } else {
+                                Epoch::new(0)
+                            },
+                            // withdrawable_epoch can never be zero under any case. It's set to
+                            // either FAR_FUTURE_EPOCH or > epoch + 1 + MAX_SEED_LOOKAHEAD
+                            withdrawable_epoch: if y.withdrawable_epoch != x.withdrawable_epoch {
+                                y.withdrawable_epoch
+                            } else {
+                                Epoch::new(0)
+                            },
+                        }
+                    }
+                } else {
+                    y.clone()
+                };
+
+                Some(ValidatorDiffEntry {
+                    index: i as u64,
+                    validator_diff,
+                })
+            })
+            .flat_map(|v_diff| v_diff.as_ssz_bytes())
+            .collect::<Vec<u8>>();
+
+        Ok(Self {
+            bytes: compress_bytes(&uncompressed_bytes, config)?,
+        })
+    }
+
+    pub fn apply(&self, xs: &mut Vec<Validator>, config: &StoreConfig) -> Result<(), Error> {
+        let validator_diff_bytes = uncompress_bytes(&self.bytes, config)?;
+
+        for diff_bytes in
+            validator_diff_bytes.chunks(<ValidatorDiffEntry as Decode>::ssz_fixed_len())
+        {
+            let ValidatorDiffEntry {
+                index,
+                validator_diff: diff,
+            } = ValidatorDiffEntry::from_ssz_bytes(diff_bytes)
+                .map_err(|_| Error::BalancesIncompleteChunk)?;
+
+            if let Some(x) = xs.get_mut(index as usize) {
+                // TODO: Precompute empty
+                // Note: a pubkey change implies index re-use. In that case over-write
+                // withdrawal_credentials and slashed inconditionally as their default values
+                // are valid values.
+                let pubkey_changed = diff.pubkey != PublicKeyBytes::empty();
+                if pubkey_changed {
+                    x.pubkey = diff.pubkey;
+                }
+                if pubkey_changed || diff.withdrawal_credentials != Hash256::ZERO {
+                    x.withdrawal_credentials = diff.withdrawal_credentials;
+                }
+                if diff.effective_balance != 0 {
+                    x.effective_balance = x.effective_balance.wrapping_add(diff.effective_balance);
+                }
+                if pubkey_changed || diff.slashed {
+                    x.slashed = diff.slashed;
+                }
+                if diff.activation_eligibility_epoch != Epoch::new(0) {
+                    x.activation_eligibility_epoch = diff.activation_eligibility_epoch;
+                }
+                if diff.activation_epoch != Epoch::new(0) {
+                    x.activation_epoch = diff.activation_epoch;
+                }
+                if diff.exit_epoch != Epoch::new(0) {
+                    x.exit_epoch = diff.exit_epoch;
+                }
+                if diff.withdrawable_epoch != Epoch::new(0) {
+                    x.withdrawable_epoch = diff.withdrawable_epoch;
+                }
+            } else {
+                xs.push(diff)
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Byte size of this instance
+    pub fn size(&self) -> usize {
+        self.bytes.len()
+    }
+}
+
+#[derive(Debug, Encode, Decode)]
+struct ValidatorDiffEntry {
+    index: u64,
+    validator_diff: Validator,
 }
 
 impl Default for HierarchyConfig {
@@ -390,6 +602,7 @@ impl StorageStrategy {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{thread_rng, Rng};
 
     #[test]
     fn default_storage_strategy() {
@@ -485,5 +698,41 @@ mod tests {
 
         // U64 diff wins by more than a factor of 3
         assert!(u64_diff.bytes.len() < 3 * bytes_diff.bytes.len());
+    }
+
+    #[test]
+    fn compressed_validators_diff() {
+        assert_eq!(<ValidatorDiffEntry as Decode>::ssz_fixed_len(), 129);
+
+        let mut rng = thread_rng();
+        let config = &StoreConfig::default();
+        let xs = (0..10)
+            .map(|_| rand_validator(&mut rng))
+            .collect::<Vec<_>>();
+        let mut ys = xs.clone();
+        ys[5] = rand_validator(&mut rng);
+        ys.push(rand_validator(&mut rng));
+        let diff = ValidatorsDiff::compute(&xs, &ys, config).unwrap();
+
+        let mut xs_out = xs.clone();
+        diff.apply(&mut xs_out, config).unwrap();
+        assert_eq!(xs_out, ys);
+    }
+
+    fn rand_validator(mut rng: impl Rng) -> Validator {
+        let mut pubkey = [0u8; 48];
+        rng.fill_bytes(&mut pubkey);
+        let withdrawal_credentials: [u8; 32] = rng.gen();
+
+        Validator {
+            pubkey: PublicKeyBytes::from_ssz_bytes(&pubkey).unwrap(),
+            withdrawal_credentials: withdrawal_credentials.into(),
+            slashed: false,
+            effective_balance: 32_000_000_000,
+            activation_eligibility_epoch: Epoch::max_value(),
+            activation_epoch: Epoch::max_value(),
+            exit_epoch: Epoch::max_value(),
+            withdrawable_epoch: Epoch::max_value(),
+        }
     }
 }

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use std::io::{Read, Write};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
+use superstruct::superstruct;
 use types::historical_summary::HistoricalSummary;
 use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, List, Slot, Validator};
 use zstd::{Decoder, Encoder};
@@ -104,7 +105,9 @@ pub struct HDiffBuffer {
 ///   this strategy the HDiff code is easily mantainable across forks, as new fields are covered
 ///   automatically. xdelta3 algorithm showed diff compute and apply times of ~200 ms on a mainnet
 ///   state from Apr 2023 (570k indexes), and a 92kB diff size.
+#[superstruct(variants(V0), variant_attributes(derive(Debug, Encode, Decode)))]
 #[derive(Debug, Encode, Decode)]
+#[ssz(enum_behaviour = "union")]
 pub struct HDiff {
     state_diff: BytesDiff,
     balances_diff: CompressedU64Diff,
@@ -241,25 +244,26 @@ impl HDiff {
         let historical_summaries =
             AppendOnlyDiff::compute(&source.historical_summaries, &target.historical_summaries)?;
 
-        Ok(Self {
+        Ok(HDiff::V0(HDiffV0 {
             state_diff,
             balances_diff,
             inactivity_scores_diff,
             validators_diff,
             historical_roots,
             historical_summaries,
-        })
+        }))
     }
 
     pub fn apply(&self, source: &mut HDiffBuffer, config: &StoreConfig) -> Result<(), Error> {
         let source_state = std::mem::take(&mut source.state);
-        self.state_diff.apply(&source_state, &mut source.state)?;
-        self.balances_diff.apply(&mut source.balances, config)?;
-        self.inactivity_scores_diff
+        self.state_diff().apply(&source_state, &mut source.state)?;
+        self.balances_diff().apply(&mut source.balances, config)?;
+        self.inactivity_scores_diff()
             .apply(&mut source.inactivity_scores, config)?;
-        self.validators_diff.apply(&mut source.validators, config)?;
-        self.historical_roots.apply(&mut source.historical_roots);
-        self.historical_summaries
+        self.validators_diff()
+            .apply(&mut source.validators, config)?;
+        self.historical_roots().apply(&mut source.historical_roots);
+        self.historical_summaries()
             .apply(&mut source.historical_summaries);
 
         Ok(())
@@ -272,12 +276,12 @@ impl HDiff {
 
     pub fn sizes(&self) -> Vec<usize> {
         vec![
-            self.state_diff.size(),
-            self.balances_diff.size(),
-            self.inactivity_scores_diff.size(),
-            self.validators_diff.size(),
-            self.historical_roots.size(),
-            self.historical_summaries.size(),
+            self.state_diff().size(),
+            self.balances_diff().size(),
+            self.inactivity_scores_diff().size(),
+            self.validators_diff().size(),
+            self.historical_roots().size(),
+            self.historical_summaries().size(),
         ]
     }
 }

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -68,6 +68,12 @@ impl FromStr for HierarchyConfig {
     }
 }
 
+impl std::fmt::Display for HierarchyConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.exponents.iter().join(","))
+    }
+}
+
 #[derive(Debug)]
 pub struct HierarchyModuli {
     moduli: Vec<u64>,

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -9,15 +9,18 @@ use std::cmp::Ordering;
 use std::io::{Read, Write};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use superstruct::superstruct;
 use types::historical_summary::HistoricalSummary;
 use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, List, Slot, Validator};
 use zstd::{Decoder, Encoder};
 
+static EMPTY_PUBKEY: LazyLock<PublicKeyBytes> = LazyLock::new(PublicKeyBytes::empty);
+
 #[derive(Debug)]
 pub enum Error {
     InvalidHierarchy,
-    U64DiffDeletionsNotSupported,
+    DiffDeletionsNotSupported,
     UnableToComputeDiff,
     UnableToApplyDiff,
     BalancesIncompleteChunk,
@@ -168,7 +171,8 @@ impl HDiffBuffer {
         {
             std::mem::take(inactivity_scores).to_vec()
         } else {
-            // TODO: What to set the diff list before altair?
+            // If this state is pre-altair consider the list empty. If the target state
+            // is post altair, all its items will show up in the diff as is.
             vec![]
         };
         let validators = std::mem::take(beacon_state.validators_mut()).to_vec();
@@ -177,6 +181,9 @@ impl HDiffBuffer {
             if let Ok(historical_summaries) = beacon_state.historical_summaries_mut() {
                 std::mem::take(historical_summaries).to_vec()
             } else {
+                // If this state is pre-capella consider the list empty. The diff will
+                // include all items in the target state. If both states are
+                // pre-capella the diff will be empty.
                 vec![]
             };
 
@@ -206,7 +213,6 @@ impl HDiffBuffer {
                 .map_err(|_| Error::InvalidBalancesLength)?;
         }
 
-        // TODO: Can we remove all this clone / copying?
         *state.validators_mut() = List::try_from_iter(self.validators.iter().cloned())
             .map_err(|_| Error::InvalidBalancesLength)?;
 
@@ -227,6 +233,8 @@ impl HDiffBuffer {
             + self.balances.len() * std::mem::size_of::<u64>()
             + self.inactivity_scores.len() * std::mem::size_of::<u64>()
             + self.validators.len() * std::mem::size_of::<Validator>()
+            + self.historical_roots.len() * std::mem::size_of::<Hash256>()
+            + self.historical_summaries.len() * std::mem::size_of::<HistoricalSummary>()
     }
 }
 
@@ -335,7 +343,7 @@ impl BytesDiff {
 impl CompressedU64Diff {
     pub fn compute(xs: &[u64], ys: &[u64], config: &StoreConfig) -> Result<Self, Error> {
         if xs.len() > ys.len() {
-            return Err(Error::U64DiffDeletionsNotSupported);
+            return Err(Error::DiffDeletionsNotSupported);
         }
 
         let uncompressed_bytes: Vec<u8> = ys
@@ -405,7 +413,7 @@ impl ValidatorsDiff {
         config: &StoreConfig,
     ) -> Result<Self, Error> {
         if xs.len() > ys.len() {
-            return Err(Error::U64DiffDeletionsNotSupported);
+            return Err(Error::DiffDeletionsNotSupported);
         }
 
         let uncompressed_bytes = ys
@@ -413,8 +421,6 @@ impl ValidatorsDiff {
             .enumerate()
             .filter_map(|(i, y)| {
                 let validator_diff = if let Some(x) = xs.get(i) {
-                    // How expensive are comparisions?
-                    // TODO: Is it worth it to optimize the comparision and do them only once here?
                     if y == x {
                         return None;
                     } else {
@@ -505,11 +511,10 @@ impl ValidatorsDiff {
                 .map_err(|_| Error::BalancesIncompleteChunk)?;
 
             if let Some(x) = xs.get_mut(index as usize) {
-                // TODO: Precompute empty
                 // Note: a pubkey change implies index re-use. In that case over-write
                 // withdrawal_credentials and slashed inconditionally as their default values
                 // are valid values.
-                let pubkey_changed = diff.pubkey != PublicKeyBytes::empty();
+                let pubkey_changed = diff.pubkey != *EMPTY_PUBKEY;
                 if pubkey_changed {
                     x.pubkey = diff.pubkey;
                 }
@@ -562,7 +567,7 @@ impl<T: Decode + Encode + Copy> AppendOnlyDiff<T> {
             }),
             // Don't even create an iterator for this common case
             Ordering::Equal => Ok(Self { values: vec![] }),
-            Ordering::Greater => Err(Error::U64DiffDeletionsNotSupported),
+            Ordering::Greater => Err(Error::DiffDeletionsNotSupported),
         }
     }
 

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -5,9 +5,11 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use ssz::{Decode, Encode};
 use ssz_derive::{Decode, Encode};
+use std::cmp::Ordering;
 use std::io::{Read, Write};
 use std::ops::RangeInclusive;
 use std::str::FromStr;
+use types::historical_summary::HistoricalSummary;
 use types::{BeaconState, ChainSpec, Epoch, EthSpec, Hash256, List, Slot, Validator};
 use zstd::{Decoder, Encoder};
 
@@ -84,6 +86,8 @@ pub struct HDiffBuffer {
     balances: Vec<u64>,
     inactivity_scores: Vec<u64>,
     validators: Vec<Validator>,
+    historical_roots: Vec<Hash256>,
+    historical_summaries: Vec<HistoricalSummary>,
 }
 
 /// Hierarchical state diff.
@@ -104,8 +108,26 @@ pub struct HDiffBuffer {
 pub struct HDiff {
     state_diff: BytesDiff,
     balances_diff: CompressedU64Diff,
+    /// inactivity_scores are small integers that change slowly epoch to epoch. And are 0 for all
+    /// participants unless there's non-finality. Computing the diff and compressing the result is
+    /// much faster than running them through a binary patch algorithm. In the default case where
+    /// all values are 0 it should also result in a tinny output.
     inactivity_scores_diff: CompressedU64Diff,
+    /// The validators array represents the vast majority of data in a BeaconState. Due to its big
+    /// size we have seen the performance of xdelta3 degreade. Comparing each entry of the
+    /// validators array manually significantly speed up the computation of the diff (+10x faster)
+    /// and result in the same minimal diff. As the `Validator` record is unlikely to change,
+    /// mantaining this extra complexity should be okay.
     validators_diff: ValidatorsDiff,
+    /// `historical_roots` is an unbounded forever growing (after Capella it's
+    /// historical_summaries) list of unique roots. This data is pure entropy so there's no point
+    /// in compressing it. As it's an append only list, the optimal diff + compression is just the
+    /// list of new entries. The size of `historical_roots` and `historical_summaries` in
+    /// non-trivial ~10 MB so throwing it to xdelta3 adds CPU cycles. With a bit of extra complexity
+    /// we can save those completely.
+    historical_roots: AppendOnlyDiff<Hash256>,
+    /// See historical_roots
+    historical_summaries: AppendOnlyDiff<HistoricalSummary>,
 }
 
 #[derive(Debug, Encode, Decode)]
@@ -123,6 +145,11 @@ pub struct ValidatorsDiff {
     bytes: Vec<u8>,
 }
 
+#[derive(Debug, Encode, Decode)]
+pub struct AppendOnlyDiff<T: Encode + Decode> {
+    values: Vec<T>,
+}
+
 impl HDiffBuffer {
     pub fn from_state<E: EthSpec>(mut beacon_state: BeaconState<E>) -> Self {
         let _t = metrics::start_timer(&metrics::STORE_BEACON_HDIFF_BUFFER_FROM_STATE_TIME);
@@ -136,6 +163,13 @@ impl HDiffBuffer {
             vec![]
         };
         let validators = std::mem::take(beacon_state.validators_mut()).to_vec();
+        let historical_roots = std::mem::take(beacon_state.historical_roots_mut()).to_vec();
+        let historical_summaries =
+            if let Ok(historical_summaries) = beacon_state.historical_summaries_mut() {
+                std::mem::take(historical_summaries).to_vec()
+            } else {
+                vec![]
+            };
 
         let state = beacon_state.as_ssz_bytes();
         let balances = balances_list.to_vec();
@@ -145,6 +179,8 @@ impl HDiffBuffer {
             balances,
             inactivity_scores,
             validators,
+            historical_roots,
+            historical_summaries,
         }
     }
 
@@ -155,8 +191,21 @@ impl HDiffBuffer {
 
         *state.balances_mut() = List::try_from_iter(self.balances.iter().copied())
             .map_err(|_| Error::InvalidBalancesLength)?;
+
         if let Ok(inactivity_scores) = state.inactivity_scores_mut() {
             *inactivity_scores = List::try_from_iter(self.inactivity_scores.iter().copied())
+                .map_err(|_| Error::InvalidBalancesLength)?;
+        }
+
+        // TODO: Can we remove all this clone / copying?
+        *state.validators_mut() = List::try_from_iter(self.validators.iter().cloned())
+            .map_err(|_| Error::InvalidBalancesLength)?;
+
+        *state.historical_roots_mut() = List::try_from_iter(self.historical_roots.iter().copied())
+            .map_err(|_| Error::InvalidBalancesLength)?;
+
+        if let Ok(historical_summaries) = state.historical_summaries_mut() {
+            *historical_summaries = List::try_from_iter(self.historical_summaries.iter().copied())
                 .map_err(|_| Error::InvalidBalancesLength)?;
         }
 
@@ -187,12 +236,18 @@ impl HDiff {
         )?;
         let validators_diff =
             ValidatorsDiff::compute(&source.validators, &target.validators, config)?;
+        let historical_roots =
+            AppendOnlyDiff::compute(&source.historical_roots, &target.historical_roots)?;
+        let historical_summaries =
+            AppendOnlyDiff::compute(&source.historical_summaries, &target.historical_summaries)?;
 
         Ok(Self {
             state_diff,
             balances_diff,
             inactivity_scores_diff,
             validators_diff,
+            historical_roots,
+            historical_summaries,
         })
     }
 
@@ -203,16 +258,27 @@ impl HDiff {
         self.inactivity_scores_diff
             .apply(&mut source.inactivity_scores, config)?;
         self.validators_diff.apply(&mut source.validators, config)?;
+        self.historical_roots.apply(&mut source.historical_roots);
+        self.historical_summaries
+            .apply(&mut source.historical_summaries);
 
         Ok(())
     }
 
     /// Byte size of this instance
     pub fn size(&self) -> usize {
-        self.state_diff.size()
-            + self.balances_diff.size()
-            + self.inactivity_scores_diff.size()
-            + self.validators_diff.size()
+        self.sizes().iter().sum()
+    }
+
+    pub fn sizes(&self) -> Vec<usize> {
+        vec![
+            self.state_diff.size(),
+            self.balances_diff.size(),
+            self.inactivity_scores_diff.size(),
+            self.validators_diff.size(),
+            self.historical_roots.size(),
+            self.historical_summaries.size(),
+        ]
     }
 }
 
@@ -477,6 +543,28 @@ impl ValidatorsDiff {
 struct ValidatorDiffEntry {
     index: u64,
     validator_diff: Validator,
+}
+
+impl<T: Decode + Encode + Copy> AppendOnlyDiff<T> {
+    pub fn compute(xs: &[T], ys: &[T]) -> Result<Self, Error> {
+        match xs.len().cmp(&ys.len()) {
+            Ordering::Less => Ok(Self {
+                values: ys.iter().skip(xs.len()).copied().collect(),
+            }),
+            // Don't even create an iterator for this common case
+            Ordering::Equal => Ok(Self { values: vec![] }),
+            Ordering::Greater => Err(Error::U64DiffDeletionsNotSupported),
+        }
+    }
+
+    pub fn apply(&self, xs: &mut Vec<T>) {
+        xs.extend(self.values.iter().copied());
+    }
+
+    /// Byte size of this instance
+    pub fn size(&self) -> usize {
+        self.values.len() * size_of::<T>()
+    }
 }
 
 impl Default for HierarchyConfig {

--- a/beacon_node/store/src/hdiff.rs
+++ b/beacon_node/store/src/hdiff.rs
@@ -120,13 +120,13 @@ pub struct HDiff {
     /// inactivity_scores are small integers that change slowly epoch to epoch. And are 0 for all
     /// participants unless there's non-finality. Computing the diff and compressing the result is
     /// much faster than running them through a binary patch algorithm. In the default case where
-    /// all values are 0 it should also result in a tinny output.
+    /// all values are 0 it should also result in a tiny output.
     inactivity_scores_diff: CompressedU64Diff,
     /// The validators array represents the vast majority of data in a BeaconState. Due to its big
-    /// size we have seen the performance of xdelta3 degreade. Comparing each entry of the
-    /// validators array manually significantly speed up the computation of the diff (+10x faster)
+    /// size we have seen the performance of xdelta3 degrade. Comparing each entry of the
+    /// validators array manually significantly speeds up the computation of the diff (+10x faster)
     /// and result in the same minimal diff. As the `Validator` record is unlikely to change,
-    /// mantaining this extra complexity should be okay.
+    /// maintaining this extra complexity should be okay.
     validators_diff: ValidatorsDiff,
     /// `historical_roots` is an unbounded forever growing (after Capella it's
     /// historical_summaries) list of unique roots. This data is pure entropy so there's no point
@@ -392,7 +392,6 @@ fn compress_bytes(input: &[u8], config: &StoreConfig) -> Result<Vec<u8>, Error> 
 }
 
 fn uncompress_bytes(input: &[u8], config: &StoreConfig) -> Result<Vec<u8>, Error> {
-    // Decompress balances diff.
     let mut out = Vec::with_capacity(config.estimate_decompressed_size(input.len()));
     let mut decoder = Decoder::new(input).map_err(Error::Compression)?;
     decoder.read_to_end(&mut out).map_err(Error::Compression)?;

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -385,8 +385,8 @@ impl<E: EthSpec> HotColdDB<E, LevelDB<E>, LevelDB<E>> {
                     info!(
                         db.log,
                         "Updating historic state config";
-                        "previous_config" => ?hierarchy_config,
-                        "new_config" => ?db.config.hierarchy_config,
+                        "previous_config" => %hierarchy_config,
+                        "new_config" => %db.config.hierarchy_config,
                     );
                 }
             }

--- a/consensus/types/src/historical_summary.rs
+++ b/consensus/types/src/historical_summary.rs
@@ -15,6 +15,7 @@ use tree_hash_derive::TreeHash;
 #[derive(
     Debug,
     PartialEq,
+    Eq,
     Serialize,
     Deserialize,
     Encode,

--- a/consensus/types/src/validator.rs
+++ b/consensus/types/src/validator.rs
@@ -15,6 +15,7 @@ use tree_hash_derive::TreeHash;
     Debug,
     Clone,
     PartialEq,
+    Eq,
     Serialize,
     Deserialize,
     Encode,

--- a/database_manager/src/cli.rs
+++ b/database_manager/src/cli.rs
@@ -22,9 +22,11 @@ use crate::InspectTarget;
 pub struct DatabaseManager {
     #[clap(
         long,
+        global = true,
         value_name = "N0,N1,N2,...",
         help = "Specifies the frequency for storing full state snapshots and hierarchical \
                 diffs in the freezer DB.",
+        default_value_t = HierarchyConfig::default(),
         display_order = 0
     )]
     pub hierarchy_exponents: HierarchyConfig,

--- a/database_manager/src/cli.rs
+++ b/database_manager/src/cli.rs
@@ -3,6 +3,7 @@ use clap_utils::get_color_style;
 use clap_utils::FLAG_HEADER;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use store::hdiff::HierarchyConfig;
 
 use crate::InspectTarget;
 
@@ -21,13 +22,12 @@ use crate::InspectTarget;
 pub struct DatabaseManager {
     #[clap(
         long,
-        value_name = "SLOT_COUNT",
-        help = "Specifies how often a freezer DB restore point should be stored. \
-                Cannot be changed after initialization. \
-                [default: 2048 (mainnet) or 64 (minimal)]",
+        value_name = "N0,N1,N2,...",
+        help = "Specifies the frequency for storing full state snapshots and hierarchical \
+                diffs in the freezer DB.",
         display_order = 0
     )]
-    pub slots_per_restore_point: Option<u64>,
+    pub hierarchy_exponents: HierarchyConfig,
 
     #[clap(
         long,

--- a/database_manager/src/lib.rs
+++ b/database_manager/src/lib.rs
@@ -39,6 +39,7 @@ fn parse_client_config<E: EthSpec>(
         .blobs_db_path
         .clone_from(&database_manager_config.blobs_dir);
     client_config.store.blob_prune_margin_epochs = database_manager_config.blob_prune_margin_epochs;
+    client_config.store.hierarchy_config = database_manager_config.hierarchy_exponents.clone();
 
     Ok(client_config)
 }


### PR DESCRIPTION
## Issue Addressed

From https://github.com/sigp/lighthouse/pull/5978#pullrequestreview-2408206432 I've seen that `xdelta3` struggles with very large inputs.

The current approach of throwing the entire state to diff algorithm is nice because we don't need to deal with forks. However the state has only a few fields that are relevant for byte size

_N = number of validators_

| BeaconStateElectra Field                        | Size (bytes) | Change
| ---------------------------- | ------------ | ------
| genesis_time                 | -
| genesis_validators_root      | -
| slot                         | -
| fork                         | -
| latest_block_header          | -
| block_roots                  | 32 * 8192    | Mutate 32 items per epoch
| state_roots                  | 32 * 8192    | Mutate 32 items per epoch
| historical_roots:            | 32 * 328724  | Frozen since capella
| eth1_data                    | -
| eth1_data_votes              | 0 .. 147456  | 1 add every slot
| eth1_deposit_index           | -
| validators                   | 121 * N      | 0..8 adds every epoch (bounded by churn), unbounded mutations
| balances                     | 8 * N        | Mutate most values change every epoch
| randao_mixes                 | 32 * 65536   | Mutate 1 every epoch
| slashings                    | -
| previous_epoch_participation | 1 * N | Mutate most values every epoch
| current_epoch_participation  | 1 * N | Mutate most values every epoch
| justification_bits           | -
| previous_justified_checkpoin | -
| current_justified_checkpoint | -
| finalized_checkpoint         | -
| inactivity_scores            | 8 * N        | Always 0 unless non-finality, then most could mutate
| current_sync_committee       | -
| next_sync_committee          | -
| latest_execution_payload_hea | -
| next_withdrawal_index        | -
| next_withdrawal_validator_in | -
| historical_summaries         | 64 * **TODO** | 1 add every 256 epochs
| deposit_requests_start_index | -
| deposit_balance_to_consume   | -
| exit_balance_to_consume      | -
| earliest_exit_epoch          | -
| consolidation_balance_to_con | -
| earliest_consolidation_epoch | -
| pending_deposits             | 192 * ??     | Unbounded push-pop queue
| pending_partial_withdrawals  | 24 * ??      | Unbounded push-pop queue
| pending_consolidations       | 16 * ??      | Unbounded push-pop queue

Plotting the impact on total state size per field we get

<img width="599" alt="Screenshot 2024-10-31 at 20 50 05" src="https://github.com/user-attachments/assets/d0880e61-0b31-403f-851a-044e2c6f092f">

So this PR explores handling the biggest offenders manually and leaving the rest to `xdelta3`

## Proposed Changes

Compute a special `ValidatorsDiff` which is:
- Compute a validator record diff where each field is the `y` value if changed, or a default value if equal.
- Instead of storing all items, store a tuple of `(index, validator_diff)` to reduce the total input the compressor has to manage. This makes a huge difference in performance!
- Compress the result. This last step of compression is not super important but makes it easier to compress records that are mostly untouched

Also re-use the existing logic for balance diffs for inactivity scores

## Results

### `tree-states-archive` branch

_commit f5b42e21662c053cb78c3a94321a3e744596fc28_

**Times**

compute hdiff n=1000000 v_mut=0 v_add=0     [35.187 ms 35.421 ms 35.843 ms]
compute hdiff n=1500000 v_mut=0 v_add=0     [54.489 ms 55.719 ms 58.521 ms]
compute hdiff n=2000000 v_mut=0 v_add=0     [73.075 ms 73.718 ms 75.247 ms]

compute hdiff n=1000000 v_mut=100 v_add=10  [342.67 ms 440.49 ms 598.40 ms]
compute hdiff n=1500000 v_mut=100 v_add=10  [518.29 ms 602.20 ms 743.59 ms]
compute hdiff n=2000000 v_mut=100 v_add=10  [649.77 ms 670.14 ms 700.15 ms]

compute hdiff n=1000000 v_mut=1000 v_add=100  [342.39 ms 353.71 ms 363.08 ms]
compute hdiff n=1500000 v_mut=1000 v_add=100  [506.88 ms 566.03 ms 643.94 ms]
compute hdiff n=2000000 v_mut=1000 v_add=100  [665.69 ms 814.25 ms 1.0424 s]

compute hdiff n=1000000 v_mut=100000 v_add=100  [1.0735 s 1.1561 s 1.2658 s]
compute hdiff n=1500000 v_mut=100000 v_add=100  [1.0565 s 1.1065 s 1.1676 s]
compute hdiff n=2000000 v_mut=100000 v_add=100  [1.6224 s 1.7003 s 1.8073 s]

**Diff size**

compute hdiff n=1000000 v_mut=1000 v_add=100  - 3,066,453
compute hdiff n=1500000 v_mut=1000 v_add=100  - 4,549,252
compute hdiff n=2000000 v_mut=1000 v_add=100  - 6,030,667

compute hdiff n=1000000 v_mut=100000 v_add=100  - 11,236,678
compute hdiff n=1500000 v_mut=100000 v_add=100  - 12,869,200

### This branch

_commit aaeffccb5310261b4a95a9a8addfd66c875018b5_

compute hdiff n=1000000 v_mut=0 v_add=0  [25.360 ms 25.402 ms 25.484 ms]
compute hdiff n=1500000 v_mut=0 v_add=0  [38.702 ms 38.886 ms 39.273 ms]
compute hdiff n=2000000 v_mut=0 v_add=0  [52.190 ms 52.402 ms 52.895 ms]

compute hdiff n=1000000 v_mut=1000 v_add=100  [26.545 ms 26.652 ms 26.848 ms]
compute hdiff n=1500000 v_mut=1000 v_add=100  [39.236 ms 39.431 ms 39.772 ms]
compute hdiff n=2000000 v_mut=1000 v_add=100  [53.665 ms 53.904 ms 54.391 ms]

compute hdiff n=1000000 v_mut=100000 v_add=100  [102.26 ms 115.23 ms 145.19 ms]
compute hdiff n=1500000 v_mut=100000 v_add=100  [110.87 ms 112.32 ms 114.46 ms]
compute hdiff n=2000000 v_mut=100000 v_add=100  [116.55 ms 136.00 ms 176.70 ms]

*Note*: Storing all validator diffs increases compute time by 10x

**Diff size**

compute hdiff n=1000000 v_mut=1000 v_add=100  - 3,011,040
compute hdiff n=1500000 v_mut=1000 v_add=100  - 4,494,934
compute hdiff n=2000000 v_mut=1000 v_add=100  - 5,978,865