### PR TITLE
Add error message for duration subtraction overflow in sim tests

### DIFF
--- a/testing/simulator/src/basic_sim.rs
+++ b/testing/simulator/src/basic_sim.rs
@@ -206,7 +206,7 @@ pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
             node.server.all_payloads_valid();
         });
 
-        let duration_to_genesis = network.duration_to_genesis().await;
+        let duration_to_genesis = network.duration_to_genesis().await?;
         println!("Duration to genesis: {}", duration_to_genesis.as_secs());
         sleep(duration_to_genesis).await;
 

--- a/testing/simulator/src/fallback_sim.rs
+++ b/testing/simulator/src/fallback_sim.rs
@@ -194,7 +194,7 @@ pub fn run_fallback_sim(matches: &ArgMatches) -> Result<(), String> {
             );
         }
 
-        let duration_to_genesis = network.duration_to_genesis().await;
+        let duration_to_genesis = network.duration_to_genesis().await?;
         println!("Duration to genesis: {}", duration_to_genesis.as_secs());
         sleep(duration_to_genesis).await;
 


### PR DESCRIPTION
## Issue Addressed

When our node startup time increases, sim tests may fail, as the `GENESIS_DELAY` is no longer sufficient and the tests requires all nodes to be started before genesis. 

When this happens, we get an error message on CI, which isn't very obvious - this PR adds some error logging:

```
thread 'main' panicked at /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/time.rs:1141:31:
overflow when subtracting durations
```

Failing job:
https://github.com/sigp/lighthouse/actions/runs/11606498668/job/32318612076