### PR TITLE
Fix doc-test in `consensus` crate

### DIFF
--- a/consensus/types/src/runtime_var_list.rs
+++ b/consensus/types/src/runtime_var_list.rs
@@ -13,7 +13,7 @@ use std::slice::SliceIndex;
 /// ## Example
 ///
 /// ```
-/// use ssz_types::{RuntimeVariableList};
+/// use types::{RuntimeVariableList};
 ///
 /// let base: Vec<u64> = vec![1, 2, 3, 4];
 ///


### PR DESCRIPTION
## Issue Addressed

I ran `make test` recently and noticed I was getting a doc-test failure in the `consensus` crate.

## Proposed Changes

Updates the import inside the doc test to use the correct crate.

## Additional Info

Curious to know why CI didn't catch this. To me that seems to indicate that `make nextest-release` doesn't cover the same set of tests as `make test`
