### PR TITLE
Deprecate `eth1` and `dummy-eth1` flags

### DIFF
--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -59,10 +59,6 @@ pub struct Config {
     /// Path where the blobs database will be located if blobs should be in a separate database.
     pub blobs_db_path: Option<PathBuf>,
     pub log_file: PathBuf,
-    /// If true, the node will use co-ordinated junk for eth1 values.
-    ///
-    /// This is the method used for the 2019 client interop in Canada.
-    pub dummy_eth1_backend: bool,
     pub sync_eth1_chain: bool,
     /// Graffiti to be inserted everytime we create a block if the validator doesn't specify.
     pub beacon_graffiti: GraffitiOrigin,
@@ -103,8 +99,7 @@ impl Default for Config {
             store: <_>::default(),
             network: NetworkConfig::default(),
             chain: <_>::default(),
-            dummy_eth1_backend: false,
-            sync_eth1_chain: false,
+            sync_eth1_chain: true,
             eth1: <_>::default(),
             execution_layer: None,
             trusted_setup,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -675,8 +675,7 @@ pub fn cli_app() -> Command {
             Arg::new("staking")
                 .long("staking")
                 .help("Standard option for a staking beacon node. This will enable the HTTP server \
-                       on localhost:5052 and import deposit logs from the execution node. This is \
-                       equivalent to `--http` on merge-ready networks, or `--http --eth1` pre-merge")
+                       on localhost:5052 and import deposit logs from the execution node.")
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
@@ -688,21 +687,21 @@ pub fn cli_app() -> Command {
         .arg(
             Arg::new("eth1")
                 .long("eth1")
-                .help("If present the node will connect to an eth1 node. This is required for \
-                       block production, you must use this flag if you wish to serve a validator.")
+                .help("DEPRECATED")
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
+                .hide(true)
         )
         .arg(
             Arg::new("dummy-eth1")
                 .long("dummy-eth1")
+                .help("DEPRECATED")
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
                 .conflicts_with("eth1")
-                .help("If present, uses an eth1 backend that generates static dummy data.\
-                      Identical to the method used at the 2019 Canada interop.")
                 .display_order(0)
+                .hide(true)
         )
         .arg(
             Arg::new("eth1-purge-cache")

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1444,6 +1444,7 @@ pub fn cli_app() -> Command {
                       Useful if you intend to run a non-validating beacon node.")
                 .action(ArgAction::SetTrue)
                 .help_heading(FLAG_HEADER)
+                .conflicts_with("staking")
                 .display_order(0)
         )
         .arg(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -121,7 +121,6 @@ pub fn get_config<E: EthSpec>(
 
     if cli_args.get_flag("staking") {
         client_config.http_api.enabled = true;
-        client_config.sync_eth1_chain = true;
     }
 
     /*
@@ -281,17 +280,6 @@ pub fn get_config<E: EthSpec>(
     // `--execution-endpoint` is required now.
     let endpoints: String = clap_utils::parse_required(cli_args, "execution-endpoint")?;
     let mut el_config = execution_layer::Config::default();
-
-    // Always follow the deposit contract when there is an execution endpoint.
-    //
-    // This is wasteful for non-staking nodes as they have no need to process deposit contract
-    // logs and build an "eth1" cache. The alternative is to explicitly require the `--eth1` or
-    // `--staking` flags, however that poses a risk to stakers since they cannot produce blocks
-    // without "eth1".
-    //
-    // The waste for non-staking nodes is relatively small so we err on the side of safety for
-    // stakers. The merge is already complicated enough.
-    client_config.sync_eth1_chain = true;
 
     // Parse a single execution endpoint, logging warnings if multiple endpoints are supplied.
     let execution_endpoint = parse_only_one_value(

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -254,18 +254,12 @@ pub fn get_config<E: EthSpec>(
      * Eth1
      */
 
-    // When present, use an eth1 backend that generates deterministic junk.
-    //
-    // Useful for running testnets without the overhead of a deposit contract.
     if cli_args.get_flag("dummy-eth1") {
-        client_config.dummy_eth1_backend = true;
+        warn!(log, "The --dummy-eth1 flag is deprecated");
     }
 
-    // When present, attempt to sync to an eth1 node.
-    //
-    // Required for block production.
     if cli_args.get_flag("eth1") {
-        client_config.sync_eth1_chain = true;
+        warn!(log, "The --eth1 flag is deprecated");
     }
 
     if let Some(val) = cli_args.get_one::<String>("eth1-blocks-per-log-query") {

--- a/beacon_node/src/lib.rs
+++ b/beacon_node/src/lib.rs
@@ -140,7 +140,7 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
         let builder = builder
             .beacon_chain_builder(client_genesis, client_config.clone())
             .await?;
-        let builder = if client_config.sync_eth1_chain && !client_config.dummy_eth1_backend {
+        let builder = if client_config.sync_eth1_chain {
             info!(
                 log,
                 "Block production enabled";
@@ -150,13 +150,6 @@ impl<E: EthSpec> ProductionBeaconNode<E> {
             builder
                 .caching_eth1_backend(client_config.eth1.clone())
                 .await?
-        } else if client_config.dummy_eth1_backend {
-            warn!(
-                log,
-                "Block production impaired";
-                "reason" => "dummy eth1 backend is enabled"
-            );
-            builder.dummy_eth1_backend()?
         } else {
             info!(
                 log,

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -468,9 +468,6 @@ Flags:
       --disable-upnp
           Disables UPnP support. Setting this will prevent Lighthouse from
           attempting to automatically establish external port mappings.
-      --dummy-eth1
-          If present, uses an eth1 backend that generates static dummy
-          data.Identical to the method used at the 2019 Canada interop.
   -e, --enr-match
           Sets the local ENR IP address and port to match those set for
           lighthouse. Specifically, the IP address will be the value of
@@ -478,10 +475,6 @@ Flags:
       --enable-private-discovery
           Lighthouse by default does not discover private IP addresses. Set this
           flag to enable connection attempts to local addresses.
-      --eth1
-          If present the node will connect to an eth1 node. This is required for
-          block production, you must use this flag if you wish to serve a
-          validator.
       --eth1-purge-cache
           Purges the eth1 block and deposit caches
       --genesis-backfill
@@ -549,8 +542,7 @@ Flags:
       --staking
           Standard option for a staking beacon node. This will enable the HTTP
           server on localhost:5052 and import deposit logs from the execution
-          node. This is equivalent to `--http` on merge-ready networks, or
-          `--http --eth1` pre-merge
+          node.
       --stdin-inputs
           If present, read all user inputs from stdin instead of tty.
       --subscribe-all-subnets

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -396,13 +396,14 @@ fn genesis_backfill_with_historic_flag() {
 }
 
 // Tests for Eth1 flags.
+// DEPRECATED but should not crash
 #[test]
 fn dummy_eth1_flag() {
     CommandLineTest::new()
         .flag("dummy-eth1", None)
-        .run_with_zero_port()
-        .with_config(|config| assert!(config.dummy_eth1_backend));
+        .run_with_zero_port();
 }
+// DEPRECATED but should not crash
 #[test]
 fn eth1_flag() {
     CommandLineTest::new()

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2476,6 +2476,21 @@ fn sync_eth1_chain_disable_deposit_contract_sync_flag() {
 }
 
 #[test]
+#[should_panic]
+fn disable_deposit_contract_sync_conflicts_with_staking() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
+    CommandLineTest::new_with_no_execution_endpoint()
+        .flag("disable-deposit-contract-sync", None)
+        .flag("staking", None)
+        .flag("execution-endpoints", Some("http://localhost:8551/"))
+        .flag(
+            "execution-jwt",
+            dir.path().join("jwt-file").as_os_str().to_str(),
+        )
+        .run_with_zero_port();
+}
+
+#[test]
 fn light_client_server_default() {
     CommandLineTest::new()
         .run_with_zero_port()

--- a/testing/node_test_rig/src/lib.rs
+++ b/testing/node_test_rig/src/lib.rs
@@ -103,8 +103,6 @@ pub fn testing_client_config() -> ClientConfig {
     client_config.http_api.enabled = true;
     client_config.http_api.listen_port = 0;
 
-    client_config.dummy_eth1_backend = true;
-
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("should get system time")


### PR DESCRIPTION
## Proposed Changes

Deprecate the following beacon node flags:

- `--eth1`: No longer required because it is enabled by default. The deposit contract sync can be disabled via a separate flag `--disable-deposit-contract-sync`, which has existed since the merge.
- `--dummy-eth1`: Very rarely used and of limited utility.
