### PR TITLE
Remove `yq` installation on CI

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -36,11 +36,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install Kurtosis
         run: |
-          # Install yq
-          sudo snap install yq --channel=v3/stable
-          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
           sudo apt install -y kurtosis-cli=1.3.1
@@ -85,11 +82,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install Kurtosis
         run: |
-          # Install yq
-          sudo snap install yq --channel=v3/stable
-          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
           sudo apt install -y kurtosis-cli=1.3.1
@@ -123,11 +117,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install Kurtosis
         run: |
-          # Install yq
-          sudo snap install yq --channel=v3/stable
-          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
           sudo apt install -y kurtosis-cli=1.3.1

--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -38,10 +38,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:rmescandon/yq
+          # Install yq
+          sudo snap install yq --channel=v3/stable
+          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1 yq
+          sudo apt install -y kurtosis-cli=1.3.1
           kurtosis analytics disable
 
       - name: Download Docker image artifact
@@ -85,10 +87,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:rmescandon/yq
+          # Install yq
+          sudo snap install yq --channel=v3/stable
+          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1 yq
+          sudo apt install -y kurtosis-cli=1.3.1
           kurtosis analytics disable
 
       - name: Download Docker image artifact
@@ -121,10 +125,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:rmescandon/yq
+          # Install yq
+          sudo snap install yq --channel=v3/stable
+          # Install Kurtosis
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1 yq
+          sudo apt install -y kurtosis-cli=1.3.1
           kurtosis analytics disable
 
       - name: Download Docker image artifact


### PR DESCRIPTION
## Issue Addressed

The `yq` PPA repo has been down for a while today and we've been unable to get a passing CI.

~~Recently we changed our doc to suggest using `snap` (instead of `apt`) to install `yq`. (https://github.com/sigp/lighthouse/pull/6468) Michael also ran into some issues with the `yq` version installed with `apt`, so I thought it might be a good time to also switch our CI over to use `snap`.~~

**UPDATE:** it turns out that GitHub Runner images come with `yq` preinstalled, so I've removed the installation altogether.