### PR TITLE
builder gas limit & some refactoring

### DIFF
--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use execution_layer::{
     BlockProposalContents, BlockProposalContentsType, BuilderParams, NewPayloadRequest,
-    PayloadAttributes, PayloadStatus,
+    PayloadAttributes, PayloadParameters, PayloadStatus,
 };
 use fork_choice::{InvalidationOperation, PayloadVerificationStatus};
 use proto_array::{Block as ProtoBlock, ExecutionStatus};
@@ -526,13 +526,17 @@ where
         parent_beacon_block_root,
     );
 
+    let payload_parameters = PayloadParameters {
+        parent_hash,
+        payload_attributes: &payload_attributes,
+        forkchoice_update_params: &forkchoice_update_params,
+        current_fork: fork,
+    };
+
     let block_contents = execution_layer
         .get_payload(
-            parent_hash,
-            &payload_attributes,
-            forkchoice_update_params,
+            payload_parameters,
             builder_params,
-            fork,
             &chain.spec,
             builder_boost_factor,
             block_production_version,

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -375,8 +375,9 @@ pub fn get_execution_payload<T: BeaconChainTypes>(
     let timestamp =
         compute_timestamp_at_slot(state, state.slot(), spec).map_err(BeaconStateError::from)?;
     let random = *state.get_randao_mix(current_epoch)?;
-    let latest_execution_payload_header_block_hash =
-        state.latest_execution_payload_header()?.block_hash();
+    let latest_execution_payload_header = state.latest_execution_payload_header()?;
+    let latest_execution_payload_header_block_hash = latest_execution_payload_header.block_hash();
+    let latest_execution_payload_header_gas_limit = latest_execution_payload_header.gas_limit();
     let withdrawals = match state {
         &BeaconState::Capella(_) | &BeaconState::Deneb(_) | &BeaconState::Electra(_) => {
             Some(get_expected_withdrawals(state, spec)?.0.into())
@@ -406,6 +407,7 @@ pub fn get_execution_payload<T: BeaconChainTypes>(
                     random,
                     proposer_index,
                     latest_execution_payload_header_block_hash,
+                    latest_execution_payload_header_gas_limit,
                     builder_params,
                     withdrawals,
                     parent_beacon_block_root,
@@ -443,6 +445,7 @@ pub async fn prepare_execution_payload<T>(
     random: Hash256,
     proposer_index: u64,
     latest_execution_payload_header_block_hash: ExecutionBlockHash,
+    latest_execution_payload_header_gas_limit: u64,
     builder_params: BuilderParams,
     withdrawals: Option<Vec<Withdrawal>>,
     parent_beacon_block_root: Option<Hash256>,
@@ -526,8 +529,11 @@ where
         parent_beacon_block_root,
     );
 
+    let target_gas_limit = execution_layer.get_proposer_gas_limit(proposer_index).await;
     let payload_parameters = PayloadParameters {
         parent_hash,
+        parent_gas_limit: latest_execution_payload_header_gas_limit,
+        proposer_gas_limit: target_gas_limit,
         payload_attributes: &payload_attributes,
         forkchoice_update_params: &forkchoice_update_params,
         current_fork: fork,

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -986,10 +986,13 @@ async fn payload_preparation() {
     // Provide preparation data to the EL for `proposer`.
     el.update_proposer_preparation(
         Epoch::new(1),
-        &[ProposerPreparationData {
-            validator_index: proposer as u64,
-            fee_recipient,
-        }],
+        [(
+            &ProposerPreparationData {
+                validator_index: proposer as u64,
+                fee_recipient,
+            },
+            &None,
+        )],
     )
     .await;
 
@@ -1119,10 +1122,13 @@ async fn payload_preparation_before_transition_block() {
     // Provide preparation data to the EL for `proposer`.
     el.update_proposer_preparation(
         Epoch::new(0),
-        &[ProposerPreparationData {
-            validator_index: proposer as u64,
-            fee_recipient,
-        }],
+        [(
+            &ProposerPreparationData {
+                validator_index: proposer as u64,
+                fee_recipient,
+            },
+            &None,
+        )],
     )
     .await;
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -27,7 +27,7 @@ use sensitive_url::SensitiveUrl;
 use serde::{Deserialize, Serialize};
 use slog::{crit, debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 use std::fmt;
 use std::future::Future;
 use std::io::Write;
@@ -322,6 +322,36 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> BlockProposalContents<E, Paylo
 pub struct ProposerPreparationDataEntry {
     update_epoch: Epoch,
     preparation_data: ProposerPreparationData,
+    gas_limit: Option<u64>,
+}
+
+impl ProposerPreparationDataEntry {
+    pub fn update(&mut self, updated: Self) -> bool {
+        let mut changed = false;
+        // Update `gas_limit` if `updated.gas_limit` is `Some` and:
+        // - `self.gas_limit` is `None`, or
+        // - both are `Some` but the values differ.
+        if let Some(updated_gas_limit) = updated.gas_limit {
+            if self.gas_limit != Some(updated_gas_limit) {
+                self.gas_limit = Some(updated_gas_limit);
+                changed = true;
+            }
+        }
+
+        // Update `update_epoch` if it differs
+        if self.update_epoch != updated.update_epoch {
+            self.update_epoch = updated.update_epoch;
+            changed = true;
+        }
+
+        // Update `preparation_data` if it differs
+        if self.preparation_data != updated.preparation_data {
+            self.preparation_data = updated.preparation_data;
+            changed = true;
+        }
+
+        changed
+    }
 }
 
 #[derive(Hash, PartialEq, Eq)]
@@ -710,23 +740,29 @@ impl<E: EthSpec> ExecutionLayer<E> {
     }
 
     /// Updates the proposer preparation data provided by validators
-    pub async fn update_proposer_preparation(
-        &self,
-        update_epoch: Epoch,
-        preparation_data: &[ProposerPreparationData],
-    ) {
+    pub async fn update_proposer_preparation<'a, I>(&self, update_epoch: Epoch, proposer_data: I)
+    where
+        I: IntoIterator<Item = (&'a ProposerPreparationData, &'a Option<u64>)>,
+    {
         let mut proposer_preparation_data = self.proposer_preparation_data().await;
-        for preparation_entry in preparation_data {
+
+        for (preparation_entry, gas_limit) in proposer_data {
             let new = ProposerPreparationDataEntry {
                 update_epoch,
                 preparation_data: preparation_entry.clone(),
+                gas_limit: *gas_limit,
             };
 
-            let existing =
-                proposer_preparation_data.insert(preparation_entry.validator_index, new.clone());
-
-            if existing != Some(new) {
-                metrics::inc_counter(&metrics::EXECUTION_LAYER_PROPOSER_DATA_UPDATED);
+            match proposer_preparation_data.entry(preparation_entry.validator_index) {
+                Entry::Occupied(mut entry) => {
+                    if entry.get_mut().update(new) {
+                        metrics::inc_counter(&metrics::EXECUTION_LAYER_PROPOSER_DATA_UPDATED);
+                    }
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(new);
+                    metrics::inc_counter(&metrics::EXECUTION_LAYER_PROPOSER_DATA_UPDATED);
+                }
             }
         }
     }

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -323,6 +323,8 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> BlockProposalContents<E, Paylo
 #[derive(Clone, Copy)]
 pub struct PayloadParameters<'a> {
     pub parent_hash: ExecutionBlockHash,
+    pub parent_gas_limit: u64,
+    pub proposer_gas_limit: Option<u64>,
     pub payload_attributes: &'a PayloadAttributes,
     pub forkchoice_update_params: &'a ForkchoiceUpdateParameters,
     pub current_fork: ForkName,
@@ -854,6 +856,13 @@ impl<E: EthSpec> ExecutionLayer<E> {
         }
     }
 
+    pub async fn get_proposer_gas_limit(&self, proposer_index: u64) -> Option<u64> {
+        self.proposer_preparation_data()
+            .await
+            .get(&proposer_index)
+            .and_then(|entry| entry.gas_limit)
+    }
+
     /// Maps to the `engine_getPayload` JSON-RPC call.
     ///
     /// However, it will attempt to call `self.prepare_payload` if it cannot find an existing
@@ -1238,6 +1247,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
             payload_attributes,
             forkchoice_update_params,
             current_fork,
+            ..
         } = payload_parameters;
 
         self.engine()
@@ -1947,6 +1957,10 @@ enum InvalidBuilderPayload {
         payload: Option<Hash256>,
         expected: Option<Hash256>,
     },
+    GasLimitMismatch {
+        payload: u64,
+        expected: u64,
+    },
 }
 
 impl fmt::Display for InvalidBuilderPayload {
@@ -1985,7 +1999,32 @@ impl fmt::Display for InvalidBuilderPayload {
                     opt_string(expected)
                 )
             }
+            InvalidBuilderPayload::GasLimitMismatch { payload, expected } => {
+                write!(f, "payload gas limit was {} not {}", payload, expected)
+            }
         }
+    }
+}
+
+/// Calculate the expected gas limit for a block.
+pub fn expected_gas_limit(
+    parent_gas_limit: u64,
+    target_gas_limit: u64,
+    spec: &ChainSpec,
+) -> Option<u64> {
+    // Calculate the maximum gas limit difference allowed safely
+    let max_gas_limit_difference = parent_gas_limit
+        .checked_div(spec.gas_limit_adjustment_factor)
+        .and_then(|result| result.checked_sub(1))
+        .unwrap_or(0);
+
+    // Adjust the gas limit safely
+    if target_gas_limit > parent_gas_limit {
+        let gas_diff = target_gas_limit.saturating_sub(parent_gas_limit);
+        parent_gas_limit.checked_add(std::cmp::min(gas_diff, max_gas_limit_difference))
+    } else {
+        let gas_diff = parent_gas_limit.saturating_sub(target_gas_limit);
+        parent_gas_limit.checked_sub(std::cmp::min(gas_diff, max_gas_limit_difference))
     }
 }
 
@@ -2000,6 +2039,8 @@ fn verify_builder_bid<E: EthSpec>(
         parent_hash,
         payload_attributes,
         current_fork,
+        parent_gas_limit,
+        proposer_gas_limit,
         ..
     } = payload_parameters;
 
@@ -2018,6 +2059,8 @@ fn verify_builder_bid<E: EthSpec>(
         .cloned()
         .map(|withdrawals| Withdrawals::<E>::from(withdrawals).tree_hash_root());
     let payload_withdrawals_root = header.withdrawals_root().ok();
+    let expected_gas_limit = proposer_gas_limit
+        .and_then(|target_gas_limit| expected_gas_limit(parent_gas_limit, target_gas_limit, spec));
 
     if header.parent_hash() != parent_hash {
         Err(Box::new(InvalidBuilderPayload::ParentHash {
@@ -2053,6 +2096,14 @@ fn verify_builder_bid<E: EthSpec>(
         Err(Box::new(InvalidBuilderPayload::WithdrawalsRoot {
             payload: payload_withdrawals_root,
             expected: expected_withdrawals_root,
+        }))
+    } else if expected_gas_limit
+        .map(|gas_limit| header.gas_limit() != gas_limit)
+        .unwrap_or(false)
+    {
+        Err(Box::new(InvalidBuilderPayload::GasLimitMismatch {
+            payload: header.gas_limit(),
+            expected: expected_gas_limit.unwrap_or(0),
         }))
     } else {
         Ok(())

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2158,6 +2158,27 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_expected_gas_limit() {
+        let spec = ChainSpec::mainnet();
+        assert_eq!(
+            expected_gas_limit(30_000_000, 30_000_000, &spec),
+            Some(30_000_000)
+        );
+        assert_eq!(
+            expected_gas_limit(30_000_000, 40_000_000, &spec),
+            Some(30_029_295)
+        );
+        assert_eq!(
+            expected_gas_limit(30_029_295, 40_000_000, &spec),
+            Some(30_058_619)
+        );
+        assert_eq!(
+            expected_gas_limit(30_058_619, 30_000_000, &spec),
+            Some(30_029_266)
+        );
+    }
+
+    #[tokio::test]
     async fn test_forked_terminal_block() {
         let runtime = TestRuntime::default();
         let (mock, block_hash) = MockExecutionLayer::default_params(runtime.task_executor.clone())

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -318,6 +318,16 @@ impl<E: EthSpec, Payload: AbstractExecPayload<E>> BlockProposalContents<E, Paylo
     }
 }
 
+// This just groups together a bunch of parameters that commonly
+// get passed around together in calls to get_payload.
+#[derive(Clone, Copy)]
+pub struct PayloadParameters<'a> {
+    pub parent_hash: ExecutionBlockHash,
+    pub payload_attributes: &'a PayloadAttributes,
+    pub forkchoice_update_params: &'a ForkchoiceUpdateParameters,
+    pub current_fork: ForkName,
+}
+
 #[derive(Clone, PartialEq)]
 pub struct ProposerPreparationDataEntry {
     update_epoch: Epoch,
@@ -853,14 +863,10 @@ impl<E: EthSpec> ExecutionLayer<E> {
     ///
     /// The result will be returned from the first node that returns successfully. No more nodes
     /// will be contacted.
-    #[allow(clippy::too_many_arguments)]
     pub async fn get_payload(
         &self,
-        parent_hash: ExecutionBlockHash,
-        payload_attributes: &PayloadAttributes,
-        forkchoice_update_params: ForkchoiceUpdateParameters,
+        payload_parameters: PayloadParameters<'_>,
         builder_params: BuilderParams,
-        current_fork: ForkName,
         spec: &ChainSpec,
         builder_boost_factor: Option<u64>,
         block_production_version: BlockProductionVersion,
@@ -868,11 +874,8 @@ impl<E: EthSpec> ExecutionLayer<E> {
         let payload_result_type = match block_production_version {
             BlockProductionVersion::V3 => match self
                 .determine_and_fetch_payload(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
+                    payload_parameters,
                     builder_params,
-                    current_fork,
                     builder_boost_factor,
                     spec,
                 )
@@ -892,25 +895,11 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     &metrics::EXECUTION_LAYER_REQUEST_TIMES,
                     &[metrics::GET_BLINDED_PAYLOAD],
                 );
-                self.determine_and_fetch_payload(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
-                    builder_params,
-                    current_fork,
-                    None,
-                    spec,
-                )
-                .await?
+                self.determine_and_fetch_payload(payload_parameters, builder_params, None, spec)
+                    .await?
             }
             BlockProductionVersion::FullV2 => self
-                .get_full_payload_with(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
-                    current_fork,
-                    noop,
-                )
+                .get_full_payload_with(payload_parameters, noop)
                 .await
                 .and_then(GetPayloadResponseType::try_into)
                 .map(ProvenancedPayload::Local)?,
@@ -957,17 +946,15 @@ impl<E: EthSpec> ExecutionLayer<E> {
     async fn fetch_builder_and_local_payloads(
         &self,
         builder: &BuilderHttpClient,
-        parent_hash: ExecutionBlockHash,
         builder_params: &BuilderParams,
-        payload_attributes: &PayloadAttributes,
-        forkchoice_update_params: ForkchoiceUpdateParameters,
-        current_fork: ForkName,
+        payload_parameters: PayloadParameters<'_>,
     ) -> (
         Result<Option<ForkVersionedResponse<SignedBuilderBid<E>>>, builder_client::Error>,
         Result<GetPayloadResponse<E>, Error>,
     ) {
         let slot = builder_params.slot;
         let pubkey = &builder_params.pubkey;
+        let parent_hash = payload_parameters.parent_hash;
 
         info!(
             self.log(),
@@ -985,17 +972,12 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     .await
             }),
             timed_future(metrics::GET_BLINDED_PAYLOAD_LOCAL, async {
-                self.get_full_payload_caching(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
-                    current_fork,
-                )
-                .await
-                .and_then(|local_result_type| match local_result_type {
-                    GetPayloadResponseType::Full(payload) => Ok(payload),
-                    GetPayloadResponseType::Blinded(_) => Err(Error::PayloadTypeMismatch),
-                })
+                self.get_full_payload_caching(payload_parameters)
+                    .await
+                    .and_then(|local_result_type| match local_result_type {
+                        GetPayloadResponseType::Full(payload) => Ok(payload),
+                        GetPayloadResponseType::Blinded(_) => Err(Error::PayloadTypeMismatch),
+                    })
             })
         );
 
@@ -1019,26 +1001,17 @@ impl<E: EthSpec> ExecutionLayer<E> {
         (relay_result, local_result)
     }
 
-    #[allow(clippy::too_many_arguments)]
     async fn determine_and_fetch_payload(
         &self,
-        parent_hash: ExecutionBlockHash,
-        payload_attributes: &PayloadAttributes,
-        forkchoice_update_params: ForkchoiceUpdateParameters,
+        payload_parameters: PayloadParameters<'_>,
         builder_params: BuilderParams,
-        current_fork: ForkName,
         builder_boost_factor: Option<u64>,
         spec: &ChainSpec,
     ) -> Result<ProvenancedPayload<BlockProposalContentsType<E>>, Error> {
         let Some(builder) = self.builder() else {
             // no builder.. return local payload
             return self
-                .get_full_payload_caching(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
-                    current_fork,
-                )
+                .get_full_payload_caching(payload_parameters)
                 .await
                 .and_then(GetPayloadResponseType::try_into)
                 .map(ProvenancedPayload::Local);
@@ -1069,26 +1042,15 @@ impl<E: EthSpec> ExecutionLayer<E> {
                 ),
             }
             return self
-                .get_full_payload_caching(
-                    parent_hash,
-                    payload_attributes,
-                    forkchoice_update_params,
-                    current_fork,
-                )
+                .get_full_payload_caching(payload_parameters)
                 .await
                 .and_then(GetPayloadResponseType::try_into)
                 .map(ProvenancedPayload::Local);
         }
 
+        let parent_hash = payload_parameters.parent_hash;
         let (relay_result, local_result) = self
-            .fetch_builder_and_local_payloads(
-                builder.as_ref(),
-                parent_hash,
-                &builder_params,
-                payload_attributes,
-                forkchoice_update_params,
-                current_fork,
-            )
+            .fetch_builder_and_local_payloads(builder.as_ref(), &builder_params, payload_parameters)
             .await;
 
         match (relay_result, local_result) {
@@ -1153,14 +1115,9 @@ impl<E: EthSpec> ExecutionLayer<E> {
                 );
 
                 // check relay payload validity
-                if let Err(reason) = verify_builder_bid(
-                    &relay,
-                    parent_hash,
-                    payload_attributes,
-                    Some(local.block_number()),
-                    current_fork,
-                    spec,
-                ) {
+                if let Err(reason) =
+                    verify_builder_bid(&relay, payload_parameters, Some(local.block_number()), spec)
+                {
                     // relay payload invalid -> return local
                     metrics::inc_counter_vec(
                         &metrics::EXECUTION_LAYER_GET_PAYLOAD_BUILDER_REJECTIONS,
@@ -1237,14 +1194,7 @@ impl<E: EthSpec> ExecutionLayer<E> {
                     "parent_hash" => ?parent_hash,
                 );
 
-                match verify_builder_bid(
-                    &relay,
-                    parent_hash,
-                    payload_attributes,
-                    None,
-                    current_fork,
-                    spec,
-                ) {
+                match verify_builder_bid(&relay, payload_parameters, None, spec) {
                     Ok(()) => Ok(ProvenancedPayload::try_from(relay.data.message)?),
                     Err(reason) => {
                         metrics::inc_counter_vec(
@@ -1269,32 +1219,27 @@ impl<E: EthSpec> ExecutionLayer<E> {
     /// Get a full payload and cache its result in the execution layer's payload cache.
     async fn get_full_payload_caching(
         &self,
-        parent_hash: ExecutionBlockHash,
-        payload_attributes: &PayloadAttributes,
-        forkchoice_update_params: ForkchoiceUpdateParameters,
-        current_fork: ForkName,
+        payload_parameters: PayloadParameters<'_>,
     ) -> Result<GetPayloadResponseType<E>, Error> {
-        self.get_full_payload_with(
-            parent_hash,
-            payload_attributes,
-            forkchoice_update_params,
-            current_fork,
-            Self::cache_payload,
-        )
-        .await
+        self.get_full_payload_with(payload_parameters, Self::cache_payload)
+            .await
     }
 
     async fn get_full_payload_with(
         &self,
-        parent_hash: ExecutionBlockHash,
-        payload_attributes: &PayloadAttributes,
-        forkchoice_update_params: ForkchoiceUpdateParameters,
-        current_fork: ForkName,
+        payload_parameters: PayloadParameters<'_>,
         cache_fn: fn(
             &ExecutionLayer<E>,
             PayloadContentsRefTuple<E>,
         ) -> Option<FullPayloadContents<E>>,
     ) -> Result<GetPayloadResponseType<E>, Error> {
+        let PayloadParameters {
+            parent_hash,
+            payload_attributes,
+            forkchoice_update_params,
+            current_fork,
+        } = payload_parameters;
+
         self.engine()
             .request(move |engine| async move {
                 let payload_id = if let Some(id) = engine
@@ -2047,12 +1992,17 @@ impl fmt::Display for InvalidBuilderPayload {
 /// Perform some cursory, non-exhaustive validation of the bid returned from the builder.
 fn verify_builder_bid<E: EthSpec>(
     bid: &ForkVersionedResponse<SignedBuilderBid<E>>,
-    parent_hash: ExecutionBlockHash,
-    payload_attributes: &PayloadAttributes,
+    payload_parameters: PayloadParameters<'_>,
     block_number: Option<u64>,
-    current_fork: ForkName,
     spec: &ChainSpec,
 ) -> Result<(), Box<InvalidBuilderPayload>> {
+    let PayloadParameters {
+        parent_hash,
+        payload_attributes,
+        current_fork,
+        ..
+    } = payload_parameters;
+
     let is_signature_valid = bid.data.verify_signature(spec);
     let header = &bid.data.message.header();
 

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -28,7 +28,7 @@ use super::DEFAULT_TERMINAL_BLOCK;
 
 const TEST_BLOB_BUNDLE: &[u8] = include_bytes!("fixtures/mainnet/test_blobs_bundle.ssz");
 
-const GAS_LIMIT: u64 = 16384;
+pub const GAS_LIMIT: u64 = 16384;
 const GAS_USED: u64 = GAS_LIMIT - 1;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -64,6 +64,13 @@ impl<E: EthSpec> Block<E> {
         match self {
             Block::PoW(block) => Some(block.total_difficulty),
             Block::PoS(_) => None,
+        }
+    }
+
+    pub fn gas_limit(&self) -> u64 {
+        match self {
+            Block::PoW(_) => GAS_LIMIT,
+            Block::PoS(payload) => payload.gas_limit(),
         }
     }
 

--- a/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
+++ b/beacon_node/execution_layer/src/test_utils/execution_block_generator.rs
@@ -28,14 +28,18 @@ use super::DEFAULT_TERMINAL_BLOCK;
 
 const TEST_BLOB_BUNDLE: &[u8] = include_bytes!("fixtures/mainnet/test_blobs_bundle.ssz");
 
-pub const GAS_LIMIT: u64 = 16384;
-const GAS_USED: u64 = GAS_LIMIT - 1;
+pub const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
+const GAS_USED: u64 = DEFAULT_GAS_LIMIT - 1;
 
 #[derive(Clone, Debug, PartialEq)]
 #[allow(clippy::large_enum_variant)] // This struct is only for testing.
 pub enum Block<E: EthSpec> {
     PoW(PoWBlock),
     PoS(ExecutionPayload<E>),
+}
+
+pub fn mock_el_extra_data<E: EthSpec>() -> types::VariableList<u8, E::MaxExtraDataBytes> {
+    "block gen was here".as_bytes().to_vec().into()
 }
 
 impl<E: EthSpec> Block<E> {
@@ -69,7 +73,7 @@ impl<E: EthSpec> Block<E> {
 
     pub fn gas_limit(&self) -> u64 {
         match self {
-            Block::PoW(_) => GAS_LIMIT,
+            Block::PoW(_) => DEFAULT_GAS_LIMIT,
             Block::PoS(payload) => payload.gas_limit(),
         }
     }
@@ -577,10 +581,10 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
                 logs_bloom: vec![0; 256].into(),
                 prev_randao: pa.prev_randao,
                 block_number: parent.block_number() + 1,
-                gas_limit: GAS_LIMIT,
+                gas_limit: DEFAULT_GAS_LIMIT,
                 gas_used: GAS_USED,
                 timestamp: pa.timestamp,
-                extra_data: "block gen was here".as_bytes().to_vec().into(),
+                extra_data: mock_el_extra_data::<E>(),
                 base_fee_per_gas: Uint256::from(1u64),
                 block_hash: ExecutionBlockHash::zero(),
                 transactions: vec![].into(),
@@ -594,10 +598,10 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
                     logs_bloom: vec![0; 256].into(),
                     prev_randao: pa.prev_randao,
                     block_number: parent.block_number() + 1,
-                    gas_limit: GAS_LIMIT,
+                    gas_limit: DEFAULT_GAS_LIMIT,
                     gas_used: GAS_USED,
                     timestamp: pa.timestamp,
-                    extra_data: "block gen was here".as_bytes().to_vec().into(),
+                    extra_data: mock_el_extra_data::<E>(),
                     base_fee_per_gas: Uint256::from(1u64),
                     block_hash: ExecutionBlockHash::zero(),
                     transactions: vec![].into(),
@@ -610,10 +614,10 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
                     logs_bloom: vec![0; 256].into(),
                     prev_randao: pa.prev_randao,
                     block_number: parent.block_number() + 1,
-                    gas_limit: GAS_LIMIT,
+                    gas_limit: DEFAULT_GAS_LIMIT,
                     gas_used: GAS_USED,
                     timestamp: pa.timestamp,
-                    extra_data: "block gen was here".as_bytes().to_vec().into(),
+                    extra_data: mock_el_extra_data::<E>(),
                     base_fee_per_gas: Uint256::from(1u64),
                     block_hash: ExecutionBlockHash::zero(),
                     transactions: vec![].into(),
@@ -630,10 +634,10 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
                     logs_bloom: vec![0; 256].into(),
                     prev_randao: pa.prev_randao,
                     block_number: parent.block_number() + 1,
-                    gas_limit: GAS_LIMIT,
+                    gas_limit: DEFAULT_GAS_LIMIT,
                     gas_used: GAS_USED,
                     timestamp: pa.timestamp,
-                    extra_data: "block gen was here".as_bytes().to_vec().into(),
+                    extra_data: mock_el_extra_data::<E>(),
                     base_fee_per_gas: Uint256::from(1u64),
                     block_hash: ExecutionBlockHash::zero(),
                     transactions: vec![].into(),
@@ -649,10 +653,10 @@ impl<E: EthSpec> ExecutionBlockGenerator<E> {
                     logs_bloom: vec![0; 256].into(),
                     prev_randao: pa.prev_randao,
                     block_number: parent.block_number() + 1,
-                    gas_limit: GAS_LIMIT,
+                    gas_limit: DEFAULT_GAS_LIMIT,
                     gas_used: GAS_USED,
                     timestamp: pa.timestamp,
-                    extra_data: "block gen was here".as_bytes().to_vec().into(),
+                    extra_data: mock_el_extra_data::<E>(),
                     base_fee_per_gas: Uint256::from(1u64),
                     block_hash: ExecutionBlockHash::zero(),
                     transactions: vec![].into(),

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -54,6 +54,10 @@ impl Operation {
     }
 }
 
+pub fn mock_builder_extra_data<E: EthSpec>() -> types::VariableList<u8, E::MaxExtraDataBytes> {
+    "mock_builder".as_bytes().to_vec().into()
+}
+
 #[derive(Debug)]
 // We don't use the string value directly, but it's used in the Debug impl which is required by `warp::reject::Reject`.
 struct Custom(#[allow(dead_code)] String);
@@ -72,6 +76,8 @@ pub trait BidStuff<E: EthSpec> {
     fn set_withdrawals_root(&mut self, withdrawals_root: Hash256);
 
     fn sign_builder_message(&mut self, sk: &SecretKey, spec: &ChainSpec) -> Signature;
+
+    fn stamp_payload(&mut self);
 }
 
 impl<E: EthSpec> BidStuff<E> for BuilderBid<E> {
@@ -203,6 +209,29 @@ impl<E: EthSpec> BidStuff<E> for BuilderBid<E> {
         let message = self.signing_root(domain);
         sk.sign(message)
     }
+
+    // this helps differentiate a builder block from a regular block
+    fn stamp_payload(&mut self) {
+        let extra_data = mock_builder_extra_data::<E>();
+        match self.to_mut().header_mut() {
+            ExecutionPayloadHeaderRefMut::Bellatrix(header) => {
+                header.extra_data = extra_data;
+                header.block_hash = ExecutionBlockHash::from_root(header.tree_hash_root());
+            }
+            ExecutionPayloadHeaderRefMut::Capella(header) => {
+                header.extra_data = extra_data;
+                header.block_hash = ExecutionBlockHash::from_root(header.tree_hash_root());
+            }
+            ExecutionPayloadHeaderRefMut::Deneb(header) => {
+                header.extra_data = extra_data;
+                header.block_hash = ExecutionBlockHash::from_root(header.tree_hash_root());
+            }
+            ExecutionPayloadHeaderRefMut::Electra(header) => {
+                header.extra_data = extra_data;
+                header.block_hash = ExecutionBlockHash::from_root(header.tree_hash_root());
+            }
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -286,6 +315,7 @@ impl<E: EthSpec> MockBuilder<E> {
         while let Some(op) = guard.pop() {
             op.apply(bid);
         }
+        bid.stamp_payload();
     }
 }
 
@@ -530,10 +560,16 @@ pub fn serve<E: EthSpec>(
                     finalized_hash: Some(finalized_execution_hash),
                 };
 
+                let proposer_gas_limit = builder
+                    .val_registration_cache
+                    .read()
+                    .get(&pubkey)
+                    .map(|v| v.message.gas_limit);
+
                 let payload_parameters = PayloadParameters {
                     parent_hash: head_execution_hash,
                     parent_gas_limit: head_gas_limit,
-                    proposer_gas_limit: Some(head_gas_limit),
+                    proposer_gas_limit,
                     payload_attributes: &payload_attributes,
                     forkchoice_update_params: &forkchoice_update_params,
                     current_fork: fork,
@@ -652,8 +688,6 @@ pub fn serve<E: EthSpec>(
                         }
                     }
                 };
-
-                message.set_gas_limit(cached_data.gas_limit);
 
                 builder.apply_operations(&mut message);
 

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -413,11 +413,12 @@ pub fn serve<E: EthSpec>(
 
                 let block = head.data.message();
                 let head_block_root = block.tree_hash_root();
-                let head_execution_hash = block
+                let head_execution_payload = block
                     .body()
                     .execution_payload()
-                    .map_err(|_| reject("pre-merge block"))?
-                    .block_hash();
+                    .map_err(|_| reject("pre-merge block"))?;
+                let head_execution_hash = head_execution_payload.block_hash();
+                let head_gas_limit = head_execution_payload.gas_limit();
                 if head_execution_hash != parent_hash {
                     return Err(reject("head mismatch"));
                 }
@@ -531,6 +532,8 @@ pub fn serve<E: EthSpec>(
 
                 let payload_parameters = PayloadParameters {
                     parent_hash: head_execution_hash,
+                    parent_gas_limit: head_gas_limit,
+                    proposer_gas_limit: Some(head_gas_limit),
                     payload_attributes: &payload_attributes,
                     forkchoice_update_params: &forkchoice_update_params,
                     current_fork: fork,

--- a/beacon_node/execution_layer/src/test_utils/mock_builder.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_builder.rs
@@ -1,5 +1,5 @@
 use crate::test_utils::{DEFAULT_BUILDER_PAYLOAD_VALUE_WEI, DEFAULT_JWT_SECRET};
-use crate::{Config, ExecutionLayer, PayloadAttributes};
+use crate::{Config, ExecutionLayer, PayloadAttributes, PayloadParameters};
 use eth2::types::{BlobsBundle, BlockId, StateId, ValidatorId};
 use eth2::{BeaconNodeHttpClient, Timeouts, CONSENSUS_VERSION_HEADER};
 use fork_choice::ForkchoiceUpdateParameters;
@@ -529,14 +529,16 @@ pub fn serve<E: EthSpec>(
                     finalized_hash: Some(finalized_execution_hash),
                 };
 
+                let payload_parameters = PayloadParameters {
+                    parent_hash: head_execution_hash,
+                    payload_attributes: &payload_attributes,
+                    forkchoice_update_params: &forkchoice_update_params,
+                    current_fork: fork,
+                };
+
                 let payload_response_type = builder
                     .el
-                    .get_full_payload_caching(
-                        head_execution_hash,
-                        &payload_attributes,
-                        forkchoice_update_params,
-                        fork,
-                    )
+                    .get_full_payload_caching(payload_parameters)
                     .await
                     .map_err(|_| reject("couldn't get payload"))?;
 

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -90,6 +90,7 @@ impl<E: EthSpec> MockExecutionLayer<E> {
         };
 
         let parent_hash = latest_execution_block.block_hash();
+        let parent_gas_limit = latest_execution_block.gas_limit();
         let block_number = latest_execution_block.block_number() + 1;
         let timestamp = block_number;
         let prev_randao = Hash256::from_low_u64_be(block_number);
@@ -133,6 +134,8 @@ impl<E: EthSpec> MockExecutionLayer<E> {
 
         let payload_parameters = PayloadParameters {
             parent_hash,
+            parent_gas_limit,
+            proposer_gas_limit: None,
             payload_attributes: &payload_attributes,
             forkchoice_update_params: &forkchoice_update_params,
             current_fork: ForkName::Bellatrix,
@@ -177,6 +180,8 @@ impl<E: EthSpec> MockExecutionLayer<E> {
 
         let payload_parameters = PayloadParameters {
             parent_hash,
+            parent_gas_limit,
+            proposer_gas_limit: None,
             payload_attributes: &payload_attributes,
             forkchoice_update_params: &forkchoice_update_params,
             current_fork: ForkName::Bellatrix,

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -131,14 +131,18 @@ impl<E: EthSpec> MockExecutionLayer<E> {
         let payload_attributes =
             PayloadAttributes::new(timestamp, prev_randao, suggested_fee_recipient, None, None);
 
+        let payload_parameters = PayloadParameters {
+            parent_hash,
+            payload_attributes: &payload_attributes,
+            forkchoice_update_params: &forkchoice_update_params,
+            current_fork: ForkName::Bellatrix,
+        };
+
         let block_proposal_content_type = self
             .el
             .get_payload(
-                parent_hash,
-                &payload_attributes,
-                forkchoice_update_params,
+                payload_parameters,
                 builder_params,
-                ForkName::Bellatrix,
                 &self.spec,
                 None,
                 BlockProductionVersion::FullV2,
@@ -171,14 +175,18 @@ impl<E: EthSpec> MockExecutionLayer<E> {
         let payload_attributes =
             PayloadAttributes::new(timestamp, prev_randao, suggested_fee_recipient, None, None);
 
+        let payload_parameters = PayloadParameters {
+            parent_hash,
+            payload_attributes: &payload_attributes,
+            forkchoice_update_params: &forkchoice_update_params,
+            current_fork: ForkName::Bellatrix,
+        };
+
         let block_proposal_content_type = self
             .el
             .get_payload(
-                parent_hash,
-                &payload_attributes,
-                forkchoice_update_params,
+                payload_parameters,
                 builder_params,
-                ForkName::Bellatrix,
                 &self.spec,
                 None,
                 BlockProductionVersion::BlindedV2,

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -25,6 +25,7 @@ use types::{EthSpec, ExecutionBlockHash, Uint256};
 use warp::{http::StatusCode, Filter, Rejection};
 
 use crate::EngineCapabilities;
+pub use execution_block_generator::GAS_LIMIT;
 pub use execution_block_generator::{
     generate_blobs, generate_genesis_block, generate_genesis_header, generate_pow_block,
     static_valid_tx, Block, ExecutionBlockGenerator,

--- a/beacon_node/execution_layer/src/test_utils/mod.rs
+++ b/beacon_node/execution_layer/src/test_utils/mod.rs
@@ -25,13 +25,13 @@ use types::{EthSpec, ExecutionBlockHash, Uint256};
 use warp::{http::StatusCode, Filter, Rejection};
 
 use crate::EngineCapabilities;
-pub use execution_block_generator::GAS_LIMIT;
+pub use execution_block_generator::DEFAULT_GAS_LIMIT;
 pub use execution_block_generator::{
     generate_blobs, generate_genesis_block, generate_genesis_header, generate_pow_block,
-    static_valid_tx, Block, ExecutionBlockGenerator,
+    mock_el_extra_data, static_valid_tx, Block, ExecutionBlockGenerator,
 };
 pub use hook::Hook;
-pub use mock_builder::{MockBuilder, Operation};
+pub use mock_builder::{mock_builder_extra_data, MockBuilder, Operation};
 pub use mock_execution_layer::MockExecutionLayer;
 
 pub const DEFAULT_TERMINAL_DIFFICULTY: u64 = 6400;

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -3691,7 +3691,10 @@ pub fn serve<T: BeaconChainTypes>(
                     );
 
                     execution_layer
-                        .update_proposer_preparation(current_epoch, &preparation_data)
+                        .update_proposer_preparation(
+                            current_epoch,
+                            preparation_data.iter().map(|data| (data, &None)),
+                        )
                         .await;
 
                     chain
@@ -3749,7 +3752,7 @@ pub fn serve<T: BeaconChainTypes>(
                         let spec = &chain.spec;
 
                         let (preparation_data, filtered_registration_data): (
-                            Vec<ProposerPreparationData>,
+                            Vec<(ProposerPreparationData, Option<u64>)>,
                             Vec<SignedValidatorRegistrationData>,
                         ) = register_val_data
                             .into_iter()
@@ -3779,12 +3782,15 @@ pub fn serve<T: BeaconChainTypes>(
                                         // Filter out validators who are not 'active' or 'pending'.
                                         is_active_or_pending.then_some({
                                             (
-                                                ProposerPreparationData {
-                                                    validator_index: validator_index as u64,
-                                                    fee_recipient: register_data
-                                                        .message
-                                                        .fee_recipient,
-                                                },
+                                                (
+                                                    ProposerPreparationData {
+                                                        validator_index: validator_index as u64,
+                                                        fee_recipient: register_data
+                                                            .message
+                                                            .fee_recipient,
+                                                    },
+                                                    Some(register_data.message.gas_limit),
+                                                ),
                                                 register_data,
                                             )
                                         })
@@ -3794,7 +3800,10 @@ pub fn serve<T: BeaconChainTypes>(
 
                         // Update the prepare beacon proposer cache based on this request.
                         execution_layer
-                            .update_proposer_preparation(current_epoch, &preparation_data)
+                            .update_proposer_preparation(
+                                current_epoch,
+                                preparation_data.iter().map(|(data, limit)| (data, limit)),
+                            )
                             .await;
 
                         // Call prepare beacon proposer blocking with the latest update in order to make

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -447,9 +447,14 @@ pub async fn proposer_boost_re_org_test(
     // Send proposer preparation data for all validators.
     let proposer_preparation_data = all_validators
         .iter()
-        .map(|i| ProposerPreparationData {
-            validator_index: *i as u64,
-            fee_recipient: Address::from_low_u64_be(*i as u64),
+        .map(|i| {
+            (
+                ProposerPreparationData {
+                    validator_index: *i as u64,
+                    fee_recipient: Address::from_low_u64_be(*i as u64),
+                },
+                None,
+            )
         })
         .collect::<Vec<_>>();
     harness
@@ -459,7 +464,7 @@ pub async fn proposer_boost_re_org_test(
         .unwrap()
         .update_proposer_preparation(
             head_slot.epoch(E::slots_per_epoch()) + 1,
-            &proposer_preparation_data,
+            proposer_preparation_data.iter().map(|(a, b)| (a, b)),
         )
         .await;
 

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -128,6 +128,11 @@ pub struct ChainSpec {
     pub deposit_contract_address: Address,
 
     /*
+     * Execution Specs
+     */
+    pub gas_limit_adjustment_factor: u64,
+
+    /*
      * Altair hard fork params
      */
     pub inactivity_penalty_quotient_altair: u64,
@@ -719,6 +724,11 @@ impl ChainSpec {
                 .expect("chain spec deposit contract address"),
 
             /*
+             * Execution Specs
+             */
+            gas_limit_adjustment_factor: 1024,
+
+            /*
              * Altair hard fork params
              */
             inactivity_penalty_quotient_altair: option_wrapper(|| {
@@ -1037,6 +1047,11 @@ impl ChainSpec {
                 .expect("chain spec deposit contract address"),
 
             /*
+             * Execution Specs
+             */
+            gas_limit_adjustment_factor: 1024,
+
+            /*
              * Altair hard fork params
              */
             inactivity_penalty_quotient_altair: option_wrapper(|| {
@@ -1296,6 +1311,10 @@ pub struct Config {
     #[serde(with = "serde_utils::address_hex")]
     deposit_contract_address: Address,
 
+    #[serde(default = "default_gas_limit_adjustment_factor")]
+    #[serde(with = "serde_utils::quoted_u64")]
+    gas_limit_adjustment_factor: u64,
+
     #[serde(default = "default_gossip_max_size")]
     #[serde(with = "serde_utils::quoted_u64")]
     gossip_max_size: u64,
@@ -1421,6 +1440,10 @@ fn default_subnets_per_node() -> u8 {
 
 const fn default_max_per_epoch_activation_churn_limit() -> u64 {
     8
+}
+
+const fn default_gas_limit_adjustment_factor() -> u64 {
+    1024
 }
 
 const fn default_gossip_max_size() -> u64 {
@@ -1690,6 +1713,8 @@ impl Config {
             deposit_network_id: spec.deposit_network_id,
             deposit_contract_address: spec.deposit_contract_address,
 
+            gas_limit_adjustment_factor: spec.gas_limit_adjustment_factor,
+
             gossip_max_size: spec.gossip_max_size,
             max_request_blocks: spec.max_request_blocks,
             epochs_per_subnet_subscription: spec.epochs_per_subnet_subscription,
@@ -1767,6 +1792,7 @@ impl Config {
             deposit_chain_id,
             deposit_network_id,
             deposit_contract_address,
+            gas_limit_adjustment_factor,
             gossip_max_size,
             min_epochs_for_block_requests,
             max_chunk_size,
@@ -1832,6 +1858,7 @@ impl Config {
             deposit_chain_id,
             deposit_network_id,
             deposit_contract_address,
+            gas_limit_adjustment_factor,
             terminal_total_difficulty,
             terminal_block_hash,
             terminal_block_hash_activation_epoch,

--- a/consensus/types/src/payload.rs
+++ b/consensus/types/src/payload.rs
@@ -32,6 +32,7 @@ pub trait ExecPayload<E: EthSpec>: Debug + Clone + PartialEq + Hash + TreeHash +
     fn prev_randao(&self) -> Hash256;
     fn block_number(&self) -> u64;
     fn timestamp(&self) -> u64;
+    fn extra_data(&self) -> VariableList<u8, E::MaxExtraDataBytes>;
     fn block_hash(&self) -> ExecutionBlockHash;
     fn fee_recipient(&self) -> Address;
     fn gas_limit(&self) -> u64;
@@ -225,6 +226,13 @@ impl<E: EthSpec> ExecPayload<E> for FullPayload<E> {
         })
     }
 
+    fn extra_data<'a>(&'a self) -> VariableList<u8, E::MaxExtraDataBytes> {
+        map_full_payload_ref!(&'a _, self.to_ref(), move |payload, cons| {
+            cons(payload);
+            payload.execution_payload.extra_data.clone()
+        })
+    }
+
     fn block_hash<'a>(&'a self) -> ExecutionBlockHash {
         map_full_payload_ref!(&'a _, self.to_ref(), move |payload, cons| {
             cons(payload);
@@ -354,6 +362,13 @@ impl<'b, E: EthSpec> ExecPayload<E> for FullPayloadRef<'b, E> {
         map_full_payload_ref!(&'a _, self, move |payload, cons| {
             cons(payload);
             payload.execution_payload.timestamp
+        })
+    }
+
+    fn extra_data<'a>(&'a self) -> VariableList<u8, E::MaxExtraDataBytes> {
+        map_full_payload_ref!(&'a _, self, move |payload, cons| {
+            cons(payload);
+            payload.execution_payload.extra_data.clone()
         })
     }
 
@@ -542,6 +557,13 @@ impl<E: EthSpec> ExecPayload<E> for BlindedPayload<E> {
         })
     }
 
+    fn extra_data<'a>(&'a self) -> VariableList<u8, <E as EthSpec>::MaxExtraDataBytes> {
+        map_blinded_payload_ref!(&'a _, self.to_ref(), move |payload, cons| {
+            cons(payload);
+            payload.execution_payload_header.extra_data.clone()
+        })
+    }
+
     fn block_hash<'a>(&'a self) -> ExecutionBlockHash {
         map_blinded_payload_ref!(&'a _, self.to_ref(), move |payload, cons| {
             cons(payload);
@@ -640,6 +662,13 @@ impl<'b, E: EthSpec> ExecPayload<E> for BlindedPayloadRef<'b, E> {
         map_blinded_payload_ref!(&'a _, self, move |payload, cons| {
             cons(payload);
             payload.execution_payload_header.timestamp
+        })
+    }
+
+    fn extra_data<'a>(&'a self) -> VariableList<u8, <E as EthSpec>::MaxExtraDataBytes> {
+        map_blinded_payload_ref!(&'a _, self, move |payload, cons| {
+            cons(payload);
+            payload.execution_payload_header.extra_data.clone()
         })
     }
 
@@ -743,6 +772,10 @@ macro_rules! impl_exec_payload_common {
 
             fn timestamp(&self) -> u64 {
                 self.$wrapped_field.timestamp
+            }
+
+            fn extra_data(&self) -> VariableList<u8, E::MaxExtraDataBytes> {
+                self.$wrapped_field.extra_data.clone()
             }
 
             fn block_hash(&self) -> ExecutionBlockHash {

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -809,10 +809,13 @@ impl<E: EthSpec> Tester<E> {
             if expected_should_override_fcu.validator_is_connected {
                 el.update_proposer_preparation(
                     next_slot_epoch,
-                    &[ProposerPreparationData {
-                        validator_index: dbg!(proposer_index) as u64,
-                        fee_recipient: Default::default(),
-                    }],
+                    [(
+                        &ProposerPreparationData {
+                            validator_index: dbg!(proposer_index) as u64,
+                            fee_recipient: Default::default(),
+                        },
+                        &None,
+                    )],
                 )
                 .await;
             } else {

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -3,7 +3,7 @@ use crate::execution_engine::{
 };
 use crate::transactions::transactions;
 use ethers_providers::Middleware;
-use execution_layer::test_utils::GAS_LIMIT;
+use execution_layer::test_utils::DEFAULT_GAS_LIMIT;
 use execution_layer::{
     BlockProposalContentsType, BuilderParams, ChainHealth, ExecutionLayer, PayloadAttributes,
     PayloadParameters, PayloadStatus,
@@ -252,7 +252,7 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
          */
 
         let parent_hash = terminal_pow_block_hash;
-        let parent_gas_limit = GAS_LIMIT;
+        let parent_gas_limit = DEFAULT_GAS_LIMIT;
         let timestamp = timestamp_now();
         let prev_randao = Hash256::zero();
         let head_root = Hash256::zero();

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -5,7 +5,7 @@ use crate::transactions::transactions;
 use ethers_providers::Middleware;
 use execution_layer::{
     BlockProposalContentsType, BuilderParams, ChainHealth, ExecutionLayer, PayloadAttributes,
-    PayloadStatus,
+    PayloadParameters, PayloadStatus,
 };
 use fork_choice::ForkchoiceUpdateParameters;
 use reqwest::{header::CONTENT_TYPE, Client};
@@ -324,15 +324,20 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
             Some(vec![]),
             None,
         );
+
+        let payload_parameters = PayloadParameters {
+            parent_hash,
+            payload_attributes: &payload_attributes,
+            forkchoice_update_params: &forkchoice_update_params,
+            current_fork: TEST_FORK,
+        };
+
         let block_proposal_content_type = self
             .ee_a
             .execution_layer
             .get_payload(
-                parent_hash,
-                &payload_attributes,
-                forkchoice_update_params,
+                payload_parameters,
                 builder_params,
-                TEST_FORK,
                 &self.spec,
                 None,
                 BlockProductionVersion::FullV2,
@@ -476,15 +481,20 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
             Some(vec![]),
             None,
         );
+
+        let payload_parameters = PayloadParameters {
+            parent_hash,
+            payload_attributes: &payload_attributes,
+            forkchoice_update_params: &forkchoice_update_params,
+            current_fork: TEST_FORK,
+        };
+
         let block_proposal_content_type = self
             .ee_a
             .execution_layer
             .get_payload(
-                parent_hash,
-                &payload_attributes,
-                forkchoice_update_params,
+                payload_parameters,
                 builder_params,
-                TEST_FORK,
                 &self.spec,
                 None,
                 BlockProductionVersion::FullV2,

--- a/testing/execution_engine_integration/src/test_rig.rs
+++ b/testing/execution_engine_integration/src/test_rig.rs
@@ -3,6 +3,7 @@ use crate::execution_engine::{
 };
 use crate::transactions::transactions;
 use ethers_providers::Middleware;
+use execution_layer::test_utils::GAS_LIMIT;
 use execution_layer::{
     BlockProposalContentsType, BuilderParams, ChainHealth, ExecutionLayer, PayloadAttributes,
     PayloadParameters, PayloadStatus,
@@ -251,6 +252,7 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
          */
 
         let parent_hash = terminal_pow_block_hash;
+        let parent_gas_limit = GAS_LIMIT;
         let timestamp = timestamp_now();
         let prev_randao = Hash256::zero();
         let head_root = Hash256::zero();
@@ -327,6 +329,8 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
 
         let payload_parameters = PayloadParameters {
             parent_hash,
+            parent_gas_limit,
+            proposer_gas_limit: None,
             payload_attributes: &payload_attributes,
             forkchoice_update_params: &forkchoice_update_params,
             current_fork: TEST_FORK,
@@ -484,6 +488,8 @@ impl<Engine: GenericExecutionEngine> TestRig<Engine> {
 
         let payload_parameters = PayloadParameters {
             parent_hash,
+            parent_gas_limit,
+            proposer_gas_limit: None,
             payload_attributes: &payload_attributes,
             forkchoice_update_params: &forkchoice_update_params,
             current_fork: TEST_FORK,


### PR DESCRIPTION
I had forgotten to finish this one when I got distracted by other stuff but I think it's good to go now.

Lighthouse now enforces validator sovereignty over the gas limit. The overwhelming majority of builders already respect this and I've notified the relays for the few that didn't and they told me they've fixed the bug. I also did some refactoring for clarity and convenience.