### PR TITLE
Add filecoin address to `FUNDING.json`

### DIFF
--- a/FUNDING.json
+++ b/FUNDING.json
@@ -2,6 +2,9 @@
     "drips": {
         "ethereum": {
             "ownedBy": "0x25c4a76E7d118705e7Ea2e9b7d8C59930d8aCD3b"
+        },
+        "filecoin": {
+            "ownedBy": "0x25c4a76E7d118705e7Ea2e9b7d8C59930d8aCD3b"
         }
     },
     "opRetro": {

--- a/FUNDING.json
+++ b/FUNDING.json
@@ -11,3 +11,4 @@
         "projectId": "0x04b1cd5a7c59117474ce414b309fa48e985bdaab4b0dab72045f74d04ebd8cff"
     }
 }
+


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Adds a Filecoin address to our `FUNDING.json`, as requested by the [Filecoin retro-PGF docs](https://docs.drips.network/get-support/claim-your-repository/).

## Additional Info

This needs to get merged into `stable` in the next day, unfortunately :(
