### PR TITLE
Ensure non-zero bits for each committee bitfield comprising an aggregate

### DIFF
--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -59,6 +59,7 @@ pub enum Error {
     UnknownValidator(usize),
     UnableToDetermineProducer,
     InvalidBitfield,
+    EmptyCommittee,
     ValidatorIsWithdrawable,
     ValidatorIsInactive {
         val_index: usize,


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/pull/4002

## Proposed Changes

Add an additional check to ensure that on-chain attestations have at least one non-zero bit set per attesting committee bitfield. This change is part of the upcoming Electra alpha release
