### PR TITLE
Increase idle connection timeout

### DIFF
--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -38,6 +38,7 @@ use std::num::{NonZeroU8, NonZeroUsize};
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 use types::{
     consts::altair::SYNC_COMMITTEE_SUBNET_COUNT, EnrForkId, EthSpec, ForkContext, Slot, SubnetId,
 };
@@ -466,6 +467,8 @@ impl<E: EthSpec> Network<E> {
             let config = libp2p::swarm::Config::with_executor(Executor(executor))
                 .with_notify_handler_buffer_size(NonZeroUsize::new(7).expect("Not zero"))
                 .with_per_connection_event_buffer_size(4)
+                .with_idle_connection_timeout(Duration::from_secs(1)) // Other clients can timeout
+                // during negotiation
                 .with_dial_concurrency_factor(NonZeroU8::new(1).unwrap());
 
             let builder = SwarmBuilder::with_existing_identity(local_keypair)

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -467,7 +467,7 @@ impl<E: EthSpec> Network<E> {
             let config = libp2p::swarm::Config::with_executor(Executor(executor))
                 .with_notify_handler_buffer_size(NonZeroUsize::new(7).expect("Not zero"))
                 .with_per_connection_event_buffer_size(4)
-                .with_idle_connection_timeout(Duration::from_secs(1)) // Other clients can timeout
+                .with_idle_connection_timeout(Duration::from_secs(10)) // Other clients can timeout
                 // during negotiation
                 .with_dial_concurrency_factor(NonZeroU8::new(1).unwrap());
 


### PR DESCRIPTION
## Issue Addressed

It was reported that when Prysm connects to us, there is occasionally a small time in negotiating protocols before we set-up gossipsub that we have an idle connection. In this case Lighthouse immediately drops the connection. 

This results in us preventing Prysm from connecting to us some fraction of the time. This PR increases the timeout from 0 seconds to 1 second to help correct this. 