### PR TITLE
Fix grammatical error Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 [![GitPOAP badge](https://public-api.gitpoap.io/v1/repo/sigp/lighthouse/badge)](https://www.gitpoap.io/gh/sigp/lighthouse)
 
 Lighthouse is an open-source Ethereum consensus client. We're community driven and
-welcome all contribution. We aim to provide a constructive, respectful and fun
+welcome all contributions. We aim to provide a constructive, respectful and fun
 environment for collaboration.
 
 We are active contributors to


### PR DESCRIPTION
**Description:**

I came across a small grammatical issue in the "Contributors Guide" section of the documentation. The sentence:

> "We're community driven and welcome all contribution."

should be:

> "We're community driven and welcome all contributions."

The word "contribution" was singular, but the context suggests that multiple contributions are being welcomed, so the plural form "contributions" is more appropriate. This change improves the clarity and correctness of the sentence, ensuring it aligns with standard English grammar.