### PR TITLE
Fix Grammar and Spelling Issues

### DIFF
--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -6,7 +6,7 @@ has two primary sub-commands:
 - `$ lighthouse beacon_node`: the largest and most fundamental component which connects to
  the p2p network, processes messages and tracks the head of the beacon
  chain.
-- `$ lighthouse validator_client`: a lightweight but important component which loads a validators private
+- `$ lighthouse validator_client`: a lightweight but important component which loads a validator's private
  key and signs messages using a `beacon_node` as a source-of-truth.
 
 There are also some ancillary binaries like `lcli` and `account_manager`, but
@@ -48,7 +48,7 @@ maintained by Sigma Prime.
 
 However, for developers, testnets can be created by following the instructions
 outlined in [testnets](./testnets.md). The steps listed here will create a
-local database specified to a new testnet.
+local database specified for a new testnet.
 
 ## Resuming from an existing database
 

--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -201,7 +201,7 @@ This suggests that the computer resources are being overwhelmed. It could be due
 
 ### <a name="bn-deposit-cache"></a> My beacon node logs `WARN Failed to finalize deposit cache`, what should I do?
 
-This is a known [bug](https://github.com/sigp/lighthouse/issues/3707) that will fix by itself.
+This is a known [bug](https://github.com/sigp/lighthouse/issues/3707) that will fix itself.
 
 ### <a name="bn-blob"></a> My beacon node logs `WARN Could not verify blob sidecar for gossip`, what does it mean?
 
@@ -413,7 +413,7 @@ expect, there are a few things to check on:
     curl localhost:5052/lighthouse/peers | jq '.[] | select(.peer_info.connection_direction=="Incoming")'
     ```
 
-    If you have incoming peers, it should return a lot of data containing information of peers. If the response is empty, it means that you have no incoming peers and there the ports are not open. You may want to double check if the port forward was correctly set up.
+    If you have incoming peers, it should return a lot of data containing information of peers. If the response is empty, it means that you have no incoming peers and the ports are not open. You may want to double check if the port forward was correctly set up.
 
 1. Check that you do not lower the number of peers using the flag `--target-peers`. The default is 100. A lower value set will lower the maximum number of peers your node can connect to, which may potentially interrupt the validator performance. We recommend users to leave the `--target peers` untouched to keep a diverse set of peers.
 

--- a/book/src/graffiti.md
+++ b/book/src/graffiti.md
@@ -4,7 +4,7 @@ Lighthouse provides four options for setting validator graffiti.
 
 ## 1. Using the "--graffiti-file" flag on the validator client
 
-Users can specify a file with the `--graffiti-file` flag. This option is useful for dynamically changing graffitis for various use cases (e.g. drawing on the beaconcha.in graffiti wall). This file is loaded once on startup and reloaded everytime a validator is chosen to propose a block.
+Users can specify a file with the `--graffiti-file` flag. This option is useful for dynamically changing graffitis for various use cases (e.g. drawing on the beaconcha.in graffiti wall). This file is loaded once on startup and reloaded every time a validator is chosen to propose a block.
 
 Usage:
 `lighthouse vc --graffiti-file graffiti_file.txt`


### PR DESCRIPTION
This PR fixes several grammatical and spelling issues across multiple documentation files to improve readability and correctness.

## Changes

### book/src/cli.md
- Changed "validators" to "validator's" in the phrase "loads a validators private key" to fix possessive form
- Changed "specified to" to "specified for" for better grammar

### book/src/faq.md
- Changed "there the ports" to "the ports" to fix redundant word
- Changed "that will fix by itself" to "that will fix itself" for correct grammar

### book/src/graffiti.md
- Changed "everytime" to "every time" as it should be two separate words


## Reasoning

These changes are needed to:
1. Fix grammatical errors that could confuse readers
2. Maintain consistent and professional documentation quality
3. Improve readability and clarity of technical documentation
4. Follow standard English language conventions
5. Ensure proper technical terminology usage
