### PR TITLE
Increase rpc rate limits

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -104,14 +104,14 @@ impl RateLimiterConfig {
     pub const DEFAULT_META_DATA_QUOTA: Quota = Quota::n_every(2, 5);
     pub const DEFAULT_STATUS_QUOTA: Quota = Quota::n_every(5, 15);
     pub const DEFAULT_GOODBYE_QUOTA: Quota = Quota::one_every(10);
-    // We request 32 blocks per batch. In a mainnet like network, where we have many peers to choose
-    // from for range sync, we should ideally be spreading out the sync requests over multiple nodes
-    // and request not more than 2 epochs from a single peer every 5 seconds.
-    pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota = Quota::n_every(160, 5);
+    // The number is chosen to balance between upload bandwidth required to serve
+    // blocks and a decent syncing rate for honest nodes. Malicious nodes would need to
+    // spread out their requests over the time window to max out bandwidth on the server.
+    pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota = Quota::n_every(128, 10);
     pub const DEFAULT_BLOCKS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
-    // `DEFAULT_BLOCKS_BY_RANGE_QUOTA` * max_blobs_per_block
-    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(960, 5);
-    pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(768, 10);
+    // `DEFAULT_BLOCKS_BY_RANGE_QUOTA` * (target + 1) to account for high usage
+    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(512, 10);
+    pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(512, 10);
     // 320 blocks worth of columns for regular node, or 40 blocks for supernode.
     // Range sync load balances when requesting blocks, and each batch is 32 blocks.
     pub const DEFAULT_DATA_COLUMNS_BY_RANGE_QUOTA: Quota = Quota::n_every(5120, 10);

--- a/beacon_node/lighthouse_network/src/rpc/config.rs
+++ b/beacon_node/lighthouse_network/src/rpc/config.rs
@@ -104,14 +104,13 @@ impl RateLimiterConfig {
     pub const DEFAULT_META_DATA_QUOTA: Quota = Quota::n_every(2, 5);
     pub const DEFAULT_STATUS_QUOTA: Quota = Quota::n_every(5, 15);
     pub const DEFAULT_GOODBYE_QUOTA: Quota = Quota::one_every(10);
-    pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota = Quota::n_every(1024, 10);
+    // We request 32 blocks per batch. In a mainnet like network, where we have many peers to choose
+    // from for range sync, we should ideally be spreading out the sync requests over multiple nodes
+    // and request not more than 2 epochs from a single peer every 5 seconds.
+    pub const DEFAULT_BLOCKS_BY_RANGE_QUOTA: Quota = Quota::n_every(160, 5);
     pub const DEFAULT_BLOCKS_BY_ROOT_QUOTA: Quota = Quota::n_every(128, 10);
-    // `BlocksByRange` and `BlobsByRange` are sent together during range sync.
-    // It makes sense for blocks and blobs quotas to be equivalent in terms of the number of blocks:
-    // 1024 blocks * 6 max blobs per block.
-    // This doesn't necessarily mean that we are sending this many blobs, because the quotas are
-    // measured against the maximum request size.
-    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(6144, 10);
+    // `DEFAULT_BLOCKS_BY_RANGE_QUOTA` * max_blobs_per_block
+    pub const DEFAULT_BLOBS_BY_RANGE_QUOTA: Quota = Quota::n_every(960, 5);
     pub const DEFAULT_BLOBS_BY_ROOT_QUOTA: Quota = Quota::n_every(768, 10);
     // 320 blocks worth of columns for regular node, or 40 blocks for supernode.
     // Range sync load balances when requesting blocks, and each batch is 32 blocks.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

In https://github.com/sigp/lighthouse/pull/6093 , we bumped the rate limits for blobs by range significantly presumably for peerdas devnets. This limit is too permissive for mainnet imo, we should reduce it down significantly so as to not get overwhelmed with requests and also keeping the upload bandwidth at check.

~~I'm proposing to increase the limits by a factor of around 3. Allowing a single epoch of blocks (32 blocks max) to be requested per second or 160 per 5 seconds to account for bursts.~~
See https://github.com/sigp/lighthouse/pull/6626#issuecomment-2505240978 for justification for final numbers on this PR after testing

