### PR TITLE
Remove `error-chain` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1418,7 +1418,6 @@ dependencies = [
  "directory",
  "dirs",
  "environment",
- "error-chain",
  "eth1",
  "eth2",
  "eth2_config",
@@ -2513,16 +2512,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "backtrace",
- "version_check",
 ]
 
 [[package]]
@@ -5309,7 +5298,6 @@ dependencies = [
  "dirs",
  "discv5",
  "either",
- "error-chain",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "fnv",
@@ -5880,7 +5868,6 @@ dependencies = [
  "bls",
  "delay_map",
  "derivative",
- "error-chain",
  "eth2",
  "eth2_network_config",
  "ethereum_ssz",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ crate_crypto_internal_eth_kzg_polynomial = "=0.5.1"
 crate_crypto_kzg_multi_open_fk20 = "=0.5.1"
 discv5 = { version = "0.9", features = ["libp2p"] }
 env_logger = "0.9"
-error-chain = "0.12"
 ethereum_hashing = "0.7.0"
 ethereum_serde_utils = "0.7"
 ethereum_ssz = "0.7"

--- a/beacon_node/client/Cargo.toml
+++ b/beacon_node/client/Cargo.toml
@@ -21,7 +21,6 @@ eth2_config = { workspace = true }
 slot_clock = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-error-chain = { workspace = true }
 slog = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }

--- a/beacon_node/client/src/error.rs
+++ b/beacon_node/client/src/error.rs
@@ -1,7 +1,0 @@
-use error_chain::error_chain;
-
-error_chain! {
-   links  {
-       Network(network::error::Error, network::error::ErrorKind);
-   }
-}

--- a/beacon_node/client/src/lib.rs
+++ b/beacon_node/client/src/lib.rs
@@ -4,7 +4,6 @@ mod metrics;
 mod notifier;
 
 pub mod builder;
-pub mod error;
 
 use beacon_chain::BeaconChain;
 use lighthouse_network::{Enr, Multiaddr, NetworkGlobals};

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -18,7 +18,6 @@ slog = { workspace = true }
 lighthouse_version = { workspace = true }
 tokio = { workspace = true }
 futures = { workspace = true }
-error-chain = { workspace = true }
 dirs = { workspace = true }
 fnv = { workspace = true }
 metrics = { workspace = true }

--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -8,8 +8,8 @@ pub mod enr_ext;
 
 // Allow external use of the lighthouse ENR builder
 use crate::service::TARGET_SUBNET_PEERS;
-use crate::{error, Enr, NetworkConfig, NetworkGlobals, Subnet, SubnetDiscovery};
 use crate::{metrics, ClearDialError};
+use crate::{Enr, NetworkConfig, NetworkGlobals, Subnet, SubnetDiscovery};
 use discv5::{enr::NodeId, Discv5};
 pub use enr::{build_enr, load_enr_from_disk, use_or_load_enr, CombinedKey, Eth2Enr};
 pub use enr_ext::{peer_id_to_node_id, CombinedKeyExt, EnrExt};
@@ -205,7 +205,7 @@ impl<E: EthSpec> Discovery<E> {
         network_globals: Arc<NetworkGlobals<E>>,
         log: &slog::Logger,
         spec: &ChainSpec,
-    ) -> error::Result<Self> {
+    ) -> Result<Self, String> {
         let log = log.clone();
 
         let enr_dir = match config.network_dir.to_str() {

--- a/beacon_node/lighthouse_network/src/lib.rs
+++ b/beacon_node/lighthouse_network/src/lib.rs
@@ -101,7 +101,7 @@ impl<'a> std::fmt::Display for ClearDialError<'a> {
 }
 
 pub use crate::types::{
-    error, Enr, EnrSyncCommitteeBitfield, GossipTopic, NetworkGlobals, PubsubMessage, Subnet,
+    Enr, EnrSyncCommitteeBitfield, GossipTopic, NetworkGlobals, PubsubMessage, Subnet,
     SubnetDiscovery,
 };
 

--- a/beacon_node/lighthouse_network/src/peer_manager/mod.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/mod.rs
@@ -4,7 +4,7 @@ use crate::discovery::enr_ext::EnrExt;
 use crate::discovery::peer_id_to_node_id;
 use crate::rpc::{GoodbyeReason, MetaData, Protocol, RPCError, RpcErrorResponse};
 use crate::service::TARGET_SUBNET_PEERS;
-use crate::{error, metrics, Gossipsub, NetworkGlobals, PeerId, Subnet, SubnetDiscovery};
+use crate::{metrics, Gossipsub, NetworkGlobals, PeerId, Subnet, SubnetDiscovery};
 use delay_map::HashSetDelay;
 use discv5::Enr;
 use libp2p::identify::Info as IdentifyInfo;
@@ -144,7 +144,7 @@ impl<E: EthSpec> PeerManager<E> {
         cfg: config::Config,
         network_globals: Arc<NetworkGlobals<E>>,
         log: &slog::Logger,
-    ) -> error::Result<Self> {
+    ) -> Result<Self, String> {
         let config::Config {
             discovery_enabled,
             metrics_enabled,

--- a/beacon_node/lighthouse_network/src/service/gossipsub_scoring_parameters.rs
+++ b/beacon_node/lighthouse_network/src/service/gossipsub_scoring_parameters.rs
@@ -1,5 +1,5 @@
 use crate::types::{GossipEncoding, GossipKind, GossipTopic};
-use crate::{error, TopicHash};
+use crate::TopicHash;
 use gossipsub::{IdentTopic as Topic, PeerScoreParams, PeerScoreThresholds, TopicScoreParams};
 use std::cmp::max;
 use std::collections::HashMap;
@@ -84,7 +84,7 @@ impl<E: EthSpec> PeerScoreSettings<E> {
         thresholds: &PeerScoreThresholds,
         enr_fork_id: &EnrForkId,
         current_slot: Slot,
-    ) -> error::Result<PeerScoreParams> {
+    ) -> Result<PeerScoreParams, String> {
         let mut params = PeerScoreParams {
             decay_interval: self.decay_interval,
             decay_to_zero: self.decay_to_zero,
@@ -175,7 +175,7 @@ impl<E: EthSpec> PeerScoreSettings<E> {
         &self,
         active_validators: usize,
         current_slot: Slot,
-    ) -> error::Result<(TopicScoreParams, TopicScoreParams, TopicScoreParams)> {
+    ) -> Result<(TopicScoreParams, TopicScoreParams, TopicScoreParams), String> {
         let (aggregators_per_slot, committees_per_slot) =
             self.expected_aggregator_count_per_slot(active_validators)?;
         let multiple_bursts_per_subnet_per_epoch =
@@ -256,7 +256,7 @@ impl<E: EthSpec> PeerScoreSettings<E> {
     fn expected_aggregator_count_per_slot(
         &self,
         active_validators: usize,
-    ) -> error::Result<(f64, usize)> {
+    ) -> Result<(f64, usize), String> {
         let committees_per_slot = E::get_committee_count_per_slot_with(
             active_validators,
             self.max_committees_per_slot,

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -20,7 +20,7 @@ use crate::types::{
 };
 use crate::EnrExt;
 use crate::Eth2Enr;
-use crate::{error, metrics, Enr, NetworkGlobals, PubsubMessage, TopicHash};
+use crate::{metrics, Enr, NetworkGlobals, PubsubMessage, TopicHash};
 use api_types::{AppRequestId, PeerRequestId, RequestId, Response};
 use futures::stream::StreamExt;
 use gossipsub::{
@@ -170,7 +170,7 @@ impl<E: EthSpec> Network<E> {
         executor: task_executor::TaskExecutor,
         mut ctx: ServiceContext<'_>,
         log: &slog::Logger,
-    ) -> error::Result<(Self, Arc<NetworkGlobals<E>>)> {
+    ) -> Result<(Self, Arc<NetworkGlobals<E>>), String> {
         let log = log.new(o!("service"=> "libp2p"));
 
         let config = ctx.config.clone();
@@ -515,7 +515,7 @@ impl<E: EthSpec> Network<E> {
     /// - Starts listening in the given ports.
     /// - Dials boot-nodes and libp2p peers.
     /// - Subscribes to starting gossipsub topics.
-    async fn start(&mut self, config: &crate::NetworkConfig) -> error::Result<()> {
+    async fn start(&mut self, config: &crate::NetworkConfig) -> Result<(), String> {
         let enr = self.network_globals.local_enr();
         info!(self.log, "Libp2p Starting"; "peer_id" => %enr.peer_id(), "bandwidth_config" => format!("{}-{}", config.network_load, NetworkLoad::from(config.network_load).name));
         debug!(self.log, "Attempting to open listening ports"; config.listen_addrs(), "discovery_enabled" => !config.disable_discovery, "quic_enabled" => !config.disable_quic_support);
@@ -920,7 +920,7 @@ impl<E: EthSpec> Network<E> {
         &mut self,
         active_validators: usize,
         current_slot: Slot,
-    ) -> error::Result<()> {
+    ) -> Result<(), String> {
         let (beacon_block_params, beacon_aggregate_proof_params, beacon_attestation_subnet_params) =
             self.score_settings
                 .get_dynamic_topic_params(active_validators, current_slot)?;

--- a/beacon_node/lighthouse_network/src/service/utils.rs
+++ b/beacon_node/lighthouse_network/src/service/utils.rs
@@ -1,9 +1,7 @@
 use crate::multiaddr::Protocol;
 use crate::rpc::methods::MetaDataV3;
 use crate::rpc::{MetaData, MetaDataV1, MetaDataV2};
-use crate::types::{
-    error, EnrAttestationBitfield, EnrSyncCommitteeBitfield, GossipEncoding, GossipKind,
-};
+use crate::types::{EnrAttestationBitfield, EnrSyncCommitteeBitfield, GossipEncoding, GossipKind};
 use crate::{GossipTopic, NetworkConfig};
 use futures::future::Either;
 use gossipsub;
@@ -83,7 +81,7 @@ pub fn build_transport(
 
 // Useful helper functions for debugging. Currently not used in the client.
 #[allow(dead_code)]
-fn keypair_from_hex(hex_bytes: &str) -> error::Result<Keypair> {
+fn keypair_from_hex(hex_bytes: &str) -> Result<Keypair, String> {
     let hex_bytes = if let Some(stripped) = hex_bytes.strip_prefix("0x") {
         stripped.to_string()
     } else {
@@ -91,18 +89,18 @@ fn keypair_from_hex(hex_bytes: &str) -> error::Result<Keypair> {
     };
 
     hex::decode(hex_bytes)
-        .map_err(|e| format!("Failed to parse p2p secret key bytes: {:?}", e).into())
+        .map_err(|e| format!("Failed to parse p2p secret key bytes: {:?}", e))
         .and_then(keypair_from_bytes)
 }
 
 #[allow(dead_code)]
-fn keypair_from_bytes(mut bytes: Vec<u8>) -> error::Result<Keypair> {
+fn keypair_from_bytes(mut bytes: Vec<u8>) -> Result<Keypair, String> {
     secp256k1::SecretKey::try_from_bytes(&mut bytes)
         .map(|secret| {
             let keypair: secp256k1::Keypair = secret.into();
             keypair.into()
         })
-        .map_err(|e| format!("Unable to parse p2p secret key: {:?}", e).into())
+        .map_err(|e| format!("Unable to parse p2p secret key: {:?}", e))
 }
 
 /// Loads a private key from disk. If this fails, a new key is

--- a/beacon_node/lighthouse_network/src/types/error.rs
+++ b/beacon_node/lighthouse_network/src/types/error.rs
@@ -1,5 +1,0 @@
-// generates error types
-
-use error_chain::error_chain;
-
-error_chain! {}

--- a/beacon_node/lighthouse_network/src/types/mod.rs
+++ b/beacon_node/lighthouse_network/src/types/mod.rs
@@ -1,4 +1,3 @@
-pub mod error;
 mod globals;
 mod pubsub;
 mod subnet;

--- a/beacon_node/network/Cargo.toml
+++ b/beacon_node/network/Cargo.toml
@@ -31,7 +31,6 @@ hex = { workspace = true }
 ethereum_ssz = { workspace = true }
 ssz_types = { workspace = true }
 futures = { workspace = true }
-error-chain = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 smallvec = { workspace = true }

--- a/beacon_node/network/src/error.rs
+++ b/beacon_node/network/src/error.rs
@@ -1,8 +1,0 @@
-// generates error types
-use error_chain::error_chain;
-
-error_chain! {
-   links  {
-       Libp2p(lighthouse_network::error::Error, lighthouse_network::error::ErrorKind);
-   }
-}

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -1,5 +1,4 @@
 /// This crate provides the network server for Lighthouse.
-pub mod error;
 pub mod service;
 
 mod metrics;

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -14,4 +14,3 @@ pub use lighthouse_network::NetworkConfig;
 pub use service::{
     NetworkMessage, NetworkReceivers, NetworkSenders, NetworkService, ValidatorSubscriptionMessage,
 };
-

--- a/beacon_node/network/src/lib.rs
+++ b/beacon_node/network/src/lib.rs
@@ -14,3 +14,4 @@ pub use lighthouse_network::NetworkConfig;
 pub use service::{
     NetworkMessage, NetworkReceivers, NetworkSenders, NetworkService, ValidatorSubscriptionMessage,
 };
+

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -5,7 +5,6 @@
 //! syncing-related responses to the Sync manager.
 #![allow(clippy::unit_arg)]
 
-use crate::error;
 use crate::network_beacon_processor::{InvalidBlockStorage, NetworkBeaconProcessor};
 use crate::service::NetworkMessage;
 use crate::status::status_message;
@@ -92,7 +91,7 @@ impl<T: BeaconChainTypes> Router<T> {
         beacon_processor_send: BeaconProcessorSend<T::EthSpec>,
         beacon_processor_reprocess_tx: mpsc::Sender<ReprocessQueueMessage>,
         log: slog::Logger,
-    ) -> error::Result<mpsc::UnboundedSender<RouterMessage<T::EthSpec>>> {
+    ) -> Result<mpsc::UnboundedSender<RouterMessage<T::EthSpec>>, String> {
         let message_handler_log = log.new(o!("service"=> "router"));
         trace!(message_handler_log, "Service starting");
 

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -1,10 +1,10 @@
+use crate::metrics;
 use crate::nat;
 use crate::network_beacon_processor::InvalidBlockStorage;
 use crate::persisted_dht::{clear_dht, load_dht, persist_dht};
 use crate::router::{Router, RouterMessage};
 use crate::subnet_service::{SubnetService, SubnetServiceMessage, Subscription};
 use crate::NetworkConfig;
-use crate::{error, metrics};
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use beacon_processor::{work_reprocessing_queue::ReprocessQueueMessage, BeaconProcessorSend};
 use futures::channel::mpsc::Sender;
@@ -208,11 +208,14 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         libp2p_registry: Option<&'_ mut Registry>,
         beacon_processor_send: BeaconProcessorSend<T::EthSpec>,
         beacon_processor_reprocess_tx: mpsc::Sender<ReprocessQueueMessage>,
-    ) -> error::Result<(
-        NetworkService<T>,
-        Arc<NetworkGlobals<T::EthSpec>>,
-        NetworkSenders<T::EthSpec>,
-    )> {
+    ) -> Result<
+        (
+            NetworkService<T>,
+            Arc<NetworkGlobals<T::EthSpec>>,
+            NetworkSenders<T::EthSpec>,
+        ),
+        String,
+    > {
         let network_log = executor.log().clone();
         // build the channels for external comms
         let (network_senders, network_receivers) = NetworkSenders::new();
@@ -367,7 +370,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
         libp2p_registry: Option<&'_ mut Registry>,
         beacon_processor_send: BeaconProcessorSend<T::EthSpec>,
         beacon_processor_reprocess_tx: mpsc::Sender<ReprocessQueueMessage>,
-    ) -> error::Result<(Arc<NetworkGlobals<T::EthSpec>>, NetworkSenders<T::EthSpec>)> {
+    ) -> Result<(Arc<NetworkGlobals<T::EthSpec>>, NetworkSenders<T::EthSpec>), String> {
         let (network_service, network_globals, network_senders) = Self::build(
             beacon_chain,
             config,


### PR DESCRIPTION
## Issue Addressed

Remove `error-chain` as a dependency. The repo has been archived since 2021, its used inconsistently in the LH codebase and is causing issues with the beta compiler CI job.
