### PR TITLE
Test: Add a test for processing multiple deposits within the same epoch for a given validator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,5 +278,8 @@ lto = "fat"
 codegen-units = 1
 incremental = false
 
+[profile.release]
+debug = true  # Enables debug symbols
+
 [patch.crates-io]
 quick-protobuf = { git = "https://github.com/sigp/quick-protobuf.git", rev = "681f413312404ab6e51f0b46f39b0075c6f4ebfd" }


### PR DESCRIPTION
## Issue Addressed

https://github.com/ethereum/consensus-specs/issues/4021

## Proposed Changes

The idea is to create pre/post electra tests that do the following
- create a deposit in block N, epoch E for validator X
- create another deposit in block N + 3, epoch E for validator X
- assert that the balance of the validator after processing the deposits in the epoch equals expectation

## Additional Info

The test case pre electra works. I have not been able to correctly model state transition to electra (this test currently panics due to the mock execution layer not being able to provide a valid payload), so help there would be appreciated. I have hence maked this PR, draft.
