### PR TITLE
Fix grammatical issue Update cli.sh

### DIFF
--- a/scripts/cli.sh
+++ b/scripts/cli.sh
@@ -62,7 +62,7 @@ check() {
     else
         cp $new_file $file
         changes=true
-        echo "$file is not found, it has just been created"
+        echo "$file was not found, it has just been created"
     fi
 
     if [[ -z $diff ]]; then # check for difference


### PR DESCRIPTION
I noticed a small grammatical issue in the bash script that might cause slight confusion. Specifically, in the following line:

```bash
echo "$file is not found, it has just been created"
```

It would be more grammatically correct to say:

```bash
echo "$file was not found, it has just been created"
```

This change clarifies the sentence, ensuring proper use of past tense and improving readability. Although it doesn't affect functionality, maintaining correct grammar in log messages and scripts is important for clarity and professionalism, especially for future contributors and users.