### PR TITLE
Correct flakey CI tests

### DIFF
--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -213,7 +213,7 @@ impl<T: BeaconChainTypes> SubnetService<T> {
     #[cfg(test)]
     pub(crate) fn is_subscribed(&self, subnet: &Subnet) -> bool {
         self.subscriptions.contains_key(subnet)
-            || self.permanent_attestation_subscriptions.contains(&subnet)
+            || self.permanent_attestation_subscriptions.contains(subnet)
     }
 
     /// Processes a list of validator subscriptions.

--- a/beacon_node/network/src/subnet_service/mod.rs
+++ b/beacon_node/network/src/subnet_service/mod.rs
@@ -213,6 +213,7 @@ impl<T: BeaconChainTypes> SubnetService<T> {
     #[cfg(test)]
     pub(crate) fn is_subscribed(&self, subnet: &Subnet) -> bool {
         self.subscriptions.contains_key(subnet)
+            || self.permanent_attestation_subscriptions.contains(&subnet)
     }
 
     /// Processes a list of validator subscriptions.

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -225,7 +225,7 @@ mod test {
         let mut committee_count = 1;
         let mut subnet = Subnet::Attestation(
             SubnetId::compute_subnet::<MainnetEthSpec>(
-                current_slot,
+                subscription_slot,
                 committee_index,
                 committee_count,
                 &subnet_service.beacon_chain.spec,
@@ -250,7 +250,7 @@ mod test {
 
         let subscriptions = vec![get_subscription(
             committee_index,
-            current_slot,
+            subscription_slot,
             committee_count,
             true,
         )];

--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -556,7 +556,8 @@ mod test {
         subnet_service.validator_subscriptions(vec![sub1, sub2].into_iter());
 
         // Unsubscription event should happen at the end of the slot.
-        let events = get_events(&mut subnet_service, None, 1).await;
+        // We wait for 2 slots, to avoid timeout issues
+        let events = get_events(&mut subnet_service, None, 2).await;
 
         let expected_subscription =
             SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id1));
@@ -567,6 +568,7 @@ mod test {
             assert_eq!(expected_subscription, events[0]);
             assert_eq!(expected_unsubscription, events[2]);
         }
+        // Check that there are no more subscriptions
         assert_eq!(subnet_service.subscriptions().count(), 0);
 
         println!("{events:?}");


### PR DESCRIPTION
## Issue Addressed

Some subnet service tests were failing occasionally. There were two bugs that I found. 

I've run these tests repeatedly without fail, so at the very least, should make these more stable. 

