### PR TITLE
Fix Typographical Errors in Documentation

### DIFF
--- a/book/src/advanced_metrics.md
+++ b/book/src/advanced_metrics.md
@@ -2,7 +2,7 @@
 
 Lighthouse provides an extensive suite of metrics and monitoring in the
 [Prometheus](https://prometheus.io/docs/introduction/overview/) export format
-via a HTTP server built into Lighthouse.
+via an HTTP server built into Lighthouse.
 
 These metrics are generally consumed by a Prometheus server and displayed via a
 Grafana dashboard. These components are available in a docker-compose format at

--- a/book/src/api-vc.md
+++ b/book/src/api-vc.md
@@ -14,7 +14,7 @@ signers. It also includes some Lighthouse-specific endpoints which are described
 
 ## Starting the server
 
-A Lighthouse validator client can be configured to expose a HTTP server by supplying the `--http` flag. The default listen address is `http://127.0.0.1:5062`.
+A Lighthouse validator client can be configured to expose an HTTP server by supplying the `--http` flag. The default listen address is `http://127.0.0.1:5062`.
 
 The following CLI flags control the HTTP server:
 

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -12,7 +12,7 @@ Commands:
           a, am, account]
   beacon_node
           The primary component which connects to the Ethereum 2.0 P2P network
-          and downloads, verifies and stores blocks. Provides a HTTP API for
+          and downloads, verifies and stores blocks. Provides an HTTP API for
           querying the beacon chain and publishing messages to the network.
           [aliases: b, bn, beacon]
   boot_node

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -61,7 +61,7 @@ Options:
           flag is used, it additionally requires the explicit use of the
           `--unencrypted-http-transport` flag to ensure the user is aware of the
           risks involved. For access via the Internet, users should apply
-          transport-layer security like a HTTPS reverse-proxy or SSH tunnelling.
+          transport-layer security like an HTTPS reverse-proxy or SSH tunnelling.
       --http-allow-origin <ORIGIN>
           Set the value of the Access-Control-Allow-Origin response HTTP header.
           Use * to allow any origin (not recommended in production). If no value
@@ -105,7 +105,7 @@ Options:
           (e.g. beaconcha.in). This flag sets the endpoint where the beacon node
           metrics will be sent. Note: This will send information to a remote
           sever which may identify and associate your validators, IP address and
-          other personal information. Always use a HTTPS connection and never
+          other personal information. Always use an HTTPS connection and never
           provide an untrusted URL.
       --monitoring-endpoint-period <SECONDS>
           Defines how many seconds to wait between each message sent to the

--- a/book/src/key-recovery.md
+++ b/book/src/key-recovery.md
@@ -47,7 +47,7 @@ the `--secrets-dir` (default `~/.lighthouse/{network}/secrets`).
 
 where `{network}` is the name of the consensus layer network passed in the `--network` parameter (default is `mainnet`).
 
-## Recover a EIP-2386 wallet
+## Recover an EIP-2386 wallet
 
 Instead of creating EIP-2335 keystores directly, an EIP-2386 wallet can be
 generated from the mnemonic. This wallet can then be used to generate validator

--- a/book/src/mainnet-validator.md
+++ b/book/src/mainnet-validator.md
@@ -138,7 +138,7 @@ Holesky testnet:
 lighthouse vc --network holesky --suggested-fee-recipient YourFeeRecipientAddress
 ```
 
-The `validator client` manages validators using data obtained from the beacon node via a HTTP API. You are highly recommended to enter a fee-recipient by changing `YourFeeRecipientAddress` to an Ethereum address under your control.
+The `validator client` manages validators using data obtained from the beacon node via an HTTP API. You are highly recommended to enter a fee-recipient by changing `YourFeeRecipientAddress` to an Ethereum address under your control.
 
 When `lighthouse vc` starts, check that the validator public key appears
 as a `voting_pubkey` as shown below:

--- a/book/src/slashing-protection.md
+++ b/book/src/slashing-protection.md
@@ -90,7 +90,7 @@ lighthouse account validator slashing-protection export filename.json
 ```
 
 The validator client needs to be stopped in order to export, to guarantee that the data exported is
-up to date.
+up-to-date.
 
 [EIP-3076]: https://eips.ethereum.org/EIPS/eip-3076
 

--- a/book/src/validator-management.md
+++ b/book/src/validator-management.md
@@ -55,7 +55,7 @@ Each permitted field of the file is listed below for reference:
  validator "enabled".
 - `voting_public_key`: A validator public key.
 - `type`: How the validator signs messages (this can be `local_keystore` or `web3signer` (see [Web3Signer](./validator-web3signer.md))).
-- `voting_keystore_path`: The path to a EIP-2335 keystore.
+- `voting_keystore_path`: The path to an EIP-2335 keystore.
 - `voting_keystore_password_path`: The path to the password for the EIP-2335 keystore.
 - `voting_keystore_password`: The password to the EIP-2335 keystore.
 


### PR DESCRIPTION
This PR addresses minor typographical inconsistencies in several documentation files related to the use of the indefinite article **'a'** vs. **'an'** before words beginning with vowel sounds or letters pronounced as vowels.

## Proposed Changes

The following changes have been made:
1. Corrected instances of **'a HTTP'** to **'an HTTP'** across multiple files.
2. Adjusted **'a EIP-XXXX'** to **'an EIP-XXXX'** where applicable, ensuring proper grammatical structure.

### Files Affected:
- `advanced_metrics.md`
- `api-vc.md`
- `help_general.md`
- `help_vc.md`
- `key-recovery.md`
- `mainnet-validator.md`
- `slashing-protection.md`
- `validator-management.md`

## Additional Info

These changes improve readability and consistency in the documentation, aligning with standard grammatical rules. No functional code or logic has been modified.

