### PR TITLE
Remove heading that isn't rendered correctly

### DIFF
--- a/book/src/security.md
+++ b/book/src/security.md
@@ -1,6 +1,5 @@
 # Security
 
-========
 Lighthouse takes security seriously. Please see our security policy on GitHub for our PGP key and information on reporting vulnerabilities:
 
 - [GitHub: Security Policy](https://github.com/sigp/lighthouse/blob/stable/SECURITY.md)


### PR DESCRIPTION
## Proposed Changes

Fix the header formatting which is not being applied correctly:

https://lighthouse-book.sigmaprime.io/security.html

We only need the `#` at the start to make `Security` the heading (`h1`) for the page.
