### PR TITLE
Add remove_promise function to GossipPromises and call function when message received from peer prior to sending IDONTWANT

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -1844,6 +1844,9 @@ where
 
         // Broadcast IDONTWANT messages
         if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
+            // Clear any pending promises for this message
+            self.gossip_promises.remove_promise(propagation_source, &msg_id);
+            // Send the IDONTWANT message to peers
             self.send_idontwant(&raw_message, &msg_id, Some(propagation_source));
         }
 
@@ -2729,7 +2732,7 @@ where
         let Some(mesh_peers) = self.mesh.get(&message.topic) else {
             return;
         };
-
+        // Get the peers that we previously sent an IWANT to.
         let iwant_peers = self.gossip_promises.peers_for_message(msg_id);
 
         let recipient_peers = mesh_peers
@@ -2750,6 +2753,9 @@ where
             if peer.kind != PeerKind::Gossipsubv1_2 {
                 continue;
             }
+
+            // Remove any pending promises for this message from this peer.
+            self.gossip_promises.remove_promise(peer_id, msg_id);
 
             if peer
                 .sender

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -1845,7 +1845,8 @@ where
         // Broadcast IDONTWANT messages
         if raw_message.raw_protobuf_len() > self.config.idontwant_message_size_threshold() {
             // Clear any pending promises for this message
-            self.gossip_promises.remove_promise(propagation_source, &msg_id);
+            self.gossip_promises
+                .remove_promise(propagation_source, &msg_id);
             // Send the IDONTWANT message to peers
             self.send_idontwant(&raw_message, &msg_id, Some(propagation_source));
         }

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -2965,7 +2965,7 @@ fn test_do_not_flood_publish_to_peer_below_publish_threshold() {
             let priority = c.priority.into_inner();
             while !priority.is_empty() {
                 if let Ok(RpcOut::Publish { message, .. }) = priority.try_recv() {
-                    collected_publish.push((peer_id, message))
+                    collected_publish.push((peer_id, message));
                 }
             }
             collected_publish
@@ -5482,4 +5482,127 @@ fn clear_stale_idontwant() {
     gs.heartbeat();
     let peer = gs.connected_peers.get_mut(&peers[2]).unwrap();
     assert!(peer.dont_send_received.is_empty());
+}
+// Test promise removal function does not clear promises for other peers
+#[test]
+fn test_remove_promises() {
+    // Create a new empty GossipPromises instance using the Default trait
+    let mut promises = GossipPromises::default();
+    
+    // Create two unique random peer IDs for testing
+    let peer1 = PeerId::random();
+    let peer2 = PeerId::random();
+    // Create a test message ID from a byte slice
+    let message_id = MessageId::new(b"test_message");
+    // Create an expiry time 60 seconds from now
+    let expiry = Instant::now() + Duration::from_secs(60);
+    
+    // Test 1: Remove promise from empty state
+    promises.remove_promise(&peer1, &message_id);
+    // Verify the message ID doesn't exist in promises (should be safe on empty state)
+    assert!(!promises.contains(&message_id));
+    
+    // Test 2: Remove promise when peer is the only one for a message
+    promises.add_promise(peer1, &[message_id.clone()], expiry);
+    assert!(promises.contains(&message_id));
+    promises.remove_promise(&peer1, &message_id);
+    assert!(!promises.contains(&message_id));
+    
+    // Test 3: Remove one peer's promise while keeping another's
+    promises.add_promise(peer1, &[message_id.clone()], expiry);
+    promises.add_promise(peer2, &[message_id.clone()], expiry);
+    promises.remove_promise(&peer1, &message_id);
+    // Message should still exist because peer2's promise remains
+    assert!(promises.contains(&message_id));
+    // Verify peer1 was removed from the promises for this message
+    assert!(!promises.peers_for_message(&message_id).contains(&peer1));
+    // Verify peer2's promise still exists
+    assert!(promises.peers_for_message(&message_id).contains(&peer2));
+    
+    // Test 4: Remove non-existent peer from existing message
+    // Create another random peer ID that has no promises
+    let non_existent_peer = PeerId::random();
+    // Try to remove a promise for this peer (should have no effect)
+    promises.remove_promise(&non_existent_peer, &message_id);
+    // Verify the message still exists
+    assert!(promises.contains(&message_id));
+    // Verify peer2's promise wasn't affected
+    assert!(promises.peers_for_message(&message_id).contains(&peer2));
+}
+
+//Test that an IWANT promise is removed when a message is received
+#[test]
+fn test_promise_removal_on_message_received() {
+    let config = ConfigBuilder::default()
+        .build()
+        .expect("Valid config");
+
+    let (mut gs, peers, _receivers, topics) = inject_nodes1()
+        .peer_no(1)
+        .topics(vec!["test".into()])
+        .to_subscribe(true)
+        .gs_config(config.clone())
+        .create_network();
+
+    // Create test message
+    let mut seq = 0;
+    let raw_message = random_message(&mut seq, &topics);
+    let message = gs.data_transform.inbound_transform(raw_message.clone())
+        .expect("Valid message transform");
+    let message_id = config.message_id(&message);
+
+    // Simulate IHAVE/IWANT exchange
+    gs.handle_ihave(&peers[0], vec![(topics[0].clone(), vec![message_id.clone()])]);
+
+    // Verify promise was created
+    assert!(gs.gossip_promises.contains(&message_id));
+    assert!(gs.gossip_promises.peers_for_message(&message_id).contains(&peers[0]));
+
+    // Receive message
+    gs.handle_received_message(raw_message, &peers[0]);
+
+    // Verify promise was removed
+    assert!(!gs.gossip_promises.contains(&message_id));
+    assert!(gs.gossip_promises.peers_for_message(&message_id).is_empty());
+}
+
+//Test that an IWANT promise is removed when an IDONTWANT message is sent
+#[test]
+fn test_promise_removal_on_idontwant_sent() {
+    let config = ConfigBuilder::default()
+    .build()
+    .expect("Failed to build config");
+    
+let (mut gs, peers, _receivers, topic_hashes) = inject_nodes1()
+    .peer_no(1)
+    .topics(vec![String::from("topic1")])
+    .to_subscribe(true)
+    .gs_config(config.clone())
+    .explicit(1)
+    .peer_kind(PeerKind::Gossipsubv1_2)
+    .create_network();
+
+let message = RawMessage {
+    source: Some(peers[0]),
+    data: vec![12u8; 1024],
+    sequence_number: Some(0),
+    topic: topic_hashes[0].clone(),
+    signature: None,
+    key: None,
+    validated: true,
+};
+
+// Get the message ID
+let transformed_message = gs.data_transform.inbound_transform(message.clone())
+    .expect("Failed message transform");
+let message_id = config.message_id(&transformed_message);
+
+// Create and verify promise
+gs.handle_ihave(&peers[0], vec![(topic_hashes[0].clone(), vec![message_id.clone()])]);
+assert!(gs.gossip_promises.contains(&message_id));
+
+// Handle message and verify promise removed
+gs.handle_received_message(message, &PeerId::random());
+assert!(!gs.gossip_promises.contains(&message_id)); 
+  
 }

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -5488,32 +5488,32 @@ fn clear_stale_idontwant() {
 fn test_remove_promises() {
     // Create a new empty GossipPromises instance using the Default trait.
     let mut promises = GossipPromises::default();
-    
+
     // Create two unique random peer IDs for testing.
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
     let message_id = MessageId::new(b"test_message");
     let expiry = Instant::now() + Duration::from_secs(60);
-    
+
     // Test 1: Remove promise from empty state.
     promises.remove_promise(&peer1, &message_id);
     // Verify the message ID doesn't exist in promises (should be safe on empty state).
     assert!(!promises.contains(&message_id));
-    
+
     // Test 2: Remove promise when peer is the only one for a message.
     promises.add_promise(peer1, &[message_id.clone()], expiry);
     assert!(promises.contains(&message_id));
     promises.remove_promise(&peer1, &message_id);
     assert!(!promises.contains(&message_id));
-    
-    // Test 3: Remove a peer's promise while retaining another promise. 
+
+    // Test 3: Remove a peer's promise while retaining another promise.
     promises.add_promise(peer1, &[message_id.clone()], expiry);
     promises.add_promise(peer2, &[message_id.clone()], expiry);
     promises.remove_promise(&peer1, &message_id);
     assert!(promises.contains(&message_id));
     assert!(!promises.peers_for_message(&message_id).contains(&peer1));
     assert!(promises.peers_for_message(&message_id).contains(&peer2));
-    
+
     // Test 4: Remove non-existent peer from existing message
     let non_existent_peer = PeerId::random();
     promises.remove_promise(&non_existent_peer, &message_id);
@@ -5524,9 +5524,7 @@ fn test_remove_promises() {
 //Test that an IWANT promise is removed when a message is received
 #[test]
 fn test_promise_removal_on_message_received() {
-    let config = ConfigBuilder::default()
-        .build()
-        .expect("Valid config");
+    let config = ConfigBuilder::default().build().expect("Valid config");
 
     let (mut gs, peers, _receivers, topics) = inject_nodes1()
         .peer_no(1)
@@ -5538,16 +5536,24 @@ fn test_promise_removal_on_message_received() {
     // Create test message
     let mut seq = 0;
     let raw_message = random_message(&mut seq, &topics);
-    let message = gs.data_transform.inbound_transform(raw_message.clone())
+    let message = gs
+        .data_transform
+        .inbound_transform(raw_message.clone())
         .expect("Valid message transform");
     let message_id = config.message_id(&message);
 
     // Simulate IHAVE/IWANT exchange
-    gs.handle_ihave(&peers[0], vec![(topics[0].clone(), vec![message_id.clone()])]);
+    gs.handle_ihave(
+        &peers[0],
+        vec![(topics[0].clone(), vec![message_id.clone()])],
+    );
 
     // Verify promise was created
     assert!(gs.gossip_promises.contains(&message_id));
-    assert!(gs.gossip_promises.peers_for_message(&message_id).contains(&peers[0]));
+    assert!(gs
+        .gossip_promises
+        .peers_for_message(&message_id)
+        .contains(&peers[0]));
 
     // Receive message
     gs.handle_received_message(raw_message, &peers[0]);
@@ -5561,39 +5567,43 @@ fn test_promise_removal_on_message_received() {
 #[test]
 fn test_promise_removal_on_idontwant_sent() {
     let config = ConfigBuilder::default()
-    .build()
-    .expect("Failed to build config");
-    
-let (mut gs, peers, _receivers, topic_hashes) = inject_nodes1()
-    .peer_no(1)
-    .topics(vec![String::from("topic1")])
-    .to_subscribe(true)
-    .gs_config(config.clone())
-    .explicit(1)
-    .peer_kind(PeerKind::Gossipsubv1_2)
-    .create_network();
+        .build()
+        .expect("Failed to build config");
 
-let message = RawMessage {
-    source: Some(peers[0]),
-    data: vec![12u8; 1024],
-    sequence_number: Some(0),
-    topic: topic_hashes[0].clone(),
-    signature: None,
-    key: None,
-    validated: true,
-};
+    let (mut gs, peers, _receivers, topic_hashes) = inject_nodes1()
+        .peer_no(1)
+        .topics(vec![String::from("topic1")])
+        .to_subscribe(true)
+        .gs_config(config.clone())
+        .explicit(1)
+        .peer_kind(PeerKind::Gossipsubv1_2)
+        .create_network();
 
-// Get the message ID
-let transformed_message = gs.data_transform.inbound_transform(message.clone())
-    .expect("Failed message transform");
-let message_id = config.message_id(&transformed_message);
+    let message = RawMessage {
+        source: Some(peers[0]),
+        data: vec![12u8; 1024],
+        sequence_number: Some(0),
+        topic: topic_hashes[0].clone(),
+        signature: None,
+        key: None,
+        validated: true,
+    };
 
-// Create and verify promise
-gs.handle_ihave(&peers[0], vec![(topic_hashes[0].clone(), vec![message_id.clone()])]);
-assert!(gs.gossip_promises.contains(&message_id));
+    // Get the message ID
+    let transformed_message = gs
+        .data_transform
+        .inbound_transform(message.clone())
+        .expect("Failed message transform");
+    let message_id = config.message_id(&transformed_message);
 
-// Handle message and verify promise removed
-gs.handle_received_message(message, &PeerId::random());
-assert!(!gs.gossip_promises.contains(&message_id)); 
-  
+    // Create and verify promise
+    gs.handle_ihave(
+        &peers[0],
+        vec![(topic_hashes[0].clone(), vec![message_id.clone()])],
+    );
+    assert!(gs.gossip_promises.contains(&message_id));
+
+    // Handle message and verify promise removed
+    gs.handle_received_message(message, &PeerId::random());
+    assert!(!gs.gossip_promises.contains(&message_id));
 }

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -2965,7 +2965,7 @@ fn test_do_not_flood_publish_to_peer_below_publish_threshold() {
             let priority = c.priority.into_inner();
             while !priority.is_empty() {
                 if let Ok(RpcOut::Publish { message, .. }) = priority.try_recv() {
-                    collected_publish.push((peer_id, message));
+                    collected_publish.push((peer_id, message))
                 }
             }
             collected_publish
@@ -5486,47 +5486,38 @@ fn clear_stale_idontwant() {
 // Test promise removal function does not clear promises for other peers
 #[test]
 fn test_remove_promises() {
-    // Create a new empty GossipPromises instance using the Default trait
+    // Create a new empty GossipPromises instance using the Default trait.
     let mut promises = GossipPromises::default();
     
-    // Create two unique random peer IDs for testing
+    // Create two unique random peer IDs for testing.
     let peer1 = PeerId::random();
     let peer2 = PeerId::random();
-    // Create a test message ID from a byte slice
     let message_id = MessageId::new(b"test_message");
-    // Create an expiry time 60 seconds from now
     let expiry = Instant::now() + Duration::from_secs(60);
     
-    // Test 1: Remove promise from empty state
+    // Test 1: Remove promise from empty state.
     promises.remove_promise(&peer1, &message_id);
-    // Verify the message ID doesn't exist in promises (should be safe on empty state)
+    // Verify the message ID doesn't exist in promises (should be safe on empty state).
     assert!(!promises.contains(&message_id));
     
-    // Test 2: Remove promise when peer is the only one for a message
+    // Test 2: Remove promise when peer is the only one for a message.
     promises.add_promise(peer1, &[message_id.clone()], expiry);
     assert!(promises.contains(&message_id));
     promises.remove_promise(&peer1, &message_id);
     assert!(!promises.contains(&message_id));
     
-    // Test 3: Remove one peer's promise while keeping another's
+    // Test 3: Remove a peer's promise while retaining another promise. 
     promises.add_promise(peer1, &[message_id.clone()], expiry);
     promises.add_promise(peer2, &[message_id.clone()], expiry);
     promises.remove_promise(&peer1, &message_id);
-    // Message should still exist because peer2's promise remains
     assert!(promises.contains(&message_id));
-    // Verify peer1 was removed from the promises for this message
     assert!(!promises.peers_for_message(&message_id).contains(&peer1));
-    // Verify peer2's promise still exists
     assert!(promises.peers_for_message(&message_id).contains(&peer2));
     
     // Test 4: Remove non-existent peer from existing message
-    // Create another random peer ID that has no promises
     let non_existent_peer = PeerId::random();
-    // Try to remove a promise for this peer (should have no effect)
     promises.remove_promise(&non_existent_peer, &message_id);
-    // Verify the message still exists
     assert!(promises.contains(&message_id));
-    // Verify peer2's promise wasn't affected
     assert!(promises.peers_for_message(&message_id).contains(&peer2));
 }
 

--- a/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
@@ -61,6 +61,17 @@ impl GossipPromises {
         }
     }
 
+    /// Remove promises for a given peer and message ID combination. 
+    pub(crate) fn remove_promise(&mut self, peer: &PeerId, message_id: &MessageId) {
+        if let Some(promises) = self.promises.get_mut(message_id) {
+            promises.retain(|peer_id, _| peer_id != peer);
+            // Clean up empty promises
+            if promises.is_empty() {
+                self.promises.remove(message_id);
+            }
+        }
+    }
+
     pub(crate) fn message_delivered(&mut self, message_id: &MessageId) {
         // Someone delivered a message, we can stop tracking all promises for it.
         self.promises.remove(message_id);

--- a/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
@@ -61,7 +61,7 @@ impl GossipPromises {
         }
     }
 
-    /// Remove promises for a given peer and message ID combination. 
+    /// Remove promises for a given peer and message ID combination.
     pub(crate) fn remove_promise(&mut self, peer: &PeerId, message_id: &MessageId) {
         if let Some(promises) = self.promises.get_mut(message_id) {
             promises.retain(|peer_id, _| peer_id != peer);


### PR DESCRIPTION
## Issue Addressed

#6644 

## Proposed Changes

To address the issue raised in #6644 where we don't remove IWANT promises from peers after sending IDONTWANT: 

- Add remove_promise function to GossipPromises in the lighthouse_network crate. This function removes a given peer's promise and cleans up empty message entries.  
- Call this function prior to sending IDONTWANT to avoid incorrectly penalising peers. 

## Additional Info

Also includes tests. 
