### PR TITLE
Manually implement SSZ for Checkpoint

### DIFF
--- a/consensus/types/src/checkpoint.rs
+++ b/consensus/types/src/checkpoint.rs
@@ -38,9 +38,14 @@ impl Encode for Checkpoint {
         self.root.ssz_append(buf);
     }
 
-    #[allow(clippy::arithmetic_side_effects)]
+    fn ssz_fixed_len() -> usize {
+        <Epoch as Decode>::ssz_fixed_len()
+            .checked_add(<Hash256 as Decode>::ssz_fixed_len())
+            .expect("checkpoint ssz_fixed_len too large")
+    }
+
     fn ssz_bytes_len(&self) -> usize {
-        self.epoch.ssz_bytes_len() + self.root.ssz_bytes_len()
+        <Self as Encode>::ssz_fixed_len()
     }
 }
 
@@ -50,9 +55,8 @@ impl Decode for Checkpoint {
         true
     }
 
-    #[allow(clippy::arithmetic_side_effects)]
     fn ssz_fixed_len() -> usize {
-        <Epoch as Decode>::ssz_fixed_len() + <Hash256 as Decode>::ssz_fixed_len()
+        <Self as Encode>::ssz_fixed_len()
     }
 
     fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, ssz::DecodeError> {


### PR DESCRIPTION
## Issue Addressed

NA

## Proposed Changes

Manually implements SSZ for `Checkpoint`. We're presently using the `ssz_derive` macros and they have some overhead due to their generic-ness.

My benchmarks indicate a >20% reduction in `ssz::Decode` times. Although we're only saving some nanoseconds, this is a very commonly used struct and it's appealing to have it nice and lean.

The complexity introduced is very minimal; it's very easy to reason about the implementation I've included.

## Benchmarks

These benchmarks are iterations of 1,000,000 decodes of a `Checkpoint` struct. There's an additional `assert!` statement included in the benchmark to prevent the compile from optimising anything out.

## Before

```
2.646833ms
2.6645ms
2.648917ms
2.648375ms
2.636334ms
2.636625ms
2.64875ms
2.656542ms
2.636625ms
2.635208ms
```

## After

```
1.926208ms
1.923208ms
1.921291ms
1.920208ms
2.00575ms
1.9165ms
1.91875ms
1.926542ms
1.921125ms
1.961834ms
```

## Additional Info

NA