### PR TITLE
Stuck lookup v6

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -171,7 +171,10 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
         self.awaiting_parent.is_some()
             || self.block_request_state.state.is_awaiting_event()
             || match &self.component_requests {
-                ComponentRequests::WaitingForBlock => true,
+                // If components are waiting for the block request to complete, here we should
+                // check if the`block_request_state.state.is_awaiting_event(). However we already
+                // checked that above, so `WaitingForBlock => false` is equivalent.
+                ComponentRequests::WaitingForBlock => false,
                 ComponentRequests::ActiveBlobRequest(request, _) => {
                     request.state.is_awaiting_event()
                 }


### PR DESCRIPTION
## Issue Addressed

PR 
- https://github.com/sigp/lighthouse/pull/6443

Introduced a regression on the lookup pruning logic. If a lookup loses all peers before the block request downloads the block, it will get stuck. This is a relatively frequent occurrence. This bug will result in occasional warn logs on the user's terminals.

**Example case events**

- Lookup created for block A, from peer X
- Peer X disconencts, lookup A now has 0 peers
- 10 seconds pass
- `drop_lookups_without_peers` runs on lookup A
  - `has_no_peers` returns true
  - elapsed condition returns true
  - `is_awaiting_event` returns true <- so it doesn't get pruned

`is_awaiting_event` checks:
- `awaiting_parent.is_some()` returns false
- `self.block_request_state.state.is_awaiting_event()` returns false (block awaiting download)
- `component_requests` is `WaitingForBlock`, so it returns true <- the bug is here

https://github.com/sigp/lighthouse/blob/193c7f82411bb7c28cec1959e2d7682d72d1452b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs#L174-L177

## Proposed Changes

Fix `is_awaiting_event` logic.
