### PR TITLE
Release v6.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "beacon_node",
  "bytes",
@@ -4674,7 +4674,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "6.0.0"
+version = "6.0.1"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "6.0.0"
+version = "6.0.1"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v6.0.0-",
-    fallback = "Lighthouse/v6.0.0"
+    prefix = "Lighthouse/v6.0.1-",
+    fallback = "Lighthouse/v6.0.1"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Proposed Changes

This is the "cut" PR for commiting the version bump change for v6.0.1

The plan is to merge PRs for v6.0.1 into `release-v6.0.1` and then merge that PR to `stable` without squashing.

## Additional Info

Blocked on:

- https://github.com/sigp/lighthouse/pull/6658
- https://github.com/sigp/lighthouse/pull/6667
- https://github.com/sigp/lighthouse/pull/6677