### PR TITLE
Enable lints for tests only running optimized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test-full: cargo-fmt test-release test-debug test-ef test-exec-engine
 # Lints the code for bad style and potentially unsafe arithmetic using Clippy.
 # Clippy lints are opt-in per-crate for now. By default, everything is allowed except for performance and correctness lints.
 lint:
-	cargo clippy --workspace --benches --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
+	RUSTFLAGS="-C debug-assertions=no $(RUSTFLAGS)" cargo clippy --workspace --benches --tests $(EXTRA_CLIPPY_OPTS) --features "$(TEST_FEATURES)" -- \
 		-D clippy::fn_to_numeric_cast_any \
 		-D clippy::manual_let_else \
 		-D clippy::large_stack_frames \

--- a/account_manager/src/validator/exit.rs
+++ b/account_manager/src/validator/exit.rs
@@ -409,6 +409,6 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(expected_pk, kp.pk.into());
+        assert_eq!(expected_pk, kp.pk);
     }
 }

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -512,7 +512,7 @@ mod test {
         }
 
         assert!(
-            !cache.contains(&shuffling_id_and_committee_caches.get(0).unwrap().0),
+            !cache.contains(&shuffling_id_and_committee_caches.first().unwrap().0),
             "should not contain oldest epoch shuffling id"
         );
         assert_eq!(

--- a/beacon_node/beacon_chain/tests/attestation_production.rs
+++ b/beacon_node/beacon_chain/tests/attestation_production.rs
@@ -70,12 +70,12 @@ async fn produces_attestations_from_attestation_simulator_service() {
     }
 
     // Compare the prometheus metrics that evaluates the performance of the unaggregated attestations
-    let hit_prometheus_metrics = vec![
+    let hit_prometheus_metrics = [
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_HEAD_ATTESTER_HIT_TOTAL,
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_TARGET_ATTESTER_HIT_TOTAL,
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_SOURCE_ATTESTER_HIT_TOTAL,
     ];
-    let miss_prometheus_metrics = vec![
+    let miss_prometheus_metrics = [
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_HEAD_ATTESTER_MISS_TOTAL,
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_TARGET_ATTESTER_MISS_TOTAL,
         metrics::VALIDATOR_MONITOR_ATTESTATION_SIMULATOR_SOURCE_ATTESTER_MISS_TOTAL,

--- a/beacon_node/beacon_chain/tests/attestation_verification.rs
+++ b/beacon_node/beacon_chain/tests/attestation_verification.rs
@@ -431,10 +431,12 @@ impl GossipTester {
             .chain
             .verify_aggregated_attestation_for_gossip(&aggregate)
             .err()
-            .expect(&format!(
-                "{} should error during verify_aggregated_attestation_for_gossip",
-                desc
-            ));
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} should error during verify_aggregated_attestation_for_gossip",
+                    desc
+                )
+            });
         inspect_err(&self, err);
 
         /*
@@ -449,10 +451,12 @@ impl GossipTester {
             .unwrap();
 
         assert_eq!(results.len(), 2);
-        let batch_err = results.pop().unwrap().err().expect(&format!(
-            "{} should error during batch_verify_aggregated_attestations_for_gossip",
-            desc
-        ));
+        let batch_err = results.pop().unwrap().err().unwrap_or_else(|| {
+            panic!(
+                "{} should error during batch_verify_aggregated_attestations_for_gossip",
+                desc
+            )
+        });
         inspect_err(&self, batch_err);
 
         self
@@ -475,10 +479,12 @@ impl GossipTester {
             .chain
             .verify_unaggregated_attestation_for_gossip(&attn, Some(subnet_id))
             .err()
-            .expect(&format!(
-                "{} should error during verify_unaggregated_attestation_for_gossip",
-                desc
-            ));
+            .unwrap_or_else(|| {
+                panic!(
+                    "{} should error during verify_unaggregated_attestation_for_gossip",
+                    desc
+                )
+            });
         inspect_err(&self, err);
 
         /*
@@ -496,10 +502,12 @@ impl GossipTester {
             )
             .unwrap();
         assert_eq!(results.len(), 2);
-        let batch_err = results.pop().unwrap().err().expect(&format!(
-            "{} should error during batch_verify_unaggregated_attestations_for_gossip",
-            desc
-        ));
+        let batch_err = results.pop().unwrap().err().unwrap_or_else(|| {
+            panic!(
+                "{} should error during batch_verify_unaggregated_attestations_for_gossip",
+                desc
+            )
+        });
         inspect_err(&self, batch_err);
 
         self
@@ -816,7 +824,7 @@ async fn aggregated_gossip_verification() {
                 let (index, sk) = tester.non_aggregator();
                 *a = SignedAggregateAndProof::from_aggregate(
                     index as u64,
-                    tester.valid_aggregate.message().aggregate().clone(),
+                    tester.valid_aggregate.message().aggregate(),
                     None,
                     &sk,
                     &chain.canonical_head.cached_head().head_fork(),

--- a/beacon_node/beacon_chain/tests/bellatrix.rs
+++ b/beacon_node/beacon_chain/tests/bellatrix.rs
@@ -82,7 +82,7 @@ async fn merge_with_terminal_block_hash_override() {
 
         let block = &harness.chain.head_snapshot().beacon_block;
 
-        let execution_payload = block.message().body().execution_payload().unwrap().clone();
+        let execution_payload = block.message().body().execution_payload().unwrap();
         if i == 0 {
             assert_eq!(execution_payload.block_hash(), genesis_pow_block_hash);
         }
@@ -207,15 +207,7 @@ async fn base_altair_bellatrix_with_terminal_block_after_fork() {
         harness.extend_slots(1).await;
 
         let block = &harness.chain.head_snapshot().beacon_block;
-        execution_payloads.push(
-            block
-                .message()
-                .body()
-                .execution_payload()
-                .unwrap()
-                .clone()
-                .into(),
-        );
+        execution_payloads.push(block.message().body().execution_payload().unwrap().into());
     }
 
     verify_execution_payload_chain(execution_payloads.as_slice());

--- a/beacon_node/beacon_chain/tests/bellatrix.rs
+++ b/beacon_node/beacon_chain/tests/bellatrix.rs
@@ -133,7 +133,7 @@ async fn base_altair_bellatrix_with_terminal_block_after_fork() {
      * Do the Bellatrix fork, without a terminal PoW block.
      */
 
-    harness.extend_to_slot(bellatrix_fork_slot).await;
+    Box::pin(harness.extend_to_slot(bellatrix_fork_slot)).await;
 
     let bellatrix_head = &harness.chain.head_snapshot().beacon_block;
     assert!(bellatrix_head.as_bellatrix().is_ok());

--- a/beacon_node/beacon_chain/tests/capella.rs
+++ b/beacon_node/beacon_chain/tests/capella.rs
@@ -54,7 +54,7 @@ async fn base_altair_bellatrix_capella() {
     /*
      * Do the Altair fork.
      */
-    harness.extend_to_slot(altair_fork_slot).await;
+    Box::pin(harness.extend_to_slot(altair_fork_slot)).await;
 
     let altair_head = &harness.chain.head_snapshot().beacon_block;
     assert!(altair_head.as_altair().is_ok());
@@ -63,7 +63,7 @@ async fn base_altair_bellatrix_capella() {
     /*
      * Do the Bellatrix fork, without a terminal PoW block.
      */
-    harness.extend_to_slot(bellatrix_fork_slot).await;
+    Box::pin(harness.extend_to_slot(bellatrix_fork_slot)).await;
 
     let bellatrix_head = &harness.chain.head_snapshot().beacon_block;
     assert!(bellatrix_head.as_bellatrix().is_ok());
@@ -81,7 +81,7 @@ async fn base_altair_bellatrix_capella() {
     /*
      * Next Bellatrix block shouldn't include an exec payload.
      */
-    harness.extend_slots(1).await;
+    Box::pin(harness.extend_slots(1)).await;
 
     let one_after_bellatrix_head = &harness.chain.head_snapshot().beacon_block;
     assert!(
@@ -112,7 +112,7 @@ async fn base_altair_bellatrix_capella() {
                 terminal_block.timestamp = timestamp;
             }
         });
-    harness.extend_slots(1).await;
+    Box::pin(harness.extend_slots(1)).await;
 
     let two_after_bellatrix_head = &harness.chain.head_snapshot().beacon_block;
     assert!(

--- a/beacon_node/beacon_chain/tests/payload_invalidation.rs
+++ b/beacon_node/beacon_chain/tests/payload_invalidation.rs
@@ -413,7 +413,7 @@ async fn invalid_payload_invalidates_parent() {
     rig.import_block(Payload::Valid).await; // Import a valid transition block.
     rig.move_to_first_justification(Payload::Syncing).await;
 
-    let roots = vec![
+    let roots = [
         rig.import_block(Payload::Syncing).await,
         rig.import_block(Payload::Syncing).await,
         rig.import_block(Payload::Syncing).await,
@@ -1049,7 +1049,7 @@ async fn invalid_parent() {
 
     // Ensure the block built atop an invalid payload is invalid for gossip.
     assert!(matches!(
-        rig.harness.chain.clone().verify_block_for_gossip(block.clone().into()).await,
+        rig.harness.chain.clone().verify_block_for_gossip(block.clone()).await,
         Err(BlockError::ParentExecutionPayloadInvalid { parent_root: invalid_root })
         if invalid_root == parent_root
     ));

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -1554,14 +1554,13 @@ async fn prunes_fork_growing_past_youngest_finalized_checkpoint() {
         .map(Into::into)
         .collect();
     let canonical_state_root = canonical_state.update_tree_hash_cache().unwrap();
-    let (canonical_blocks, _, _, _) = rig
-        .add_attested_blocks_at_slots(
-            canonical_state,
-            canonical_state_root,
-            &canonical_slots,
-            &honest_validators,
-        )
-        .await;
+    let (canonical_blocks, _, _, _) = Box::pin(rig.add_attested_blocks_at_slots(
+        canonical_state,
+        canonical_state_root,
+        &canonical_slots,
+        &honest_validators,
+    ))
+    .await;
 
     // Postconditions
     let canonical_blocks: HashMap<Slot, SignedBeaconBlockHash> = canonical_blocks_zeroth_epoch
@@ -1956,31 +1955,45 @@ async fn prune_shared_skip_states_mid_epoch() {
 #[tokio::test]
 async fn prune_shared_skip_states_epoch_boundaries() {
     let slots_per_epoch = E::slots_per_epoch();
-    pruning_test(slots_per_epoch - 1, 1, slots_per_epoch, 2, slots_per_epoch).await;
-    pruning_test(slots_per_epoch - 1, 2, slots_per_epoch, 1, slots_per_epoch).await;
-    pruning_test(
+    Box::pin(pruning_test(
+        slots_per_epoch - 1,
+        1,
+        slots_per_epoch,
+        2,
+        slots_per_epoch,
+    ))
+    .await;
+    Box::pin(pruning_test(
+        slots_per_epoch - 1,
+        2,
+        slots_per_epoch,
+        1,
+        slots_per_epoch,
+    ))
+    .await;
+    Box::pin(pruning_test(
         2 * slots_per_epoch + slots_per_epoch / 2,
         slots_per_epoch / 2,
         slots_per_epoch,
         slots_per_epoch / 2 + 1,
         slots_per_epoch,
-    )
+    ))
     .await;
-    pruning_test(
+    Box::pin(pruning_test(
         2 * slots_per_epoch + slots_per_epoch / 2,
         slots_per_epoch / 2,
         slots_per_epoch,
         slots_per_epoch / 2 + 1,
         slots_per_epoch,
-    )
+    ))
     .await;
-    pruning_test(
+    Box::pin(pruning_test(
         2 * slots_per_epoch - 1,
         slots_per_epoch,
         1,
         0,
         2 * slots_per_epoch,
-    )
+    ))
     .await;
 }
 
@@ -2608,8 +2621,7 @@ async fn process_blocks_and_attestations_for_unaligned_checkpoint() {
         harness.advance_slot();
     }
     harness.extend_to_slot(finalizing_slot - 1).await;
-    harness
-        .add_block_at_slot(finalizing_slot, harness.get_current_state())
+    Box::pin(harness.add_block_at_slot(finalizing_slot, harness.get_current_state()))
         .await
         .unwrap();
 

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -330,7 +330,7 @@ async fn long_skip() {
             final_blocks as usize,
             BlockStrategy::ForkCanonicalChainAt {
                 previous_slot: Slot::new(initial_blocks),
-                first_slot: Slot::new(initial_blocks + skip_slots as u64 + 1),
+                first_slot: Slot::new(initial_blocks + skip_slots + 1),
             },
             AttestationStrategy::AllValidators,
         )
@@ -381,8 +381,7 @@ async fn randao_genesis_storage() {
         .beacon_state
         .randao_mixes()
         .iter()
-        .find(|x| **x == genesis_value)
-        .is_some());
+        .any(|x| *x == genesis_value));
 
     // Then upon adding one more block, it isn't
     harness.advance_slot();
@@ -393,14 +392,13 @@ async fn randao_genesis_storage() {
             AttestationStrategy::AllValidators,
         )
         .await;
-    assert!(harness
+    assert!(!harness
         .chain
         .head_snapshot()
         .beacon_state
         .randao_mixes()
         .iter()
-        .find(|x| **x == genesis_value)
-        .is_none());
+        .any(|x| *x == genesis_value));
 
     check_finalization(&harness, num_slots);
     check_split_slot(&harness, store);
@@ -1062,7 +1060,7 @@ fn check_shuffling_compatible(
         let current_epoch_shuffling_is_compatible = harness.chain.shuffling_is_compatible(
             &block_root,
             head_state.current_epoch(),
-            &head_state,
+            head_state,
         );
 
         // Check for consistency with the more expensive shuffling lookup.
@@ -1102,7 +1100,7 @@ fn check_shuffling_compatible(
         let previous_epoch_shuffling_is_compatible = harness.chain.shuffling_is_compatible(
             &block_root,
             head_state.previous_epoch(),
-            &head_state,
+            head_state,
         );
         harness
             .chain
@@ -1130,14 +1128,11 @@ fn check_shuffling_compatible(
 
         // Targeting two epochs before the current epoch should always return false
         if head_state.current_epoch() >= 2 {
-            assert_eq!(
-                harness.chain.shuffling_is_compatible(
-                    &block_root,
-                    head_state.current_epoch() - 2,
-                    &head_state
-                ),
-                false
-            );
+            assert!(!harness.chain.shuffling_is_compatible(
+                &block_root,
+                head_state.current_epoch() - 2,
+                head_state
+            ));
         }
     }
 }
@@ -1939,7 +1934,7 @@ async fn prune_single_block_long_skip() {
         2 * slots_per_epoch,
         1,
         2 * slots_per_epoch,
-        2 * slots_per_epoch as u64,
+        2 * slots_per_epoch,
         1,
     )
     .await;
@@ -1965,23 +1960,23 @@ async fn prune_shared_skip_states_epoch_boundaries() {
     pruning_test(slots_per_epoch - 1, 2, slots_per_epoch, 1, slots_per_epoch).await;
     pruning_test(
         2 * slots_per_epoch + slots_per_epoch / 2,
-        slots_per_epoch as u64 / 2,
+        slots_per_epoch / 2,
         slots_per_epoch,
-        slots_per_epoch as u64 / 2 + 1,
+        slots_per_epoch / 2 + 1,
         slots_per_epoch,
     )
     .await;
     pruning_test(
         2 * slots_per_epoch + slots_per_epoch / 2,
-        slots_per_epoch as u64 / 2,
+        slots_per_epoch / 2,
         slots_per_epoch,
-        slots_per_epoch as u64 / 2 + 1,
+        slots_per_epoch / 2 + 1,
         slots_per_epoch,
     )
     .await;
     pruning_test(
         2 * slots_per_epoch - 1,
-        slots_per_epoch as u64,
+        slots_per_epoch,
         1,
         0,
         2 * slots_per_epoch,
@@ -2094,7 +2089,7 @@ async fn pruning_test(
     );
     check_chain_dump(
         &harness,
-        (num_initial_blocks + num_canonical_middle_blocks + num_finalization_blocks + 1) as u64,
+        num_initial_blocks + num_canonical_middle_blocks + num_finalization_blocks + 1,
     );
 
     let all_canonical_states = harness

--- a/beacon_node/beacon_chain/tests/sync_committee_verification.rs
+++ b/beacon_node/beacon_chain/tests/sync_committee_verification.rs
@@ -73,7 +73,7 @@ fn get_valid_sync_committee_message_for_block(
     let head_state = harness.chain.head_beacon_state_cloned();
     let (signature, _) = harness
         .make_sync_committee_messages(&head_state, block_root, slot, relative_sync_committee)
-        .get(0)
+        .first()
         .expect("sync messages should exist")
         .get(message_index)
         .expect("first sync message should exist")
@@ -104,7 +104,7 @@ fn get_valid_sync_contribution(
     );
 
     let (_, contribution_opt) = sync_contributions
-        .get(0)
+        .first()
         .expect("sync contributions should exist");
     let contribution = contribution_opt
         .as_ref()

--- a/beacon_node/beacon_chain/tests/tests.rs
+++ b/beacon_node/beacon_chain/tests/tests.rs
@@ -170,7 +170,7 @@ async fn find_reorgs() {
 
     harness
         .extend_chain(
-            num_blocks_produced as usize,
+            num_blocks_produced,
             BlockStrategy::OnCanonicalHead,
             // No need to produce attestations for this test.
             AttestationStrategy::SomeValidators(vec![]),
@@ -203,7 +203,7 @@ async fn find_reorgs() {
     assert_eq!(
         find_reorg_slot(
             &harness.chain,
-            &head_state,
+            head_state,
             harness.chain.head_beacon_block().canonical_root()
         ),
         head_slot
@@ -503,7 +503,6 @@ async fn unaggregated_attestations_added_to_fork_choice_some_none() {
         .unwrap();
 
     let validator_slots: Vec<(usize, Slot)> = (0..VALIDATOR_COUNT)
-        .into_iter()
         .map(|validator_index| {
             let slot = state
                 .get_attestation_duties(validator_index, RelativeEpoch::Current)

--- a/beacon_node/http_api/tests/broadcast_validation_tests.rs
+++ b/beacon_node/http_api/tests/broadcast_validation_tests.rs
@@ -322,7 +322,7 @@ pub async fn consensus_gossip() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn consensus_partial_pass_only_consensus() {
     /* this test targets gossip-level validation */
-    let validation_level: Option<BroadcastValidation> = Some(BroadcastValidation::Consensus);
+    let validation_level = BroadcastValidation::Consensus;
 
     // Validator count needs to be at least 32 or proposer boost gets set to 0 when computing
     // `validator_count // 32`.
@@ -378,7 +378,7 @@ pub async fn consensus_partial_pass_only_consensus() {
         tester.harness.chain.clone(),
         &channel.0,
         test_logger,
-        validation_level.unwrap(),
+        validation_level,
         StatusCode::ACCEPTED,
         network_globals,
     )
@@ -615,8 +615,7 @@ pub async fn equivocation_gossip() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn equivocation_consensus_late_equivocation() {
     /* this test targets gossip-level validation */
-    let validation_level: Option<BroadcastValidation> =
-        Some(BroadcastValidation::ConsensusAndEquivocation);
+    let validation_level = BroadcastValidation::ConsensusAndEquivocation;
 
     // Validator count needs to be at least 32 or proposer boost gets set to 0 when computing
     // `validator_count // 32`.
@@ -671,7 +670,7 @@ pub async fn equivocation_consensus_late_equivocation() {
         tester.harness.chain,
         &channel.0,
         test_logger,
-        validation_level.unwrap(),
+        validation_level,
         StatusCode::ACCEPTED,
         network_globals,
     )
@@ -1228,8 +1227,7 @@ pub async fn blinded_equivocation_gossip() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 pub async fn blinded_equivocation_consensus_late_equivocation() {
     /* this test targets gossip-level validation */
-    let validation_level: Option<BroadcastValidation> =
-        Some(BroadcastValidation::ConsensusAndEquivocation);
+    let validation_level = BroadcastValidation::ConsensusAndEquivocation;
 
     // Validator count needs to be at least 32 or proposer boost gets set to 0 when computing
     // `validator_count // 32`.
@@ -1311,7 +1309,7 @@ pub async fn blinded_equivocation_consensus_late_equivocation() {
         tester.harness.chain,
         &channel.0,
         test_logger,
-        validation_level.unwrap(),
+        validation_level,
         StatusCode::ACCEPTED,
         network_globals,
     )
@@ -1465,8 +1463,8 @@ pub async fn block_seen_on_gossip_with_some_blobs() {
         "need at least 2 blobs for partial reveal"
     );
 
-    let partial_kzg_proofs = vec![blobs.0.get(0).unwrap().clone()];
-    let partial_blobs = vec![blobs.1.get(0).unwrap().clone()];
+    let partial_kzg_proofs = vec![*blobs.0.first().unwrap()];
+    let partial_blobs = vec![blobs.1.first().unwrap().clone()];
 
     // Simulate the block being seen on gossip.
     block

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -139,7 +139,7 @@ impl ForkChoiceUpdates {
     fn insert(&mut self, update: ForkChoiceUpdateMetadata) {
         self.updates
             .entry(update.state.head_block_hash)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(update);
     }
 

--- a/beacon_node/http_api/tests/status_tests.rs
+++ b/beacon_node/http_api/tests/status_tests.rs
@@ -57,18 +57,18 @@ async fn el_syncing_then_synced() {
     mock_el.el.upcheck().await;
 
     let api_response = tester.client.get_node_syncing().await.unwrap().data;
-    assert_eq!(api_response.el_offline, false);
-    assert_eq!(api_response.is_optimistic, false);
-    assert_eq!(api_response.is_syncing, false);
+    assert!(!api_response.el_offline);
+    assert!(!api_response.is_optimistic);
+    assert!(!api_response.is_syncing);
 
     // EL synced
     mock_el.server.set_syncing_response(Ok(false));
     mock_el.el.upcheck().await;
 
     let api_response = tester.client.get_node_syncing().await.unwrap().data;
-    assert_eq!(api_response.el_offline, false);
-    assert_eq!(api_response.is_optimistic, false);
-    assert_eq!(api_response.is_syncing, false);
+    assert!(!api_response.el_offline);
+    assert!(!api_response.is_optimistic);
+    assert!(!api_response.is_syncing);
 }
 
 /// Check `syncing` endpoint when the EL is offline (errors on upcheck).
@@ -85,9 +85,9 @@ async fn el_offline() {
     mock_el.el.upcheck().await;
 
     let api_response = tester.client.get_node_syncing().await.unwrap().data;
-    assert_eq!(api_response.el_offline, true);
-    assert_eq!(api_response.is_optimistic, false);
-    assert_eq!(api_response.is_syncing, false);
+    assert!(api_response.el_offline);
+    assert!(!api_response.is_optimistic);
+    assert!(!api_response.is_syncing);
 }
 
 /// Check `syncing` endpoint when the EL errors on newPaylod but is not fully offline.
@@ -128,9 +128,9 @@ async fn el_error_on_new_payload() {
 
     // The EL should now be *offline* according to the API.
     let api_response = tester.client.get_node_syncing().await.unwrap().data;
-    assert_eq!(api_response.el_offline, true);
-    assert_eq!(api_response.is_optimistic, false);
-    assert_eq!(api_response.is_syncing, false);
+    assert!(api_response.el_offline);
+    assert!(!api_response.is_optimistic);
+    assert!(!api_response.is_syncing);
 
     // Processing a block successfully should remove the status.
     mock_el.server.set_new_payload_status(
@@ -144,9 +144,9 @@ async fn el_error_on_new_payload() {
     harness.process_block_result((block, blobs)).await.unwrap();
 
     let api_response = tester.client.get_node_syncing().await.unwrap().data;
-    assert_eq!(api_response.el_offline, false);
-    assert_eq!(api_response.is_optimistic, false);
-    assert_eq!(api_response.is_syncing, false);
+    assert!(!api_response.el_offline);
+    assert!(!api_response.is_optimistic);
+    assert!(!api_response.is_syncing);
 }
 
 /// Check `node health` endpoint when the EL is offline.

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3508,7 +3508,7 @@ impl ApiTester {
         self
     }
 
-    #[allow(clippy::await_holding_lock)]  // This is a test, so it should be fine.
+    #[allow(clippy::await_holding_lock)] // This is a test, so it should be fine.
     pub async fn test_get_validator_aggregate_attestation(self) -> Self {
         if self
             .chain
@@ -6053,30 +6053,30 @@ async fn test_unsupported_media_response() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn beacon_get() {
+async fn beacon_get_state_hashes() {
+    ApiTester::new()
+        .await
+        .test_beacon_states_root_finalized()
+        .await
+        .test_beacon_states_finality_checkpoints_finalized()
+        .await
+        .test_beacon_states_root()
+        .await
+        .test_beacon_states_finality_checkpoints()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beacon_get_state_info() {
     ApiTester::new()
         .await
         .test_beacon_genesis()
         .await
-        .test_beacon_states_root_finalized()
-        .await
         .test_beacon_states_fork_finalized()
-        .await
-        .test_beacon_states_finality_checkpoints_finalized()
-        .await
-        .test_beacon_headers_block_id_finalized()
-        .await
-        .test_beacon_blocks_finalized()
-        .await
-        .test_beacon_blinded_blocks_finalized()
         .await
         .test_debug_beacon_states_finalized()
         .await
-        .test_beacon_states_root()
-        .await
         .test_beacon_states_fork()
-        .await
-        .test_beacon_states_finality_checkpoints()
         .await
         .test_beacon_states_validators()
         .await
@@ -6087,6 +6087,18 @@ async fn beacon_get() {
         .test_beacon_states_validator_id()
         .await
         .test_beacon_states_randao()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beacon_get_blocks() {
+    ApiTester::new()
+        .await
+        .test_beacon_headers_block_id_finalized()
+        .await
+        .test_beacon_blocks_finalized()
+        .await
+        .test_beacon_blinded_blocks_finalized()
         .await
         .test_beacon_headers_all_slots()
         .await
@@ -6101,6 +6113,12 @@ async fn beacon_get() {
         .test_beacon_blocks_attestations()
         .await
         .test_beacon_blocks_root()
+        .await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beacon_get_pools() {
+    ApiTester::new()
         .await
         .test_get_beacon_pool_attestations()
         .await

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -3508,6 +3508,7 @@ impl ApiTester {
         self
     }
 
+    #[allow(clippy::await_holding_lock)]  // This is a test, so it should be fine.
     pub async fn test_get_validator_aggregate_attestation(self) -> Self {
         if self
             .chain

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -272,10 +272,10 @@ impl ApiTester {
         let mock_builder_server = harness.set_mock_builder(beacon_url.clone());
 
         // Start the mock builder service prior to building the chain out.
-        harness.runtime.task_executor.spawn(
-            async move { mock_builder_server.await },
-            "mock_builder_server",
-        );
+        harness
+            .runtime
+            .task_executor
+            .spawn(mock_builder_server, "mock_builder_server");
 
         let mock_builder = harness.mock_builder.clone();
 
@@ -640,7 +640,7 @@ impl ApiTester {
         self
     }
 
-    pub async fn test_beacon_blocks_finalized<E: EthSpec>(self) -> Self {
+    pub async fn test_beacon_blocks_finalized(self) -> Self {
         for block_id in self.interesting_block_ids() {
             let block_root = block_id.root(&self.chain);
             let block = block_id.full_block(&self.chain).await;
@@ -677,7 +677,7 @@ impl ApiTester {
         self
     }
 
-    pub async fn test_beacon_blinded_blocks_finalized<E: EthSpec>(self) -> Self {
+    pub async fn test_beacon_blinded_blocks_finalized(self) -> Self {
         for block_id in self.interesting_block_ids() {
             let block_root = block_id.root(&self.chain);
             let block = block_id.full_block(&self.chain).await;
@@ -818,7 +818,7 @@ impl ApiTester {
                 let validator_index_ids = validator_indices
                     .iter()
                     .cloned()
-                    .map(|i| ValidatorId::Index(i))
+                    .map(ValidatorId::Index)
                     .collect::<Vec<ValidatorId>>();
 
                 let unsupported_media_response = self
@@ -858,7 +858,7 @@ impl ApiTester {
                 let validator_index_ids = validator_indices
                     .iter()
                     .cloned()
-                    .map(|i| ValidatorId::Index(i))
+                    .map(ValidatorId::Index)
                     .collect::<Vec<ValidatorId>>();
                 let validator_pubkey_ids = validator_indices
                     .iter()
@@ -909,7 +909,7 @@ impl ApiTester {
                     for i in validator_indices {
                         if i < state.balances().len() as u64 {
                             validators.push(ValidatorBalanceData {
-                                index: i as u64,
+                                index: i,
                                 balance: *state.balances().get(i as usize).unwrap(),
                             });
                         }
@@ -943,7 +943,7 @@ impl ApiTester {
                     let validator_index_ids = validator_indices
                         .iter()
                         .cloned()
-                        .map(|i| ValidatorId::Index(i))
+                        .map(ValidatorId::Index)
                         .collect::<Vec<ValidatorId>>();
                     let validator_pubkey_ids = validator_indices
                         .iter()
@@ -1011,7 +1011,7 @@ impl ApiTester {
                                 || statuses.contains(&status.superstatus())
                             {
                                 validators.push(ValidatorData {
-                                    index: i as u64,
+                                    index: i,
                                     balance: *state.balances().get(i as usize).unwrap(),
                                     status,
                                     validator,
@@ -1640,11 +1640,7 @@ impl ApiTester {
         let (block, _, _) = block_id.full_block(&self.chain).await.unwrap();
         let num_blobs = block.num_expected_blobs();
         let blob_indices = if use_indices {
-            Some(
-                (0..num_blobs.saturating_sub(1) as u64)
-                    .into_iter()
-                    .collect::<Vec<_>>(),
-            )
+            Some((0..num_blobs.saturating_sub(1) as u64).collect::<Vec<_>>())
         } else {
             None
         };
@@ -1662,7 +1658,7 @@ impl ApiTester {
             blob_indices.map_or(num_blobs, |indices| indices.len())
         );
         let expected = block.slot();
-        assert_eq!(result.get(0).unwrap().slot(), expected);
+        assert_eq!(result.first().unwrap().slot(), expected);
 
         self
     }
@@ -1700,9 +1696,9 @@ impl ApiTester {
                 break;
             }
         }
-        let test_slot = test_slot.expect(&format!(
-            "should be able to find a block matching zero_blobs={zero_blobs}"
-        ));
+        let test_slot = test_slot.unwrap_or_else(|| {
+            panic!("should be able to find a block matching zero_blobs={zero_blobs}")
+        });
 
         match self
             .client
@@ -1771,7 +1767,6 @@ impl ApiTester {
                         .attestations()
                         .map(|att| att.clone_as_attestation())
                         .collect::<Vec<_>>()
-                        .into()
                 },
             );
 
@@ -1908,7 +1903,7 @@ impl ApiTester {
 
         let result = match self
             .client
-            .get_beacon_light_client_updates::<E>(current_sync_committee_period as u64, 1)
+            .get_beacon_light_client_updates::<E>(current_sync_committee_period, 1)
             .await
         {
             Ok(result) => result,
@@ -1920,7 +1915,7 @@ impl ApiTester {
             .light_client_server_cache
             .get_light_client_updates(
                 &self.chain.store,
-                current_sync_committee_period as u64,
+                current_sync_committee_period,
                 1,
                 &self.chain.spec,
             )
@@ -2313,7 +2308,7 @@ impl ApiTester {
             .unwrap()
             .data
             .is_syncing;
-        assert_eq!(is_syncing, true);
+        assert!(is_syncing);
 
         // Reset sync state.
         *self
@@ -2363,7 +2358,7 @@ impl ApiTester {
     pub async fn test_get_node_peers_by_id(self) -> Self {
         let result = self
             .client
-            .get_node_peers_by_id(self.external_peer_id.clone())
+            .get_node_peers_by_id(self.external_peer_id)
             .await
             .unwrap()
             .data;
@@ -4029,7 +4024,7 @@ impl ApiTester {
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 11_111_111);
 
@@ -4056,7 +4051,7 @@ impl ApiTester {
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 16_384);
 
@@ -4083,7 +4078,7 @@ impl ApiTester {
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 11_111_111);
 
@@ -4107,7 +4102,7 @@ impl ApiTester {
             .unwrap()
             .into();
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 11_111_111);
 
@@ -4147,7 +4142,7 @@ impl ApiTester {
             .unwrap()
             .into();
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 30_000_000);
 
@@ -4188,7 +4183,7 @@ impl ApiTester {
             ProduceBlockV3Response::Full(_) => panic!("Expecting a blinded payload"),
         };
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
         assert_eq!(payload.gas_limit(), 30_000_000);
 
@@ -5032,9 +5027,8 @@ impl ApiTester {
 
     pub async fn test_builder_chain_health_optimistic_head(self) -> Self {
         // Make sure the next payload verification will return optimistic before advancing the chain.
-        self.harness.mock_execution_layer.as_ref().map(|el| {
+        self.harness.mock_execution_layer.as_ref().inspect(|el| {
             el.server.all_payloads_syncing(true);
-            el
         });
         self.harness
             .extend_chain(
@@ -5061,7 +5055,7 @@ impl ApiTester {
             .unwrap()
             .into();
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
 
         // If this cache is populated, it indicates fallback to the local EE was correctly used.
@@ -5078,9 +5072,8 @@ impl ApiTester {
 
     pub async fn test_builder_v3_chain_health_optimistic_head(self) -> Self {
         // Make sure the next payload verification will return optimistic before advancing the chain.
-        self.harness.mock_execution_layer.as_ref().map(|el| {
+        self.harness.mock_execution_layer.as_ref().inspect(|el| {
             el.server.all_payloads_syncing(true);
-            el
         });
         self.harness
             .extend_chain(
@@ -5110,7 +5103,7 @@ impl ApiTester {
             ProduceBlockV3Response::Blinded(_) => panic!("Expecting a full payload"),
         };
 
-        let expected_fee_recipient = Address::from_low_u64_be(proposer_index as u64);
+        let expected_fee_recipient = Address::from_low_u64_be(proposer_index);
         assert_eq!(payload.fee_recipient(), expected_fee_recipient);
 
         self
@@ -5979,16 +5972,17 @@ impl ApiTester {
         assert_eq!(result.execution_optimistic, Some(false));
 
         // Change head to be optimistic.
-        self.chain
+        if let Some(head_node) = self
+            .chain
             .canonical_head
             .fork_choice_write_lock()
             .proto_array_mut()
             .core_proto_array_mut()
             .nodes
             .last_mut()
-            .map(|head_node| {
-                head_node.execution_status = ExecutionStatus::Optimistic(ExecutionBlockHash::zero())
-            });
+        {
+            head_node.execution_status = ExecutionStatus::Optimistic(ExecutionBlockHash::zero())
+        }
 
         // Check responses are now optimistic.
         let result = self
@@ -6021,8 +6015,8 @@ async fn poll_events<S: Stream<Item = Result<EventKind<E>, eth2::Error>> + Unpin
     };
 
     tokio::select! {
-            _ = collect_stream_fut => {events}
-            _ = tokio::time::sleep(timeout) => { return events; }
+        _ = collect_stream_fut => { events }
+        _ = tokio::time::sleep(timeout) => { events }
     }
 }
 
@@ -6071,9 +6065,9 @@ async fn beacon_get() {
         .await
         .test_beacon_headers_block_id_finalized()
         .await
-        .test_beacon_blocks_finalized::<MainnetEthSpec>()
+        .test_beacon_blocks_finalized()
         .await
-        .test_beacon_blinded_blocks_finalized::<MainnetEthSpec>()
+        .test_beacon_blinded_blocks_finalized()
         .await
         .test_debug_beacon_states_finalized()
         .await

--- a/beacon_node/lighthouse_network/src/service/gossip_cache.rs
+++ b/beacon_node/lighthouse_network/src/service/gossip_cache.rs
@@ -252,7 +252,7 @@ impl futures::stream::Stream for GossipCache {
                 let (topic, data) = expired.into_inner();
                 let topic_msg = self.topic_msgs.get_mut(&topic);
                 debug_assert!(
-                    topic_msg.is_none(),
+                    topic_msg.is_some(),
                     "Topic for registered message is not present."
                 );
                 if let Some(msgs) = topic_msg {

--- a/beacon_node/lighthouse_network/src/service/gossip_cache.rs
+++ b/beacon_node/lighthouse_network/src/service/gossip_cache.rs
@@ -250,18 +250,17 @@ impl futures::stream::Stream for GossipCache {
             Poll::Ready(Some(expired)) => {
                 let expected_key = expired.key();
                 let (topic, data) = expired.into_inner();
-                match self.topic_msgs.get_mut(&topic) {
-                    Some(msgs) => {
-                        let key = msgs.remove(&data);
-                        debug_assert_eq!(key, Some(expected_key));
-                        if msgs.is_empty() {
-                            // no more messages for this topic.
-                            self.topic_msgs.remove(&topic);
-                        }
-                    }
-                    None => {
-                        #[cfg(debug_assertions)]
-                        panic!("Topic for registered message is not present.")
+                let topic_msg = self.topic_msgs.get_mut(&topic);
+                debug_assert!(
+                    topic_msg.is_none(),
+                    "Topic for registered message is not present."
+                );
+                if let Some(msgs) = topic_msg {
+                    let key = msgs.remove(&data);
+                    debug_assert_eq!(key, Some(expected_key));
+                    if msgs.is_empty() {
+                        // no more messages for this topic.
+                        self.topic_msgs.remove(&topic);
                     }
                 }
                 Poll::Ready(Some(Ok(topic)))

--- a/beacon_node/network/src/network_beacon_processor/tests.rs
+++ b/beacon_node/network/src/network_beacon_processor/tests.rs
@@ -527,7 +527,7 @@ impl TestRig {
         self.assert_event_journal(
             &expected
                 .iter()
-                .map(|ev| Into::<&'static str>::into(ev))
+                .map(Into::<&'static str>::into)
                 .chain(std::iter::once(WORKER_FREED))
                 .chain(std::iter::once(NOTHING_TO_DO))
                 .collect::<Vec<_>>(),

--- a/beacon_node/network/src/service/tests.rs
+++ b/beacon_node/network/src/service/tests.rs
@@ -1,235 +1,229 @@
-#[cfg(not(debug_assertions))]
-#[cfg(test)]
-mod tests {
-    use crate::persisted_dht::load_dht;
-    use crate::{NetworkConfig, NetworkService};
-    use beacon_chain::test_utils::BeaconChainHarness;
-    use beacon_chain::BeaconChainTypes;
-    use beacon_processor::{BeaconProcessorChannels, BeaconProcessorConfig};
-    use futures::StreamExt;
-    use lighthouse_network::types::{GossipEncoding, GossipKind};
-    use lighthouse_network::{Enr, GossipTopic};
-    use slog::{o, Drain, Level, Logger};
-    use sloggers::{null::NullLoggerBuilder, Build};
-    use std::str::FromStr;
-    use std::sync::Arc;
-    use tokio::runtime::Runtime;
-    use types::{Epoch, EthSpec, ForkName, MinimalEthSpec, SubnetId};
+#![cfg(not(debug_assertions))]
+#![cfg(test)]
+use crate::persisted_dht::load_dht;
+use crate::{NetworkConfig, NetworkService};
+use beacon_chain::test_utils::BeaconChainHarness;
+use beacon_chain::BeaconChainTypes;
+use beacon_processor::{BeaconProcessorChannels, BeaconProcessorConfig};
+use futures::StreamExt;
+use lighthouse_network::types::{GossipEncoding, GossipKind};
+use lighthouse_network::{Enr, GossipTopic};
+use slog::{o, Drain, Level, Logger};
+use sloggers::{null::NullLoggerBuilder, Build};
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use types::{Epoch, EthSpec, ForkName, MinimalEthSpec, SubnetId};
 
-    impl<T: BeaconChainTypes> NetworkService<T> {
-        fn get_topic_params(&self, topic: GossipTopic) -> Option<&gossipsub::TopicScoreParams> {
-            self.libp2p.get_topic_params(topic)
-        }
+impl<T: BeaconChainTypes> NetworkService<T> {
+    fn get_topic_params(&self, topic: GossipTopic) -> Option<&gossipsub::TopicScoreParams> {
+        self.libp2p.get_topic_params(topic)
     }
+}
 
-    fn get_logger(actual_log: bool) -> Logger {
-        if actual_log {
-            let drain = {
-                let decorator = slog_term::TermDecorator::new().build();
-                let decorator =
-                    logging::AlignedTermDecorator::new(decorator, logging::MAX_MESSAGE_WIDTH);
-                let drain = slog_term::FullFormat::new(decorator).build().fuse();
-                let drain = slog_async::Async::new(drain).chan_size(2048).build();
-                drain.filter_level(Level::Debug)
-            };
+fn get_logger(actual_log: bool) -> Logger {
+    if actual_log {
+        let drain = {
+            let decorator = slog_term::TermDecorator::new().build();
+            let decorator =
+                logging::AlignedTermDecorator::new(decorator, logging::MAX_MESSAGE_WIDTH);
+            let drain = slog_term::FullFormat::new(decorator).build().fuse();
+            let drain = slog_async::Async::new(drain).chan_size(2048).build();
+            drain.filter_level(Level::Debug)
+        };
 
-            Logger::root(drain.fuse(), o!())
-        } else {
-            let builder = NullLoggerBuilder;
-            builder.build().expect("should build logger")
-        }
+        Logger::root(drain.fuse(), o!())
+    } else {
+        let builder = NullLoggerBuilder;
+        builder.build().expect("should build logger")
     }
+}
 
-    #[test]
-    fn test_dht_persistence() {
-        let log = get_logger(false);
+#[test]
+fn test_dht_persistence() {
+    let log = get_logger(false);
 
-        let beacon_chain = BeaconChainHarness::builder(MinimalEthSpec)
-            .default_spec()
-            .deterministic_keypairs(8)
-            .fresh_ephemeral_store()
-            .build()
-            .chain;
+    let beacon_chain = BeaconChainHarness::builder(MinimalEthSpec)
+        .default_spec()
+        .deterministic_keypairs(8)
+        .fresh_ephemeral_store()
+        .build()
+        .chain;
 
-        let store = beacon_chain.store.clone();
+    let store = beacon_chain.store.clone();
 
-        let enr1 = Enr::from_str("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8").unwrap();
-        let enr2 = Enr::from_str("enr:-IS4QJ2d11eu6dC7E7LoXeLMgMP3kom1u3SE8esFSWvaHoo0dP1jg8O3-nx9ht-EO3CmG7L6OkHcMmoIh00IYWB92QABgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIB_c-jQMOXsbjWkbN-Oj99H57gfId5pfb4wa1qxwV4CIN1ZHCCIyk").unwrap();
-        let enrs = vec![enr1, enr2];
+    let enr1 = Enr::from_str("enr:-IS4QHCYrYZbAKWCBRlAy5zzaDZXJBGkcnh4MHcBFZntXNFrdvJjX04jRzjzCBOonrkTfj499SZuOh8R33Ls8RRcy5wBgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPKY0yuDUmstAHYpMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8").unwrap();
+    let enr2 = Enr::from_str("enr:-IS4QJ2d11eu6dC7E7LoXeLMgMP3kom1u3SE8esFSWvaHoo0dP1jg8O3-nx9ht-EO3CmG7L6OkHcMmoIh00IYWB92QABgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIB_c-jQMOXsbjWkbN-Oj99H57gfId5pfb4wa1qxwV4CIN1ZHCCIyk").unwrap();
+    let enrs = vec![enr1, enr2];
 
-        let runtime = Arc::new(Runtime::new().unwrap());
+    let runtime = Arc::new(Runtime::new().unwrap());
 
-        let (signal, exit) = async_channel::bounded(1);
+    let (signal, exit) = async_channel::bounded(1);
+    let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
+    let executor =
+        task_executor::TaskExecutor::new(Arc::downgrade(&runtime), exit, log.clone(), shutdown_tx);
+
+    let mut config = NetworkConfig::default();
+    config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 21212, 21212, 21213);
+    config.discv5_config.table_filter = |_| true; // Do not ignore local IPs
+    config.upnp_enabled = false;
+    config.boot_nodes_enr = enrs.clone();
+    let config = Arc::new(config);
+    runtime.block_on(async move {
+        // Create a new network service which implicitly gets dropped at the
+        // end of the block.
+
+        let BeaconProcessorChannels {
+            beacon_processor_tx,
+            beacon_processor_rx: _beacon_processor_rx,
+            work_reprocessing_tx,
+            work_reprocessing_rx: _work_reprocessing_rx,
+        } = <_>::default();
+
+        let _network_service = NetworkService::start(
+            beacon_chain.clone(),
+            config,
+            executor,
+            None,
+            beacon_processor_tx,
+            work_reprocessing_tx,
+        )
+        .await
+        .unwrap();
+        drop(signal);
+    });
+
+    let raw_runtime = Arc::try_unwrap(runtime).unwrap();
+    raw_runtime.shutdown_timeout(tokio::time::Duration::from_secs(300));
+
+    // Load the persisted dht from the store
+    let persisted_enrs = load_dht(store);
+    assert!(
+        persisted_enrs.contains(&enrs[0]),
+        "should have persisted the first ENR to store"
+    );
+    assert!(
+        persisted_enrs.contains(&enrs[1]),
+        "should have persisted the second ENR to store"
+    );
+}
+
+// Test removing topic weight on old topics when a fork happens.
+#[test]
+fn test_removing_topic_weight_on_old_topics() {
+    let runtime = Arc::new(Runtime::new().unwrap());
+
+    // Capella spec
+    let mut spec = MinimalEthSpec::default_spec();
+    spec.altair_fork_epoch = Some(Epoch::new(0));
+    spec.bellatrix_fork_epoch = Some(Epoch::new(0));
+    spec.capella_fork_epoch = Some(Epoch::new(1));
+
+    // Build beacon chain.
+    let beacon_chain = BeaconChainHarness::builder(MinimalEthSpec)
+        .spec(spec.clone().into())
+        .deterministic_keypairs(8)
+        .fresh_ephemeral_store()
+        .mock_execution_layer()
+        .build()
+        .chain;
+    let (next_fork_name, _) = beacon_chain.duration_to_next_fork().expect("next fork");
+    assert_eq!(next_fork_name, ForkName::Capella);
+
+    // Build network service.
+    let (mut network_service, network_globals, _network_senders) = runtime.block_on(async {
+        let (_, exit) = async_channel::bounded(1);
         let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
         let executor = task_executor::TaskExecutor::new(
             Arc::downgrade(&runtime),
             exit,
-            log.clone(),
+            get_logger(false),
             shutdown_tx,
         );
 
         let mut config = NetworkConfig::default();
-        config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 21212, 21212, 21213);
+        config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 21214, 21214, 21215);
         config.discv5_config.table_filter = |_| true; // Do not ignore local IPs
         config.upnp_enabled = false;
-        config.boot_nodes_enr = enrs.clone();
         let config = Arc::new(config);
-        runtime.block_on(async move {
-            // Create a new network service which implicitly gets dropped at the
-            // end of the block.
 
-            let BeaconProcessorChannels {
-                beacon_processor_tx,
-                beacon_processor_rx: _beacon_processor_rx,
-                work_reprocessing_tx,
-                work_reprocessing_rx: _work_reprocessing_rx,
-            } = <_>::default();
+        let beacon_processor_channels =
+            BeaconProcessorChannels::new(&BeaconProcessorConfig::default());
+        NetworkService::build(
+            beacon_chain.clone(),
+            config,
+            executor.clone(),
+            None,
+            beacon_processor_channels.beacon_processor_tx,
+            beacon_processor_channels.work_reprocessing_tx,
+        )
+        .await
+        .unwrap()
+    });
 
-            let _network_service = NetworkService::start(
-                beacon_chain.clone(),
-                config,
-                executor,
-                None,
-                beacon_processor_tx,
-                work_reprocessing_tx,
-            )
-            .await
-            .unwrap();
-            drop(signal);
-        });
-
-        let raw_runtime = Arc::try_unwrap(runtime).unwrap();
-        raw_runtime.shutdown_timeout(tokio::time::Duration::from_secs(300));
-
-        // Load the persisted dht from the store
-        let persisted_enrs = load_dht(store);
-        assert!(
-            persisted_enrs.contains(&enrs[0]),
-            "should have persisted the first ENR to store"
-        );
-        assert!(
-            persisted_enrs.contains(&enrs[1]),
-            "should have persisted the second ENR to store"
-        );
-    }
-
-    // Test removing topic weight on old topics when a fork happens.
-    #[test]
-    fn test_removing_topic_weight_on_old_topics() {
-        let runtime = Arc::new(Runtime::new().unwrap());
-
-        // Capella spec
-        let mut spec = MinimalEthSpec::default_spec();
-        spec.altair_fork_epoch = Some(Epoch::new(0));
-        spec.bellatrix_fork_epoch = Some(Epoch::new(0));
-        spec.capella_fork_epoch = Some(Epoch::new(1));
-
-        // Build beacon chain.
-        let beacon_chain = BeaconChainHarness::builder(MinimalEthSpec)
-            .spec(spec.clone().into())
-            .deterministic_keypairs(8)
-            .fresh_ephemeral_store()
-            .mock_execution_layer()
-            .build()
-            .chain;
-        let (next_fork_name, _) = beacon_chain.duration_to_next_fork().expect("next fork");
-        assert_eq!(next_fork_name, ForkName::Capella);
-
-        // Build network service.
-        let (mut network_service, network_globals, _network_senders) = runtime.block_on(async {
-            let (_, exit) = async_channel::bounded(1);
-            let (shutdown_tx, _) = futures::channel::mpsc::channel(1);
-            let executor = task_executor::TaskExecutor::new(
-                Arc::downgrade(&runtime),
-                exit,
-                get_logger(false),
-                shutdown_tx,
-            );
-
-            let mut config = NetworkConfig::default();
-            config.set_ipv4_listening_address(std::net::Ipv4Addr::UNSPECIFIED, 21214, 21214, 21215);
-            config.discv5_config.table_filter = |_| true; // Do not ignore local IPs
-            config.upnp_enabled = false;
-            let config = Arc::new(config);
-
-            let beacon_processor_channels =
-                BeaconProcessorChannels::new(&BeaconProcessorConfig::default());
-            NetworkService::build(
-                beacon_chain.clone(),
-                config,
-                executor.clone(),
-                None,
-                beacon_processor_channels.beacon_processor_tx,
-                beacon_processor_channels.work_reprocessing_tx,
-            )
-            .await
-            .unwrap()
-        });
-
-        // Subscribe to the topics.
-        runtime.block_on(async {
-            while network_globals.gossipsub_subscriptions.read().len() < 2 {
-                if let Some(msg) = network_service.subnet_service.next().await {
-                    network_service.on_subnet_service_msg(msg);
-                }
+    // Subscribe to the topics.
+    runtime.block_on(async {
+        while network_globals.gossipsub_subscriptions.read().len() < 2 {
+            if let Some(msg) = network_service.subnet_service.next().await {
+                network_service.on_subnet_service_msg(msg);
             }
-        });
-
-        // Make sure the service is subscribed to the topics.
-        let (old_topic1, old_topic2) = {
-            let mut subnets = SubnetId::compute_attestation_subnets(
-                network_globals.local_enr().node_id().raw(),
-                &spec,
-            )
-            .collect::<Vec<_>>();
-            assert_eq!(2, subnets.len());
-
-            let old_fork_digest = beacon_chain.enr_fork_id().fork_digest;
-            let old_topic1 = GossipTopic::new(
-                GossipKind::Attestation(subnets.pop().unwrap()),
-                GossipEncoding::SSZSnappy,
-                old_fork_digest,
-            );
-            let old_topic2 = GossipTopic::new(
-                GossipKind::Attestation(subnets.pop().unwrap()),
-                GossipEncoding::SSZSnappy,
-                old_fork_digest,
-            );
-
-            (old_topic1, old_topic2)
-        };
-        let subscriptions = network_globals.gossipsub_subscriptions.read().clone();
-        assert_eq!(2, subscriptions.len());
-        assert!(subscriptions.contains(&old_topic1));
-        assert!(subscriptions.contains(&old_topic2));
-        let old_topic_params1 = network_service
-            .get_topic_params(old_topic1.clone())
-            .expect("topic score params");
-        assert!(old_topic_params1.topic_weight > 0.0);
-        let old_topic_params2 = network_service
-            .get_topic_params(old_topic2.clone())
-            .expect("topic score params");
-        assert!(old_topic_params2.topic_weight > 0.0);
-
-        // Advance slot to the next fork
-        for _ in 0..MinimalEthSpec::slots_per_epoch() {
-            beacon_chain.slot_clock.advance_slot();
         }
+    });
 
-        // Run `NetworkService::update_next_fork()`.
-        runtime.block_on(async {
-            network_service.update_next_fork();
-        });
+    // Make sure the service is subscribed to the topics.
+    let (old_topic1, old_topic2) = {
+        let mut subnets = SubnetId::compute_attestation_subnets(
+            network_globals.local_enr().node_id().raw(),
+            &spec,
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(2, subnets.len());
 
-        // Check that topic_weight on the old topics has been zeroed.
-        let old_topic_params1 = network_service
-            .get_topic_params(old_topic1)
-            .expect("topic score params");
-        assert_eq!(0.0, old_topic_params1.topic_weight);
+        let old_fork_digest = beacon_chain.enr_fork_id().fork_digest;
+        let old_topic1 = GossipTopic::new(
+            GossipKind::Attestation(subnets.pop().unwrap()),
+            GossipEncoding::SSZSnappy,
+            old_fork_digest,
+        );
+        let old_topic2 = GossipTopic::new(
+            GossipKind::Attestation(subnets.pop().unwrap()),
+            GossipEncoding::SSZSnappy,
+            old_fork_digest,
+        );
 
-        let old_topic_params2 = network_service
-            .get_topic_params(old_topic2)
-            .expect("topic score params");
-        assert_eq!(0.0, old_topic_params2.topic_weight);
+        (old_topic1, old_topic2)
+    };
+    let subscriptions = network_globals.gossipsub_subscriptions.read().clone();
+    assert_eq!(2, subscriptions.len());
+    assert!(subscriptions.contains(&old_topic1));
+    assert!(subscriptions.contains(&old_topic2));
+    let old_topic_params1 = network_service
+        .get_topic_params(old_topic1.clone())
+        .expect("topic score params");
+    assert!(old_topic_params1.topic_weight > 0.0);
+    let old_topic_params2 = network_service
+        .get_topic_params(old_topic2.clone())
+        .expect("topic score params");
+    assert!(old_topic_params2.topic_weight > 0.0);
+
+    // Advance slot to the next fork
+    for _ in 0..MinimalEthSpec::slots_per_epoch() {
+        beacon_chain.slot_clock.advance_slot();
     }
+
+    // Run `NetworkService::update_next_fork()`.
+    runtime.block_on(async {
+        network_service.update_next_fork();
+    });
+
+    // Check that topic_weight on the old topics has been zeroed.
+    let old_topic_params1 = network_service
+        .get_topic_params(old_topic1)
+        .expect("topic score params");
+    assert_eq!(0.0, old_topic_params1.topic_weight);
+
+    let old_topic_params2 = network_service
+        .get_topic_params(old_topic2)
+        .expect("topic score params");
+    assert_eq!(0.0, old_topic_params2.topic_weight);
 }

--- a/common/eth2_wallet_manager/src/wallet_manager.rs
+++ b/common/eth2_wallet_manager/src/wallet_manager.rs
@@ -296,10 +296,10 @@ mod tests {
             )
             .expect("should create first wallet");
 
-        let uuid = w.wallet().uuid().clone();
+        let uuid = *w.wallet().uuid();
 
         assert_eq!(
-            load_wallet_raw(&base_dir, &uuid).nextaccount(),
+            load_wallet_raw(base_dir, &uuid).nextaccount(),
             0,
             "should start wallet with nextaccount 0"
         );
@@ -308,7 +308,7 @@ mod tests {
             w.next_validator(WALLET_PASSWORD, &[50; 32], &[51; 32])
                 .expect("should create validator");
             assert_eq!(
-                load_wallet_raw(&base_dir, &uuid).nextaccount(),
+                load_wallet_raw(base_dir, &uuid).nextaccount(),
                 i,
                 "should update wallet with nextaccount {}",
                 i
@@ -333,54 +333,54 @@ mod tests {
         let base_dir = dir.path();
         let mgr = WalletManager::open(base_dir).unwrap();
 
-        let uuid_a = create_wallet(&mgr, 0).wallet().uuid().clone();
-        let uuid_b = create_wallet(&mgr, 1).wallet().uuid().clone();
+        let uuid_a = *create_wallet(&mgr, 0).wallet().uuid();
+        let uuid_b = *create_wallet(&mgr, 1).wallet().uuid();
 
-        let locked_a = LockedWallet::open(&base_dir, &uuid_a).expect("should open wallet a");
+        let locked_a = LockedWallet::open(base_dir, &uuid_a).expect("should open wallet a");
 
         assert!(
-            lockfile_path(&base_dir, &uuid_a).exists(),
+            lockfile_path(base_dir, &uuid_a).exists(),
             "lockfile should exist"
         );
 
         drop(locked_a);
 
         assert!(
-            !lockfile_path(&base_dir, &uuid_a).exists(),
+            !lockfile_path(base_dir, &uuid_a).exists(),
             "lockfile have been cleaned up"
         );
 
-        let locked_a = LockedWallet::open(&base_dir, &uuid_a).expect("should open wallet a");
-        let locked_b = LockedWallet::open(&base_dir, &uuid_b).expect("should open wallet b");
+        let locked_a = LockedWallet::open(base_dir, &uuid_a).expect("should open wallet a");
+        let locked_b = LockedWallet::open(base_dir, &uuid_b).expect("should open wallet b");
 
         assert!(
-            lockfile_path(&base_dir, &uuid_a).exists(),
+            lockfile_path(base_dir, &uuid_a).exists(),
             "lockfile a should exist"
         );
 
         assert!(
-            lockfile_path(&base_dir, &uuid_b).exists(),
+            lockfile_path(base_dir, &uuid_b).exists(),
             "lockfile b should exist"
         );
 
-        match LockedWallet::open(&base_dir, &uuid_a) {
+        match LockedWallet::open(base_dir, &uuid_a) {
             Err(Error::LockfileError(_)) => {}
             _ => panic!("did not get locked error"),
         };
 
         drop(locked_a);
 
-        LockedWallet::open(&base_dir, &uuid_a)
+        LockedWallet::open(base_dir, &uuid_a)
             .expect("should open wallet a after previous instance is dropped");
 
-        match LockedWallet::open(&base_dir, &uuid_b) {
+        match LockedWallet::open(base_dir, &uuid_b) {
             Err(Error::LockfileError(_)) => {}
             _ => panic!("did not get locked error"),
         };
 
         drop(locked_b);
 
-        LockedWallet::open(&base_dir, &uuid_b)
+        LockedWallet::open(base_dir, &uuid_b)
             .expect("should open wallet a after previous instance is dropped");
     }
 }

--- a/consensus/fork_choice/tests/tests.rs
+++ b/consensus/fork_choice/tests/tests.rs
@@ -1156,18 +1156,20 @@ async fn weak_subjectivity_check_epoch_boundary_is_skip_slot() {
     };
 
     // recreate the chain exactly
-    ForkChoiceTest::new_with_chain_config(chain_config.clone())
-        .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch == 0)
-        .await
-        .unwrap()
-        .skip_slots(E::slots_per_epoch() as usize)
-        .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch < 5)
-        .await
-        .unwrap()
-        .apply_blocks(1)
-        .await
-        .assert_finalized_epoch(5)
-        .assert_shutdown_signal_not_sent();
+    Box::pin(
+        ForkChoiceTest::new_with_chain_config(chain_config.clone())
+            .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch == 0)
+            .await
+            .unwrap()
+            .skip_slots(E::slots_per_epoch() as usize)
+            .apply_blocks_while(|_, state| state.finalized_checkpoint().epoch < 5)
+            .await
+            .unwrap()
+            .apply_blocks(1),
+    )
+    .await
+    .assert_finalized_epoch(5)
+    .assert_shutdown_signal_not_sent();
 }
 
 #[tokio::test]

--- a/crypto/eth2_keystore/tests/eip2335_vectors.rs
+++ b/crypto/eth2_keystore/tests/eip2335_vectors.rs
@@ -58,7 +58,7 @@ fn eip2335_test_vector_scrypt() {
         }
         "#;
 
-    let keystore = decode_and_check_sk(&vector);
+    let keystore = decode_and_check_sk(vector);
     assert_eq!(
         *keystore.uuid(),
         Uuid::parse_str("1d85ae20-35c5-4611-98e8-aa14a633906f").unwrap(),
@@ -102,7 +102,7 @@ fn eip2335_test_vector_pbkdf() {
         }
         "#;
 
-    let keystore = decode_and_check_sk(&vector);
+    let keystore = decode_and_check_sk(vector);
     assert_eq!(
         *keystore.uuid(),
         Uuid::parse_str("64625def-3331-4eea-ab6f-782f3ed16a83").unwrap(),

--- a/crypto/eth2_keystore/tests/tests.rs
+++ b/crypto/eth2_keystore/tests/tests.rs
@@ -54,25 +54,17 @@ fn file() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("keystore.json");
 
-    let get_file = || {
-        File::options()
-            .write(true)
-            .read(true)
-            .create(true)
-            .open(path.clone())
-            .expect("should create file")
-    };
-
     let keystore = KeystoreBuilder::new(&keypair, GOOD_PASSWORD, "".into())
         .unwrap()
         .build()
         .unwrap();
 
     keystore
-        .to_json_writer(&mut get_file())
+        .to_json_writer(File::create_new(&path).unwrap())
         .expect("should write to file");
 
-    let decoded = Keystore::from_json_reader(&mut get_file()).expect("should read from file");
+    let decoded =
+        Keystore::from_json_reader(File::open(&path).unwrap()).expect("should read from file");
 
     assert_eq!(
         decoded.decrypt_keypair(BAD_PASSWORD).err().unwrap(),

--- a/crypto/eth2_wallet/tests/tests.rs
+++ b/crypto/eth2_wallet/tests/tests.rs
@@ -132,20 +132,11 @@ fn file_round_trip() {
     let dir = tempdir().unwrap();
     let path = dir.path().join("keystore.json");
 
-    let get_file = || {
-        File::options()
-            .write(true)
-            .read(true)
-            .create(true)
-            .open(path.clone())
-            .expect("should create file")
-    };
-
     wallet
-        .to_json_writer(&mut get_file())
+        .to_json_writer(File::create_new(&path).unwrap())
         .expect("should write to file");
 
-    let decoded = Wallet::from_json_reader(&mut get_file()).unwrap();
+    let decoded = Wallet::from_json_reader(File::open(&path).unwrap()).unwrap();
 
     assert_eq!(
         decoded.decrypt_seed(&[1, 2, 3]).err().unwrap(),

--- a/lighthouse/tests/account_manager.rs
+++ b/lighthouse/tests/account_manager.rs
@@ -114,7 +114,7 @@ fn create_wallet<P: AsRef<Path>>(
             .arg(base_dir.as_ref().as_os_str())
             .arg(CREATE_CMD)
             .arg(format!("--{}", NAME_FLAG))
-            .arg(&name)
+            .arg(name)
             .arg(format!("--{}", PASSWORD_FLAG))
             .arg(password.as_ref().as_os_str())
             .arg(format!("--{}", MNEMONIC_FLAG))
@@ -272,16 +272,16 @@ impl TestValidator {
             .expect("stdout is not utf8")
             .to_string();
 
-        if stdout == "" {
+        if stdout.is_empty() {
             return Ok(vec![]);
         }
 
         let pubkeys = stdout[..stdout.len() - 1]
             .split("\n")
-            .filter_map(|line| {
+            .map(|line| {
                 let tab = line.find("\t").expect("line must have tab");
                 let (_, pubkey) = line.split_at(tab + 1);
-                Some(pubkey.to_string())
+                pubkey.to_string()
             })
             .collect::<Vec<_>>();
 
@@ -445,7 +445,9 @@ fn validator_import_launchpad() {
         }
     }
 
-    stdin.write(format!("{}\n", PASSWORD).as_bytes()).unwrap();
+    stdin
+        .write_all(format!("{}\n", PASSWORD).as_bytes())
+        .unwrap();
 
     child.wait().unwrap();
 
@@ -503,7 +505,7 @@ fn validator_import_launchpad() {
     };
 
     assert!(
-        defs.as_slice() == &[expected_def.clone()],
+        defs.as_slice() == [expected_def.clone()],
         "validator defs file should be accurate"
     );
 
@@ -524,7 +526,7 @@ fn validator_import_launchpad() {
     expected_def.enabled = true;
 
     assert!(
-        defs.as_slice() == &[expected_def.clone()],
+        defs.as_slice() == [expected_def.clone()],
         "validator defs file should be accurate"
     );
 }
@@ -581,7 +583,7 @@ fn validator_import_launchpad_no_password_then_add_password() {
     let mut child = validator_import_key_cmd();
     wait_for_password_prompt(&mut child);
     let stdin = child.stdin.as_mut().unwrap();
-    stdin.write("\n".as_bytes()).unwrap();
+    stdin.write_all("\n".as_bytes()).unwrap();
     child.wait().unwrap();
 
     assert!(
@@ -627,14 +629,16 @@ fn validator_import_launchpad_no_password_then_add_password() {
     };
 
     assert!(
-        defs.as_slice() == &[expected_def.clone()],
+        defs.as_slice() == [expected_def.clone()],
         "validator defs file should be accurate"
     );
 
     let mut child = validator_import_key_cmd();
     wait_for_password_prompt(&mut child);
     let stdin = child.stdin.as_mut().unwrap();
-    stdin.write(format!("{}\n", PASSWORD).as_bytes()).unwrap();
+    stdin
+        .write_all(format!("{}\n", PASSWORD).as_bytes())
+        .unwrap();
     child.wait().unwrap();
 
     let expected_def = ValidatorDefinition {
@@ -656,7 +660,7 @@ fn validator_import_launchpad_no_password_then_add_password() {
 
     let defs = ValidatorDefinitions::open(&dst_dir).unwrap();
     assert!(
-        defs.as_slice() == &[expected_def.clone()],
+        defs.as_slice() == [expected_def.clone()],
         "validator defs file should be accurate"
     );
 }
@@ -758,7 +762,7 @@ fn validator_import_launchpad_password_file() {
     };
 
     assert!(
-        defs.as_slice() == &[expected_def],
+        defs.as_slice() == [expected_def],
         "validator defs file should be accurate"
     );
 }

--- a/lighthouse/tests/boot_node.rs
+++ b/lighthouse/tests/boot_node.rs
@@ -149,7 +149,7 @@ fn disable_packet_filter_flag() {
         .flag("disable-packet-filter", None)
         .run_with_ip()
         .with_config(|config| {
-            assert_eq!(config.disable_packet_filter, true);
+            assert!(config.disable_packet_filter);
         });
 }
 
@@ -159,7 +159,7 @@ fn enable_enr_auto_update_flag() {
         .flag("enable-enr-auto-update", None)
         .run_with_ip()
         .with_config(|config| {
-            assert_eq!(config.enable_enr_auto_update, true);
+            assert!(config.enable_enr_auto_update);
         });
 }
 

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -136,7 +136,7 @@ fn beacon_nodes_tls_certs_flag() {
         .flag(
             "beacon-nodes-tls-certs",
             Some(
-                vec![
+                [
                     dir.path().join("certificate.crt").to_str().unwrap(),
                     dir.path().join("certificate2.crt").to_str().unwrap(),
                 ]
@@ -205,7 +205,7 @@ fn graffiti_file_with_pk_flag() {
     let mut file = File::create(dir.path().join("graffiti.txt")).expect("Unable to create file");
     let new_key = Keypair::random();
     let pubkeybytes = PublicKeyBytes::from(new_key.pk);
-    let contents = format!("{}:nice-graffiti", pubkeybytes.to_string());
+    let contents = format!("{}:nice-graffiti", pubkeybytes);
     file.write_all(contents.as_bytes())
         .expect("Unable to write to file");
     CommandLineTest::new()
@@ -404,13 +404,13 @@ pub fn malloc_tuning_flag() {
     CommandLineTest::new()
         .flag("disable-malloc-tuning", None)
         .run()
-        .with_config(|config| assert_eq!(config.http_metrics.allocator_metrics_enabled, false));
+        .with_config(|config| assert!(!config.http_metrics.allocator_metrics_enabled));
 }
 #[test]
 pub fn malloc_tuning_default() {
     CommandLineTest::new()
         .run()
-        .with_config(|config| assert_eq!(config.http_metrics.allocator_metrics_enabled, true));
+        .with_config(|config| assert!(config.http_metrics.allocator_metrics_enabled));
 }
 #[test]
 fn doppelganger_protection_flag() {

--- a/lighthouse/tests/validator_manager.rs
+++ b/lighthouse/tests/validator_manager.rs
@@ -136,7 +136,7 @@ pub fn validator_create_defaults() {
                 count: 1,
                 deposit_gwei: MainnetEthSpec::default_spec().max_effective_balance,
                 mnemonic_path: None,
-                stdin_inputs: cfg!(windows) || false,
+                stdin_inputs: cfg!(windows),
                 disable_deposits: false,
                 specify_voting_keystore_password: false,
                 eth1_withdrawal_address: None,
@@ -201,7 +201,7 @@ pub fn validator_create_disable_deposits() {
         .flag("--disable-deposits", None)
         .flag("--builder-proposals", Some("false"))
         .assert_success(|config| {
-            assert_eq!(config.disable_deposits, true);
+            assert!(config.disable_deposits);
             assert_eq!(config.builder_proposals, Some(false));
         });
 }
@@ -300,7 +300,7 @@ pub fn validator_move_defaults() {
                 fee_recipient: None,
                 gas_limit: None,
                 password_source: PasswordSource::Interactive {
-                    stdin_inputs: cfg!(windows) || false,
+                    stdin_inputs: cfg!(windows),
                 },
             };
             assert_eq!(expected, config);
@@ -350,7 +350,7 @@ pub fn validator_move_misc_flags_1() {
         .flag("--src-vc-token", Some("./1.json"))
         .flag("--dest-vc-url", Some("http://localhost:2"))
         .flag("--dest-vc-token", Some("./2.json"))
-        .flag("--validators", Some(&format!("{}", EXAMPLE_PUBKEY_0)))
+        .flag("--validators", Some(EXAMPLE_PUBKEY_0))
         .flag("--builder-proposals", Some("false"))
         .flag("--prefer-builder-proposals", Some("false"))
         .assert_success(|config| {
@@ -368,7 +368,7 @@ pub fn validator_move_misc_flags_1() {
                 fee_recipient: None,
                 gas_limit: None,
                 password_source: PasswordSource::Interactive {
-                    stdin_inputs: cfg!(windows) || false,
+                    stdin_inputs: cfg!(windows),
                 },
             };
             assert_eq!(expected, config);
@@ -382,7 +382,7 @@ pub fn validator_move_misc_flags_2() {
         .flag("--src-vc-token", Some("./1.json"))
         .flag("--dest-vc-url", Some("http://localhost:2"))
         .flag("--dest-vc-token", Some("./2.json"))
-        .flag("--validators", Some(&format!("{}", EXAMPLE_PUBKEY_0)))
+        .flag("--validators", Some(EXAMPLE_PUBKEY_0))
         .flag("--builder-proposals", Some("false"))
         .flag("--builder-boost-factor", Some("100"))
         .assert_success(|config| {
@@ -400,7 +400,7 @@ pub fn validator_move_misc_flags_2() {
                 fee_recipient: None,
                 gas_limit: None,
                 password_source: PasswordSource::Interactive {
-                    stdin_inputs: cfg!(windows) || false,
+                    stdin_inputs: cfg!(windows),
                 },
             };
             assert_eq!(expected, config);
@@ -428,7 +428,7 @@ pub fn validator_move_count() {
                 fee_recipient: None,
                 gas_limit: None,
                 password_source: PasswordSource::Interactive {
-                    stdin_inputs: cfg!(windows) || false,
+                    stdin_inputs: cfg!(windows),
                 },
             };
             assert_eq!(expected, config);

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -169,14 +169,19 @@ mod tests {
     }
 
     impl Web3SignerRig {
+        // We need to hold that lock as we want to get the binary only once
+        #[allow(clippy::await_holding_lock)]
         pub async fn new(network: &str, listen_address: &str, listen_port: u16) -> Self {
             GET_WEB3SIGNER_BIN
                 .get_or_init(|| async {
                     // Read a Github API token from the environment. This is intended to prevent rate-limits on CI.
                     // We use a name that is unlikely to accidentally collide with anything the user has configured.
                     let github_token = env::var("LIGHTHOUSE_GITHUB_TOKEN");
-                    let dest_dir = TEMP_DIR.lock().path().to_path_buf();
-                    download_binary(dest_dir, github_token.as_deref().unwrap_or("")).await;
+                    download_binary(
+                        TEMP_DIR.lock().path().to_path_buf(),
+                        github_token.as_deref().unwrap_or(""),
+                    )
+                    .await;
                 })
                 .await;
 

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -175,11 +175,8 @@ mod tests {
                     // Read a Github API token from the environment. This is intended to prevent rate-limits on CI.
                     // We use a name that is unlikely to accidentally collide with anything the user has configured.
                     let github_token = env::var("LIGHTHOUSE_GITHUB_TOKEN");
-                    download_binary(
-                        TEMP_DIR.lock().path().to_path_buf(),
-                        github_token.as_deref().unwrap_or(""),
-                    )
-                    .await;
+                    let dest_dir = TEMP_DIR.lock().path().to_path_buf();
+                    download_binary(dest_dir, github_token.as_deref().unwrap_or("")).await;
                 })
                 .await;
 

--- a/testing/web3signer_tests/src/lib.rs
+++ b/testing/web3signer_tests/src/lib.rs
@@ -206,7 +206,7 @@ mod tests {
                 keystore_password_file: keystore_password_filename.to_string(),
             };
             let key_config_file =
-                File::create(&keystore_dir.path().join("key-config.yaml")).unwrap();
+                File::create(keystore_dir.path().join("key-config.yaml")).unwrap();
             serde_yaml::to_writer(key_config_file, &key_config).unwrap();
 
             let tls_keystore_file = tls_dir().join("web3signer").join("key.p12");

--- a/validator_client/http_api/src/tests.rs
+++ b/validator_client/http_api/src/tests.rs
@@ -52,8 +52,10 @@ struct ApiTester {
 
 impl ApiTester {
     pub async fn new() -> Self {
-        let mut config = ValidatorStoreConfig::default();
-        config.fee_recipient = Some(TEST_DEFAULT_FEE_RECIPIENT);
+        let config = ValidatorStoreConfig {
+            fee_recipient: Some(TEST_DEFAULT_FEE_RECIPIENT),
+            ..Default::default()
+        };
         Self::new_with_config(config).await
     }
 
@@ -136,7 +138,7 @@ impl ApiTester {
         let (listening_socket, server) =
             super::serve(ctx, test_runtime.task_executor.exit()).unwrap();
 
-        tokio::spawn(async { server.await });
+        tokio::spawn(server);
 
         let url = SensitiveUrl::parse(&format!(
             "http://{}:{}",
@@ -342,22 +344,21 @@ impl ApiTester {
             .set_nextaccount(s.key_derivation_path_offset)
             .unwrap();
 
-        for i in 0..s.count {
+        for validator in response.iter().take(s.count) {
             let keypairs = wallet
                 .next_validator(PASSWORD_BYTES, PASSWORD_BYTES, PASSWORD_BYTES)
                 .unwrap();
             let voting_keypair = keypairs.voting.decrypt_keypair(PASSWORD_BYTES).unwrap();
 
             assert_eq!(
-                response[i].voting_pubkey,
+                validator.voting_pubkey,
                 voting_keypair.pk.clone().into(),
                 "the locally generated voting pk should match the server response"
             );
 
             let withdrawal_keypair = keypairs.withdrawal.decrypt_keypair(PASSWORD_BYTES).unwrap();
 
-            let deposit_bytes =
-                serde_utils::hex::decode(&response[i].eth1_deposit_tx_data).unwrap();
+            let deposit_bytes = serde_utils::hex::decode(&validator.eth1_deposit_tx_data).unwrap();
 
             let (deposit_data, _) =
                 decode_eth1_tx_data(&deposit_bytes, E::default_spec().max_effective_balance)

--- a/validator_client/http_api/src/tests/keystores.rs
+++ b/validator_client/http_api/src/tests/keystores.rs
@@ -129,7 +129,7 @@ fn check_keystore_get_response<'a>(
     for (ks1, ks2) in response.data.iter().zip_eq(expected_keystores) {
         assert_eq!(ks1.validating_pubkey, keystore_pubkey(ks2));
         assert_eq!(ks1.derivation_path, ks2.path());
-        assert!(ks1.readonly == None || ks1.readonly == Some(false));
+        assert!(ks1.readonly.is_none() || ks1.readonly == Some(false));
     }
 }
 
@@ -146,7 +146,7 @@ fn check_keystore_import_response(
     }
 }
 
-fn check_keystore_delete_response<'a>(
+fn check_keystore_delete_response(
     response: &DeleteKeystoresResponse,
     expected_statuses: impl IntoIterator<Item = DeleteKeystoreStatus>,
 ) {
@@ -633,7 +633,7 @@ async fn check_get_set_fee_recipient() {
             assert_eq!(
                 get_res,
                 GetFeeRecipientResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     ethaddress: TEST_DEFAULT_FEE_RECIPIENT,
                 }
             );
@@ -653,7 +653,7 @@ async fn check_get_set_fee_recipient() {
             .post_fee_recipient(
                 &all_pubkeys[1],
                 &UpdateFeeRecipientRequest {
-                    ethaddress: fee_recipient_public_key_1.clone(),
+                    ethaddress: fee_recipient_public_key_1,
                 },
             )
             .await
@@ -666,14 +666,14 @@ async fn check_get_set_fee_recipient() {
                 .await
                 .expect("should get fee recipient");
             let expected = if i == 1 {
-                fee_recipient_public_key_1.clone()
+                fee_recipient_public_key_1
             } else {
                 TEST_DEFAULT_FEE_RECIPIENT
             };
             assert_eq!(
                 get_res,
                 GetFeeRecipientResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     ethaddress: expected,
                 }
             );
@@ -685,7 +685,7 @@ async fn check_get_set_fee_recipient() {
             .post_fee_recipient(
                 &all_pubkeys[2],
                 &UpdateFeeRecipientRequest {
-                    ethaddress: fee_recipient_public_key_2.clone(),
+                    ethaddress: fee_recipient_public_key_2,
                 },
             )
             .await
@@ -698,16 +698,16 @@ async fn check_get_set_fee_recipient() {
                 .await
                 .expect("should get fee recipient");
             let expected = if i == 1 {
-                fee_recipient_public_key_1.clone()
+                fee_recipient_public_key_1
             } else if i == 2 {
-                fee_recipient_public_key_2.clone()
+                fee_recipient_public_key_2
             } else {
                 TEST_DEFAULT_FEE_RECIPIENT
             };
             assert_eq!(
                 get_res,
                 GetFeeRecipientResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     ethaddress: expected,
                 }
             );
@@ -719,7 +719,7 @@ async fn check_get_set_fee_recipient() {
             .post_fee_recipient(
                 &all_pubkeys[1],
                 &UpdateFeeRecipientRequest {
-                    ethaddress: fee_recipient_override.clone(),
+                    ethaddress: fee_recipient_override,
                 },
             )
             .await
@@ -731,16 +731,16 @@ async fn check_get_set_fee_recipient() {
                 .await
                 .expect("should get fee recipient");
             let expected = if i == 1 {
-                fee_recipient_override.clone()
+                fee_recipient_override
             } else if i == 2 {
-                fee_recipient_public_key_2.clone()
+                fee_recipient_public_key_2
             } else {
                 TEST_DEFAULT_FEE_RECIPIENT
             };
             assert_eq!(
                 get_res,
                 GetFeeRecipientResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     ethaddress: expected,
                 }
             );
@@ -760,14 +760,14 @@ async fn check_get_set_fee_recipient() {
                 .await
                 .expect("should get fee recipient");
             let expected = if i == 2 {
-                fee_recipient_public_key_2.clone()
+                fee_recipient_public_key_2
             } else {
                 TEST_DEFAULT_FEE_RECIPIENT
             };
             assert_eq!(
                 get_res,
                 GetFeeRecipientResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     ethaddress: expected,
                 }
             );
@@ -813,7 +813,7 @@ async fn check_get_set_gas_limit() {
             assert_eq!(
                 get_res,
                 GetGasLimitResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     gas_limit: DEFAULT_GAS_LIMIT,
                 }
             );
@@ -842,14 +842,14 @@ async fn check_get_set_gas_limit() {
                 .await
                 .expect("should get gas limit");
             let expected = if i == 1 {
-                gas_limit_public_key_1.clone()
+                gas_limit_public_key_1
             } else {
                 DEFAULT_GAS_LIMIT
             };
             assert_eq!(
                 get_res,
                 GetGasLimitResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     gas_limit: expected,
                 }
             );
@@ -883,7 +883,7 @@ async fn check_get_set_gas_limit() {
             assert_eq!(
                 get_res,
                 GetGasLimitResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     gas_limit: expected,
                 }
             );
@@ -916,7 +916,7 @@ async fn check_get_set_gas_limit() {
             assert_eq!(
                 get_res,
                 GetGasLimitResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     gas_limit: expected,
                 }
             );
@@ -943,7 +943,7 @@ async fn check_get_set_gas_limit() {
             assert_eq!(
                 get_res,
                 GetGasLimitResponse {
-                    pubkey: pubkey.clone(),
+                    pubkey: *pubkey,
                     gas_limit: expected,
                 }
             );
@@ -1304,7 +1304,7 @@ async fn delete_concurrent_with_signing() {
         let handle = handle.spawn(async move {
             for j in 0..num_attestations {
                 let mut att = make_attestation(j, j + 1);
-                for (_validator_id, public_key) in thread_pubkeys.iter().enumerate() {
+                for public_key in thread_pubkeys.iter() {
                     let _ = validator_store
                         .sign_attestation(*public_key, 0, &mut att, Epoch::new(j + 1))
                         .await;
@@ -2083,7 +2083,7 @@ async fn import_remotekey_web3signer_disabled() {
         web3signer_req.enable = false;
 
         // Import web3signers.
-        let _ = tester
+        tester
             .client
             .post_lighthouse_validators_web3signer(&vec![web3signer_req])
             .await

--- a/validator_client/http_api/src/tests/keystores.rs
+++ b/validator_client/http_api/src/tests/keystores.rs
@@ -2147,8 +2147,11 @@ async fn import_remotekey_web3signer_enabled() {
         // 1 validator imported.
         assert_eq!(tester.vals_total(), 1);
         assert_eq!(tester.vals_enabled(), 1);
-        let vals = tester.initialized_validators.read();
-        let web3_vals = vals.validator_definitions();
+        let web3_vals = tester
+            .initialized_validators
+            .read()
+            .validator_definitions()
+            .to_vec();
 
         // Import remotekeys.
         let import_res = tester
@@ -2165,11 +2168,13 @@ async fn import_remotekey_web3signer_enabled() {
 
         assert_eq!(tester.vals_total(), 1);
         assert_eq!(tester.vals_enabled(), 1);
-        let vals = tester.initialized_validators.read();
-        let remote_vals = vals.validator_definitions();
+        {
+            let vals = tester.initialized_validators.read();
+            let remote_vals = vals.validator_definitions();
 
-        // Web3signer should not be overwritten since it is enabled.
-        assert!(web3_vals == remote_vals);
+            // Web3signer should not be overwritten since it is enabled.
+            assert!(web3_vals == remote_vals);
+        }
 
         // Remotekey should not be imported.
         let expected_responses = vec![SingleListRemotekeysResponse {

--- a/validator_manager/src/import_validators.rs
+++ b/validator_manager/src/import_validators.rs
@@ -522,7 +522,7 @@ pub mod tests {
 
                 let local_validators: Vec<ValidatorSpecification> = {
                     let contents =
-                        fs::read_to_string(&self.import_config.validators_file_path.unwrap())
+                        fs::read_to_string(self.import_config.validators_file_path.unwrap())
                             .unwrap();
                     serde_json::from_str(&contents).unwrap()
                 };
@@ -559,7 +559,7 @@ pub mod tests {
                 self.vc.ensure_key_cache_consistency().await;
 
                 let local_keystore: Keystore =
-                    Keystore::from_json_file(&self.import_config.keystore_file_path.unwrap())
+                    Keystore::from_json_file(self.import_config.keystore_file_path.unwrap())
                         .unwrap();
 
                 let list_keystores_response = self.vc.client.get_keystores().await.unwrap().data;

--- a/validator_manager/src/move_validators.rs
+++ b/validator_manager/src/move_validators.rs
@@ -977,13 +977,13 @@ mod test {
                     })
                     .unwrap();
                 // Set all definitions to use the same password path as the primary.
-                definitions.iter_mut().enumerate().for_each(|(_, def)| {
-                    match &mut def.signing_definition {
-                        SigningDefinition::LocalKeystore {
-                            voting_keystore_password_path: Some(path),
-                            ..
-                        } => *path = primary_path.clone(),
-                        _ => (),
+                definitions.iter_mut().for_each(|def| {
+                    if let SigningDefinition::LocalKeystore {
+                        voting_keystore_password_path: Some(path),
+                        ..
+                    } = &mut def.signing_definition
+                    {
+                        *path = primary_path.clone()
                     }
                 })
             }


### PR DESCRIPTION
## Issue Addressed

Previously, tests gated with `#[cfg(not(debug_assertions))]` were not linted, as Clippy does not run in `--release` mode to save time. 

## Proposed Changes

This PR enables linting these tests by setting the compiler option `-C debug-assertions=no` when invoking Clippy. This retains the time saved by not optimizing while linting. Also, this PR fixes allllll the lint errors uncovered by this.

## Additional Info

For easier review, this PR is split into several commits:

1. **[fix automatically fixable or obvious lints](https://github.com/sigp/lighthouse/commit/a22e66a7efbd0b9dcff4f7620585323df11ccd3e)**: Most of the new errors were "machine fixable" (stuff like superfluous `&` or `.into()`s). Some errors were not machine fixable but really obvious to fix anyway (at my discretion). Feel free to scroll through this anyway. I checked machine fixable occurrences manually to make sure they're sane.
2. **[fix `suspicious_open_options` by removing manual options](https://github.com/sigp/lighthouse/commit/b5a8bd77497619544dad3f75b57ec5a2b0a07654)**: Here I modified the code beyond the scope of the lint to make it a bit nicer, but that is a matter of taste.
3. **[fix `await_holding_locks`](https://github.com/sigp/lighthouse/commit/3c872c95ad29787f0b1535b65bc8a063113edc1a)**: Here we held locks across await points, so I had to shuffle things around a bit. In one case, it was annoying to avoid as `NaiveAggregationPool` is not `Clone`able, so I disabled the lint here (as there is some precedent for that in the codebase). (edit: I now realize one lock is used for inter-test ratelimiting, so I reverted and disabled the lint there in a later commit)
4. **[avoid failing lint due to now disabled `#[cfg(debug_assertions)]`](https://github.com/sigp/lighthouse/commit/5fd8d37928db1a07379a4920b7e0e1c6b6425f13)**: This one is interesting: The newly set compiler flag caused an issue in this non-test code as the `None` branch was now empty. I pulled the check out of the `match` and then applied the lint suggestion. (edit: By accident, I flipped the condition which I fixed in a later commit) 
5. **[reduce future sizes in tests](https://github.com/sigp/lighthouse/commit/cdef1ffa1c706da14c17bda6a994e0d826a6cff4)**: Some async test functions now had a too large stack size. I mostly sprinkled some `Box::pin` around some of the invoked futures, and split up the test in one case.
