### PR TITLE
Compact more when pruning states

### DIFF
--- a/beacon_node/beacon_chain/src/schema_change/migration_schema_v22.rs
+++ b/beacon_node/beacon_chain/src/schema_change/migration_schema_v22.rs
@@ -152,7 +152,7 @@ pub fn delete_old_schema_freezer_data<T: BeaconChainTypes>(
     db.cold_db.do_atomically(cold_ops)?;
 
     // In order to reclaim space, we need to compact the freezer DB as well.
-    db.cold_db.compact()?;
+    db.compact_freezer()?;
 
     Ok(())
 }


### PR DESCRIPTION
## Proposed Changes

@chong-he noticed that nodes running v6.0.0 do not reclaim disk space after pruning states. This is because the generic `compact` method on the database only compacts a handful of columns: `BeaconState`, `BeaconStateSummary`, `BeaconBlock`.

For pre-v6.0.0 databases, most of the data for historic states will have been stored in the `BeaconState` column, so users upgrading from v5.x to v6 should have been able to reclaim most of the used space. There are only a handful of old columns like `BeaconStateRoots` which won't have been compacted.

For nodes running v6 that prune states after upgrading, the compaction currently misses the two most important columns: `BeaconStateSnapshot` and `BeaconStateDiff`. I've added a new `compact_freezer` method which compacts all of the current-schema columns, and all the old schema columns for good measure.
