### PR TITLE
Tweak reconstruction batch size

### DIFF
--- a/beacon_node/beacon_chain/src/migrate.rs
+++ b/beacon_node/beacon_chain/src/migrate.rs
@@ -26,8 +26,10 @@ const MIN_COMPACTION_PERIOD_SECONDS: u64 = 7200;
 const COMPACTION_FINALITY_DISTANCE: u64 = 1024;
 /// Maximum number of blocks applied in each reconstruction burst.
 ///
-/// This limits the amount of time that the finalization migration is paused for.
-const BLOCKS_PER_RECONSTRUCTION: usize = 8192 * 4;
+/// This limits the amount of time that the finalization migration is paused for. We set this
+/// conservatively because pausing the finalization migration for too long can cause hot state
+/// cache misses and excessive disk use.
+const BLOCKS_PER_RECONSTRUCTION: usize = 1024;
 
 /// Default number of epochs to wait between finalization migrations.
 pub const DEFAULT_EPOCHS_PER_MIGRATION: u64 = 1;


### PR DESCRIPTION
## Issue Addressed

Address a performance issue reported by @mcdee which boils down to reconstruction taking too long and starving the finalization migration.

## Proposed Changes

Jim's node with per-slot diffs spent 110 epochs doing reconstruction before picking up another finalization migration. This is very slow, and causes severe issues for the caches (similar to 110 epochs of non-finality).

To address this I've reduced the maximum number of blocks processed in a single reconstruction batch by a factor of 32, down to 1024. This should mean that a node like Jim's spends around 110/32 = 3.5 epochs doing reconstruction before it does another finalization migration. This is much more manageable for the hot state cache (4 epochs * 32 slots = 128 states, which fits inside the cache with default sizing).
