### PR TITLE
Prevent reconstruction starting prematurely

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1037,7 +1037,10 @@ where
         );
 
         // Check for states to reconstruct (in the background).
-        if beacon_chain.config.reconstruct_historic_states {
+        if beacon_chain.config.reconstruct_historic_states
+            && beacon_chain.genesis_backfill_slot == 0
+            && beacon_chain.store.get_oldest_block_slot() == 0
+        {
             beacon_chain.store_migrator.process_reconstruction();
         }
 

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -1038,7 +1038,6 @@ where
 
         // Check for states to reconstruct (in the background).
         if beacon_chain.config.reconstruct_historic_states
-            && beacon_chain.genesis_backfill_slot == 0
             && beacon_chain.store.get_oldest_block_slot() == 0
         {
             beacon_chain.store_migrator.process_reconstruction();


### PR DESCRIPTION
## Issue Addressed

Fix a long-standing issue most recently reported by @xrchz whereby Lighthouse attempts to start state reconstruction too early.

> Dec 02 07:11:49.453 ERRO State reconstruction failed             error: MissingHistoricBlocks { oldest_block_slot: Slot(543328) }, service: beacon

## Proposed Changes

When starting up, only attempt to start state reconstruction if block backfill is already complete. A similar guard condition already exists at the point in block backfill where we start reconstruction:

https://github.com/sigp/lighthouse/blob/c042dc14d74352512b7632e0ee6ec07f1aa26b3a/beacon_node/beacon_chain/src/historical_blocks.rs#L279-L284

## Additional Info

Alternatively we could refactor the reconstruction code itself to just log a debug message and return `Ok(())` in the case where reconstruction is not yet ready to start. However due to the limited number of places from which reconstruction can be triggered, I think the current approach is preferable, as it avoids sending and processing an unnecessary event.
