### PR TITLE
Fix Kurtosis, web3signer and cargo-audit for CI

### DIFF
--- a/.github/workflows/local-testnet.yml
+++ b/.github/workflows/local-testnet.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1
+          sudo apt install -y kurtosis-cli
           kurtosis analytics disable
 
       - name: Download Docker image artifact
@@ -86,7 +86,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1
+          sudo apt install -y kurtosis-cli
           kurtosis analytics disable
 
       - name: Download Docker image artifact
@@ -121,7 +121,7 @@ jobs:
         run: |
           echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
           sudo apt update
-          sudo apt install -y kurtosis-cli=1.3.1
+          sudo apt install -y kurtosis-cli
           kurtosis analytics disable
 
       - name: Download Docker image artifact

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -83,6 +83,11 @@ jobs:
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
     - uses: actions/checkout@v4
+    # Set Java version to 21. (required since Web3Signer 24.12.0).
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1

--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,7 @@ install-audit:
 	cargo install --force cargo-audit
 
 audit-CI:
-	cargo audit
+	cargo audit --ignore RUSTSEC-2024-0421
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:

--- a/scripts/tests/doppelganger_protection.sh
+++ b/scripts/tests/doppelganger_protection.sh
@@ -71,7 +71,7 @@ if [[ "$BEHAVIOR" == "failure" ]]; then
     # This process should not last longer than 2 epochs
     vc_1_range_start=0
     vc_1_range_end=$(($KEYS_PER_NODE - 1))
-    vc_1_keys_artifact_id="1-lighthouse-geth-$vc_1_range_start-$vc_1_range_end-0"
+    vc_1_keys_artifact_id="1-lighthouse-geth-$vc_1_range_start-$vc_1_range_end"
     service_name=vc-1-doppelganger
 
     kurtosis service add \
@@ -107,7 +107,7 @@ if [[ "$BEHAVIOR" == "success" ]]; then
 
     vc_4_range_start=$(($KEYS_PER_NODE * 3))
     vc_4_range_end=$(($KEYS_PER_NODE * 4 - 1))
-    vc_4_keys_artifact_id="4-lighthouse-geth-$vc_4_range_start-$vc_4_range_end-0"
+    vc_4_keys_artifact_id="4-lighthouse-geth-$vc_4_range_start-$vc_4_range_end"
     service_name=vc-4
 
     kurtosis service add \


### PR DESCRIPTION
## Issue Addressed

Fix the failing Kurtosis jobs on CI, e.g.

https://github.com/sigp/lighthouse/actions/runs/12226785831/job/34102825704?pr=6669

## Proposed Changes

- Kurtosis fix: Remove the `-0` that was being erroneously added to the artifact name reference in the doppelganger script. Something must have changed upstream to break this.
- Web3signer fix: update to Java 21.
- Cargo audit: temporarily ignore vuln for `idna` until upstream patch is available.
- May-as-well: install the latest version of `kurtosis-cli`, rather than pinning `1.3.1`.

