### PR TITLE
Set Java Version to 21 to fix Web3Signer tests

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -99,6 +99,9 @@ jobs:
         version: nightly-ca67d15f4abd46394b324c50e21e66f306a1162d
     - name: Run tests in release
       run: make nextest-release
+      env:
+        # Set Java version to 21. (required since Web3Signer 24.12.0)
+        JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
     - name: Show cache stats
       if: env.SELF_HOSTED_RUNNERS == 'true'
       run: sccache --show-stats


### PR DESCRIPTION
## Issue Addressed

Latest [Web3Signer release 24.12.0 ](https://github.com/Consensys/web3signer/releases/tag/24.12.0)requires Java 21 runtime. 

GitHub runners uses Java 11 by default, hence Web3Signer fails to start in our release tests. The runner already has Java 21 pre-installed, this PR sets the used Java version to 21.