### PR TITLE
Set Java Version to 21 (required since Web3Signer 24.12.0).

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -83,6 +83,11 @@ jobs:
     runs-on: ${{ github.repository == 'sigp/lighthouse' && fromJson('["self-hosted", "linux", "CI", "large"]') || 'ubuntu-latest'  }}
     steps:
     - uses: actions/checkout@v4
+    # Set Java version to 21. (required since Web3Signer 24.12.0).
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
     - name: Get latest version of stable Rust
       if: env.SELF_HOSTED_RUNNERS == 'false'
       uses: moonrepo/setup-rust@v1

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,9 @@ audit: install-audit audit-CI
 install-audit:
 	cargo install --force cargo-audit
 
+# Remove --ignore once upstream fix is released: https://github.com/hickory-dns/hickory-dns/pull/2662
 audit-CI:
-	cargo audit
+	cargo audit --ignore RUSTSEC-2024-0421
 
 # Runs `cargo vendor` to make sure dependencies can be vendored for packaging, reproducibility and archival purpose.
 vendor:


### PR DESCRIPTION
## Issue Addressed

Latest [Web3Signer release 24.12.0 ](https://github.com/Consensys/web3signer/releases/tag/24.12.0) requires Java 21 runtime. 

Our GitHub runners uses Java 19, hence Web3Signer fails to start in our release tests. This PR install Java 21 using the `setup-java` action. We could also include this in our runner image to avoid downloading during CI runs.