### PR TITLE
Fix subnet service test

### DIFF
--- a/beacon_node/network/src/subnet_service/tests/mod.rs
+++ b/beacon_node/network/src/subnet_service/tests/mod.rs
@@ -166,9 +166,9 @@ async fn get_events<S: Stream<Item = SubnetServiceMessage> + Unpin>(
 }
 
 mod test {
-
     #[cfg(not(windows))]
     use crate::subnet_service::MIN_PEER_DISCOVERY_SLOT_LOOK_AHEAD;
+    use itertools::Itertools;
 
     use super::*;
 
@@ -344,7 +344,10 @@ mod test {
         // Unsubscription event should happen at slot 2 (since subnet id's are the same, unsubscription event should be at higher slot + 1)
         let expected = SubnetServiceMessage::Subscribe(Subnet::Attestation(subnet_id1));
 
-        if subnet_service.is_subscribed(&Subnet::Attestation(subnet_id1)) {
+        if subnet_service
+            .permanent_subscriptions()
+            .contains(&Subnet::Attestation(subnet_id1))
+        {
             // If we are permanently subscribed to this subnet, we won't see a subscribe message
             let _ = get_events(&mut subnet_service, None, 1).await;
         } else {


### PR DESCRIPTION
## Issue Addressed

This PR fixes an intermittently failing test:
https://github.com/sigp/lighthouse/actions/runs/12246911324/job/34163756917

It fails when the validator subnets happens to be in the permanent subscriptions - the existing check doesn't actually handle this correctly as `subnet_service.is_subscribed` checks for short-lived subscription. In the case where the subnet is already subscribed as a permanent subscription, there will be no new subscription events.