### PR TITLE
Correct `/nat` API for libp2p

### DIFF
--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -141,10 +141,6 @@ impl<E: EthSpec> NetworkBehaviour for PeerManager<E> {
                 debug!(self.log, "Failed to dial peer"; "peer_id"=> ?peer_id, "error" => %ClearDialError(error));
                 self.on_dial_failure(peer_id);
             }
-            FromSwarm::ExternalAddrConfirmed(_) => {
-                // We have an external address confirmed, means we are able to do NAT traversal.
-                metrics::set_gauge_vec(&metrics::NAT_OPEN, &["libp2p"], 1);
-            }
             _ => {
                 // NOTE: FromSwarm is a non exhaustive enum so updates should be based on release
                 // notes more than compiler feedback

--- a/common/system_health/src/lib.rs
+++ b/common/system_health/src/lib.rs
@@ -235,14 +235,14 @@ pub fn observe_nat() -> NatState {
 
     let libp2p_ipv4 = lighthouse_network::metrics::get_int_gauge(
         &lighthouse_network::metrics::NAT_OPEN,
-        &["libp2p"],
+        &["libp2p_ipv4"],
     )
     .map(|g| g.get() == 1)
     .unwrap_or_default();
 
     let libp2p_ipv6 = lighthouse_network::metrics::get_int_gauge(
         &lighthouse_network::metrics::NAT_OPEN,
-        &["libp2p"],
+        &["libp2p_ipv6"],
     )
     .map(|g| g.get() == 1)
     .unwrap_or_default();


### PR DESCRIPTION
## Issue Addressed

There was a mismatch in the metric naming, resulting in the `/nat` api always returning false, when the underlying metric may actually be true. 