### PR TITLE
Remove lighthouse_network dependency from eth2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,7 +2571,6 @@ dependencies = [
  "futures",
  "futures-util",
  "libsecp256k1",
- "lighthouse_network",
  "mediatype",
  "pretty_reqwest_error",
  "procfs",

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -43,9 +43,9 @@ store = { workspace = true }
 bytes = { workspace = true }
 beacon_processor = { workspace = true }
 rand = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 proto_array = { workspace = true }
 genesis = { workspace = true }
 logging = { workspace = true }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -46,11 +46,14 @@ use bytes::Bytes;
 use directory::DEFAULT_ROOT_DIR;
 use eth2::types::{
     self as api_types, BroadcastValidation, EndpointVersion, ForkChoice, ForkChoiceNode,
-    LightClientUpdatesQuery, PublishBlockRequest, ValidatorBalancesRequestBody, ValidatorId,
-    ValidatorStatus, ValidatorsRequestBody,
+    LightClientUpdatesQuery, PeerDirection, PublishBlockRequest, ValidatorBalancesRequestBody,
+    ValidatorId, ValidatorStatus, ValidatorsRequestBody,
 };
 use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
-use lighthouse_network::{types::SyncState, EnrExt, NetworkGlobals, PeerId, PubsubMessage};
+use lighthouse_network::{
+    types::SyncState, ConnectionDirection, EnrExt, NetworkGlobals, PeerConnectionStatus, PeerId,
+    PubsubMessage,
+};
 use lighthouse_version::version_with_platform;
 use logging::SSELoggingComponents;
 use network::{NetworkMessage, NetworkSenders, ValidatorSubscriptionMessage};
@@ -2870,9 +2873,15 @@ pub fn serve<T: BeaconChainTypes>(
                     let meta_data = network_globals.local_metadata.read();
                     Ok(api_types::GenericResponse::from(api_types::IdentityData {
                         peer_id: network_globals.local_peer_id().to_base58(),
-                        enr,
-                        p2p_addresses,
-                        discovery_addresses,
+                        enr: enr.to_string(),
+                        p2p_addresses: p2p_addresses
+                            .into_iter()
+                            .map(|addr| addr.to_string())
+                            .collect(),
+                        discovery_addresses: discovery_addresses
+                            .into_iter()
+                            .map(|addr| addr.to_string())
+                            .collect(),
                         metadata: api_types::MetaData {
                             seq_number: *meta_data.seq_number(),
                             attnets: format!(
@@ -3059,10 +3068,26 @@ pub fn serve<T: BeaconChainTypes>(
                                 peer_id: peer_id.to_string(),
                                 enr: peer_info.enr().map(|enr| enr.to_base64()),
                                 last_seen_p2p_address: address,
-                                direction: api_types::PeerDirection::from_connection_direction(dir),
-                                state: api_types::PeerState::from_peer_connection_status(
-                                    peer_info.connection_status(),
-                                ),
+                                direction: match dir {
+                                    ConnectionDirection::Incoming => PeerDirection::Inbound,
+                                    ConnectionDirection::Outgoing => PeerDirection::Outbound,
+                                },
+                                state: match peer_info.connection_status() {
+                                    PeerConnectionStatus::Connected { .. } => {
+                                        api_types::PeerState::Connected
+                                    }
+                                    PeerConnectionStatus::Dialing { .. } => {
+                                        api_types::PeerState::Connecting
+                                    }
+                                    PeerConnectionStatus::Disconnecting { .. } => {
+                                        api_types::PeerState::Disconnecting
+                                    }
+                                    PeerConnectionStatus::Disconnected { .. }
+                                    | PeerConnectionStatus::Banned { .. }
+                                    | PeerConnectionStatus::Unknown => {
+                                        api_types::PeerState::Disconnected
+                                    }
+                                },
                             }));
                         }
                     }
@@ -3104,11 +3129,26 @@ pub fn serve<T: BeaconChainTypes>(
 
                             // the eth2 API spec implies only peers we have been connected to at some point should be included.
                             if let Some(dir) = peer_info.connection_direction() {
-                                let direction =
-                                    api_types::PeerDirection::from_connection_direction(dir);
-                                let state = api_types::PeerState::from_peer_connection_status(
-                                    peer_info.connection_status(),
-                                );
+                                let direction = match dir {
+                                    ConnectionDirection::Incoming => PeerDirection::Inbound,
+                                    ConnectionDirection::Outgoing => PeerDirection::Outbound,
+                                };
+                                let state = match peer_info.connection_status() {
+                                    PeerConnectionStatus::Connected { .. } => {
+                                        api_types::PeerState::Connected
+                                    }
+                                    PeerConnectionStatus::Dialing { .. } => {
+                                        api_types::PeerState::Connecting
+                                    }
+                                    PeerConnectionStatus::Disconnecting { .. } => {
+                                        api_types::PeerState::Disconnecting
+                                    }
+                                    PeerConnectionStatus::Disconnected { .. }
+                                    | PeerConnectionStatus::Banned { .. }
+                                    | PeerConnectionStatus::Unknown => {
+                                        api_types::PeerState::Disconnected
+                                    }
+                                };
 
                                 let state_matches = query.state.as_ref().map_or(true, |states| {
                                     states.iter().any(|state_param| *state_param == state)
@@ -3159,16 +3199,13 @@ pub fn serve<T: BeaconChainTypes>(
                         .peers
                         .read()
                         .peers()
-                        .for_each(|(_, peer_info)| {
-                            let state = api_types::PeerState::from_peer_connection_status(
-                                peer_info.connection_status(),
-                            );
-                            match state {
-                                api_types::PeerState::Connected => connected += 1,
-                                api_types::PeerState::Connecting => connecting += 1,
-                                api_types::PeerState::Disconnected => disconnected += 1,
-                                api_types::PeerState::Disconnecting => disconnecting += 1,
-                            }
+                        .for_each(|(_, peer_info)| match peer_info.connection_status() {
+                            PeerConnectionStatus::Connected { .. } => connected += 1,
+                            PeerConnectionStatus::Dialing { .. } => connecting += 1,
+                            PeerConnectionStatus::Disconnecting { .. } => disconnecting += 1,
+                            PeerConnectionStatus::Disconnected { .. }
+                            | PeerConnectionStatus::Banned { .. }
+                            | PeerConnectionStatus::Unknown => disconnected += 1,
                         });
 
                     Ok(api_types::GenericResponse::from(api_types::PeerCount {
@@ -4166,15 +4203,18 @@ pub fn serve<T: BeaconChainTypes>(
             |task_spawner: TaskSpawner<T::EthSpec>,
              network_globals: Arc<NetworkGlobals<T::EthSpec>>| {
                 task_spawner.blocking_json_task(Priority::P1, move || {
-                    Ok(network_globals
-                        .peers
-                        .read()
-                        .peers()
-                        .map(|(peer_id, peer_info)| eth2::lighthouse::Peer {
+                    let mut peers = vec![];
+                    for (peer_id, peer_info) in network_globals.peers.read().peers() {
+                        peers.push(eth2::lighthouse::Peer {
                             peer_id: peer_id.to_string(),
-                            peer_info: peer_info.clone(),
-                        })
-                        .collect::<Vec<_>>())
+                            peer_info: serde_json::to_value(peer_info).map_err(|e| {
+                                warp_utils::reject::custom_not_found(format!(
+                                    "unable to serialize peer_info: {e:?}",
+                                ))
+                            })?,
+                        });
+                    }
+                    Ok(peers)
                 })
             },
         );
@@ -4190,15 +4230,18 @@ pub fn serve<T: BeaconChainTypes>(
             |task_spawner: TaskSpawner<T::EthSpec>,
              network_globals: Arc<NetworkGlobals<T::EthSpec>>| {
                 task_spawner.blocking_json_task(Priority::P1, move || {
-                    Ok(network_globals
-                        .peers
-                        .read()
-                        .connected_peers()
-                        .map(|(peer_id, peer_info)| eth2::lighthouse::Peer {
+                    let mut peers = vec![];
+                    for (peer_id, peer_info) in network_globals.peers.read().connected_peers() {
+                        peers.push(eth2::lighthouse::Peer {
                             peer_id: peer_id.to_string(),
-                            peer_info: peer_info.clone(),
-                        })
-                        .collect::<Vec<_>>())
+                            peer_info: serde_json::to_value(peer_info).map_err(|e| {
+                                warp_utils::reject::custom_not_found(format!(
+                                    "unable to serialize peer_info: {e:?}",
+                                ))
+                            })?,
+                        });
+                    }
+                    Ok(peers)
                 })
             },
         );

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -12,7 +12,6 @@ serde_json = { workspace = true }
 ssz_types = { workspace = true }
 types = { workspace = true }
 reqwest = { workspace = true }
-lighthouse_network = { workspace = true }
 proto_array = { workspace = true }
 ethereum_serde_utils = { workspace = true }
 eth2_keystore = { workspace = true }

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -19,7 +19,6 @@ use self::types::{Error as ResponseError, *};
 use derivative::Derivative;
 use futures::Stream;
 use futures_util::StreamExt;
-use lighthouse_network::PeerId;
 use pretty_reqwest_error::PrettyReqwestError;
 pub use reqwest;
 use reqwest::{
@@ -47,6 +46,8 @@ pub const CONSENSUS_BLOCK_VALUE_HEADER: &str = "Eth-Consensus-Block-Value";
 
 pub const CONTENT_TYPE_HEADER: &str = "Content-Type";
 pub const SSZ_CONTENT_TYPE_HEADER: &str = "application/octet-stream";
+
+type PeerId = String;
 
 #[derive(Debug)]
 pub enum Error {

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -8,9 +8,7 @@ mod standard_block_rewards;
 mod sync_committee_rewards;
 
 use crate::{
-    types::{
-        DepositTreeSnapshot, Epoch, EthSpec, FinalizedExecutionBlock, GenericResponse, ValidatorId,
-    },
+    types::{DepositTreeSnapshot, Epoch, FinalizedExecutionBlock, GenericResponse, ValidatorId},
     BeaconNodeHttpClient, DepositData, Error, Eth1Data, Hash256, Slot,
 };
 use proto_array::core::ProtoArray;
@@ -27,7 +25,6 @@ pub use block_packing_efficiency::{
     BlockPackingEfficiency, BlockPackingEfficiencyQuery, ProposerInfo, UniqueAttestation,
 };
 pub use block_rewards::{AttestationRewards, BlockReward, BlockRewardMeta, BlockRewardsQuery};
-pub use lighthouse_network::{types::SyncState, PeerInfo};
 pub use standard_block_rewards::StandardBlockReward;
 pub use sync_committee_rewards::SyncCommitteeReward;
 
@@ -39,12 +36,11 @@ four_byte_option_impl!(four_byte_option_hash256, Hash256);
 /// Information returned by `peers` and `connected_peers`.
 // TODO: this should be deserializable..
 #[derive(Debug, Clone, Serialize)]
-#[serde(bound = "E: EthSpec")]
-pub struct Peer<E: EthSpec> {
+pub struct Peer {
     /// The Peer's ID
     pub peer_id: String,
     /// The PeerInfo associated with the peer.
-    pub peer_info: PeerInfo<E>,
+    pub peer_info: serde_json::Value,
 }
 
 /// The results of validators voting during an epoch.
@@ -379,7 +375,9 @@ impl BeaconNodeHttpClient {
     }
 
     /// `GET lighthouse/syncing`
-    pub async fn get_lighthouse_syncing(&self) -> Result<GenericResponse<SyncState>, Error> {
+    pub async fn get_lighthouse_syncing(
+        &self,
+    ) -> Result<GenericResponse<serde_json::Value>, Error> {
         let mut path = self.server.full.clone();
 
         path.path_segments_mut()

--- a/common/eth2/src/types.rs
+++ b/common/eth2/src/types.rs
@@ -5,7 +5,6 @@ use crate::{
     Error as ServerError, CONSENSUS_BLOCK_VALUE_HEADER, CONSENSUS_VERSION_HEADER,
     EXECUTION_PAYLOAD_BLINDED_HEADER, EXECUTION_PAYLOAD_VALUE_HEADER,
 };
-use lighthouse_network::{ConnectionDirection, Enr, Multiaddr, PeerConnectionStatus};
 use mediatype::{names, MediaType, MediaTypeList};
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -578,9 +577,9 @@ pub struct ChainHeadData {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IdentityData {
     pub peer_id: String,
-    pub enr: Enr,
-    pub p2p_addresses: Vec<Multiaddr>,
-    pub discovery_addresses: Vec<Multiaddr>,
+    pub enr: String,
+    pub p2p_addresses: Vec<String>,
+    pub discovery_addresses: Vec<String>,
     pub metadata: MetaData,
 }
 
@@ -853,19 +852,6 @@ pub enum PeerState {
     Disconnecting,
 }
 
-impl PeerState {
-    pub fn from_peer_connection_status(status: &PeerConnectionStatus) -> Self {
-        match status {
-            PeerConnectionStatus::Connected { .. } => PeerState::Connected,
-            PeerConnectionStatus::Dialing { .. } => PeerState::Connecting,
-            PeerConnectionStatus::Disconnecting { .. } => PeerState::Disconnecting,
-            PeerConnectionStatus::Disconnected { .. }
-            | PeerConnectionStatus::Banned { .. }
-            | PeerConnectionStatus::Unknown => PeerState::Disconnected,
-        }
-    }
-}
-
 impl FromStr for PeerState {
     type Err = String;
 
@@ -896,15 +882,6 @@ impl fmt::Display for PeerState {
 pub enum PeerDirection {
     Inbound,
     Outbound,
-}
-
-impl PeerDirection {
-    pub fn from_connection_direction(direction: &ConnectionDirection) -> Self {
-        match direction {
-            ConnectionDirection::Incoming => PeerDirection::Inbound,
-            ConnectionDirection::Outgoing => PeerDirection::Outbound,
-        }
-    }
 }
 
 impl FromStr for PeerDirection {


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

The eth2 which contains our http api client crate depends on the lighthouse_network crate for some networking types.
This is completely unnecessary imo because we can just return strings/serde_json::Value types for the networking types. 
These types don't require us using any of the functions on the type structs. They just exist for some typing.

This is an enormous source of pain for any dependency that pulls the eth2 crate for using a `BeaconNodeHttpClient` because importing lighthouse_network pulls in a bunch of other dependencies that just bloats the dep tree.

I don't see any reason why the networking related types cannot be represented as `String` or json values. Let me know if that is not the case. 

## Todo

- [ ] Test all affected endpoints