### PR TITLE
Unsaturate dial negotiation queue

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -964,6 +964,9 @@ where
         request_info: (Id, RequestType<E>),
         error: StreamUpgradeError<RPCError>,
     ) {
+        // This dialing is now considered failed
+        self.dial_negotiated -= 1;
+
         let (id, req) = request_info;
 
         // map the error
@@ -988,9 +991,6 @@ where
             }
             StreamUpgradeError::Apply(other) => other,
         };
-
-        // This dialing is now considered failed
-        self.dial_negotiated -= 1;
 
         self.outbound_io_error_retries = 0;
         self.events_out


### PR DESCRIPTION
## Issue Addressed

It seems to me there is a bug, where if we fail dials via io errors, we attempt a re-connection for a number of times before failing the RPC request. However, in the re-attempts we keep adding to the `dial_negotiation` count. 

I suspect, after a number of failures, the `dial_negotiation` count can saturate and become larger than our max of 8 concurrent dials. In which case, we will no longer perform any further dials. Our dial queue will just grow and grow and nothing will happen because the RPC thinks we have already too many dials. 

We've witnessed logs of this form. I haven't tested this, but I think my logic here is sound.

I think resolves #6703 