### PR TITLE
Fix anvil 404 link in docs

### DIFF
--- a/testing/eth1_test_rig/src/lib.rs
+++ b/testing/eth1_test_rig/src/lib.rs
@@ -1,6 +1,6 @@
 //! Provides utilities for deploying and manipulating the eth2 deposit contract on the eth1 chain.
 //!
-//! Presently used with [`anvil`](https://github.com/foundry-rs/foundry/tree/master/anvil) to simulate
+//! Presently used with [`anvil`](https://github.com/foundry-rs/foundry/tree/master/crates/anvil) to simulate
 //! the deposit contract for testing beacon node eth1 integration.
 //!
 //! Not tested to work with actual clients (e.g., geth). It should work fine, however there may be


### PR DESCRIPTION
## Proposed Changes

Fix a stale link to stem the tide of bot PRs.

Eventually we should set up something like `cargo-deadlinks`:

https://github.com/deadlinks/cargo-deadlinks
