### PR TITLE
Make sure we have fanout peers when publish

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -679,9 +679,15 @@ where
                 // Gossipsub peers
                 None => {
                     tracing::debug!(topic=%topic_hash, "Topic not in the mesh");
+                    // `fanout_peers` is always non-empty if it's `Some`.
+                    let fanout_peers = self
+                        .fanout
+                        .get(&topic_hash)
+                        .map(|peers| if peers.is_empty() { None } else { Some(peers) })
+                        .unwrap_or(None);
                     // If we have fanout peers add them to the map.
-                    if self.fanout.contains_key(&topic_hash) {
-                        for peer in self.fanout.get(&topic_hash).expect("Topic must exist") {
+                    if let Some(peers) = fanout_peers {
+                        for peer in peers {
                             recipient_peers.insert(*peer);
                         }
                     } else {


### PR DESCRIPTION
## Issue Addressed

I'm not sure if this PR solves #6698, but it seems related.

An `InsufficientPeers` error can occur under the following condition when publish, even if we have peers subscribed to the topic in `self.connected_peers`:

- We don't have any mesh peers for the topic.
- We have an entry in `self.fanout` for the topic, but **the entry is empty**.
  - This can happen due to unsubscribes or disconnections.
- We have peers subscribed to the topic in `self.connected_peers`.

## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

Ensure that the `self.fanout` entry is not empty

<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->