### PR TITLE
typo-Update beacon_block_reward.rs

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_block_reward.rs
+++ b/beacon_node/beacon_chain/src/beacon_block_reward.rs
@@ -201,7 +201,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                     }
                 };
 
-                // If the next epoch end is no longer phase0, no proposer rewards are awarded, as Altair epoch boundry
+                // If the next epoch end is no longer phase0, no proposer rewards are awarded, as Altair epoch boundary
                 // processing kicks in. We check this here, as we know that current_epoch_end will always be phase0.
                 if !matches!(next_epoch_end, BeaconState::Base(_)) {
                     continue;


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
- `beacon_node/beacon_chain/src/beacon_block_reward.rs:204`: "boundry" corrected to "boundary".

## Purpose
- Improved code accuracy and ensured professionalism by fixing the typo.
