### PR TITLE
fix typo in comment regarding version update process

### DIFF
--- a/scripts/change_version.sh
+++ b/scripts/change_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Change the version across multiple files, prior to a release. Use `sed` to
-# find/replace the exiting version with the new one.
+# find/replace the existing version with the new one.
 #
 # Takes two arguments:
 #


### PR DESCRIPTION
## Issue Addressed

I noticed a typo in one of the comments within the script. The word "exiting" was used, but it should be "existing" to correctly describe the process of finding and replacing the current version with the new one.

## Proposed Changes

- Corrected "exiting version" to "existing version" in the comment to ensure clarity and accuracy.

