### PR TITLE
Use oldest_block_slot to break off pruning payloads

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2629,7 +2629,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
             "Pruning finalized payloads";
             "info" => "you may notice degraded I/O performance while this runs"
         );
-        let anchor_slot = self.get_anchor_info().anchor_slot;
+        let anchor_info = self.get_anchor_info();
 
         let mut ops = vec![];
         let mut last_pruned_block_root = None;
@@ -2670,10 +2670,10 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 ops.push(StoreOp::DeleteExecutionPayload(block_root));
             }
 
-            if slot == anchor_slot {
+            if slot < anchor_info.oldest_block_slot {
                 info!(
                     self.log,
-                    "Payload pruning reached anchor state";
+                    "Payload pruning reached anchor oldest block slot";
                     "slot" => slot
                 );
                 break;

--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -2670,7 +2670,7 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
                 ops.push(StoreOp::DeleteExecutionPayload(block_root));
             }
 
-            if slot < anchor_info.oldest_block_slot {
+            if slot <= anchor_info.oldest_block_slot {
                 info!(
                     self.log,
                     "Payload pruning reached anchor oldest block slot";


### PR DESCRIPTION
## Issue Addressed

Lighthouse DB persists an "anchor" which has some useful data. One is the `anchor_slot`. Tree-states on the hot DB wants to use that value and change it's meaning slightly. The only blocker for that change is `try_prune_execution_payloads` which uses the anchor_slot as optimization to break of early the pruning routine.

BUT it's an easy fix. From @michaelsproul 

> I was thinking maybe we could recycle the `anchor_slot` for use here, as it is _fairly useless_ and not used for much. The only load-bearing use of the `anchor_slot` that I can find is in `try_prune_execution_payloads` where it is used to halt the pruning process. However, this is not necessary as we could either:
>
> 1. Keep iterating back to Bellatrix, or
> 2. Stop iterating back once we find a payload that is missing, or
> 3. Use the `oldest_block_slot` to determine when to stop iterating back. This is my preferred option, as it is also compatible with storing execution payloads older than the `anchor_slot`, i.e. https://github.com/sigp/lighthouse/issues/6510

ref https://github.com/dapplion/lighthouse/pull/39#discussion_r1891039644

## Proposed Changes

This PR implements option 3 of the above citation, quite painless

