### PR TITLE
Fix incorrect VC default HTTP token path when the `--datadir` flag is present

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -345,7 +345,7 @@ fn http_store_keystore_passwords_in_secrets_dir_present() {
 }
 
 #[test]
-fn http_token_path_flag() {
+fn http_token_path_flag_present() {
     let dir = TempDir::new().expect("Unable to create temporary directory");
     CommandLineTest::new()
         .flag("http", None)
@@ -355,6 +355,19 @@ fn http_token_path_flag() {
             assert_eq!(
                 config.http_api.http_token_path,
                 dir.path().join("api-token.txt")
+            );
+        });
+}
+
+#[test]
+fn http_token_path_default() {
+    CommandLineTest::new()
+        .flag("http", None)
+        .run()
+        .with_config(|config| {
+            assert_eq!(
+                config.http_api.http_token_path,
+                config.validator_dir.join("api-token.txt")
             );
         });
 }

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -106,6 +106,7 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
+        // This value is always overridden when building config from CLI.
         let http_token_path = dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join(DEFAULT_ROOT_DIR)

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -314,10 +314,11 @@ impl Config {
             config.http_api.store_passwords_in_secrets_dir = true;
         }
 
-        if cli_args.get_one::<String>("http-token-path").is_some() {
-            config.http_api.http_token_path = parse_required(cli_args, "http-token-path")
-                // For backward compatibility, default to the path under the validator dir if not provided.
-                .unwrap_or_else(|_| config.validator_dir.join(PK_FILENAME));
+        if let Some(http_token_path) = cli_args.get_one::<String>("http-token-path") {
+            config.http_api.http_token_path = PathBuf::from(http_token_path);
+        } else {
+            // For backward compatibility, default to the path under the validator dir if not provided.
+            config.http_api.http_token_path = config.validator_dir.join(PK_FILENAME);
         }
 
         /*


### PR DESCRIPTION
## Issue Addressed

Fixes a validator client bug introduced in #6577.

When a custom `--datadir` flag is provided, the default http token path changes to `$HOME/.lighthouse/mainnet/validators/api-token.txt`, rather than the previous default `<datadir>/validators/api-token.txt`

This causes a `CRIT` in some setups where the validator client does not have write access to the home directory (e.g. `eth-docker`):

```
CRIT Failed to start validator client        reason: Unable to create parent directories for "/nonexistent/.lighthouse/mainnet/validators/api-token.txt": Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
``` 

## Proposed Changes

Set the correct default VC API token path, if a `datadir` or `validators-dir` is provided.
