### PR TITLE
Update link

### DIFF
--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -72,7 +72,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
         state.fork_mut().previous_version = spec.bellatrix_fork_version;
 
         // Override latest execution payload header.
-        // See https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/bellatrix/beacon-chain.md#testing
+        // See https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#testing
         if let Some(ExecutionPayloadHeader::Bellatrix(ref header)) = execution_payload_header {
             *state.latest_execution_payload_header_bellatrix_mut()? = header.clone();
         }


### PR DESCRIPTION
This pull request updates the link in `genesis.rs` to point to the latest version of the Ethereum consensus specifications. The previous link was outdated and referenced a specific version (`v1.1.0`) of the specs, which has been moved to the `dev` branch. The new link ensures that the code remains aligned with the most up-to-date documentation.

### Issue Addressed
N/A

### Proposed Changes
- Updated the outdated link in `genesis.rs`:
  - **Old Link**: [https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/bellatrix/beacon-chain.md#testing](https://github.com/ethereum/consensus-specs/blob/v1.1.0/specs/bellatrix/beacon-chain.md#testing)
  - **New Link**: [https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#testing](https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#testing)

### Additional Info
- This change keeps the documentation links relevant and helpful for developers working on the repository.
- No functional code changes were made; this PR is purely a documentation update.
