### PR TITLE
Sort dependencies in Cargo.toml not detected by `cargo sort`

### DIFF
--- a/beacon_node/genesis/Cargo.toml
+++ b/beacon_node/genesis/Cargo.toml
@@ -9,16 +9,16 @@ eth1_test_rig = { workspace = true }
 sensitive_url = { workspace = true }
 
 [dependencies]
-futures = { workspace = true }
-types = { workspace = true }
 environment = { workspace = true }
 eth1 = { workspace = true }
-rayon = { workspace = true }
-state_processing = { workspace = true }
-merkle_proof = { workspace = true }
-ethereum_ssz = { workspace = true }
 ethereum_hashing = { workspace = true }
-tree_hash = { workspace = true }
-tokio = { workspace = true }
-slog = { workspace = true }
+ethereum_ssz = { workspace = true }
+futures = { workspace = true }
 int_to_bytes = { workspace = true }
+merkle_proof = { workspace = true }
+rayon = { workspace = true }
+slog = { workspace = true }
+state_processing = { workspace = true }
+tokio = { workspace = true }
+tree_hash = { workspace = true }
+types = { workspace = true }

--- a/beacon_node/operation_pool/Cargo.toml
+++ b/beacon_node/operation_pool/Cargo.toml
@@ -5,24 +5,24 @@ authors = ["Michael Sproul <michael@sigmaprime.io>"]
 edition = { workspace = true }
 
 [dependencies]
+bitvec = { workspace = true }
 derivative = { workspace = true }
+ethereum_ssz = { workspace = true }
+ethereum_ssz_derive = { workspace = true }
 itertools = { workspace = true }
 metrics = { workspace = true }
 parking_lot = { workspace = true }
-types = { workspace = true }
-state_processing = { workspace = true }
-ethereum_ssz = { workspace = true }
-ethereum_ssz_derive = { workspace = true }
+rand = { workspace = true }
 rayon = { workspace = true }
 serde = { workspace = true }
+state_processing = { workspace = true }
 store = { workspace = true }
-bitvec = { workspace = true }
-rand = { workspace = true }
+types = { workspace = true }
 
 [dev-dependencies]
 beacon_chain = { workspace = true }
-tokio = { workspace = true }
 maplit = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 portable = ["beacon_chain/portable"]

--- a/common/filesystem/Cargo.toml
+++ b/common/filesystem/Cargo.toml
@@ -3,7 +3,6 @@ name = "filesystem"
 version = "0.1.0"
 authors = ["Mark Mackey <mark@sigmaprime.io>"]
 edition = { workspace = true }
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/consensus/merkle_proof/Cargo.toml
+++ b/consensus/merkle_proof/Cargo.toml
@@ -7,8 +7,8 @@ edition = { workspace = true }
 [dependencies]
 alloy-primitives = { workspace = true }
 ethereum_hashing = { workspace = true }
-safe_arith = { workspace = true }
 fixed_bytes = { workspace = true }
+safe_arith = { workspace = true }
 
 [dev-dependencies]
 quickcheck = { workspace = true }

--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -10,56 +10,56 @@ harness = false
 
 [dependencies]
 alloy-primitives = { workspace = true }
-merkle_proof = { workspace = true }
-bls = { workspace = true, features = ["arbitrary"] }
-kzg = { workspace = true }
-compare_fields = { workspace = true }
-compare_fields_derive = { workspace = true }
-eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
-ethereum_hashing = { workspace = true }
-hex = { workspace = true }
-int_to_bytes = { workspace = true }
-log = { workspace = true }
-rayon = { workspace = true }
-rand = { workspace = true }
-safe_arith = { workspace = true }
-serde = { workspace = true, features = ["rc"] }
-slog = { workspace = true }
-ethereum_ssz = { workspace = true, features = ["arbitrary"] }
-ethereum_ssz_derive = { workspace = true }
-ssz_types = { workspace = true, features = ["arbitrary"] }
-swap_or_not_shuffle = { workspace = true, features = ["arbitrary"] }
-test_random_derive = { path = "../../common/test_random_derive" }
-tree_hash = { workspace = true }
-tree_hash_derive = { workspace = true }
-rand_xorshift = "0.3.0"
-serde_yaml = { workspace = true }
-tempfile = { workspace = true }
-derivative = { workspace = true }
-rusqlite = { workspace = true }
+alloy-rlp = { version = "0.3.4", features = ["derive"] }
 # The arbitrary dependency is enabled by default since Capella to avoid complexity introduced by
 # `AbstractExecPayload`
 arbitrary = { workspace = true, features = ["derive"] }
+bls = { workspace = true, features = ["arbitrary"] }
+compare_fields = { workspace = true }
+compare_fields_derive = { workspace = true }
+derivative = { workspace = true }
+eth2_interop_keypairs = { path = "../../common/eth2_interop_keypairs" }
+ethereum_hashing = { workspace = true }
 ethereum_serde_utils = { workspace = true }
-regex = { workspace = true }
-parking_lot = { workspace = true }
-itertools = { workspace = true }
-superstruct = { workspace = true }
-metastruct = "0.1.0"
-serde_json = { workspace = true }
-smallvec = { workspace = true }
-maplit = { workspace = true }
-alloy-rlp = { version = "0.3.4", features = ["derive"] }
-milhouse = { workspace = true }
-rpds = { workspace = true }
+ethereum_ssz = { workspace = true, features = ["arbitrary"] }
+ethereum_ssz_derive = { workspace = true }
 fixed_bytes = { workspace = true }
+hex = { workspace = true }
+int_to_bytes = { workspace = true }
+itertools = { workspace = true }
+kzg = { workspace = true }
+log = { workspace = true }
+maplit = { workspace = true }
+merkle_proof = { workspace = true }
+metastruct = "0.1.0"
+milhouse = { workspace = true }
+parking_lot = { workspace = true }
+rand = { workspace = true }
+rand_xorshift = "0.3.0"
+rayon = { workspace = true }
+regex = { workspace = true }
+rpds = { workspace = true }
+rusqlite = { workspace = true }
+safe_arith = { workspace = true }
+serde = { workspace = true, features = ["rc"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+slog = { workspace = true }
+smallvec = { workspace = true }
+ssz_types = { workspace = true, features = ["arbitrary"] }
+superstruct = { workspace = true }
+swap_or_not_shuffle = { workspace = true, features = ["arbitrary"] }
+tempfile = { workspace = true }
+test_random_derive = { path = "../../common/test_random_derive" }
+tree_hash = { workspace = true }
+tree_hash_derive = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 beacon_chain = { workspace = true }
+criterion = { workspace = true }
+paste = { workspace = true }
 state_processing = { workspace = true }
 tokio = { workspace = true }
-paste = { workspace = true }
 
 [features]
 default = ["sqlite", "legacy-arith"]


### PR DESCRIPTION
There seems to be some Cargo.toml not sorted alphabetically, after discussion with @macladson , it could be due to a bug in `cargo sort` . This PR sorts the Cargo.toml files that are not detected by `cargo sort` for some reasons. 