### PR TITLE
Add libssl install to udeps task

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -392,6 +392,10 @@ jobs:
           cache: false
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Fetch libssl1.1
+      run: wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+    - name: Install libssl1.1
+      run: sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
     - name: Create Cargo config dir
       run: mkdir -p .cargo
     - name: Install custom Cargo config

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -393,7 +393,7 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Fetch libssl1.1
-      run: wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
+      run: wget https://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
     - name: Install libssl1.1
       run: sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
     - name: Create Cargo config dir


### PR DESCRIPTION
I'm not really sure what happened between now and yesterday, but I do know libssl1.1 has reached EOL recently. The udeps ci task wants to access libssl1.1 for some reason, so I've added a step to install it. It's not the cleanest fix, if anyone has better ideas please let me know

Here's the original error message
`error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory`

And some informational links
https://stackoverflow.com/questions/72133316/libssl-so-1-1-cannot-open-shared-object-file-no-such-file-or-directory
https://openssl-library.org/post/2023-03-28-1.1.1-eol/