### PR TITLE
Rust 1.84 lints

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -573,7 +573,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             .start_slot(T::EthSpec::slots_per_epoch());
         let is_canonical = self
             .block_root_at_slot(block_slot, WhenSlotSkipped::None)?
-            .map_or(false, |canonical_root| block_root == &canonical_root);
+            .is_some_and(|canonical_root| block_root == &canonical_root);
         Ok(block_slot <= finalized_slot && is_canonical)
     }
 
@@ -604,7 +604,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         let slot_is_finalized = state_slot <= finalized_slot;
         let canonical = self
             .state_root_at_slot(state_slot)?
-            .map_or(false, |canonical_root| state_root == &canonical_root);
+            .is_some_and(|canonical_root| state_root == &canonical_root);
         Ok(FinalizationAndCanonicity {
             slot_is_finalized,
             canonical,
@@ -5118,9 +5118,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 .start_of(slot)
                 .unwrap_or_else(|| Duration::from_secs(0)),
         );
-        block_delays.observed.map_or(false, |delay| {
-            delay >= self.slot_clock.unagg_attestation_production_delay()
-        })
+        block_delays
+            .observed
+            .is_some_and(|delay| delay >= self.slot_clock.unagg_attestation_production_delay())
     }
 
     /// Produce a block for some `slot` upon the given `state`.

--- a/beacon_node/beacon_chain/src/canonical_head.rs
+++ b/beacon_node/beacon_chain/src/canonical_head.rs
@@ -1254,11 +1254,7 @@ pub fn find_reorg_slot<E: EthSpec>(
         ($state: ident, $block_root: ident) => {
             std::iter::once(Ok(($state.slot(), $block_root)))
                 .chain($state.rev_iter_block_roots(spec))
-                .skip_while(|result| {
-                    result
-                        .as_ref()
-                        .map_or(false, |(slot, _)| *slot > lowest_slot)
-                })
+                .skip_while(|result| result.as_ref().is_ok_and(|(slot, _)| *slot > lowest_slot))
         };
     }
 

--- a/beacon_node/beacon_chain/src/data_availability_checker.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker.rs
@@ -519,13 +519,13 @@ impl<T: BeaconChainTypes> DataAvailabilityChecker<T> {
     /// Returns true if the given epoch lies within the da boundary and false otherwise.
     pub fn da_check_required_for_epoch(&self, block_epoch: Epoch) -> bool {
         self.data_availability_boundary()
-            .map_or(false, |da_epoch| block_epoch >= da_epoch)
+            .is_some_and(|da_epoch| block_epoch >= da_epoch)
     }
 
     /// Returns `true` if the current epoch is greater than or equal to the `Deneb` epoch.
     pub fn is_deneb(&self) -> bool {
-        self.slot_clock.now().map_or(false, |slot| {
-            self.spec.deneb_fork_epoch.map_or(false, |deneb_epoch| {
+        self.slot_clock.now().is_some_and(|slot| {
+            self.spec.deneb_fork_epoch.is_some_and(|deneb_epoch| {
                 let now_epoch = slot.epoch(T::EthSpec::slots_per_epoch());
                 now_epoch >= deneb_epoch
             })

--- a/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
+++ b/beacon_node/beacon_chain/src/data_availability_checker/overflow_lru_cache.rs
@@ -228,13 +228,10 @@ impl<E: EthSpec> PendingComponents<E> {
         );
 
         let all_blobs_received = block_kzg_commitments_count_opt
-            .map_or(false, |num_expected_blobs| {
-                num_expected_blobs == num_received_blobs
-            });
+            .is_some_and(|num_expected_blobs| num_expected_blobs == num_received_blobs);
 
-        let all_columns_received = expected_columns_opt.map_or(false, |num_expected_columns| {
-            num_expected_columns == num_received_columns
-        });
+        let all_columns_received = expected_columns_opt
+            .is_some_and(|num_expected_columns| num_expected_columns == num_received_columns);
 
         all_blobs_received || all_columns_received
     }

--- a/beacon_node/beacon_chain/src/early_attester_cache.rs
+++ b/beacon_node/beacon_chain/src/early_attester_cache.rs
@@ -145,7 +145,7 @@ impl<E: EthSpec> EarlyAttesterCache<E> {
         self.item
             .read()
             .as_ref()
-            .map_or(false, |item| item.beacon_block_root == block_root)
+            .is_some_and(|item| item.beacon_block_root == block_root)
     }
 
     /// Returns the block, if `block_root` matches the cached item.

--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -153,7 +153,7 @@ fn get_sync_status<E: EthSpec>(
     // Lighthouse is "cached and ready" when it has cached enough blocks to cover the start of the
     // current voting period.
     let lighthouse_is_cached_and_ready =
-        latest_cached_block_timestamp.map_or(false, |t| t >= voting_target_timestamp);
+        latest_cached_block_timestamp.is_some_and(|t| t >= voting_target_timestamp);
 
     Some(Eth1SyncStatusData {
         head_block_number,

--- a/beacon_node/beacon_chain/src/execution_payload.rs
+++ b/beacon_node/beacon_chain/src/execution_payload.rs
@@ -127,9 +127,9 @@ impl<T: BeaconChainTypes> PayloadNotifier<T> {
 /// contains a few extra checks by running `partially_verify_execution_payload` first:
 ///
 /// https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/bellatrix/beacon-chain.md#notify_new_payload
-async fn notify_new_payload<'a, T: BeaconChainTypes>(
+async fn notify_new_payload<T: BeaconChainTypes>(
     chain: &Arc<BeaconChain<T>>,
-    block: BeaconBlockRef<'a, T::EthSpec>,
+    block: BeaconBlockRef<'_, T::EthSpec>,
 ) -> Result<PayloadVerificationStatus, BlockError> {
     let execution_layer = chain
         .execution_layer
@@ -230,9 +230,9 @@ async fn notify_new_payload<'a, T: BeaconChainTypes>(
 /// Equivalent to the `validate_merge_block` function in the merge Fork Choice Changes:
 ///
 /// https://github.com/ethereum/consensus-specs/blob/v1.1.5/specs/merge/fork-choice.md#validate_merge_block
-pub async fn validate_merge_block<'a, T: BeaconChainTypes>(
+pub async fn validate_merge_block<T: BeaconChainTypes>(
     chain: &Arc<BeaconChain<T>>,
-    block: BeaconBlockRef<'a, T::EthSpec>,
+    block: BeaconBlockRef<'_, T::EthSpec>,
     allow_optimistic_import: AllowOptimisticImport,
 ) -> Result<(), BlockError> {
     let spec = &chain.spec;

--- a/beacon_node/beacon_chain/src/graffiti_calculator.rs
+++ b/beacon_node/beacon_chain/src/graffiti_calculator.rs
@@ -293,10 +293,7 @@ mod tests {
             .await
             .unwrap();
 
-        let version_bytes = std::cmp::min(
-            lighthouse_version::VERSION.as_bytes().len(),
-            GRAFFITI_BYTES_LEN,
-        );
+        let version_bytes = std::cmp::min(lighthouse_version::VERSION.len(), GRAFFITI_BYTES_LEN);
         // grab the slice of the graffiti that corresponds to the lighthouse version
         let graffiti_slice =
             &harness.chain.graffiti_calculator.get_graffiti(None).await.0[..version_bytes];
@@ -361,7 +358,7 @@ mod tests {
 
         let graffiti_str = "nice graffiti bro";
         let mut graffiti_bytes = [0u8; GRAFFITI_BYTES_LEN];
-        graffiti_bytes[..graffiti_str.as_bytes().len()].copy_from_slice(graffiti_str.as_bytes());
+        graffiti_bytes[..graffiti_str.len()].copy_from_slice(graffiti_str.as_bytes());
 
         let found_graffiti = harness
             .chain

--- a/beacon_node/beacon_chain/src/observed_aggregates.rs
+++ b/beacon_node/beacon_chain/src/observed_aggregates.rs
@@ -293,7 +293,7 @@ impl<I> SlotHashSet<I> {
         Ok(self
             .map
             .get(&root)
-            .map_or(false, |agg| agg.iter().any(|val| item.is_subset(val))))
+            .is_some_and(|agg| agg.iter().any(|val| item.is_subset(val))))
     }
 
     /// The number of observed items in `self`.

--- a/beacon_node/beacon_chain/src/observed_attesters.rs
+++ b/beacon_node/beacon_chain/src/observed_attesters.rs
@@ -130,7 +130,7 @@ impl Item<()> for EpochBitfield {
     fn get(&self, validator_index: usize) -> Option<()> {
         self.bitfield
             .get(validator_index)
-            .map_or(false, |bit| *bit)
+            .is_some_and(|bit| *bit)
             .then_some(())
     }
 }
@@ -336,7 +336,7 @@ impl<T: Item<()>, E: EthSpec> AutoPruningEpochContainer<T, E> {
         let exists = self
             .items
             .get(&epoch)
-            .map_or(false, |item| item.get(validator_index).is_some());
+            .is_some_and(|item| item.get(validator_index).is_some());
 
         Ok(exists)
     }

--- a/beacon_node/beacon_chain/src/observed_data_sidecars.rs
+++ b/beacon_node/beacon_chain/src/observed_data_sidecars.rs
@@ -118,7 +118,7 @@ impl<T: ObservableDataSidecar> ObservedDataSidecars<T> {
                 slot: data_sidecar.slot(),
                 proposer: data_sidecar.block_proposer_index(),
             })
-            .map_or(false, |indices| indices.contains(&data_sidecar.index()));
+            .is_some_and(|indices| indices.contains(&data_sidecar.index()));
         Ok(is_known)
     }
 

--- a/beacon_node/beacon_chain/src/shuffling_cache.rs
+++ b/beacon_node/beacon_chain/src/shuffling_cache.rs
@@ -253,7 +253,7 @@ impl BlockShufflingIds {
         } else if self
             .previous
             .as_ref()
-            .map_or(false, |id| id.shuffling_epoch == epoch)
+            .is_some_and(|id| id.shuffling_epoch == epoch)
         {
             self.previous.clone()
         } else if epoch == self.next.shuffling_epoch {

--- a/beacon_node/beacon_processor/src/lib.rs
+++ b/beacon_node/beacon_processor/src/lib.rs
@@ -1022,7 +1022,7 @@ impl<E: EthSpec> BeaconProcessor<E> {
                 let can_spawn = self.current_workers < self.config.max_workers;
                 let drop_during_sync = work_event
                     .as_ref()
-                    .map_or(false, |event| event.drop_during_sync);
+                    .is_some_and(|event| event.drop_during_sync);
 
                 let idle_tx = idle_tx.clone();
                 let modified_queue_id = match work_event {

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -910,7 +910,7 @@ where
                         .forkchoice_update_parameters();
                     if params
                         .head_hash
-                        .map_or(false, |hash| hash != ExecutionBlockHash::zero())
+                        .is_some_and(|hash| hash != ExecutionBlockHash::zero())
                     {
                         // Spawn a new task to update the EE without waiting for it to complete.
                         let inner_chain = beacon_chain.clone();

--- a/beacon_node/client/src/notifier.rs
+++ b/beacon_node/client/src/notifier.rs
@@ -197,7 +197,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 );
 
                 let speed = speedo.slots_per_second();
-                let display_speed = speed.map_or(false, |speed| speed != 0.0);
+                let display_speed = speed.is_some_and(|speed| speed != 0.0);
 
                 if display_speed {
                     info!(
@@ -233,7 +233,7 @@ pub fn spawn_notifier<T: BeaconChainTypes>(
                 );
 
                 let speed = speedo.slots_per_second();
-                let display_speed = speed.map_or(false, |speed| speed != 0.0);
+                let display_speed = speed.is_some_and(|speed| speed != 0.0);
 
                 if display_speed {
                     info!(
@@ -339,9 +339,7 @@ async fn bellatrix_readiness_logging<T: BeaconChainTypes>(
         .message()
         .body()
         .execution_payload()
-        .map_or(false, |payload| {
-            payload.parent_hash() != ExecutionBlockHash::zero()
-        });
+        .is_ok_and(|payload| payload.parent_hash() != ExecutionBlockHash::zero());
 
     let has_execution_layer = beacon_chain.execution_layer.is_some();
 

--- a/beacon_node/execution_layer/src/engine_api/http.rs
+++ b/beacon_node/execution_layer/src/engine_api/http.rs
@@ -158,9 +158,7 @@ pub mod deposit_log {
             };
 
             let signature_is_valid = deposit_pubkey_signature_message(&deposit_data, spec)
-                .map_or(false, |(public_key, signature, msg)| {
-                    signature.verify(&public_key, msg)
-                });
+                .is_some_and(|(public_key, signature, msg)| signature.verify(&public_key, msg));
 
             Ok(DepositLog {
                 deposit_data,
@@ -592,7 +590,7 @@ impl<T: Clone> CachedResponse<T> {
 
     /// returns `true` if the entry's age is >= age_limit
     pub fn older_than(&self, age_limit: Option<Duration>) -> bool {
-        age_limit.map_or(false, |limit| self.age() >= limit)
+        age_limit.is_some_and(|limit| self.age() >= limit)
     }
 }
 
@@ -720,9 +718,9 @@ impl HttpJsonRpc {
         .await
     }
 
-    pub async fn get_block_by_number<'a>(
+    pub async fn get_block_by_number(
         &self,
-        query: BlockByNumberQuery<'a>,
+        query: BlockByNumberQuery<'_>,
     ) -> Result<Option<ExecutionBlock>, Error> {
         let params = json!([query, RETURN_FULL_TRANSACTION_OBJECTS]);
 

--- a/beacon_node/execution_layer/src/lib.rs
+++ b/beacon_node/execution_layer/src/lib.rs
@@ -2095,7 +2095,7 @@ fn verify_builder_bid<E: EthSpec>(
             payload: header.timestamp(),
             expected: payload_attributes.timestamp(),
         }))
-    } else if block_number.map_or(false, |n| n != header.block_number()) {
+    } else if block_number.is_some_and(|n| n != header.block_number()) {
         Err(Box::new(InvalidBuilderPayload::BlockNumber {
             payload: header.block_number(),
             expected: block_number,

--- a/beacon_node/execution_layer/src/payload_status.rs
+++ b/beacon_node/execution_layer/src/payload_status.rs
@@ -41,7 +41,7 @@ pub fn process_payload_status(
             PayloadStatusV1Status::Valid => {
                 if response
                     .latest_valid_hash
-                    .map_or(false, |h| h == head_block_hash)
+                    .is_some_and(|h| h == head_block_hash)
                 {
                     // The response is only valid if `latest_valid_hash` is not `null` and
                     // equal to the provided `block_hash`.

--- a/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
+++ b/beacon_node/execution_layer/src/test_utils/mock_execution_layer.rs
@@ -318,7 +318,7 @@ impl<E: EthSpec> MockExecutionLayer<E> {
         (self, block_hash)
     }
 
-    pub async fn with_terminal_block<'a, U, V>(self, func: U) -> Self
+    pub async fn with_terminal_block<U, V>(self, func: U) -> Self
     where
         U: Fn(ChainSpec, ExecutionLayer<E>, Option<ExecutionBlock>) -> V,
         V: Future<Output = ()>,

--- a/beacon_node/genesis/src/eth1_genesis_service.rs
+++ b/beacon_node/genesis/src/eth1_genesis_service.rs
@@ -270,7 +270,7 @@ impl Eth1GenesisService {
 
             // Ignore any block that has already been processed or update the highest processed
             // block.
-            if highest_processed_block.map_or(false, |highest| highest >= block.number) {
+            if highest_processed_block.is_some_and(|highest| highest >= block.number) {
                 continue;
             } else {
                 self.stats

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1164,7 +1164,7 @@ pub fn serve<T: BeaconChainTypes>(
                                     .map_err(warp_utils::reject::beacon_chain_error)?
                                     // Ignore any skip-slots immediately following the parent.
                                     .find(|res| {
-                                        res.as_ref().map_or(false, |(root, _)| *root != parent_root)
+                                        res.as_ref().is_ok_and(|(root, _)| *root != parent_root)
                                     })
                                     .transpose()
                                     .map_err(warp_utils::reject::beacon_chain_error)?
@@ -1249,7 +1249,7 @@ pub fn serve<T: BeaconChainTypes>(
                     let canonical = chain
                         .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
                         .map_err(warp_utils::reject::beacon_chain_error)?
-                        .map_or(false, |canonical| root == canonical);
+                        .is_some_and(|canonical| root == canonical);
 
                     let data = api_types::BlockHeaderData {
                         root,

--- a/beacon_node/http_api/src/validator.rs
+++ b/beacon_node/http_api/src/validator.rs
@@ -14,7 +14,7 @@ pub fn pubkey_to_validator_index<T: BeaconChainTypes>(
             state
                 .validators()
                 .get(index)
-                .map_or(false, |v| v.pubkey == *pubkey)
+                .is_some_and(|v| v.pubkey == *pubkey)
         })
         .map(Result::Ok)
         .transpose()

--- a/beacon_node/http_api/tests/interactive_tests.rs
+++ b/beacon_node/http_api/tests/interactive_tests.rs
@@ -161,7 +161,7 @@ impl ForkChoiceUpdates {
                 update
                     .payload_attributes
                     .as_ref()
-                    .map_or(false, |payload_attributes| {
+                    .is_some_and(|payload_attributes| {
                         payload_attributes.timestamp() == proposal_timestamp
                     })
             })

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1278,7 +1278,7 @@ impl ApiTester {
                 .chain
                 .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
                 .unwrap()
-                .map_or(false, |canonical| block_root == canonical);
+                .is_some_and(|canonical| block_root == canonical);
 
             assert_eq!(result.canonical, canonical, "{:?}", block_id);
             assert_eq!(result.root, block_root, "{:?}", block_id);

--- a/beacon_node/lighthouse_network/gossipsub/src/backoff.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/backoff.rs
@@ -124,7 +124,7 @@ impl BackoffStorage {
     pub(crate) fn is_backoff_with_slack(&self, topic: &TopicHash, peer: &PeerId) -> bool {
         self.backoffs
             .get(topic)
-            .map_or(false, |m| m.contains_key(peer))
+            .is_some_and(|m| m.contains_key(peer))
     }
 
     pub(crate) fn get_backoff_time(&self, topic: &TopicHash, peer: &PeerId) -> Option<Instant> {

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs
@@ -1770,8 +1770,7 @@ where
         // reject messages claiming to be from ourselves but not locally published
         let self_published = !self.config.allow_self_origin()
             && if let Some(own_id) = self.publish_config.get_own_id() {
-                own_id != propagation_source
-                    && raw_message.source.as_ref().map_or(false, |s| s == own_id)
+                own_id != propagation_source && raw_message.source.as_ref() == Some(own_id)
             } else {
                 self.published_message_ids.contains(msg_id)
             };

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -166,7 +166,7 @@ impl Config {
             tcp_port,
         });
         self.discv5_config.listen_config = discv5::ListenConfig::from_ip(addr.into(), disc_port);
-        self.discv5_config.table_filter = |enr| enr.ip4().as_ref().map_or(false, is_global_ipv4)
+        self.discv5_config.table_filter = |enr| enr.ip4().as_ref().is_some_and(is_global_ipv4)
     }
 
     /// Sets the listening address to use an ipv6 address. The discv5 ip_mode and table filter is
@@ -187,7 +187,7 @@ impl Config {
         });
 
         self.discv5_config.listen_config = discv5::ListenConfig::from_ip(addr.into(), disc_port);
-        self.discv5_config.table_filter = |enr| enr.ip6().as_ref().map_or(false, is_global_ipv6)
+        self.discv5_config.table_filter = |enr| enr.ip6().as_ref().is_some_and(is_global_ipv6)
     }
 
     /// Sets the listening address to use both an ipv4 and ipv6 address. The discv5 ip_mode and
@@ -317,7 +317,7 @@ impl Default for Config {
             .filter_rate_limiter(filter_rate_limiter)
             .filter_max_bans_per_ip(Some(5))
             .filter_max_nodes_per_ip(Some(10))
-            .table_filter(|enr| enr.ip4().map_or(false, |ip| is_global_ipv4(&ip))) // Filter non-global IPs
+            .table_filter(|enr| enr.ip4().is_some_and(|ip| is_global_ipv4(&ip))) // Filter non-global IPs
             .ban_duration(Some(Duration::from_secs(3600)))
             .ping_interval(Duration::from_secs(300))
             .build();

--- a/beacon_node/lighthouse_network/src/discovery/subnet_predicate.rs
+++ b/beacon_node/lighthouse_network/src/discovery/subnet_predicate.rs
@@ -35,7 +35,7 @@ where
                 .unwrap_or(false),
             Subnet::SyncCommittee(s) => sync_committee_bitfield
                 .as_ref()
-                .map_or(false, |b| b.get(*s.deref() as usize).unwrap_or(false)),
+                .is_ok_and(|b| b.get(*s.deref() as usize).unwrap_or(false)),
             Subnet::DataColumn(s) => {
                 if let Ok(custody_subnet_count) = enr.custody_subnet_count::<E>(&spec) {
                     DataColumnSubnetId::compute_custody_subnets::<E>(
@@ -43,7 +43,7 @@ where
                         custody_subnet_count,
                         &spec,
                     )
-                    .map_or(false, |mut subnets| subnets.contains(s))
+                    .is_ok_and(|mut subnets| subnets.contains(s))
                 } else {
                     false
                 }

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb.rs
@@ -1305,7 +1305,7 @@ impl BannedPeersCount {
     pub fn ip_is_banned(&self, ip: &IpAddr) -> bool {
         self.banned_peers_per_ip
             .get(ip)
-            .map_or(false, |count| *count > BANNED_PEERS_PER_IP_THRESHOLD)
+            .is_some_and(|count| *count > BANNED_PEERS_PER_IP_THRESHOLD)
     }
 }
 

--- a/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/peerdb/peer_info.rs
@@ -99,7 +99,7 @@ impl<E: EthSpec> PeerInfo<E> {
                 Subnet::SyncCommittee(id) => {
                     return meta_data
                         .syncnets()
-                        .map_or(false, |s| s.get(**id as usize).unwrap_or(false))
+                        .is_ok_and(|s| s.get(**id as usize).unwrap_or(false))
                 }
                 Subnet::DataColumn(column) => return self.custody_subnets.contains(column),
             }
@@ -264,7 +264,7 @@ impl<E: EthSpec> PeerInfo<E> {
 
     /// Reports if this peer has some future validator duty in which case it is valuable to keep it.
     pub fn has_future_duty(&self) -> bool {
-        self.min_ttl.map_or(false, |i| i >= Instant::now())
+        self.min_ttl.is_some_and(|i| i >= Instant::now())
     }
 
     /// Returns score of the peer.

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -3129,7 +3129,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .chain
             .slot_clock
             .now()
-            .map_or(false, |current_slot| sync_message_slot == current_slot);
+            .is_some_and(|current_slot| sync_message_slot == current_slot);
 
         self.propagate_if_timely(is_timely, message_id, peer_id)
     }

--- a/beacon_node/operation_pool/src/lib.rs
+++ b/beacon_node/operation_pool/src/lib.rs
@@ -186,7 +186,7 @@ impl<E: EthSpec> OperationPool<E> {
         self.sync_contributions.write().retain(|_, contributions| {
             // All the contributions in this bucket have the same data, so we only need to
             // check the first one.
-            contributions.first().map_or(false, |contribution| {
+            contributions.first().is_some_and(|contribution| {
                 current_slot <= contribution.slot.saturating_add(Slot::new(1))
             })
         });
@@ -401,7 +401,7 @@ impl<E: EthSpec> OperationPool<E> {
                     && state
                         .validators()
                         .get(slashing.as_inner().signed_header_1.message.proposer_index as usize)
-                        .map_or(false, |validator| !validator.slashed)
+                        .is_some_and(|validator| !validator.slashed)
             },
             |slashing| slashing.as_inner().clone(),
             E::MaxProposerSlashings::to_usize(),
@@ -484,7 +484,7 @@ impl<E: EthSpec> OperationPool<E> {
                     validator.exit_epoch > head_state.finalized_checkpoint().epoch
                 },
             )
-            .map_or(false, |indices| !indices.is_empty());
+            .is_ok_and(|indices| !indices.is_empty());
 
             signature_ok && slashing_ok
         });
@@ -583,9 +583,7 @@ impl<E: EthSpec> OperationPool<E> {
                 address_change.signature_is_still_valid(&state.fork())
                     && state
                         .get_validator(address_change.as_inner().message.validator_index as usize)
-                        .map_or(false, |validator| {
-                            !validator.has_execution_withdrawal_credential(spec)
-                        })
+                        .is_ok_and(|validator| !validator.has_execution_withdrawal_credential(spec))
             },
             |address_change| address_change.as_inner().clone(),
             E::MaxBlsToExecutionChanges::to_usize(),
@@ -609,9 +607,7 @@ impl<E: EthSpec> OperationPool<E> {
                 address_change.signature_is_still_valid(&state.fork())
                     && state
                         .get_validator(address_change.as_inner().message.validator_index as usize)
-                        .map_or(false, |validator| {
-                            !validator.has_eth1_withdrawal_credential(spec)
-                        })
+                        .is_ok_and(|validator| !validator.has_eth1_withdrawal_credential(spec))
             },
             |address_change| address_change.as_inner().clone(),
             usize::MAX,

--- a/beacon_node/store/src/forwards_iter.rs
+++ b/beacon_node/store/src/forwards_iter.rs
@@ -265,7 +265,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
                 // `end_slot`. If it tries to continue further a `NoContinuationData` error will be
                 // returned.
                 let continuation_data =
-                    if end_slot.map_or(false, |end_slot| end_slot < freezer_upper_bound) {
+                    if end_slot.is_some_and(|end_slot| end_slot < freezer_upper_bound) {
                         None
                     } else {
                         Some(Box::new(get_state()?))
@@ -306,7 +306,7 @@ impl<'a, E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>>
                     None => {
                         // If the iterator has an end slot (inclusive) which has already been
                         // covered by the (exclusive) frozen forwards iterator, then we're done!
-                        if end_slot.map_or(false, |end_slot| iter.end_slot == end_slot + 1) {
+                        if end_slot.is_some_and(|end_slot| iter.end_slot == end_slot + 1) {
                             *self = Finished;
                             return Ok(None);
                         }

--- a/beacon_node/store/src/reconstruct.rs
+++ b/beacon_node/store/src/reconstruct.rs
@@ -111,7 +111,7 @@ where
                 self.store_cold_state(&state_root, &state, &mut io_batch)?;
 
                 let batch_complete =
-                    num_blocks.map_or(false, |n_blocks| slot == lower_limit_slot + n_blocks as u64);
+                    num_blocks.is_some_and(|n_blocks| slot == lower_limit_slot + n_blocks as u64);
                 let reconstruction_complete = slot + 1 == upper_limit_slot;
 
                 // Commit the I/O batch if:

--- a/beacon_node/store/src/state_cache.rs
+++ b/beacon_node/store/src/state_cache.rs
@@ -77,9 +77,7 @@ impl<E: EthSpec> StateCache<E> {
         if self
             .finalized_state
             .as_ref()
-            .map_or(false, |finalized_state| {
-                state.slot() < finalized_state.state.slot()
-            })
+            .is_some_and(|finalized_state| state.slot() < finalized_state.state.slot())
         {
             return Err(Error::FinalizedStateDecreasingSlot);
         }
@@ -127,9 +125,7 @@ impl<E: EthSpec> StateCache<E> {
         if self
             .finalized_state
             .as_ref()
-            .map_or(false, |finalized_state| {
-                finalized_state.state_root == state_root
-            })
+            .is_some_and(|finalized_state| finalized_state.state_root == state_root)
         {
             return Ok(PutStateOutcome::Finalized);
         }

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -435,7 +435,7 @@ pub fn recursively_find_voting_keystores<P: AsRef<Path>>(
             && dir_entry
                 .file_name()
                 .to_str()
-                .map_or(false, is_voting_keystore)
+                .is_some_and(is_voting_keystore)
         {
             matches.push(dir_entry.path())
         }

--- a/common/logging/src/lib.rs
+++ b/common/logging/src/lib.rs
@@ -204,7 +204,7 @@ impl TimeLatch {
     pub fn elapsed(&mut self) -> bool {
         let now = Instant::now();
 
-        let is_elapsed = self.0.map_or(false, |elapse_time| now > elapse_time);
+        let is_elapsed = self.0.is_some_and(|elapse_time| now > elapse_time);
 
         if is_elapsed || self.0.is_none() {
             self.0 = Some(now + LOG_DEBOUNCE_INTERVAL);

--- a/consensus/proto_array/src/proto_array.rs
+++ b/consensus/proto_array/src/proto_array.rs
@@ -468,7 +468,7 @@ impl ProtoArray {
         // 1. The `head_block_root` is a descendant of `latest_valid_ancestor_hash`
         // 2. The `latest_valid_ancestor_hash` is equal to or a descendant of the finalized block.
         let latest_valid_ancestor_is_descendant =
-            latest_valid_ancestor_root.map_or(false, |ancestor_root| {
+            latest_valid_ancestor_root.is_some_and(|ancestor_root| {
                 self.is_descendant(ancestor_root, head_block_root)
                     && self.is_finalized_checkpoint_or_descendant::<E>(ancestor_root)
             });
@@ -505,13 +505,13 @@ impl ProtoArray {
                         // head.
                         if node
                             .best_child
-                            .map_or(false, |i| invalidated_indices.contains(&i))
+                            .is_some_and(|i| invalidated_indices.contains(&i))
                         {
                             node.best_child = None
                         }
                         if node
                             .best_descendant
-                            .map_or(false, |i| invalidated_indices.contains(&i))
+                            .is_some_and(|i| invalidated_indices.contains(&i))
                         {
                             node.best_descendant = None
                         }
@@ -999,7 +999,7 @@ impl ProtoArray {
             node.unrealized_finalized_checkpoint,
             node.unrealized_justified_checkpoint,
         ] {
-            if checkpoint.map_or(false, |cp| cp == self.finalized_checkpoint) {
+            if checkpoint.is_some_and(|cp| cp == self.finalized_checkpoint) {
                 return true;
             }
         }
@@ -1037,7 +1037,7 @@ impl ProtoArray {
             .find(|node| {
                 node.execution_status
                     .block_hash()
-                    .map_or(false, |node_block_hash| node_block_hash == *block_hash)
+                    .is_some_and(|node_block_hash| node_block_hash == *block_hash)
             })
             .map(|node| node.root)
     }

--- a/consensus/state_processing/src/genesis.rs
+++ b/consensus/state_processing/src/genesis.rs
@@ -53,7 +53,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     // https://github.com/ethereum/eth2.0-specs/pull/2323
     if spec
         .altair_fork_epoch
-        .map_or(false, |fork_epoch| fork_epoch == E::genesis_epoch())
+        .is_some_and(|fork_epoch| fork_epoch == E::genesis_epoch())
     {
         upgrade_to_altair(&mut state, spec)?;
 
@@ -63,7 +63,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     // Similarly, perform an upgrade to the merge if configured from genesis.
     if spec
         .bellatrix_fork_epoch
-        .map_or(false, |fork_epoch| fork_epoch == E::genesis_epoch())
+        .is_some_and(|fork_epoch| fork_epoch == E::genesis_epoch())
     {
         // this will set state.latest_execution_payload_header = ExecutionPayloadHeaderBellatrix::default()
         upgrade_to_bellatrix(&mut state, spec)?;
@@ -81,7 +81,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     // Upgrade to capella if configured from genesis
     if spec
         .capella_fork_epoch
-        .map_or(false, |fork_epoch| fork_epoch == E::genesis_epoch())
+        .is_some_and(|fork_epoch| fork_epoch == E::genesis_epoch())
     {
         upgrade_to_capella(&mut state, spec)?;
 
@@ -98,7 +98,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     // Upgrade to deneb if configured from genesis
     if spec
         .deneb_fork_epoch
-        .map_or(false, |fork_epoch| fork_epoch == E::genesis_epoch())
+        .is_some_and(|fork_epoch| fork_epoch == E::genesis_epoch())
     {
         upgrade_to_deneb(&mut state, spec)?;
 
@@ -115,7 +115,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
     // Upgrade to electra if configured from genesis.
     if spec
         .electra_fork_epoch
-        .map_or(false, |fork_epoch| fork_epoch == E::genesis_epoch())
+        .is_some_and(|fork_epoch| fork_epoch == E::genesis_epoch())
     {
         let post = upgrade_state_to_electra(&mut state, Epoch::new(0), Epoch::new(0), spec)?;
         state = post;
@@ -153,7 +153,7 @@ pub fn initialize_beacon_state_from_eth1<E: EthSpec>(
 pub fn is_valid_genesis_state<E: EthSpec>(state: &BeaconState<E>, spec: &ChainSpec) -> bool {
     state
         .get_active_validator_indices(E::genesis_epoch(), spec)
-        .map_or(false, |active_validators| {
+        .is_ok_and(|active_validators| {
             state.genesis_time() >= spec.min_genesis_time
                 && active_validators.len() as u64 >= spec.min_genesis_active_validator_count
         })

--- a/consensus/state_processing/src/per_block_processing/altair/sync_committee.rs
+++ b/consensus/state_processing/src/per_block_processing/altair/sync_committee.rs
@@ -38,7 +38,7 @@ pub fn process_sync_aggregate<E: EthSpec>(
         )?;
 
         // If signature set is `None` then the signature is valid (infinity).
-        if signature_set.map_or(false, |signature| !signature.verify()) {
+        if signature_set.is_some_and(|signature| !signature.verify()) {
             return Err(SyncAggregateInvalid::SignatureInvalid.into());
         }
     }

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -151,7 +151,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_active_in_current_epoch && !s.is_slashed),
+                .is_some_and(|s| s.is_active_in_current_epoch && !s.is_slashed),
             EpochProcessingSummary::Altair { participation, .. } => {
                 participation.is_active_and_unslashed(val_index, participation.current_epoch)
             }
@@ -176,7 +176,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => Ok(statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_current_epoch_target_attester)),
+                .is_some_and(|s| s.is_current_epoch_target_attester)),
             EpochProcessingSummary::Altair { participation, .. } => participation
                 .is_current_epoch_unslashed_participating_index(
                     val_index,
@@ -247,7 +247,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_active_in_previous_epoch && !s.is_slashed),
+                .is_some_and(|s| s.is_active_in_previous_epoch && !s.is_slashed),
             EpochProcessingSummary::Altair { participation, .. } => {
                 participation.is_active_and_unslashed(val_index, participation.previous_epoch)
             }
@@ -267,7 +267,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => Ok(statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_previous_epoch_target_attester)),
+                .is_some_and(|s| s.is_previous_epoch_target_attester)),
             EpochProcessingSummary::Altair { participation, .. } => participation
                 .is_previous_epoch_unslashed_participating_index(
                     val_index,
@@ -294,7 +294,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => Ok(statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_previous_epoch_head_attester)),
+                .is_some_and(|s| s.is_previous_epoch_head_attester)),
             EpochProcessingSummary::Altair { participation, .. } => participation
                 .is_previous_epoch_unslashed_participating_index(val_index, TIMELY_HEAD_FLAG_INDEX),
         }
@@ -318,7 +318,7 @@ impl<E: EthSpec> EpochProcessingSummary<E> {
         match self {
             EpochProcessingSummary::Base { statuses, .. } => Ok(statuses
                 .get(val_index)
-                .map_or(false, |s| s.is_previous_epoch_attester)),
+                .is_some_and(|s| s.is_previous_epoch_attester)),
             EpochProcessingSummary::Altair { participation, .. } => participation
                 .is_previous_epoch_unslashed_participating_index(
                     val_index,

--- a/consensus/types/src/beacon_block_body.rs
+++ b/consensus/types/src/beacon_block_body.rs
@@ -283,7 +283,7 @@ impl<'a, E: EthSpec, Payload: AbstractExecPayload<E>> BeaconBlockBodyRef<'a, E, 
     /// Return `true` if this block body has a non-zero number of blobs.
     pub fn has_blobs(self) -> bool {
         self.blob_kzg_commitments()
-            .map_or(false, |blobs| !blobs.is_empty())
+            .is_ok_and(|blobs| !blobs.is_empty())
     }
 
     pub fn attestations_len(&self) -> usize {

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -1856,7 +1856,7 @@ impl<E: EthSpec> BeaconState<E> {
     pub fn committee_cache_is_initialized(&self, relative_epoch: RelativeEpoch) -> bool {
         let i = Self::committee_cache_index(relative_epoch);
 
-        self.committee_cache_at_index(i).map_or(false, |cache| {
+        self.committee_cache_at_index(i).is_ok_and(|cache| {
             cache.is_initialized_at(relative_epoch.into_epoch(self.current_epoch()))
         })
     }

--- a/consensus/types/src/beacon_state/progressive_balances_cache.rs
+++ b/consensus/types/src/beacon_state/progressive_balances_cache.rs
@@ -145,7 +145,7 @@ impl ProgressiveBalancesCache {
     pub fn is_initialized_at(&self, epoch: Epoch) -> bool {
         self.inner
             .as_ref()
-            .map_or(false, |inner| inner.current_epoch == epoch)
+            .is_some_and(|inner| inner.current_epoch == epoch)
     }
 
     /// When a new target attestation has been processed, we update the cached

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -420,14 +420,13 @@ impl ChainSpec {
 
     /// Returns true if the given epoch is greater than or equal to the `EIP7594_FORK_EPOCH`.
     pub fn is_peer_das_enabled_for_epoch(&self, block_epoch: Epoch) -> bool {
-        self.eip7594_fork_epoch.map_or(false, |eip7594_fork_epoch| {
-            block_epoch >= eip7594_fork_epoch
-        })
+        self.eip7594_fork_epoch
+            .is_some_and(|eip7594_fork_epoch| block_epoch >= eip7594_fork_epoch)
     }
 
     /// Returns true if `EIP7594_FORK_EPOCH` is set and is not set to `FAR_FUTURE_EPOCH`.
     pub fn is_peer_das_scheduled(&self) -> bool {
-        self.eip7594_fork_epoch.map_or(false, |eip7594_fork_epoch| {
+        self.eip7594_fork_epoch.is_some_and(|eip7594_fork_epoch| {
             eip7594_fork_epoch != self.far_future_epoch
         })
     }

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -426,9 +426,8 @@ impl ChainSpec {
 
     /// Returns true if `EIP7594_FORK_EPOCH` is set and is not set to `FAR_FUTURE_EPOCH`.
     pub fn is_peer_das_scheduled(&self) -> bool {
-        self.eip7594_fork_epoch.is_some_and(|eip7594_fork_epoch| {
-            eip7594_fork_epoch != self.far_future_epoch
-        })
+        self.eip7594_fork_epoch
+            .is_some_and(|eip7594_fork_epoch| eip7594_fork_epoch != self.far_future_epoch)
     }
 
     /// Returns a full `Fork` struct for a given epoch.

--- a/consensus/types/src/deposit_tree_snapshot.rs
+++ b/consensus/types/src/deposit_tree_snapshot.rs
@@ -72,8 +72,7 @@ impl DepositTreeSnapshot {
         Some(Hash256::from_slice(&deposit_root))
     }
     pub fn is_valid(&self) -> bool {
-        self.calculate_root()
-            .map_or(false, |calculated| self.deposit_root == calculated)
+        self.calculate_root() == Some(self.deposit_root)
     }
 }
 

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -57,6 +57,7 @@ impl FromStr for GraffitiString {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::needless_as_bytes)]
         if s.as_bytes().len() > GRAFFITI_BYTES_LEN {
             return Err(format!(
                 "Graffiti exceeds max length {}",

--- a/consensus/types/src/graffiti.rs
+++ b/consensus/types/src/graffiti.rs
@@ -57,8 +57,7 @@ impl FromStr for GraffitiString {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        #[allow(clippy::needless_as_bytes)]
-        if s.as_bytes().len() > GRAFFITI_BYTES_LEN {
+        if s.len() > GRAFFITI_BYTES_LEN {
             return Err(format!(
                 "Graffiti exceeds max length {}",
                 GRAFFITI_BYTES_LEN

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -223,7 +223,7 @@ pub fn run<E: EthSpec>(
             .update_tree_hash_cache()
             .map_err(|e| format!("Unable to build THC: {:?}", e))?;
 
-        if state_root_opt.map_or(false, |expected| expected != state_root) {
+        if state_root_opt.is_some_and(|expected| expected != state_root) {
             return Err(format!(
                 "State root mismatch! Expected {}, computed {}",
                 state_root_opt.unwrap(),
@@ -331,7 +331,7 @@ fn do_transition<E: EthSpec>(
             .map_err(|e| format!("Unable to build tree hash cache: {:?}", e))?;
         debug!("Initial tree hash: {:?}", t.elapsed());
 
-        if state_root_opt.map_or(false, |expected| expected != state_root) {
+        if state_root_opt.is_some_and(|expected| expected != state_root) {
             return Err(format!(
                 "State root mismatch! Expected {}, computed {}",
                 state_root_opt.unwrap(),

--- a/slasher/src/database.rs
+++ b/slasher/src/database.rs
@@ -406,7 +406,7 @@ impl<E: EthSpec> SlasherDB<E> {
     ) -> Result<(), Error> {
         // Don't update maximum if new target is less than or equal to previous. In the case of
         // no previous we *do* want to update.
-        if previous_max_target.map_or(false, |prev_max| max_target <= prev_max) {
+        if previous_max_target.is_some_and(|prev_max| max_target <= prev_max) {
             return Ok(());
         }
 

--- a/testing/ef_tests/src/cases/fork_choice.rs
+++ b/testing/ef_tests/src/cases/fork_choice.rs
@@ -523,7 +523,7 @@ impl<E: EthSpec> Tester<E> {
                 || Ok(()),
             ))?
             .map(|avail: AvailabilityProcessingStatus| avail.try_into());
-        let success = blob_success && result.as_ref().map_or(false, |inner| inner.is_ok());
+        let success = blob_success && result.as_ref().is_ok_and(|inner| inner.is_ok());
         if success != valid {
             return Err(Error::DidntFail(format!(
                 "block with root {} was valid={} whilst test expects valid={}. result: {:?}",

--- a/testing/ef_tests/src/cases/operations.rs
+++ b/testing/ef_tests/src/cases/operations.rs
@@ -322,7 +322,7 @@ impl<E: EthSpec> Operation<E> for BeaconBlockBody<E, FullPayload<E>> {
         let valid = extra
             .execution_metadata
             .as_ref()
-            .map_or(false, |e| e.execution_valid);
+            .is_some_and(|e| e.execution_valid);
         if valid {
             process_execution_payload::<E, FullPayload<E>>(state, self.to_ref(), spec)
         } else {
@@ -377,7 +377,7 @@ impl<E: EthSpec> Operation<E> for BeaconBlockBody<E, BlindedPayload<E>> {
         let valid = extra
             .execution_metadata
             .as_ref()
-            .map_or(false, |e| e.execution_valid);
+            .is_some_and(|e| e.execution_valid);
         if valid {
             process_execution_payload::<E, BlindedPayload<E>>(state, self.to_ref(), spec)
         } else {

--- a/testing/ef_tests/src/decode.rs
+++ b/testing/ef_tests/src/decode.rs
@@ -28,7 +28,7 @@ pub fn log_file_access<P: AsRef<Path>>(file_accessed: P) {
 
     writeln!(&mut file, "{:?}", file_accessed.as_ref()).expect("should write to file");
 
-    file.unlock().expect("unable to unlock file");
+    fs2::FileExt::unlock(&file).expect("unable to unlock file");
 }
 
 pub fn yaml_decode<T: serde::de::DeserializeOwned>(string: &str) -> Result<T, Error> {

--- a/validator_client/doppelganger_service/src/lib.rs
+++ b/validator_client/doppelganger_service/src/lib.rs
@@ -162,7 +162,7 @@ impl DoppelgangerState {
 /// If the BN fails to respond to either of these requests, simply return an empty response.
 /// This behaviour is to help prevent spurious failures on the BN from needlessly preventing
 /// doppelganger progression.
-async fn beacon_node_liveness<'a, T: 'static + SlotClock, E: EthSpec>(
+async fn beacon_node_liveness<T: 'static + SlotClock, E: EthSpec>(
     beacon_nodes: Arc<BeaconNodeFallback<T, E>>,
     log: Logger,
     current_epoch: Epoch,

--- a/validator_client/slashing_protection/src/slashing_database.rs
+++ b/validator_client/slashing_protection/src/slashing_database.rs
@@ -1113,9 +1113,7 @@ fn max_or<T: Copy + Ord>(opt_x: Option<T>, y: T) -> T {
 ///
 /// If prev is `None` and `new` is `Some` then `true` is returned.
 fn monotonic<T: PartialOrd>(new: Option<T>, prev: Option<T>) -> bool {
-    new.map_or(false, |new_val| {
-        prev.map_or(true, |prev_val| new_val >= prev_val)
-    })
+    new.is_some_and(|new_val| prev.map_or(true, |prev_val| new_val >= prev_val))
 }
 
 /// The result of importing a single entry from an interchange file.

--- a/validator_client/validator_services/src/preparation_service.rs
+++ b/validator_client/validator_services/src/preparation_service.rs
@@ -258,7 +258,7 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
             .slot_clock
             .now()
             .map_or(E::genesis_epoch(), |slot| slot.epoch(E::slots_per_epoch()));
-        spec.bellatrix_fork_epoch.map_or(false, |fork_epoch| {
+        spec.bellatrix_fork_epoch.is_some_and(|fork_epoch| {
             current_epoch + PROPOSER_PREPARATION_LOOKAHEAD_EPOCHS >= fork_epoch
         })
     }

--- a/validator_client/validator_services/src/sync.rs
+++ b/validator_client/validator_services/src/sync.rs
@@ -94,7 +94,7 @@ impl<E: EthSpec> SyncDutiesMap<E> {
         self.committees
             .read()
             .get(&committee_period)
-            .map_or(false, |committee_duties| {
+            .is_some_and(|committee_duties| {
                 let validator_duties = committee_duties.validators.read();
                 validator_indices
                     .iter()

--- a/validator_manager/src/create_validators.rs
+++ b/validator_manager/src/create_validators.rs
@@ -286,7 +286,7 @@ struct ValidatorsAndDeposits {
 }
 
 impl ValidatorsAndDeposits {
-    async fn new<'a, E: EthSpec>(config: CreateConfig, spec: &ChainSpec) -> Result<Self, String> {
+    async fn new<E: EthSpec>(config: CreateConfig, spec: &ChainSpec) -> Result<Self, String> {
         let CreateConfig {
             // The output path is handled upstream.
             output_path: _,
@@ -545,7 +545,7 @@ pub async fn cli_run<E: EthSpec>(
     }
 }
 
-async fn run<'a, E: EthSpec>(config: CreateConfig, spec: &ChainSpec) -> Result<(), String> {
+async fn run<E: EthSpec>(config: CreateConfig, spec: &ChainSpec) -> Result<(), String> {
     let output_path = config.output_path.clone();
 
     if !output_path.exists() {

--- a/validator_manager/src/delete_validators.rs
+++ b/validator_manager/src/delete_validators.rs
@@ -86,7 +86,7 @@ pub async fn cli_run(matches: &ArgMatches, dump_config: DumpConfig) -> Result<()
     }
 }
 
-async fn run<'a>(config: DeleteConfig) -> Result<(), String> {
+async fn run(config: DeleteConfig) -> Result<(), String> {
     let DeleteConfig {
         vc_url,
         vc_token_path,

--- a/validator_manager/src/import_validators.rs
+++ b/validator_manager/src/import_validators.rs
@@ -209,7 +209,7 @@ pub async fn cli_run(matches: &ArgMatches, dump_config: DumpConfig) -> Result<()
     }
 }
 
-async fn run<'a>(config: ImportConfig) -> Result<(), String> {
+async fn run(config: ImportConfig) -> Result<(), String> {
     let ImportConfig {
         validators_file_path,
         keystore_file_path,

--- a/validator_manager/src/list_validators.rs
+++ b/validator_manager/src/list_validators.rs
@@ -58,7 +58,7 @@ pub async fn cli_run(matches: &ArgMatches, dump_config: DumpConfig) -> Result<()
     }
 }
 
-async fn run<'a>(config: ListConfig) -> Result<Vec<SingleKeystoreResponse>, String> {
+async fn run(config: ListConfig) -> Result<Vec<SingleKeystoreResponse>, String> {
     let ListConfig {
         vc_url,
         vc_token_path,

--- a/validator_manager/src/move_validators.rs
+++ b/validator_manager/src/move_validators.rs
@@ -277,7 +277,7 @@ pub async fn cli_run(matches: &ArgMatches, dump_config: DumpConfig) -> Result<()
     }
 }
 
-async fn run<'a>(config: MoveConfig) -> Result<(), String> {
+async fn run(config: MoveConfig) -> Result<(), String> {
     let MoveConfig {
         src_vc_url,
         src_vc_token_path,


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Fix all lints from rust 1.84.

- The majority of the fixes are moving from `.map_or(false..` to `is_ok_and../is_some_and..` [unnecessay_map_or](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or)
- Removed some unneeded lifetimes from [extra_unused_lifetimes](https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes)
- .len() on a `&str` returns the number of bytes anyway so we were using as_bytes() unnecesssarily [needless_as_bytes](https://rust-lang.github.io/rust-clippy/master/index.html#needless_as_bytes
)