### PR TITLE
Remove ineffectual block RPC limits post merge

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -17,12 +17,11 @@ use tokio_util::{
     compat::{Compat, FuturesAsyncReadCompatExt},
 };
 use types::{
-    BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BeaconBlockCapella, BeaconBlockElectra,
-    BeaconBlockFulu, BlobSidecar, ChainSpec, DataColumnSidecar, EmptyBlock, EthSpec, EthSpecId,
-    ForkContext, ForkName, LightClientBootstrap, LightClientBootstrapAltair,
-    LightClientFinalityUpdate, LightClientFinalityUpdateAltair, LightClientOptimisticUpdate,
-    LightClientOptimisticUpdateAltair, LightClientUpdate, MainnetEthSpec, MinimalEthSpec,
-    Signature, SignedBeaconBlock,
+    BeaconBlock, BeaconBlockAltair, BeaconBlockBase, BlobSidecar, ChainSpec, DataColumnSidecar,
+    EmptyBlock, EthSpec, EthSpecId, ForkContext, ForkName, LightClientBootstrap,
+    LightClientBootstrapAltair, LightClientFinalityUpdate, LightClientFinalityUpdateAltair,
+    LightClientOptimisticUpdate, LightClientOptimisticUpdateAltair, LightClientUpdate,
+    MainnetEthSpec, MinimalEthSpec, Signature, SignedBeaconBlock,
 };
 
 // Note: Hardcoding the `EthSpec` type for `SignedBeaconBlock` as min/max values is
@@ -55,33 +54,6 @@ pub static SIGNED_BEACON_BLOCK_ALTAIR_MAX: LazyLock<usize> = LazyLock::new(|| {
     .len()
 });
 
-pub static SIGNED_BEACON_BLOCK_CAPELLA_MAX_WITHOUT_PAYLOAD: LazyLock<usize> = LazyLock::new(|| {
-    SignedBeaconBlock::<MainnetEthSpec>::from_block(
-        BeaconBlock::Capella(BeaconBlockCapella::full(&MainnetEthSpec::default_spec())),
-        Signature::empty(),
-    )
-    .as_ssz_bytes()
-    .len()
-});
-
-pub static SIGNED_BEACON_BLOCK_ELECTRA_MAX_WITHOUT_PAYLOAD: LazyLock<usize> = LazyLock::new(|| {
-    SignedBeaconBlock::<MainnetEthSpec>::from_block(
-        BeaconBlock::Electra(BeaconBlockElectra::full(&MainnetEthSpec::default_spec())),
-        Signature::empty(),
-    )
-    .as_ssz_bytes()
-    .len()
-});
-
-pub static SIGNED_BEACON_BLOCK_FULU_MAX_WITHOUT_PAYLOAD: LazyLock<usize> = LazyLock::new(|| {
-    SignedBeaconBlock::<MainnetEthSpec>::from_block(
-        BeaconBlock::Fulu(BeaconBlockFulu::full(&MainnetEthSpec::default_spec())),
-        Signature::empty(),
-    )
-    .as_ssz_bytes()
-    .len()
-});
-
 /// The `BeaconBlockBellatrix` block has an `ExecutionPayload` field which has a max size ~16 GiB for future proofing.
 /// We calculate the value from its fields instead of constructing the block and checking the length.
 /// Note: This is only the theoretical upper bound. We further bound the max size we receive over the network
@@ -95,33 +67,6 @@ pub static SIGNED_BEACON_BLOCK_BELLATRIX_MAX: LazyLock<usize> =
     *SIGNED_BEACON_BLOCK_ALTAIR_MAX
     + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_bellatrix_size() // adding max size of execution payload (~16gb)
     + ssz::BYTES_PER_LENGTH_OFFSET); // Adding the additional ssz offset for the `ExecutionPayload` field
-
-pub static SIGNED_BEACON_BLOCK_CAPELLA_MAX: LazyLock<usize> = LazyLock::new(|| {
-    *SIGNED_BEACON_BLOCK_CAPELLA_MAX_WITHOUT_PAYLOAD
-    + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_capella_size() // adding max size of execution payload (~16gb)
-    + ssz::BYTES_PER_LENGTH_OFFSET
-}); // Adding the additional ssz offset for the `ExecutionPayload` field
-
-pub static SIGNED_BEACON_BLOCK_DENEB_MAX: LazyLock<usize> = LazyLock::new(|| {
-    *SIGNED_BEACON_BLOCK_CAPELLA_MAX_WITHOUT_PAYLOAD
-    + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_deneb_size() // adding max size of execution payload (~16gb)
-    + ssz::BYTES_PER_LENGTH_OFFSET // Adding the additional offsets for the `ExecutionPayload`
-    + ssz::BYTES_PER_LENGTH_OFFSET
-}); // Length offset for the blob commitments field.
-    //
-pub static SIGNED_BEACON_BLOCK_ELECTRA_MAX: LazyLock<usize> = LazyLock::new(|| {
-    *SIGNED_BEACON_BLOCK_ELECTRA_MAX_WITHOUT_PAYLOAD
-    + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_electra_size() // adding max size of execution payload (~16gb)
-    + ssz::BYTES_PER_LENGTH_OFFSET // Adding the additional ssz offset for the `ExecutionPayload` field
-    + ssz::BYTES_PER_LENGTH_OFFSET
-}); // Length offset for the blob commitments field.
-
-pub static SIGNED_BEACON_BLOCK_FULU_MAX: LazyLock<usize> = LazyLock::new(|| {
-    *SIGNED_BEACON_BLOCK_FULU_MAX_WITHOUT_PAYLOAD
-        + types::ExecutionPayload::<MainnetEthSpec>::max_execution_payload_fulu_size()
-        + ssz::BYTES_PER_LENGTH_OFFSET
-        + ssz::BYTES_PER_LENGTH_OFFSET
-});
 
 pub static BLOB_SIDECAR_SIZE: LazyLock<usize> =
     LazyLock::new(BlobSidecar::<MainnetEthSpec>::max_size);
@@ -203,25 +148,11 @@ pub fn rpc_block_limits_by_fork(current_fork: ForkName) -> RpcLimits {
             *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than altair blocks
             *SIGNED_BEACON_BLOCK_ALTAIR_MAX, // Altair block is larger than base blocks
         ),
-        ForkName::Bellatrix => RpcLimits::new(
+        // After the merge the max SSZ size of a block is absurdly big. The size is actually
+        // bound by other constants, so here we default to the bellatrix's max value
+        _ => RpcLimits::new(
             *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than altair and bellatrix blocks
             *SIGNED_BEACON_BLOCK_BELLATRIX_MAX, // Bellatrix block is larger than base and altair blocks
-        ),
-        ForkName::Capella => RpcLimits::new(
-            *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than altair and bellatrix blocks
-            *SIGNED_BEACON_BLOCK_CAPELLA_MAX, // Capella block is larger than base, altair and merge blocks
-        ),
-        ForkName::Deneb => RpcLimits::new(
-            *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than altair and bellatrix blocks
-            *SIGNED_BEACON_BLOCK_DENEB_MAX, // Deneb block is larger than all prior fork blocks
-        ),
-        ForkName::Electra => RpcLimits::new(
-            *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than altair and bellatrix blocks
-            *SIGNED_BEACON_BLOCK_ELECTRA_MAX, // Electra block is larger than Deneb block
-        ),
-        ForkName::Fulu => RpcLimits::new(
-            *SIGNED_BEACON_BLOCK_BASE_MIN, // Base block is smaller than all other blocks
-            *SIGNED_BEACON_BLOCK_FULU_MAX, // Fulu block is largest
         ),
     }
 }

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -58,10 +58,6 @@ pub static SIGNED_BEACON_BLOCK_ALTAIR_MAX: LazyLock<usize> = LazyLock::new(|| {
 /// We calculate the value from its fields instead of constructing the block and checking the length.
 /// Note: This is only the theoretical upper bound. We further bound the max size we receive over the network
 /// with `max_chunk_size`.
-///
-/// FIXME: Given that these limits are useless we should probably delete them. See:
-///
-/// https://github.com/sigp/lighthouse/issues/6790
 pub static SIGNED_BEACON_BLOCK_BELLATRIX_MAX: LazyLock<usize> =
     LazyLock::new(||     // Size of a full altair block
     *SIGNED_BEACON_BLOCK_ALTAIR_MAX

--- a/consensus/types/src/execution_payload.rs
+++ b/consensus/types/src/execution_payload.rs
@@ -128,58 +128,6 @@ impl<E: EthSpec> ExecutionPayload<E> {
             // Max size of variable length `transactions` field
             + (E::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + E::max_bytes_per_transaction()))
     }
-
-    #[allow(clippy::arithmetic_side_effects)]
-    /// Returns the maximum size of an execution payload.
-    pub fn max_execution_payload_capella_size() -> usize {
-        // Fixed part
-        ExecutionPayloadCapella::<E>::default().as_ssz_bytes().len()
-            // Max size of variable length `extra_data` field
-            + (E::max_extra_data_bytes() * <u8 as Encode>::ssz_fixed_len())
-            // Max size of variable length `transactions` field
-            + (E::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + E::max_bytes_per_transaction()))
-            // Max size of variable length `withdrawals` field
-            + (E::max_withdrawals_per_payload() * <Withdrawal as Encode>::ssz_fixed_len())
-    }
-
-    #[allow(clippy::arithmetic_side_effects)]
-    /// Returns the maximum size of an execution payload.
-    pub fn max_execution_payload_deneb_size() -> usize {
-        // Fixed part
-        ExecutionPayloadDeneb::<E>::default().as_ssz_bytes().len()
-            // Max size of variable length `extra_data` field
-            + (E::max_extra_data_bytes() * <u8 as Encode>::ssz_fixed_len())
-            // Max size of variable length `transactions` field
-            + (E::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + E::max_bytes_per_transaction()))
-            // Max size of variable length `withdrawals` field
-            + (E::max_withdrawals_per_payload() * <Withdrawal as Encode>::ssz_fixed_len())
-    }
-
-    #[allow(clippy::arithmetic_side_effects)]
-    /// Returns the maximum size of an execution payload.
-    pub fn max_execution_payload_electra_size() -> usize {
-        // Fixed part
-        ExecutionPayloadElectra::<E>::default().as_ssz_bytes().len()
-            // Max size of variable length `extra_data` field
-            + (E::max_extra_data_bytes() * <u8 as Encode>::ssz_fixed_len())
-            // Max size of variable length `transactions` field
-            + (E::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + E::max_bytes_per_transaction()))
-            // Max size of variable length `withdrawals` field
-            + (E::max_withdrawals_per_payload() * <Withdrawal as Encode>::ssz_fixed_len())
-    }
-
-    #[allow(clippy::arithmetic_side_effects)]
-    /// Returns the maximum size of an execution payload.
-    pub fn max_execution_payload_fulu_size() -> usize {
-        // Fixed part
-        ExecutionPayloadFulu::<E>::default().as_ssz_bytes().len()
-            // Max size of variable length `extra_data` field
-            + (E::max_extra_data_bytes() * <u8 as Encode>::ssz_fixed_len())
-            // Max size of variable length `transactions` field
-            + (E::max_transactions_per_payload() * (ssz::BYTES_PER_LENGTH_OFFSET + E::max_bytes_per_transaction()))
-            // Max size of variable length `withdrawals` field
-            + (E::max_withdrawals_per_payload() * <Withdrawal as Encode>::ssz_fixed_len())
-    }
 }
 
 impl<E: EthSpec> ForkVersionDeserialize for ExecutionPayload<E> {


### PR DESCRIPTION
## Issue Addressed

After the merge the max SSZ size of a block is absurdly big. The size is actually bound by other constants, so computing the fork's actual max size is pointless.

We can get rid of more fork boilerplate.

Close https://github.com/sigp/lighthouse/issues/6790

## Proposed Changes

Use bellatrix's max value in block's rpc_block_limits_by_fork for post-merge forks


