### PR TITLE
Misc. dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,9 +2571,7 @@ dependencies = [
  "lighthouse_network",
  "mediatype",
  "pretty_reqwest_error",
- "procfs",
  "proto_array",
- "psutil",
  "reqwest",
  "reqwest-eventsource",
  "sensitive_url",
@@ -3710,6 +3708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "health_metrics"
+version = "0.1.0"
+dependencies = [
+ "eth2",
+ "metrics",
+ "procfs",
+ "psutil",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3950,6 +3958,7 @@ dependencies = [
  "execution_layer",
  "futures",
  "genesis",
+ "health_metrics",
  "hex",
  "lighthouse_network",
  "lighthouse_version",
@@ -3985,6 +3994,7 @@ name = "http_metrics"
 version = "0.1.0"
 dependencies = [
  "beacon_chain",
+ "health_metrics",
  "lighthouse_network",
  "lighthouse_version",
  "logging",
@@ -5715,6 +5725,7 @@ name = "monitoring_api"
 version = "0.1.0"
 dependencies = [
  "eth2",
+ "health_metrics",
  "lighthouse_version",
  "metrics",
  "regex",
@@ -9587,6 +9598,7 @@ dependencies = [
  "filesystem",
  "futures",
  "graffiti_file",
+ "health_metrics",
  "initialized_validators",
  "itertools 0.10.5",
  "lighthouse_version",
@@ -9619,6 +9631,7 @@ dependencies = [
 name = "validator_http_metrics"
 version = "0.1.0"
 dependencies = [
+ "health_metrics",
  "lighthouse_version",
  "malloc_utils",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,6 @@ dependencies = [
 name = "account_utils"
 version = "0.1.0"
 dependencies = [
- "directory",
  "eth2_keystore",
  "eth2_wallet",
  "filesystem",
@@ -9561,7 +9560,6 @@ dependencies = [
  "bls",
  "deposit_contract",
  "derivative",
- "directory",
  "eth2_keystore",
  "filesystem",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9797,7 +9797,6 @@ dependencies = [
 name = "warp_utils"
 version = "0.1.0"
 dependencies = [
- "beacon_chain",
  "bytes",
  "eth2",
  "headers",
@@ -9806,7 +9805,6 @@ dependencies = [
  "serde",
  "serde_array_query",
  "serde_json",
- "state_processing",
  "tokio",
  "types",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "common/eth2_network_config",
     "common/eth2_wallet_manager",
     "common/filesystem",
+    "common/health_metrics",
     "common/lighthouse_version",
     "common/lockfile",
     "common/logging",
@@ -252,6 +253,7 @@ filesystem = { path = "common/filesystem" }
 fork_choice = { path = "consensus/fork_choice" }
 genesis = { path = "beacon_node/genesis" }
 gossipsub = { path = "beacon_node/lighthouse_network/gossipsub/" }
+health_metrics = { path = "common/health_metrics" }
 http_api = { path = "beacon_node/http_api" }
 initialized_validators = { path = "validator_client/initialized_validators" }
 int_to_bytes = { path = "consensus/int_to_bytes" }

--- a/account_manager/src/validator/create.rs
+++ b/account_manager/src/validator/create.rs
@@ -6,14 +6,13 @@ use account_utils::{
 };
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use clap_utils::FLAG_HEADER;
-use directory::{
-    ensure_dir_exists, parse_path_or_default_with_flag, DEFAULT_SECRET_DIR, DEFAULT_WALLET_DIR,
-};
+use directory::{parse_path_or_default_with_flag, DEFAULT_SECRET_DIR, DEFAULT_WALLET_DIR};
 use environment::Environment;
 use eth2_wallet_manager::WalletManager;
 use slashing_protection::{SlashingDatabase, SLASHING_PROTECTION_FILENAME};
 use std::ffi::OsStr;
 use std::fs;
+use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use types::EthSpec;
 use validator_dir::Builder as ValidatorDirBuilder;
@@ -156,8 +155,10 @@ pub fn cli_run<E: EthSpec>(
         ));
     }
 
-    ensure_dir_exists(&validator_dir)?;
-    ensure_dir_exists(&secrets_dir)?;
+    create_dir_all(&validator_dir)
+        .map_err(|e| format!("Could not create validator dir at {validator_dir:?}: {e:?}"))?;
+    create_dir_all(&secrets_dir)
+        .map_err(|e| format!("Could not create secrets dir at {secrets_dir:?}: {e:?}"))?;
 
     eprintln!("secrets-dir path {:?}", secrets_dir);
     eprintln!("wallets-dir path {:?}", wallet_base_dir);

--- a/account_manager/src/validator/recover.rs
+++ b/account_manager/src/validator/recover.rs
@@ -5,10 +5,10 @@ use account_utils::eth2_keystore::{keypair_from_secret, Keystore, KeystoreBuilde
 use account_utils::{random_password, read_mnemonic_from_cli, STDIN_INPUTS_FLAG};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use clap_utils::FLAG_HEADER;
-use directory::ensure_dir_exists;
 use directory::{parse_path_or_default_with_flag, DEFAULT_SECRET_DIR};
 use eth2_wallet::bip39::Seed;
 use eth2_wallet::{recover_validator_secret_from_mnemonic, KeyType, ValidatorKeystores};
+use std::fs::create_dir_all;
 use std::path::PathBuf;
 use validator_dir::Builder as ValidatorDirBuilder;
 pub const CMD: &str = "recover";
@@ -91,8 +91,10 @@ pub fn cli_run(matches: &ArgMatches, validator_dir: PathBuf) -> Result<(), Strin
 
     eprintln!("secrets-dir path: {:?}", secrets_dir);
 
-    ensure_dir_exists(&validator_dir)?;
-    ensure_dir_exists(&secrets_dir)?;
+    create_dir_all(&validator_dir)
+        .map_err(|e| format!("Could not create validator dir at {validator_dir:?}: {e:?}"))?;
+    create_dir_all(&secrets_dir)
+        .map_err(|e| format!("Could not create secrets dir at {secrets_dir:?}: {e:?}"))?;
 
     eprintln!();
     eprintln!("WARNING: KEY RECOVERY CAN LEAD TO DUPLICATING VALIDATORS KEYS, WHICH CAN LEAD TO SLASHING.");

--- a/account_manager/src/wallet/mod.rs
+++ b/account_manager/src/wallet/mod.rs
@@ -5,7 +5,8 @@ pub mod recover;
 use crate::WALLETS_DIR_FLAG;
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use clap_utils::FLAG_HEADER;
-use directory::{ensure_dir_exists, parse_path_or_default_with_flag, DEFAULT_WALLET_DIR};
+use directory::{parse_path_or_default_with_flag, DEFAULT_WALLET_DIR};
+use std::fs::create_dir_all;
 use std::path::PathBuf;
 
 pub const CMD: &str = "wallet";
@@ -44,7 +45,7 @@ pub fn cli_run(matches: &ArgMatches) -> Result<(), String> {
     } else {
         parse_path_or_default_with_flag(matches, WALLETS_DIR_FLAG, DEFAULT_WALLET_DIR)?
     };
-    ensure_dir_exists(&wallet_base_dir)?;
+    create_dir_all(&wallet_base_dir).map_err(|_| "Could not create wallet base dir")?;
 
     eprintln!("wallet-dir path: {:?}", wallet_base_dir);
 

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -17,6 +17,7 @@ ethereum_serde_utils = { workspace = true }
 ethereum_ssz = { workspace = true }
 execution_layer = { workspace = true }
 futures = { workspace = true }
+health_metrics = { workspace = true }
 hex = { workspace = true }
 lighthouse_network = { workspace = true }
 lighthouse_version = { workspace = true }

--- a/beacon_node/http_api/src/block_packing_efficiency.rs
+++ b/beacon_node/http_api/src/block_packing_efficiency.rs
@@ -13,7 +13,7 @@ use types::{
     AttestationRef, BeaconCommittee, BeaconState, BeaconStateError, BlindedPayload, ChainSpec,
     Epoch, EthSpec, Hash256, OwnedBeaconCommittee, RelativeEpoch, SignedBeaconBlock, Slot,
 };
-use warp_utils::reject::{beacon_chain_error, custom_bad_request, custom_server_error};
+use warp_utils::reject::{custom_bad_request, custom_server_error, unhandled_error};
 
 /// Load blocks from block roots in chunks to reduce load on memory.
 const BLOCK_ROOT_CHUNK_SIZE: usize = 100;
@@ -263,9 +263,9 @@ pub fn get_block_packing_efficiency<T: BeaconChainTypes>(
     // Load block roots.
     let mut block_roots: Vec<Hash256> = chain
         .forwards_iter_block_roots_until(start_slot_of_prior_epoch, end_slot)
-        .map_err(beacon_chain_error)?
+        .map_err(unhandled_error)?
         .collect::<Result<Vec<(Hash256, Slot)>, _>>()
-        .map_err(beacon_chain_error)?
+        .map_err(unhandled_error)?
         .iter()
         .map(|(root, _)| *root)
         .collect();
@@ -280,7 +280,7 @@ pub fn get_block_packing_efficiency<T: BeaconChainTypes>(
         .and_then(|maybe_block| {
             maybe_block.ok_or(BeaconChainError::MissingBeaconBlock(*first_block_root))
         })
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error)?;
 
     // Load state for block replay.
     let starting_state_root = first_block.state_root();
@@ -290,7 +290,7 @@ pub fn get_block_packing_efficiency<T: BeaconChainTypes>(
         .and_then(|maybe_state| {
             maybe_state.ok_or(BeaconChainError::MissingBeaconState(starting_state_root))
         })
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error)?;
 
     // Initialize response vector.
     let mut response = Vec::new();
@@ -392,7 +392,7 @@ pub fn get_block_packing_efficiency<T: BeaconChainTypes>(
                     .and_then(|maybe_block| {
                         maybe_block.ok_or(BeaconChainError::MissingBeaconBlock(*root))
                     })
-                    .map_err(beacon_chain_error)
+                    .map_err(unhandled_error)
             })
             .collect::<Result<Vec<_>, _>>()?;
 

--- a/beacon_node/http_api/src/build_block_contents.rs
+++ b/beacon_node/http_api/src/build_block_contents.rs
@@ -23,7 +23,7 @@ pub fn build_block_contents<E: EthSpec>(
                 } = block;
 
                 let Some((kzg_proofs, blobs)) = blob_items else {
-                    return Err(warp_utils::reject::block_production_error(
+                    return Err(warp_utils::reject::unhandled_error(
                         BlockProductionError::MissingBlobs,
                     ));
                 };

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -938,9 +938,9 @@ pub fn serve<T: BeaconChainTypes>(
                                                         )
                                                     }
                                                 }
-                                                _ => {
-                                                    warp_utils::reject::beacon_chain_error(e.into())
-                                                }
+                                                _ => warp_utils::reject::unhandled_error(
+                                                    BeaconChainError::from(e),
+                                                ),
                                             }
                                         })?;
 
@@ -1067,7 +1067,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let validators = chain
                         .validator_indices(sync_committee.pubkeys.iter())
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                        .map_err(warp_utils::reject::unhandled_error)?;
 
                     let validator_aggregates = validators
                         .chunks_exact(T::EthSpec::sync_subcommittee_size())
@@ -1147,7 +1147,7 @@ pub fn serve<T: BeaconChainTypes>(
                                 let (cached_head, execution_status) = chain
                                     .canonical_head
                                     .head_and_execution_status()
-                                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                                    .map_err(warp_utils::reject::unhandled_error)?;
                                 (
                                     cached_head.head_block_root(),
                                     cached_head.snapshot.beacon_block.clone_as_blinded(),
@@ -1161,13 +1161,13 @@ pub fn serve<T: BeaconChainTypes>(
                                     BlockId::from_root(parent_root).blinded_block(&chain)?;
                                 let (root, _slot) = chain
                                     .forwards_iter_block_roots(parent.slot())
-                                    .map_err(warp_utils::reject::beacon_chain_error)?
+                                    .map_err(warp_utils::reject::unhandled_error)?
                                     // Ignore any skip-slots immediately following the parent.
                                     .find(|res| {
                                         res.as_ref().is_ok_and(|(root, _)| *root != parent_root)
                                     })
                                     .transpose()
-                                    .map_err(warp_utils::reject::beacon_chain_error)?
+                                    .map_err(warp_utils::reject::unhandled_error)?
                                     .ok_or_else(|| {
                                         warp_utils::reject::custom_not_found(format!(
                                             "child of block with root {}",
@@ -1248,7 +1248,7 @@ pub fn serve<T: BeaconChainTypes>(
 
                     let canonical = chain
                         .block_root_at_slot(block.slot(), WhenSlotSkipped::None)
-                        .map_err(warp_utils::reject::beacon_chain_error)?
+                        .map_err(warp_utils::reject::unhandled_error)?
                         .is_some_and(|canonical| root == canonical);
 
                     let data = api_types::BlockHeaderData {
@@ -2932,7 +2932,7 @@ pub fn serve<T: BeaconChainTypes>(
                             let (head, head_execution_status) = chain
                                 .canonical_head
                                 .head_and_execution_status()
-                                .map_err(warp_utils::reject::beacon_chain_error)?;
+                                .map_err(warp_utils::reject::unhandled_error)?;
                             let head_slot = head.head_slot();
                             let current_slot =
                                 chain.slot_clock.now_or_genesis().ok_or_else(|| {
@@ -2992,7 +2992,7 @@ pub fn serve<T: BeaconChainTypes>(
                         .blocking_response_task(Priority::P0, move || {
                             let is_optimistic = chain
                                 .is_optimistic_or_invalid_head()
-                                .map_err(warp_utils::reject::beacon_chain_error)?;
+                                .map_err(warp_utils::reject::unhandled_error)?;
 
                             let is_syncing = !network_globals.sync_state.read().is_synced();
 
@@ -3302,9 +3302,7 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_json_task(Priority::P0, move || {
                     not_synced_filter?;
 
-                    let current_slot = chain
-                        .slot()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_slot = chain.slot().map_err(warp_utils::reject::unhandled_error)?;
 
                     // allow a tolerance of one slot to account for clock skew
                     if query.slot > current_slot + 1 {
@@ -3318,7 +3316,7 @@ pub fn serve<T: BeaconChainTypes>(
                         .produce_unaggregated_attestation(query.slot, query.committee_index)
                         .map(|attestation| attestation.data().clone())
                         .map(api_types::GenericResponse::from)
-                        .map_err(warp_utils::reject::beacon_chain_error)
+                        .map_err(warp_utils::reject::unhandled_error)
                 })
             },
         );
@@ -3690,11 +3688,9 @@ pub fn serve<T: BeaconChainTypes>(
                         .execution_layer
                         .as_ref()
                         .ok_or(BeaconChainError::ExecutionLayerMissing)
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                        .map_err(warp_utils::reject::unhandled_error)?;
 
-                    let current_slot = chain
-                        .slot()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_slot = chain.slot().map_err(warp_utils::reject::unhandled_error)?;
                     let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
 
                     debug!(
@@ -3747,12 +3743,12 @@ pub fn serve<T: BeaconChainTypes>(
                             .execution_layer
                             .as_ref()
                             .ok_or(BeaconChainError::ExecutionLayerMissing)
-                            .map_err(warp_utils::reject::beacon_chain_error)?;
+                            .map_err(warp_utils::reject::unhandled_error)?;
                         let current_slot = chain
                             .slot_clock
                             .now_or_genesis()
                             .ok_or(BeaconChainError::UnableToReadSlot)
-                            .map_err(warp_utils::reject::beacon_chain_error)?;
+                            .map_err(warp_utils::reject::unhandled_error)?;
                         let current_epoch = current_slot.epoch(T::EthSpec::slots_per_epoch());
 
                         debug!(
@@ -3848,12 +3844,12 @@ pub fn serve<T: BeaconChainTypes>(
                                 .execution_layer
                                 .as_ref()
                                 .ok_or(BeaconChainError::ExecutionLayerMissing)
-                                .map_err(warp_utils::reject::beacon_chain_error)?
+                                .map_err(warp_utils::reject::unhandled_error)?
                                 .builder();
                             let builder = arc_builder
                                 .as_ref()
                                 .ok_or(BeaconChainError::BuilderMissing)
-                                .map_err(warp_utils::reject::beacon_chain_error)?;
+                                .map_err(warp_utils::reject::unhandled_error)?;
                             builder
                                 .post_builder_validators(&filtered_registration_data)
                                 .await
@@ -3969,9 +3965,8 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
                     // Ensure the request is for either the current, previous or next epoch.
-                    let current_epoch = chain
-                        .epoch()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_epoch =
+                        chain.epoch().map_err(warp_utils::reject::unhandled_error)?;
                     let prev_epoch = current_epoch.saturating_sub(Epoch::new(1));
                     let next_epoch = current_epoch.saturating_add(Epoch::new(1));
 
@@ -4010,9 +4005,8 @@ pub fn serve<T: BeaconChainTypes>(
              chain: Arc<BeaconChain<T>>| {
                 task_spawner.blocking_json_task(Priority::P0, move || {
                     // Ensure the request is for either the current, previous or next epoch.
-                    let current_epoch = chain
-                        .epoch()
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                    let current_epoch =
+                        chain.epoch().map_err(warp_utils::reject::unhandled_error)?;
                     let prev_epoch = current_epoch.saturating_sub(Epoch::new(1));
                     let next_epoch = current_epoch.saturating_add(Epoch::new(1));
 

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -50,6 +50,7 @@ use eth2::types::{
     ValidatorStatus, ValidatorsRequestBody,
 };
 use eth2::{CONSENSUS_VERSION_HEADER, CONTENT_TYPE_HEADER, SSZ_CONTENT_TYPE_HEADER};
+use health_metrics::observe::Observe;
 use lighthouse_network::{types::SyncState, EnrExt, NetworkGlobals, PeerId, PubsubMessage};
 use lighthouse_version::version_with_platform;
 use logging::SSELoggingComponents;

--- a/beacon_node/http_api/src/produce_block.rs
+++ b/beacon_node/http_api/src/produce_block.rs
@@ -153,7 +153,7 @@ pub async fn produce_blinded_block_v2<T: BeaconChainTypes>(
             BlockProductionVersion::BlindedV2,
         )
         .await
-        .map_err(warp_utils::reject::block_production_error)?;
+        .map_err(warp_utils::reject::unhandled_error)?;
 
     build_response_v2(chain, block_response_type, endpoint_version, accept_header)
 }
@@ -184,7 +184,7 @@ pub async fn produce_block_v2<T: BeaconChainTypes>(
             BlockProductionVersion::FullV2,
         )
         .await
-        .map_err(warp_utils::reject::block_production_error)?;
+        .map_err(warp_utils::reject::unhandled_error)?;
 
     build_response_v2(chain, block_response_type, endpoint_version, accept_header)
 }

--- a/beacon_node/http_api/src/standard_block_rewards.rs
+++ b/beacon_node/http_api/src/standard_block_rewards.rs
@@ -4,7 +4,7 @@ use crate::ExecutionOptimistic;
 use beacon_chain::{BeaconChain, BeaconChainTypes};
 use eth2::lighthouse::StandardBlockReward;
 use std::sync::Arc;
-use warp_utils::reject::beacon_chain_error;
+use warp_utils::reject::unhandled_error;
 /// The difference between block_rewards and beacon_block_rewards is the later returns block
 /// reward format that satisfies beacon-api specs
 pub fn compute_beacon_block_rewards<T: BeaconChainTypes>(
@@ -19,7 +19,7 @@ pub fn compute_beacon_block_rewards<T: BeaconChainTypes>(
 
     let rewards = chain
         .compute_beacon_block_reward(block_ref, &mut state)
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error)?;
 
     Ok((rewards, execution_optimistic, finalized))
 }

--- a/beacon_node/http_api/src/state_id.rs
+++ b/beacon_node/http_api/src/state_id.rs
@@ -30,7 +30,7 @@ impl StateId {
                 let (cached_head, execution_status) = chain
                     .canonical_head
                     .head_and_execution_status()
-                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                    .map_err(warp_utils::reject::unhandled_error)?;
                 return Ok((
                     cached_head.head_state_root(),
                     execution_status.is_optimistic_or_invalid(),
@@ -56,7 +56,7 @@ impl StateId {
                 *slot,
                 chain
                     .is_optimistic_or_invalid_head()
-                    .map_err(warp_utils::reject::beacon_chain_error)?,
+                    .map_err(warp_utils::reject::unhandled_error)?,
                 *slot
                     <= chain
                         .canonical_head
@@ -70,11 +70,11 @@ impl StateId {
                     .store
                     .load_hot_state_summary(root)
                     .map_err(BeaconChainError::DBError)
-                    .map_err(warp_utils::reject::beacon_chain_error)?
+                    .map_err(warp_utils::reject::unhandled_error)?
                 {
                     let finalization_status = chain
                         .state_finalization_and_canonicity(root, hot_summary.slot)
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                        .map_err(warp_utils::reject::unhandled_error)?;
                     let finalized = finalization_status.is_finalized();
                     let fork_choice = chain.canonical_head.fork_choice_read_lock();
                     let execution_optimistic = if finalization_status.slot_is_finalized
@@ -94,14 +94,14 @@ impl StateId {
                         fork_choice
                             .is_optimistic_or_invalid_block(&hot_summary.latest_block_root)
                             .map_err(BeaconChainError::ForkChoiceError)
-                            .map_err(warp_utils::reject::beacon_chain_error)?
+                            .map_err(warp_utils::reject::unhandled_error)?
                     };
                     return Ok((*root, execution_optimistic, finalized));
                 } else if let Some(_cold_state_slot) = chain
                     .store
                     .load_cold_state_slot(root)
                     .map_err(BeaconChainError::DBError)
-                    .map_err(warp_utils::reject::beacon_chain_error)?
+                    .map_err(warp_utils::reject::unhandled_error)?
                 {
                     let fork_choice = chain.canonical_head.fork_choice_read_lock();
                     let finalized_root = fork_choice
@@ -111,7 +111,7 @@ impl StateId {
                     let execution_optimistic = fork_choice
                         .is_optimistic_or_invalid_block_no_fallback(&finalized_root)
                         .map_err(BeaconChainError::ForkChoiceError)
-                        .map_err(warp_utils::reject::beacon_chain_error)?;
+                        .map_err(warp_utils::reject::unhandled_error)?;
                     return Ok((*root, execution_optimistic, true));
                 } else {
                     return Err(warp_utils::reject::custom_not_found(format!(
@@ -124,7 +124,7 @@ impl StateId {
 
         let root = chain
             .state_root_at_slot(slot)
-            .map_err(warp_utils::reject::beacon_chain_error)?
+            .map_err(warp_utils::reject::unhandled_error)?
             .ok_or_else(|| {
                 warp_utils::reject::custom_not_found(format!("beacon state at slot {}", slot))
             })?;
@@ -178,7 +178,7 @@ impl StateId {
                 let (cached_head, execution_status) = chain
                     .canonical_head
                     .head_and_execution_status()
-                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                    .map_err(warp_utils::reject::unhandled_error)?;
                 return Ok((
                     cached_head.snapshot.beacon_state.clone(),
                     execution_status.is_optimistic_or_invalid(),
@@ -191,7 +191,7 @@ impl StateId {
 
         let state = chain
             .get_state(&state_root, slot_opt)
-            .map_err(warp_utils::reject::beacon_chain_error)
+            .map_err(warp_utils::reject::unhandled_error)
             .and_then(|opt| {
                 opt.ok_or_else(|| {
                     warp_utils::reject::custom_not_found(format!(
@@ -224,7 +224,7 @@ impl StateId {
                 let (head, execution_status) = chain
                     .canonical_head
                     .head_and_execution_status()
-                    .map_err(warp_utils::reject::beacon_chain_error)?;
+                    .map_err(warp_utils::reject::unhandled_error)?;
                 return func(
                     &head.snapshot.beacon_state,
                     execution_status.is_optimistic_or_invalid(),
@@ -273,7 +273,7 @@ pub fn checkpoint_slot_and_execution_optimistic<T: BeaconChainTypes>(
     let execution_optimistic = fork_choice
         .is_optimistic_or_invalid_block_no_fallback(root)
         .map_err(BeaconChainError::ForkChoiceError)
-        .map_err(warp_utils::reject::beacon_chain_error)?;
+        .map_err(warp_utils::reject::unhandled_error)?;
 
     Ok((slot, execution_optimistic))
 }

--- a/beacon_node/http_api/src/sync_committee_rewards.rs
+++ b/beacon_node/http_api/src/sync_committee_rewards.rs
@@ -6,7 +6,7 @@ use slog::{debug, Logger};
 use state_processing::BlockReplayer;
 use std::sync::Arc;
 use types::{BeaconState, SignedBlindedBeaconBlock};
-use warp_utils::reject::{beacon_chain_error, custom_not_found};
+use warp_utils::reject::{custom_not_found, unhandled_error};
 
 pub fn compute_sync_committee_rewards<T: BeaconChainTypes>(
     chain: Arc<BeaconChain<T>>,
@@ -20,7 +20,7 @@ pub fn compute_sync_committee_rewards<T: BeaconChainTypes>(
 
     let reward_payload = chain
         .compute_sync_committee_rewards(block.message(), &mut state)
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error)?;
 
     let data = if reward_payload.is_empty() {
         debug!(log, "compute_sync_committee_rewards returned empty");
@@ -71,7 +71,7 @@ pub fn get_state_before_applying_block<T: BeaconChainTypes>(
         .state_root_iter([Ok((parent_block.state_root(), parent_block.slot()))].into_iter())
         .minimal_block_root_verification()
         .apply_blocks(vec![], Some(block.slot()))
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error::<BeaconChainError>)?;
 
     Ok(replayer.into_state())
 }

--- a/beacon_node/http_api/src/sync_committees.rs
+++ b/beacon_node/http_api/src/sync_committees.rs
@@ -39,7 +39,7 @@ pub fn sync_committee_duties<T: BeaconChainTypes>(
     // still dependent on the head. So using `is_optimistic_head` is fine for both cases.
     let execution_optimistic = chain
         .is_optimistic_or_invalid_head()
-        .map_err(warp_utils::reject::beacon_chain_error)?;
+        .map_err(warp_utils::reject::unhandled_error)?;
 
     // Try using the head's sync committees to satisfy the request. This should be sufficient for
     // the vast majority of requests. Rather than checking if we think the request will succeed in a
@@ -55,7 +55,7 @@ pub fn sync_committee_duties<T: BeaconChainTypes>(
             ..
         }))
         | Err(BeaconChainError::SyncDutiesError(BeaconStateError::IncorrectStateVariant)) => (),
-        Err(e) => return Err(warp_utils::reject::beacon_chain_error(e)),
+        Err(e) => return Err(warp_utils::reject::unhandled_error(e)),
     }
 
     let duties = duties_from_state_load(request_epoch, request_indices, altair_fork_epoch, chain)
@@ -67,7 +67,7 @@ pub fn sync_committee_duties<T: BeaconChainTypes>(
             "invalid epoch: {}, current epoch: {}",
             request_epoch, current_epoch
         )),
-        e => warp_utils::reject::beacon_chain_error(e),
+        e => warp_utils::reject::unhandled_error(e),
     })?;
     Ok(convert_to_response(
         verify_unknown_validators(duties, request_epoch, chain)?,
@@ -164,7 +164,7 @@ fn verify_unknown_validators<T: BeaconChainTypes>(
             BeaconChainError::SyncDutiesError(BeaconStateError::UnknownValidator(idx)) => {
                 warp_utils::reject::custom_bad_request(format!("invalid validator index: {idx}"))
             }
-            e => warp_utils::reject::beacon_chain_error(e),
+            e => warp_utils::reject::unhandled_error(e),
         })
 }
 

--- a/beacon_node/http_api/src/ui.rs
+++ b/beacon_node/http_api/src/ui.rs
@@ -5,7 +5,7 @@ use eth2::types::{Epoch, ValidatorStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use warp_utils::reject::beacon_chain_error;
+use warp_utils::reject::unhandled_error;
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorCountResponse {
@@ -58,7 +58,7 @@ pub fn get_validator_count<T: BeaconChainTypes>(
             }
             Ok::<(), BeaconChainError>(())
         })
-        .map_err(beacon_chain_error)?;
+        .map_err(unhandled_error)?;
 
     Ok(ValidatorCountResponse {
         active_ongoing,
@@ -101,7 +101,7 @@ pub fn get_validator_info<T: BeaconChainTypes>(
     request_data: ValidatorInfoRequestData,
     chain: Arc<BeaconChain<T>>,
 ) -> Result<ValidatorInfoResponse, warp::Rejection> {
-    let current_epoch = chain.epoch().map_err(beacon_chain_error)?;
+    let current_epoch = chain.epoch().map_err(unhandled_error)?;
 
     let epochs = current_epoch.saturating_sub(HISTORIC_EPOCHS).as_u64()..=current_epoch.as_u64();
 

--- a/beacon_node/http_metrics/Cargo.toml
+++ b/beacon_node/http_metrics/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 
 [dependencies]
 beacon_chain = { workspace = true }
+health_metrics = { workspace = true }
 lighthouse_network = { workspace = true }
 lighthouse_version = { workspace = true }
 malloc_utils = { workspace = true }

--- a/beacon_node/http_metrics/src/metrics.rs
+++ b/beacon_node/http_metrics/src/metrics.rs
@@ -39,7 +39,7 @@ pub fn gather_prometheus_metrics<T: BeaconChainTypes>(
 
     lighthouse_network::scrape_discovery_metrics();
 
-    warp_utils::metrics::scrape_health_metrics();
+    health_metrics::metrics::scrape_health_metrics();
 
     // It's important to ensure these metrics are explicitly enabled in the case that users aren't
     // using glibc and this function causes panics.

--- a/common/account_utils/Cargo.toml
+++ b/common/account_utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-directory = { workspace = true }
 eth2_keystore = { workspace = true }
 eth2_wallet = { workspace = true }
 filesystem = { workspace = true }

--- a/common/account_utils/src/validator_definitions.rs
+++ b/common/account_utils/src/validator_definitions.rs
@@ -4,13 +4,12 @@
 //! attempt) to load into the `crate::intialized_validators::InitializedValidators` struct.
 
 use crate::{default_keystore_password_path, read_password_string, write_file_via_temporary};
-use directory::ensure_dir_exists;
 use eth2_keystore::Keystore;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use slog::{error, Logger};
 use std::collections::HashSet;
-use std::fs::{self, File};
+use std::fs::{self, create_dir_all, File};
 use std::io;
 use std::path::{Path, PathBuf};
 use types::{graffiti::GraffitiString, Address, PublicKey};
@@ -229,7 +228,7 @@ impl From<Vec<ValidatorDefinition>> for ValidatorDefinitions {
 impl ValidatorDefinitions {
     /// Open an existing file or create a new, empty one if it does not exist.
     pub fn open_or_create<P: AsRef<Path>>(validators_dir: P) -> Result<Self, Error> {
-        ensure_dir_exists(validators_dir.as_ref()).map_err(|_| {
+        create_dir_all(validators_dir.as_ref()).map_err(|_| {
             Error::UnableToCreateValidatorDir(PathBuf::from(validators_dir.as_ref()))
         })?;
         let config_path = validators_dir.as_ref().join(CONFIG_FILENAME);

--- a/common/directory/src/lib.rs
+++ b/common/directory/src/lib.rs
@@ -1,6 +1,6 @@
 use clap::ArgMatches;
 pub use eth2_network_config::DEFAULT_HARDCODED_NETWORK;
-use std::fs::{self, create_dir_all};
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Names for the default directories.
@@ -28,17 +28,6 @@ pub fn get_network_dir(matches: &ArgMatches) -> String {
     } else {
         eth2_network_config::DEFAULT_HARDCODED_NETWORK.to_string()
     }
-}
-
-/// Checks if a directory exists in the given path and creates a directory if it does not exist.
-pub fn ensure_dir_exists<P: AsRef<Path>>(path: P) -> Result<(), String> {
-    let path = path.as_ref();
-
-    if !path.exists() {
-        create_dir_all(path).map_err(|e| format!("Unable to create {:?}: {:?}", path, e))?;
-    }
-
-    Ok(())
 }
 
 /// If `arg` is in `matches`, parses the value as a path.

--- a/common/eth2/Cargo.toml
+++ b/common/eth2/Cargo.toml
@@ -31,10 +31,6 @@ zeroize = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-psutil = { version = "3.3.0", optional = true }
-procfs = { version = "0.15.1", optional = true }
-
 [features]
 default = ["lighthouse"]
-lighthouse = ["psutil", "procfs"]
+lighthouse = []

--- a/common/eth2/src/lighthouse.rs
+++ b/common/eth2/src/lighthouse.rs
@@ -88,12 +88,6 @@ pub struct ValidatorInclusionData {
     pub is_previous_epoch_head_attester: bool,
 }
 
-#[cfg(target_os = "linux")]
-use {
-    psutil::cpu::os::linux::CpuTimesExt, psutil::memory::os::linux::VirtualMemoryExt,
-    psutil::process::Process,
-};
-
 /// Reports on the health of the Lighthouse instance.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Health {
@@ -164,69 +158,6 @@ pub struct SystemHealth {
     pub misc_os: String,
 }
 
-impl SystemHealth {
-    #[cfg(not(target_os = "linux"))]
-    pub fn observe() -> Result<Self, String> {
-        Err("Health is only available on Linux".into())
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn observe() -> Result<Self, String> {
-        let vm = psutil::memory::virtual_memory()
-            .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
-        let loadavg =
-            psutil::host::loadavg().map_err(|e| format!("Unable to get loadavg: {:?}", e))?;
-
-        let cpu =
-            psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
-
-        let disk_usage = psutil::disk::disk_usage("/")
-            .map_err(|e| format!("Unable to disk usage info: {:?}", e))?;
-
-        let disk = psutil::disk::DiskIoCountersCollector::default()
-            .disk_io_counters()
-            .map_err(|e| format!("Unable to get disk counters: {:?}", e))?;
-
-        let net = psutil::network::NetIoCountersCollector::default()
-            .net_io_counters()
-            .map_err(|e| format!("Unable to get network io counters: {:?}", e))?;
-
-        let boot_time = psutil::host::boot_time()
-            .map_err(|e| format!("Unable to get system boot time: {:?}", e))?
-            .duration_since(std::time::UNIX_EPOCH)
-            .map_err(|e| format!("Boot time is lower than unix epoch: {}", e))?
-            .as_secs();
-
-        Ok(Self {
-            sys_virt_mem_total: vm.total(),
-            sys_virt_mem_available: vm.available(),
-            sys_virt_mem_used: vm.used(),
-            sys_virt_mem_free: vm.free(),
-            sys_virt_mem_cached: vm.cached(),
-            sys_virt_mem_buffers: vm.buffers(),
-            sys_virt_mem_percent: vm.percent(),
-            sys_loadavg_1: loadavg.one,
-            sys_loadavg_5: loadavg.five,
-            sys_loadavg_15: loadavg.fifteen,
-            cpu_cores: psutil::cpu::cpu_count_physical(),
-            cpu_threads: psutil::cpu::cpu_count(),
-            system_seconds_total: cpu.system().as_secs(),
-            cpu_time_total: cpu.total().as_secs(),
-            user_seconds_total: cpu.user().as_secs(),
-            iowait_seconds_total: cpu.iowait().as_secs(),
-            idle_seconds_total: cpu.idle().as_secs(),
-            disk_node_bytes_total: disk_usage.total(),
-            disk_node_bytes_free: disk_usage.free(),
-            disk_node_reads_total: disk.read_count(),
-            disk_node_writes_total: disk.write_count(),
-            network_node_bytes_total_received: net.bytes_recv(),
-            network_node_bytes_total_transmit: net.bytes_sent(),
-            misc_node_boot_ts_seconds: boot_time,
-            misc_os: std::env::consts::OS.to_string(),
-        })
-    }
-}
-
 /// Process specific health
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProcessHealth {
@@ -242,59 +173,6 @@ pub struct ProcessHealth {
     pub pid_mem_shared_memory_size: u64,
     /// Number of cpu seconds consumed by this pid.
     pub pid_process_seconds_total: u64,
-}
-
-impl ProcessHealth {
-    #[cfg(not(target_os = "linux"))]
-    pub fn observe() -> Result<Self, String> {
-        Err("Health is only available on Linux".into())
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn observe() -> Result<Self, String> {
-        let process =
-            Process::current().map_err(|e| format!("Unable to get current process: {:?}", e))?;
-
-        let process_mem = process
-            .memory_info()
-            .map_err(|e| format!("Unable to get process memory info: {:?}", e))?;
-
-        let me = procfs::process::Process::myself()
-            .map_err(|e| format!("Unable to get process: {:?}", e))?;
-        let stat = me
-            .stat()
-            .map_err(|e| format!("Unable to get stat: {:?}", e))?;
-
-        let process_times = process
-            .cpu_times()
-            .map_err(|e| format!("Unable to get process cpu times : {:?}", e))?;
-
-        Ok(Self {
-            pid: process.pid(),
-            pid_num_threads: stat.num_threads,
-            pid_mem_resident_set_size: process_mem.rss(),
-            pid_mem_virtual_memory_size: process_mem.vms(),
-            pid_mem_shared_memory_size: process_mem.shared(),
-            pid_process_seconds_total: process_times.busy().as_secs()
-                + process_times.children_system().as_secs()
-                + process_times.children_system().as_secs(),
-        })
-    }
-}
-
-impl Health {
-    #[cfg(not(target_os = "linux"))]
-    pub fn observe() -> Result<Self, String> {
-        Err("Health is only available on Linux".into())
-    }
-
-    #[cfg(target_os = "linux")]
-    pub fn observe() -> Result<Self, String> {
-        Ok(Self {
-            process: ProcessHealth::observe()?,
-            system: SystemHealth::observe()?,
-        })
-    }
 }
 
 /// Indicates how up-to-date the Eth1 caches are.

--- a/common/health_metrics/Cargo.toml
+++ b/common/health_metrics/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "health_metrics"
+version = "0.1.0"
+edition = { workspace = true }
+
+[dependencies]
+eth2 = { workspace = true }
+metrics = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+psutil = "3.3.0"
+procfs = "0.15.1"

--- a/common/health_metrics/src/lib.rs
+++ b/common/health_metrics/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod metrics;
+pub mod observe;

--- a/common/health_metrics/src/metrics.rs
+++ b/common/health_metrics/src/metrics.rs
@@ -1,3 +1,4 @@
+use crate::observe::Observe;
 use eth2::lighthouse::{ProcessHealth, SystemHealth};
 use metrics::*;
 use std::sync::LazyLock;

--- a/common/health_metrics/src/observe.rs
+++ b/common/health_metrics/src/observe.rs
@@ -1,0 +1,127 @@
+use eth2::lighthouse::{Health, ProcessHealth, SystemHealth};
+
+#[cfg(target_os = "linux")]
+use {
+    psutil::cpu::os::linux::CpuTimesExt, psutil::memory::os::linux::VirtualMemoryExt,
+    psutil::process::Process,
+};
+
+pub trait Observe: Sized {
+    fn observe() -> Result<Self, String>;
+}
+
+impl Observe for Health {
+    #[cfg(not(target_os = "linux"))]
+    fn observe() -> Result<Self, String> {
+        Err("Health is only available on Linux".into())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn observe() -> Result<Self, String> {
+        Ok(Self {
+            process: ProcessHealth::observe()?,
+            system: SystemHealth::observe()?,
+        })
+    }
+}
+
+impl Observe for SystemHealth {
+    #[cfg(not(target_os = "linux"))]
+    fn observe() -> Result<Self, String> {
+        Err("Health is only available on Linux".into())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn observe() -> Result<Self, String> {
+        let vm = psutil::memory::virtual_memory()
+            .map_err(|e| format!("Unable to get virtual memory: {:?}", e))?;
+        let loadavg =
+            psutil::host::loadavg().map_err(|e| format!("Unable to get loadavg: {:?}", e))?;
+
+        let cpu =
+            psutil::cpu::cpu_times().map_err(|e| format!("Unable to get cpu times: {:?}", e))?;
+
+        let disk_usage = psutil::disk::disk_usage("/")
+            .map_err(|e| format!("Unable to disk usage info: {:?}", e))?;
+
+        let disk = psutil::disk::DiskIoCountersCollector::default()
+            .disk_io_counters()
+            .map_err(|e| format!("Unable to get disk counters: {:?}", e))?;
+
+        let net = psutil::network::NetIoCountersCollector::default()
+            .net_io_counters()
+            .map_err(|e| format!("Unable to get network io counters: {:?}", e))?;
+
+        let boot_time = psutil::host::boot_time()
+            .map_err(|e| format!("Unable to get system boot time: {:?}", e))?
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("Boot time is lower than unix epoch: {}", e))?
+            .as_secs();
+
+        Ok(Self {
+            sys_virt_mem_total: vm.total(),
+            sys_virt_mem_available: vm.available(),
+            sys_virt_mem_used: vm.used(),
+            sys_virt_mem_free: vm.free(),
+            sys_virt_mem_cached: vm.cached(),
+            sys_virt_mem_buffers: vm.buffers(),
+            sys_virt_mem_percent: vm.percent(),
+            sys_loadavg_1: loadavg.one,
+            sys_loadavg_5: loadavg.five,
+            sys_loadavg_15: loadavg.fifteen,
+            cpu_cores: psutil::cpu::cpu_count_physical(),
+            cpu_threads: psutil::cpu::cpu_count(),
+            system_seconds_total: cpu.system().as_secs(),
+            cpu_time_total: cpu.total().as_secs(),
+            user_seconds_total: cpu.user().as_secs(),
+            iowait_seconds_total: cpu.iowait().as_secs(),
+            idle_seconds_total: cpu.idle().as_secs(),
+            disk_node_bytes_total: disk_usage.total(),
+            disk_node_bytes_free: disk_usage.free(),
+            disk_node_reads_total: disk.read_count(),
+            disk_node_writes_total: disk.write_count(),
+            network_node_bytes_total_received: net.bytes_recv(),
+            network_node_bytes_total_transmit: net.bytes_sent(),
+            misc_node_boot_ts_seconds: boot_time,
+            misc_os: std::env::consts::OS.to_string(),
+        })
+    }
+}
+
+impl Observe for ProcessHealth {
+    #[cfg(not(target_os = "linux"))]
+    fn observe() -> Result<Self, String> {
+        Err("Health is only available on Linux".into())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn observe() -> Result<Self, String> {
+        let process =
+            Process::current().map_err(|e| format!("Unable to get current process: {:?}", e))?;
+
+        let process_mem = process
+            .memory_info()
+            .map_err(|e| format!("Unable to get process memory info: {:?}", e))?;
+
+        let me = procfs::process::Process::myself()
+            .map_err(|e| format!("Unable to get process: {:?}", e))?;
+        let stat = me
+            .stat()
+            .map_err(|e| format!("Unable to get stat: {:?}", e))?;
+
+        let process_times = process
+            .cpu_times()
+            .map_err(|e| format!("Unable to get process cpu times : {:?}", e))?;
+
+        Ok(Self {
+            pid: process.pid(),
+            pid_num_threads: stat.num_threads,
+            pid_mem_resident_set_size: process_mem.rss(),
+            pid_mem_virtual_memory_size: process_mem.vms(),
+            pid_mem_shared_memory_size: process_mem.shared(),
+            pid_process_seconds_total: process_times.busy().as_secs()
+                + process_times.children_system().as_secs()
+                + process_times.children_system().as_secs(),
+        })
+    }
+}

--- a/common/monitoring_api/Cargo.toml
+++ b/common/monitoring_api/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 
 [dependencies]
 eth2 = { workspace = true }
+health_metrics = { workspace = true }
 lighthouse_version = { workspace = true }
 metrics = { workspace = true }
 regex = { workspace = true }

--- a/common/monitoring_api/src/gather.rs
+++ b/common/monitoring_api/src/gather.rs
@@ -1,4 +1,5 @@
 use super::types::{BeaconProcessMetrics, ValidatorProcessMetrics};
+use health_metrics::observe::Observe;
 use metrics::{MetricFamily, MetricType};
 use serde_json::json;
 use std::collections::HashMap;

--- a/common/monitoring_api/src/lib.rs
+++ b/common/monitoring_api/src/lib.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, time::Duration};
 
 use eth2::lighthouse::SystemHealth;
 use gather::{gather_beacon_metrics, gather_validator_metrics};
+use health_metrics::observe::Observe;
 use reqwest::{IntoUrl, Response};
 pub use reqwest::{StatusCode, Url};
 use sensitive_url::SensitiveUrl;

--- a/common/validator_dir/Cargo.toml
+++ b/common/validator_dir/Cargo.toml
@@ -12,7 +12,6 @@ insecure_keys = []
 bls = { workspace = true }
 deposit_contract = { workspace = true }
 derivative = { workspace = true }
-directory = { workspace = true }
 eth2_keystore = { workspace = true }
 filesystem = { workspace = true }
 hex = { workspace = true }

--- a/common/validator_dir/src/builder.rs
+++ b/common/validator_dir/src/builder.rs
@@ -1,7 +1,6 @@
 use crate::{Error as DirError, ValidatorDir};
 use bls::get_withdrawal_credentials;
 use deposit_contract::{encode_eth1_tx_data, Error as DepositError};
-use directory::ensure_dir_exists;
 use eth2_keystore::{Error as KeystoreError, Keystore, KeystoreBuilder, PlainText};
 use filesystem::create_with_600_perms;
 use rand::{distributions::Alphanumeric, Rng};
@@ -42,7 +41,7 @@ pub enum Error {
     #[cfg(feature = "insecure_keys")]
     InsecureKeysError(String),
     MissingPasswordDir,
-    UnableToCreatePasswordDir(String),
+    UnableToCreatePasswordDir(io::Error),
 }
 
 impl From<KeystoreError> for Error {
@@ -163,7 +162,7 @@ impl<'a> Builder<'a> {
         }
 
         if let Some(password_dir) = &self.password_dir {
-            ensure_dir_exists(password_dir).map_err(Error::UnableToCreatePasswordDir)?;
+            create_dir_all(password_dir).map_err(Error::UnableToCreatePasswordDir)?;
         }
 
         // The withdrawal keystore must be initialized in order to store it or create an eth1

--- a/common/warp_utils/Cargo.toml
+++ b/common/warp_utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-beacon_chain = { workspace = true }
 bytes = { workspace = true }
 eth2 = { workspace = true }
 headers = "0.3.2"
@@ -15,7 +14,6 @@ safe_arith = { workspace = true }
 serde = { workspace = true }
 serde_array_query = "0.1.0"
 serde_json = { workspace = true }
-state_processing = { workspace = true }
 tokio = { workspace = true }
 types = { workspace = true }
 warp = { workspace = true }

--- a/common/warp_utils/src/lib.rs
+++ b/common/warp_utils/src/lib.rs
@@ -3,7 +3,6 @@
 
 pub mod cors;
 pub mod json;
-pub mod metrics;
 pub mod query;
 pub mod reject;
 pub mod task;

--- a/validator_client/http_api/Cargo.toml
+++ b/validator_client/http_api/Cargo.toml
@@ -21,6 +21,7 @@ eth2_keystore  = { workspace = true }
 ethereum_serde_utils = { workspace = true }
 filesystem = { workspace = true }
 graffiti_file = { workspace = true }
+health_metrics = { workspace = true }
 initialized_validators = { workspace = true }
 lighthouse_version = { workspace = true }
 logging = { workspace = true }

--- a/validator_client/http_api/src/lib.rs
+++ b/validator_client/http_api/src/lib.rs
@@ -32,6 +32,7 @@ use eth2::lighthouse_vc::{
         PublicKeyBytes, SetGraffitiRequest,
     },
 };
+use health_metrics::observe::Observe;
 use lighthouse_version::version_with_platform;
 use logging::SSELoggingComponents;
 use parking_lot::RwLock;

--- a/validator_client/http_metrics/Cargo.toml
+++ b/validator_client/http_metrics/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 
 [dependencies]
+health_metrics = { workspace = true }
 lighthouse_version = { workspace = true }
 malloc_utils = { workspace = true }
 metrics = { workspace = true }

--- a/validator_client/http_metrics/src/lib.rs
+++ b/validator_client/http_metrics/src/lib.rs
@@ -206,7 +206,7 @@ pub fn gather_prometheus_metrics<E: EthSpec>(
         scrape_allocator_metrics();
     }
 
-    warp_utils::metrics::scrape_health_metrics();
+    health_metrics::metrics::scrape_health_metrics();
 
     encoder
         .encode(&metrics::gather(), &mut buffer)


### PR DESCRIPTION
## Issue Addressed

Anchor depends on some parts of Lighthouse. Due to certain dependencies between crates, it pulled in far more crates than necessary, causing longer builds.

## Proposed Changes

**[remove ensure_dir_exists](https://github.com/sigp/lighthouse/commit/a174d6780e2209bfe8c71b0a26cf16fb8364192d)**: `account_utils` and `validator_dir` used the `directory` crate for a single function: `ensure_dir_exists`. This function had questionable value, as `create_dir_all` is a no-op if the directory exists anyway. Remove `ensure_dir_exists` and the two dependencies on `directory`, which is potentially expensive to depend on due to its dependency on `clap_utils`.

**[group UNHANDLED_ERRORs into a generic](https://github.com/sigp/lighthouse/commit/6221455f91df1b62b73ab76dc620f7eb8cd5d370)**: `warp_utils` depends on `beacon_chain` to provide `beacon_chain_error`. This causes `validator_client` to depend on `beacon_chain` transitively, which is not nice.
Remove `beacon_chain_error` and similar functions and provide a generic `unhandled_error` instead, which behaves exactly the same.

**[Introduce separate `health_metrics` crate](https://github.com/sigp/lighthouse/commit/cd05981018e2b7adb4a0ce58033f41622557d4b5) by Sayan**: The `warp_utils` crate contained facilities for capturing health metrics. Anchor wants those metrics, but also wants to avoid pulling in `warp`, as we are `axum`-only, so we introduce a new crate called `health_metrics`. We use the opportunity to also move the logic for capturing this data from `eth2` to that new crate.

## Additional Info

Lighthouse also benefits from this, as the build can run more parallelized.
