### PR TITLE
fix: add libpq-dev to the packages that need to be installed as pre-requiste

### DIFF
--- a/book/src/installation-source.md
+++ b/book/src/installation-source.md
@@ -28,7 +28,7 @@ operating system.
 Install the following packages:
 
 ```bash
-sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang
+sudo apt update && sudo apt install -y git gcc g++ make cmake pkg-config llvm-dev libclang-dev clang libpq-dev
 ```
 
 > Tips:


### PR DESCRIPTION

## Issue Addressed
This will fix the compilation error when issuing `cargo build --all`

Which issue # does this PR address?
- NA

## Proposed Changes

- Just add `libpq-dev` to the list of packages that needs to be installed before hand.

## Additional Info

- postgresql client is also used in this project