### PR TITLE
Fix custodial peer assumption on lookup custody requests

### DIFF
--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -153,14 +153,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
     pub(crate) fn active_single_lookups(&self) -> Vec<BlockLookupSummary> {
         self.single_block_lookups
             .iter()
-            .map(|(id, l)| {
-                (
-                    *id,
-                    l.block_root(),
-                    l.awaiting_parent(),
-                    l.all_peers().copied().collect(),
-                )
-            })
+            .map(|(id, l)| (*id, l.block_root(), l.awaiting_parent(), l.all_peers()))
             .collect()
     }
 

--- a/beacon_node/network/src/sync/block_lookups/mod.rs
+++ b/beacon_node/network/src/sync/block_lookups/mod.rs
@@ -283,7 +283,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                         .find(|(_, l)| l.block_root() == parent_chain_tip)
                     {
                         cx.send_sync_message(SyncMessage::AddPeersForceRangeSync {
-                            peers: lookup.all_peers().copied().collect(),
+                            peers: lookup.all_peers(),
                             head_slot: tip_lookup.peek_downloaded_block_slot(),
                             head_root: parent_chain_tip,
                         });
@@ -682,7 +682,7 @@ impl<T: BeaconChainTypes> BlockLookups<T> {
                 lookup.continue_requests(cx)
             }
             Action::ParentUnknown { parent_root } => {
-                let peers = lookup.all_peers().copied().collect::<Vec<_>>();
+                let peers = lookup.all_peers();
                 lookup.set_awaiting_parent(parent_root);
                 debug!(self.log, "Marking lookup as awaiting parent"; "id" => lookup.id, "block_root" => ?block_root, "parent_root" => ?parent_root);
                 self.search_parent_of_child(parent_root, block_root, &peers, cx);

--- a/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
+++ b/beacon_node/network/src/sync/block_lookups/single_block_lookup.rs
@@ -7,7 +7,7 @@ use crate::sync::network_context::{
 use beacon_chain::{BeaconChainTypes, BlockProcessStatus};
 use derivative::Derivative;
 use lighthouse_network::service::api_types::Id;
-use rand::seq::IteratorRandom;
+use parking_lot::RwLock;
 use std::collections::HashSet;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -33,8 +33,6 @@ pub enum LookupRequestError {
         /// The failed attempts were primarily due to processing failures.
         cannot_process: bool,
     },
-    /// No peers left to serve this lookup
-    NoPeers,
     /// Error sending event to network
     SendFailedNetwork(RpcRequestSendError),
     /// Error sending event to processor
@@ -63,9 +61,12 @@ pub struct SingleBlockLookup<T: BeaconChainTypes> {
     pub id: Id,
     pub block_request_state: BlockRequestState<T::EthSpec>,
     pub component_requests: ComponentRequests<T::EthSpec>,
-    /// Peers that claim to have imported this set of block components
+    /// Peers that claim to have imported this set of block components. This state is shared with
+    /// the custody request to have an updated view of the peers that claim to have imported the
+    /// block associated with this lookup. The peer set of a lookup can change rapidly, and faster
+    /// than the lifetime of a custody request.
     #[derivative(Debug(format_with = "fmt_peer_set_as_len"))]
-    peers: HashSet<PeerId>,
+    peers: Arc<RwLock<HashSet<PeerId>>>,
     block_root: Hash256,
     awaiting_parent: Option<Hash256>,
     created: Instant,
@@ -92,7 +93,7 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
             id,
             block_request_state: BlockRequestState::new(requested_block_root),
             component_requests: ComponentRequests::WaitingForBlock,
-            peers: HashSet::from_iter(peers.iter().copied()),
+            peers: Arc::new(RwLock::new(HashSet::from_iter(peers.iter().copied()))),
             block_root: requested_block_root,
             awaiting_parent,
             created: Instant::now(),
@@ -283,24 +284,11 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
                 return Err(LookupRequestError::TooManyAttempts { cannot_process });
             }
 
-            let Some(peer_id) = self.use_rand_available_peer() else {
-                // Allow lookup to not have any peers and do nothing. This is an optimization to not
-                // lose progress of lookups created from a block with unknown parent before we receive
-                // attestations for said block.
-                // Lookup sync event safety: If a lookup requires peers to make progress, and does
-                // not receive any new peers for some time it will be dropped. If it receives a new
-                // peer it must attempt to make progress.
-                R::request_state_mut(self)
-                    .map_err(|e| LookupRequestError::BadState(e.to_owned()))?
-                    .get_state_mut()
-                    .update_awaiting_download_status("no peers");
-                return Ok(());
-            };
-
+            let peers = self.peers.clone();
             let request = R::request_state_mut(self)
                 .map_err(|e| LookupRequestError::BadState(e.to_owned()))?;
 
-            match request.make_request(id, peer_id, expected_blobs, cx)? {
+            match request.make_request(id, peers, expected_blobs, cx)? {
                 LookupRequestResult::RequestSent(req_id) => {
                     // Lookup sync event safety: If make_request returns `RequestSent`, we are
                     // guaranteed that `BlockLookups::on_download_response` will be called exactly
@@ -348,29 +336,24 @@ impl<T: BeaconChainTypes> SingleBlockLookup<T> {
     }
 
     /// Get all unique peers that claim to have imported this set of block components
-    pub fn all_peers(&self) -> impl Iterator<Item = &PeerId> + '_ {
-        self.peers.iter()
+    pub fn all_peers(&self) -> Vec<PeerId> {
+        self.peers.read().iter().copied().collect()
     }
 
     /// Add peer to all request states. The peer must be able to serve this request.
     /// Returns true if the peer was newly inserted into some request state.
     pub fn add_peer(&mut self, peer_id: PeerId) -> bool {
-        self.peers.insert(peer_id)
+        self.peers.write().insert(peer_id)
     }
 
     /// Remove peer from available peers.
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
-        self.peers.remove(peer_id);
+        self.peers.write().remove(peer_id);
     }
 
     /// Returns true if this lookup has zero peers
     pub fn has_no_peers(&self) -> bool {
-        self.peers.is_empty()
-    }
-
-    /// Selects a random peer from available peers if any
-    fn use_rand_available_peer(&mut self) -> Option<PeerId> {
-        self.peers.iter().choose(&mut rand::thread_rng()).copied()
+        self.peers.read().is_empty()
     }
 }
 
@@ -689,8 +672,8 @@ impl<T: Clone> std::fmt::Debug for State<T> {
 }
 
 fn fmt_peer_set_as_len(
-    peer_set: &HashSet<PeerId>,
+    peer_set: &Arc<RwLock<HashSet<PeerId>>>,
     f: &mut std::fmt::Formatter,
 ) -> Result<(), std::fmt::Error> {
-    write!(f, "{}", peer_set.len())
+    write!(f, "{}", peer_set.read().len())
 }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -27,7 +27,8 @@ use lighthouse_network::service::api_types::{
     DataColumnsByRootRequester, Id, SingleLookupReqId, SyncRequestId,
 };
 use lighthouse_network::{Client, NetworkGlobals, PeerAction, PeerId, ReportSource};
-use rand::seq::SliceRandom;
+use parking_lot::RwLock;
+use rand::prelude::IteratorRandom;
 use rand::thread_rng;
 pub use requests::LookupVerifyError;
 use requests::{
@@ -308,8 +309,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     pub fn get_random_custodial_peer(&self, column_index: ColumnIndex) -> Option<PeerId> {
         self.get_custodial_peers(column_index)
+            .into_iter()
             .choose(&mut thread_rng())
-            .cloned()
     }
 
     pub fn network_globals(&self) -> &NetworkGlobals<T::EthSpec> {
@@ -562,9 +563,24 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     pub fn block_lookup_request(
         &mut self,
         lookup_id: SingleLookupId,
-        peer_id: PeerId,
+        lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
         block_root: Hash256,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
+        let Some(peer_id) = lookup_peers
+            .read()
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .copied()
+        else {
+            // Allow lookup to not have any peers and do nothing. This is an optimization to not
+            // lose progress of lookups created from a block with unknown parent before we receive
+            // attestations for said block.
+            // Lookup sync event safety: If a lookup requires peers to make progress, and does
+            // not receive any new peers for some time it will be dropped. If it receives a new
+            // peer it must attempt to make progress.
+            return Ok(LookupRequestResult::Pending("no peers"));
+        };
+
         match self.chain.get_block_process_status(&block_root) {
             // Unknown block, continue request to download
             BlockProcessStatus::Unknown => {}
@@ -634,10 +650,25 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
     pub fn blob_lookup_request(
         &mut self,
         lookup_id: SingleLookupId,
-        peer_id: PeerId,
+        lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
         block_root: Hash256,
         expected_blobs: usize,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
+        let Some(peer_id) = lookup_peers
+            .read()
+            .iter()
+            .choose(&mut rand::thread_rng())
+            .copied()
+        else {
+            // Allow lookup to not have any peers and do nothing. This is an optimization to not
+            // lose progress of lookups created from a block with unknown parent before we receive
+            // attestations for said block.
+            // Lookup sync event safety: If a lookup requires peers to make progress, and does
+            // not receive any new peers for some time it will be dropped. If it receives a new
+            // peer it must attempt to make progress.
+            return Ok(LookupRequestResult::Pending("no peers"));
+        };
+
         let imported_blob_indexes = self
             .chain
             .data_availability_checker
@@ -740,6 +771,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         &mut self,
         lookup_id: SingleLookupId,
         block_root: Hash256,
+        lookup_peers: Arc<RwLock<HashSet<PeerId>>>,
     ) -> Result<LookupRequestResult, RpcRequestSendError> {
         let custody_indexes_imported = self
             .chain
@@ -777,6 +809,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             block_root,
             CustodyId { requester },
             &custody_indexes_to_fetch,
+            lookup_peers,
             self.log.clone(),
         );
 


### PR DESCRIPTION
## Issue Addressed

Current unstable assumes that all peers to which we request columns by root, MUST have the columns in custody

https://github.com/sigp/lighthouse/blob/06329ec2d105fc60c4c7218561cff11fb6b398a3/beacon_node/network/src/sync/network_context/custody.rs#L286-L289

This statement is incorrect, as we pick a random peer from the global set of peers. The result, is a lot of downscore events like

```
VerifyError(NotEnoughResponsesReturned { actual: 0 })
```

for innocent peers.

## Proposed Changes

Provide the custody request with an up-to-date list of peers that claim to have imported the lookup block. If peers give us that signal we can expect and enforce that they MUST have the columns in custody. If we don't have any such peers, we draw from the global set, but don't enforce then to have the columns in custody.

Since we need share state between the custody request and the overall lookup request I introduced a Mutex. I don't see another way around it if we want the custody request to have the most up-to-date view of the peer set. With @michaelsproul we discussed using an immutable HashSet and clone it, but that would result in the custody request having a quickly stale view. Only when the overall custody request fails (after 3 retries) the peer set would update. 

Consider the following sequence of events, if we don't use a Mutex:
- Receive attestation for block A
- Lookup for block A is created with a single peer
- Custody request is created with a single peer
- Receive attestations for block A from 50 other peers
- (..) wait for custody request to fail 3 times (could take many seconds)
- Re-create custody request with 51 peers

During a significant duration the custody request has a stale view, rendering this feature not that useful.
