### PR TITLE
Avoid computing columns from EL blobs if block has already been imported

### DIFF
--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -262,18 +262,21 @@ fn spawn_compute_and_publish_data_columns_task<T: BeaconChainTypes>(
                 }
             };
 
-            if let Err(e) = data_columns_sender.send(all_data_columns.clone()) {
-                error!(log, "Failed to send computed data columns"; "error" => ?e);
+            if data_columns_sender.send(all_data_columns.clone()).is_err() {
+                // Data column receiver have been dropped - block may have already been imported.
+                // This race condition exists because gossip columns may arrive and trigger block
+                // import during the computation. Here we just drop the computed columns.
+                debug!(
+                    log,
+                    "Failed to send computed data columns";
+                );
+                return;
             };
-
-            // Check indices from cache before sending the columns, to make sure we don't
-            // publish components already seen on gossip.
-            let is_supernode = chain_cloned.data_availability_checker.is_supernode();
 
             // At the moment non supernodes are not required to publish any columns.
             // TODO(das): we could experiment with having full nodes publish their custodied
             // columns here.
-            if !is_supernode {
+            if !chain_cloned.data_availability_checker.is_supernode() {
                 return;
             }
 

--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -163,6 +163,20 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
             return Ok(None);
         }
 
+        if chain
+            .canonical_head
+            .fork_choice_read_lock()
+            .contains_block(&block_root)
+        {
+            // Avoid computing columns if block has already been imported.
+            debug!(
+                log,
+                "Ignoring EL blobs response";
+                "info" => "block has already been imported",
+            );
+            return Ok(None);
+        }
+
         let data_columns_receiver = spawn_compute_and_publish_data_columns_task(
             &chain,
             block.clone(),


### PR DESCRIPTION
## Issue Addressed

From PeerDAS local testing I noticed some errors with failing to send computed columns to receiver:

https://github.com/sigp/lighthouse/blob/dd7591f7123dfe072631c0deb0abc1b78cc82733/beacon_node/beacon_chain/src/fetch_blobs.rs#L252

I believe there is a race condition, the sequence:
1. Fetch EL blobs triggered, received 4 blobs from the EL, triggered column computation
1. All 8 custody columns received via gossip
1. Columns written to db, block imported. (Column receiver dropped)
1. Computed columns but fail to send as receiver was dropped.

We should not even try to compute the columns if we've already imported the block from gossip. This consumes extra resources and bandwidth and is unnecessary.
