### PR TITLE
Increase jemalloc aarch64 page size limit (#5244)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,3 @@
 [env]
 # Set the number of arenas to 16 when using jemalloc.
 JEMALLOC_SYS_WITH_MALLOC_CONF = "abort_conf:true,narenas:16"
-

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,14 @@ pre-build = ["apt-get install -y cmake clang-5.0"]
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = ["apt-get install -y cmake clang-5.0"]
+
+# Allow setting page size limits for jemalloc at build time:
+# For certain architectures (like aarch64), we must compile
+# jemalloc with support for large page sizes, otherwise the host's
+# system page size will be used, which may not work on the target systems.
+# JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
+# pages. See: https://github.com/sigp/lighthouse/issues/5244
+[build.env]
+passthrough = [
+    "JEMALLOC_SYS_WITH_LG_PAGE",
+]

--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,17 @@ install-lcli:
 build-x86_64:
 	cross build --bin lighthouse --target x86_64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 build-aarch64:
-    # JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
-    # pages, which are commonly used by aarch64 systems.
-    # See: https://github.com/sigp/lighthouse/issues/5244
+	# JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
+	# pages, which are commonly used by aarch64 systems.
+	# See: https://github.com/sigp/lighthouse/issues/5244
 	JEMALLOC_SYS_WITH_LG_PAGE=16 cross build --bin lighthouse --target aarch64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 
 build-lcli-x86_64:
 	cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 build-lcli-aarch64:
-    # JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
-    # pages, which are commonly used by aarch64 systems.
-    # See: https://github.com/sigp/lighthouse/issues/5244
+	# JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
+	# pages, which are commonly used by aarch64 systems.
+	# See: https://github.com/sigp/lighthouse/issues/5244
 	JEMALLOC_SYS_WITH_LG_PAGE=16 cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 
 # Create a `.tar.gz` containing a binary for a specific target.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ install-lcli:
 build-x86_64:
 	cross build --bin lighthouse --target x86_64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 build-aarch64:
-	cross build --bin lighthouse --target aarch64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
+    # JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
+    # pages, which are commonly used by aarch64 systems.
+    # See: https://github.com/sigp/lighthouse/issues/5244
+	JEMALLOC_SYS_WITH_LG_PAGE=16 cross build --bin lighthouse --target aarch64-unknown-linux-gnu --features "portable,$(CROSS_FEATURES)" --profile "$(CROSS_PROFILE)" --locked
 
 build-lcli-x86_64:
 	cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,10 @@ build-aarch64:
 build-lcli-x86_64:
 	cross build --bin lcli --target x86_64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 build-lcli-aarch64:
-	cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
+    # JEMALLOC_SYS_WITH_LG_PAGE=16 tells jemalloc to support up to 64-KiB
+    # pages, which are commonly used by aarch64 systems.
+    # See: https://github.com/sigp/lighthouse/issues/5244
+	JEMALLOC_SYS_WITH_LG_PAGE=16 cross build --bin lcli --target aarch64-unknown-linux-gnu --features "portable" --profile "$(CROSS_PROFILE)" --locked
 
 # Create a `.tar.gz` containing a binary for a specific target.
 define tarball_release_binary

--- a/common/malloc_utils/src/jemalloc.rs
+++ b/common/malloc_utils/src/jemalloc.rs
@@ -9,7 +9,7 @@
 //! B) `_RJEM_MALLOC_CONF` at runtime.
 use metrics::{set_gauge, try_create_int_gauge, IntGauge};
 use std::sync::LazyLock;
-use tikv_jemalloc_ctl::{arenas, epoch, stats, Error};
+use tikv_jemalloc_ctl::{arenas, epoch, stats, Access, AsName, Error};
 
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
@@ -51,4 +51,19 @@ pub fn scrape_jemalloc_metrics_fallible() -> Result<(), Error> {
     set_gauge(&BYTES_RETAINED, stats::retained::read()? as i64);
 
     Ok(())
+}
+
+pub fn page_size() -> Result<usize, Error> {
+    // Full list of keys: https://jemalloc.net/jemalloc.3.html
+    "arenas.page\0".name().read()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn page_size_ok() {
+        assert!(page_size().is_ok());
+    }
 }

--- a/common/malloc_utils/src/lib.rs
+++ b/common/malloc_utils/src/lib.rs
@@ -29,10 +29,10 @@
     not(target_env = "musl"),
     not(feature = "jemalloc")
 ))]
-mod glibc;
+pub mod glibc;
 
 #[cfg(feature = "jemalloc")]
-mod jemalloc;
+pub mod jemalloc;
 
 pub use interface::*;
 

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -66,11 +66,15 @@ fn bls_hardware_acceleration() -> bool {
     return std::arch::is_aarch64_feature_detected!("neon");
 }
 
-fn allocator_name() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "system"
-    } else {
-        "jemalloc"
+fn allocator_name() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        "system".to_string()
+    }
+    #[cfg(not(target_os = "windows"))]
+    match malloc_utils::jemalloc::page_size() {
+        Ok(page_size) => format!("jemalloc ({}K)", page_size / 1024),
+        Err(e) => format!("jemalloc (error: {e:?})"),
     }
 }
 


### PR DESCRIPTION
## Issue Addressed

#5244

## Proposed Changes

Pass `JEMALLOC_SYS_WITH_LG_PAGE=16` env to aarch64 cross-compilation to support systems with up to 64-KiB page sizes. This is backwards-compatible for the current (most usual) 4-KiB systems.
