### PR TITLE
Merge `stable` into `unstable`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
 
   - name: Approve trivial maintainer PRs
     conditions:
-      - base=master
+      - base=unstable
       - label=trivial
       - author=@sigp/lighthouse
     actions:
@@ -25,8 +25,8 @@ pull_request_rules:
   - name: Add ready-to-merge labeled PRs to merge queue
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
-      - base=master
-      - label=send-it
+      - base=unstable
+      - label=ready-to-merge
     actions:
       queue:
 

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,3 +1,36 @@
+pull_request_rules:
+  - name: Ask to resolve conflict
+    conditions:
+      - conflict
+      - -author=dependabot[bot]
+      - or:
+          - -draft # Don't report conflicts on regular draft.
+          - and: # Do report conflicts on draft that are scheduled for the next major release.
+              - draft
+              - milestone~=v[0-9]\.[0-9]{2}
+    actions:
+      comment:
+        message: This pull request has merge conflicts. Could you please resolve them
+          @{{author}}? 🙏
+
+  - name: Approve trivial maintainer PRs
+    conditions:
+      - base=master
+      - label=trivial
+      - author=@sigp/lighthouse
+    actions:
+      review:
+        type: APPROVE
+
+  - name: Add ready-to-merge labeled PRs to merge queue
+    conditions:
+      # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
+      - base=master
+      - label=send-it
+    actions:
+      queue:
+
+
 queue_rules:
   - name: default
     batch_size: 8
@@ -6,10 +39,11 @@ queue_rules:
     merge_method: squash
     commit_message_template: |
       {{ title }} (#{{ number }})
-      
-      {% for commit in commits %}
-      * {{ commit.commit_message }}
-      {% endfor %}
+
+        {{ body | get_section("## Issue Addressed", "") }}
+
+
+        {{ body | get_section("## Proposed Changes", "") }}
     queue_conditions:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"


### PR DESCRIPTION
## Issue Addressed

Update `unstable` for the mergify config change merged to `stable`:

- https://github.com/sigp/lighthouse/pull/6597

## Additional Info

We should merge this with a merge commit rather than a squash.
