### PR TITLE
Improve mergify config

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
       - base=unstable
       - label=trivial
       - author=@sigp/lighthouse
-      - conflict
+      - -conflict
     actions:
       review:
         type: APPROVE

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,6 +18,7 @@ pull_request_rules:
       - base=unstable
       - label=trivial
       - author=@sigp/lighthouse
+      - conflict
     actions:
       review:
         type: APPROVE
@@ -26,10 +27,10 @@ pull_request_rules:
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
       - base=unstable
-      - label=ready-to-merge
+      - label=ready-for-merge
+      - label!=do-not-merge
     actions:
       queue:
-
 
 queue_rules:
   - name: default
@@ -48,6 +49,7 @@ queue_rules:
       - "#approved-reviews-by >= 1"
       - "check-success=license/cla"
       - "check-success=target-branch-check"
+      - "label!=do-not-merge"
     merge_conditions:
       - "check-success=test-suite-success"
       - "check-success=local-testnet-success"


### PR DESCRIPTION
## Issue Addressed

And partially address https://github.com/sigp/lighthouse/issues/6845

- [x] use `ready-for-merge` label instead of `ready-to-merge`
- [ ] We should ideally remove approval on `trivial` PRs if the `trivial` label is removed.
- [x] Do not let the bot approve `trivial` PRs that have conflicts.
- [x] Do not let the bot queue PRs that are labelled `do-not-merge.

the missing one seems impossible as I didn't find a [condition](https://docs.mergify.com/configuration/conditions/) for a removed label.