### PR TITLE
More gossipsub metrics

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/gossip_promises.rs
@@ -41,6 +41,13 @@ impl GossipPromises {
         self.promises.contains_key(message)
     }
 
+    /// Returns true if the message id exists in the promises and contains the given peer.
+    pub(crate) fn contains_peer(&self, message: &MessageId, peer: &PeerId) -> bool {
+        self.promises
+            .get(message)
+            .is_some_and(|peers| peers.contains_key(peer))
+    }
+
     ///Get the peers we sent IWANT the input message id.
     pub(crate) fn peers_for_message(&self, message_id: &MessageId) -> Vec<PeerId> {
         self.promises


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Add metrics that tell us if a duplicate message that we received was from a mesh peer or from a non mesh peer that we requested with iwant message.
