### PR TITLE
Fix mdbook build.

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build-and-upload-to-s3:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/actions/runs/13063781937/job/36452383133

`mdbook` ci job above is failing because the latest release now requires a newer version of glibc:

> Updated the Linux pre-built binaries which requires a newer version of glibc (2.34). https://github.com/rust-lang/mdBook/pull/2523

https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md

Updating to latest ubuntu to fix this.