### PR TITLE
chore: update peerDAS KZG library to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_bls12_381"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23be5253f1bd7fd411721a58712308c4747d0a41d040bbf8ebb78d52909a480"
+checksum = "48603155907d588e487aea229f61a28d9a918c95c9aa987055ba29502225810b"
 dependencies = [
  "blst",
  "blstrs",
@@ -1590,9 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_erasure_codes"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2067ce20ef380ff33a93ce0af62bea22d35531b7f3586224d8d5176ec6cf578"
+checksum = "cdf616e4b4f1799191bb1e70b8a29f65e95ab5d74c59972a34998de488d01efd"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
  "crate_crypto_internal_eth_kzg_polynomial",
@@ -1600,24 +1600,24 @@ dependencies = [
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_maybe_rayon"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558f50324ff016e5fe93113c78a72776d790d52f244ae9602a8013a67a189b66"
+checksum = "f1ddd0330f34f0b92a9f0b29bc3f8494b30d596ab8b951233ec90b2d72ab132c"
 
 [[package]]
 name = "crate_crypto_internal_eth_kzg_polynomial"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e051c4f5aa5696bd7c504930485436ec62bf14f30a4c2d78504f3f8ec6a3daf"
+checksum = "7488314261926373e1c20121c404fabf5b57ca09f48eddc7fef38be1df79a006"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
 ]
 
 [[package]]
 name = "crate_crypto_kzg_multi_open_fk20"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ed6bf8993d9f3b361da4ed38f067503e08c0b948af0d6f4bb941dd647c0f2c"
+checksum = "d24efdb64e7518848f11069dd9de23bd04455146a9fd5486345d99ed8bfdb049"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
  "crate_crypto_internal_eth_kzg_maybe_rayon",
@@ -4758,11 +4758,6 @@ version = "0.1.0"
 dependencies = [
  "arbitrary",
  "c-kzg",
- "crate_crypto_internal_eth_kzg_bls12_381",
- "crate_crypto_internal_eth_kzg_erasure_codes",
- "crate_crypto_internal_eth_kzg_maybe_rayon",
- "crate_crypto_internal_eth_kzg_polynomial",
- "crate_crypto_kzg_multi_open_fk20",
  "criterion",
  "derivative",
  "ethereum_hashing",
@@ -7524,9 +7519,9 @@ dependencies = [
 
 [[package]]
 name = "rust_eth_kzg"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291fd0d9c629a56537d74bbc1e7bcaf5be610f2f7b55af85c4fea843c6aeca3"
+checksum = "a237a478ee68e491a0f40bbcbb958b79ba9b37aacce459f7ab3ba78f3cbfa9d0"
 dependencies = [
  "crate_crypto_internal_eth_kzg_bls12_381",
  "crate_crypto_internal_eth_kzg_erasure_codes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,14 +132,7 @@ delay_map = "0.4"
 derivative = "2"
 dirs = "3"
 either = "1.9"
-# TODO: rust_eth_kzg is pinned for now while a perf regression is investigated
-# The crate_crypto_* dependencies can be removed from this file completely once we update
-rust_eth_kzg = "=0.5.1"
-crate_crypto_internal_eth_kzg_bls12_381 = "=0.5.1"
-crate_crypto_internal_eth_kzg_erasure_codes = "=0.5.1"
-crate_crypto_internal_eth_kzg_maybe_rayon = "=0.5.1"
-crate_crypto_internal_eth_kzg_polynomial = "=0.5.1"
-crate_crypto_kzg_multi_open_fk20 = "=0.5.1"
+rust_eth_kzg = "0.5.3"
 discv5 = { version = "0.9", features = ["libp2p"] }
 env_logger = "0.9"
 ethereum_hashing = "0.7.0"

--- a/crypto/kzg/Cargo.toml
+++ b/crypto/kzg/Cargo.toml
@@ -8,12 +8,6 @@ edition = "2021"
 [dependencies]
 arbitrary = { workspace = true }
 c-kzg = { workspace = true }
-# Required to maintain the pin from https://github.com/sigp/lighthouse/pull/6608
-crate_crypto_internal_eth_kzg_bls12_381 = { workspace = true }
-crate_crypto_internal_eth_kzg_erasure_codes = { workspace = true }
-crate_crypto_internal_eth_kzg_maybe_rayon = { workspace = true }
-crate_crypto_internal_eth_kzg_polynomial = { workspace = true }
-crate_crypto_kzg_multi_open_fk20 = { workspace = true }
 derivative = { workspace = true }
 ethereum_hashing = { workspace = true }
 ethereum_serde_utils = { workspace = true }


### PR DESCRIPTION
## Issue Addressed

This optimizes the time it takes to load the context, so that tests do not time out