### PR TITLE
Sync active request byrange ids logs

### DIFF
--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -1,14 +1,13 @@
-use std::sync::Arc;
-
-use libp2p::swarm::ConnectionId;
-use types::{
-    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, Hash256, LightClientBootstrap,
-    LightClientFinalityUpdate, LightClientOptimisticUpdate, LightClientUpdate, SignedBeaconBlock,
-};
-
 use crate::rpc::{
     methods::{ResponseTermination, RpcResponse, RpcSuccessResponse, StatusMessage},
     SubstreamId,
+};
+use libp2p::swarm::ConnectionId;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+use types::{
+    BlobSidecar, DataColumnSidecar, Epoch, EthSpec, Hash256, LightClientBootstrap,
+    LightClientFinalityUpdate, LightClientOptimisticUpdate, LightClientUpdate, SignedBeaconBlock,
 };
 
 /// Identifier of requests sent by a peer.
@@ -235,9 +234,138 @@ impl slog::Value for RequestId {
     }
 }
 
+// Since each request Id is deeply nested with various types, if rendered with Debug on logs they
+// take too much visual space. This custom Display implementations make the overall Id short while
+// not losing information
+impl Display for BlocksByRangeRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id, self.parent_request_id)
+    }
+}
+
+impl Display for BlobsByRangeRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id, self.parent_request_id)
+    }
+}
+
+impl Display for DataColumnsByRangeRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id, self.parent_request_id)
+    }
+}
+
+impl Display for ComponentsByRangeRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id, self.requester)
+    }
+}
+
+impl Display for SingleLookupReqId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/Lookup/{}", self.req_id, self.lookup_id)
+    }
+}
+
 // This custom impl reduces log boilerplate not printing `DataColumnsByRootRequestId` on each id log
-impl std::fmt::Display for DataColumnsByRootRequestId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {:?}", self.id, self.requester)
+impl Display for DataColumnsByRootRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.id, self.requester)
+    }
+}
+
+impl Display for DataColumnsByRootRequester {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Custody(id) => write!(f, "Custody/{id}"),
+            Self::Sampling(id) => write!(f, "Sampling/{id}"),
+        }
+    }
+}
+
+impl Display for CustodyId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.requester)
+    }
+}
+
+impl Display for CustodyRequester {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Display for RangeRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RangeSync { chain_id, batch_id } => write!(f, "RangeSync/{batch_id}/{chain_id}"),
+            Self::BackfillSync { batch_id } => write!(f, "BackfillSync/{batch_id}"),
+        }
+    }
+}
+
+impl Display for SamplingId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.sampling_request_id, self.id)
+    }
+}
+
+impl Display for SamplingRequestId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Display for SamplingRequester {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ImportedBlock(block) => write!(f, "ImportedBlock/{block}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_id_data_columns_by_root_custody() {
+        let id = DataColumnsByRootRequestId {
+            id: 123,
+            requester: DataColumnsByRootRequester::Custody(CustodyId {
+                requester: CustodyRequester(SingleLookupReqId {
+                    req_id: 121,
+                    lookup_id: 101,
+                }),
+            }),
+        };
+        assert_eq!(format!("{id}"), "123/Custody/121/Lookup/101");
+    }
+
+    #[test]
+    fn display_id_data_columns_by_root_sampling() {
+        let id = DataColumnsByRootRequestId {
+            id: 123,
+            requester: DataColumnsByRootRequester::Sampling(SamplingId {
+                id: SamplingRequester::ImportedBlock(Hash256::ZERO),
+                sampling_request_id: SamplingRequestId(101),
+            }),
+        };
+        assert_eq!(format!("{id}"), "123/Sampling/101/ImportedBlock/0x0000000000000000000000000000000000000000000000000000000000000000");
+    }
+
+    #[test]
+    fn display_id_data_columns_by_range() {
+        let id = DataColumnsByRangeRequestId {
+            id: 123,
+            parent_request_id: ComponentsByRangeRequestId {
+                id: 122,
+                requester: RangeRequestId::RangeSync {
+                    chain_id: 5492900659401505034,
+                    batch_id: Epoch::new(0),
+                },
+            },
+        };
+        assert_eq!(format!("{id}"), "123/122/RangeSync/0/5492900659401505034");
     }
 }

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -234,45 +234,27 @@ impl slog::Value for RequestId {
     }
 }
 
+macro_rules! impl_display {
+    ($structname: ty, $format: literal, $($field:ident),*) => {
+        impl Display for $structname {
+            fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+                write!(f, $format, $(self.$field,)*)
+            }
+        }
+    };
+}
+
 // Since each request Id is deeply nested with various types, if rendered with Debug on logs they
 // take too much visual space. This custom Display implementations make the overall Id short while
 // not losing information
-impl Display for BlocksByRangeRequestId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.id, self.parent_request_id)
-    }
-}
-
-impl Display for BlobsByRangeRequestId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.id, self.parent_request_id)
-    }
-}
-
-impl Display for DataColumnsByRangeRequestId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.id, self.parent_request_id)
-    }
-}
-
-impl Display for ComponentsByRangeRequestId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.id, self.requester)
-    }
-}
-
-impl Display for SingleLookupReqId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/Lookup/{}", self.req_id, self.lookup_id)
-    }
-}
-
-// This custom impl reduces log boilerplate not printing `DataColumnsByRootRequestId` on each id log
-impl Display for DataColumnsByRootRequestId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.id, self.requester)
-    }
-}
+impl_display!(BlocksByRangeRequestId, "{}/{}", id, parent_request_id);
+impl_display!(BlobsByRangeRequestId, "{}/{}", id, parent_request_id);
+impl_display!(DataColumnsByRangeRequestId, "{}/{}", id, parent_request_id);
+impl_display!(ComponentsByRangeRequestId, "{}/{}", id, requester);
+impl_display!(DataColumnsByRootRequestId, "{}/{}", id, requester);
+impl_display!(SingleLookupReqId, "{}/Lookup/{}", req_id, lookup_id);
+impl_display!(CustodyId, "{}", requester);
+impl_display!(SamplingId, "{}/{}", sampling_request_id, id);
 
 impl Display for DataColumnsByRootRequester {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -280,12 +262,6 @@ impl Display for DataColumnsByRootRequester {
             Self::Custody(id) => write!(f, "Custody/{id}"),
             Self::Sampling(id) => write!(f, "Sampling/{id}"),
         }
-    }
-}
-
-impl Display for CustodyId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.requester)
     }
 }
 
@@ -301,12 +277,6 @@ impl Display for RangeRequestId {
             Self::RangeSync { chain_id, batch_id } => write!(f, "RangeSync/{batch_id}/{chain_id}"),
             Self::BackfillSync { batch_id } => write!(f, "BackfillSync/{batch_id}"),
         }
-    }
-}
-
-impl Display for SamplingId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}/{}", self.sampling_request_id, self.id)
     }
 }
 
@@ -361,11 +331,11 @@ mod tests {
             parent_request_id: ComponentsByRangeRequestId {
                 id: 122,
                 requester: RangeRequestId::RangeSync {
-                    chain_id: 5492900659401505034,
+                    chain_id: 54,
                     batch_id: Epoch::new(0),
                 },
             },
         };
-        assert_eq!(format!("{id}"), "123/122/RangeSync/0/5492900659401505034");
+        assert_eq!(format!("{id}"), "123/122/RangeSync/0/54");
     }
 }

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -612,13 +612,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         process_id: ChainSegmentProcessId,
         blocks: Vec<RpcBlock<T::EthSpec>>,
     ) -> Result<(), Error<T::EthSpec>> {
+        let is_backfill = matches!(&process_id, ChainSegmentProcessId::BackSyncBatchId { .. });
         debug!(self.log, "Batch sending for process";
             "blocks" => blocks.len(),
             "id" => ?process_id,
         );
 
         let processor = self.clone();
-        let id = process_id.clone();
         let process_fn = async move {
             let notify_execution_layer = if processor
                 .network_globals
@@ -631,16 +631,17 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 NotifyExecutionLayer::Yes
             };
             processor
-                .process_chain_segment(id, blocks, notify_execution_layer)
+                .process_chain_segment(process_id, blocks, notify_execution_layer)
                 .await;
         };
         let process_fn = Box::pin(process_fn);
 
         // Back-sync batches are dispatched with a different `Work` variant so
         // they can be rate-limited.
-        let work = match process_id {
-            ChainSegmentProcessId::RangeBatchId { .. } => Work::ChainSegment(process_fn),
-            ChainSegmentProcessId::BackSyncBatchId { .. } => Work::ChainSegmentBackfill(process_fn),
+        let work = if is_backfill {
+            Work::ChainSegmentBackfill(process_fn)
+        } else {
+            Work::ChainSegment(process_fn)
         };
 
         self.try_send(BeaconWorkEvent {

--- a/beacon_node/network/src/network_beacon_processor/mod.rs
+++ b/beacon_node/network/src/network_beacon_processor/mod.rs
@@ -612,13 +612,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         process_id: ChainSegmentProcessId,
         blocks: Vec<RpcBlock<T::EthSpec>>,
     ) -> Result<(), Error<T::EthSpec>> {
-        let is_backfill = matches!(&process_id, ChainSegmentProcessId::BackSyncBatchId { .. });
         debug!(self.log, "Batch sending for process";
             "blocks" => blocks.len(),
             "id" => ?process_id,
         );
 
         let processor = self.clone();
+        let id = process_id.clone();
         let process_fn = async move {
             let notify_execution_layer = if processor
                 .network_globals
@@ -631,17 +631,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 NotifyExecutionLayer::Yes
             };
             processor
-                .process_chain_segment(process_id, blocks, notify_execution_layer)
+                .process_chain_segment(id, blocks, notify_execution_layer)
                 .await;
         };
         let process_fn = Box::pin(process_fn);
 
         // Back-sync batches are dispatched with a different `Work` variant so
         // they can be rate-limited.
-        let work = if is_backfill {
-            Work::ChainSegmentBackfill(process_fn)
-        } else {
-            Work::ChainSegment(process_fn)
+        let work = match process_id {
+            ChainSegmentProcessId::RangeBatchId { .. } => Work::ChainSegment(process_fn),
+            ChainSegmentProcessId::BackSyncBatchId { .. } => Work::ChainSegmentBackfill(process_fn),
         };
 
         self.try_send(BeaconWorkEvent {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -37,6 +37,7 @@ use requests::{
 use slog::{debug, error, warn};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -538,15 +539,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let req_id = self.next_id();
         let id = SingleLookupReqId { lookup_id, req_id };
 
-        debug!(
-            self.log,
-            "Sending BlocksByRoot Request";
-            "method" => "BlocksByRoot",
-            "block_root" => ?block_root,
-            "peer" => %peer_id,
-            "id" => ?id
-        );
-
         let request = BlocksByRootSingleRequest(block_root);
 
         // Lookup sync event safety: If network_send.send() returns Ok(_) we are guaranteed that
@@ -562,6 +554,15 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
+
+        debug!(
+            self.log,
+            "Sync RPC request sent";
+            "method" => "BlocksByRoot",
+            "block_root" => ?block_root,
+            "peer" => %peer_id,
+            "id" => ?id
+        );
 
         self.blocks_by_root_requests.insert(
             id,
@@ -621,19 +622,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let req_id = self.next_id();
         let id = SingleLookupReqId { lookup_id, req_id };
 
-        debug!(
-            self.log,
-            "Sending BlobsByRoot Request";
-            "method" => "BlobsByRoot",
-            "block_root" => ?block_root,
-            "blob_indices" => ?indices,
-            "peer" => %peer_id,
-            "id" => ?id
-        );
-
         let request = BlobsByRootSingleBlockRequest {
             block_root,
-            indices,
+            indices: indices.clone(),
         };
 
         // Lookup sync event safety: Refer to `Self::block_lookup_request` `network_send.send` call
@@ -644,6 +635,16 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
+
+        debug!(
+            self.log,
+            "Sync RPC request sent";
+            "method" => "BlobsByRoot",
+            "block_root" => ?block_root,
+            "blob_indices" => ?indices,
+            "peer" => %peer_id,
+            "id" => ?id
+        );
 
         self.blobs_by_root_requests.insert(
             id,
@@ -670,9 +671,16 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             id: self.next_id(),
             requester,
         };
+
+        self.send_network_msg(NetworkMessage::SendRequest {
+            peer_id,
+            request: RequestType::DataColumnsByRoot(request.clone().into_request(&self.chain.spec)),
+            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRoot(req_id)),
+        })?;
+
         debug!(
             self.log,
-            "Sending DataColumnsByRoot Request";
+            "Sync RPC request sent";
             "method" => "DataColumnsByRoot",
             "block_root" => ?request.block_root,
             "indices" => ?request.indices,
@@ -680,12 +688,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             "requester" => ?requester,
             "req_id" => %req_id,
         );
-
-        self.send_network_msg(NetworkMessage::SendRequest {
-            peer_id,
-            request: RequestType::DataColumnsByRoot(request.clone().into_request(&self.chain.spec)),
-            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRoot(req_id)),
-        })?;
 
         self.data_columns_by_root_requests.insert(
             req_id,
@@ -770,15 +772,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             id: self.next_id(),
             parent_request_id,
         };
-        debug!(
-            self.log,
-            "Sending BlocksByRange request";
-            "method" => "BlocksByRange",
-            "count" => request.count(),
-            "epoch" => Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch()),
-            "peer" => %peer_id,
-            "id" => ?id,
-        );
         self.network_send
             .send(NetworkMessage::SendRequest {
                 peer_id,
@@ -786,6 +779,16 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 request_id: AppRequestId::Sync(SyncRequestId::BlocksByRange(id)),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
+
+        debug!(
+            self.log,
+            "Sync RPC request sent";
+            "method" => "BlocksByRange",
+            "count" => request.count(),
+            "epoch" => Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch()),
+            "peer" => %peer_id,
+            "id" => ?id,
+        );
 
         self.blocks_by_range_requests.insert(
             id,
@@ -809,15 +812,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             parent_request_id,
         };
         let request_epoch = Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch());
-        debug!(
-            self.log,
-            "Sending BlobsByRange requests";
-            "method" => "BlobsByRange",
-            "count" => request.count,
-            "epoch" => request_epoch,
-            "peer" => %peer_id,
-            "id" => ?id,
-        );
 
         // Create the blob request based on the blocks request.
         self.network_send
@@ -827,6 +821,16 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 request_id: AppRequestId::Sync(SyncRequestId::BlobsByRange(id)),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
+
+        debug!(
+            self.log,
+            "Sync RPC request sent";
+            "method" => "BlobsByRange",
+            "count" => request.count,
+            "epoch" => request_epoch,
+            "peer" => %peer_id,
+            "id" => ?id,
+        );
 
         let max_blobs_per_block = self.chain.spec.max_blobs_per_block(request_epoch);
         self.blobs_by_range_requests.insert(
@@ -850,16 +854,6 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             id: self.next_id(),
             parent_request_id,
         };
-        debug!(
-            self.log,
-            "Sending DataColumnsByRange requests";
-            "method" => "DataColumnsByRange",
-            "count" => request.count,
-            "epoch" => Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch()),
-            "columns" => ?request.columns,
-            "peer" => %peer_id,
-            "id" => ?id,
-        );
 
         self.send_network_msg(NetworkMessage::SendRequest {
             peer_id,
@@ -867,6 +861,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRange(id)),
         })
         .map_err(|_| RpcRequestSendError::NetworkSendError)?;
+
+        debug!(
+            self.log,
+            "Sync RPC request sent";
+            "method" => "DataColumnsByRange",
+            "count" => request.count,
+            "epoch" => Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch()),
+            "columns" => ?request.columns,
+            "peer" => %peer_id,
+            "id" => ?id,
+        );
 
         self.data_columns_by_range_requests.insert(
             id,
@@ -1011,8 +1016,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         peer_id: PeerId,
         rpc_event: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) -> Option<RpcResponseResult<Arc<SignedBeaconBlock<T::EthSpec>>>> {
-        let response = self.blocks_by_root_requests.on_response(id, rpc_event);
-        let response = response.map(|res| {
+        let resp = self.blocks_by_root_requests.on_response(id, rpc_event);
+        let resp = resp.map(|res| {
             res.and_then(|(mut blocks, seen_timestamp)| {
                 // Enforce that exactly one chunk = one block is returned. ReqResp behavior limits the
                 // response count to at most 1.
@@ -1024,10 +1029,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 }
             })
         });
-        if let Some(Err(RpcResponseError::VerifyError(e))) = &response {
-            self.report_peer(peer_id, PeerAction::LowToleranceError, e.into());
-        }
-        response
+        self.on_rpc_response_result(id, "BlocksByRoot", resp, peer_id, |_| 1)
     }
 
     pub(crate) fn on_single_blob_response(
@@ -1036,8 +1038,8 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         peer_id: PeerId,
         rpc_event: RpcEvent<Arc<BlobSidecar<T::EthSpec>>>,
     ) -> Option<RpcResponseResult<FixedBlobSidecarList<T::EthSpec>>> {
-        let response = self.blobs_by_root_requests.on_response(id, rpc_event);
-        let response = response.map(|res| {
+        let resp = self.blobs_by_root_requests.on_response(id, rpc_event);
+        let resp = resp.map(|res| {
             res.and_then(|(blobs, seen_timestamp)| {
                 if let Some(max_len) = blobs
                     .first()
@@ -1056,10 +1058,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 }
             })
         });
-        if let Some(Err(RpcResponseError::VerifyError(e))) = &response {
-            self.report_peer(peer_id, PeerAction::LowToleranceError, e.into());
-        }
-        response
+        self.on_rpc_response_result(id, "BlobsByRoot", resp, peer_id, |_| 1)
     }
 
     #[allow(clippy::type_complexity)]
@@ -1072,7 +1071,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let resp = self
             .data_columns_by_root_requests
             .on_response(id, rpc_event);
-        self.report_rpc_response_errors(resp, peer_id)
+        self.on_rpc_response_result(id, "DataColumnsByRoot", resp, peer_id, |_| 1)
     }
 
     #[allow(clippy::type_complexity)]
@@ -1083,7 +1082,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         rpc_event: RpcEvent<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) -> Option<RpcResponseResult<Vec<Arc<SignedBeaconBlock<T::EthSpec>>>>> {
         let resp = self.blocks_by_range_requests.on_response(id, rpc_event);
-        self.report_rpc_response_errors(resp, peer_id)
+        self.on_rpc_response_result(id, "BlocksByRange", resp, peer_id, |b| b.len())
     }
 
     #[allow(clippy::type_complexity)]
@@ -1094,7 +1093,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         rpc_event: RpcEvent<Arc<BlobSidecar<T::EthSpec>>>,
     ) -> Option<RpcResponseResult<Vec<Arc<BlobSidecar<T::EthSpec>>>>> {
         let resp = self.blobs_by_range_requests.on_response(id, rpc_event);
-        self.report_rpc_response_errors(resp, peer_id)
+        self.on_rpc_response_result(id, "BlobsByRangeRequest", resp, peer_id, |b| b.len())
     }
 
     #[allow(clippy::type_complexity)]
@@ -1107,14 +1106,38 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let resp = self
             .data_columns_by_range_requests
             .on_response(id, rpc_event);
-        self.report_rpc_response_errors(resp, peer_id)
+        self.on_rpc_response_result(id, "DataColumnsByRange", resp, peer_id, |d| d.len())
     }
 
-    fn report_rpc_response_errors<R>(
+    fn on_rpc_response_result<I: Debug, R, F: FnOnce(&R) -> usize>(
         &mut self,
+        id: I,
+        method: &'static str,
         resp: Option<RpcResponseResult<R>>,
         peer_id: PeerId,
+        get_count: F,
     ) -> Option<RpcResponseResult<R>> {
+        match &resp {
+            None => {}
+            Some(Ok((v, _))) => {
+                debug!(
+                    self.log,
+                    "Sync RPC request completed";
+                    "id" => ?id,
+                    "method" => method,
+                    "count" => get_count(v)
+                );
+            }
+            Some(Err(e)) => {
+                debug!(
+                    self.log,
+                    "Sync RPC request error";
+                    "id" => ?id,
+                    "method" => method,
+                    "error" => ?e
+                );
+            }
+        }
         if let Some(Err(RpcResponseError::VerifyError(e))) = &resp {
             self.report_peer(peer_id, PeerAction::LowToleranceError, e.into());
         }

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -536,8 +536,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             }
         }
 
-        let req_id = self.next_id();
-        let id = SingleLookupReqId { lookup_id, req_id };
+        let id = SingleLookupReqId {
+            lookup_id,
+            req_id: self.next_id(),
+        };
 
         let request = BlocksByRootSingleRequest(block_root);
 
@@ -561,7 +563,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             "method" => "BlocksByRoot",
             "block_root" => ?block_root,
             "peer" => %peer_id,
-            "id" => ?id
+            "id" => %id
         );
 
         self.blocks_by_root_requests.insert(
@@ -573,7 +575,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             BlocksByRootRequestItems::new(request),
         );
 
-        Ok(LookupRequestResult::RequestSent(req_id))
+        Ok(LookupRequestResult::RequestSent(id.req_id))
     }
 
     /// Request necessary blobs for `block_root`. Requests only the necessary blobs by checking:
@@ -619,8 +621,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Ok(LookupRequestResult::NoRequestNeeded("no indices to fetch"));
         }
 
-        let req_id = self.next_id();
-        let id = SingleLookupReqId { lookup_id, req_id };
+        let id = SingleLookupReqId {
+            lookup_id,
+            req_id: self.next_id(),
+        };
 
         let request = BlobsByRootSingleBlockRequest {
             block_root,
@@ -643,7 +647,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             "block_root" => ?block_root,
             "blob_indices" => ?indices,
             "peer" => %peer_id,
-            "id" => ?id
+            "id" => %id
         );
 
         self.blobs_by_root_requests.insert(
@@ -656,7 +660,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             BlobsByRootRequestItems::new(request),
         );
 
-        Ok(LookupRequestResult::RequestSent(req_id))
+        Ok(LookupRequestResult::RequestSent(id.req_id))
     }
 
     /// Request to send a single `data_columns_by_root` request to the network.
@@ -667,7 +671,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         request: DataColumnsByRootSingleBlockRequest,
         expect_max_responses: bool,
     ) -> Result<LookupRequestResult<DataColumnsByRootRequestId>, &'static str> {
-        let req_id = DataColumnsByRootRequestId {
+        let id = DataColumnsByRootRequestId {
             id: self.next_id(),
             requester,
         };
@@ -675,7 +679,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.send_network_msg(NetworkMessage::SendRequest {
             peer_id,
             request: RequestType::DataColumnsByRoot(request.clone().into_request(&self.chain.spec)),
-            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRoot(req_id)),
+            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRoot(id)),
         })?;
 
         debug!(
@@ -685,18 +689,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             "block_root" => ?request.block_root,
             "indices" => ?request.indices,
             "peer" => %peer_id,
-            "requester" => ?requester,
-            "req_id" => %req_id,
+            "id" => %id,
         );
 
         self.data_columns_by_root_requests.insert(
-            req_id,
+            id,
             peer_id,
             expect_max_responses,
             DataColumnsByRootRequestItems::new(request),
         );
 
-        Ok(LookupRequestResult::RequestSent(req_id))
+        Ok(LookupRequestResult::RequestSent(id))
     }
 
     /// Request to fetch all needed custody columns of a specific block. This function may not send
@@ -729,15 +732,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             return Ok(LookupRequestResult::NoRequestNeeded("no indices to fetch"));
         }
 
-        let req_id = self.next_id();
-        let id = SingleLookupReqId { lookup_id, req_id };
+        let id = SingleLookupReqId {
+            lookup_id,
+            req_id: self.next_id(),
+        };
 
         debug!(
             self.log,
             "Starting custody columns request";
             "block_root" => ?block_root,
             "indices" => ?custody_indexes_to_fetch,
-            "id" => ?id
+            "id" => %id
         );
 
         let requester = CustodyRequester(id);
@@ -756,7 +761,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 // created cannot return data immediately, it must send some request to the network
                 // first. And there must exist some request, `custody_indexes_to_fetch` is not empty.
                 self.custody_by_root_requests.insert(requester, request);
-                Ok(LookupRequestResult::RequestSent(req_id))
+                Ok(LookupRequestResult::RequestSent(id.req_id))
             }
             Err(e) => Err(RpcRequestSendError::CustodyRequestError(e)),
         }
@@ -784,10 +789,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.log,
             "Sync RPC request sent";
             "method" => "BlocksByRange",
-            "count" => request.count(),
+            "slots" => request.count(),
             "epoch" => Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch()),
             "peer" => %peer_id,
-            "id" => ?id,
+            "id" => %id,
         );
 
         self.blocks_by_range_requests.insert(
@@ -826,10 +831,10 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.log,
             "Sync RPC request sent";
             "method" => "BlobsByRange",
-            "count" => request.count,
+            "slots" => request.count,
             "epoch" => request_epoch,
             "peer" => %peer_id,
-            "id" => ?id,
+            "id" => %id,
         );
 
         let max_blobs_per_block = self.chain.spec.max_blobs_per_block(request_epoch);
@@ -866,11 +871,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.log,
             "Sync RPC request sent";
             "method" => "DataColumnsByRange",
-            "count" => request.count,
+            "slots" => request.count,
             "epoch" => Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch()),
             "columns" => ?request.columns,
             "peer" => %peer_id,
-            "id" => ?id,
+            "id" => %id,
         );
 
         self.data_columns_by_range_requests.insert(
@@ -1109,7 +1114,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.on_rpc_response_result(id, "DataColumnsByRange", resp, peer_id, |d| d.len())
     }
 
-    fn on_rpc_response_result<I: Debug, R, F: FnOnce(&R) -> usize>(
+    fn on_rpc_response_result<I: std::fmt::Display, R, F: FnOnce(&R) -> usize>(
         &mut self,
         id: I,
         method: &'static str,
@@ -1123,7 +1128,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 debug!(
                     self.log,
                     "Sync RPC request completed";
-                    "id" => ?id,
+                    "id" => %id,
                     "method" => method,
                     "count" => get_count(v)
                 );
@@ -1132,7 +1137,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 debug!(
                     self.log,
                     "Sync RPC request error";
-                    "id" => ?id,
+                    "id" => %id,
                     "method" => method,
                     "error" => ?e
                 );


### PR DESCRIPTION
## Issue Addressed

- Re-opened PR from https://github.com/sigp/lighthouse/pull/6869

Writing and running tests I noted that the sync RPC requests are very verbose now.

`DataColumnsByRootRequestId { id: 123, requester: Custody(CustodyId { requester: CustodyRequester(SingleLookupReqId { req_id: 121, lookup_id: 101 }) }) }`

Since this Id is logged rather often I believe there's value in 
1. Making them more succinct for log verbosity
2. Make them a string that's easy to copy and work with elastic

## Proposed Changes

Write custom `Display` implementations to render Ids in a more DX format

_ DataColumnsByRootRequestId with a block lookup_

```
123/Custody/121/Lookup/101
```

_DataColumnsByRangeRequestId_

```
123/122/RangeSync/0/5492900659401505034
```

- This one will be shorter after https://github.com/sigp/lighthouse/pull/6868

Also made the logs format and text consistent across all methods