### PR TITLE
Use old geth version due to breaking changes.

### DIFF
--- a/testing/execution_engine_integration/src/geth.rs
+++ b/testing/execution_engine_integration/src/geth.rs
@@ -7,7 +7,10 @@ use std::{env, fs};
 use tempfile::TempDir;
 use unused_port::unused_tcp4_port;
 
-const GETH_BRANCH: &str = "master";
+// This is not currently used due to the following breaking changes in geth that requires updating our tests:
+// 1. removal of `personal` namespace in v1.14.12: See #30704
+// 2. removal of `totalDifficulty` field from RPC in v1.14.11. See #30386.
+// const GETH_BRANCH: &str = "master";
 const GETH_REPO_URL: &str = "https://github.com/ethereum/go-ethereum";
 
 pub fn build_result(repo_dir: &Path) -> Output {
@@ -27,12 +30,14 @@ pub fn build(execution_clients_dir: &Path) {
     }
 
     // Get the latest tag on the branch
-    let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
-    build_utils::checkout(&repo_dir, dbg!(&last_release)).unwrap();
+    // let last_release = build_utils::get_latest_release(&repo_dir, GETH_BRANCH).unwrap();
+    // Using an older release due to breaking changes in recent releases. See comment on `GETH_BRANCH` const.
+    let release_tag = "v1.14.10";
+    build_utils::checkout(&repo_dir, dbg!(release_tag)).unwrap();
 
     // Build geth
     build_utils::check_command_output(build_result(&repo_dir), || {
-        format!("geth make failed using release {last_release}")
+        format!("geth make failed using release {release_tag}")
     });
 }
 


### PR DESCRIPTION
## Issue Addressed

A temporary workaround for the failing execution tests for geth.

https://github.com/sigp/lighthouse/actions/runs/13192297954

The test is broken due to the following breaking changes in geth that requires updating our tests:
1. removal of `personal` namespace in v1.14.12: See #30704
2. removal of `totalDifficulty` field from RPC in v1.14.11. See #30386.

Using an older version for now (` 1.14.10`) as we need to get things merged for the upcoming release.

Will create a separate issue to fix this.