### PR TITLE
Fix fetch blobs in all-null case

### DIFF
--- a/beacon_node/beacon_chain/src/fetch_blobs.rs
+++ b/beacon_node/beacon_chain/src/fetch_blobs.rs
@@ -91,7 +91,7 @@ pub async fn fetch_and_process_engine_blobs<T: BeaconChainTypes>(
         .await
         .map_err(FetchEngineBlobError::RequestFailed)?;
 
-    if response.is_empty() {
+    if response.is_empty() || response.iter().all(|opt| opt.is_none()) {
         debug!(
            log,
             "No blobs fetched from the EL";


### PR DESCRIPTION
## Issue Addressed

Fix another issue with fetch-blobs, similar to:

- https://github.com/sigp/lighthouse/pull/6911

## Proposed Changes

Check if the list of blobs returned is all `None`, and if so, do not proceed any further.

This prevents an ugly error like:

> Feb 03 17:32:12.384 ERRO Error fetching or processing blobs from EL, block_root: 0x7326fe2dc1cb9036c9de7a07a662c86a339085597849016eadf061b70b7815ba, error: BlobProcessingError(AvailabilityCheck(Unexpected)), module
: network::network_beacon_processor:1011
