### PR TITLE
Enable Light Client server by default

### DIFF
--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -124,7 +124,7 @@ impl Default for ChainConfig {
             genesis_backfill: false,
             always_prepare_payload: false,
             epochs_per_migration: crate::migrate::DEFAULT_EPOCHS_PER_MIGRATION,
-            enable_light_client_server: false,
+            enable_light_client_server: true,
             malicious_withhold_count: 0,
             enable_sampling: false,
             blob_publication_batches: 4,

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -170,7 +170,7 @@ impl Default for Config {
             sse_capacity_multiplier: 1,
             enable_beacon_processor: true,
             duplicate_block_status_code: StatusCode::ACCEPTED,
-            enable_light_client_server: false,
+            enable_light_client_server: true,
             target_peers: 100,
         }
     }

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -354,7 +354,7 @@ impl Default for Config {
             topics: Vec::new(),
             proposer_only: false,
             metrics_enabled: false,
-            enable_light_client_server: false,
+            enable_light_client_server: true,
             outbound_rate_limiter_config: None,
             invalid_block_storage: None,
             inbound_rate_limiter_config: None,

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1494,9 +1494,18 @@ pub fn cli_app() -> Command {
         .arg(
             Arg::new("light-client-server")
                 .long("light-client-server")
-                .help("Act as a full node supporting light clients on the p2p network \
-                       [experimental]")
+                .help("DEPRECATED")
                 .action(ArgAction::SetTrue)
+
+                .help_heading(FLAG_HEADER)
+                .display_order(0)
+        )
+        .arg(
+            Arg::new("disable-light-client-server")
+                .long("light-client-server")
+                .help("DEPRECATED")
+                .action(ArgAction::SetTrue)
+
                 .help_heading(FLAG_HEADER)
                 .display_order(0)
         )

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1502,8 +1502,8 @@ pub fn cli_app() -> Command {
         )
         .arg(
             Arg::new("disable-light-client-server")
-                .long("light-client-server")
-                .help("DEPRECATED")
+                .long("disable-light-client-server")
+                .help("Disables light client support on the p2p network")
                 .action(ArgAction::SetTrue)
 
                 .help_heading(FLAG_HEADER)

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -179,6 +179,14 @@ pub fn get_config<E: EthSpec>(
             !cli_args.get_flag("disable-light-client-server");
     }
 
+    if cli_args.get_flag("light-client-server") {
+        warn!(
+            log,
+            "The --light-client-server flag is deprecated. The light client server is enabled \
+             by default"
+        );
+    }
+
     if cli_args.get_flag("disable-light-client-server") {
         client_config.chain.enable_light_client_server = false;
     }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -179,8 +179,8 @@ pub fn get_config<E: EthSpec>(
             cli_args.get_flag("light-client-server");
     }
 
-    if cli_args.get_flag("light-client-server") {
-        client_config.chain.enable_light_client_server = true;
+    if cli_args.get_flag("disable-light-client-server") {
+        client_config.chain.enable_light_client_server = false;
     }
 
     if let Some(cache_size) = clap_utils::parse_optional(cli_args, "shuffling-cache-size")? {
@@ -1419,7 +1419,7 @@ pub fn set_network_config(
     }
 
     // Light client server config.
-    config.enable_light_client_server = parse_flag(cli_args, "light-client-server");
+    config.enable_light_client_server = !parse_flag(cli_args, "disable-light-client-server");
 
     // The self limiter is enabled by default. If the `self-limiter-protocols` flag is not provided,
     // the default params will be used.

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -176,7 +176,7 @@ pub fn get_config<E: EthSpec>(
             parse_required(cli_args, "http-duplicate-block-status")?;
 
         client_config.http_api.enable_light_client_server =
-            cli_args.get_flag("light-client-server");
+            !cli_args.get_flag("disable-light-client-server");
     }
 
     if cli_args.get_flag("disable-light-client-server") {

--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -458,6 +458,8 @@ Flags:
           boot.
       --disable-inbound-rate-limiter
           Disables the inbound rate limiter (requests received by this node).
+      --disable-light-client-server
+          Disables light client support on the p2p network
       --disable-log-timestamp
           If present, do not include timestamps in logging output.
       --disable-malloc-tuning
@@ -511,8 +513,7 @@ Flags:
           already-subscribed subnets, use with --subscribe-all-subnets to ensure
           all attestations are received for import.
       --light-client-server
-          Act as a full node supporting light clients on the p2p network
-          [experimental]
+          DEPRECATED
       --log-color
           Force outputting colors when emitting logs to the terminal.
       --logfile-compress

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2522,13 +2522,24 @@ fn light_client_server_enabled() {
 }
 
 #[test]
-fn light_client_http_server_enabled() {
+fn light_client_server_disabled() {
     CommandLineTest::new()
-        .flag("http", None)
-        .flag("light-client-server", None)
+        .flag("disable-light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(config.http_api.enable_light_client_server);
+            assert!(!config.network.enable_light_client_server);
+            assert!(!config.chain.enable_light_client_server);
+        });
+}
+
+#[test]
+fn light_client_http_server_disabled() {
+    CommandLineTest::new()
+        .flag("http", None)
+        .flag("disable-light-client-server", None)
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert!(!config.http_api.enable_light_client_server);
         });
 }
 

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2504,9 +2504,9 @@ fn light_client_server_default() {
     CommandLineTest::new()
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(!config.network.enable_light_client_server);
-            assert!(!config.chain.enable_light_client_server);
-            assert!(!config.http_api.enable_light_client_server);
+            assert!(config.network.enable_light_client_server);
+            assert!(config.chain.enable_light_client_server);
+            assert!(config.http_api.enable_light_client_server);
         });
 }
 
@@ -2540,6 +2540,8 @@ fn light_client_http_server_disabled() {
         .run_with_zero_port()
         .with_config(|config| {
             assert!(!config.http_api.enable_light_client_server);
+            assert!(!config.network.enable_light_client_server);
+            assert!(!config.chain.enable_light_client_server);
         });
 }
 


### PR DESCRIPTION
Deprecate the `light-client-server` flag, enable light client server by default and introduce a new flag `disable-light-client-server`
