### PR TITLE
Remove duplicated fork_epoch and fork_version implementation

### DIFF
--- a/consensus/types/src/fork_context.rs
+++ b/consensus/types/src/fork_context.rs
@@ -25,11 +25,11 @@ impl ForkContext {
         let fork_to_digest: HashMap<ForkName, [u8; 4]> = ForkName::list_all()
             .into_iter()
             .filter_map(|fork| {
-                if fork.fork_epoch(spec).is_some() {
+                if spec.fork_epoch(fork).is_some() {
                     Some((
                         fork,
                         ChainSpec::compute_fork_digest(
-                            ForkName::fork_version(fork, spec),
+                            spec.fork_version_for_name(fork),
                             genesis_validators_root,
                         ),
                     ))

--- a/consensus/types/src/fork_name.rs
+++ b/consensus/types/src/fork_name.rs
@@ -38,33 +38,8 @@ impl ForkName {
             .into_iter()
             // Skip Base
             .skip(1)
-            .map(|fork| (fork, fork.fork_epoch(spec)))
+            .map(|fork| (fork, spec.fork_epoch(fork)))
             .collect()
-    }
-
-    pub fn fork_epoch(self, spec: &ChainSpec) -> Option<Epoch> {
-        match self {
-            Self::Base => Some(Epoch::new(0)),
-            Self::Altair => spec.altair_fork_epoch,
-            Self::Bellatrix => spec.bellatrix_fork_epoch,
-            Self::Capella => spec.capella_fork_epoch,
-            Self::Deneb => spec.deneb_fork_epoch,
-            Self::Electra => spec.electra_fork_epoch,
-            Self::Fulu => spec.fulu_fork_epoch,
-        }
-    }
-
-    /// Returns the fork version of a fork
-    pub fn fork_version(self, spec: &ChainSpec) -> [u8; 4] {
-        match self {
-            Self::Base => spec.genesis_fork_version,
-            Self::Altair => spec.altair_fork_version,
-            Self::Bellatrix => spec.bellatrix_fork_version,
-            Self::Capella => spec.capella_fork_version,
-            Self::Deneb => spec.deneb_fork_version,
-            Self::Electra => spec.electra_fork_version,
-            Self::Fulu => spec.fulu_fork_version,
-        }
     }
 
     pub fn latest() -> ForkName {


### PR DESCRIPTION
## Issue Addressed

This PR adds an implementation to get fork_version and fork_epoch given a `ForkName`. I didn't realize that this is already implemented in the `ChainSpec` sorry

- https://github.com/sigp/lighthouse/pull/6933

## Proposed Changes

Remove duplicated fork_epoch and fork_version implementation