### PR TITLE
Update EF tests to spec v1.5.0-beta.2

### DIFF
--- a/testing/ef_tests/Makefile
+++ b/testing/ef_tests/Makefile
@@ -1,4 +1,4 @@
-TESTS_TAG := v1.5.0-beta.1
+TESTS_TAG := v1.5.0-beta.2
 TESTS = general minimal mainnet
 TARBALLS = $(patsubst %,%-$(TESTS_TAG).tar.gz,$(TESTS))
 

--- a/testing/ef_tests/check_all_files_accessed.py
+++ b/testing/ef_tests/check_all_files_accessed.py
@@ -49,9 +49,8 @@ excluded_paths = [
     "bls12-381-tests/hash_to_G2",
     "tests/.*/eip6110",
     "tests/.*/whisk",
-    # TODO(electra): SingleAttestation tests are waiting on Eitan's PR
-    "tests/.*/electra/ssz_static/SingleAttestation",
-    "tests/.*/fulu/ssz_static/SingleAttestation",
+    # TODO(das): Fulu tests are ignored for now
+    "tests/.*/fulu",
     "tests/.*/fulu/ssz_static/MatrixEntry",
 ]
 

--- a/testing/ef_tests/src/handler.rs
+++ b/testing/ef_tests/src/handler.rs
@@ -680,6 +680,11 @@ impl<E: EthSpec + TypeName> Handler for ForkChoiceHandler<E> {
             return false;
         }
 
+        // Deposit tests exist only after Electra.
+        if self.handler_name == "deposit_with_reorg" && !fork_name.electra_enabled() {
+            return false;
+        }
+
         // These tests check block validity (which may include signatures) and there is no need to
         // run them with fake crypto.
         cfg!(not(feature = "fake_crypto"))

--- a/testing/ef_tests/src/type_name.rs
+++ b/testing/ef_tests/src/type_name.rs
@@ -155,6 +155,7 @@ type_name!(SignedBeaconBlockHeader);
 type_name_generic!(SignedContributionAndProof);
 type_name!(SignedVoluntaryExit);
 type_name!(SigningData);
+type_name!(SingleAttestation);
 type_name_generic!(SyncCommitteeContribution);
 type_name!(SyncCommitteeMessage);
 type_name!(SyncAggregatorSelectionData);

--- a/testing/ef_tests/tests/tests.rs
+++ b/testing/ef_tests/tests/tests.rs
@@ -283,6 +283,12 @@ mod ssz_static {
     }
 
     #[test]
+    fn single_attestation() {
+        SszStaticHandler::<SingleAttestation, MinimalEthSpec>::electra_and_later().run();
+        SszStaticHandler::<SingleAttestation, MainnetEthSpec>::electra_and_later().run();
+    }
+
+    #[test]
     fn attester_slashing() {
         SszStaticHandler::<AttesterSlashingBase<MinimalEthSpec>, MinimalEthSpec>::pre_electra()
             .run();
@@ -878,6 +884,12 @@ fn fork_choice_should_override_forkchoice_update() {
 fn fork_choice_get_proposer_head() {
     ForkChoiceHandler::<MinimalEthSpec>::new("get_proposer_head").run();
     ForkChoiceHandler::<MainnetEthSpec>::new("get_proposer_head").run();
+}
+
+#[test]
+fn fork_choice_deposit_with_reorg() {
+    ForkChoiceHandler::<MinimalEthSpec>::new("deposit_with_reorg").run();
+    // There is no mainnet variant for this test.
 }
 
 #[test]


### PR DESCRIPTION
## Issue Addressed

Update spec tests for recent v1.5.0-beta.2 release. There are no substantial changes for Electra and earlier, and the Fulu test updates to be made are tracked here:

- https://github.com/sigp/lighthouse/issues/6957

## Proposed Changes

- Add `SingleAttestation` SSZ tests
- Add new `deposit_with_reorg` fork choice tests
- Update tag to v1.5.0-beta.2
- Ignore Fulu tests
