### PR TITLE
Release v7.0.0-beta.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "beacon_node",
  "bytes",
@@ -4811,7 +4811,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v6.0.1-",
-    fallback = "Lighthouse/v6.0.1"
+    prefix = "Lighthouse/v7.0.0-beta.0-",
+    fallback = "Lighthouse/v7.0.0-beta.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.
@@ -54,7 +54,7 @@ pub fn version_with_platform() -> String {
 ///
 /// `1.5.1`
 pub fn version() -> &'static str {
-    "6.0.1"
+    "7.0.0-beta.0"
 }
 
 /// Returns the name of the current client running.
@@ -71,9 +71,10 @@ mod test {
 
     #[test]
     fn version_formatting() {
-        let re =
-            Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?(-[[:xdigit:]]{7})?\+?$")
-                .unwrap();
+        let re = Regex::new(
+            r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta).[0-9])?(-[[:xdigit:]]{7})?\+?$",
+        )
+        .unwrap();
         assert!(
             re.is_match(VERSION),
             "version doesn't match regex: {}",

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Proposed Changes

New release for Electra on Holesky and Sepolia.

Includes PRs:

- https://github.com/sigp/lighthouse/pull/6808
- https://github.com/sigp/lighthouse/pull/6914
- https://github.com/sigp/lighthouse/pull/6949
- https://github.com/sigp/lighthouse/pull/6950
- https://github.com/sigp/lighthouse/pull/6958

## Additional Info

The plan for this release is a little different, due to it being a beta release:

- [x] 1. Merge all `v7.0.0-beta.0` feature PRs to `unstable` ASAP (everything except this PR).
- [x] 2. Branch off a `release-v7.0.0-beta.0` branch after all feature PRs are merged.
- [x] 3. Re-target this PR at `release-v7.0.0-beta.0` branch.
- [x] 4. Resume merges to `unstable` so we can unblock Fulu and other dev work.
- [ ] 5. Release `v7.0.0-beta.0` by merging this branch to `release-v7.0.0-beta.0` and tagging that release. _DO NOT_ update `stable` at this point, as we don't want to mark this beta release as stable, or have people auto-updating to it on mainnet.
- [ ] 6. Back-merge `release-v7.0.0-beta.0` to `unstable` so that `unstable`'s version increments to v7 as well.
- [ ] 7. Create subsequent `v7.0.0*` releases from the `release-v7.0.0-beta.0` branch, or `unstable` if deemed stable enough. If we want to unblock spicy merges to `unstable` sooner, we should maintain the v7 release branch separately, right up to the point of the stable `v7.0.0` release for mainnet.
