### PR TITLE
Allow compilation without LevelDB

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -27,7 +27,8 @@ env:
   # Disable incremental compilation
   CARGO_INCREMENTAL: 0
   # Enable portable to prevent issues with caching `blst` for the wrong CPU type
-  TEST_FEATURES: portable
+  # Enable LevelDB as it is now excluded from default features at the dependency level
+  TEST_FEATURES: portable,store/leveldb
 jobs:
   check-labels:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,7 +275,7 @@ slasher = { path = "slasher", default-features = false }
 slashing_protection = { path = "validator_client/slashing_protection" }
 slot_clock = { path = "common/slot_clock" }
 state_processing = { path = "consensus/state_processing" }
-store = { path = "beacon_node/store" }
+store = { path = "beacon_node/store", default-features = false }
 swap_or_not_shuffle = { path = "consensus/swap_or_not_shuffle" }
 system_health = { path = "common/system_health" }
 task_executor = { path = "common/task_executor" }

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ CROSS_FEATURES ?= gnosis,slasher-lmdb,slasher-mdbx,slasher-redb,jemalloc,beacon-
 CROSS_PROFILE ?= release
 
 # List of features to use when running EF tests.
-EF_TEST_FEATURES ?=
+EF_TEST_FEATURES ?= store/leveldb
 
 # List of features to use when running CI tests.
-TEST_FEATURES ?=
+TEST_FEATURES ?= store/leveldb
 
 # Cargo profile for regular builds.
 PROFILE ?= release

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -361,3 +361,20 @@ pub enum DatabaseBackend {
     #[cfg(feature = "redb")]
     Redb,
 }
+
+impl Default for DatabaseBackend {
+    fn default() -> Self {
+        #[cfg(feature = "leveldb")]
+        {
+            DatabaseBackend::LevelDb
+        }
+        #[cfg(all(not(feature = "leveldb"), feature = "redb"))]
+        {
+            DatabaseBackend::Redb
+        }
+        #[cfg(all(not(feature = "leveldb"), not(feature = "redb")))]
+        {
+            compile_error!("No database backend enabled. You must enable at least one")
+        }
+    }
+}

--- a/beacon_node/store/src/config.rs
+++ b/beacon_node/store/src/config.rs
@@ -352,29 +352,24 @@ mod test {
 }
 
 #[derive(
-    Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Display, EnumString, EnumVariantNames,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    Display,
+    EnumString,
+    EnumVariantNames,
 )]
 #[strum(serialize_all = "lowercase")]
 pub enum DatabaseBackend {
     #[cfg(feature = "leveldb")]
+    #[cfg_attr(feature = "leveldb", default)]
     LevelDb,
     #[cfg(feature = "redb")]
+    #[cfg_attr(all(feature = "redb", not(feature = "leveldb")), default)]
     Redb,
-}
-
-impl Default for DatabaseBackend {
-    fn default() -> Self {
-        #[cfg(feature = "leveldb")]
-        {
-            DatabaseBackend::LevelDb
-        }
-        #[cfg(all(not(feature = "leveldb"), feature = "redb"))]
-        {
-            DatabaseBackend::Redb
-        }
-        #[cfg(all(not(feature = "leveldb"), not(feature = "redb")))]
-        {
-            compile_error!("No database backend enabled. You must enable at least one")
-        }
-    }
 }

--- a/database_manager/src/cli.rs
+++ b/database_manager/src/cli.rs
@@ -62,7 +62,7 @@ pub struct DatabaseManager {
         value_name = "DATABASE",
         help = "Set the database backend to be used by the beacon node.",
         display_order = 0,
-        default_value_t = store::config::DatabaseBackend::LevelDb
+        default_value_t
     )]
     pub backend: store::config::DatabaseBackend,
 


### PR DESCRIPTION
## Proposed Changes

To enable _pure Rust_ builds of Lighthouse without LevelDB/LMDB/MDBX, this PR turns off LevelDB as a default feature at the `store` dependency level.

Without this change, the `--no-default-features` flag is not sufficient to compile Lighthouse without LevelDB, because it only disables the default features of the top-level crate (`./lighthouse/`). With this change, you can pass `--no-default-features` and get a binary that only has Redb available as an argument to `--beacon-node-backend`.
