### PR TITLE
Remove AppRequestId from api_types,

### DIFF
--- a/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
+++ b/beacon_node/lighthouse_network/src/rpc/self_limiter.rs
@@ -217,7 +217,7 @@ mod tests {
     use crate::rpc::rate_limiter::Quota;
     use crate::rpc::self_limiter::SelfRateLimiter;
     use crate::rpc::{Ping, Protocol, RequestType};
-    use crate::service::api_types::{AppRequestId, RequestId, SingleLookupReqId, SyncRequestId};
+    use crate::service::api_types::{RequestId, SingleLookupReqId, SyncRequestId};
     use libp2p::PeerId;
     use std::time::Duration;
     use types::{EthSpec, ForkContext, Hash256, MainnetEthSpec, Slot};
@@ -243,12 +243,12 @@ mod tests {
         for i in 1..=5u32 {
             let _ = limiter.allows(
                 peer_id,
-                RequestId::Application(AppRequestId::Sync(SyncRequestId::SingleBlock {
+                RequestId::Application(SyncRequestId::SingleBlock {
                     id: SingleLookupReqId {
                         lookup_id,
                         req_id: i,
                     },
-                })),
+                }),
                 RequestType::Ping(Ping { data: i as u64 }),
             );
         }
@@ -265,9 +265,9 @@ mod tests {
             for i in 2..=5u32 {
                 assert!(matches!(
                     iter.next().unwrap().request_id,
-                    RequestId::Application(AppRequestId::Sync(SyncRequestId::SingleBlock {
+                    RequestId::Application(SyncRequestId::SingleBlock {
                         id: SingleLookupReqId { req_id, .. },
-                    })) if req_id == i,
+                    }) if req_id == i,
                 ));
             }
 
@@ -290,9 +290,9 @@ mod tests {
             for i in 3..=5 {
                 assert!(matches!(
                     iter.next().unwrap().request_id,
-                    RequestId::Application(AppRequestId::Sync(SyncRequestId::SingleBlock {
+                    RequestId::Application(SyncRequestId::SingleBlock {
                         id: SingleLookupReqId { req_id, .. },
-                    })) if req_id == i,
+                    }) if req_id == i,
                 ));
             }
 

--- a/beacon_node/lighthouse_network/src/service/api_types.rs
+++ b/beacon_node/lighthouse_network/src/service/api_types.rs
@@ -36,6 +36,8 @@ pub enum SyncRequestId {
     BlobsByRange(BlobsByRangeRequestId),
     /// Data columns by range request
     DataColumnsByRange(DataColumnsByRangeRequestId),
+    /// Status Request
+    Status,
 }
 
 /// Request ID for data_columns_by_root requests. Block lookups do not issue this request directly.
@@ -125,17 +127,10 @@ pub struct CustodyId {
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub struct CustodyRequester(pub SingleLookupReqId);
 
-/// Application level requests sent to the network.
-#[derive(Debug, Clone, Copy)]
-pub enum AppRequestId {
-    Sync(SyncRequestId),
-    Router,
-}
-
 /// Global identifier of a request.
 #[derive(Debug, Clone, Copy)]
 pub enum RequestId {
-    Application(AppRequestId),
+    Application(SyncRequestId),
     Internal,
 }
 

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -21,7 +21,7 @@ use crate::types::{
 use crate::EnrExt;
 use crate::Eth2Enr;
 use crate::{metrics, Enr, NetworkGlobals, PubsubMessage, TopicHash};
-use api_types::{AppRequestId, PeerRequestId, RequestId, Response};
+use api_types::{PeerRequestId, RequestId, Response, SyncRequestId};
 use futures::stream::StreamExt;
 use gossipsub::{
     IdentTopic as Topic, MessageAcceptance, MessageAuthenticity, MessageId, PublishError,
@@ -66,7 +66,7 @@ pub enum NetworkEvent<E: EthSpec> {
     /// An RPC Request that was sent failed.
     RPCFailed {
         /// The id of the failed request.
-        id: AppRequestId,
+        id: SyncRequestId,
         /// The peer to which this request was sent.
         peer_id: PeerId,
         /// The error of the failed request.
@@ -84,7 +84,7 @@ pub enum NetworkEvent<E: EthSpec> {
         /// Peer that sent the response.
         peer_id: PeerId,
         /// Id of the request to which the peer is responding.
-        id: AppRequestId,
+        id: SyncRequestId,
         /// Response the peer sent.
         response: Response<E>,
     },
@@ -965,9 +965,9 @@ impl<E: EthSpec> Network<E> {
     pub fn send_request(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         request: RequestType<E>,
-    ) -> Result<(), (AppRequestId, RPCError)> {
+    ) -> Result<(), (SyncRequestId, RPCError)> {
         // Check if the peer is connected before sending an RPC request
         if !self.swarm.is_connected(&peer_id) {
             return Err((request_id, RPCError::Disconnected));

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::Protocol;
 use lighthouse_network::rpc::{methods::*, RequestType};
-use lighthouse_network::service::api_types::AppRequestId;
+use lighthouse_network::service::api_types::SyncRequestId;
 use lighthouse_network::{rpc::max_rpc_size, NetworkEvent, ReportSource, Response};
 use slog::{debug, warn, Level};
 use ssz::Encode;
@@ -100,12 +100,12 @@ fn test_tcp_status_rpc() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
                         peer_id: _,
-                        id: AppRequestId::Router,
+                        id: SyncRequestId::Status,
                         response,
                     } => {
                         // Should receive the RPC response
@@ -208,7 +208,7 @@ fn test_tcp_blocks_by_range_chunked_rpc() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
@@ -344,7 +344,7 @@ fn test_blobs_by_range_chunked_rpc() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
@@ -468,12 +468,12 @@ fn test_tcp_blocks_by_range_over_limit() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     // The request will fail because the sender will refuse to send anything > MAX_RPC_SIZE
                     NetworkEvent::RPCFailed { id, .. } => {
-                        assert!(matches!(id, AppRequestId::Router));
+                        assert!(matches!(id, SyncRequestId::Status));
                         return;
                     }
                     _ => {} // Ignore other behaviour events
@@ -576,7 +576,7 @@ fn test_tcp_blocks_by_range_chunked_rpc_terminates_correctly() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
@@ -711,12 +711,12 @@ fn test_tcp_blocks_by_range_single_empty_rpc() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
                         peer_id: _,
-                        id: AppRequestId::Router,
+                        id: SyncRequestId::Status,
                         response,
                     } => match response {
                         Response::BlocksByRange(Some(_)) => {
@@ -849,12 +849,12 @@ fn test_tcp_blocks_by_root_chunked_rpc() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
                         peer_id: _,
-                        id: AppRequestId::Router,
+                        id: SyncRequestId::Status,
                         response,
                     } => match response {
                         Response::BlocksByRoot(Some(_)) => {
@@ -990,12 +990,12 @@ fn test_tcp_blocks_by_root_chunked_rpc_terminates_correctly() {
                         // Send a STATUS message
                         debug!(log, "Sending RPC");
                         sender
-                            .send_request(peer_id, AppRequestId::Router, rpc_request.clone())
+                            .send_request(peer_id, SyncRequestId::Status, rpc_request.clone())
                             .unwrap();
                     }
                     NetworkEvent::ResponseReceived {
                         peer_id: _,
-                        id: AppRequestId::Router,
+                        id: SyncRequestId::Status,
                         response,
                     } => {
                         debug!(log, "Sender received a response");

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -17,9 +17,8 @@ use futures::prelude::*;
 use lighthouse_network::discovery::ConnectionId;
 use lighthouse_network::rpc::*;
 use lighthouse_network::{
-    rpc,
-    service::api_types::{AppRequestId, SyncRequestId},
-    MessageId, NetworkGlobals, PeerId, PeerRequestId, PubsubMessage, Response,
+    rpc, service::api_types::SyncRequestId, MessageId, NetworkGlobals, PeerId, PeerRequestId,
+    PubsubMessage, Response,
 };
 use logging::TimeLatch;
 use slog::{crit, debug, o, trace};
@@ -62,13 +61,13 @@ pub enum RouterMessage<E: EthSpec> {
     /// An RPC response has been received.
     RPCResponseReceived {
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         response: Response<E>,
     },
     /// An RPC request failed
     RPCFailed {
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         error: RPCError,
     },
     /// A gossip message has been received. The fields are: message id, the peer that sent us this
@@ -331,7 +330,7 @@ impl<T: BeaconChainTypes> Router<T> {
     fn handle_rpc_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         response: Response<T::EthSpec>,
     ) {
         match response {
@@ -560,8 +559,11 @@ impl<T: BeaconChainTypes> Router<T> {
     fn send_status(&mut self, peer_id: PeerId) {
         let status_message = status_message(&self.chain);
         debug!(self.log, "Sending Status Request"; "peer" => %peer_id, &status_message);
-        self.network
-            .send_processor_request(peer_id, RequestType::Status(status_message));
+        self.network.inform_network(NetworkMessage::SendRequest {
+            peer_id,
+            request_id: SyncRequestId::Status,
+            request: RequestType::Status(status_message),
+        })
     }
 
     fn send_to_sync(&mut self, message: SyncMessage<T::EthSpec>) {
@@ -576,15 +578,12 @@ impl<T: BeaconChainTypes> Router<T> {
 
     /// An error occurred during an RPC request. The state is maintained by the sync manager, so
     /// this function notifies the sync manager of the error.
-    pub fn on_rpc_error(&mut self, peer_id: PeerId, request_id: AppRequestId, error: RPCError) {
-        // Check if the failed RPC belongs to sync
-        if let AppRequestId::Sync(request_id) = request_id {
-            self.send_to_sync(SyncMessage::RpcError {
-                peer_id,
-                request_id,
-                error,
-            });
-        }
+    pub fn on_rpc_error(&mut self, peer_id: PeerId, request_id: SyncRequestId, error: RPCError) {
+        self.send_to_sync(SyncMessage::RpcError {
+            peer_id,
+            request_id,
+            error,
+        });
     }
 
     /// Handle a `Status` request.
@@ -619,19 +618,13 @@ impl<T: BeaconChainTypes> Router<T> {
     pub fn on_blocks_by_range_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) {
         let request_id = match request_id {
-            AppRequestId::Sync(sync_id) => match sync_id {
-                id @ SyncRequestId::BlocksByRange { .. } => id,
-                other => {
-                    crit!(self.log, "BlocksByRange response on incorrect request"; "request" => ?other);
-                    return;
-                }
-            },
-            AppRequestId::Router => {
-                crit!(self.log, "All BBRange requests belong to sync"; "peer_id" => %peer_id);
+            id @ SyncRequestId::BlocksByRange { .. } => id,
+            other => {
+                crit!(self.log, "BlocksByRange response on incorrect request"; "request" => ?other);
                 return;
             }
         };
@@ -653,7 +646,7 @@ impl<T: BeaconChainTypes> Router<T> {
     pub fn on_blobs_by_range_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         blob_sidecar: Option<Arc<BlobSidecar<T::EthSpec>>>,
     ) {
         trace!(
@@ -662,38 +655,25 @@ impl<T: BeaconChainTypes> Router<T> {
             "peer" => %peer_id,
         );
 
-        if let AppRequestId::Sync(id) = request_id {
-            self.send_to_sync(SyncMessage::RpcBlob {
-                peer_id,
-                request_id: id,
-                blob_sidecar,
-                seen_timestamp: timestamp_now(),
-            });
-        } else {
-            crit!(
-                self.log,
-                "All blobs by range responses should belong to sync"
-            );
-        }
+        self.send_to_sync(SyncMessage::RpcBlob {
+            peer_id,
+            request_id,
+            blob_sidecar,
+            seen_timestamp: timestamp_now(),
+        });
     }
 
     /// Handle a `BlocksByRoot` response from the peer.
     pub fn on_blocks_by_root_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         beacon_block: Option<Arc<SignedBeaconBlock<T::EthSpec>>>,
     ) {
-        let request_id = match request_id {
-            AppRequestId::Sync(sync_id) => match sync_id {
-                id @ SyncRequestId::SingleBlock { .. } => id,
-                other => {
-                    crit!(self.log, "BlocksByRoot response on incorrect request"; "request" => ?other);
-                    return;
-                }
-            },
-            AppRequestId::Router => {
-                crit!(self.log, "All BBRoot requests belong to sync"; "peer_id" => %peer_id);
+        match request_id {
+            id @ SyncRequestId::SingleBlock { .. } => id,
+            other => {
+                crit!(self.log, "BlocksByRoot response on incorrect request"; "request" => ?other);
                 return;
             }
         };
@@ -715,19 +695,13 @@ impl<T: BeaconChainTypes> Router<T> {
     pub fn on_blobs_by_root_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         blob_sidecar: Option<Arc<BlobSidecar<T::EthSpec>>>,
     ) {
-        let request_id = match request_id {
-            AppRequestId::Sync(sync_id) => match sync_id {
-                id @ SyncRequestId::SingleBlob { .. } => id,
-                other => {
-                    crit!(self.log, "BlobsByRoot response on incorrect request"; "request" => ?other);
-                    return;
-                }
-            },
-            AppRequestId::Router => {
-                crit!(self.log, "All BlobsByRoot requests belong to sync"; "peer_id" => %peer_id);
+        match request_id {
+            id @ SyncRequestId::SingleBlob { .. } => id,
+            other => {
+                crit!(self.log, "BlobsByRoot response on incorrect request"; "request" => ?other);
                 return;
             }
         };
@@ -749,19 +723,13 @@ impl<T: BeaconChainTypes> Router<T> {
     pub fn on_data_columns_by_root_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         data_column: Option<Arc<DataColumnSidecar<T::EthSpec>>>,
     ) {
-        let request_id = match request_id {
-            AppRequestId::Sync(sync_id) => match sync_id {
-                id @ SyncRequestId::DataColumnsByRoot { .. } => id,
-                other => {
-                    crit!(self.log, "DataColumnsByRoot response on incorrect request"; "request" => ?other);
-                    return;
-                }
-            },
-            AppRequestId::Router => {
-                crit!(self.log, "All DataColumnsByRoot requests belong to sync"; "peer_id" => %peer_id);
+        match request_id {
+            id @ SyncRequestId::DataColumnsByRoot { .. } => id,
+            other => {
+                crit!(self.log, "DataColumnsByRoot response on incorrect request"; "request" => ?other);
                 return;
             }
         };
@@ -782,7 +750,7 @@ impl<T: BeaconChainTypes> Router<T> {
     pub fn on_data_columns_by_range_response(
         &mut self,
         peer_id: PeerId,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
         data_column: Option<Arc<DataColumnSidecar<T::EthSpec>>>,
     ) {
         trace!(
@@ -791,19 +759,12 @@ impl<T: BeaconChainTypes> Router<T> {
             "peer" => %peer_id,
         );
 
-        if let AppRequestId::Sync(id) = request_id {
-            self.send_to_sync(SyncMessage::RpcDataColumn {
-                peer_id,
-                request_id: id,
-                data_column,
-                seen_timestamp: timestamp_now(),
-            });
-        } else {
-            crit!(
-                self.log,
-                "All data columns by range responses should belong to sync"
-            );
-        }
+        self.send_to_sync(SyncMessage::RpcDataColumn {
+            peer_id,
+            request_id,
+            data_column,
+            seen_timestamp: timestamp_now(),
+        });
     }
 
     fn handle_beacon_processor_send_result(
@@ -845,15 +806,6 @@ impl<E: EthSpec> HandlerNetworkContext<E> {
         self.network_send.send(msg).unwrap_or_else(
             |e| warn!(self.log, "Could not send message to the network service"; "error" => %e),
         )
-    }
-
-    /// Sends a request to the network task.
-    pub fn send_processor_request(&mut self, peer_id: PeerId, request: RequestType<E>) {
-        self.inform_network(NetworkMessage::SendRequest {
-            peer_id,
-            request_id: AppRequestId::Router,
-            request,
-        })
     }
 
     /// Sends a response to the network task.

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -12,6 +12,7 @@ use futures::future::OptionFuture;
 use futures::prelude::*;
 use futures::StreamExt;
 use lighthouse_network::rpc::{RequestId, RequestType};
+use lighthouse_network::service::api_types::SyncRequestId;
 use lighthouse_network::service::Network;
 use lighthouse_network::types::GossipKind;
 use lighthouse_network::{prometheus_client::registry::Registry, MessageAcceptance};
@@ -20,7 +21,6 @@ use lighthouse_network::{
     Context, PeerAction, PeerRequestId, PubsubMessage, ReportSource, Response, Subnet,
 };
 use lighthouse_network::{
-    service::api_types::AppRequestId,
     types::{core_topics_to_subscribe, GossipEncoding, GossipTopic},
     MessageId, NetworkEvent, NetworkGlobals, PeerId,
 };
@@ -60,7 +60,7 @@ pub enum NetworkMessage<E: EthSpec> {
     SendRequest {
         peer_id: PeerId,
         request: RequestType<E>,
-        request_id: AppRequestId,
+        request_id: SyncRequestId,
     },
     /// Send a successful Response to the libp2p service.
     SendResponse {

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -505,6 +505,9 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             SyncRequestId::DataColumnsByRange(req_id) => {
                 self.on_data_columns_by_range_response(req_id, peer_id, RpcEvent::RPCError(error))
             }
+            SyncRequestId::Status => {
+                unreachable!("Status request doesn't reach sync!");
+            }
         }
     }
 

--- a/beacon_node/network/src/sync/manager.rs
+++ b/beacon_node/network/src/sync/manager.rs
@@ -505,9 +505,8 @@ impl<T: BeaconChainTypes> SyncManager<T> {
             SyncRequestId::DataColumnsByRange(req_id) => {
                 self.on_data_columns_by_range_response(req_id, peer_id, RpcEvent::RPCError(error))
             }
-            SyncRequestId::Status => {
-                unreachable!("Status request doesn't reach sync!");
-            }
+            // Ignore Status requests.
+            SyncRequestId::Status => {}
         }
     }
 

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -21,8 +21,8 @@ use lighthouse_network::rpc::methods::{BlobsByRangeRequest, DataColumnsByRangeRe
 use lighthouse_network::rpc::{BlocksByRangeRequest, GoodbyeReason, RPCError, RequestType};
 pub use lighthouse_network::service::api_types::RangeRequestId;
 use lighthouse_network::service::api_types::{
-    AppRequestId, BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId,
-    CustodyId, CustodyRequester, DataColumnsByRangeRequestId, DataColumnsByRootRequestId,
+    BlobsByRangeRequestId, BlocksByRangeRequestId, ComponentsByRangeRequestId, CustodyId,
+    CustodyRequester, DataColumnsByRangeRequestId, DataColumnsByRootRequestId,
     DataColumnsByRootRequester, Id, SingleLookupReqId, SyncRequestId,
 };
 use lighthouse_network::{Client, NetworkGlobals, PeerAction, PeerId, ReportSource};
@@ -342,7 +342,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             );
 
             let request = RequestType::Status(status_message.clone());
-            let request_id = AppRequestId::Router;
+            let request_id = SyncRequestId::Status;
             let _ = self.send_network_msg(NetworkMessage::SendRequest {
                 peer_id,
                 request,
@@ -553,7 +553,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .send(NetworkMessage::SendRequest {
                 peer_id,
                 request: RequestType::BlocksByRoot(request.into_request(&self.fork_context)),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
+                request_id: SyncRequestId::SingleBlock { id },
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
 
@@ -636,7 +636,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .send(NetworkMessage::SendRequest {
                 peer_id,
                 request: RequestType::BlobsByRoot(request.clone().into_request(&self.fork_context)),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
+                request_id: SyncRequestId::SingleBlob { id },
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
 
@@ -679,7 +679,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.send_network_msg(NetworkMessage::SendRequest {
             peer_id,
             request: RequestType::DataColumnsByRoot(request.clone().into_request(&self.chain.spec)),
-            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRoot(id)),
+            request_id: SyncRequestId::DataColumnsByRoot(id),
         })?;
 
         debug!(
@@ -781,7 +781,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .send(NetworkMessage::SendRequest {
                 peer_id,
                 request: RequestType::BlocksByRange(request.clone().into()),
-                request_id: AppRequestId::Sync(SyncRequestId::BlocksByRange(id)),
+                request_id: SyncRequestId::BlocksByRange(id),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
 
@@ -823,7 +823,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             .send(NetworkMessage::SendRequest {
                 peer_id,
                 request: RequestType::BlobsByRange(request.clone()),
-                request_id: AppRequestId::Sync(SyncRequestId::BlobsByRange(id)),
+                request_id: SyncRequestId::BlobsByRange(id),
             })
             .map_err(|_| RpcRequestSendError::NetworkSendError)?;
 
@@ -863,7 +863,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         self.send_network_msg(NetworkMessage::SendRequest {
             peer_id,
             request: RequestType::DataColumnsByRange(request.clone()),
-            request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRange(id)),
+            request_id: SyncRequestId::DataColumnsByRange(id),
         })
         .map_err(|_| RpcRequestSendError::NetworkSendError)?;
 

--- a/beacon_node/network/src/sync/tests/lookups.rs
+++ b/beacon_node/network/src/sync/tests/lookups.rs
@@ -31,8 +31,8 @@ use lighthouse_network::discovery::CombinedKey;
 use lighthouse_network::{
     rpc::{RPCError, RequestType, RpcErrorResponse},
     service::api_types::{
-        AppRequestId, DataColumnsByRootRequestId, DataColumnsByRootRequester, Id,
-        SamplingRequester, SingleLookupReqId, SyncRequestId,
+        DataColumnsByRootRequestId, DataColumnsByRootRequester, Id, SamplingRequester,
+        SingleLookupReqId, SyncRequestId,
     },
     types::SyncState,
     NetworkConfig, NetworkGlobals, PeerId,
@@ -804,7 +804,7 @@ impl TestRig {
         while let Ok(request_id) = self.pop_received_network_event(|ev| match ev {
             NetworkMessage::SendRequest {
                 peer_id,
-                request_id: AppRequestId::Sync(id),
+                request_id: id,
                 ..
             } if *peer_id == disconnected_peer_id => Some(*id),
             _ => None,
@@ -895,7 +895,7 @@ impl TestRig {
             NetworkMessage::SendRequest {
                 peer_id: _,
                 request: RequestType::BlocksByRoot(request),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
+                request_id: SyncRequestId::SingleBlock { id },
             } if request.block_roots().to_vec().contains(&for_block) => Some(*id),
             _ => None,
         })
@@ -915,7 +915,7 @@ impl TestRig {
             NetworkMessage::SendRequest {
                 peer_id: _,
                 request: RequestType::BlobsByRoot(request),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
+                request_id: SyncRequestId::SingleBlob { id },
             } if request
                 .blob_ids
                 .to_vec()
@@ -940,7 +940,7 @@ impl TestRig {
             NetworkMessage::SendRequest {
                 peer_id: _,
                 request: RequestType::BlocksByRoot(request),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlock { id }),
+                request_id: SyncRequestId::SingleBlock { id },
             } if request.block_roots().to_vec().contains(&for_block) => Some(*id),
             _ => None,
         })
@@ -962,7 +962,7 @@ impl TestRig {
             NetworkMessage::SendRequest {
                 peer_id: _,
                 request: RequestType::BlobsByRoot(request),
-                request_id: AppRequestId::Sync(SyncRequestId::SingleBlob { id }),
+                request_id: SyncRequestId::SingleBlob { id },
             } if request
                 .blob_ids
                 .to_vec()
@@ -990,7 +990,7 @@ impl TestRig {
                     NetworkMessage::SendRequest {
                         peer_id: _,
                         request: RequestType::DataColumnsByRoot(request),
-                        request_id: AppRequestId::Sync(id @ SyncRequestId::DataColumnsByRoot { .. }),
+                        request_id: id @ SyncRequestId::DataColumnsByRoot { .. },
                     } if request
                         .data_column_ids
                         .to_vec()

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -15,8 +15,7 @@ use lighthouse_network::rpc::methods::{
 };
 use lighthouse_network::rpc::{RequestType, StatusMessage};
 use lighthouse_network::service::api_types::{
-    AppRequestId, BlobsByRangeRequestId, BlocksByRangeRequestId, DataColumnsByRangeRequestId,
-    SyncRequestId,
+    BlobsByRangeRequestId, BlocksByRangeRequestId, DataColumnsByRangeRequestId, SyncRequestId,
 };
 use lighthouse_network::{PeerId, SyncInfo};
 use std::time::Duration;
@@ -223,7 +222,7 @@ impl TestRig {
                         RequestType::BlocksByRange(OldBlocksByRangeRequest::V2(
                             OldBlocksByRangeRequestV2 { start_slot, .. },
                         )),
-                    request_id: AppRequestId::Sync(SyncRequestId::BlocksByRange(id)),
+                    request_id: SyncRequestId::BlocksByRange(id),
                 } if filter_f(*peer_id, *start_slot) => Some((*id, *peer_id)),
                 _ => None,
             })
@@ -240,7 +239,7 @@ impl TestRig {
                         RequestType::DataColumnsByRange(DataColumnsByRangeRequest {
                             start_slot, ..
                         }),
-                    request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRange(id)),
+                    request_id: SyncRequestId::DataColumnsByRange(id),
                 } if filter_f(*peer_id, *start_slot) => Some((*id, *peer_id)),
                 _ => None,
             }) {
@@ -256,7 +255,7 @@ impl TestRig {
                     NetworkMessage::SendRequest {
                         peer_id,
                         request: RequestType::BlobsByRange(BlobsByRangeRequest { start_slot, .. }),
-                        request_id: AppRequestId::Sync(SyncRequestId::BlobsByRange(id)),
+                        request_id: SyncRequestId::BlobsByRange(id),
                     } if filter_f(*peer_id, *start_slot) => Some((*id, *peer_id)),
                     _ => None,
                 })


### PR DESCRIPTION
It seems we are never matching on it to react on it but rather to log `crit!` as those situations should not exist first hand.
`Status` request handling doesnt seem to care if it's `Router` or `Sync`.
Therefore it seems redundant to have it, but please give it a check as I may have missed something