### PR TITLE
De-duplicate `enable_light_client_server`

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -4035,7 +4035,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // compute state proofs for light client updates before inserting the state into the
         // snapshot cache.
-        if self.config.enable_light_client_server {
+        if *self.config.enable_light_client_server {
             self.light_client_server_cache
                 .cache_state_data(
                     &self.spec, block, block_root,
@@ -4415,7 +4415,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         // Do not trigger light_client server update producer for old blocks, to extra work
         // during sync.
-        if self.config.enable_light_client_server
+        if *self.config.enable_light_client_server
             && block_delay_total < self.slot_clock.slot_duration() * 32
         {
             if let Some(mut light_client_server_tx) = self.light_client_server_tx.clone() {

--- a/beacon_node/beacon_chain/src/chain_config.rs
+++ b/beacon_node/beacon_chain/src/chain_config.rs
@@ -1,5 +1,6 @@
 pub use proto_array::{DisallowedReOrgOffsets, ReOrgThreshold};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::time::Duration;
 use types::{Checkpoint, Epoch};
 
@@ -83,7 +84,7 @@ pub struct ChainConfig {
     /// Number of epochs between each migration of data from the hot database to the freezer.
     pub epochs_per_migration: u64,
     /// When set to true Light client server computes and caches state proofs for serving updates
-    pub enable_light_client_server: bool,
+    pub enable_light_client_server: Arc<bool>,
     /// The number of data columns to withhold / exclude from publishing when proposing a block.
     pub malicious_withhold_count: usize,
     /// Enable peer sampling on blocks.
@@ -124,7 +125,7 @@ impl Default for ChainConfig {
             genesis_backfill: false,
             always_prepare_payload: false,
             epochs_per_migration: crate::migrate::DEFAULT_EPOCHS_PER_MIGRATION,
-            enable_light_client_server: true,
+            enable_light_client_server: Arc::new(true),
             malicious_withhold_count: 0,
             enable_sampling: false,
             blob_publication_batches: 4,

--- a/beacon_node/client/src/builder.rs
+++ b/beacon_node/client/src/builder.rs
@@ -225,7 +225,7 @@ where
             builder
         };
 
-        let builder = if config.network.enable_light_client_server {
+        let builder = if *config.network.enable_light_client_server {
             let (tx, rv) = futures::channel::mpsc::channel::<LightClientProducerEvent<E>>(
                 LIGHT_CLIENT_SERVER_CHANNEL_CAPACITY,
             );

--- a/beacon_node/client/src/config.rs
+++ b/beacon_node/client/src/config.rs
@@ -10,6 +10,7 @@ use sensitive_url::SensitiveUrl;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Default directory name for the freezer database under the top-level data dir.
@@ -82,6 +83,7 @@ pub struct Config {
     pub genesis_state_url: Option<String>,
     pub genesis_state_url_timeout: Duration,
     pub allow_insecure_genesis_sync: bool,
+    pub enable_light_client_server: Arc<bool>,
 }
 
 impl Default for Config {
@@ -115,6 +117,7 @@ impl Default for Config {
             // This default value should always be overwritten by the CLI default value.
             genesis_state_url_timeout: Duration::from_secs(60),
             allow_insecure_genesis_sync: false,
+            enable_light_client_server: Arc::new(true),
         }
     }
 }

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -155,7 +155,7 @@ pub struct Config {
     pub enable_beacon_processor: bool,
     #[serde(with = "eth2::types::serde_status_code")]
     pub duplicate_block_status_code: StatusCode,
-    pub enable_light_client_server: bool,
+    pub enable_light_client_server: Arc<bool>,
     pub target_peers: usize,
 }
 
@@ -171,7 +171,7 @@ impl Default for Config {
             sse_capacity_multiplier: 1,
             enable_beacon_processor: true,
             duplicate_block_status_code: StatusCode::ACCEPTED,
-            enable_light_client_server: true,
+            enable_light_client_server: Arc::new(true),
             target_peers: 100,
         }
     }
@@ -4724,19 +4724,19 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_lighthouse_block_rewards)
                 .uor(get_lighthouse_attestation_performance)
                 .uor(
-                    enable(ctx.config.enable_light_client_server)
+                    enable(*ctx.config.enable_light_client_server)
                         .and(get_beacon_light_client_optimistic_update),
                 )
                 .uor(
-                    enable(ctx.config.enable_light_client_server)
+                    enable(*ctx.config.enable_light_client_server)
                         .and(get_beacon_light_client_finality_update),
                 )
                 .uor(
-                    enable(ctx.config.enable_light_client_server)
+                    enable(*ctx.config.enable_light_client_server)
                         .and(get_beacon_light_client_bootstrap),
                 )
                 .uor(
-                    enable(ctx.config.enable_light_client_server)
+                    enable(*ctx.config.enable_light_client_server)
                         .and(get_beacon_light_client_updates),
                 )
                 .uor(get_lighthouse_block_packing_efficiency)

--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -249,7 +249,7 @@ pub async fn create_api_server_with_config<T: BeaconChainTypes>(
             enabled: true,
             listen_port: port,
             data_dir: std::path::PathBuf::from(DEFAULT_ROOT_DIR),
-            enable_light_client_server: true,
+            enable_light_client_server: Arc::new(true),
             ..http_config
         },
         chain: Some(chain),

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -134,7 +134,7 @@ pub struct Config {
     pub metrics_enabled: bool,
 
     /// Whether light client protocols should be enabled.
-    pub enable_light_client_server: bool,
+    pub enable_light_client_server: Arc<bool>,
 
     /// Configuration for the outbound rate limiter (requests made by this node).
     pub outbound_rate_limiter_config: Option<OutboundRateLimiterConfig>,
@@ -367,7 +367,7 @@ impl Default for Config {
             topics: Vec::new(),
             proposer_only: false,
             metrics_enabled: false,
-            enable_light_client_server: true,
+            enable_light_client_server: Arc::new(true),
             outbound_rate_limiter_config: None,
             invalid_block_storage: None,
             inbound_rate_limiter_config: None,

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -355,7 +355,7 @@ impl<E: EthSpec> Network<E> {
         };
         let eth2_rpc = RPC::new(
             ctx.fork_context.clone(),
-            config.enable_light_client_server,
+            *config.enable_light_client_server,
             config.inbound_rate_limiter_config.clone(),
             config.outbound_rate_limiter_config.clone(),
             log.clone(),

--- a/beacon_node/lighthouse_network/src/types/globals.rs
+++ b/beacon_node/lighthouse_network/src/types/globals.rs
@@ -187,7 +187,7 @@ impl<E: EthSpec> NetworkGlobals<E> {
     /// Returns the TopicConfig to compute the set of Gossip topics for a given fork
     pub fn as_topic_config(&self) -> TopicConfig {
         TopicConfig {
-            enable_light_client_server: self.config.enable_light_client_server,
+            enable_light_client_server: *self.config.enable_light_client_server,
             subscribe_all_subnets: self.config.subscribe_all_subnets,
             subscribe_all_data_column_subnets: self.config.subscribe_all_data_column_subnets,
             sampling_subnets: &self.sampling_subnets,

--- a/beacon_node/network/src/service.rs
+++ b/beacon_node/network/src/service.rs
@@ -354,7 +354,7 @@ impl<T: BeaconChainTypes> NetworkService<T> {
             gossipsub_parameter_update,
             fork_context,
             log: network_log,
-            enable_light_client_server: config.enable_light_client_server,
+            enable_light_client_server: *config.enable_light_client_server,
         };
 
         Ok((network_service, network_globals, network_senders))

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -28,6 +28,7 @@ use std::net::{IpAddr, Ipv4Addr, ToSocketAddrs};
 use std::num::NonZeroU16;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use types::graffiti::GraffitiString;
 use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes};
@@ -107,12 +108,26 @@ pub fn get_config<E: EthSpec>(
     info!(log, "Data directory initialised"; "datadir" => log_dir.into_os_string().into_string().expect("Datadir should be a valid os string"));
 
     /*
+     * Light client server
+     */
+
+    let enable_light_client_server = Arc::new(!cli_args.get_flag("disable-light-client-server"));
+    client_config.enable_light_client_server = enable_light_client_server.clone();
+    client_config.chain.enable_light_client_server = enable_light_client_server.clone();
+
+    /*
      * Networking
      */
 
     let data_dir_ref = client_config.data_dir().clone();
 
-    set_network_config(&mut client_config.network, cli_args, &data_dir_ref, log)?;
+    set_network_config(
+        &mut client_config.network,
+        cli_args,
+        &data_dir_ref,
+        log,
+        enable_light_client_server,
+    )?;
 
     /*
      * Staking flag
@@ -176,7 +191,7 @@ pub fn get_config<E: EthSpec>(
             parse_required(cli_args, "http-duplicate-block-status")?;
 
         client_config.http_api.enable_light_client_server =
-            !cli_args.get_flag("disable-light-client-server");
+            client_config.enable_light_client_server.clone();
     }
 
     if cli_args.get_flag("light-client-server") {
@@ -185,10 +200,6 @@ pub fn get_config<E: EthSpec>(
             "The --light-client-server flag is deprecated. The light client server is enabled \
              by default"
         );
-    }
-
-    if cli_args.get_flag("disable-light-client-server") {
-        client_config.chain.enable_light_client_server = false;
     }
 
     if let Some(cache_size) = clap_utils::parse_optional(cli_args, "shuffling-cache-size")? {
@@ -1146,6 +1157,7 @@ pub fn set_network_config(
     cli_args: &ArgMatches,
     data_dir: &Path,
     log: &Logger,
+    enable_light_client_server: Arc<bool>,
 ) -> Result<(), String> {
     // If a network dir has been specified, override the `datadir` definition.
     if let Some(dir) = cli_args.get_one::<String>("network-dir") {
@@ -1439,7 +1451,7 @@ pub fn set_network_config(
     }
 
     // Light client server config.
-    config.enable_light_client_server = !parse_flag(cli_args, "disable-light-client-server");
+    config.enable_light_client_server = enable_light_client_server;
 
     // The self limiter is enabled by default. If the `self-limiter-protocols` flag is not provided,
     // the default params will be used.

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -10,6 +10,7 @@ use lighthouse_network::{
 use serde::{Deserialize, Serialize};
 use ssz::Encode;
 use std::net::{SocketAddrV4, SocketAddrV6};
+use std::sync::Arc;
 use std::time::Duration;
 use std::{marker::PhantomData, path::PathBuf};
 use types::EthSpec;
@@ -55,7 +56,14 @@ impl<E: EthSpec> BootNodeConfig<E> {
 
         let logger = slog_scope::logger();
 
-        set_network_config(&mut network_config, matches, &data_dir, &logger)?;
+        // Light client server is disabled for boot nodes
+        set_network_config(
+            &mut network_config,
+            matches,
+            &data_dir,
+            &logger,
+            Arc::new(false),
+        )?;
 
         // Set the Enr Discovery ports to the listening ports if not present.
         if let Some(listening_addr_v4) = network_config.listen_addrs().v4() {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2504,9 +2504,9 @@ fn light_client_server_default() {
     CommandLineTest::new()
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(config.network.enable_light_client_server);
-            assert!(config.chain.enable_light_client_server);
-            assert!(config.http_api.enable_light_client_server);
+            assert!(*config.network.enable_light_client_server);
+            assert!(*config.chain.enable_light_client_server);
+            assert!(*config.http_api.enable_light_client_server);
         });
 }
 
@@ -2516,8 +2516,8 @@ fn light_client_server_enabled() {
         .flag("light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(config.network.enable_light_client_server);
-            assert!(config.chain.enable_light_client_server);
+            assert!(*config.network.enable_light_client_server);
+            assert!(*config.chain.enable_light_client_server);
         });
 }
 
@@ -2527,8 +2527,8 @@ fn light_client_server_disabled() {
         .flag("disable-light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(!config.network.enable_light_client_server);
-            assert!(!config.chain.enable_light_client_server);
+            assert!(!*config.network.enable_light_client_server);
+            assert!(!*config.chain.enable_light_client_server);
         });
 }
 
@@ -2539,9 +2539,9 @@ fn light_client_http_server_disabled() {
         .flag("disable-light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(!config.http_api.enable_light_client_server);
-            assert!(!config.network.enable_light_client_server);
-            assert!(!config.chain.enable_light_client_server);
+            assert!(!*config.http_api.enable_light_client_server);
+            assert!(!*config.network.enable_light_client_server);
+            assert!(!*config.chain.enable_light_client_server);
         });
 }
 

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -41,10 +41,10 @@ fn default_client_config(network_params: LocalNetworkParams, genesis_time: u64) 
     beacon_config.network.target_peers =
         network_params.node_count + network_params.proposer_nodes + network_params.extra_nodes - 1;
     beacon_config.network.enr_address = (Some(Ipv4Addr::LOCALHOST), None);
-    beacon_config.network.enable_light_client_server = true;
+    beacon_config.network.enable_light_client_server = Arc::new(true);
     beacon_config.network.discv5_config.enable_packet_filter = false;
-    beacon_config.chain.enable_light_client_server = true;
-    beacon_config.http_api.enable_light_client_server = true;
+    beacon_config.chain.enable_light_client_server = Arc::new(true);
+    beacon_config.http_api.enable_light_client_server = Arc::new(true);
     beacon_config.chain.optimistic_finalized_sync = false;
     beacon_config.trusted_setup = serde_json::from_reader(get_trusted_setup().as_slice())
         .expect("Trusted setup bytes should be valid");


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/6959

## Proposed Changes

- Use `Arc<bool>` type to create a single source of truth
- A new field `enable_light_client_server: Arc<bool>` has been added to [`Config`](https://github.com/EllipticPoint/lighthouse/blob/e0b5603b946de1d9ef2e827cd874fa37a8818d7c/beacon_node/client/src/config.rs#L86).
- The 3 existing struct fields mentioned in the issue have been changed to `Arc<bool>`