### PR TITLE
Update mergify conditions for `trivial` and `ready-for-merge` labels to satisfy if base is not `stable`

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
 
   - name: Approve trivial maintainer PRs
     conditions:
-      - base=unstable
+      - base!=stable
       - label=trivial
       - author=@sigp/lighthouse
       - -conflict
@@ -26,7 +26,7 @@ pull_request_rules:
   - name: Add ready-to-merge labeled PRs to merge queue
     conditions:
       # All branch protection rules are implicit: https://docs.mergify.com/conditions/#about-branch-protection
-      - base=unstable
+      - base!=stable
       - label=ready-for-merge
       - label!=do-not-merge
     actions:


### PR DESCRIPTION
Currently PRs only get merged if the base branch is `unstable`. 
We could apply this condition to all branches except for `stable`, so that we don't have to manually queue the PRs.

I've changed the conditions to `base!=stable`, as we probably don't want auto approval or auto queue to `stable`.