### PR TITLE
Merge v7.0.0-beta.0 to unstable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "beacon_node",
  "bytes",
@@ -4811,7 +4811,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -5366,7 +5366,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/beacon_node/http_api/src/aggregate_attestation.rs
+++ b/beacon_node/http_api/src/aggregate_attestation.rs
@@ -18,13 +18,14 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
     endpoint_version: EndpointVersion,
     chain: Arc<BeaconChain<T>>,
 ) -> Result<Response<Body>, warp::reject::Rejection> {
-    if endpoint_version == V2 {
+    let fork_name = chain.spec.fork_name_at_slot::<T::EthSpec>(slot);
+    let aggregate_attestation = if fork_name.electra_enabled() {
         let Some(committee_index) = committee_index else {
             return Err(warp_utils::reject::custom_bad_request(
                 "missing committee index".to_string(),
             ));
         };
-        let aggregate_attestation = chain
+        chain
             .get_aggregated_attestation_electra(slot, attestation_data_root, committee_index)
             .map_err(|e| {
                 warp_utils::reject::custom_bad_request(format!(
@@ -34,8 +35,22 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
             })?
             .ok_or_else(|| {
                 warp_utils::reject::custom_not_found("no matching aggregate found".to_string())
-            })?;
-        let fork_name = chain.spec.fork_name_at_slot::<T::EthSpec>(slot);
+            })?
+    } else {
+        chain
+            .get_pre_electra_aggregated_attestation_by_slot_and_root(slot, attestation_data_root)
+            .map_err(|e| {
+                warp_utils::reject::custom_bad_request(format!(
+                    "unable to fetch aggregate: {:?}",
+                    e
+                ))
+            })?
+            .ok_or_else(|| {
+                warp_utils::reject::custom_not_found("no matching aggregate found".to_string())
+            })?
+    };
+
+    if endpoint_version == V2 {
         let fork_versioned_response = ForkVersionedResponse {
             version: Some(fork_name),
             metadata: EmptyMetadata {},
@@ -46,19 +61,7 @@ pub fn get_aggregate_attestation<T: BeaconChainTypes>(
             fork_name,
         ))
     } else if endpoint_version == V1 {
-        let aggregate_attestation = chain
-            .get_pre_electra_aggregated_attestation_by_slot_and_root(slot, attestation_data_root)
-            .map_err(|e| {
-                warp_utils::reject::custom_bad_request(format!(
-                    "unable to fetch aggregate: {:?}",
-                    e
-                ))
-            })?
-            .map(GenericResponse::from)
-            .ok_or_else(|| {
-                warp_utils::reject::custom_not_found("no matching aggregate found".to_string())
-            })?;
-        Ok(warp::reply::json(&aggregate_attestation).into_response())
+        Ok(warp::reply::json(&GenericResponse::from(aggregate_attestation)).into_response())
     } else {
         return Err(unsupported_version_rejection(endpoint_version));
     }

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v6.0.1-",
-    fallback = "Lighthouse/v6.0.1"
+    prefix = "Lighthouse/v7.0.0-beta.0-",
+    fallback = "Lighthouse/v7.0.0-beta.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.
@@ -54,7 +54,7 @@ pub fn version_with_platform() -> String {
 ///
 /// `1.5.1`
 pub fn version() -> &'static str {
-    "6.0.1"
+    "7.0.0-beta.0"
 }
 
 /// Returns the name of the current client running.
@@ -71,9 +71,10 @@ mod test {
 
     #[test]
     fn version_formatting() {
-        let re =
-            Regex::new(r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-rc.[0-9])?(-[[:xdigit:]]{7})?\+?$")
-                .unwrap();
+        let re = Regex::new(
+            r"^Lighthouse/v[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta).[0-9])?(-[[:xdigit:]]{7})?\+?$",
+        )
+        .unwrap();
         assert!(
             re.is_match(VERSION),
             "version doesn't match regex: {}",

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "6.0.1"
+version = "7.0.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Proposed Changes

Back-merge the latest changes from v7.0.0-beta.0 to unstable, including the version bump.

This PR should not be squash merged, I will merge it manually with a fast-forward after approval.

## Additional Info

Interestingly, the branch protection rules prevent `origin/merge-v7-to-unstable` from being deleted. I assume because it's checking `string.contains("unstable")`. I'm going to look into fixing that.