### PR TITLE
feat: implement new beacon APIs(accessors for pending_deposits/pending_partial_withdrawals)

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1133,15 +1133,6 @@ pub fn serve<T: BeaconChainTypes>(
                         .map_state_and_execution_optimistic_and_finalized(
                             &chain,
                             |state, execution_optimistic, finalized| {
-                                if !state.fork_name_unchecked().electra_enabled() {
-                                    return Err(warp_utils::reject::pre_electra_not_supported(
-                                        format!(
-                                            "state at epoch {} is not activated for Electra",
-                                            state.current_epoch()
-                                        ),
-                                    ));
-                                }
-
                                 let Ok(deposits) = state.pending_deposits() else {
                                     return Err(warp_utils::reject::custom_bad_request(
                                         "Pending deposits not found".to_string(),
@@ -1179,15 +1170,6 @@ pub fn serve<T: BeaconChainTypes>(
                         .map_state_and_execution_optimistic_and_finalized(
                             &chain,
                             |state, execution_optimistic, finalized| {
-                                if !state.fork_name_unchecked().electra_enabled() {
-                                    return Err(warp_utils::reject::pre_electra_not_supported(
-                                        format!(
-                                            "state at epoch {} is not activated for Electra",
-                                            state.current_epoch()
-                                        ),
-                                    ));
-                                }
-
                                 let Ok(withdrawals) = state.pending_partial_withdrawals() else {
                                     return Err(warp_utils::reject::custom_bad_request(
                                         "Pending withdrawals not found".to_string(),

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1119,6 +1119,81 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
+    // GET beacon/states/{state_id}/pending_deposits
+    let get_beacon_state_pending_deposits = beacon_states_path
+        .clone()
+        .and(warp::path("pending_deposits"))
+        .and(warp::path::end())
+        .then(
+            |state_id: StateId,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_json_task(Priority::P1, move || {
+                    let (data, execution_optimistic, finalized) = state_id
+                        .map_state_and_execution_optimistic_and_finalized(
+                            &chain,
+                            |state, execution_optimistic, finalized| {
+                                if !state.fork_name_unchecked().electra_enabled() {
+                                    return Err(warp_utils::reject::pre_electra_not_supported(
+                                        format!("state at epoch {} is not activated for Electra", state.current_epoch())
+                                    ));
+                                }
+
+                                let Ok(deposits) = state.pending_deposits() else {
+                                    return Err(warp_utils::reject::custom_bad_request("Pending deposits not found".to_string()));
+                                };
+
+                                Ok((deposits.iter().cloned().collect::<Vec<_>>(), execution_optimistic, finalized))
+                            }
+                        )?;
+
+                        Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                            data,
+                            execution_optimistic: Some(execution_optimistic),
+                            finalized: Some(finalized),
+                        })
+                })
+            },
+        );
+
+    // GET beacon/states/{state_id}/pending_partial_withdrawals
+    let get_beacon_state_pending_partial_withdrawals = beacon_states_path
+        .clone()
+        .and(warp::path("pending_partial_withdrawals"))
+        .and(warp::path::end())
+        .then(
+            |state_id: StateId,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_json_task(Priority::P1, move || {
+                    let (data, execution_optimistic, finalized) = state_id
+                        .map_state_and_execution_optimistic_and_finalized(
+                            &chain,
+                            |state, execution_optimistic, finalized| {
+                                if !state.fork_name_unchecked().electra_enabled() {
+                                    return Err(warp_utils::reject::pre_electra_not_supported(
+                                        format!("state at epoch {} is not activated for Electra", state.current_epoch())
+                                    ));
+                                }
+
+                                let Ok(withdrawals) = state.pending_partial_withdrawals() else {
+                                    return Err(warp_utils::reject::custom_bad_request("Pending withdrawals not found".to_string()));
+                                };
+
+                                Ok((withdrawals.iter().cloned().collect::<Vec<_>>(), execution_optimistic, finalized))
+                            }
+                        )?;
+
+                        Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                            data,
+                            execution_optimistic: Some(execution_optimistic),
+                            finalized: Some(finalized),
+                        })
+                })
+            },
+        );
+
+
     // GET beacon/headers
     //
     // Note: this endpoint only returns information about blocks in the canonical chain. Given that
@@ -4667,6 +4742,8 @@ pub fn serve<T: BeaconChainTypes>(
                 .uor(get_beacon_state_committees)
                 .uor(get_beacon_state_sync_committees)
                 .uor(get_beacon_state_randao)
+                .uor(get_beacon_state_pending_deposits)
+                .uor(get_beacon_state_pending_partial_withdrawals)
                 .uor(get_beacon_headers)
                 .uor(get_beacon_headers_block_id)
                 .uor(get_beacon_block)

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1135,23 +1135,32 @@ pub fn serve<T: BeaconChainTypes>(
                             |state, execution_optimistic, finalized| {
                                 if !state.fork_name_unchecked().electra_enabled() {
                                     return Err(warp_utils::reject::pre_electra_not_supported(
-                                        format!("state at epoch {} is not activated for Electra", state.current_epoch())
+                                        format!(
+                                            "state at epoch {} is not activated for Electra",
+                                            state.current_epoch()
+                                        ),
                                     ));
                                 }
 
                                 let Ok(deposits) = state.pending_deposits() else {
-                                    return Err(warp_utils::reject::custom_bad_request("Pending deposits not found".to_string()));
+                                    return Err(warp_utils::reject::custom_bad_request(
+                                        "Pending deposits not found".to_string(),
+                                    ));
                                 };
 
-                                Ok((deposits.iter().cloned().collect::<Vec<_>>(), execution_optimistic, finalized))
-                            }
+                                Ok((
+                                    deposits.iter().cloned().collect::<Vec<_>>(),
+                                    execution_optimistic,
+                                    finalized,
+                                ))
+                            },
                         )?;
 
-                        Ok(api_types::ExecutionOptimisticFinalizedResponse {
-                            data,
-                            execution_optimistic: Some(execution_optimistic),
-                            finalized: Some(finalized),
-                        })
+                    Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                        data,
+                        execution_optimistic: Some(execution_optimistic),
+                        finalized: Some(finalized),
+                    })
                 })
             },
         );
@@ -1172,27 +1181,35 @@ pub fn serve<T: BeaconChainTypes>(
                             |state, execution_optimistic, finalized| {
                                 if !state.fork_name_unchecked().electra_enabled() {
                                     return Err(warp_utils::reject::pre_electra_not_supported(
-                                        format!("state at epoch {} is not activated for Electra", state.current_epoch())
+                                        format!(
+                                            "state at epoch {} is not activated for Electra",
+                                            state.current_epoch()
+                                        ),
                                     ));
                                 }
 
                                 let Ok(withdrawals) = state.pending_partial_withdrawals() else {
-                                    return Err(warp_utils::reject::custom_bad_request("Pending withdrawals not found".to_string()));
+                                    return Err(warp_utils::reject::custom_bad_request(
+                                        "Pending withdrawals not found".to_string(),
+                                    ));
                                 };
 
-                                Ok((withdrawals.iter().cloned().collect::<Vec<_>>(), execution_optimistic, finalized))
-                            }
+                                Ok((
+                                    withdrawals.iter().cloned().collect::<Vec<_>>(),
+                                    execution_optimistic,
+                                    finalized,
+                                ))
+                            },
                         )?;
 
-                        Ok(api_types::ExecutionOptimisticFinalizedResponse {
-                            data,
-                            execution_optimistic: Some(execution_optimistic),
-                            finalized: Some(finalized),
-                        })
+                    Ok(api_types::ExecutionOptimisticFinalizedResponse {
+                        data,
+                        execution_optimistic: Some(execution_optimistic),
+                        finalized: Some(finalized),
+                    })
                 })
             },
         );
-
 
     // GET beacon/headers
     //

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -1139,11 +1139,7 @@ pub fn serve<T: BeaconChainTypes>(
                                     ));
                                 };
 
-                                Ok((
-                                    deposits.iter().cloned().collect::<Vec<_>>(),
-                                    execution_optimistic,
-                                    finalized,
-                                ))
+                                Ok((deposits.clone(), execution_optimistic, finalized))
                             },
                         )?;
 
@@ -1176,11 +1172,7 @@ pub fn serve<T: BeaconChainTypes>(
                                     ));
                                 };
 
-                                Ok((
-                                    withdrawals.iter().cloned().collect::<Vec<_>>(),
-                                    execution_optimistic,
-                                    finalized,
-                                ))
+                                Ok((withdrawals.clone(), execution_optimistic, finalized))
                             },
                         )?;
 

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1211,9 +1211,7 @@ impl ApiTester {
             }
 
             let state = state_opt.as_mut().expect("result should be none");
-            let expected = state
-                .pending_deposits()
-                .unwrap();
+            let expected = state.pending_deposits().unwrap();
 
             assert_eq!(result.unwrap(), expected.to_vec());
         }
@@ -1240,9 +1238,7 @@ impl ApiTester {
             }
 
             let state = state_opt.as_mut().expect("result should be none");
-            let expected = state
-                .pending_partial_withdrawals()
-                .unwrap();
+            let expected = state.pending_partial_withdrawals().unwrap();
 
             assert_eq!(result.unwrap(), expected.to_vec());
         }
@@ -6389,7 +6385,6 @@ async fn beacon_get_state_info_electra() {
         .test_beacon_states_pending_partial_withdrawals()
         .await;
 }
-
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn beacon_get_blocks() {

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -1192,6 +1192,64 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_beacon_states_pending_deposits(self) -> Self {
+        for state_id in self.interesting_state_ids() {
+            let mut state_opt = state_id
+                .state(&self.chain)
+                .ok()
+                .map(|(state, _execution_optimistic, _finalized)| state);
+
+            let result = self
+                .client
+                .get_beacon_states_pending_deposits(state_id.0)
+                .await
+                .unwrap()
+                .map(|res| res.data);
+
+            if result.is_none() && state_opt.is_none() {
+                continue;
+            }
+
+            let state = state_opt.as_mut().expect("result should be none");
+            let expected = state
+                .pending_deposits()
+                .unwrap();
+
+            assert_eq!(result.unwrap(), expected.to_vec());
+        }
+
+        self
+    }
+
+    pub async fn test_beacon_states_pending_partial_withdrawals(self) -> Self {
+        for state_id in self.interesting_state_ids() {
+            let mut state_opt = state_id
+                .state(&self.chain)
+                .ok()
+                .map(|(state, _execution_optimistic, _finalized)| state);
+
+            let result = self
+                .client
+                .get_beacon_states_pending_partial_withdrawals(state_id.0)
+                .await
+                .unwrap()
+                .map(|res| res.data);
+
+            if result.is_none() && state_opt.is_none() {
+                continue;
+            }
+
+            let state = state_opt.as_mut().expect("result should be none");
+            let expected = state
+                .pending_partial_withdrawals()
+                .unwrap();
+
+            assert_eq!(result.unwrap(), expected.to_vec());
+        }
+
+        self
+    }
+
     pub async fn test_beacon_headers_all_slots(self) -> Self {
         for slot in 0..CHAIN_LENGTH {
             let slot = Slot::from(slot);
@@ -6315,6 +6373,23 @@ async fn beacon_get_state_info() {
         .test_beacon_states_randao()
         .await;
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn beacon_get_state_info_electra() {
+    let mut config = ApiTesterConfig::default();
+    config.spec.altair_fork_epoch = Some(Epoch::new(0));
+    config.spec.bellatrix_fork_epoch = Some(Epoch::new(0));
+    config.spec.capella_fork_epoch = Some(Epoch::new(0));
+    config.spec.deneb_fork_epoch = Some(Epoch::new(0));
+    config.spec.electra_fork_epoch = Some(Epoch::new(0));
+    ApiTester::new_from_config(config)
+        .await
+        .test_beacon_states_pending_deposits()
+        .await
+        .test_beacon_states_pending_partial_withdrawals()
+        .await;
+}
+
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn beacon_get_blocks() {

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -782,6 +782,44 @@ impl BeaconNodeHttpClient {
         self.get_opt(path).await
     }
 
+    /// `GET beacon/states/{state_id}/pending_deposits`
+    ///
+    /// Returns `Ok(None)` on a 404 error.
+    pub async fn get_beacon_states_pending_deposits(
+        &self,
+        state_id: StateId,
+    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingDeposit>>>, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("states")
+            .push(&state_id.to_string())
+            .push("pending_deposits");
+
+        self.get_opt(path).await
+    }
+
+    /// `GET beacon/states/{state_id}/pending_partial_withdrawals`
+    ///
+    /// Returns `Ok(None)` on a 404 error.
+    pub async fn get_beacon_states_pending_partial_withdrawals(
+        &self,
+        state_id: StateId,
+    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingPartialWithdrawal>>>, Error> {
+        let mut path = self.eth_path(V1)?;
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("beacon")
+            .push("states")
+            .push(&state_id.to_string())
+            .push("pending_partial_withdrawals");
+
+        self.get_opt(path).await
+    }
+
     /// `GET beacon/light_client/updates`
     ///
     /// Returns `Ok(None)` on a 404 error.

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -807,7 +807,8 @@ impl BeaconNodeHttpClient {
     pub async fn get_beacon_states_pending_partial_withdrawals(
         &self,
         state_id: StateId,
-    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingPartialWithdrawal>>>, Error> {
+    ) -> Result<Option<ExecutionOptimisticFinalizedResponse<Vec<PendingPartialWithdrawal>>>, Error>
+    {
         let mut path = self.eth_path(V1)?;
 
         path.path_segments_mut()

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -140,6 +140,15 @@ pub fn indexed_bad_request(message: String, failures: Vec<Failure>) -> warp::rej
     warp::reject::custom(IndexedBadRequestErrors { message, failures })
 }
 
+#[derive(Debug)]
+pub struct PreElectraNotSupported(pub String);
+
+impl Reject for PreElectraNotSupported {}
+
+pub fn pre_electra_not_supported(msg: String) -> warp::reject::Rejection {
+    warp::reject::custom(PreElectraNotSupported(msg))
+}
+
 /// This function receives a `Rejection` and tries to return a custom
 /// value, otherwise simply passes the rejection along.
 pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, Infallible> {
@@ -202,6 +211,9 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if let Some(e) = err.find::<crate::reject::InvalidAuthorization>() {
         code = StatusCode::FORBIDDEN;
         message = format!("FORBIDDEN: Invalid auth token: {}", e.0);
+    } else if let Some(e) = err.find::<crate::reject::PreElectraNotSupported>() {
+        code = StatusCode::BAD_REQUEST;
+        message = format!("BAD_REQUEST: Pre-Electra not supported: {}", e.0);
     } else if let Some(e) = err.find::<warp::reject::MissingHeader>() {
         if e.name().eq("Authorization") {
             code = StatusCode::UNAUTHORIZED;

--- a/common/warp_utils/src/reject.rs
+++ b/common/warp_utils/src/reject.rs
@@ -140,15 +140,6 @@ pub fn indexed_bad_request(message: String, failures: Vec<Failure>) -> warp::rej
     warp::reject::custom(IndexedBadRequestErrors { message, failures })
 }
 
-#[derive(Debug)]
-pub struct PreElectraNotSupported(pub String);
-
-impl Reject for PreElectraNotSupported {}
-
-pub fn pre_electra_not_supported(msg: String) -> warp::reject::Rejection {
-    warp::reject::custom(PreElectraNotSupported(msg))
-}
-
 /// This function receives a `Rejection` and tries to return a custom
 /// value, otherwise simply passes the rejection along.
 pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, Infallible> {
@@ -211,9 +202,6 @@ pub async fn handle_rejection(err: warp::Rejection) -> Result<impl warp::Reply, 
     } else if let Some(e) = err.find::<crate::reject::InvalidAuthorization>() {
         code = StatusCode::FORBIDDEN;
         message = format!("FORBIDDEN: Invalid auth token: {}", e.0);
-    } else if let Some(e) = err.find::<crate::reject::PreElectraNotSupported>() {
-        code = StatusCode::BAD_REQUEST;
-        message = format!("BAD_REQUEST: Pre-Electra not supported: {}", e.0);
     } else if let Some(e) = err.find::<warp::reject::MissingHeader>() {
         if e.name().eq("Authorization") {
             code = StatusCode::UNAUTHORIZED;


### PR DESCRIPTION
## Issue Addressed

Resolves #7003 

## Proposed Changes

Added two endpoints as https://github.com/ethereum/beacon-APIs/pull/500 proposed:
- `/eth/v1/beacon/states/{state_id}/pending_deposits`
- `/eth/v1/beacon/states/{state_id}/pending_partial_withdrawals`
