### PR TITLE
Remove LC server config from HTTP API

### DIFF
--- a/beacon_node/http_api/src/test_utils.rs
+++ b/beacon_node/http_api/src/test_utils.rs
@@ -249,7 +249,6 @@ pub async fn create_api_server_with_config<T: BeaconChainTypes>(
             enabled: true,
             listen_port: port,
             data_dir: std::path::PathBuf::from(DEFAULT_ROOT_DIR),
-            enable_light_client_server: true,
             ..http_config
         },
         chain: Some(chain),

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -174,9 +174,6 @@ pub fn get_config<E: EthSpec>(
 
         client_config.http_api.duplicate_block_status_code =
             parse_required(cli_args, "http-duplicate-block-status")?;
-
-        client_config.http_api.enable_light_client_server =
-            !cli_args.get_flag("disable-light-client-server");
     }
 
     if cli_args.get_flag("light-client-server") {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2506,7 +2506,6 @@ fn light_client_server_default() {
         .with_config(|config| {
             assert!(config.network.enable_light_client_server);
             assert!(config.chain.enable_light_client_server);
-            assert!(config.http_api.enable_light_client_server);
         });
 }
 
@@ -2539,7 +2538,6 @@ fn light_client_http_server_disabled() {
         .flag("disable-light-client-server", None)
         .run_with_zero_port()
         .with_config(|config| {
-            assert!(!config.http_api.enable_light_client_server);
             assert!(!config.network.enable_light_client_server);
             assert!(!config.chain.enable_light_client_server);
         });

--- a/testing/simulator/src/local_network.rs
+++ b/testing/simulator/src/local_network.rs
@@ -44,7 +44,6 @@ fn default_client_config(network_params: LocalNetworkParams, genesis_time: u64) 
     beacon_config.network.enable_light_client_server = true;
     beacon_config.network.discv5_config.enable_packet_filter = false;
     beacon_config.chain.enable_light_client_server = true;
-    beacon_config.http_api.enable_light_client_server = true;
     beacon_config.chain.optimistic_finalized_sync = false;
     beacon_config.trusted_setup = serde_json::from_reader(get_trusted_setup().as_slice())
         .expect("Trusted setup bytes should be valid");


### PR DESCRIPTION
## Issue Addressed

Partly addresses

- https://github.com/sigp/lighthouse/issues/6959

## Proposed Changes

Use the `enable_light_client_server` field from the beacon chain config in the HTTP API. I think we can make this the single source of truth, as I think the network crate also has access to the beacon chain config.
