### PR TITLE
update codeowners, to be more specific

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-beacon_node/network/                @jxs
-beacon_node/lighthouse_network/     @jxs
+/beacon_node/network/                @jxs
+/beacon_node/lighthouse_network/     @jxs


### PR DESCRIPTION
## Issue Addressed

I keep being notified for PR's like https://github.com/sigp/lighthouse/pull/7009 where it doesn't touch the specified directories in the `CODEOWNERS` file.
After reading the [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) not having a forward slash in beginning of the path means:
>  In this example, @octocat owns any file in an apps directory
> anywhere in your repository.

whereas with the slashes:
> In this example, @doctocat owns any file in the `/docs`
> directory in the root of your repository and any of its
> subdirectories.

this update makes it more rigid for the files in the jxs ownership