### PR TITLE
Disable light client when fork epoch is misaligned

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2204,7 +2204,9 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             | LightClientFinalityUpdateError::SigSlotStartIsNone => {
                 metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_ERRORS)
             }
-            LightClientFinalityUpdateError::TooEarly | LightClientFinalityUpdateError::TooLate => {
+            LightClientFinalityUpdateError::TooEarly
+            | LightClientFinalityUpdateError::TooLate
+            | LightClientFinalityUpdateError::Disabled => {
                 metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_IGNORES)
             }
         })
@@ -2256,6 +2258,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
             LightClientOptimisticUpdateError::TooEarly
             | LightClientOptimisticUpdateError::TooLate
+            | LightClientOptimisticUpdateError::Disabled
             | LightClientOptimisticUpdateError::UnknownBlockParentRoot(_) => {
                 metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_IGNORES)
             }
@@ -7301,6 +7304,27 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
         }
 
         Ok(None)
+    }
+
+    /// The current sync committee is considered misaligned if a fork is scheduled inside it.
+    /// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
+    /// is equal to the `fork_epoch` sync committee period.
+    pub fn is_current_sync_committee_period_misaligned<E: EthSpec>(
+        &self,
+        current_slot: Slot,
+    ) -> bool {
+        let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
+            current_slot
+                .epoch(E::slots_per_epoch())
+                .sync_committee_period(&self.spec)
+                == fork_epoch.sync_committee_period(&self.spec)
+                && fork_epoch % self.spec.epochs_per_sync_committee_period != 0
+        };
+
+        ForkName::list_all_fork_epochs(&self.spec)
+            .iter()
+            .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
+            .any(is_fork_boundary_inside_sync_committee_period)
     }
 }
 

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2198,6 +2198,16 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self,
             seen_timestamp,
         )
+        .inspect_err(|e| match e {
+            LightClientFinalityUpdateError::FailedConstructingUpdate
+            | LightClientFinalityUpdateError::InvalidLightClientFinalityUpdate
+            | LightClientFinalityUpdateError::SigSlotStartIsNone => {
+                metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_ERRORS)
+            }
+            LightClientFinalityUpdateError::TooEarly => {
+                metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_IGNORES)
+            }
+        })
         .inspect(|_| {
             metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_SUCCESSES);
         })
@@ -2238,6 +2248,17 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             self,
             seen_timestamp,
         )
+        .inspect_err(|e| match e {
+            LightClientOptimisticUpdateError::FailedConstructingUpdate
+            | LightClientOptimisticUpdateError::InvalidLightClientOptimisticUpdate
+            | LightClientOptimisticUpdateError::SigSlotStartIsNone => {
+                metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_ERRORS)
+            }
+            LightClientOptimisticUpdateError::TooEarly
+            | LightClientOptimisticUpdateError::UnknownBlockParentRoot(_) => {
+                metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_IGNORES)
+            }
+        })
         .inspect(|_| {
             metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_SUCCESSES);
         })

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7305,27 +7305,6 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
 
         Ok(None)
     }
-
-    /// The current sync committee is considered misaligned if a fork is scheduled inside it.
-    /// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
-    /// is equal to the `fork_epoch` sync committee period.
-    pub fn is_current_sync_committee_period_misaligned<E: EthSpec>(
-        &self,
-        current_slot: Slot,
-    ) -> bool {
-        let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
-            current_slot
-                .epoch(E::slots_per_epoch())
-                .sync_committee_period(&self.spec)
-                == fork_epoch.sync_committee_period(&self.spec)
-                && fork_epoch % self.spec.epochs_per_sync_committee_period != 0
-        };
-
-        ForkName::list_all_fork_epochs(&self.spec)
-            .iter()
-            .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
-            .any(is_fork_boundary_inside_sync_committee_period)
-    }
 }
 
 impl<T: BeaconChainTypes> Drop for BeaconChain<T> {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -2204,7 +2204,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             | LightClientFinalityUpdateError::SigSlotStartIsNone => {
                 metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_ERRORS)
             }
-            LightClientFinalityUpdateError::TooEarly => {
+            LightClientFinalityUpdateError::TooEarly | LightClientFinalityUpdateError::TooLate => {
                 metrics::inc_counter(&metrics::FINALITY_UPDATE_PROCESSING_IGNORES)
             }
         })
@@ -2255,6 +2255,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
                 metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_ERRORS)
             }
             LightClientOptimisticUpdateError::TooEarly
+            | LightClientOptimisticUpdateError::TooLate
             | LightClientOptimisticUpdateError::UnknownBlockParentRoot(_) => {
                 metrics::inc_counter(&metrics::OPTIMISTIC_UPDATE_PROCESSING_IGNORES)
             }

--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -24,6 +24,8 @@ pub enum Error {
     /// Light client finality update message has been received too late to be compared
     /// against the locally constructed one.
     TooLate,
+    /// Light client functionality is temporarily disabled
+    Disabled,
     /// Light client finality update message does not match the locally constructed one.
     InvalidLightClientFinalityUpdate,
     /// Signature slot start time is none.
@@ -48,6 +50,12 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
         chain: &BeaconChain<T>,
         seen_timestamp: Duration,
     ) -> Result<Self, Error> {
+        // the fork epoch is misaligned, the light client server is temporarily disabled
+        if chain.is_current_sync_committee_period_misaligned::<T::EthSpec>(
+            *rcv_finality_update.signature_slot(),
+        ) {
+            return Err(Error::Disabled);
+        }
         // verify that enough time has passed for the block to have been propagated
         let start_time = chain
             .slot_clock

--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -51,9 +51,12 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
         seen_timestamp: Duration,
     ) -> Result<Self, Error> {
         // the fork epoch is misaligned, the light client server is temporarily disabled
-        if chain.is_current_sync_committee_period_misaligned::<T::EthSpec>(
-            *rcv_finality_update.signature_slot(),
-        ) {
+        if chain
+            .spec
+            .is_current_sync_committee_period_misaligned::<T::EthSpec>(
+                *rcv_finality_update.signature_slot(),
+            )
+        {
             return Err(Error::Disabled);
         }
         // verify that enough time has passed for the block to have been propagated

--- a/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_finality_update_verification.rs
@@ -21,6 +21,9 @@ pub enum Error {
     ///
     /// Assuming the local clock is correct, the peer has sent an invalid message.
     TooEarly,
+    /// Light client finality update message has been received too late to be compared
+    /// against the locally constructed one.
+    TooLate,
     /// Light client finality update message does not match the locally constructed one.
     InvalidLightClientFinalityUpdate,
     /// Signature slot start time is none.
@@ -61,6 +64,11 @@ impl<T: BeaconChainTypes> VerifiedLightClientFinalityUpdate<T> {
             .light_client_server_cache
             .get_latest_finality_update()
             .ok_or(Error::FailedConstructingUpdate)?;
+
+        // verify that the gossiped finality update isn't stale
+        if latest_finality_update.signature_slot() > rcv_finality_update.signature_slot() {
+            return Err(Error::TooLate);
+        }
 
         // verify that the gossiped finality update is the same as the locally constructed one.
         if latest_finality_update != rcv_finality_update {

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -25,6 +25,8 @@ pub enum Error {
     /// Light client optimistic update message has been received too late to be compared
     /// against locally constructed one.
     TooLate,
+    /// Light client functionality is temporarily disabled
+    Disabled,
     /// Light client optimistic update message does not match the locally constructed one.
     InvalidLightClientOptimisticUpdate,
     /// Signature slot start time is none.
@@ -52,6 +54,12 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
         chain: &BeaconChain<T>,
         seen_timestamp: Duration,
     ) -> Result<Self, Error> {
+        // the fork epoch is misaligned, the light client server is temporarily disabled
+        if chain.is_current_sync_committee_period_misaligned::<T::EthSpec>(
+            *rcv_optimistic_update.signature_slot(),
+        ) {
+            return Err(Error::Disabled);
+        }
         // verify that enough time has passed for the block to have been propagated
         let start_time = chain
             .slot_clock

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -22,11 +22,14 @@ pub enum Error {
     ///
     /// Assuming the local clock is correct, the peer has sent an invalid message.
     TooEarly,
+    /// Light client optimistic update message has been received too late to be compared
+    /// against locally constructed one.
+    TooLate,
     /// Light client optimistic update message does not match the locally constructed one.
     InvalidLightClientOptimisticUpdate,
     /// Signature slot start time is none.
     SigSlotStartIsNone,
-    /// Failed to construct a LightClientOptimisticUpdate from state.
+    /// Failed to construct a `LightClientOptimisticUpdate` from state.
     FailedConstructingUpdate,
     /// Unknown block with parent root.
     UnknownBlockParentRoot(Hash256),
@@ -75,6 +78,11 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
             .light_client_server_cache
             .get_latest_optimistic_update()
             .ok_or(Error::FailedConstructingUpdate)?;
+
+        // verify that the gossiped finality update isn't stale
+        if latest_optimistic_update.signature_slot() > rcv_optimistic_update.signature_slot() {
+            return Err(Error::TooLate);
+        }
 
         // verify that the gossiped optimistic update is the same as the locally constructed one.
         if latest_optimistic_update != rcv_optimistic_update {

--- a/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
+++ b/beacon_node/beacon_chain/src/light_client_optimistic_update_verification.rs
@@ -55,9 +55,12 @@ impl<T: BeaconChainTypes> VerifiedLightClientOptimisticUpdate<T> {
         seen_timestamp: Duration,
     ) -> Result<Self, Error> {
         // the fork epoch is misaligned, the light client server is temporarily disabled
-        if chain.is_current_sync_committee_period_misaligned::<T::EthSpec>(
-            *rcv_optimistic_update.signature_slot(),
-        ) {
+        if chain
+            .spec
+            .is_current_sync_committee_period_misaligned::<T::EthSpec>(
+                *rcv_optimistic_update.signature_slot(),
+            )
+        {
             return Err(Error::Disabled);
         }
         // verify that enough time has passed for the block to have been propagated

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -86,7 +86,7 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         chain_spec: &ChainSpec,
     ) -> Result<(), BeaconChainError> {
         // We temporarily skip computing light client updates if the current sync committee period is "misaligned"
-        if is_current_sync_committee_period_misaligned::<T::EthSpec>(block_slot, chain_spec) {
+        if chain_spec.is_current_sync_committee_period_misaligned::<T::EthSpec>(block_slot) {
             debug!(
                 log,
                 "The current sync committee period is misaligned, no light client updates have been computed.";
@@ -444,25 +444,4 @@ impl<E: EthSpec> LightClientCachedData<E> {
             finalized_block_root: state.finalized_checkpoint().root,
         })
     }
-}
-
-/// The current sync committee is considered misaligned if a fork is scheduled inside it.
-/// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
-/// is equal to the `fork_epoch` sync committee period.
-fn is_current_sync_committee_period_misaligned<E: EthSpec>(
-    current_slot: Slot,
-    spec: &ChainSpec,
-) -> bool {
-    let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
-        current_slot
-            .epoch(E::slots_per_epoch())
-            .sync_committee_period(spec)
-            == fork_epoch.sync_committee_period(spec)
-            && fork_epoch % spec.epochs_per_sync_committee_period != 0
-    };
-
-    ForkName::list_all_fork_epochs(spec)
-        .iter()
-        .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
-        .any(is_fork_boundary_inside_sync_committee_period)
 }

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -85,6 +85,15 @@ impl<T: BeaconChainTypes> LightClientServerCache<T> {
         log: &Logger,
         chain_spec: &ChainSpec,
     ) -> Result<(), BeaconChainError> {
+        // We temporarily skip computing light client updates if the current sync committee period is "misaligned"
+        if is_current_sync_committee_period_misaligned::<T::EthSpec>(block_slot, chain_spec) {
+            debug!(
+                log,
+                "The current sync committee period is misaligned, no light client updates have been computed.";
+                "slot" => block_slot
+            );
+            return Ok(());
+        }
         metrics::inc_counter(&metrics::LIGHT_CLIENT_SERVER_CACHE_PROCESSING_REQUESTS);
         let _timer =
             metrics::start_timer(&metrics::LIGHT_CLIENT_SERVER_CACHE_RECOMPUTE_UPDATES_TIMES);
@@ -435,4 +444,25 @@ impl<E: EthSpec> LightClientCachedData<E> {
             finalized_block_root: state.finalized_checkpoint().root,
         })
     }
+}
+
+/// The current sync committee is considered misaligned if a fork is scheduled inside it.
+/// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
+/// is equal to the `fork_epoch` sync committee period.
+fn is_current_sync_committee_period_misaligned<E: EthSpec>(
+    current_slot: Slot,
+    spec: &ChainSpec,
+) -> bool {
+    let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
+        current_slot
+            .epoch(E::slots_per_epoch())
+            .sync_committee_period(spec)
+            == fork_epoch.sync_committee_period(spec)
+            && fork_epoch % spec.epochs_per_sync_committee_period != 0
+    };
+
+    ForkName::list_all_fork_epochs(spec)
+        .iter()
+        .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
+        .any(is_fork_boundary_inside_sync_committee_period)
 }

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -11,7 +11,7 @@ use store::KeyValueStore;
 use tree_hash::TreeHash;
 use types::non_zero_usize::new_non_zero_usize;
 use types::{
-    BeaconBlockRef, BeaconState, ChainSpec, Checkpoint, EthSpec, ForkName, Hash256,
+    BeaconBlockRef, BeaconState, ChainSpec, Checkpoint, Epoch, EthSpec, ForkName, Hash256,
     LightClientBootstrap, LightClientFinalityUpdate, LightClientOptimisticUpdate,
     LightClientUpdate, MerkleProof, Slot, SyncAggregate, SyncCommittee,
 };

--- a/beacon_node/beacon_chain/src/light_client_server_cache.rs
+++ b/beacon_node/beacon_chain/src/light_client_server_cache.rs
@@ -11,7 +11,7 @@ use store::KeyValueStore;
 use tree_hash::TreeHash;
 use types::non_zero_usize::new_non_zero_usize;
 use types::{
-    BeaconBlockRef, BeaconState, ChainSpec, Checkpoint, Epoch, EthSpec, ForkName, Hash256,
+    BeaconBlockRef, BeaconState, ChainSpec, Checkpoint, EthSpec, ForkName, Hash256,
     LightClientBootstrap, LightClientFinalityUpdate, LightClientOptimisticUpdate,
     LightClientUpdate, MerkleProof, Slot, SyncAggregate, SyncCommittee,
 };

--- a/beacon_node/beacon_chain/src/metrics.rs
+++ b/beacon_node/beacon_chain/src/metrics.rs
@@ -1697,6 +1697,18 @@ pub static FINALITY_UPDATE_PROCESSING_SUCCESSES: LazyLock<Result<IntCounter>> =
             "Number of light client finality updates verified for gossip",
         )
     });
+pub static FINALITY_UPDATE_PROCESSING_ERRORS: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "light_client_finality_update_verification_errors_total",
+        "Number of light client finality updates errors",
+    )
+});
+pub static FINALITY_UPDATE_PROCESSING_IGNORES: LazyLock<Result<IntCounter>> = LazyLock::new(|| {
+    try_create_int_counter(
+        "light_client_finality_update_verification_ignores_total",
+        "Number of light client finality updates ignores",
+    )
+});
 /*
  * Light server message verification
  */
@@ -1705,6 +1717,20 @@ pub static OPTIMISTIC_UPDATE_PROCESSING_SUCCESSES: LazyLock<Result<IntCounter>> 
         try_create_int_counter(
             "light_client_optimistic_update_verification_success_total",
             "Number of light client optimistic updates verified for gossip",
+        )
+    });
+pub static OPTIMISTIC_UPDATE_PROCESSING_ERRORS: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "light_client_optimistic_update_verification_errors_total",
+            "Number of light client optimistic updates errors",
+        )
+    });
+pub static OPTIMISTIC_UPDATE_PROCESSING_IGNORES: LazyLock<Result<IntCounter>> =
+    LazyLock::new(|| {
+        try_create_int_counter(
+            "light_client_optimistic_update_verification_ignores_total",
+            "Number of light client optimistic updates ignores",
         )
     });
 /*

--- a/beacon_node/beacon_chain/tests/store_tests.rs
+++ b/beacon_node/beacon_chain/tests/store_tests.rs
@@ -175,35 +175,23 @@ async fn light_client_bootstrap_test() {
 }
 
 #[tokio::test]
-async fn light_client_updates_test() {
-    let spec = test_spec::<E>();
-    let Some(_) = spec.altair_fork_epoch else {
-        // No-op prior to Altair.
-        return;
-    };
+async fn light_client_updates_misaligned_fork_epoch() {
+    let mut spec = MinimalEthSpec::default_spec();
+    spec.altair_fork_epoch = Some(Epoch::new(1));
 
-    let num_final_blocks = E::slots_per_epoch() * 2;
     let db_path = tempdir().unwrap();
-    let store = get_store_generic(&db_path, StoreConfig::default(), test_spec::<E>());
+    let store = get_store_generic(&db_path, StoreConfig::default(), spec.clone());
     let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
-    let all_validators = (0..LOW_VALIDATOR_COUNT).collect::<Vec<_>>();
-    let num_initial_slots = E::slots_per_epoch() * 10;
-    let slots: Vec<Slot> = (1..num_initial_slots).map(Slot::new).collect();
+    // we subtract 2 because the test harness starts at slot 0 and we want the slot before the next sync committee period
+    let num_slots_in_sync_committee_period =
+        spec.epochs_per_sync_committee_period.as_u64() * E::slots_per_epoch() - 2;
 
-    let (genesis_state, genesis_state_root) = harness.get_current_state_and_root();
-    harness
-        .add_attested_blocks_at_slots(
-            genesis_state.clone(),
-            genesis_state_root,
-            &slots,
-            &all_validators,
-        )
-        .await;
-
+    // advance to the end of the current sync committee period
+    // this sync committee period is misaligned so no client data should be produced
     harness.advance_slot();
     harness
         .extend_chain_with_light_client_data(
-            num_final_blocks as usize,
+            num_slots_in_sync_committee_period as usize,
             BlockStrategy::OnCanonicalHead,
             AttestationStrategy::AllValidators,
         )
@@ -211,14 +199,74 @@ async fn light_client_updates_test() {
 
     let current_state = harness.get_current_state();
 
-    // calculate the sync period from the previous slot
-    let sync_period = (current_state.slot() - Slot::new(1))
+    let sync_period = (current_state.slot())
         .epoch(E::slots_per_epoch())
         .sync_committee_period(&spec)
         .unwrap();
 
-    // fetch a range of light client updates. right now there should only be one light client update
-    // in the db.
+    let lc_updates = harness
+        .chain
+        .get_light_client_updates(sync_period, 1)
+        .unwrap();
+
+    assert_eq!(lc_updates.len(), 0);
+
+    // advance to the next sync committee period
+    // this sync committee period is not misaligned so a
+    // light client update should be produced
+    harness.advance_slot();
+    harness
+        .extend_chain_with_light_client_data(
+            1,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+    let current_state = harness.get_current_state();
+    let sync_period = (current_state.slot())
+        .epoch(E::slots_per_epoch())
+        .sync_committee_period(&spec)
+        .unwrap();
+
+    let lc_updates = harness
+        .chain
+        .get_light_client_updates(sync_period, 1)
+        .unwrap();
+
+    assert_eq!(lc_updates.len(), 1);
+}
+
+#[tokio::test]
+async fn light_client_updates_test() {
+    let spec = test_spec::<E>();
+    let Some(_) = spec.altair_fork_epoch else {
+        // No-op prior to Altair.
+        return;
+    };
+    let db_path = tempdir().unwrap();
+    let store = get_store_generic(&db_path, StoreConfig::default(), spec.clone());
+    let harness = get_harness(store.clone(), LOW_VALIDATOR_COUNT);
+    let num_slots_in_sync_committee_period =
+        spec.epochs_per_sync_committee_period.as_u64() * E::slots_per_epoch() - 2;
+
+    // advance to the end of the current sync committee period
+    // exactly one light client update should exist in the db
+    harness.advance_slot();
+    harness
+        .extend_chain_with_light_client_data(
+            num_slots_in_sync_committee_period as usize,
+            BlockStrategy::OnCanonicalHead,
+            AttestationStrategy::AllValidators,
+        )
+        .await;
+
+    let current_state = harness.get_current_state();
+
+    let sync_period = (current_state.slot())
+        .epoch(E::slots_per_epoch())
+        .sync_committee_period(&spec)
+        .unwrap();
+
     let lc_updates = harness
         .chain
         .get_light_client_updates(sync_period, 100)
@@ -226,20 +274,22 @@ async fn light_client_updates_test() {
 
     assert_eq!(lc_updates.len(), 1);
 
-    // Advance to the next sync committee period
-    for _i in 0..(E::slots_per_epoch() * u64::from(spec.epochs_per_sync_committee_period)) {
-        harness.advance_slot();
-    }
-
+    // advance to the next sync committee period
+    // another light client update should be produced
+    harness.advance_slot();
     harness
         .extend_chain_with_light_client_data(
-            num_final_blocks as usize,
+            1,
             BlockStrategy::OnCanonicalHead,
             AttestationStrategy::AllValidators,
         )
         .await;
 
-    // we should now have two light client updates in the db
+    let sync_period = (current_state.slot())
+        .epoch(E::slots_per_epoch())
+        .sync_committee_period(&spec)
+        .unwrap();
+
     let lc_updates = harness
         .chain
         .get_light_client_updates(sync_period, 100)

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2190,6 +2190,13 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "error" => ?e,
                     ),
+                    LightClientFinalityUpdateError::Disabled
+                    | LightClientFinalityUpdateError::TooLate => debug!(
+                        self.log,
+                        ":ight client finality update ignored";
+                        "peer" => %peer_id,
+                        "error" => ?e
+                    ),
                 }
                 self.propagate_validation_result(message_id, peer_id, MessageAcceptance::Ignore);
             }
@@ -2308,6 +2315,15 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         debug!(
                             self.log,
                             "Light client error constructing optimistic update";
+                            "peer" => %peer_id,
+                            "error" => ?e,
+                        )
+                    }
+                    LightClientOptimisticUpdateError::Disabled
+                    | LightClientOptimisticUpdateError::TooLate => {
+                        debug!(
+                            self.log,
+                            "Light client optimistic update ignored";
                             "peer" => %peer_id,
                             "error" => ?e,
                         )

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -2193,7 +2193,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     LightClientFinalityUpdateError::Disabled
                     | LightClientFinalityUpdateError::TooLate => debug!(
                         self.log,
-                        ":ight client finality update ignored";
+                        "Light client finality update ignored";
                         "peer" => %peer_id,
                         "error" => ?e
                     ),

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1304,8 +1304,8 @@ impl ChainSpec {
     }
 
     /// The current sync committee is considered misaligned if a fork is scheduled inside it.
-    /// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
-    /// is equal to the `fork_epoch` sync committee period.
+    /// That is, if `fork_epoch` is not divisible by `epochs_per_sync_committee_period` and the current
+    /// sync committee period is equal to the `fork_epoch` sync committee period.
     pub fn is_current_sync_committee_period_misaligned<E: EthSpec>(
         &self,
         current_slot: Slot,
@@ -1313,12 +1313,15 @@ impl ChainSpec {
         let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
             current_slot
                 .epoch(E::slots_per_epoch())
-                .sync_committee_period(&self)
-                == fork_epoch.sync_committee_period(&self)
-                && fork_epoch % self.epochs_per_sync_committee_period != 0
+                .sync_committee_period(self)
+                == fork_epoch.sync_committee_period(self)
+                && fork_epoch
+                    .safe_rem(self.epochs_per_sync_committee_period)
+                    .unwrap_or(Epoch::new(0))
+                    != 0
         };
 
-        ForkName::list_all_fork_epochs(&self)
+        ForkName::list_all_fork_epochs(self)
             .iter()
             .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
             .any(is_fork_boundary_inside_sync_committee_period)

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -1302,6 +1302,27 @@ impl ChainSpec {
             domain_bls_to_execution_change: 10,
         }
     }
+
+    /// The current sync committee is considered misaligned if a fork is scheduled inside it.
+    /// That is, if `fork_epoch` is not divisible by 256 and the current sync committee period
+    /// is equal to the `fork_epoch` sync committee period.
+    pub fn is_current_sync_committee_period_misaligned<E: EthSpec>(
+        &self,
+        current_slot: Slot,
+    ) -> bool {
+        let is_fork_boundary_inside_sync_committee_period = |fork_epoch: Epoch| {
+            current_slot
+                .epoch(E::slots_per_epoch())
+                .sync_committee_period(&self)
+                == fork_epoch.sync_committee_period(&self)
+                && fork_epoch % self.epochs_per_sync_committee_period != 0
+        };
+
+        ForkName::list_all_fork_epochs(&self)
+            .iter()
+            .filter_map(|(_, fork_epoch_opt)| *fork_epoch_opt)
+            .any(is_fork_boundary_inside_sync_committee_period)
+    }
 }
 
 impl Default for ChainSpec {

--- a/consensus/types/src/chain_spec.rs
+++ b/consensus/types/src/chain_spec.rs
@@ -2356,4 +2356,40 @@ mod yaml_tests {
             [0, 0, 0, 1]
         );
     }
+
+    #[test]
+    fn test_is_current_sync_committee_period_misaligned() {
+        let mut spec = ChainSpec::mainnet();
+        for (_, epoch_opt) in ForkName::list_all_fork_epochs(&spec) {
+            if let Some(epoch) = epoch_opt {
+                let start_slot = epoch.start_slot(MainnetEthSpec::slots_per_epoch());
+                assert!(
+                    !spec.is_current_sync_committee_period_misaligned::<MainnetEthSpec>(start_slot)
+                );
+            };
+        }
+        // a fork epoch occurs within the sync committee period
+        let new_altair_fork_epoch = Epoch::new(1);
+        spec.altair_fork_epoch = Some(new_altair_fork_epoch);
+        assert!(
+            spec.is_current_sync_committee_period_misaligned::<MainnetEthSpec>(
+                new_altair_fork_epoch.start_slot(MainnetEthSpec::slots_per_epoch())
+            )
+        );
+        let next_sync_committee_slot = Slot::new(
+            spec.epochs_per_sync_committee_period.as_u64() * MainnetEthSpec::slots_per_epoch(),
+        );
+        // the slot immediately before the next sync committee period post fork
+        assert!(
+            spec.is_current_sync_committee_period_misaligned::<MainnetEthSpec>(
+                next_sync_committee_slot - 1
+            )
+        );
+        // the next sync committee period post fork
+        assert!(
+            !spec.is_current_sync_committee_period_misaligned::<MainnetEthSpec>(
+                next_sync_committee_slot
+            )
+        );
+    }
 }


### PR DESCRIPTION
Closes #7002

Temporarily disables light client functionality when fork epoch is misaligned

Add metrics for Light client gossip verification failures. I've added two categories of errors `Failures` and `Ignores` so we can differentiate between "real" failures and janky data. I've also added a new error type `TooLate` so that we dont include stale data as part of our "Failures" metrics. Ideally it'd be nice to have this included in the 7.0 release 