### PR TITLE
Cache validator registration only after successful publish

### DIFF
--- a/validator_client/validator_services/src/preparation_service.rs
+++ b/validator_client/validator_services/src/preparation_service.rs
@@ -428,7 +428,7 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                     pubkey,
                 } = key.clone();
 
-                let signed_data = match self
+                match self
                     .validator_store
                     .sign_validator_registration_data(ValidatorRegistrationData {
                         fee_recipient,
@@ -458,9 +458,7 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                         );
                         continue;
                     }
-                };
-
-                signed_data
+                }
             };
             signed.push(signed_data);
         }

--- a/validator_client/validator_services/src/preparation_service.rs
+++ b/validator_client/validator_services/src/preparation_service.rs
@@ -460,10 +460,6 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                     }
                 };
 
-                self.validator_registration_cache
-                    .write()
-                    .insert(key, signed_data.clone());
-
                 signed_data
             };
             signed.push(signed_data);
@@ -478,11 +474,20 @@ impl<T: SlotClock + 'static, E: EthSpec> PreparationService<T, E> {
                     })
                     .await
                 {
-                    Ok(()) => info!(
-                        log,
-                        "Published validator registrations to the builder network";
-                        "count" => batch.len(),
-                    ),
+                    Ok(()) => {
+                        info!(
+                            log,
+                            "Published validator registrations to the builder network";
+                            "count" => batch.len(),
+                        );
+                        let mut guard = self.validator_registration_cache.write();
+                        for signed_data in batch {
+                            guard.insert(
+                                ValidatorRegistrationKey::from(signed_data.message.clone()),
+                                signed_data.clone(),
+                            );
+                        }
+                    }
                     Err(e) => warn!(
                         log,
                         "Unable to publish validator registrations to the builder network";


### PR DESCRIPTION
We are caching validator registrations after signing is successful rather than after publish is successful. And the purpose of this cache is to suppress publishing. Here, I move the caching to post-publish.

We re-publish registrations regardless of this cache every epoch so this isn't a huge issue. The place where this helps is kurtosis testing with the `mev` flow. On starting a new testnet, we fail the initial publish, and this bug means we need to wait till the next epoch to actually test the `mev` flow. 
