### PR TITLE
Use BTreeMap for Milhouse pending updates (v7.0.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,6 +2371,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
 name = "ef_tests"
 version = "0.2.0"
 dependencies = [
@@ -2485,6 +2497,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -2847,20 +2879,25 @@ dependencies = [
 
 [[package]]
 name = "ethereum_ssz"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e999563461faea0ab9bc0024e5e66adcee35881f3d5062f52f31a4070fe1522"
+checksum = "862e41ea8eea7508f70cfd8cd560f0c34bb0af37c719a8e06c2672f0f031d8e5"
 dependencies = [
  "alloy-primitives",
+ "arbitrary",
+ "ethereum_serde_utils",
  "itertools 0.13.0",
+ "serde",
+ "serde_derive",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "ethereum_ssz_derive"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3deae99c8e74829a00ba7a92d49055732b3c1f093f2ccfa3cbc621679b6fa91"
+checksum = "d31ecf6640112f61dc34b4d8359c081102969af0edd18381fed2052f6db6a410"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -5760,13 +5797,12 @@ dependencies = [
 
 [[package]]
 name = "milhouse"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f68e33f98199224d1073f7c1468ea6abfea30736306fb79c7181a881e97ea32f"
+version = "0.5.0"
+source = "git+https://github.com/sigp/milhouse.git?branch=generic-update-map#3b0c852b70d52303558274072c90b3e94d346f25"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
- "derivative",
+ "educe",
  "ethereum_hashing",
  "ethereum_ssz",
  "ethereum_ssz_derive",
@@ -8565,12 +8601,11 @@ dependencies = [
 
 [[package]]
 name = "ssz_types"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e0719d2b86ac738a55ae71a8429f52aa2741da988f1fd0975b4cc610fd1e08"
+checksum = "22bc24c8a61256950632fb6b68ea09f6b5c988070924c6292eb5933635202e00"
 dependencies = [
  "arbitrary",
- "derivative",
  "ethereum_serde_utils",
  "ethereum_ssz",
  "itertools 0.13.0",
@@ -9480,20 +9515,22 @@ dependencies = [
 
 [[package]]
 name = "tree_hash"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373495c23db675a5192de8b610395e1bec324d596f9e6111192ce903dc11403a"
+checksum = "3cc60ae4c4236ee721305d0f0b5aa3e8ef5b66f3fa61d17072430bc246d6694a"
 dependencies = [
  "alloy-primitives",
  "ethereum_hashing",
+ "ethereum_ssz",
  "smallvec",
+ "typenum",
 ]
 
 [[package]]
 name = "tree_hash_derive"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0857056ca4eb5de8c417309be42bcff6017b47e86fbaddde609b4633f66061e"
+checksum = "5c8ee219344a44410237d7b849d150a445a621d0cae92d6fbab10d84d4428870"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ discv5 = { version = "0.9", features = ["libp2p"] }
 env_logger = "0.9"
 ethereum_hashing = "0.7.0"
 ethereum_serde_utils = "0.7"
-ethereum_ssz = "0.7"
-ethereum_ssz_derive = "0.7"
+ethereum_ssz = "0.8.2"
+ethereum_ssz_derive = "0.8.2"
 ethers-core = "1"
 ethers-providers = { version = "1", default-features = false }
 exit-future = "0.2"
@@ -156,7 +156,7 @@ libsecp256k1 = "0.7"
 log = "0.4"
 lru = "0.12"
 maplit = "1"
-milhouse = "0.3"
+milhouse = { git = "https://github.com/sigp/milhouse.git", branch = "main" }
 mockito = "1.5.0"
 num_cpus = "1"
 parking_lot = "0.12"
@@ -194,7 +194,7 @@ slog-term = "2"
 sloggers = { version = "2", features = ["json"] }
 smallvec = { version = "1.11.2", features = ["arbitrary"] }
 snap = "1"
-ssz_types = "0.8"
+ssz_types = "0.10"
 strum = { version = "0.24", features = ["derive"] }
 superstruct = "0.8"
 syn = "1"
@@ -213,8 +213,8 @@ tracing-appender = "0.2"
 tracing-core = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tree_hash = "0.8"
-tree_hash_derive = "0.8"
+tree_hash = "0.9"
+tree_hash_derive = "0.9"
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = { version = "0.3.7", default-features = false, features = ["tls"] }

--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -6,6 +6,7 @@ use crate::{DBColumn, Error, KeyValueStore, KeyValueStoreOp};
 use ssz::{Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
 use std::sync::Arc;
+use types::beacon_state::{Balances, Validators};
 use types::historical_summary::HistoricalSummary;
 use types::superstruct;
 use types::*;
@@ -49,8 +50,8 @@ where
     pub eth1_deposit_index: u64,
 
     // Registry
-    pub validators: List<Validator, E::ValidatorRegistryLimit>,
-    pub balances: List<u64, E::ValidatorRegistryLimit>,
+    pub validators: Validators<E>,
+    pub balances: Balances<E>,
 
     // Shuffling
     /// Randao value from the current slot, for patching into the per-epoch randao vector.

--- a/consensus/state_processing/src/per_block_processing/errors.rs
+++ b/consensus/state_processing/src/per_block_processing/errors.rs
@@ -60,6 +60,7 @@ pub enum BlockProcessingError {
     SignatureSetError(SignatureSetError),
     SszTypesError(ssz_types::Error),
     SszDecodeError(DecodeError),
+    BitfieldError(ssz::BitfieldError),
     MerkleTreeError(MerkleTreeError),
     ArithError(ArithError),
     InconsistentBlockFork(InconsistentFork),
@@ -153,6 +154,7 @@ impl From<BlockOperationError<HeaderInvalid>> for BlockProcessingError {
             BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+            BlockOperationError::BitfieldError(e) => BlockProcessingError::BitfieldError(e),
             BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
         }
@@ -181,6 +183,7 @@ macro_rules! impl_into_block_processing_error_with_index {
                         BlockOperationError::BeaconStateError(e) => BlockProcessingError::BeaconStateError(e),
                         BlockOperationError::SignatureSetError(e) => BlockProcessingError::SignatureSetError(e),
                         BlockOperationError::SszTypesError(e) => BlockProcessingError::SszTypesError(e),
+                        BlockOperationError::BitfieldError(e) => BlockProcessingError::BitfieldError(e),
                         BlockOperationError::ConsensusContext(e) => BlockProcessingError::ConsensusContext(e),
                         BlockOperationError::ArithError(e) => BlockProcessingError::ArithError(e),
                     }
@@ -215,6 +218,7 @@ pub enum BlockOperationError<T> {
     BeaconStateError(BeaconStateError),
     SignatureSetError(SignatureSetError),
     SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     ConsensusContext(ContextError),
     ArithError(ArithError),
 }
@@ -239,6 +243,12 @@ impl<T> From<SignatureSetError> for BlockOperationError<T> {
 impl<T> From<ssz_types::Error> for BlockOperationError<T> {
     fn from(error: ssz_types::Error) -> Self {
         BlockOperationError::SszTypesError(error)
+    }
+}
+
+impl<T> From<ssz::BitfieldError> for BlockOperationError<T> {
+    fn from(error: ssz::BitfieldError) -> Self {
+        BlockOperationError::BitfieldError(error)
     }
 }
 
@@ -367,6 +377,7 @@ impl From<BlockOperationError<IndexedAttestationInvalid>>
             BlockOperationError::BeaconStateError(e) => BlockOperationError::BeaconStateError(e),
             BlockOperationError::SignatureSetError(e) => BlockOperationError::SignatureSetError(e),
             BlockOperationError::SszTypesError(e) => BlockOperationError::SszTypesError(e),
+            BlockOperationError::BitfieldError(e) => BlockOperationError::BitfieldError(e),
             BlockOperationError::ConsensusContext(e) => BlockOperationError::ConsensusContext(e),
             BlockOperationError::ArithError(e) => BlockOperationError::ArithError(e),
         }

--- a/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
+++ b/consensus/state_processing/src/per_epoch_processing/epoch_processing_summary.rs
@@ -2,9 +2,10 @@ use super::base::{validator_statuses::InclusionInfo, TotalBalances, ValidatorSta
 use crate::metrics;
 use std::sync::Arc;
 use types::{
+    beacon_state::Validators,
     consts::altair::{TIMELY_HEAD_FLAG_INDEX, TIMELY_SOURCE_FLAG_INDEX, TIMELY_TARGET_FLAG_INDEX},
     BeaconStateError, Epoch, EthSpec, List, ParticipationFlags, ProgressiveBalancesCache,
-    SyncCommittee, Validator,
+    SyncCommittee,
 };
 
 /// Provides a summary of validator participation during the epoch.
@@ -25,7 +26,7 @@ pub enum EpochProcessingSummary<E: EthSpec> {
 #[derive(PartialEq, Debug)]
 pub struct ParticipationEpochSummary<E: EthSpec> {
     /// Copy of the validator registry prior to mutation.
-    validators: List<Validator, E::ValidatorRegistryLimit>,
+    validators: Validators<E>,
     /// Copy of the participation flags for the previous epoch.
     previous_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
     /// Copy of the participation flags for the current epoch.
@@ -36,7 +37,7 @@ pub struct ParticipationEpochSummary<E: EthSpec> {
 
 impl<E: EthSpec> ParticipationEpochSummary<E> {
     pub fn new(
-        validators: List<Validator, E::ValidatorRegistryLimit>,
+        validators: Validators<E>,
         previous_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
         current_epoch_participation: List<ParticipationFlags, E::ValidatorRegistryLimit>,
         previous_epoch: Epoch,

--- a/consensus/state_processing/src/per_epoch_processing/errors.rs
+++ b/consensus/state_processing/src/per_epoch_processing/errors.rs
@@ -19,9 +19,10 @@ pub enum EpochProcessingError {
     BeaconStateError(BeaconStateError),
     InclusionError(InclusionError),
     SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     ArithError(safe_arith::ArithError),
     InconsistentStateFork(InconsistentFork),
-    InvalidJustificationBit(ssz_types::Error),
+    InvalidJustificationBit(ssz::BitfieldError),
     InvalidFlagIndex(usize),
     MilhouseError(milhouse::Error),
     EpochCache(EpochCacheError),
@@ -46,6 +47,12 @@ impl From<BeaconStateError> for EpochProcessingError {
 impl From<ssz_types::Error> for EpochProcessingError {
     fn from(e: ssz_types::Error) -> EpochProcessingError {
         EpochProcessingError::SszTypesError(e)
+    }
+}
+
+impl From<ssz::BitfieldError> for EpochProcessingError {
+    fn from(e: ssz::BitfieldError) -> EpochProcessingError {
+        EpochProcessingError::BitfieldError(e)
     }
 }
 

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -18,6 +18,7 @@ use super::{
 #[derive(Debug, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     AlreadySigned(usize),
     IncorrectStateVariant,
     InvalidCommitteeLength,
@@ -223,7 +224,7 @@ impl<E: EthSpec> Attestation<E> {
         }
     }
 
-    pub fn get_aggregation_bit(&self, index: usize) -> Result<bool, ssz_types::Error> {
+    pub fn get_aggregation_bit(&self, index: usize) -> Result<bool, ssz::BitfieldError> {
         match self {
             Attestation::Base(att) => att.aggregation_bits.get(index),
             Attestation::Electra(att) => att.aggregation_bits.get(index),
@@ -353,13 +354,13 @@ impl<E: EthSpec> AttestationElectra<E> {
         if self
             .aggregation_bits
             .get(committee_position)
-            .map_err(Error::SszTypesError)?
+            .map_err(Error::BitfieldError)?
         {
             Err(Error::AlreadySigned(committee_position))
         } else {
             self.aggregation_bits
                 .set(committee_position, true)
-                .map_err(Error::SszTypesError)?;
+                .map_err(Error::BitfieldError)?;
 
             self.signature.add_assign(signature);
 
@@ -427,13 +428,13 @@ impl<E: EthSpec> AttestationBase<E> {
         if self
             .aggregation_bits
             .get(committee_position)
-            .map_err(Error::SszTypesError)?
+            .map_err(Error::BitfieldError)?
         {
             Err(Error::AlreadySigned(committee_position))
         } else {
             self.aggregation_bits
                 .set(committee_position, true)
-                .map_err(Error::SszTypesError)?;
+                .map_err(Error::BitfieldError)?;
 
             self.signature.add_assign(signature);
 
@@ -443,7 +444,7 @@ impl<E: EthSpec> AttestationBase<E> {
 
     pub fn extend_aggregation_bits(
         &self,
-    ) -> Result<BitList<E::MaxValidatorsPerSlot>, ssz_types::Error> {
+    ) -> Result<BitList<E::MaxValidatorsPerSlot>, ssz::BitfieldError> {
         self.aggregation_bits.resize::<E::MaxValidatorsPerSlot>()
     }
 }

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -14,6 +14,7 @@ use safe_arith::{ArithError, SafeArith};
 use serde::{Deserialize, Serialize};
 use ssz::{ssz_encode, Decode, DecodeError, Encode};
 use ssz_derive::{Decode, Encode};
+use std::collections::BTreeMap;
 use std::hash::Hash;
 use std::{fmt, mem, sync::Arc};
 use superstruct::superstruct;
@@ -48,8 +49,9 @@ pub const CACHED_EPOCHS: usize = 3;
 const MAX_RANDOM_BYTE: u64 = (1 << 8) - 1;
 const MAX_RANDOM_VALUE: u64 = (1 << 16) - 1;
 
-pub type Validators<E> = List<Validator, <E as EthSpec>::ValidatorRegistryLimit>;
-pub type Balances<E> = List<u64, <E as EthSpec>::ValidatorRegistryLimit>;
+pub type Validators<E> =
+    List<Validator, <E as EthSpec>::ValidatorRegistryLimit, BTreeMap<usize, Validator>>;
+pub type Balances<E> = List<u64, <E as EthSpec>::ValidatorRegistryLimit, BTreeMap<usize, u64>>;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Error {
@@ -399,11 +401,11 @@ where
     // Registry
     #[compare_fields(as_iter)]
     #[test_random(default)]
-    pub validators: List<Validator, E::ValidatorRegistryLimit>,
+    pub validators: Validators<E>,
     #[serde(with = "ssz_types::serde_utils::quoted_u64_var_list")]
     #[compare_fields(as_iter)]
     #[test_random(default)]
-    pub balances: List<u64, E::ValidatorRegistryLimit>,
+    pub balances: Balances<E>,
 
     // Randomness
     #[test_random(default)]

--- a/consensus/types/src/sync_aggregate.rs
+++ b/consensus/types/src/sync_aggregate.rs
@@ -11,6 +11,7 @@ use tree_hash_derive::TreeHash;
 #[derive(Debug, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     ArithError(ArithError),
 }
 
@@ -68,7 +69,7 @@ impl<E: EthSpec> SyncAggregate<E> {
                     sync_aggregate
                         .sync_committee_bits
                         .set(participant_index, true)
-                        .map_err(Error::SszTypesError)?;
+                        .map_err(Error::BitfieldError)?;
                 }
             }
             sync_aggregate

--- a/consensus/types/src/sync_committee_contribution.rs
+++ b/consensus/types/src/sync_committee_contribution.rs
@@ -9,6 +9,7 @@ use tree_hash_derive::TreeHash;
 #[derive(Debug, PartialEq)]
 pub enum Error {
     SszTypesError(ssz_types::Error),
+    BitfieldError(ssz::BitfieldError),
     AlreadySigned(usize),
 }
 
@@ -51,7 +52,7 @@ impl<E: EthSpec> SyncCommitteeContribution<E> {
     ) -> Result<Self, Error> {
         let mut bits = BitVector::new();
         bits.set(validator_sync_committee_index, true)
-            .map_err(Error::SszTypesError)?;
+            .map_err(Error::BitfieldError)?;
         Ok(Self {
             slot: message.slot,
             beacon_block_root: message.beacon_block_root,


### PR DESCRIPTION
## Proposed Changes

Optimisation to remove `VecMap` usage, as with millions of validators it is becoming a significant contributor to peak memory usage.

## CPU Benchmarks

CPU benchmarks show that `BTreeMap` is faster for recent slots. Originally when we introduced `milhouse` the `BTreeMap` was slower than `VecMap`. I suspect the memory allocation time is now dominating the memory access time, which was `VecMap`'s main advantage.

Benchmark command:

```
RUST_LOG=debug lcli transition-blocks --pre-state-path bench/state_10876895.ssz --block-path bench/block_10876896.ssz --runs 100 --exclude-cache-builds
```

on `unstable` (as of 06329ec2d105fc60c4c7218561cff11fb6b398a3):

> [2025-01-20T07:26:22Z DEBUG lcli::transition_blocks] Slot processing: 635.089345ms
[2025-01-20T07:26:22Z DEBUG lcli::transition_blocks] Build all caches (again): 620ns
[2025-01-20T07:26:22Z DEBUG lcli::transition_blocks] Batch verify block signatures: 31.863842ms
[2025-01-20T07:26:22Z DEBUG lcli::transition_blocks] Process block: 15.014572ms
[2025-01-20T07:26:22Z DEBUG lcli::transition_blocks] Post-block tree hash: 174.293822ms
[2025-01-20T07:26:22Z INFO  lcli::transition_blocks] Run 99: 856.36194ms


on this branch using `BTreeMap` for `validators` and `balances`:

> [2025-01-20T06:54:31Z DEBUG lcli::transition_blocks] Slot processing: 605.424233ms
[2025-01-20T06:54:31Z DEBUG lcli::transition_blocks] Build all caches (again): 580ns
[2025-01-20T06:54:31Z DEBUG lcli::transition_blocks] Batch verify block signatures: 30.883823ms
[2025-01-20T06:54:31Z DEBUG lcli::transition_blocks] Process block: 16.656031ms
[2025-01-20T06:54:31Z DEBUG lcli::transition_blocks] Post-block tree hash: 132.007032ms
[2025-01-20T06:54:31Z INFO  lcli::transition_blocks] Run 99: 785.045689ms

## Memory Metrics

Pending. Initial tests on Holesky while syncing during non-finality show that the VecMap uses substantial memory (20GB+).

## Additional Info

Ideally merge after:

- https://github.com/sigp/milhouse/pull/63
