### PR TITLE
Add test flag to override `SYNC_TOLERANCE_EPOCHS` for range sync testing (#7030)

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -112,7 +112,7 @@ const API_PREFIX: &str = "eth";
 ///
 /// This helps prevent attacks where nodes can convince us that we're syncing some non-existent
 /// finalized head.
-const SYNC_TOLERANCE_EPOCHS: u64 = 8;
+const DEFAULT_SYNC_TOLERANCE_EPOCHS: u64 = 8;
 
 /// A custom type which allows for both unsecured and TLS-enabled HTTP servers.
 type HttpServer = (SocketAddr, Pin<Box<dyn Future<Output = ()> + Send>>);
@@ -157,6 +157,7 @@ pub struct Config {
     pub duplicate_block_status_code: StatusCode,
     pub enable_light_client_server: bool,
     pub target_peers: usize,
+    pub sync_tolerance_epochs: Option<u64>,
 }
 
 impl Default for Config {
@@ -173,6 +174,7 @@ impl Default for Config {
             duplicate_block_status_code: StatusCode::ACCEPTED,
             enable_light_client_server: true,
             target_peers: 100,
+            sync_tolerance_epochs: None,
         }
     }
 }
@@ -473,7 +475,10 @@ pub fn serve<T: BeaconChainTypes>(
                                     )
                                 })?;
 
-                            let tolerance = SYNC_TOLERANCE_EPOCHS * T::EthSpec::slots_per_epoch();
+                            let sync_tolerance_epochs = config
+                                .sync_tolerance_epochs
+                                .unwrap_or(DEFAULT_SYNC_TOLERANCE_EPOCHS);
+                            let tolerance = sync_tolerance_epochs * T::EthSpec::slots_per_epoch();
 
                             if head_slot + tolerance >= current_slot {
                                 Ok(())

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -1519,6 +1519,19 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            Arg::new("sync-tolerance-epochs")
+                .long("sync-tolerance-epochs")
+                .help("Overrides the default SYNC_TOLERANCE_EPOCHS. This flag is not intended \
+                    for production and MUST only be used in TESTING only. This is primarily used \
+                    for testing range sync, to prevent the node from producing a block before the \
+                    node is synced with the network which may result in the node getting \
+                    disconnected from peers immediately.")
+                .hide(true)
+                .requires("enable_http")
+                .action(ArgAction::Set)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("gui")
                 .long("gui")
                 .help("Enable the graphical user interface and all its requirements. \

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -8,7 +8,7 @@ use beacon_chain::graffiti_calculator::GraffitiOrigin;
 use beacon_chain::TrustedSetup;
 use clap::{parser::ValueSource, ArgMatches, Id};
 use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
-use clap_utils::{parse_flag, parse_required};
+use clap_utils::{parse_flag, parse_optional, parse_required};
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
@@ -177,6 +177,9 @@ pub fn get_config<E: EthSpec>(
 
         client_config.http_api.enable_light_client_server =
             !cli_args.get_flag("disable-light-client-server");
+
+        client_config.http_api.sync_tolerance_epochs =
+            parse_optional(cli_args, "sync-tolerance-epochs")?;
     }
 
     if cli_args.get_flag("light-client-server") {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2580,6 +2580,17 @@ fn light_client_http_server_disabled() {
 }
 
 #[test]
+fn sync_tolerance_epochs() {
+    CommandLineTest::new()
+        .flag("http", None)
+        .flag("sync-tolerance-epochs", Some("0"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            assert_eq!(config.http_api.sync_tolerance_epochs, Some(0));
+        });
+}
+
+#[test]
 fn gui_flag() {
     CommandLineTest::new()
         .flag("gui", None)

--- a/scripts/local_testnet/network_params_das.yaml
+++ b/scripts/local_testnet/network_params_das.yaml
@@ -4,11 +4,15 @@ participants:
     cl_extra_params:
       - --subscribe-all-data-column-subnets
       - --subscribe-all-subnets
+      # Note: useful for testing range sync (only produce block if node is in sync to prevent forking)
+      - --sync-tolerance-epochs=0
       - --target-peers=3
     count: 2
   - cl_type: lighthouse
     cl_image: lighthouse:local
     cl_extra_params:
+      # Note: useful for testing range sync (only produce block if node is in sync to prevent forking)
+      - --sync-tolerance-epochs=0
       - --target-peers=3
     count: 2
 network_params:


### PR DESCRIPTION
This is #7030 cherry-picked from `unstable` to `release-v7.0.0`.

I'm proposing we merge this to make the diff (and conflict resolution) clearer when we merge `release-v7.0.0` back into `unstable`.

Best if we don't merge this PR with a squash, so the commit message can be preserved (this helps `git`).