### PR TITLE
Add `--disable-attesting` flag to validator client

### DIFF
--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -175,6 +175,10 @@ Flags:
           If this flag is set, Lighthouse will query the Beacon Node for only
           block headers during proposals and will sign over headers. Useful for
           outsourcing execution payload construction during proposals.
+      --disable-attesting
+          Disable the performance of attestation duties (and sync committee
+          duties). This flag should only be used in emergencies to prioritise
+          block proposal duties.
       --disable-auto-discover
           If present, do not attempt to discover new validators in the
           validators-dir. Validators will need to be manually added to the

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -99,6 +99,15 @@ pub struct ValidatorClient {
 
     #[clap(
         long,
+        help = "Disable the performance of attestation duties (and sync committee duties). This \
+                flag should only be used in emergencies to prioritise block proposal duties.",
+        display_order = 0,
+        help_heading = FLAG_HEADER
+    )]
+    pub disable_attesting: bool,
+
+    #[clap(
+        long,
         help = "If present, the validator client will use longer timeouts for requests \
                 made to the beacon node. This flag is generally not recommended, \
                 longer timeouts can cause missed duties when fallbacks are used.",

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -85,6 +85,7 @@ pub struct Config {
     /// Configuration for the initialized validators
     #[serde(flatten)]
     pub initialized_validators: InitializedValidatorsConfig,
+    pub disable_attesting: bool,
 }
 
 impl Default for Config {
@@ -126,6 +127,7 @@ impl Default for Config {
             validator_registration_batch_size: 500,
             distributed: false,
             initialized_validators: <_>::default(),
+            disable_attesting: false,
         }
     }
 }
@@ -378,6 +380,8 @@ impl Config {
             } else {
                 true
             };
+
+        config.disable_attesting = validator_client_config.disable_attesting;
 
         Ok(config)
     }

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -478,6 +478,7 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
             context: duties_context,
             enable_high_validator_count_metrics: config.enable_high_validator_count_metrics,
             distributed: config.distributed,
+            disable_attesting: config.disable_attesting,
         });
 
         // Update the metrics server.
@@ -507,6 +508,7 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
             .validator_store(validator_store.clone())
             .beacon_nodes(beacon_nodes.clone())
             .runtime_context(context.service_context("attestation".into()))
+            .disable(config.disable_attesting)
             .build()?;
 
         let preparation_service = PreparationServiceBuilder::new()

--- a/validator_client/validator_services/src/duties_service.rs
+++ b/validator_client/validator_services/src/duties_service.rs
@@ -230,6 +230,7 @@ pub struct DutiesService<T, E: EthSpec> {
     pub enable_high_validator_count_metrics: bool,
     /// If this validator is running in distributed mode.
     pub distributed: bool,
+    pub disable_attesting: bool,
 }
 
 impl<T: SlotClock + 'static, E: EthSpec> DutiesService<T, E> {
@@ -402,6 +403,11 @@ pub fn start_update_service<T: SlotClock + 'static, E: EthSpec>(
         },
         "duties_service_proposers",
     );
+
+    // Skip starting attestation duties or sync committee services.
+    if core_duties_service.disable_attesting {
+        return;
+    }
 
     /*
      * Spawn the task which keeps track of local attestation duties.

--- a/validator_client/validator_services/src/sync_committee_service.rs
+++ b/validator_client/validator_services/src/sync_committee_service.rs
@@ -87,6 +87,11 @@ impl<T: SlotClock + 'static, E: EthSpec> SyncCommitteeService<T, E> {
 
     pub fn start_update_service(self, spec: &ChainSpec) -> Result<(), String> {
         let log = self.context.log().clone();
+        if self.duties_service.disable_attesting {
+            info!(log, "Sync committee service disabled");
+            return Ok(());
+        }
+
         let slot_duration = Duration::from_secs(spec.seconds_per_slot);
         let duration_to_next_slot = self
             .slot_clock


### PR DESCRIPTION
## Proposed Changes

Cleaned up and isolated version of the `--disable-attesting` flag for the VC, from the `holesky-rescue` branch:

- https://github.com/sigp/lighthouse/pull/7041

I figured we don't need the `--disable-attesting` flag on the BN for now, and it was a much more invasive impl.
