### PR TITLE
Add `--long-timeouts-multiplier` CLI flag

### DIFF
--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -250,7 +250,7 @@ Flags:
       --long-timeouts-multiplier <LONG_TIMEOUTS_MULTIPLIER>
           If present, the validator client will use a multiplier for the timeout
           when making requests to the beacon node. This only takes effect when
-          the `--use-long_timeouts` flag is present. The timeouts will be the
+          the `--use-long-timeouts` flag is present. The timeouts will be the
           slot duration multiplied by this value. This flag is generally not
           recommended, longer timeouts can cause missed duties when fallbacks
           are used. [default: 1]

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -247,6 +247,13 @@ Flags:
           contain sensitive information about your validator and so this flag
           should be used with caution. For Windows users, the log file
           permissions will be inherited from the parent folder.
+      --long-timeouts-multiplier <LONG_TIMEOUTS_MULTIPLIER>
+          If present, the validator client will use a multiplier for the timeout
+          when making requests to the beacon node. This only takes effect when
+          the `--use-long_timeouts` flag is present. The timeouts will be the
+          slot duration multiplied by this value. This flag is generally not
+          recommended, longer timeouts can cause missed duties when fallbacks
+          are used. [default: 1]
       --metrics
           Enable the Prometheus metrics HTTP server. Disabled by default.
       --prefer-builder-proposals

--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -130,6 +130,22 @@ fn use_long_timeouts_flag() {
 }
 
 #[test]
+fn long_timeouts_multiplier_flag_default() {
+    CommandLineTest::new()
+        .run()
+        .with_config(|config| assert_eq!(config.long_timeouts_multiplier, 1));
+}
+
+#[test]
+fn long_timeouts_multiplier_flag() {
+    CommandLineTest::new()
+        .flag("use-long-timeouts", None)
+        .flag("long-timeouts-multiplier", Some("10"))
+        .run()
+        .with_config(|config| assert_eq!(config.long_timeouts_multiplier, 10));
+}
+
+#[test]
 fn beacon_nodes_tls_certs_flag() {
     let dir = TempDir::new().expect("Unable to create temporary directory");
     CommandLineTest::new()

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -114,9 +114,8 @@ pub struct ValidatorClient {
         help = "If present, the validator client will use a multiplier for the timeout \
                 when making requests to the beacon node. This only takes effect when \
                 the `--use-long_timeouts` flag is present. The timeouts will be the slot \
-                duration multiplied by this value.
-                This flag is generally not recommended, longer timeouts can cause missed \
-                duties when fallbacks are used.",
+                duration multiplied by this value. This flag is generally not recommended, \
+                longer timeouts can cause missed duties when fallbacks are used.",
         display_order = 0,
         help_heading = FLAG_HEADER,
     )]

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -113,7 +113,7 @@ pub struct ValidatorClient {
         default_value_t = 1,
         help = "If present, the validator client will use a multiplier for the timeout \
                 when making requests to the beacon node. This only takes effect when \
-                the `--use-long_timeouts` flag is present. The timeouts will be the slot \
+                the `--use-long-timeouts` flag is present. The timeouts will be the slot \
                 duration multiplied by this value. This flag is generally not recommended, \
                 longer timeouts can cause missed duties when fallbacks are used.",
         display_order = 0,

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -109,6 +109,21 @@ pub struct ValidatorClient {
 
     #[clap(
         long,
+        requires = "use_long_timeouts",
+        default_value_t = 1,
+        help = "If present, the validator client will use a multiplier for the timeout \
+                when making requests to the beacon node. This only takes effect when \
+                the `--use-long_timeouts` flag is present. The timeouts will be the slot \
+                duration multiplied by this value.
+                This flag is generally not recommended, longer timeouts can cause missed \
+                duties when fallbacks are used.",
+        display_order = 0,
+        help_heading = FLAG_HEADER,
+    )]
+    pub long_timeouts_multiplier: u32,
+
+    #[clap(
+        long,
         value_name = "CERTIFICATE-FILES",
         value_delimiter = ',',
         help = "Comma-separated paths to custom TLS certificates to use when connecting \

--- a/validator_client/src/config.rs
+++ b/validator_client/src/config.rs
@@ -49,6 +49,8 @@ pub struct Config {
     pub init_slashing_protection: bool,
     /// If true, use longer timeouts for requests made to the beacon node.
     pub use_long_timeouts: bool,
+    /// Multiplier to use for long timeouts.
+    pub long_timeouts_multiplier: u32,
     /// Graffiti to be inserted everytime we create a block.
     pub graffiti: Option<Graffiti>,
     /// Graffiti file to load per validator graffitis.
@@ -111,6 +113,7 @@ impl Default for Config {
             disable_auto_discover: false,
             init_slashing_protection: false,
             use_long_timeouts: false,
+            long_timeouts_multiplier: 1,
             graffiti: None,
             graffiti_file: None,
             http_api: <_>::default(),
@@ -194,6 +197,7 @@ impl Config {
         config.disable_auto_discover = validator_client_config.disable_auto_discover;
         config.init_slashing_protection = validator_client_config.init_slashing_protection;
         config.use_long_timeouts = validator_client_config.use_long_timeouts;
+        config.long_timeouts_multiplier = validator_client_config.long_timeouts_multiplier;
 
         if let Some(graffiti_file_path) = validator_client_config.graffiti_file.as_ref() {
             let mut graffiti_file = GraffitiFile::new(graffiti_file_path.into());

--- a/validator_client/src/lib.rs
+++ b/validator_client/src/lib.rs
@@ -325,7 +325,7 @@ impl<E: EthSpec> ProductionValidatorClient<E> {
                     get_validator_block: slot_duration / HTTP_GET_VALIDATOR_BLOCK_TIMEOUT_QUOTIENT,
                 }
             } else {
-                Timeouts::set_all(slot_duration)
+                Timeouts::set_all(slot_duration.saturating_mul(config.long_timeouts_multiplier))
             };
 
             Ok(BeaconNodeHttpClient::from_components(


### PR DESCRIPTION
## Proposed Changes

Adds the `--long-timeouts-multiplier` flag.
Allows granular control for VC timeouts which has proved useful in Holesky.

## Additional Info

Defaults to `1` and for clarity requires use of the `--use-long-timeouts` flag in order to function. 
A multiplier of `0` is technically possible which I believe will disable timeouts.
