### PR TITLE
Change state cache size default to 32

### DIFF
--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -828,7 +828,7 @@ pub fn cli_app() -> Command {
                 .long("state-cache-size")
                 .value_name("STATE_CACHE_SIZE")
                 .help("Specifies the size of the state cache")
-                .default_value("128")
+                .default_value("32")
                 .action(ArgAction::Set)
                 .display_order(0)
         )

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -1873,7 +1873,7 @@ fn block_cache_size_flag() {
 fn state_cache_size_default() {
     CommandLineTest::new()
         .run_with_zero_port()
-        .with_config(|config| assert_eq!(config.store.state_cache_size, new_non_zero_usize(128)));
+        .with_config(|config| assert_eq!(config.store.state_cache_size, new_non_zero_usize(32)));
 }
 #[test]
 fn state_cache_size_flag() {


### PR DESCRIPTION
## Issue Addressed

Part of #7053 to mitigate OOM issues on holesky.

Each epoch boundary state diffs are 180MB+, 128 (current default) of them would add up to 20GB in state cache.

This PR changes the default to 32 (`180 * 32 ~= 6GB`  which is not too bad).

**Note**: we're still getting too many state cache misses from `*ByRange` - this is addressed in #7058 