### PR TITLE
Delete expensive chain compatibility checks in check_peer_relevance

### DIFF
--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -13,11 +13,12 @@ use lighthouse_network::{PeerId, PeerRequestId, ReportSource, Response, SyncInfo
 use methods::LightClientUpdatesByRangeRequest;
 use slog::{debug, error, warn};
 use slot_clock::SlotClock;
+use std::cmp::Ordering;
 use std::collections::{hash_map::Entry, HashMap};
 use std::sync::Arc;
 use tokio_stream::StreamExt;
 use types::blob_sidecar::BlobIdentifier;
-use types::{Epoch, EthSpec, Hash256, Slot};
+use types::{EthSpec, Hash256, Slot};
 
 impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     /* Auxiliary functions */
@@ -73,7 +74,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         remote: &StatusMessage,
     ) -> Result<Option<String>, BeaconChainError> {
         let local = self.chain.status_message();
-        let start_slot = |epoch: Epoch| epoch.start_slot(T::EthSpec::slots_per_epoch());
 
         let irrelevant_reason = if local.fork_digest != remote.fork_digest {
             // The node is on a different network/fork
@@ -93,41 +93,33 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             // current slot. This could be because they are using a different genesis time, or that
             // their or our system's clock is incorrect.
             Some("Different system clocks or genesis time".to_string())
-        } else if (remote.finalized_epoch == local.finalized_epoch
-            && remote.finalized_root == local.finalized_root)
-            || remote.finalized_root.is_zero()
-            || local.finalized_root.is_zero()
-            || remote.finalized_epoch > local.finalized_epoch
-        {
-            // Fast path. Remote finalized checkpoint is either identical, or genesis, or we are at
-            // genesis, or they are ahead. In all cases, we should allow this peer to connect to us
-            // so we can sync from them.
-            None
         } else {
-            // Remote finalized epoch is less than ours.
-            let remote_finalized_slot = start_slot(remote.finalized_epoch);
-            if remote_finalized_slot < self.chain.store.get_oldest_block_slot() {
-                // Peer's finalized checkpoint is older than anything in our DB. We are unlikely
-                // to be able to help them sync.
-                Some("Old finality out of range".to_string())
-            } else if remote_finalized_slot < self.chain.store.get_split_slot() {
-                // Peer's finalized slot is in range for a quick block root check in our freezer DB.
-                // If that block root check fails, reject them as they're on a different finalized
-                // chain.
-                if self
-                    .chain
-                    .block_root_at_slot(remote_finalized_slot, WhenSlotSkipped::Prev)
-                    .map(|root_opt| root_opt != Some(remote.finalized_root))?
-                {
-                    Some("Different finalized chain".to_string())
-                } else {
-                    None
+            match remote.finalized_epoch.cmp(&local.finalized_epoch) {
+                // This peer has a finalized epoch less than ours. We could check here if their
+                // finalized root matches one in imported chain. However this check can be very
+                // expensive. Consider the cases:
+                // - Peer is our chain: we should forward peer to sync to allow them to sync from us
+                // - Peer is on a different chain: the peer will query blocks from us which they
+                //   won't be able to import. The peer will eventually disconnect from us as we are
+                //   not useful to them. If the peer is synced, it will forward us blocks over
+                //   gossip from a different chain, and will eventually be disconnected. If the
+                //   peer does nothing, the peer manager will eventually disconnect the peer for low
+                //   gossip score. So we choose to NOT eagerly check that the peer is our chain for
+                //   performance reasons and simplicity.
+                Ordering::Less => None,
+                Ordering::Equal => {
+                    if remote.finalized_root == local.finalized_root {
+                        // Definitely on same finalized chain, forward peer to sync
+                        None
+                    } else {
+                        // Definitely on a different chain, disconnect immediatelly
+                        Some("Different finalized chain".to_string())
+                    }
                 }
-            } else {
-                // Peer's finality is older than ours, but newer than our split point, making a
-                // block root check infeasible. This case shouldn't happen particularly often so
-                // we give the peer the benefit of the doubt and let them connect to us.
-                None
+                // Peer claims to know about a finalized checkpoint ahead of hours. Send peer to
+                // sync to query its blocks. If the peer turns out to be in an invalid fork, block
+                // processing will error and we will disconnect the peer.
+                Ordering::Greater => None,
             }
         };
 

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -95,25 +95,59 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             Some("Different system clocks or genesis time".to_string())
         } else {
             match remote.finalized_epoch.cmp(&local.finalized_epoch) {
-                // This peer has a finalized epoch less than ours. We could check here if their
-                // finalized root matches one in imported chain. However this check can be very
-                // expensive. Consider the cases:
+                // This peer has a finalized epoch less than ours. This peer is likely to not be
+                // useful to us, as they want to sync from us. As a nice gesture, we could do work
+                // from them and check if their finalized_root matches our imported chain.
+                // However, this check is unncessary, as if we are incompatible the peer will be
+                // eventually disconnected anyway. Consider the two cases:
+                //
                 // - Peer is our chain: we should forward peer to sync to allow them to sync from us
                 // - Peer is on a different chain: the peer will query blocks from us which they
                 //   won't be able to import. The peer will eventually disconnect from us as we are
                 //   not useful to them. If the peer is synced, it will forward us blocks over
                 //   gossip from a different chain, and will eventually be disconnected. If the
                 //   peer does nothing, the peer manager will eventually disconnect the peer for low
-                //   gossip score. So we choose to NOT eagerly check that the peer is our chain for
-                //   performance reasons and simplicity.
-                Ordering::Less => None,
+                //   gossip score.
+                //
+                // Doing a DB read to check _any_ finalized root has proven to be very expensive and
+                // REKT lighthouse in multiple ocassions, see https://github.com/sigp/lighthouse/pull/5481
+                // So we won't do that. But, we can use the cached head to check recent roots, which is
+                // free and covers most cases of peers close to be considered fully synced (the most
+                // useful peers to us).
+                Ordering::Less => {
+                    match self
+                        .chain
+                        .canonical_head
+                        .cached_head()
+                        .snapshot
+                        .beacon_state
+                        .get_block_root_at_epoch(remote.finalized_epoch)
+                    {
+                        Ok(block_root_at_remote_finalized_epoch) => {
+                            if remote.finalized_root == *block_root_at_remote_finalized_epoch {
+                                // Definitely on same finalized chain, forward peer to sync
+                                None
+                            } else {
+                                Some(format!(
+                                    "Different finalized chain, expected {} got {}",
+                                    block_root_at_remote_finalized_epoch, remote.finalized_root
+                                ))
+                            }
+                        }
+                        // Out of bounds root check, allow the peer to connected to us and expect
+                        // they to disconnect or be disconnected if we are in incompatible chains
+                        Err(_) => None,
+                    }
+                }
                 Ordering::Equal => {
                     if remote.finalized_root == local.finalized_root {
                         // Definitely on same finalized chain, forward peer to sync
                         None
                     } else {
-                        // Definitely on a different chain, disconnect immediatelly
-                        Some("Different finalized chain".to_string())
+                        Some(format!(
+                            "Different finalized chain, expected {} got {}",
+                            local.finalized_root, remote.finalized_root
+                        ))
                     }
                 }
                 // Peer claims to know about a finalized checkpoint ahead of hours. Send peer to


### PR DESCRIPTION
## Issue Addressed

Extends https://github.com/sigp/lighthouse/pull/5481 not to do **any** DB reads when processing status messages. These have proven to be very expensive during the Holesky incident

## Proposed Changes

I added extensive comments to justify the changes, please check those :)

A working solution that doesn't read anything from the chain is 92a39362eaedb42d4c3203f5bfeb4db17045e461. Then 33870c1621f59518eabf156e3fa88eac905b9cbc covers a bit more ground by using the existing cached head which should be free

