### PR TITLE
docs: fix dead links

### DIFF
--- a/book/src/faq.md
+++ b/book/src/faq.md
@@ -323,7 +323,7 @@ Another possible reason for missing the head vote is due to a chain "reorg". A r
 
 ### <a name="vc-exit"></a> Can I submit a voluntary exit message without running a beacon node?
 
-Yes. Beaconcha.in provides the tool to broadcast the message. You can create the voluntary exit message file with [ethdo](https://github.com/wealdtech/ethdo/releases/tag/v1.30.0) and submit the message via the [beaconcha.in](https://beaconcha.in/tools/broadcast) website. A guide on how to use `ethdo` to perform voluntary exit can be found [here](https://github.com/eth-educators/ethstaker-guides/blob/main/voluntary-exit.md).
+Yes. Beaconcha.in provides the tool to broadcast the message. You can create the voluntary exit message file with [ethdo](https://github.com/wealdtech/ethdo/releases/tag/v1.30.0) and submit the message via the [beaconcha.in](https://beaconcha.in/tools/broadcast) website. A guide on how to use `ethdo` to perform voluntary exit can be found [here](https://github.com/eth-educators/ethstaker-guides/blob/main/docs/voluntary-exit.md).
 
 It is also noted that you can submit your BLS-to-execution-change message to update your withdrawal credentials from type `0x00` to `0x01` using the same link.
 

--- a/book/src/slashing-protection.md
+++ b/book/src/slashing-protection.md
@@ -66,7 +66,7 @@ basically a portable slashing protection database!
 
 To import a slashing protection database to Lighthouse, you first need to export your existing client's database. Instructions to export the slashing protection database for other clients are listed below:
 
-* [Lodestar](https://chainsafe.github.io/lodestar/reference/cli/#validator-slashing-protection-export)
+* [Lodestar](https://chainsafe.github.io/lodestar/run/validator-management/validator-cli#validator-slashing-protection-export)
 * [Nimbus](https://nimbus.guide/migration.html#2-export-slashing-protection-history)
 * [Prysm](https://docs.prylabs.network/docs/wallet/slashing-protection#exporting-your-validators-slashing-protection-history)
 * [Teku](https://docs.teku.consensys.net/HowTo/Prevent-Slashing#export-a-slashing-protection-file)

--- a/testing/eth1_test_rig/src/lib.rs
+++ b/testing/eth1_test_rig/src/lib.rs
@@ -1,6 +1,6 @@
 //! Provides utilities for deploying and manipulating the eth2 deposit contract on the eth1 chain.
 //!
-//! Presently used with [`anvil`](https://github.com/foundry-rs/foundry/tree/master/anvil) to simulate
+//! Presently used with [`anvil`](https://github.com/foundry-rs/foundry/tree/master/crates/anvil) to simulate
 //! the deposit contract for testing beacon node eth1 integration.
 //!
 //! Not tested to work with actual clients (e.g., geth). It should work fine, however there may be


### PR DESCRIPTION
## Issue Addressed

Hi! While going through the docs and code, I noticed a few links that were either broken or pointing to outdated resources. This PR fixes those to make sure everything stays accurate and helpful for everyone using the project.

## Proposed Changes

Here’s what’s been updated:

1. In `faq.md`, fixed the link to the `ethstaker-guides` voluntary exit guide. It now points to the correct location.
2. In `slashing-protection.md`, updated the Lodestar CLI link for exporting slashing protection data. The old link was outdated.
3. In `lib.rs`, corrected the link to the `anvil` crate in the Foundry repository. It now points to the right spot.


## Additional Info

All the new links have been double-checked to make sure they’re correct and up-to-date.
