### PR TITLE
Add backtrace logging when state cache missed

### DIFF
--- a/beacon_node/store/src/hot_cold_store.rs
+++ b/beacon_node/store/src/hot_cold_store.rs
@@ -991,11 +991,13 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
         let split = self.split.read_recursive();
 
         if state_root != split.state_root {
+            let backtrace = std::backtrace::Backtrace::capture();
             warn!(
                 self.log,
                 "State cache missed";
                 "state_root"  => ?state_root,
                 "block_root" => ?block_root,
+                "backtrace" => %backtrace,
             );
         }
 
@@ -1512,10 +1514,12 @@ impl<E: EthSpec, Hot: ItemStore<E>, Cold: ItemStore<E>> HotColdDB<E, Hot, Cold> 
 
         if *state_root != self.get_split_info().state_root {
             // Do not warn on start up when loading the split state.
+            let backtrace = std::backtrace::Backtrace::capture();
             warn!(
                 self.log,
                 "State cache missed";
                 "state_root" => ?state_root,
+                "backtrace" => %backtrace,
             );
         }
 


### PR DESCRIPTION
## Issue Addressed

Add backtrace logging when state cache missed.