### PR TITLE
Calculate tree hash root before `intra_rebase`

### DIFF
--- a/consensus/state_processing/src/per_epoch_processing/single_pass.rs
+++ b/consensus/state_processing/src/per_epoch_processing/single_pass.rs
@@ -11,6 +11,7 @@ use itertools::izip;
 use safe_arith::{SafeArith, SafeArithIter};
 use std::cmp::{max, min};
 use std::collections::{BTreeSet, HashMap};
+use tree_hash::TreeHash;
 use types::{
     consts::altair::{
         NUM_FLAG_INDICES, PARTICIPATION_FLAG_WEIGHTS, TIMELY_HEAD_FLAG_INDEX,
@@ -452,6 +453,7 @@ pub fn process_epoch_single_pass<E: EthSpec>(
     // As an optimisation, perform an intra-rebase on `inactivity_scores`. They have a tendency to
     // be exactly the same for large swathes of consecutive validator indices, so this helps reduce
     // memory usage quite a lot.
+    state.inactivity_scores()?.tree_hash_root();
     state.inactivity_scores_mut()?.intra_rebase()?;
 
     Ok(summary)

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -2472,6 +2472,7 @@ impl<E: EthSpec> BeaconState<E> {
 
         // Perform an intra-rebase of the inactivity scores (if any).
         if let Ok(inactivity_scores) = self.inactivity_scores_mut() {
+            inactivity_scores.tree_hash_root();
             inactivity_scores.intra_rebase()?;
         }
 


### PR DESCRIPTION
We saw the following error messages on `gown` today

```
WARN BlockProcessingFailure                  outcome: DBError(BeaconStateError(MilhouseError(IntraRebaseZeroHash))), msg: unexpected condition in processing block.
```

This is related to the new milhouse changes introduced the other day. I think we just need to calc the tree hash root before the intra rebase to fix this issue
