### PR TITLE
Add BlocksBy* protocols with specific block_root

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7269,6 +7269,31 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
             }
         }
     }
+
+    /// Retrieves block roots (in ascending slot order) within some slot range from fork choice.
+    pub fn block_roots_from_fork_choice(&self, start_slot: u64, count: u64) -> Vec<Hash256> {
+        let head_block_root = self.canonical_head.cached_head().head_block_root();
+        let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
+        let block_roots_iter = fork_choice_read_lock
+            .proto_array()
+            .iter_block_roots(&head_block_root);
+        let end_slot = start_slot.saturating_add(count);
+        let mut roots = vec![];
+
+        for (root, slot) in block_roots_iter {
+            if slot < end_slot && slot >= start_slot {
+                roots.push(root);
+            }
+            if slot < start_slot {
+                break;
+            }
+        }
+
+        drop(fork_choice_read_lock);
+        // return in ascending slot order
+        roots.reverse();
+        roots
+    }
 }
 
 impl<T: BeaconChainTypes> Drop for BeaconChain<T> {

--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -7271,12 +7271,18 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     }
 
     /// Retrieves block roots (in ascending slot order) within some slot range from fork choice.
-    pub fn block_roots_from_fork_choice(&self, start_slot: u64, count: u64) -> Vec<Hash256> {
-        let head_block_root = self.canonical_head.cached_head().head_block_root();
+    pub fn block_roots_from_fork_choice(
+        &self,
+        start_slot: u64,
+        count: u64,
+        block_root: Option<Hash256>,
+    ) -> Vec<Hash256> {
+        let from_block_root =
+            block_root.unwrap_or_else(|| self.canonical_head.cached_head().head_block_root());
         let fork_choice_read_lock = self.canonical_head.fork_choice_read_lock();
         let block_roots_iter = fork_choice_read_lock
             .proto_array()
-            .iter_block_roots(&head_block_root);
+            .iter_block_roots(&from_block_root);
         let end_slot = start_slot.saturating_add(count);
         let mut roots = vec![];
 

--- a/beacon_node/http_api/Cargo.toml
+++ b/beacon_node/http_api/Cargo.toml
@@ -28,6 +28,7 @@ metrics = { workspace = true }
 network = { workspace = true }
 operation_pool = { workspace = true }
 parking_lot = { workspace = true }
+proto_array = { workspace = true }
 rand = { workspace = true }
 safe_arith = { workspace = true }
 sensitive_url = { workspace = true }

--- a/beacon_node/lighthouse_network/src/rpc/codec.rs
+++ b/beacon_node/lighthouse_network/src/rpc/codec.rs
@@ -333,14 +333,21 @@ impl<E: EthSpec> Encoder<RequestType<E>> for SSZSnappyOutboundCodec<E> {
             RequestType::BlocksByRange(r) => match r {
                 OldBlocksByRangeRequest::V1(req) => req.as_ssz_bytes(),
                 OldBlocksByRangeRequest::V2(req) => req.as_ssz_bytes(),
+                OldBlocksByRangeRequest::V2_3845(req) => req.as_ssz_bytes(),
             },
             RequestType::BlocksByRoot(r) => match r {
                 BlocksByRootRequest::V1(req) => req.block_roots.as_ssz_bytes(),
                 BlocksByRootRequest::V2(req) => req.block_roots.as_ssz_bytes(),
             },
-            RequestType::BlobsByRange(req) => req.as_ssz_bytes(),
+            RequestType::BlobsByRange(r) => match r {
+                BlobsByRangeRequest::V1(req) => req.as_ssz_bytes(),
+                BlobsByRangeRequest::V1_3845(req) => req.as_ssz_bytes(),
+            },
             RequestType::BlobsByRoot(req) => req.blob_ids.as_ssz_bytes(),
-            RequestType::DataColumnsByRange(req) => req.as_ssz_bytes(),
+            RequestType::DataColumnsByRange(r) => match r {
+                DataColumnsByRangeRequest::V1(req) => req.as_ssz_bytes(),
+                DataColumnsByRangeRequest::V1_3845(req) => req.as_ssz_bytes(),
+            },
             RequestType::DataColumnsByRoot(req) => req.data_column_ids.as_ssz_bytes(),
             RequestType::Ping(req) => req.as_ssz_bytes(),
             RequestType::LightClientBootstrap(req) => req.as_ssz_bytes(),
@@ -558,6 +565,11 @@ fn handle_rpc_request<E: EthSpec>(
         SupportedProtocol::GoodbyeV1 => Ok(Some(RequestType::Goodbye(
             GoodbyeReason::from_ssz_bytes(decoded_buffer)?,
         ))),
+        SupportedProtocol::BlocksByRangeV2_3845 => Ok(Some(RequestType::BlocksByRange(
+            OldBlocksByRangeRequest::V2_3845(OldBlocksByRangeRequestV2_3845::from_ssz_bytes(
+                decoded_buffer,
+            )?),
+        ))),
         SupportedProtocol::BlocksByRangeV2 => Ok(Some(RequestType::BlocksByRange(
             OldBlocksByRangeRequest::V2(OldBlocksByRangeRequestV2::from_ssz_bytes(decoded_buffer)?),
         ))),
@@ -581,7 +593,12 @@ fn handle_rpc_request<E: EthSpec>(
             }),
         ))),
         SupportedProtocol::BlobsByRangeV1 => Ok(Some(RequestType::BlobsByRange(
-            BlobsByRangeRequest::from_ssz_bytes(decoded_buffer)?,
+            BlobsByRangeRequest::V1(BlobsByRangeRequestV1::from_ssz_bytes(decoded_buffer)?),
+        ))),
+        SupportedProtocol::BlobsByRangeV1_3845 => Ok(Some(RequestType::BlobsByRange(
+            BlobsByRangeRequest::V1_3845(BlobsByRangeRequestV1_3845::from_ssz_bytes(
+                decoded_buffer,
+            )?),
         ))),
         SupportedProtocol::BlobsByRootV1 => {
             Ok(Some(RequestType::BlobsByRoot(BlobsByRootRequest {
@@ -592,7 +609,14 @@ fn handle_rpc_request<E: EthSpec>(
             })))
         }
         SupportedProtocol::DataColumnsByRangeV1 => Ok(Some(RequestType::DataColumnsByRange(
-            DataColumnsByRangeRequest::from_ssz_bytes(decoded_buffer)?,
+            DataColumnsByRangeRequest::V1(DataColumnsByRangeRequestV1::from_ssz_bytes(
+                decoded_buffer,
+            )?),
+        ))),
+        SupportedProtocol::DataColumnsByRangeV1_3845 => Ok(Some(RequestType::DataColumnsByRange(
+            DataColumnsByRangeRequest::V1_3845(DataColumnsByRangeRequestV1_3845::from_ssz_bytes(
+                decoded_buffer,
+            )?),
         ))),
         SupportedProtocol::DataColumnsByRootV1 => Ok(Some(RequestType::DataColumnsByRoot(
             DataColumnsByRootRequest {
@@ -678,27 +702,29 @@ fn handle_rpc_response<E: EthSpec>(
         SupportedProtocol::BlocksByRootV1 => Ok(Some(RpcSuccessResponse::BlocksByRoot(Arc::new(
             SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
         )))),
-        SupportedProtocol::BlobsByRangeV1 => match fork_name {
-            Some(fork_name) => {
-                if fork_name.deneb_enabled() {
-                    Ok(Some(RpcSuccessResponse::BlobsByRange(Arc::new(
-                        BlobSidecar::from_ssz_bytes(decoded_buffer)?,
-                    ))))
-                } else {
-                    Err(RPCError::ErrorResponse(
-                        RpcErrorResponse::InvalidRequest,
-                        "Invalid fork name for blobs by range".to_string(),
-                    ))
+        SupportedProtocol::BlobsByRangeV1 | SupportedProtocol::BlobsByRangeV1_3845 => {
+            match fork_name {
+                Some(fork_name) => {
+                    if fork_name.deneb_enabled() {
+                        Ok(Some(RpcSuccessResponse::BlobsByRange(Arc::new(
+                            BlobSidecar::from_ssz_bytes(decoded_buffer)?,
+                        ))))
+                    } else {
+                        Err(RPCError::ErrorResponse(
+                            RpcErrorResponse::InvalidRequest,
+                            "Invalid fork name for blobs by range".to_string(),
+                        ))
+                    }
                 }
+                None => Err(RPCError::ErrorResponse(
+                    RpcErrorResponse::InvalidRequest,
+                    format!(
+                        "No context bytes provided for {:?} response",
+                        versioned_protocol
+                    ),
+                )),
             }
-            None => Err(RPCError::ErrorResponse(
-                RpcErrorResponse::InvalidRequest,
-                format!(
-                    "No context bytes provided for {:?} response",
-                    versioned_protocol
-                ),
-            )),
-        },
+        }
         SupportedProtocol::BlobsByRootV1 => match fork_name {
             Some(fork_name) => {
                 if fork_name.deneb_enabled() {
@@ -741,27 +767,29 @@ fn handle_rpc_response<E: EthSpec>(
                 ),
             )),
         },
-        SupportedProtocol::DataColumnsByRangeV1 => match fork_name {
-            Some(fork_name) => {
-                if fork_name.fulu_enabled() {
-                    Ok(Some(RpcSuccessResponse::DataColumnsByRange(Arc::new(
-                        DataColumnSidecar::from_ssz_bytes(decoded_buffer)?,
-                    ))))
-                } else {
-                    Err(RPCError::ErrorResponse(
-                        RpcErrorResponse::InvalidRequest,
-                        "Invalid fork name for data columns by range".to_string(),
-                    ))
+        SupportedProtocol::DataColumnsByRangeV1 | SupportedProtocol::DataColumnsByRangeV1_3845 => {
+            match fork_name {
+                Some(fork_name) => {
+                    if fork_name.fulu_enabled() {
+                        Ok(Some(RpcSuccessResponse::DataColumnsByRange(Arc::new(
+                            DataColumnSidecar::from_ssz_bytes(decoded_buffer)?,
+                        ))))
+                    } else {
+                        Err(RPCError::ErrorResponse(
+                            RpcErrorResponse::InvalidRequest,
+                            "Invalid fork name for data columns by range".to_string(),
+                        ))
+                    }
                 }
+                None => Err(RPCError::ErrorResponse(
+                    RpcErrorResponse::InvalidRequest,
+                    format!(
+                        "No context bytes provided for {:?} response",
+                        versioned_protocol
+                    ),
+                )),
             }
-            None => Err(RPCError::ErrorResponse(
-                RpcErrorResponse::InvalidRequest,
-                format!(
-                    "No context bytes provided for {:?} response",
-                    versioned_protocol
-                ),
-            )),
-        },
+        }
         SupportedProtocol::PingV1 => Ok(Some(RpcSuccessResponse::Pong(Ping {
             data: u64::from_ssz_bytes(decoded_buffer)?,
         }))),
@@ -832,43 +860,49 @@ fn handle_rpc_response<E: EthSpec>(
         SupportedProtocol::MetaDataV2 => Ok(Some(RpcSuccessResponse::MetaData(MetaData::V2(
             MetaDataV2::from_ssz_bytes(decoded_buffer)?,
         )))),
-        SupportedProtocol::BlocksByRangeV2 => match fork_name {
-            Some(ForkName::Altair) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Altair(SignedBeaconBlockAltair::from_ssz_bytes(decoded_buffer)?),
-            )))),
+        SupportedProtocol::BlocksByRangeV2 | SupportedProtocol::BlocksByRangeV2_3845 => {
+            match fork_name {
+                Some(ForkName::Altair) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Altair(SignedBeaconBlockAltair::from_ssz_bytes(
+                        decoded_buffer,
+                    )?),
+                )))),
 
-            Some(ForkName::Base) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
-            )))),
-            Some(ForkName::Bellatrix) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Bellatrix(SignedBeaconBlockBellatrix::from_ssz_bytes(
-                    decoded_buffer,
-                )?),
-            )))),
-            Some(ForkName::Capella) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Capella(SignedBeaconBlockCapella::from_ssz_bytes(
-                    decoded_buffer,
-                )?),
-            )))),
-            Some(ForkName::Deneb) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Deneb(SignedBeaconBlockDeneb::from_ssz_bytes(decoded_buffer)?),
-            )))),
-            Some(ForkName::Electra) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Electra(SignedBeaconBlockElectra::from_ssz_bytes(
-                    decoded_buffer,
-                )?),
-            )))),
-            Some(ForkName::Fulu) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
-                SignedBeaconBlock::Fulu(SignedBeaconBlockFulu::from_ssz_bytes(decoded_buffer)?),
-            )))),
-            None => Err(RPCError::ErrorResponse(
-                RpcErrorResponse::InvalidRequest,
-                format!(
-                    "No context bytes provided for {:?} response",
-                    versioned_protocol
-                ),
-            )),
-        },
+                Some(ForkName::Base) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Base(SignedBeaconBlockBase::from_ssz_bytes(decoded_buffer)?),
+                )))),
+                Some(ForkName::Bellatrix) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Bellatrix(SignedBeaconBlockBellatrix::from_ssz_bytes(
+                        decoded_buffer,
+                    )?),
+                )))),
+                Some(ForkName::Capella) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Capella(SignedBeaconBlockCapella::from_ssz_bytes(
+                        decoded_buffer,
+                    )?),
+                )))),
+                Some(ForkName::Deneb) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Deneb(SignedBeaconBlockDeneb::from_ssz_bytes(
+                        decoded_buffer,
+                    )?),
+                )))),
+                Some(ForkName::Electra) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Electra(SignedBeaconBlockElectra::from_ssz_bytes(
+                        decoded_buffer,
+                    )?),
+                )))),
+                Some(ForkName::Fulu) => Ok(Some(RpcSuccessResponse::BlocksByRange(Arc::new(
+                    SignedBeaconBlock::Fulu(SignedBeaconBlockFulu::from_ssz_bytes(decoded_buffer)?),
+                )))),
+                None => Err(RPCError::ErrorResponse(
+                    RpcErrorResponse::InvalidRequest,
+                    format!(
+                        "No context bytes provided for {:?} response",
+                        versioned_protocol
+                    ),
+                )),
+            }
+        }
         SupportedProtocol::BlocksByRootV2 => match fork_name {
             Some(ForkName::Altair) => Ok(Some(RpcSuccessResponse::BlocksByRoot(Arc::new(
                 SignedBeaconBlock::Altair(SignedBeaconBlockAltair::from_ssz_bytes(decoded_buffer)?),
@@ -1056,18 +1090,18 @@ mod tests {
     }
 
     fn blbrange_request() -> BlobsByRangeRequest {
-        BlobsByRangeRequest {
+        BlobsByRangeRequest::V1(BlobsByRangeRequestV1 {
             start_slot: 0,
             count: 10,
-        }
+        })
     }
 
     fn dcbrange_request() -> DataColumnsByRangeRequest {
-        DataColumnsByRangeRequest {
+        DataColumnsByRangeRequest::V1(DataColumnsByRangeRequestV1 {
             start_slot: 0,
             count: 10,
             columns: vec![1, 2, 3],
-        }
+        })
     }
 
     fn dcbroot_request(spec: &ChainSpec) -> DataColumnsByRootRequest {

--- a/beacon_node/lighthouse_network/src/rpc/handler.rs
+++ b/beacon_node/lighthouse_network/src/rpc/handler.rs
@@ -878,7 +878,7 @@ where
             }
             RequestType::BlobsByRange(request) => {
                 let max_requested_blobs = request
-                    .count
+                    .count()
                     .saturating_mul(spec.max_blobs_per_block_by_fork(current_fork));
                 let max_allowed = spec.max_request_blob_sidecars(current_fork) as u64;
                 if max_requested_blobs > max_allowed {

--- a/beacon_node/lighthouse_network/src/rpc/methods.rs
+++ b/beacon_node/lighthouse_network/src/rpc/methods.rs
@@ -293,8 +293,11 @@ impl ssz::Decode for GoodbyeReason {
 }
 
 /// Request a number of beacon block roots from a peer.
+///
+/// V2_3845 implements the spec proposal https://github.com/ethereum/consensus-specs/pull/3845 on
+/// top of version V2
 #[superstruct(
-    variants(V1, V2),
+    variants(V1, V2, V2_3845),
     variant_attributes(derive(Encode, Decode, Clone, Debug, PartialEq))
 )]
 #[derive(Clone, Debug, PartialEq)]
@@ -304,12 +307,24 @@ pub struct BlocksByRangeRequest {
 
     /// The number of blocks from the start slot.
     pub count: u64,
+
+    /// The root to base the chain to query from
+    #[superstruct(only(V2_3845))]
+    pub block_root: Hash256,
 }
 
 impl BlocksByRangeRequest {
     /// The default request is V2
-    pub fn new(start_slot: u64, count: u64) -> Self {
-        Self::V2(BlocksByRangeRequestV2 { start_slot, count })
+    pub fn new(start_slot: u64, count: u64, block_root: Option<Hash256>) -> Self {
+        if let Some(block_root) = block_root {
+            Self::V2_3845(BlocksByRangeRequestV2_3845 {
+                start_slot,
+                count,
+                block_root,
+            })
+        } else {
+            Self::V2(BlocksByRangeRequestV2 { start_slot, count })
+        }
     }
 
     pub fn new_v1(start_slot: u64, count: u64) -> Self {
@@ -318,24 +333,54 @@ impl BlocksByRangeRequest {
 }
 
 /// Request a number of beacon blobs from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+///
+/// V1_3845 implements the spec proposal https://github.com/ethereum/consensus-specs/pull/3845 on
+/// top of version V1
+#[superstruct(
+    variants(V1, V1_3845),
+    variant_attributes(derive(Encode, Decode, Clone, Debug, PartialEq))
+)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BlobsByRangeRequest {
     /// The starting slot to request blobs.
     pub start_slot: u64,
 
     /// The number of slots from the start slot.
     pub count: u64,
+
+    /// The root to base the chain to query from
+    #[superstruct(only(V1_3845))]
+    pub block_root: Hash256,
 }
 
 impl BlobsByRangeRequest {
+    pub fn new(start_slot: u64, count: u64, block_root: Option<Hash256>) -> Self {
+        if let Some(block_root) = block_root {
+            Self::V1_3845(BlobsByRangeRequestV1_3845 {
+                start_slot,
+                count,
+                block_root,
+            })
+        } else {
+            Self::V1(BlobsByRangeRequestV1 { start_slot, count })
+        }
+    }
+
     pub fn max_blobs_requested(&self, current_fork: ForkName, spec: &ChainSpec) -> u64 {
         let max_blobs_per_block = spec.max_blobs_per_block_by_fork(current_fork);
-        self.count.saturating_mul(max_blobs_per_block)
+        self.count().saturating_mul(max_blobs_per_block)
     }
 }
 
 /// Request a number of beacon data columns from a peer.
-#[derive(Encode, Decode, Clone, Debug, PartialEq)]
+///
+/// V1_3845 implements the spec proposal https://github.com/ethereum/consensus-specs/pull/3845 on
+/// top of version V1
+#[superstruct(
+    variants(V1, V1_3845),
+    variant_attributes(derive(Encode, Decode, Clone, Debug, PartialEq))
+)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DataColumnsByRangeRequest {
     /// The starting slot to request data columns.
     pub start_slot: u64,
@@ -343,15 +388,40 @@ pub struct DataColumnsByRangeRequest {
     pub count: u64,
     /// The list column indices being requested.
     pub columns: Vec<ColumnIndex>,
+    /// The root to base the chain to query from
+    #[superstruct(only(V1_3845))]
+    pub block_root: Hash256,
 }
 
 impl DataColumnsByRangeRequest {
+    pub fn new(
+        start_slot: u64,
+        count: u64,
+        columns: Vec<ColumnIndex>,
+        block_root: Option<Hash256>,
+    ) -> Self {
+        if let Some(block_root) = block_root {
+            Self::V1_3845(DataColumnsByRangeRequestV1_3845 {
+                start_slot,
+                count,
+                columns,
+                block_root,
+            })
+        } else {
+            Self::V1(DataColumnsByRangeRequestV1 {
+                start_slot,
+                count,
+                columns,
+            })
+        }
+    }
+
     pub fn max_requested<E: EthSpec>(&self) -> u64 {
-        self.count.saturating_mul(self.columns.len() as u64)
+        self.count().saturating_mul(self.columns().len() as u64)
     }
 
     pub fn ssz_min_len() -> usize {
-        DataColumnsByRangeRequest {
+        DataColumnsByRangeRequestV1 {
             start_slot: 0,
             count: 0,
             columns: vec![0],
@@ -361,10 +431,11 @@ impl DataColumnsByRangeRequest {
     }
 
     pub fn ssz_max_len(spec: &ChainSpec) -> usize {
-        DataColumnsByRangeRequest {
+        DataColumnsByRangeRequestV1_3845 {
             start_slot: 0,
             count: 0,
             columns: vec![0; spec.number_of_columns as usize],
+            block_root: Hash256::ZERO,
         }
         .as_ssz_bytes()
         .len()
@@ -372,8 +443,11 @@ impl DataColumnsByRangeRequest {
 }
 
 /// Request a number of beacon block roots from a peer.
+///
+/// V2_3845 implements the spec proposal https://github.com/ethereum/consensus-specs/pull/3845 on
+/// top of version V2
 #[superstruct(
-    variants(V1, V2),
+    variants(V1, V2, V2_3845),
     variant_attributes(derive(Encode, Decode, Clone, Debug, PartialEq))
 )]
 #[derive(Clone, Debug, PartialEq)]
@@ -390,6 +464,10 @@ pub struct OldBlocksByRangeRequest {
     /// A value of 2 returns every second block.
     /// A value of 3 returns every third block and so on.
     pub step: u64,
+
+    /// The root to base the chain to query from
+    #[superstruct(only(V2_3845))]
+    pub block_root: Hash256,
 }
 
 impl OldBlocksByRangeRequest {
@@ -426,6 +504,14 @@ impl From<BlocksByRangeRequest> for OldBlocksByRangeRequest {
                     start_slot: req.start_slot,
                     count: req.count,
                     step: 1,
+                })
+            }
+            BlocksByRangeRequest::V2_3845(ref req) => {
+                OldBlocksByRangeRequest::V2_3845(OldBlocksByRangeRequestV2_3845 {
+                    start_slot: req.start_slot,
+                    count: req.count,
+                    step: 1,
+                    block_root: req.block_root,
                 })
             }
         }
@@ -845,13 +931,25 @@ impl std::fmt::Display for BlobsByRootRequest {
     }
 }
 
+// TODO: can delete this?
 impl std::fmt::Display for BlobsByRangeRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Request: BlobsByRange: Start Slot: {}, Count: {}",
-            self.start_slot, self.count
-        )
+        if let Ok(block_root) = self.block_root() {
+            write!(
+                f,
+                "Request: BlobsByRange: Start Slot: {}, Count: {}, Root {:?}",
+                self.start_slot(),
+                self.count(),
+                block_root,
+            )
+        } else {
+            write!(
+                f,
+                "Request: BlobsByRange: Start Slot: {}, Count: {}",
+                self.start_slot(),
+                self.count(),
+            )
+        }
     }
 }
 

--- a/beacon_node/lighthouse_network/src/rpc/protocol.rs
+++ b/beacon_node/lighthouse_network/src/rpc/protocol.rs
@@ -310,12 +310,15 @@ pub enum SupportedProtocol {
     GoodbyeV1,
     BlocksByRangeV1,
     BlocksByRangeV2,
+    BlocksByRangeV2_3845,
     BlocksByRootV1,
     BlocksByRootV2,
     BlobsByRangeV1,
+    BlobsByRangeV1_3845,
     BlobsByRootV1,
     DataColumnsByRootV1,
     DataColumnsByRangeV1,
+    DataColumnsByRangeV1_3845,
     PingV1,
     MetaDataV1,
     MetaDataV2,
@@ -333,12 +336,15 @@ impl SupportedProtocol {
             SupportedProtocol::GoodbyeV1 => "1",
             SupportedProtocol::BlocksByRangeV1 => "1",
             SupportedProtocol::BlocksByRangeV2 => "2",
+            SupportedProtocol::BlocksByRangeV2_3845 => "2_3845",
             SupportedProtocol::BlocksByRootV1 => "1",
             SupportedProtocol::BlocksByRootV2 => "2",
             SupportedProtocol::BlobsByRangeV1 => "1",
+            SupportedProtocol::BlobsByRangeV1_3845 => "1_3845",
             SupportedProtocol::BlobsByRootV1 => "1",
             SupportedProtocol::DataColumnsByRootV1 => "1",
             SupportedProtocol::DataColumnsByRangeV1 => "1",
+            SupportedProtocol::DataColumnsByRangeV1_3845 => "1_3845",
             SupportedProtocol::PingV1 => "1",
             SupportedProtocol::MetaDataV1 => "1",
             SupportedProtocol::MetaDataV2 => "2",
@@ -356,12 +362,15 @@ impl SupportedProtocol {
             SupportedProtocol::GoodbyeV1 => Protocol::Goodbye,
             SupportedProtocol::BlocksByRangeV1 => Protocol::BlocksByRange,
             SupportedProtocol::BlocksByRangeV2 => Protocol::BlocksByRange,
+            SupportedProtocol::BlocksByRangeV2_3845 => Protocol::BlocksByRange,
             SupportedProtocol::BlocksByRootV1 => Protocol::BlocksByRoot,
             SupportedProtocol::BlocksByRootV2 => Protocol::BlocksByRoot,
             SupportedProtocol::BlobsByRangeV1 => Protocol::BlobsByRange,
+            SupportedProtocol::BlobsByRangeV1_3845 => Protocol::BlobsByRange,
             SupportedProtocol::BlobsByRootV1 => Protocol::BlobsByRoot,
             SupportedProtocol::DataColumnsByRootV1 => Protocol::DataColumnsByRoot,
             SupportedProtocol::DataColumnsByRangeV1 => Protocol::DataColumnsByRange,
+            SupportedProtocol::DataColumnsByRangeV1_3845 => Protocol::DataColumnsByRange,
             SupportedProtocol::PingV1 => Protocol::Ping,
             SupportedProtocol::MetaDataV1 => Protocol::MetaData,
             SupportedProtocol::MetaDataV2 => Protocol::MetaData,
@@ -379,7 +388,8 @@ impl SupportedProtocol {
         let mut supported = vec![
             ProtocolId::new(Self::StatusV1, Encoding::SSZSnappy),
             ProtocolId::new(Self::GoodbyeV1, Encoding::SSZSnappy),
-            // V2 variants have higher preference then V1
+            // Newer variants have higher preference then V1
+            ProtocolId::new(Self::BlocksByRangeV2_3845, Encoding::SSZSnappy),
             ProtocolId::new(Self::BlocksByRangeV2, Encoding::SSZSnappy),
             ProtocolId::new(Self::BlocksByRangeV1, Encoding::SSZSnappy),
             ProtocolId::new(Self::BlocksByRootV2, Encoding::SSZSnappy),
@@ -402,12 +412,17 @@ impl SupportedProtocol {
         if fork_context.fork_exists(ForkName::Deneb) {
             supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::BlobsByRootV1, Encoding::SSZSnappy),
+                ProtocolId::new(SupportedProtocol::BlobsByRangeV1_3845, Encoding::SSZSnappy),
                 ProtocolId::new(SupportedProtocol::BlobsByRangeV1, Encoding::SSZSnappy),
             ]);
         }
         if fork_context.spec.is_peer_das_scheduled() {
             supported.extend_from_slice(&[
                 ProtocolId::new(SupportedProtocol::DataColumnsByRootV1, Encoding::SSZSnappy),
+                ProtocolId::new(
+                    SupportedProtocol::DataColumnsByRangeV1_3845,
+                    Encoding::SSZSnappy,
+                ),
                 ProtocolId::new(SupportedProtocol::DataColumnsByRangeV1, Encoding::SSZSnappy),
             ]);
         }
@@ -510,13 +525,13 @@ impl ProtocolId {
             ),
             // V1 and V2 requests are the same
             Protocol::BlocksByRange => RpcLimits::new(
-                <OldBlocksByRangeRequestV2 as Encode>::ssz_fixed_len(),
-                <OldBlocksByRangeRequestV2 as Encode>::ssz_fixed_len(),
+                <OldBlocksByRangeRequestV2_3845 as Encode>::ssz_fixed_len(),
+                <OldBlocksByRangeRequestV2_3845 as Encode>::ssz_fixed_len(),
             ),
             Protocol::BlocksByRoot => RpcLimits::new(0, spec.max_blocks_by_root_request),
             Protocol::BlobsByRange => RpcLimits::new(
-                <BlobsByRangeRequest as Encode>::ssz_fixed_len(),
-                <BlobsByRangeRequest as Encode>::ssz_fixed_len(),
+                <BlobsByRangeRequestV1_3845 as Encode>::ssz_fixed_len(),
+                <BlobsByRangeRequestV1_3845 as Encode>::ssz_fixed_len(),
             ),
             Protocol::BlobsByRoot => RpcLimits::new(0, spec.max_blobs_by_root_request),
             Protocol::DataColumnsByRoot => RpcLimits::new(0, spec.max_data_columns_by_root_request),
@@ -587,12 +602,15 @@ impl ProtocolId {
     /// beginning of the stream, else returns `false`.
     pub fn has_context_bytes(&self) -> bool {
         match self.versioned_protocol {
-            SupportedProtocol::BlocksByRangeV2
+            SupportedProtocol::BlocksByRangeV2_3845
+            | SupportedProtocol::BlocksByRangeV2
             | SupportedProtocol::BlocksByRootV2
             | SupportedProtocol::BlobsByRangeV1
+            | SupportedProtocol::BlobsByRangeV1_3845
             | SupportedProtocol::BlobsByRootV1
             | SupportedProtocol::DataColumnsByRootV1
             | SupportedProtocol::DataColumnsByRangeV1
+            | SupportedProtocol::DataColumnsByRangeV1_3845
             | SupportedProtocol::LightClientBootstrapV1
             | SupportedProtocol::LightClientOptimisticUpdateV1
             | SupportedProtocol::LightClientFinalityUpdateV1
@@ -768,6 +786,7 @@ impl<E: EthSpec> RequestType<E> {
             RequestType::BlocksByRange(req) => match req {
                 OldBlocksByRangeRequest::V1(_) => SupportedProtocol::BlocksByRangeV1,
                 OldBlocksByRangeRequest::V2(_) => SupportedProtocol::BlocksByRangeV2,
+                OldBlocksByRangeRequest::V2_3845(_) => SupportedProtocol::BlocksByRangeV2_3845,
             },
             RequestType::BlocksByRoot(req) => match req {
                 BlocksByRootRequest::V1(_) => SupportedProtocol::BlocksByRootV1,

--- a/beacon_node/lighthouse_network/tests/rpc_tests.rs
+++ b/beacon_node/lighthouse_network/tests/rpc_tests.rs
@@ -324,10 +324,11 @@ fn test_blobs_by_range_chunked_rpc() {
         .await;
 
         // BlobsByRange Request
-        let rpc_request = RequestType::BlobsByRange(BlobsByRangeRequest {
-            start_slot: 0,
-            count: slot_count,
-        });
+        let rpc_request =
+            RequestType::BlobsByRange(BlobsByRangeRequest::V1(BlobsByRangeRequestV1 {
+                start_slot: 0,
+                count: slot_count,
+            }));
 
         // BlocksByRange Response
         let blob = BlobSidecar::<E>::empty();

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -655,15 +655,21 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
         let req_start_slot = *req.start_slot();
         let req_count = *req.count();
+        let req_block_root = req.block_root().ok().copied();
 
         debug!(self.log, "Received BlocksByRange Request";
             "peer_id" => %peer_id,
             "start_slot" => req_start_slot,
             "count" => req_count,
+            "block_root" => ?req_block_root,
         );
 
-        let block_roots =
-            self.get_block_roots_for_slot_range(req_start_slot, req_count, "BlocksByRange")?;
+        let block_roots = self.get_block_roots_for_slot_range(
+            req_start_slot,
+            req_count,
+            req_block_root,
+            "BlocksByRange",
+        )?;
         let current_slot = self
             .chain
             .slot()
@@ -781,6 +787,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         &self,
         req_start_slot: u64,
         req_count: u64,
+        req_block_root: Option<Hash256>,
         req_type: &str,
     ) -> Result<Vec<Hash256>, (RpcErrorResponse, &'static str)> {
         let block_roots_timer = std::time::Instant::now();
@@ -796,7 +803,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             // If the entire requested range is after finalization, use fork_choice
             (
                 self.chain
-                    .block_roots_from_fork_choice(req_start_slot, req_count),
+                    .block_roots_from_fork_choice(req_start_slot, req_count, req_block_root),
                 "fork_choice",
             )
         } else if req_start_slot + req_count <= finalized_slot.as_u64() {
@@ -816,9 +823,11 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 self.get_block_roots_from_store(req_start_slot, count_from_store)?;
 
             // Get roots from fork choice (after finalized slot)
-            let roots_from_fork_choice = self
-                .chain
-                .block_roots_from_fork_choice(start_slot_fork_choice, count_from_fork_choice);
+            let roots_from_fork_choice = self.chain.block_roots_from_fork_choice(
+                start_slot_fork_choice,
+                count_from_fork_choice,
+                req_block_root,
+            );
 
             roots_from_store.extend(roots_from_fork_choice);
 
@@ -938,11 +947,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
         debug!(self.log, "Received BlobsByRange Request";
             "peer_id" => %peer_id,
-            "count" => req.count,
-            "start_slot" => req.start_slot,
+            "count" => req.count(),
+            "start_slot" => req.start_slot(),
+            "block_root" => ?req.block_root().ok(),
         );
 
-        let request_start_slot = Slot::from(req.start_slot);
+        let request_start_slot = Slot::from(*req.start_slot());
 
         let data_availability_boundary_slot = match self.chain.data_availability_boundary() {
             Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
@@ -980,8 +990,12 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             };
         }
 
-        let block_roots =
-            self.get_block_roots_for_slot_range(req.start_slot, req.count, "BlobsByRange")?;
+        let block_roots = self.get_block_roots_for_slot_range(
+            *req.start_slot(),
+            *req.count(),
+            req.block_root().ok().copied(),
+            "BlobsByRange",
+        )?;
 
         let current_slot = self
             .chain
@@ -993,9 +1007,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 self.log,
                 "BlobsByRange outgoing response processed";
                 "peer" => %peer_id,
-                "start_slot" => req.start_slot,
+                "start_slot" => req.start_slot(),
+                "block_root" => ?req.block_root().ok(),
                 "current_slot" => current_slot,
-                "requested" => req.count,
+                "requested" => req.count(),
                 "returned" => blobs_sent
             );
         };
@@ -1074,8 +1089,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
         debug!(self.log, "Received DataColumnsByRange Request";
             "peer_id" => %peer_id,
-            "count" => req.count,
-            "start_slot" => req.start_slot,
+            "count" => req.count(),
+            "start_slot" => req.start_slot(),
+            "block_root" => ?req.block_root().ok(),
         );
 
         // Should not send more than max request data columns
@@ -1086,7 +1102,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             ));
         }
 
-        let request_start_slot = Slot::from(req.start_slot);
+        let request_start_slot = Slot::from(*req.start_slot());
 
         let data_availability_boundary_slot = match self.chain.data_availability_boundary() {
             Some(boundary) => boundary.start_slot(T::EthSpec::slots_per_epoch()),
@@ -1125,12 +1141,16 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             };
         }
 
-        let block_roots =
-            self.get_block_roots_for_slot_range(req.start_slot, req.count, "DataColumnsByRange")?;
+        let block_roots = self.get_block_roots_for_slot_range(
+            *req.start_slot(),
+            *req.count(),
+            req.block_root().ok().copied(),
+            "DataColumnsByRange",
+        )?;
         let mut data_columns_sent = 0;
 
         for root in block_roots {
-            for index in &req.columns {
+            for index in req.columns() {
                 match self.chain.get_data_column(&root, index) {
                     Ok(Some(data_column_sidecar)) => {
                         data_columns_sent += 1;
@@ -1171,9 +1191,10 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             self.log,
             "DataColumnsByRange Response processed";
             "peer" => %peer_id,
-            "start_slot" => req.start_slot,
+            "start_slot" => req.start_slot(),
+            "block_root" => ?req.block_root().ok(),
             "current_slot" => current_slot,
-            "requested" => req.count,
+            "requested" => req.count(),
             "returned" => data_columns_sent
         );
 

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -653,86 +653,32 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
         request_id: RequestId,
         req: BlocksByRangeRequest,
     ) -> Result<(), (RpcErrorResponse, &'static str)> {
+        let req_start_slot = *req.start_slot();
+        let req_count = *req.count();
+
         debug!(self.log, "Received BlocksByRange Request";
             "peer_id" => %peer_id,
-            "count" => req.count(),
-            "start_slot" => req.start_slot(),
+            "start_slot" => req_start_slot,
+            "count" => req_count,
         );
 
-        let forwards_block_root_iter = match self
-            .chain
-            .forwards_iter_block_roots(Slot::from(*req.start_slot()))
-        {
-            Ok(iter) => iter,
-            Err(BeaconChainError::HistoricalBlockOutOfRange {
-                slot,
-                oldest_block_slot,
-            }) => {
-                debug!(self.log, "Range request failed during backfill";
-                    "requested_slot" => slot,
-                    "oldest_known_slot" => oldest_block_slot
-                );
-                return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
-            }
-            Err(e) => {
-                error!(self.log, "Unable to obtain root iter";
-                    "request" => ?req,
-                    "peer" => %peer_id,
-                    "error" => ?e
-                );
-                return Err((RpcErrorResponse::ServerError, "Database error"));
-            }
-        };
-
-        // Pick out the required blocks, ignoring skip-slots.
-        let mut last_block_root = None;
-        let maybe_block_roots = process_results(forwards_block_root_iter, |iter| {
-            iter.take_while(|(_, slot)| {
-                slot.as_u64() < req.start_slot().saturating_add(*req.count())
-            })
-            // map skip slots to None
-            .map(|(root, _)| {
-                let result = if Some(root) == last_block_root {
-                    None
-                } else {
-                    Some(root)
-                };
-                last_block_root = Some(root);
-                result
-            })
-            .collect::<Vec<Option<Hash256>>>()
-        });
-
-        let block_roots = match maybe_block_roots {
-            Ok(block_roots) => block_roots,
-            Err(e) => {
-                error!(self.log, "Error during iteration over blocks";
-                    "request" => ?req,
-                    "peer" => %peer_id,
-                    "error" => ?e
-                );
-                return Err((RpcErrorResponse::ServerError, "Iteration error"));
-            }
-        };
-
-        // remove all skip slots
-        let block_roots = block_roots.into_iter().flatten().collect::<Vec<_>>();
-
+        let block_roots =
+            self.get_block_roots_for_slot_range(req_start_slot, req_count, "BlocksByRange")?;
         let current_slot = self
             .chain
             .slot()
             .unwrap_or_else(|_| self.chain.slot_clock.genesis_slot());
 
-        let log_results = |req: BlocksByRangeRequest, peer_id, blocks_sent| {
-            if blocks_sent < (*req.count() as usize) {
+        let log_results = |peer_id, blocks_sent| {
+            if blocks_sent < (req_count as usize) {
                 debug!(
                     self.log,
                     "BlocksByRange outgoing response processed";
                     "peer" => %peer_id,
                     "msg" => "Failed to return all requested blocks",
-                    "start_slot" => req.start_slot(),
+                    "start_slot" => req_start_slot,
                     "current_slot" => current_slot,
-                    "requested" => req.count(),
+                    "requested" => req_count,
                     "returned" => blocks_sent
                 );
             } else {
@@ -740,9 +686,9 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                     self.log,
                     "BlocksByRange outgoing response processed";
                     "peer" => %peer_id,
-                    "start_slot" => req.start_slot(),
+                    "start_slot" => req_start_slot,
                     "current_slot" => current_slot,
-                    "requested" => req.count(),
+                    "requested" => req_count,
                     "returned" => blocks_sent
                 );
             }
@@ -763,8 +709,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                 Ok(Some(block)) => {
                     // Due to skip slots, blocks could be out of the range, we ensure they
                     // are in the range before sending
-                    if block.slot() >= *req.start_slot()
-                        && block.slot() < req.start_slot() + req.count()
+                    if block.slot() >= req_start_slot && block.slot() < req_start_slot + req.count()
                     {
                         blocks_sent += 1;
                         self.send_network_message(NetworkMessage::SendResponse {
@@ -783,7 +728,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "peer" => %peer_id,
                         "request_root" => ?root
                     );
-                    log_results(req, peer_id, blocks_sent);
+                    log_results(peer_id, blocks_sent);
                     return Err((RpcErrorResponse::ServerError, "Database inconsistency"));
                 }
                 Err(BeaconChainError::BlockHashMissingFromExecutionLayer(_)) => {
@@ -793,7 +738,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         "block_root" => ?root,
                         "reason" => "execution layer not synced",
                     );
-                    log_results(req, peer_id, blocks_sent);
+                    log_results(peer_id, blocks_sent);
                     // send the stream terminator
                     return Err((
                         RpcErrorResponse::ResourceUnavailable,
@@ -821,15 +766,119 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                             "error" => ?e
                         );
                     }
-                    log_results(req, peer_id, blocks_sent);
+                    log_results(peer_id, blocks_sent);
                     // send the stream terminator
                     return Err((RpcErrorResponse::ServerError, "Failed fetching blocks"));
                 }
             }
         }
 
-        log_results(req, peer_id, blocks_sent);
+        log_results(peer_id, blocks_sent);
         Ok(())
+    }
+
+    fn get_block_roots_for_slot_range(
+        &self,
+        req_start_slot: u64,
+        req_count: u64,
+        req_type: &str,
+    ) -> Result<Vec<Hash256>, (RpcErrorResponse, &'static str)> {
+        let block_roots_timer = std::time::Instant::now();
+        let finalized_slot = self
+            .chain
+            .canonical_head
+            .cached_head()
+            .finalized_checkpoint()
+            .epoch
+            .start_slot(T::EthSpec::slots_per_epoch());
+
+        let (block_roots, block_roots_source) = if req_start_slot >= finalized_slot.as_u64() {
+            (
+                self.chain
+                    .block_roots_from_fork_choice(req_start_slot, req_count),
+                "fork_choice",
+            )
+        } else {
+            (
+                self.get_block_roots_from_store(req_start_slot, req_count)?,
+                "store",
+            )
+        };
+
+        debug!(
+            self.log,
+            "Range request block roots retrieved";
+            "req_type" => req_type,
+            "start_slot" => req_start_slot,
+            "count" => req_count,
+            "block_roots_count" => block_roots.len(),
+            "block_roots_source" => block_roots_source,
+            "elapsed" => ?block_roots_timer.elapsed()
+        );
+
+        Ok(block_roots)
+    }
+
+    /// Get block roots for a `BlocksByRangeRequest` from the store using roots iterator.
+    fn get_block_roots_from_store(
+        &self,
+        start_slot: u64,
+        count: u64,
+    ) -> Result<Vec<Hash256>, (RpcErrorResponse, &'static str)> {
+        let forwards_block_root_iter =
+            match self.chain.forwards_iter_block_roots(Slot::from(start_slot)) {
+                Ok(iter) => iter,
+                Err(BeaconChainError::HistoricalBlockOutOfRange {
+                    slot,
+                    oldest_block_slot,
+                }) => {
+                    debug!(self.log, "Range request failed during backfill";
+                        "requested_slot" => slot,
+                        "oldest_known_slot" => oldest_block_slot
+                    );
+                    return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
+                }
+                Err(e) => {
+                    error!(self.log, "Unable to obtain root iter for range request";
+                        "start_slot" => start_slot,
+                        "count" => count,
+                        "error" => ?e
+                    );
+                    return Err((RpcErrorResponse::ServerError, "Database error"));
+                }
+            };
+
+        // Pick out the required blocks, ignoring skip-slots.
+        let mut last_block_root = None;
+        let maybe_block_roots = process_results(forwards_block_root_iter, |iter| {
+            iter.take_while(|(_, slot)| slot.as_u64() < start_slot.saturating_add(count))
+                // map skip slots to None
+                .map(|(root, _)| {
+                    let result = if Some(root) == last_block_root {
+                        None
+                    } else {
+                        Some(root)
+                    };
+                    last_block_root = Some(root);
+                    result
+                })
+                .collect::<Vec<Option<Hash256>>>()
+        });
+
+        let block_roots = match maybe_block_roots {
+            Ok(block_roots) => block_roots,
+            Err(e) => {
+                error!(self.log, "Error during iteration over blocks for range request";
+                    "start_slot" => start_slot,
+                    "count" => count,
+                    "error" => ?e
+                );
+                return Err((RpcErrorResponse::ServerError, "Iteration error"));
+            }
+        };
+
+        // remove all skip slots
+        Ok(block_roots.into_iter().flatten().collect::<Vec<_>>())
     }
 
     /// Handle a `BlobsByRange` request from the peer.
@@ -910,65 +959,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             };
         }
 
-        let forwards_block_root_iter =
-            match self.chain.forwards_iter_block_roots(request_start_slot) {
-                Ok(iter) => iter,
-                Err(BeaconChainError::HistoricalBlockOutOfRange {
-                    slot,
-                    oldest_block_slot,
-                }) => {
-                    debug!(self.log, "Range request failed during backfill";
-                        "requested_slot" => slot,
-                        "oldest_known_slot" => oldest_block_slot
-                    );
-                    return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
-                }
-                Err(e) => {
-                    error!(self.log, "Unable to obtain root iter";
-                        "request" => ?req,
-                        "peer" => %peer_id,
-                        "error" => ?e
-                    );
-                    return Err((RpcErrorResponse::ServerError, "Database error"));
-                }
-            };
-
-        // Use `WhenSlotSkipped::Prev` to get the most recent block root prior to
-        // `request_start_slot` in order to check whether the `request_start_slot` is a skip.
-        let mut last_block_root = req.start_slot.checked_sub(1).and_then(|prev_slot| {
-            self.chain
-                .block_root_at_slot(Slot::new(prev_slot), WhenSlotSkipped::Prev)
-                .ok()
-                .flatten()
-        });
-
-        // Pick out the required blocks, ignoring skip-slots.
-        let maybe_block_roots = process_results(forwards_block_root_iter, |iter| {
-            iter.take_while(|(_, slot)| slot.as_u64() < req.start_slot.saturating_add(req.count))
-                // map skip slots to None
-                .map(|(root, _)| {
-                    let result = if Some(root) == last_block_root {
-                        None
-                    } else {
-                        Some(root)
-                    };
-                    last_block_root = Some(root);
-                    result
-                })
-                .collect::<Vec<Option<Hash256>>>()
-        });
-
-        let block_roots = match maybe_block_roots {
-            Ok(block_roots) => block_roots,
-            Err(e) => {
-                error!(self.log, "Error during iteration over blocks";
-                    "request" => ?req,
-                    "peer" => %peer_id,
-                    "error" => ?e
-                );
-                return Err((RpcErrorResponse::ServerError, "Database error"));
-            }
-        };
+        let block_roots =
+            self.get_block_roots_for_slot_range(req.start_slot, req.count, "BlobsByRange")?;
 
         let current_slot = self
             .chain
@@ -987,8 +979,6 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             );
         };
 
-        // remove all skip slots
-        let block_roots = block_roots.into_iter().flatten();
         let mut blobs_sent = 0;
 
         for root in block_roots {
@@ -1114,68 +1104,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             };
         }
 
-        let forwards_block_root_iter =
-            match self.chain.forwards_iter_block_roots(request_start_slot) {
-                Ok(iter) => iter,
-                Err(BeaconChainError::HistoricalBlockOutOfRange {
-                    slot,
-                    oldest_block_slot,
-                }) => {
-                    debug!(self.log, "Range request failed during backfill";
-                        "requested_slot" => slot,
-                        "oldest_known_slot" => oldest_block_slot
-                    );
-                    return Err((RpcErrorResponse::ResourceUnavailable, "Backfilling"));
-                }
-                Err(e) => {
-                    error!(self.log, "Unable to obtain root iter";
-                        "request" => ?req,
-                        "peer" => %peer_id,
-                        "error" => ?e
-                    );
-                    return Err((RpcErrorResponse::ServerError, "Database error"));
-                }
-            };
-
-        // Use `WhenSlotSkipped::Prev` to get the most recent block root prior to
-        // `request_start_slot` in order to check whether the `request_start_slot` is a skip.
-        let mut last_block_root = req.start_slot.checked_sub(1).and_then(|prev_slot| {
-            self.chain
-                .block_root_at_slot(Slot::new(prev_slot), WhenSlotSkipped::Prev)
-                .ok()
-                .flatten()
-        });
-
-        // Pick out the required blocks, ignoring skip-slots.
-        let maybe_block_roots = process_results(forwards_block_root_iter, |iter| {
-            iter.take_while(|(_, slot)| slot.as_u64() < req.start_slot.saturating_add(req.count))
-                // map skip slots to None
-                .map(|(root, _)| {
-                    let result = if Some(root) == last_block_root {
-                        None
-                    } else {
-                        Some(root)
-                    };
-                    last_block_root = Some(root);
-                    result
-                })
-                .collect::<Vec<Option<Hash256>>>()
-        });
-
-        let block_roots = match maybe_block_roots {
-            Ok(block_roots) => block_roots,
-            Err(e) => {
-                error!(self.log, "Error during iteration over blocks";
-                    "request" => ?req,
-                    "peer" => %peer_id,
-                    "error" => ?e
-                );
-                return Err((RpcErrorResponse::ServerError, "Database error"));
-            }
-        };
-
-        // remove all skip slots
-        let block_roots = block_roots.into_iter().flatten();
+        let block_roots =
+            self.get_block_roots_for_slot_range(req.start_slot, req.count, "DataColumnsByRange")?;
         let mut data_columns_sent = 0;
 
         for root in block_roots {

--- a/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/rpc_methods.rs
@@ -793,16 +793,36 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             .start_slot(T::EthSpec::slots_per_epoch());
 
         let (block_roots, block_roots_source) = if req_start_slot >= finalized_slot.as_u64() {
+            // If the entire requested range is after finalization, use fork_choice
             (
                 self.chain
                     .block_roots_from_fork_choice(req_start_slot, req_count),
                 "fork_choice",
             )
-        } else {
+        } else if req_start_slot + req_count <= finalized_slot.as_u64() {
+            // If the entire requested range is before finalization, use store
             (
                 self.get_block_roots_from_store(req_start_slot, req_count)?,
                 "store",
             )
+        } else {
+            // Split the request at the finalization boundary
+            let count_from_store = finalized_slot.as_u64() - req_start_slot;
+            let count_from_fork_choice = req_count - count_from_store;
+            let start_slot_fork_choice = finalized_slot.as_u64();
+
+            // Get roots from store (up to and including finalized slot)
+            let mut roots_from_store =
+                self.get_block_roots_from_store(req_start_slot, count_from_store)?;
+
+            // Get roots from fork choice (after finalized slot)
+            let roots_from_fork_choice = self
+                .chain
+                .block_roots_from_fork_choice(start_slot_fork_choice, count_from_fork_choice);
+
+            roots_from_store.extend(roots_from_fork_choice);
+
+            (roots_from_store, "mixed")
         };
 
         debug!(
@@ -813,7 +833,8 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             "count" => req_count,
             "block_roots_count" => block_roots.len(),
             "block_roots_source" => block_roots_source,
-            "elapsed" => ?block_roots_timer.elapsed()
+            "elapsed" => ?block_roots_timer.elapsed(),
+            "finalized_slot" => finalized_slot
         );
 
         Ok(block_roots)

--- a/beacon_node/network/src/router.rs
+++ b/beacon_node/network/src/router.rs
@@ -223,7 +223,10 @@ impl<T: BeaconChainTypes> Router<T> {
                         BlocksByRangeRequest::new_v1(req.start_slot, count)
                     }
                     methods::OldBlocksByRangeRequest::V2(req) => {
-                        BlocksByRangeRequest::new(req.start_slot, count)
+                        BlocksByRangeRequest::new(req.start_slot, count, None)
+                    }
+                    methods::OldBlocksByRangeRequest::V2_3845(req) => {
+                        BlocksByRangeRequest::new(req.start_slot, count, Some(req.block_root))
                     }
                 };
 

--- a/beacon_node/network/src/sync/backfill_sync/mod.rs
+++ b/beacon_node/network/src/sync/backfill_sync/mod.rs
@@ -1073,6 +1073,10 @@ impl<T: BeaconChainTypes> BackFillSync<T> {
                 entry.insert(BatchInfo::new(
                     &batch_id,
                     BACKFILL_EPOCHS_PER_BATCH,
+                    // We are requesting finalized blocks, no need to request a specific root. If
+                    // requesting a specific root becomes mandatory just query the finalized root at
+                    // the start of the backfill process.
+                    None,
                     batch_type,
                 ));
                 if self.would_complete(batch_id) {

--- a/beacon_node/network/src/sync/network_context.rs
+++ b/beacon_node/network/src/sync/network_context.rs
@@ -372,10 +372,11 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
         let blobs_req_id = if matches!(batch_type, ByRangeRequestType::BlocksAndBlobs) {
             Some(self.send_blobs_by_range_request(
                 peer_id,
-                BlobsByRangeRequest {
-                    start_slot: *request.start_slot(),
-                    count: *request.count(),
-                },
+                BlobsByRangeRequest::new(
+                    *request.start_slot(),
+                    *request.count(),
+                    request.block_root().ok().copied(),
+                ),
                 id,
             )?)
         } else {
@@ -387,12 +388,17 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 let column_indexes = self.network_globals().sampling_columns.clone();
 
                 let data_column_requests = self
-                    .make_columns_by_range_requests(request, &column_indexes)?
+                    .make_columns_by_range_requests(&column_indexes)?
                     .into_iter()
-                    .map(|(peer_id, columns_by_range_request)| {
+                    .map(|(peer_id, columns_to_request)| {
                         self.send_data_columns_by_range_request(
                             peer_id,
-                            columns_by_range_request,
+                            DataColumnsByRangeRequest::new(
+                                *request.start_slot(),
+                                *request.count(),
+                                columns_to_request,
+                                request.block_root().ok().copied(),
+                            ),
                             id,
                         )
                     })
@@ -419,10 +425,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
 
     fn make_columns_by_range_requests(
         &self,
-        request: BlocksByRangeRequest,
         custody_indexes: &HashSet<ColumnIndex>,
-    ) -> Result<HashMap<PeerId, DataColumnsByRangeRequest>, RpcRequestSendError> {
-        let mut peer_id_to_request_map = HashMap::new();
+    ) -> Result<HashMap<PeerId, Vec<ColumnIndex>>, RpcRequestSendError> {
+        let mut peer_id_to_request_map = HashMap::<PeerId, Vec<ColumnIndex>>::new();
 
         for column_index in custody_indexes {
             // TODO(das): The peer selection logic here needs to be improved - we should probably
@@ -437,15 +442,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
                 return Err(RpcRequestSendError::NoCustodyPeers);
             };
 
-            let columns_by_range_request = peer_id_to_request_map
-                .entry(custody_peer)
-                .or_insert_with(|| DataColumnsByRangeRequest {
-                    start_slot: *request.start_slot(),
-                    count: *request.count(),
-                    columns: vec![],
-                });
+            let columns_by_range_request = peer_id_to_request_map.entry(custody_peer).or_default();
 
-            columns_by_range_request.columns.push(*column_index);
+            columns_by_range_request.push(*column_index);
         }
 
         Ok(peer_id_to_request_map)
@@ -818,7 +817,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             id: self.next_id(),
             parent_request_id,
         };
-        let request_epoch = Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch());
+        let request_epoch = Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch());
 
         // Create the blob request based on the blocks request.
         self.network_send
@@ -833,7 +832,7 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.log,
             "Sync RPC request sent";
             "method" => "BlobsByRange",
-            "slots" => request.count,
+            "slots" => request.count(),
             "epoch" => request_epoch,
             "peer" => %peer_id,
             "id" => %id,
@@ -873,9 +872,9 @@ impl<T: BeaconChainTypes> SyncNetworkContext<T> {
             self.log,
             "Sync RPC request sent";
             "method" => "DataColumnsByRange",
-            "slots" => request.count,
-            "epoch" => Slot::new(request.start_slot).epoch(T::EthSpec::slots_per_epoch()),
-            "columns" => ?request.columns,
+            "slots" => request.count(),
+            "epoch" => Slot::new(*request.start_slot()).epoch(T::EthSpec::slots_per_epoch()),
+            "columns" => ?request.columns(),
             "peer" => %peer_id,
             "id" => %id,
         );

--- a/beacon_node/network/src/sync/network_context/requests/blobs_by_range.rs
+++ b/beacon_node/network/src/sync/network_context/requests/blobs_by_range.rs
@@ -25,8 +25,8 @@ impl<E: EthSpec> ActiveRequestItems for BlobsByRangeRequestItems<E> {
     type Item = Arc<BlobSidecar<E>>;
 
     fn add(&mut self, blob: Self::Item) -> Result<bool, LookupVerifyError> {
-        if blob.slot() < self.request.start_slot
-            || blob.slot() >= self.request.start_slot + self.request.count
+        if blob.slot() < *self.request.start_slot()
+            || blob.slot() >= *self.request.start_slot() + *self.request.count()
         {
             return Err(LookupVerifyError::UnrequestedSlot(blob.slot()));
         }

--- a/beacon_node/network/src/sync/network_context/requests/data_columns_by_range.rs
+++ b/beacon_node/network/src/sync/network_context/requests/data_columns_by_range.rs
@@ -23,12 +23,12 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRangeRequestItems<E> {
     type Item = Arc<DataColumnSidecar<E>>;
 
     fn add(&mut self, data_column: Self::Item) -> Result<bool, LookupVerifyError> {
-        if data_column.slot() < self.request.start_slot
-            || data_column.slot() >= self.request.start_slot + self.request.count
+        if data_column.slot() < *self.request.start_slot()
+            || data_column.slot() >= *self.request.start_slot() + *self.request.count()
         {
             return Err(LookupVerifyError::UnrequestedSlot(data_column.slot()));
         }
-        if !self.request.columns.contains(&data_column.index) {
+        if !self.request.columns().contains(&data_column.index) {
             return Err(LookupVerifyError::UnrequestedIndex(data_column.index));
         }
         if !data_column.verify_inclusion_proof() {
@@ -45,7 +45,7 @@ impl<E: EthSpec> ActiveRequestItems for DataColumnsByRangeRequestItems<E> {
 
         self.items.push(data_column);
 
-        Ok(self.items.len() >= self.request.count as usize * self.request.columns.len())
+        Ok(self.items.len() >= (*self.request.count()) as usize * self.request.columns().len())
     }
 
     fn consume(&mut self) -> Vec<Self::Item> {

--- a/beacon_node/network/src/sync/range_sync/batch.rs
+++ b/beacon_node/network/src/sync/range_sync/batch.rs
@@ -7,7 +7,7 @@ use std::hash::{Hash, Hasher};
 use std::ops::Sub;
 use std::time::{Duration, Instant};
 use strum::Display;
-use types::{Epoch, EthSpec, Slot};
+use types::{Epoch, EthSpec, Hash256, Slot};
 
 /// The number of times to retry a batch before it is considered failed.
 const MAX_BATCH_DOWNLOAD_ATTEMPTS: u8 = 5;
@@ -99,6 +99,8 @@ pub struct BatchInfo<E: EthSpec, B: BatchConfig = RangeSyncBatchConfig> {
     start_slot: Slot,
     /// End slot of the batch.
     end_slot: Slot,
+    /// Target root to sync the batch too
+    end_block_root: Option<Hash256>,
     /// The `Attempts` that have been made and failed to send us this batch.
     failed_processing_attempts: Vec<Attempt>,
     /// Number of processing attempts that have failed but we do not count.
@@ -157,12 +159,19 @@ impl<E: EthSpec, B: BatchConfig> BatchInfo<E, B> {
     /// fork boundary will be of mixed type (all blocks and one last blockblob), and I don't want to
     /// deal with this for now.
     /// This means finalization might be slower in deneb
-    pub fn new(start_epoch: &Epoch, num_of_epochs: u64, batch_type: ByRangeRequestType) -> Self {
+    pub fn new(
+        start_epoch: &Epoch,
+        num_of_epochs: u64,
+        // TODO: make sure that end_slot is less than this block root
+        end_block_root: Option<Hash256>,
+        batch_type: ByRangeRequestType,
+    ) -> Self {
         let start_slot = start_epoch.start_slot(E::slots_per_epoch());
         let end_slot = start_slot + num_of_epochs * E::slots_per_epoch();
         BatchInfo {
             start_slot,
             end_slot,
+            end_block_root,
             failed_processing_attempts: Vec::new(),
             failed_download_attempts: Vec::new(),
             non_faulty_processing_attempts: 0,
@@ -238,6 +247,7 @@ impl<E: EthSpec, B: BatchConfig> BatchInfo<E, B> {
             BlocksByRangeRequest::new(
                 self.start_slot.into(),
                 self.end_slot.sub(self.start_slot).into(),
+                self.end_block_root,
             ),
             self.batch_type,
         )

--- a/beacon_node/network/src/sync/range_sync/chain.rs
+++ b/beacon_node/network/src/sync/range_sync/chain.rs
@@ -190,6 +190,19 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             .sum()
     }
 
+    fn end_block_root(&self) -> Option<Hash256> {
+        match self.chain_type {
+            // https://github.com/ethereum/consensus-specs/pull/3845 may be spec-ed such that only
+            // blocks up to head_root are returned if the count exceeds that block. When syncing the
+            // last epoch of chain (the epoch including head_root) we may query blocks descendant of
+            // that block. Depending on the final spec we should edit this logic to not request
+            // above `target_head_slot`.
+            SyncingChainType::Head => Some(self.target_head_root),
+            SyncingChainType::Finalized => None,
+            SyncingChainType::Backfill => None,
+        }
+    }
+
     /// Removes a peer from the chain.
     /// If the peer has active batches, those are considered failed and re-requested.
     pub fn remove_peer(
@@ -1062,7 +1075,8 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             if let Entry::Vacant(entry) = self.batches.entry(epoch) {
                 if let Some(peer) = idle_peers.pop() {
                     let batch_type = network.batch_type(epoch);
-                    let optimistic_batch = BatchInfo::new(&epoch, EPOCHS_PER_BATCH, batch_type);
+                    let optimistic_batch =
+                        BatchInfo::new(&epoch, EPOCHS_PER_BATCH, self.end_block_root(), batch_type);
                     entry.insert(optimistic_batch);
                     self.send_batch(network, epoch, peer)?;
                 }
@@ -1164,7 +1178,12 @@ impl<T: BeaconChainTypes> SyncingChain<T> {
             }
             Entry::Vacant(entry) => {
                 let batch_type = network.batch_type(batch_id);
-                entry.insert(BatchInfo::new(&batch_id, EPOCHS_PER_BATCH, batch_type));
+                entry.insert(BatchInfo::new(
+                    &batch_id,
+                    EPOCHS_PER_BATCH,
+                    self.end_block_root(),
+                    batch_type,
+                ));
                 self.to_be_downloaded += EPOCHS_PER_BATCH;
                 Some(batch_id)
             }

--- a/beacon_node/network/src/sync/tests/range.rs
+++ b/beacon_node/network/src/sync/tests/range.rs
@@ -10,8 +10,8 @@ use beacon_chain::test_utils::{AttestationStrategy, BlockStrategy};
 use beacon_chain::{block_verification_types::RpcBlock, EngineState, NotifyExecutionLayer};
 use beacon_processor::WorkType;
 use lighthouse_network::rpc::methods::{
-    BlobsByRangeRequest, DataColumnsByRangeRequest, OldBlocksByRangeRequest,
-    OldBlocksByRangeRequestV2,
+    BlobsByRangeRequest, BlobsByRangeRequestV1, DataColumnsByRangeRequest,
+    DataColumnsByRangeRequestV1, OldBlocksByRangeRequest, OldBlocksByRangeRequestV2,
 };
 use lighthouse_network::rpc::{RequestType, StatusMessage};
 use lighthouse_network::service::api_types::{
@@ -237,9 +237,9 @@ impl TestRig {
                 NetworkMessage::SendRequest {
                     peer_id,
                     request:
-                        RequestType::DataColumnsByRange(DataColumnsByRangeRequest {
-                            start_slot, ..
-                        }),
+                        RequestType::DataColumnsByRange(DataColumnsByRangeRequest::V1(
+                            DataColumnsByRangeRequestV1 { start_slot, .. },
+                        )),
                     request_id: AppRequestId::Sync(SyncRequestId::DataColumnsByRange(id)),
                 } if filter_f(*peer_id, *start_slot) => Some((*id, *peer_id)),
                 _ => None,
@@ -255,7 +255,7 @@ impl TestRig {
                 .pop_received_network_event(|ev| match ev {
                     NetworkMessage::SendRequest {
                         peer_id,
-                        request: RequestType::BlobsByRange(BlobsByRangeRequest { start_slot, .. }),
+                        request: RequestType::BlobsByRange(BlobsByRangeRequest::V1(BlobsByRangeRequestV1 { start_slot, .. })),
                         request_id: AppRequestId::Sync(SyncRequestId::BlobsByRange(id)),
                     } if filter_f(*peer_id, *start_slot) => Some((*id, *peer_id)),
                     _ => None,

--- a/consensus/proto_array/src/proto_array_fork_choice.rs
+++ b/consensus/proto_array/src/proto_array_fork_choice.rs
@@ -856,8 +856,16 @@ impl ProtoArrayForkChoice {
     }
 
     /// See `ProtoArray::iter_nodes`
-    pub fn iter_nodes<'a>(&'a self, block_root: &Hash256) -> Iter<'a> {
+    pub fn iter_nodes(&self, block_root: &Hash256) -> Iter {
         self.proto_array.iter_nodes(block_root)
+    }
+
+    /// See `ProtoArray::iter_block_roots`
+    pub fn iter_block_roots(
+        &self,
+        block_root: &Hash256,
+    ) -> impl Iterator<Item = (Hash256, Slot)> + use<'_> {
+        self.proto_array.iter_block_roots(block_root)
     }
 
     pub fn as_bytes(&self) -> Vec<u8> {


### PR DESCRIPTION
## Issue Addressed

_@AgeManning pointed to me that we can have experimental ReqResp protocols in Lighthouse :) so here we go_

Implements 
- https://github.com/ethereum/consensus-specs/pull/3845

a new ReqResp protocol to make have better attributability of malicious sync peers when range syncing. See the spec PR for more details

## Proposed Changes

Since the spec is not agreed upon yet, this PR implements a new namespaces "feature" protocol suffixed by the spec PR number: `BlocksByRangeV2_3845`, `BlobsByRangeV1_3845`, `DataColumnsByRangeV1_3845`. Note that we may have a new `BlocksByRangeV3` protocol in the future before the 3845 feature is merged, thus having `BlocksByRangeV2_3845` and `BlocksByRangeV3_3845`.

These new protocol can exist in Lighthouse nodes only who will use them between themselves. They can also be deprecated in the future without coordination if the feature is merged or abandoned.

**Requester changes**

On a syncing chain of type Head that with peers with a Status message (head_root, head_slot), include `head_root` in the request.

**Server changes**

- I cherry-picked https://github.com/sigp/lighthouse/pull/7058 + https://github.com/sigp/lighthouse/pull/7066 to have fork-choice access

Then instead of querying the fork-choice for blocks with the head root, query by the request block_root.