### PR TITLE
Fix descent from split check

### DIFF
--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -1783,10 +1783,17 @@ pub fn check_block_is_finalized_checkpoint_or_descendant<
     block: B,
 ) -> Result<B, BlockError> {
     // If we have a split block newer than finalization then we also ban blocks which are not
-    // descended from that split block.
+    // descended from that split block. It's important not to try checking `is_descendant` if
+    // finality is ahead of the split and the split block has been pruned, as `is_descendant` will
+    // return `false` in this case.
+    let finalized_slot = fork_choice
+        .finalized_checkpoint()
+        .epoch
+        .start_slot(T::EthSpec::slots_per_epoch());
     let split = chain.store.get_split_info();
-    let is_descendant_from_split_block =
-        split.slot == 0 || fork_choice.is_descendant(split.block_root, block.parent_root());
+    let is_descendant_from_split_block = split.slot == 0
+        || split.slot <= finalized_slot
+        || fork_choice.is_descendant(split.block_root, block.parent_root());
 
     if fork_choice.is_finalized_checkpoint_or_descendant(block.parent_root())
         && is_descendant_from_split_block


### PR DESCRIPTION
## Issue Addressed

Fix an issue on Holesky after true finalization was reached, whereby blocks on the canonical chain were rejected due to "not descending from the split block".

I think the issue here is that `is_descendant` will return `false` for any `ancestor_root` that has been pruned. Once we got true finality back fork choice got pruned before the split block was updated on some/most nodes, so they hit this error case.

## Proposed Changes

Only do the `is_descent` check if the `split.slot` is greater than the `finalized_slot`, or equivalently, set `is_descendant_from_split_block` when `split.slot <= finalized_slot`.
