### PR TITLE
Remove duplicate sync_tolerance_epochs config

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -149,7 +149,6 @@ pub struct Config {
     #[serde(with = "eth2::types::serde_status_code")]
     pub duplicate_block_status_code: StatusCode,
     pub target_peers: usize,
-    pub sync_tolerance_epochs: Option<u64>,
 }
 
 impl Default for Config {
@@ -165,7 +164,6 @@ impl Default for Config {
             enable_beacon_processor: true,
             duplicate_block_status_code: StatusCode::ACCEPTED,
             target_peers: 100,
-            sync_tolerance_epochs: None,
         }
     }
 }

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -8,7 +8,7 @@ use beacon_chain::graffiti_calculator::GraffitiOrigin;
 use beacon_chain::TrustedSetup;
 use clap::{parser::ValueSource, ArgMatches, Id};
 use clap_utils::flags::DISABLE_MALLOC_TUNING_FLAG;
-use clap_utils::{parse_flag, parse_optional, parse_required};
+use clap_utils::{parse_flag, parse_required};
 use client::{ClientConfig, ClientGenesis};
 use directory::{DEFAULT_BEACON_NODE_DIR, DEFAULT_NETWORK_DIR, DEFAULT_ROOT_DIR};
 use environment::RuntimeContext;
@@ -174,9 +174,6 @@ pub fn get_config<E: EthSpec>(
 
         client_config.http_api.duplicate_block_status_code =
             parse_required(cli_args, "http-duplicate-block-status")?;
-
-        client_config.http_api.sync_tolerance_epochs =
-            parse_optional(cli_args, "sync-tolerance-epochs")?;
     }
 
     if cli_args.get_flag("light-client-server") {


### PR DESCRIPTION
## Proposed Changes

Delete duplicate sync tolerance epoch config in the HTTP API which is unused.

We introduced the `sync-tolerance-epoch` flag in this PR:

- https://github.com/sigp/lighthouse/pull/7030

Then refined it in this PR:

- https://github.com/sigp/lighthouse/pull/7044

Somewhere in the merge of `release-v7.0.0` into `unstable`, the config from the original PR which had been deleted came back. I think I resolved these conflicts, so my bad.
