### PR TITLE
Change `genesis-state-url-timeout`

### DIFF
--- a/book/src/help_bn.md
+++ b/book/src/help_bn.md
@@ -167,7 +167,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --graffiti <GRAFFITI>
           Specify your custom graffiti to be included in blocks. Defaults to the
           current version and commit, truncated to fit in 32 bytes.

--- a/book/src/help_general.md
+++ b/book/src/help_general.md
@@ -52,7 +52,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --log-format <FORMAT>
           Specifies the log format used when emitting logs to the terminal.
           [possible values: JSON]

--- a/book/src/help_vc.md
+++ b/book/src/help_vc.md
@@ -50,7 +50,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --graffiti <GRAFFITI>
           Specify your custom graffiti to be included in blocks.
       --graffiti-file <GRAFFITI-FILE>

--- a/book/src/help_vm.md
+++ b/book/src/help_vm.md
@@ -49,7 +49,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --log-format <FORMAT>
           Specifies the log format used when emitting logs to the terminal.
           [possible values: JSON]

--- a/book/src/help_vm_create.md
+++ b/book/src/help_vm_create.md
@@ -56,7 +56,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --log-format <FORMAT>
           Specifies the log format used when emitting logs to the terminal.
           [possible values: JSON]

--- a/book/src/help_vm_import.md
+++ b/book/src/help_vm_import.md
@@ -37,7 +37,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --keystore-file <PATH_TO_KEYSTORE_FILE>
           The path to a keystore JSON file to be imported to the validator
           client. This file is usually created using staking-deposit-cli or

--- a/book/src/help_vm_move.md
+++ b/book/src/help_vm_move.md
@@ -45,7 +45,7 @@ Options:
           then this value will be ignored.
       --genesis-state-url-timeout <SECONDS>
           The timeout in seconds for the request to --genesis-state-url.
-          [default: 180]
+          [default: 300]
       --log-format <FORMAT>
           Specifies the log format used when emitting logs to the terminal.
           [possible values: JSON]

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -387,7 +387,7 @@ fn main() {
                     "The timeout in seconds for the request to --genesis-state-url.",
                 )
                 .action(ArgAction::Set)
-                .default_value("180")
+                .default_value("300")
                 .global(true)
                 .display_order(0)
         )

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2743,7 +2743,7 @@ fn genesis_state_url_default() {
         .run_with_zero_port()
         .with_config(|config| {
             assert_eq!(config.genesis_state_url, None);
-            assert_eq!(config.genesis_state_url_timeout, Duration::from_secs(180));
+            assert_eq!(config.genesis_state_url_timeout, Duration::from_secs(300));
         });
 }
 


### PR DESCRIPTION
## Issue Addressed

Timeouts sometimes occur on downloading the Holeksy genesis state from AWS, we've had reputable outside reports on this.  
It's around 200MB and hosted in APAC, it makes sense to bump the default, at least for Holesky. 

## Proposed Changes

Bump default timeout from 180 to 300 secs

## Additional Info

After interop, we noticed an outsized bill for this AWS bucket. This change could prevent or alleviate this in the future, if there are ever lots of genesis syncs on Holeksy again. 