### PR TITLE
Slasher HTTP API to import attestations from blocks

### DIFF
--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -4537,10 +4537,15 @@ pub fn serve<T: BeaconChainTypes>(
                 task_spawner.blocking_response_task(Priority::P0, move || {
                     if let Some(block) = deserialize_block_payload::<T>(payload) {
                         if let Some(attestations) = export_indexed_attestations(block, chain) {
-                            return Ok(warp::reply::json(&attestations));
+                            return Ok::<_, warp::reject::Rejection>(
+                                warp::reply::json(&api_types::GenericResponse::from(attestations))
+                                    .into_response(),
+                            );
                         }
                     }
-                    Ok(warp::reply::json(&()))
+                    return Err(warp_utils::reject::custom_server_error(
+                        "Unable to export attestations".to_string(),
+                    ));
                 })
             },
         );
@@ -4548,7 +4553,7 @@ pub fn serve<T: BeaconChainTypes>(
     // POST lighthouse/slasher/import_block
     let post_lighthouse_slasher_import_block = warp::path("lighthouse")
         .and(warp::path("slasher"))
-        .and(warp::path("export_attestations"))
+        .and(warp::path("import_block"))
         .and(warp_utils::json::json())
         .and(warp::path::end())
         .and(task_spawner_filter.clone())

--- a/beacon_node/http_api/src/lib.rs
+++ b/beacon_node/http_api/src/lib.rs
@@ -20,6 +20,7 @@ mod produce_block;
 mod proposer_duties;
 mod publish_attestations;
 mod publish_blocks;
+mod slasher;
 mod standard_block_rewards;
 mod state_id;
 mod sync_committee_rewards;
@@ -64,6 +65,10 @@ pub use publish_blocks::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use slasher::{
+    deserialize_block_payload, export_indexed_attestations, import_block,
+    import_indexed_attestations,
+};
 use slog::{crit, debug, error, info, warn, Logger};
 use slot_clock::SlotClock;
 use ssz::Encode;
@@ -87,10 +92,10 @@ use tokio_stream::{
 use types::{
     fork_versioned_response::EmptyMetadata, Attestation, AttestationData, AttestationShufflingId,
     AttesterSlashing, BeaconStateError, ChainSpec, CommitteeCache, ConfigAndPreset, Epoch, EthSpec,
-    ForkName, ForkVersionedResponse, Hash256, ProposerPreparationData, ProposerSlashing,
-    RelativeEpoch, SignedAggregateAndProof, SignedBlindedBeaconBlock, SignedBlsToExecutionChange,
-    SignedContributionAndProof, SignedValidatorRegistrationData, SignedVoluntaryExit, Slot,
-    SyncCommitteeMessage, SyncContributionData,
+    ForkName, ForkVersionedResponse, Hash256, IndexedAttestation, ProposerPreparationData,
+    ProposerSlashing, RelativeEpoch, SignedAggregateAndProof, SignedBlindedBeaconBlock,
+    SignedBlsToExecutionChange, SignedContributionAndProof, SignedValidatorRegistrationData,
+    SignedVoluntaryExit, Slot, SyncCommitteeMessage, SyncContributionData,
 };
 use validator::pubkey_to_validator_index;
 use version::{
@@ -4500,6 +4505,65 @@ pub fn serve<T: BeaconChainTypes>(
             },
         );
 
+    // POST lighthouse/slasher/import_attestations
+    let post_lighthouse_slasher_import_attestations = warp::path("lighthouse")
+        .and(warp::path("slasher"))
+        .and(warp::path("import_attestations"))
+        .and(warp_utils::json::json())
+        .and(warp::path::end())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |indexed_attestations: Vec<IndexedAttestation<T::EthSpec>>,
+             task_spawner: TaskSpawner<T::EthSpec>,
+             chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_response_task(Priority::P0, move || {
+                    import_indexed_attestations(indexed_attestations, chain);
+                    Ok(warp::reply::json(&()))
+                })
+            },
+        );
+
+    // POST lighthouse/slasher/export_attestations
+    let post_lighthouse_slasher_export_attestations = warp::path("lighthouse")
+        .and(warp::path("slasher"))
+        .and(warp::path("export_attestations"))
+        .and(warp_utils::json::json())
+        .and(warp::path::end())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |payload: Value, task_spawner: TaskSpawner<T::EthSpec>, chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_response_task(Priority::P0, move || {
+                    if let Some(block) = deserialize_block_payload::<T>(payload) {
+                        if let Some(attestations) = export_indexed_attestations(block, chain) {
+                            return Ok(warp::reply::json(&attestations));
+                        }
+                    }
+                    Ok(warp::reply::json(&()))
+                })
+            },
+        );
+
+    // POST lighthouse/slasher/import_block
+    let post_lighthouse_slasher_import_block = warp::path("lighthouse")
+        .and(warp::path("slasher"))
+        .and(warp::path("export_attestations"))
+        .and(warp_utils::json::json())
+        .and(warp::path::end())
+        .and(task_spawner_filter.clone())
+        .and(chain_filter.clone())
+        .then(
+            |payload: Value, task_spawner: TaskSpawner<T::EthSpec>, chain: Arc<BeaconChain<T>>| {
+                task_spawner.blocking_response_task(Priority::P0, move || {
+                    if let Some(block) = deserialize_block_payload::<T>(payload) {
+                        import_block(block, chain);
+                    }
+                    Ok(warp::reply::json(&()))
+                })
+            },
+        );
+
     let get_events = eth_v1
         .and(warp::path("events"))
         .and(warp::path::end())
@@ -4780,6 +4844,9 @@ pub fn serve<T: BeaconChainTypes>(
                     .uor(post_lighthouse_block_rewards)
                     .uor(post_lighthouse_ui_validator_metrics)
                     .uor(post_lighthouse_ui_validator_info)
+                    .uor(post_lighthouse_slasher_import_block)
+                    .uor(post_lighthouse_slasher_export_attestations)
+                    .uor(post_lighthouse_slasher_import_attestations)
                     .recover(warp_utils::reject::handle_rejection),
             ),
         )

--- a/beacon_node/http_api/src/slasher.rs
+++ b/beacon_node/http_api/src/slasher.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use beacon_chain::{BeaconChain, BeaconChainTypes};
+use either::Either;
+use serde_json::Value;
+use types::{IndexedAttestation, SignedBeaconBlock, SignedBlindedBeaconBlock};
+
+#[allow(clippy::type_complexity)]
+pub fn deserialize_block_payload<T: BeaconChainTypes>(
+    payload: Value,
+) -> Option<Either<SignedBeaconBlock<T::EthSpec>, SignedBlindedBeaconBlock<T::EthSpec>>> {
+    if let Ok(block) = serde_json::from_value::<SignedBeaconBlock<T::EthSpec>>(payload.clone()) {
+        Some(Either::Left(block))
+    } else {
+        serde_json::from_value::<SignedBlindedBeaconBlock<T::EthSpec>>(payload)
+            .ok()
+            .map(Either::Right)
+    }
+}
+
+pub fn import_indexed_attestations<T: BeaconChainTypes>(
+    indexed_attestations: Vec<IndexedAttestation<T::EthSpec>>,
+    chain: Arc<BeaconChain<T>>,
+) {
+    if let Some(slasher) = chain.slasher.as_ref() {
+        for indexed_attestation in indexed_attestations {
+            slasher.accept_attestation(indexed_attestation);
+        }
+    }
+}
+
+pub fn export_indexed_attestations<T: BeaconChainTypes>(
+    block: Either<SignedBeaconBlock<T::EthSpec>, SignedBlindedBeaconBlock<T::EthSpec>>,
+    chain: Arc<BeaconChain<T>>,
+) -> Option<Vec<IndexedAttestation<T::EthSpec>>> {
+    let (block_root, attestation_epoch) = match &block {
+        Either::Left(full_block) => (full_block.canonical_root(), full_block.message().epoch()),
+        Either::Right(blinded_block) => (
+            blinded_block.canonical_root(),
+            blinded_block.message().epoch(),
+        ),
+    };
+
+    chain
+        .with_committee_cache(block_root, attestation_epoch, |committee_cache, _| {
+            let mut result = vec![];
+            let attestations = match &block {
+                Either::Left(full_block) => full_block.message().body().attestations(),
+                Either::Right(blinded_block) => blinded_block.message().body().attestations(),
+            };
+            for attestation in attestations {
+                if let Ok(committees) =
+                    committee_cache.get_beacon_committees_at_slot(attestation.data().slot)
+                {
+                    result.extend(IndexedAttestation::from_attestation(
+                        attestation,
+                        &committees,
+                    ))
+                };
+            }
+            Ok(result)
+        })
+        .ok()
+}
+
+pub fn import_block<T: BeaconChainTypes>(
+    block: Either<SignedBeaconBlock<T::EthSpec>, SignedBlindedBeaconBlock<T::EthSpec>>,
+    chain: Arc<BeaconChain<T>>,
+) {
+    if let Some(slasher) = chain.slasher.as_ref() {
+        match block {
+            Either::Left(full_block) => {
+                slasher.accept_block_header(full_block.signed_block_header())
+            }
+            Either::Right(blinded_block) => {
+                slasher.accept_block_header(blinded_block.signed_block_header())
+            }
+        }
+    }
+}

--- a/beacon_node/http_api/tests/tests.rs
+++ b/beacon_node/http_api/tests/tests.rs
@@ -5714,6 +5714,75 @@ impl ApiTester {
         self
     }
 
+    pub async fn test_post_lighthouse_slasher_import_block(self) -> Self {
+        let block = self
+            .chain
+            .block_at_slot(Slot::new(CHAIN_LENGTH - 1), WhenSlotSkipped::Prev)
+            .unwrap()
+            .unwrap();
+
+        self.client
+            .post_lighthouse_slasher_import_block(Either::Right(block.clone()))
+            .await
+            .unwrap();
+
+        self
+    }
+
+    pub async fn test_post_lighthouse_slasher_import_attestations(self) -> Self {
+        let block = self
+            .chain
+            .block_at_slot(Slot::new(CHAIN_LENGTH - 1), WhenSlotSkipped::Prev)
+            .unwrap()
+            .unwrap();
+
+        // export attestations that we can then import
+        let indexed_attestations = self
+            .client
+            .post_lighthouse_slasher_export_attestations(Either::Right(block.clone()))
+            .await
+            .unwrap()
+            .data;
+
+        self.client
+            .post_lighthouse_slasher_import_attestations(indexed_attestations)
+            .await
+            .unwrap();
+
+        self
+    }
+
+    pub async fn test_post_lighthouse_slasher_export_attestations(self) -> Self {
+        let block = self
+            .chain
+            .block_at_slot(Slot::new(CHAIN_LENGTH - 1), WhenSlotSkipped::Prev)
+            .unwrap()
+            .unwrap();
+
+        let indexed_attestations = self
+            .client
+            .post_lighthouse_slasher_export_attestations(Either::Right(block.clone()))
+            .await
+            .unwrap()
+            .data;
+
+        let attestations = block.message().body().attestations();
+
+        let mut num_set_agg_bits = 0;
+        for attestation in attestations {
+            num_set_agg_bits += attestation.num_set_aggregation_bits();
+        }
+
+        let mut num_attesting_indices = 0;
+        for indexed_attestation in indexed_attestations {
+            num_attesting_indices += indexed_attestation.attesting_indices_len();
+        }
+
+        assert_eq!(num_set_agg_bits, num_attesting_indices);
+
+        self
+    }
+
     pub async fn test_post_lighthouse_liveness(self) -> Self {
         let epoch = self.chain.epoch().unwrap();
         let head_state = self.chain.head_beacon_state_cloned();
@@ -7264,6 +7333,12 @@ async fn lighthouse_endpoints() {
         .test_post_lighthouse_database_reconstruct()
         .await
         .test_post_lighthouse_liveness()
+        .await
+        .test_post_lighthouse_slasher_export_attestations()
+        .await
+        .test_post_lighthouse_slasher_import_attestations()
+        .await
+        .test_post_lighthouse_slasher_import_block()
         .await;
 }
 

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -409,7 +409,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
 
     /// Process an unaggregated attestation requiring conversion.
     ///
-    /// This function performs the conversion, and if successfull queues a new message to be
+    /// This function performs the conversion, and if successful queues a new message to be
     /// processed by `process_gossip_attestation`. If unsuccessful due to block unavailability,
     /// a retry message will be pushed to the `reprocess_tx` if it is `Some`.
     #[allow(clippy::too_many_arguments)]

--- a/common/eth2/src/lib.rs
+++ b/common/eth2/src/lib.rs
@@ -2474,6 +2474,79 @@ impl BeaconNodeHttpClient {
         .await
     }
 
+    /// `POST lighthouse/import_attestations`
+    pub async fn post_lighthouse_slasher_import_attestations<E: EthSpec>(
+        &self,
+        attestations: Vec<IndexedAttestation<E>>,
+    ) -> Result<(), Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("slasher")
+            .push("import_attestations");
+
+        self.post_with_timeout(path, &attestations, self.timeouts.liveness)
+            .await?;
+
+        Ok(())
+    }
+
+    /// `POST lighthouse/export_attestations`
+    pub async fn post_lighthouse_slasher_export_attestations<E: EthSpec>(
+        &self,
+        block: Either<SignedBeaconBlock<E>, SignedBlindedBeaconBlock<E>>,
+    ) -> Result<GenericResponse<Vec<IndexedAttestation<E>>>, Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("slasher")
+            .push("export_attestations");
+
+        let attestations = match block {
+            Either::Left(signed_block) => {
+                self.post_with_timeout_and_response(path, &signed_block, self.timeouts.liveness)
+                    .await?
+            }
+            Either::Right(blinded_block) => {
+                self.post_with_timeout_and_response(path, &blinded_block, self.timeouts.liveness)
+                    .await?
+            }
+        };
+
+        Ok(attestations)
+    }
+
+    /// `POST lighthouse/import_block`
+    pub async fn post_lighthouse_slasher_import_block<E: EthSpec>(
+        &self,
+        block: Either<SignedBeaconBlock<E>, SignedBlindedBeaconBlock<E>>,
+    ) -> Result<(), Error> {
+        let mut path = self.server.full.clone();
+
+        path.path_segments_mut()
+            .map_err(|()| Error::InvalidUrl(self.server.clone()))?
+            .push("lighthouse")
+            .push("slasher")
+            .push("import_block");
+
+        match block {
+            Either::Left(signed_block) => {
+                self.post_with_timeout(path, &signed_block, self.timeouts.liveness)
+                    .await?;
+            }
+            Either::Right(blinded_block) => {
+                self.post_with_timeout(path, &blinded_block, self.timeouts.liveness)
+                    .await?;
+            }
+        };
+
+        Ok(())
+    }
+
     /// `POST validator/liveness/{epoch}`
     pub async fn post_validator_liveness_epoch(
         &self,

--- a/consensus/types/src/attestation.rs
+++ b/consensus/types/src/attestation.rs
@@ -394,6 +394,14 @@ impl<E: EthSpec> AttestationBase<E> {
         self.signature.add_assign_aggregate(&other.signature);
     }
 
+    pub fn get_aggregation_bits(&self) -> Vec<u64> {
+        self.aggregation_bits
+            .iter()
+            .enumerate()
+            .filter_map(|(index, bit)| if bit { Some(index as u64) } else { None })
+            .collect()
+    }
+
     /// Signs `self`, setting the `committee_position`'th bit of `aggregation_bits` to `true`.
     ///
     /// Returns an `AlreadySigned` error if the `committee_position`'th bit is already `true`.

--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -1,4 +1,7 @@
-use crate::{test_utils::TestRandom, AggregateSignature, AttestationData, EthSpec, VariableList};
+use crate::{
+    test_utils::TestRandom, AggregateSignature, AttestationData, AttestationRef, BeaconCommittee,
+    EthSpec, VariableList,
+};
 use core::slice::Iter;
 use derivative::Derivative;
 use serde::{Deserialize, Serialize};
@@ -131,6 +134,54 @@ impl<E: EthSpec> IndexedAttestation<E> {
             }
             Self::Electra(att) => att,
         }
+    }
+
+    pub fn from_attestation(
+        attestation: AttestationRef<E>,
+        committees: &[BeaconCommittee],
+    ) -> Vec<IndexedAttestation<E>> {
+        let (committee_indices, aggregation_bits) = match attestation {
+            AttestationRef::Base(base_attestation) => (
+                vec![base_attestation.data.index],
+                base_attestation.get_aggregation_bits(),
+            ),
+            AttestationRef::Electra(electra_attestation) => (
+                electra_attestation.get_committee_indices(),
+                electra_attestation.get_aggregation_bits(),
+            ),
+        };
+
+        committee_indices
+            .iter()
+            .filter_map(|&index| committees.get(index as usize))
+            .map(|beacon_committee| {
+                let attesting_indices: Vec<u64> = beacon_committee
+                    .committee
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, &validator_index)| {
+                        aggregation_bits.get(i).map(|_| validator_index as u64)
+                    })
+                    .collect();
+
+                match &attestation {
+                    AttestationRef::Base(base_attestation) => {
+                        IndexedAttestation::Base(IndexedAttestationBase {
+                            attesting_indices: attesting_indices.into(),
+                            data: base_attestation.data.clone(),
+                            signature: base_attestation.signature.clone(),
+                        })
+                    }
+                    AttestationRef::Electra(electra_attestation) => {
+                        IndexedAttestation::Electra(IndexedAttestationElectra {
+                            attesting_indices: attesting_indices.into(),
+                            data: electra_attestation.data.clone(),
+                            signature: electra_attestation.signature.clone(),
+                        })
+                    }
+                }
+            })
+            .collect()
     }
 }
 

--- a/consensus/types/src/indexed_attestation.rs
+++ b/consensus/types/src/indexed_attestation.rs
@@ -136,6 +136,8 @@ impl<E: EthSpec> IndexedAttestation<E> {
         }
     }
 
+    /// Returns a list of indexed attestations from the provided `attestation`. Note that
+    /// if the `attestation` is unaggregated, only one indexed attestation will be created.
     pub fn from_attestation(
         attestation: AttestationRef<E>,
         committees: &[BeaconCommittee],


### PR DESCRIPTION
## Issue Addressed

Closes #7110 

## Proposed Changes

Adds three new endpoints

- `/lighthouse/slasher/import_attestations`: imports indexed attestations to the slasher db
- `/lighthouse/slasher/export_attestations`: exports indexed attestations from a provided block
- `/lighthouse/slasher/import_block`: imports a block header to the slasher db

## Additional Info

The endpoints don't ever fail, we might want to handle specific failures and return relevant status codes in those cases.

TODOs:
- [x] Add test cases
- [ ] Test on holesky
- [ ] Support SSZ?
