### PR TITLE
Remove gas-limit flag dependency on builder-proposals

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -487,7 +487,6 @@ fn no_gas_limit_flag() {
 fn gas_limit_flag() {
     CommandLineTest::new()
         .flag("gas-limit", Some("600"))
-        .flag("builder-proposals", None)
         .run()
         .with_config(|config| assert_eq!(config.validator_store.gas_limit, Some(600)));
 }

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -389,7 +389,6 @@ pub struct ValidatorClient {
         long,
         value_name = "INTEGER",
         default_value_t = 30_000_000,
-        requires = "builder_proposals",
         help = "The gas limit to be used in all builder proposals for all validators managed \
                 by this validator client. Note this will not necessarily be used if the gas limit \
                 set here moves too far from the previous block's gas limit.",


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Even though the VC doesn't affect gas limit without using an external builder, I don't think there's a hard requirement at the cli flag level for the requires("builder-proposals"). 

This is also causing issues with some devops scenarios as raised by @barnabasbusa