### PR TITLE
Feat: add new `--advertise-false-custody-group-count` cli flag for PeerDAS testing

### DIFF
--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -150,7 +150,6 @@ pub struct Config {
     pub idontwant_message_size_threshold: usize,
 
     /// Advertise a false custody group count in metadata.
-    /// Makes peers think this node custodies more columns than it actually does.
     pub advertise_false_custody_group_count: Option<u64>,
 }
 

--- a/beacon_node/lighthouse_network/src/config.rs
+++ b/beacon_node/lighthouse_network/src/config.rs
@@ -148,6 +148,10 @@ pub struct Config {
     /// Configuration for the minimum message size for which IDONTWANT messages are send in the mesh.
     /// Lower the value reduces the optimization effect of the IDONTWANT messages.
     pub idontwant_message_size_threshold: usize,
+
+    /// Advertise a false custody group count in metadata.
+    /// Makes peers think this node custodies more columns than it actually does.
+    pub advertise_false_custody_group_count: Option<u64>,
 }
 
 impl Config {
@@ -372,6 +376,7 @@ impl Default for Config {
             invalid_block_storage: None,
             inbound_rate_limiter_config: None,
             idontwant_message_size_threshold: DEFAULT_IDONTWANT_MESSAGE_SIZE_THRESHOLD,
+            advertise_false_custody_group_count: None,
         }
     }
 }

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -203,7 +203,8 @@ impl<E: EthSpec> Network<E> {
             if let Some(false_count) = config.advertise_false_custody_group_count {
                 false_count
             } else {
-                ctx.chain_spec.custody_group_count(config.subscribe_all_data_column_subnets)
+                ctx.chain_spec
+                    .custody_group_count(config.subscribe_all_data_column_subnets)
             }
         });
         let meta_data = utils::load_or_build_metadata(&config.network_dir, custody_group_count);

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -199,8 +199,23 @@ impl<E: EthSpec> Network<E> {
 
         // Construct the metadata
         let custody_group_count = ctx.chain_spec.is_peer_das_scheduled().then(|| {
-            ctx.chain_spec
-                .custody_group_count(config.subscribe_all_data_column_subnets)
+            // Use the false custody group count if specified, otherwise use the normal one
+            if let Some(false_count) = config.advertise_false_custody_group_count {
+                // Ensure the false count is within valid range
+                if (ctx.chain_spec.custody_requirement..=ctx.chain_spec.number_of_custody_groups).contains(&false_count) {
+                    warn!(log, "Using false custody group count for testing"; "count" => false_count);
+                    false_count
+                } else {
+                    warn!(log, "Specified false custody group count is out of valid range, using normal count"; 
+                        "false_count" => false_count,
+                        "min" => ctx.chain_spec.custody_requirement,
+                        "max" => ctx.chain_spec.number_of_custody_groups
+                    );
+                    ctx.chain_spec.custody_group_count(config.subscribe_all_data_column_subnets)
+                }
+            } else {
+                ctx.chain_spec.custody_group_count(config.subscribe_all_data_column_subnets)
+            }
         });
         let meta_data = utils::load_or_build_metadata(&config.network_dir, custody_group_count);
         let seq_number = *meta_data.seq_number();

--- a/beacon_node/lighthouse_network/src/service/mod.rs
+++ b/beacon_node/lighthouse_network/src/service/mod.rs
@@ -201,18 +201,7 @@ impl<E: EthSpec> Network<E> {
         let custody_group_count = ctx.chain_spec.is_peer_das_scheduled().then(|| {
             // Use the false custody group count if specified, otherwise use the normal one
             if let Some(false_count) = config.advertise_false_custody_group_count {
-                // Ensure the false count is within valid range
-                if (ctx.chain_spec.custody_requirement..=ctx.chain_spec.number_of_custody_groups).contains(&false_count) {
-                    warn!(log, "Using false custody group count for testing"; "count" => false_count);
-                    false_count
-                } else {
-                    warn!(log, "Specified false custody group count is out of valid range, using normal count"; 
-                        "false_count" => false_count,
-                        "min" => ctx.chain_spec.custody_requirement,
-                        "max" => ctx.chain_spec.number_of_custody_groups
-                    );
-                    ctx.chain_spec.custody_group_count(config.subscribe_all_data_column_subnets)
-                }
+                false_count
             } else {
                 ctx.chain_spec.custody_group_count(config.subscribe_all_data_column_subnets)
             }

--- a/beacon_node/src/cli.rs
+++ b/beacon_node/src/cli.rs
@@ -69,6 +69,20 @@ pub fn cli_app() -> Command {
                 .display_order(0)
         )
         .arg(
+            // TODO(das): remove this before PeerDAS release
+            Arg::new("advertise-false-custody-group-count")
+                .long("advertise-false-custody-group-count")
+                .action(ArgAction::Set)
+                .help_heading(FLAG_HEADER)
+                .help("TESTING ONLY: Advertise a false custody group count in metadata. Makes \
+                        peers think this node custodies more columns than it actually does. \
+                        It's used to override the actual custody group count when building node metadata, \
+                        but only when PeerDAS is scheduled and the value is within valid range.
+                        DO NOT USE IN PRODUCTION.")
+                .hide(true)
+                .display_order(0)
+        )
+        .arg(
             Arg::new("enable-sampling")
                 .long("enable-sampling")
                 .action(ArgAction::SetTrue)

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -30,7 +30,7 @@ use std::str::FromStr;
 use std::time::Duration;
 use tracing::{error, info, warn};
 use types::graffiti::GraffitiString;
-use types::{Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes};
+use types::{ChainSpec, Checkpoint, Epoch, EthSpec, Hash256, PublicKeyBytes};
 
 const PURGE_DB_CONFIRMATION: &str = "confirm";
 
@@ -48,17 +48,6 @@ pub fn get_config<E: EthSpec>(
     let spec = &context.eth2_config.spec;
 
     let mut client_config = ClientConfig::default();
-
-    if let Some(false_custody_group_count) =
-        clap_utils::parse_optional::<u64>(cli_args, "advertise-false-custody-group-count")?
-    {
-        if false_custody_group_count > spec.number_of_custody_groups {
-            return Err(format!(
-                "advertise-false-custody-group-count ({}) exceeds number_of_custody_groups ({})",
-                false_custody_group_count, spec.number_of_custody_groups
-            ));
-        }
-    }
 
     // Update the client's data directory
     client_config.set_data_dir(get_data_dir(cli_args));
@@ -119,7 +108,12 @@ pub fn get_config<E: EthSpec>(
 
     let data_dir_ref = client_config.data_dir().clone();
 
-    set_network_config(&mut client_config.network, cli_args, &data_dir_ref)?;
+    set_network_config(
+        &mut client_config.network,
+        cli_args,
+        &data_dir_ref,
+        Some(spec),
+    )?;
 
     /*
      * Staking flag
@@ -1155,6 +1149,7 @@ pub fn set_network_config(
     config: &mut NetworkConfig,
     cli_args: &ArgMatches,
     data_dir: &Path,
+    spec: Option<&ChainSpec>,
 ) -> Result<(), String> {
     // If a network dir has been specified, override the `datadir` definition.
     if let Some(dir) = cli_args.get_one::<String>("network-dir") {
@@ -1184,6 +1179,14 @@ pub fn set_network_config(
     if let Some(false_custody_group_count) =
         clap_utils::parse_optional(cli_args, "advertise-false-custody-group-count")?
     {
+        if let Some(spec) = spec {
+            if false_custody_group_count > spec.number_of_custody_groups {
+                return Err(format!(
+                    "advertise-false-custody-group-count ({}) exceeds number_of_custody_groups ({})",
+                    false_custody_group_count, spec.number_of_custody_groups
+                ));
+            }
+        }
         config.advertise_false_custody_group_count = Some(false_custody_group_count);
     }
 

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -1170,6 +1170,12 @@ pub fn set_network_config(
 
     config.set_listening_addr(parse_listening_addresses(cli_args)?);
 
+    if let Some(false_custody_group_count) =
+        clap_utils::parse_optional(cli_args, "advertise-false-custody-group-count")?
+    {
+        config.advertise_false_custody_group_count = Some(false_custody_group_count);
+    }
+
     // A custom target-peers command will overwrite the --proposer-only default.
     if let Some(target_peers_str) = cli_args.get_one::<String>("target-peers") {
         config.target_peers = target_peers_str

--- a/beacon_node/src/config.rs
+++ b/beacon_node/src/config.rs
@@ -49,6 +49,17 @@ pub fn get_config<E: EthSpec>(
 
     let mut client_config = ClientConfig::default();
 
+    if let Some(false_custody_group_count) =
+        clap_utils::parse_optional::<u64>(cli_args, "advertise-false-custody-group-count")?
+    {
+        if false_custody_group_count > spec.number_of_custody_groups {
+            return Err(format!(
+                "advertise-false-custody-group-count ({}) exceeds number_of_custody_groups ({})",
+                false_custody_group_count, spec.number_of_custody_groups
+            ));
+        }
+    }
+
     // Update the client's data directory
     client_config.set_data_dir(get_data_dir(cli_args));
 

--- a/boot_node/src/config.rs
+++ b/boot_node/src/config.rs
@@ -53,7 +53,9 @@ impl<E: EthSpec> BootNodeConfig<E> {
 
         let mut network_config = NetworkConfig::default();
 
-        set_network_config(&mut network_config, matches, &data_dir)?;
+        let spec = eth2_network_config.chain_spec::<E>()?;
+
+        set_network_config(&mut network_config, matches, &data_dir, Some(&spec))?;
 
         // Set the Enr Discovery ports to the listening ports if not present.
         if let Some(listening_addr_v4) = network_config.listen_addrs().v4() {

--- a/lighthouse/tests/beacon_node.rs
+++ b/lighthouse/tests/beacon_node.rs
@@ -2033,6 +2033,20 @@ fn malicious_withhold_count_flag() {
         .with_config(|config| assert_eq!(config.chain.malicious_withhold_count, 128));
 }
 
+#[test]
+fn advertise_false_custody_group_count_flag() {
+    CommandLineTest::new()
+        .flag("advertise-false-custody-group-count", Some("128"))
+        .run_with_zero_port()
+        .with_config(|config| {
+            let network_config = &config.network;
+            assert_eq!(
+                network_config.advertise_false_custody_group_count,
+                Some(128)
+            );
+        });
+}
+
 // Tests for Slasher flags.
 // Using `--slasher-max-db-size` to work around https://github.com/sigp/lighthouse/issues/2342
 #[test]


### PR DESCRIPTION
## Issue Addressed

Closes: #6973

## Proposed Changes

This PR adds a new CLI flag `--advertise-false-custody-group-count` that allows nodes to advertise a false custody group count in their metadata for PeerDAS testing purposes. This enables testing scenarios where nodes need to mislead peers about their custody group count without altering the actual RPC logic.

## Additional Info

### When this flag is set:
- If PeerDAS is scheduled, the node will advertise the specified custody group count in its metadata.
- If the specified count is outside the valid range (`<= number_of_custody_groups`), the node will log a warning and use the normal count.
- If PeerDAS is not scheduled, the flag has no effect.


### Future Work
This flag is intended to be temporary and will be removed before the PeerDAS release, as indicated by the TODO comment.
