### PR TITLE
Add error reason on UnknownValidator

### DIFF
--- a/beacon_node/beacon_chain/src/beacon_chain.rs
+++ b/beacon_node/beacon_chain/src/beacon_chain.rs
@@ -1584,7 +1584,7 @@ impl<T: BeaconChainTypes> BeaconChain<T> {
     pub fn validator_pubkey(&self, validator_index: usize) -> Result<Option<PublicKey>, Error> {
         let pubkey_cache = self.validator_pubkey_cache.read();
 
-        Ok(pubkey_cache.get(validator_index).cloned())
+        Ok(pubkey_cache.get(validator_index).ok().cloned())
     }
 
     /// As per `Self::validator_pubkey`, but returns `PublicKeyBytes`.

--- a/beacon_node/beacon_chain/src/blob_verification.rs
+++ b/beacon_node/beacon_chain/src/blob_verification.rs
@@ -82,7 +82,7 @@ pub enum GossipBlobError {
     /// ## Peer scoring
     ///
     /// The blob is invalid and the peer is faulty.
-    UnknownValidator(u64),
+    UnknownValidator(u64, /* reason */ String),
 
     /// The provided blob is not from a later slot than its parent.
     ///
@@ -547,7 +547,7 @@ pub fn validate_blob_sidecar_for_gossip<T: BeaconChainTypes, O: ObservationStrat
 
         let pubkey = pubkey_cache
             .get(proposer_index)
-            .ok_or_else(|| GossipBlobError::UnknownValidator(proposer_index as u64))?;
+            .map_err(|e| GossipBlobError::UnknownValidator(proposer_index as u64, e))?;
         signed_block_header.verify_signature::<T::EthSpec>(
             pubkey,
             &fork,

--- a/beacon_node/beacon_chain/src/block_verification.rs
+++ b/beacon_node/beacon_chain/src/block_verification.rs
@@ -77,6 +77,7 @@ use safe_arith::ArithError;
 use slot_clock::SlotClock;
 use ssz::Encode;
 use ssz_derive::{Decode, Encode};
+use state_processing::block_signature_verifier::GetPubkeyFnReturn;
 use state_processing::per_block_processing::{errors::IntoWithIndex, is_merge_transition_block};
 use state_processing::{
     block_signature_verifier::{BlockSignatureVerifier, Error as BlockSignatureVerifierError},
@@ -213,7 +214,7 @@ pub enum BlockError {
     /// ## Peer scoring
     ///
     /// The block is invalid and the peer is faulty.
-    UnknownValidator(u64),
+    UnknownValidator(u64, /* reason */ String),
     /// A signature in the block is invalid
     ///
     /// ## Peer scoring
@@ -959,7 +960,7 @@ impl<T: BeaconChainTypes> GossipVerifiedBlock<T> {
             let pubkey_cache = get_validator_pubkey_cache(chain)?;
             let pubkey = pubkey_cache
                 .get(block.message().proposer_index() as usize)
-                .ok_or_else(|| BlockError::UnknownValidator(block.message().proposer_index()))?;
+                .map_err(|e| BlockError::UnknownValidator(block.message().proposer_index(), e))?;
             block.verify_signature(
                 Some(block_root),
                 pubkey,
@@ -1109,7 +1110,10 @@ impl<T: BeaconChainTypes> SignatureVerifiedBlock<T> {
             // Re-verify the proposer signature in isolation to attribute fault
             let pubkey = pubkey_cache
                 .get(block.message().proposer_index() as usize)
-                .ok_or_else(|| BlockError::UnknownValidator(block.message().proposer_index()))?;
+                .map_err(|e| {
+                    // TODO: bound by state
+                    BlockError::UnknownValidator(block.message().proposer_index(), e)
+                })?;
             if block.as_block().verify_signature(
                 Some(block_root),
                 pubkey,
@@ -1980,7 +1984,7 @@ fn load_parent<T: BeaconChainTypes, B: AsBlock<T::EthSpec>>(
 /// This trait is used to unify `BlockError` and `GossipBlobError`.
 pub trait BlockBlobError: From<BeaconStateError> + From<BeaconChainError> + Debug {
     fn not_later_than_parent_error(block_slot: Slot, state_slot: Slot) -> Self;
-    fn unknown_validator_error(validator_index: u64) -> Self;
+    fn unknown_validator_error(validator_index: u64, e: String) -> Self;
     fn proposer_signature_invalid() -> Self;
 }
 
@@ -1992,8 +1996,8 @@ impl BlockBlobError for BlockError {
         }
     }
 
-    fn unknown_validator_error(validator_index: u64) -> Self {
-        BlockError::UnknownValidator(validator_index)
+    fn unknown_validator_error(validator_index: u64, e: String) -> Self {
+        BlockError::UnknownValidator(validator_index, e)
     }
 
     fn proposer_signature_invalid() -> Self {
@@ -2009,8 +2013,8 @@ impl BlockBlobError for GossipBlobError {
         }
     }
 
-    fn unknown_validator_error(validator_index: u64) -> Self {
-        GossipBlobError::UnknownValidator(validator_index)
+    fn unknown_validator_error(validator_index: u64, e: String) -> Self {
+        GossipBlobError::UnknownValidator(validator_index, e)
     }
 
     fn proposer_signature_invalid() -> Self {
@@ -2026,8 +2030,8 @@ impl BlockBlobError for GossipDataColumnError {
         }
     }
 
-    fn unknown_validator_error(validator_index: u64) -> Self {
-        GossipDataColumnError::UnknownValidator(validator_index)
+    fn unknown_validator_error(validator_index: u64, e: String) -> Self {
+        GossipDataColumnError::UnknownValidator(validator_index, e)
     }
 
     fn proposer_signature_invalid() -> Self {
@@ -2098,7 +2102,7 @@ fn get_signature_verifier<'a, T: BeaconChainTypes>(
 ) -> BlockSignatureVerifier<
     'a,
     T::EthSpec,
-    impl Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone,
+    impl Fn(usize) -> GetPubkeyFnReturn<'a> + Clone,
     impl Fn(&'a PublicKeyBytes) -> Option<Cow<'a, PublicKey>>,
 > {
     let get_pubkey = move |validator_index| {
@@ -2108,7 +2112,10 @@ fn get_signature_verifier<'a, T: BeaconChainTypes>(
                 .get(validator_index)
                 .map(Cow::Borrowed)
         } else {
-            None
+            Err(format!(
+                "AboveStateRegistryLimit({})",
+                state.validators().len()
+            ))
         }
     };
 
@@ -2116,7 +2123,7 @@ fn get_signature_verifier<'a, T: BeaconChainTypes>(
         // Map compressed pubkey to validator index.
         let validator_index = validator_pubkey_cache.get_index(pk_bytes)?;
         // Map validator index to pubkey (respecting guard on unknown validators).
-        get_pubkey(validator_index)
+        get_pubkey(validator_index).ok()
     };
 
     BlockSignatureVerifier::new(state, get_pubkey, decompressor, spec)
@@ -2132,7 +2139,7 @@ pub fn verify_header_signature<T: BeaconChainTypes, Err: BlockBlobError>(
     let proposer_pubkey = get_validator_pubkey_cache(chain)?
         .get(header.message.proposer_index as usize)
         .cloned()
-        .ok_or(Err::unknown_validator_error(header.message.proposer_index))?;
+        .map_err(|e| Err::unknown_validator_error(header.message.proposer_index, e))?;
     let head_fork = chain.canonical_head.cached_head().head_fork();
 
     if header.verify_signature::<T::EthSpec>(

--- a/beacon_node/beacon_chain/src/data_column_verification.rs
+++ b/beacon_node/beacon_chain/src/data_column_verification.rs
@@ -44,7 +44,7 @@ pub enum GossipDataColumnError {
     /// ## Peer scoring
     ///
     /// The data column is invalid and the peer is faulty.
-    UnknownValidator(u64),
+    UnknownValidator(u64, /* reason */ String),
     /// The provided data column is not from a later slot than its parent.
     ///
     /// ## Peer scoring
@@ -623,7 +623,7 @@ fn verify_proposer_and_signature<T: BeaconChainTypes>(
 
         let pubkey = pubkey_cache
             .get(proposer_index)
-            .ok_or_else(|| GossipDataColumnError::UnknownValidator(proposer_index as u64))?;
+            .map_err(|e| GossipDataColumnError::UnknownValidator(proposer_index as u64, e))?;
         let signed_block_header = &data_column.signed_block_header;
         signed_block_header.verify_signature::<T::EthSpec>(
             pubkey,

--- a/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
+++ b/beacon_node/beacon_chain/src/validator_pubkey_cache.rs
@@ -135,13 +135,17 @@ impl<T: BeaconChainTypes> ValidatorPubkeyCache<T> {
     }
 
     /// Get the public key for a validator with index `i`.
-    pub fn get(&self, i: usize) -> Option<&PublicKey> {
-        self.pubkeys.get(i)
+    /// Returns an Err with the length of the cache at query time.
+    pub fn get(&self, i: usize) -> Result<&PublicKey, String> {
+        self.pubkeys
+            .get(i)
+            .ok_or(format!("UnknownIndexInCache({})", self.pubkeys.len()))
     }
 
     /// Get the `PublicKey` for a validator with `PublicKeyBytes`.
     pub fn get_pubkey_from_pubkey_bytes(&self, pubkey: &PublicKeyBytes) -> Option<&PublicKey> {
-        self.get_index(pubkey).and_then(|index| self.get(index))
+        self.get_index(pubkey)
+            .and_then(|index| self.get(index).ok())
     }
 
     /// Get the public key (in bytes form) for a validator with index `i`.
@@ -255,7 +259,7 @@ mod test {
                 );
             } else {
                 assert_eq!(
-                    cache.get(i),
+                    cache.get(i).ok(),
                     None,
                     "should not get pubkey for out of bounds index",
                 );

--- a/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
+++ b/beacon_node/network/src/network_beacon_processor/gossip_methods.rs
@@ -817,7 +817,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         )
                     }
                     GossipDataColumnError::ProposalSignatureInvalid
-                    | GossipDataColumnError::UnknownValidator(_)
+                    | GossipDataColumnError::UnknownValidator { .. }
                     | GossipDataColumnError::ProposerIndexMismatch { .. }
                     | GossipDataColumnError::IsNotLaterThanParent { .. }
                     | GossipDataColumnError::InvalidSubnetId { .. }
@@ -965,7 +965,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
                         )
                     }
                     GossipBlobError::ProposalSignatureInvalid
-                    | GossipBlobError::UnknownValidator(_)
+                    | GossipBlobError::UnknownValidator { .. }
                     | GossipBlobError::ProposerIndexMismatch { .. }
                     | GossipBlobError::BlobIsNotLaterThanParent { .. }
                     | GossipBlobError::InvalidSubnet { .. }
@@ -1394,7 +1394,7 @@ impl<T: BeaconChainTypes> NetworkBeaconProcessor<T> {
             | Err(e @ BlockError::IncorrectBlockProposer { .. })
             | Err(e @ BlockError::BlockSlotLimitReached)
             | Err(e @ BlockError::NonLinearSlots)
-            | Err(e @ BlockError::UnknownValidator(_))
+            | Err(e @ BlockError::UnknownValidator { .. })
             | Err(e @ BlockError::PerBlockProcessingError(_))
             | Err(e @ BlockError::NonLinearParentRoots)
             | Err(e @ BlockError::BlockIsNotLaterThanParent { .. })

--- a/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
+++ b/consensus/state_processing/src/per_block_processing/block_signature_verifier.rs
@@ -66,6 +66,8 @@ impl From<BlockOperationError<AttestationInvalid>> for Error {
     }
 }
 
+pub type GetPubkeyFnReturn<'a> = std::result::Result<Cow<'a, PublicKey>, String>;
+
 /// Reads the BLS signatures and keys from a `SignedBeaconBlock`, storing them as a `Vec<SignatureSet>`.
 ///
 /// This allows for optimizations related to batch BLS operations (see the
@@ -73,7 +75,7 @@ impl From<BlockOperationError<AttestationInvalid>> for Error {
 pub struct BlockSignatureVerifier<'a, E, F, D>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a> + Clone,
     D: Fn(&'a PublicKeyBytes) -> Option<Cow<'a, PublicKey>>,
 {
     get_pubkey: F,
@@ -97,7 +99,7 @@ impl<'a> From<Vec<SignatureSet<'a>>> for ParallelSignatureSets<'a> {
 impl<'a, E, F, D> BlockSignatureVerifier<'a, E, F, D>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a> + Clone,
     D: Fn(&'a PublicKeyBytes) -> Option<Cow<'a, PublicKey>>,
 {
     /// Create a new verifier without any included signatures. See the `include...` functions to

--- a/consensus/state_processing/src/per_block_processing/signature_sets.rs
+++ b/consensus/state_processing/src/per_block_processing/signature_sets.rs
@@ -2,6 +2,7 @@
 //! validated individually, or alongside in others in a potentially cheaper bulk operation.
 //!
 //! This module exposes one function to extract each type of `SignatureSet` from a `BeaconBlock`.
+use crate::block_signature_verifier::GetPubkeyFnReturn;
 use bls::SignatureSet;
 use ssz::DecodeError;
 use std::borrow::Cow;
@@ -26,7 +27,7 @@ pub enum Error {
     BeaconStateError(BeaconStateError),
     /// Attempted to find the public key of a validator that does not exist. You cannot distinguish
     /// between an error and an invalid block in this case.
-    ValidatorUnknown(u64),
+    ValidatorUnknown(u64, /* reason */ String),
     /// Attempted to find the public key of a validator that does not exist. You cannot distinguish
     /// between an error and an invalid block in this case.
     ValidatorPubkeyUnknown(PublicKeyBytes),
@@ -53,10 +54,7 @@ impl From<BeaconStateError> for Error {
 }
 
 /// Helper function to get a public key from a `state`.
-pub fn get_pubkey_from_state<E>(
-    state: &BeaconState<E>,
-    validator_index: usize,
-) -> Option<Cow<PublicKey>>
+pub fn get_pubkey_from_state<E>(state: &BeaconState<E>, validator_index: usize) -> GetPubkeyFnReturn
 where
     E: EthSpec,
 {
@@ -68,6 +66,10 @@ where
             pk
         })
         .map(Cow::Owned)
+        .ok_or(format!(
+            "Index above registry len {}",
+            state.validators().len()
+        ))
 }
 
 /// A signature set that is valid if a block was signed by the expected block producer.
@@ -81,7 +83,7 @@ pub fn block_proposal_signature_set<'a, E, F, Payload: AbstractExecPayload<E>>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let block = signed_block.message();
 
@@ -124,7 +126,7 @@ pub fn block_proposal_signature_set_from_parts<'a, E, F, Payload: AbstractExecPa
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     // Verify that the `SignedBeaconBlock` instantiation matches the fork at `signed_block.slot()`.
     signed_block
@@ -151,7 +153,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         signed_block.signature(),
-        get_pubkey(proposer_index as usize).ok_or(Error::ValidatorUnknown(proposer_index))?,
+        get_pubkey(proposer_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(proposer_index, e))?,
         message,
     ))
 }
@@ -192,7 +195,7 @@ pub fn randao_signature_set<'a, E, F, Payload: AbstractExecPayload<E>>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let proposer_index = if let Some(proposer_index) = verified_proposer_index {
         proposer_index
@@ -214,7 +217,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         block.body().randao_reveal(),
-        get_pubkey(proposer_index as usize).ok_or(Error::ValidatorUnknown(proposer_index))?,
+        get_pubkey(proposer_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(proposer_index, e))?,
         message,
     ))
 }
@@ -228,7 +232,7 @@ pub fn proposer_slashing_signature_set<'a, E, F>(
 ) -> Result<(SignatureSet<'a>, SignatureSet<'a>)>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let proposer_index = proposer_slashing.signed_header_1.message.proposer_index as usize;
 
@@ -236,13 +240,15 @@ where
         block_header_signature_set(
             state,
             &proposer_slashing.signed_header_1,
-            get_pubkey(proposer_index).ok_or(Error::ValidatorUnknown(proposer_index as u64))?,
+            get_pubkey(proposer_index)
+                .map_err(|e| Error::ValidatorUnknown(proposer_index as u64, e))?,
             spec,
         ),
         block_header_signature_set(
             state,
             &proposer_slashing.signed_header_2,
-            get_pubkey(proposer_index).ok_or(Error::ValidatorUnknown(proposer_index as u64))?,
+            get_pubkey(proposer_index)
+                .map_err(|e| Error::ValidatorUnknown(proposer_index as u64, e))?,
             spec,
         ),
     ))
@@ -277,12 +283,13 @@ pub fn indexed_attestation_signature_set<'a, 'b, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let mut pubkeys = Vec::with_capacity(indexed_attestation.attesting_indices_len());
     for &validator_idx in indexed_attestation.attesting_indices_iter() {
         pubkeys.push(
-            get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?,
+            get_pubkey(validator_idx as usize)
+                .map_err(|e| Error::ValidatorUnknown(validator_idx, e))?,
         );
     }
 
@@ -310,12 +317,13 @@ pub fn indexed_attestation_signature_set_from_pubkeys<'a, 'b, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let mut pubkeys = Vec::with_capacity(indexed_attestation.attesting_indices_len());
     for &validator_idx in indexed_attestation.attesting_indices_iter() {
         pubkeys.push(
-            get_pubkey(validator_idx as usize).ok_or(Error::ValidatorUnknown(validator_idx))?,
+            get_pubkey(validator_idx as usize)
+                .map_err(|e| Error::ValidatorUnknown(validator_idx, e))?,
         );
     }
 
@@ -340,7 +348,7 @@ pub fn attester_slashing_signature_sets<'a, E, F>(
 ) -> Result<(SignatureSet<'a>, SignatureSet<'a>)>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>> + Clone,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a> + Clone,
 {
     Ok((
         indexed_attestation_signature_set(
@@ -382,7 +390,7 @@ pub fn exit_signature_set<'a, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let exit = &signed_exit.message;
     let proposer_index = exit.validator_index as usize;
@@ -407,7 +415,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         &signed_exit.signature,
-        get_pubkey(proposer_index).ok_or(Error::ValidatorUnknown(proposer_index as u64))?,
+        get_pubkey(proposer_index)
+            .map_err(|e| Error::ValidatorUnknown(proposer_index as u64, e))?,
         message,
     ))
 }
@@ -421,7 +430,7 @@ pub fn signed_aggregate_selection_proof_signature_set<'a, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let slot = signed_aggregate_and_proof.message().aggregate().data().slot;
 
@@ -436,7 +445,8 @@ where
     let validator_index = signed_aggregate_and_proof.message().aggregator_index();
     Ok(SignatureSet::single_pubkey(
         signature,
-        get_pubkey(validator_index as usize).ok_or(Error::ValidatorUnknown(validator_index))?,
+        get_pubkey(validator_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(validator_index, e))?,
         message,
     ))
 }
@@ -450,7 +460,7 @@ pub fn signed_aggregate_signature_set<'a, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let target_epoch = signed_aggregate_and_proof
         .message()
@@ -471,7 +481,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         signature,
-        get_pubkey(validator_index as usize).ok_or(Error::ValidatorUnknown(validator_index))?,
+        get_pubkey(validator_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(validator_index, e))?,
         message,
     ))
 }
@@ -485,7 +496,7 @@ pub fn signed_sync_aggregate_selection_proof_signature_set<'a, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let slot = signed_contribution_and_proof.message.contribution.slot;
 
@@ -508,7 +519,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         signature,
-        get_pubkey(validator_index as usize).ok_or(Error::ValidatorUnknown(validator_index))?,
+        get_pubkey(validator_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(validator_index, e))?,
         message,
     ))
 }
@@ -522,7 +534,7 @@ pub fn signed_sync_aggregate_signature_set<'a, E, F>(
 ) -> Result<SignatureSet<'a>>
 where
     E: EthSpec,
-    F: Fn(usize) -> Option<Cow<'a, PublicKey>>,
+    F: Fn(usize) -> GetPubkeyFnReturn<'a>,
 {
     let epoch = signed_contribution_and_proof
         .message
@@ -542,7 +554,8 @@ where
 
     Ok(SignatureSet::single_pubkey(
         signature,
-        get_pubkey(validator_index as usize).ok_or(Error::ValidatorUnknown(validator_index))?,
+        get_pubkey(validator_index as usize)
+            .map_err(|e| Error::ValidatorUnknown(validator_index, e))?,
         message,
     ))
 }

--- a/lcli/src/transition_blocks.rs
+++ b/lcli/src/transition_blocks.rs
@@ -371,7 +371,7 @@ fn do_transition<E: EthSpec>(
             // Map compressed pubkey to validator index.
             let validator_index = validator_pubkey_cache.get_index(pk_bytes)?;
             // Map validator index to pubkey (respecting guard on unknown validators).
-            get_pubkey(validator_index)
+            get_pubkey(validator_index).ok()
         };
 
         let t = Instant::now();


### PR DESCRIPTION
## Issue Addressed

This PR would be helpful to debug a current `UnknownValidator` error. Includes a hint on the size of the validator pubkey cache at the time of query.
