### PR TITLE
availability when fetching sync committees

### DIFF
--- a/beacon_node/http_api/src/sync_committees.rs
+++ b/beacon_node/http_api/src/sync_committees.rs
@@ -108,11 +108,13 @@ fn duties_from_state_load<T: BeaconChainTypes>(
         // have to transition the head to start of the current period).
         //
         // We also need to ensure that the load slot is after the Altair fork.
+        let anchor_info = chain.store.get_anchor_info();
+        let state_upper_limit = anchor_info.state_upper_limit;
         let load_slot = max(
-            chain.spec.epochs_per_sync_committee_period * sync_committee_period.saturating_sub(1),
-            altair_fork_epoch,
-        )
-        .start_slot(T::EthSpec::slots_per_epoch());
+            max(chain.spec.epochs_per_sync_committee_period * sync_committee_period.saturating_sub(1), 
+                altair_fork_epoch),
+            state_upper_limit
+        ).start_slot(T::EthSpec::slots_per_epoch());
 
         let state = chain.state_at_slot(load_slot, StateSkipConfig::WithoutStateRoots)?;
 

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -2,6 +2,7 @@ use crate::local_network::LocalNetwork;
 use node_test_rig::eth2::types::{BlockId, FinalityCheckpointsData, StateId};
 use std::time::Duration;
 use types::{Epoch, EthSpec, ExecPayload, ExecutionBlockHash, Slot, Unsigned};
+use crate::hot_cold_db::HotColdDB;
 
 /// Checks that all of the validators have on-boarded by the start of the second eth1 voting
 /// period.
@@ -172,15 +173,17 @@ pub async fn verify_fork_version<E: EthSpec>(
 /// have full aggregates.
 pub async fn verify_full_sync_aggregates_up_to<E: EthSpec>(
     network: LocalNetwork<E>,
+    db: Arc<HotColdDB<E, LevelDB<E>, LevelDB<E>>>,
     sync_committee_start_slot: Slot,
     upto_slot: Slot,
     slot_duration: Duration,
 ) -> Result<(), String> {
     slot_delay(upto_slot, slot_duration).await;
-    let remote_nodes = network.remote_nodes()?;
-    let remote_node = remote_nodes.first().unwrap();
+    let anchor_info = db.get_anchor_info();
+    let state_upper_limit = anchor_info.state_upper_limit;
+    let effective_start_slot = max(sync_committee_start_slot, state_upper_limit);
 
-    for slot in sync_committee_start_slot.as_u64()..=upto_slot.as_u64() {
+    for slot in effective_start_slot.as_u64()..=upto_slot.as_u64() {
         let sync_aggregate_count = remote_node
             .get_beacon_blocks::<E>(BlockId::Slot(Slot::new(slot)))
             .await

--- a/testing/simulator/src/checks.rs
+++ b/testing/simulator/src/checks.rs
@@ -182,6 +182,8 @@ pub async fn verify_full_sync_aggregates_up_to<E: EthSpec>(
     let anchor_info = db.get_anchor_info();
     let state_upper_limit = anchor_info.state_upper_limit;
     let effective_start_slot = max(sync_committee_start_slot, state_upper_limit);
+    let remote_nodes = network.remote_nodes()?;
+    let remote_node = remote_nodes.first().unwrap();
 
     for slot in effective_start_slot.as_u64()..=upto_slot.as_u64() {
         let sync_aggregate_count = remote_node


### PR DESCRIPTION
## Issue Addressed

Which issue # does this PR address?
This is dummy pr for this issue #7115 

## Proposed Changes

Added logic to consider `state_upper_limit` when verifying full sync aggregates.
Modified `verify_full_sync_aggregates_up_to` to use `state_upper_limit` from `AnchorInfo`.
Introduced `HotColdDB` dependency to fetch `AnchorInfo`.

## Additional Info

PR is not final yet, but feel free to review it and give some pointers!
