### PR TITLE
Remove unnecessary `filter_layer` in logger builder

### DIFF
--- a/lighthouse/environment/src/tracing_common.rs
+++ b/lighthouse/environment/src/tracing_common.rs
@@ -3,7 +3,7 @@ use clap::ArgMatches;
 use logging::Libp2pDiscv5TracingLayer;
 use logging::{tracing_logging_layer::LoggingLayer, SSELoggingComponents};
 use std::process;
-use tracing_subscriber::filter::{EnvFilter, FilterFn, LevelFilter};
+use tracing_subscriber::filter::{FilterFn, LevelFilter};
 use types::EthSpec;
 
 pub fn construct_logger<E: EthSpec>(
@@ -12,7 +12,6 @@ pub fn construct_logger<E: EthSpec>(
     environment_builder: EnvironmentBuilder<E>,
 ) -> (
     EnvironmentBuilder<E>,
-    EnvFilter,
     Libp2pDiscv5TracingLayer,
     LoggingLayer,
     LoggingLayer,
@@ -32,16 +31,11 @@ pub fn construct_logger<E: EthSpec>(
     let (builder, file_logging_layer, stdout_logging_layer, sse_logging_layer_opt) =
         environment_builder.init_tracing(logger_config.clone(), logfile_prefix);
 
-    let filter_layer = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new(logger_config.debug_level.to_string().to_lowercase()))
-        .unwrap();
-
     let dependency_log_filter =
         FilterFn::new(filter_dependency_log as fn(&tracing::Metadata<'_>) -> bool);
 
     (
         builder,
-        filter_layer,
         libp2p_discv5_layer,
         file_logging_layer,
         stdout_logging_layer,

--- a/lighthouse/src/main.rs
+++ b/lighthouse/src/main.rs
@@ -592,7 +592,6 @@ fn run<E: EthSpec>(
 
     let (
         builder,
-        filter_layer,
         libp2p_discv5_layer,
         file_logging_layer,
         stdout_logging_layer,
@@ -622,7 +621,6 @@ fn run<E: EthSpec>(
 
     let logging = tracing_subscriber::registry()
         .with(dependency_log_filter)
-        .with(filter_layer)
         .with(file_logging_layer.with_filter(logger_config.logfile_debug_level))
         .with(stdout_logging_layer.with_filter(logger_config.debug_level))
         .with(MetricsLayer)

--- a/testing/simulator/src/basic_sim.rs
+++ b/testing/simulator/src/basic_sim.rs
@@ -90,7 +90,6 @@ pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
 
     let (
         env_builder,
-        filter_layer,
         _libp2p_discv5_layer,
         file_logging_layer,
         stdout_logging_layer,
@@ -119,7 +118,6 @@ pub fn run_basic_sim(matches: &ArgMatches) -> Result<(), String> {
     );
 
     if let Err(e) = tracing_subscriber::registry()
-        .with(filter_layer)
         .with(file_logging_layer.with_filter(logger_config.logfile_debug_level))
         .with(stdout_logging_layer.with_filter(logger_config.debug_level))
         .with(MetricsLayer)

--- a/testing/simulator/src/fallback_sim.rs
+++ b/testing/simulator/src/fallback_sim.rs
@@ -94,7 +94,6 @@ pub fn run_fallback_sim(matches: &ArgMatches) -> Result<(), String> {
 
     let (
         env_builder,
-        filter_layer,
         libp2p_discv5_layer,
         file_logging_layer,
         stdout_logging_layer,
@@ -124,7 +123,6 @@ pub fn run_fallback_sim(matches: &ArgMatches) -> Result<(), String> {
 
     if let Err(e) = tracing_subscriber::registry()
         .with(dependency_log_filter)
-        .with(filter_layer)
         .with(file_logging_layer.with_filter(logger_config.logfile_debug_level))
         .with(stdout_logging_layer.with_filter(logger_config.debug_level))
         .with(libp2p_discv5_layer)


### PR DESCRIPTION
## Issue Addressed

https://github.com/sigp/lighthouse/issues/7146

## Proposed Changes

Removes `filter_layer` from the builder as this was acting as a "global minimum". We don't actually need this, since we are using more granular control in `stdout_logging_layer` and `file_logging_layer`. Removing this restores control of the logfiles level back to the `--logfile-debug-level` flag (and defaults to debug).

## Additional Info

Discv5 logs are still present in the output, so that is still an ongoing issue.
