### PR TITLE
Remove `discv5` logs from logfile output

### DIFF
--- a/lighthouse/environment/src/lib.rs
+++ b/lighthouse/environment/src/lib.rs
@@ -248,7 +248,7 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
                             config.log_format.clone(),
                             config.logfile_format.clone(),
                             config.extra_info,
-                            true,
+                            false,
                         )
                     }
                     Err(e) => {
@@ -264,7 +264,7 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
                             config.log_format.clone(),
                             config.logfile_format.clone(),
                             config.extra_info,
-                            true,
+                            false,
                         )
                     }
                 }
@@ -280,7 +280,7 @@ impl<E: EthSpec> EnvironmentBuilder<E> {
                     config.log_format.clone(),
                     config.logfile_format.clone(),
                     config.extra_info,
-                    true,
+                    false,
                 )
             }
         };


### PR DESCRIPTION
## Issue Addressed

#7146 

## Proposed Changes

Set `dep_logs` to false when building the `file_logging_layer`. This will remove both `discv5` and `libp2p` logs from the output.

## Additional Info

There's more cleanup required here but this is the simplest fix for now.
