### PR TITLE
Ensure sqlite and rusqlite are optional in `consensus/types`

### DIFF
--- a/consensus/types/Cargo.toml
+++ b/consensus/types/Cargo.toml
@@ -38,7 +38,7 @@ rand_xorshift = "0.3.0"
 rayon = { workspace = true }
 regex = { workspace = true }
 rpds = { workspace = true }
-rusqlite = { workspace = true }
+rusqlite = { workspace = true, optional = true }
 safe_arith = { workspace = true }
 serde = { workspace = true, features = ["rc"] }
 serde_json = { workspace = true }
@@ -64,7 +64,7 @@ tokio = { workspace = true }
 default = ["sqlite", "legacy-arith"]
 # Allow saturating arithmetic on slots and epochs. Enabled by default, but deprecated.
 legacy-arith = []
-sqlite = []
+sqlite = ["dep:rusqlite"]
 # The `arbitrary-fuzz` feature is a no-op provided for backwards compatibility.
 # For simplicity `Arbitrary` is now derived regardless of the feature's presence.
 arbitrary-fuzz = []


### PR DESCRIPTION
## Issue Addressed

Even though the `consensus/types` crate has a feature named `sqlite`, it unconditionally depends on the `rusqlite` crate, which then depends on the `sqlite` crate — even when the feature is disabled. When the feature is disabled, the code that imports from `rusqlite` is disabled, so this dependency is not needed when the feature is disabled.

This is not a problem for Lighthouse itself, but I’m interested in using the types defined here in a different Rust project, which depends on a conflicting version of the `sqlite` crate.

## Proposed Changes

Ensure that the dependency on `rusqlite` is only present when the `sqlite` feature is enabled.