### PR TITLE
Add missing `osaka-time` lcli param

### DIFF
--- a/lcli/src/main.rs
+++ b/lcli/src/main.rs
@@ -553,6 +553,15 @@ fn main() {
                                 until Prague is triggered on mainnet.")
                         .display_order(0)
                 )
+                .arg(
+                    Arg::new("osaka-time")
+                        .long("osaka-time")
+                        .value_name("UNIX_TIMESTAMP")
+                        .action(ArgAction::Set)
+                        .help("The payload timestamp that enables Osaka. No default is provided \
+                                until Osaka is triggered on mainnet.")
+                        .display_order(0)
+                )
         )
         .subcommand(
             Command::new("http-sync")


### PR DESCRIPTION
## Issue Addressed

Getting this when running lcli with `--osaka-time`:

```
error: unexpected argument '--osaka-time' found

  tip: a similar argument exists: '--shanghai-time'
```

This PR adds the missing `--osaka-time` option to `lcli`.
