### PR TITLE
Top-up pubkey cache on startup

### DIFF
--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -850,7 +850,7 @@ where
         let validator_pubkey_cache = self
             .validator_pubkey_cache
             .map(|mut validator_pubkey_cache| {
-                // If any validators weren't persisted to disk on previous runs, this will use the genesis_state to
+                // If any validators weren't persisted to disk on previous runs, this will use the head state to
                 // "top-up" the in-memory validator cache and its on-disk representation with any missing validators.
                 let pubkey_store_ops = validator_pubkey_cache
                     .import_new_pubkeys(&head_snapshot.beacon_state)

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -325,7 +325,7 @@ where
                 .unwrap_or_else(OperationPool::new),
         );
 
-        let pubkey_cache = ValidatorPubkeyCache::load_from_store(store.clone())
+        let pubkey_cache = ValidatorPubkeyCache::load_from_store(store)
             .map_err(|e| format!("Unable to open persisted pubkey cache: {:?}", e))?;
 
         self.genesis_block_root = Some(chain.genesis_block_root);

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -325,8 +325,19 @@ where
                 .unwrap_or_else(OperationPool::new),
         );
 
-        let pubkey_cache = ValidatorPubkeyCache::load_from_store(store)
+        let mut pubkey_cache = ValidatorPubkeyCache::load_from_store(store.clone())
             .map_err(|e| format!("Unable to open persisted pubkey cache: {:?}", e))?;
+
+        // If any validators weren't persisted to disk on previous runs, this will use the genesis_state to
+        // "top-up" the in-memory validator cache and its on-disk representation with any missing validators.
+        let pubkey_store_ops = pubkey_cache
+            .import_new_pubkeys(&genesis_state)
+            .map_err(|e| format!("Unable to top-up persisted pubkey cache {:?}", e))?;
+
+        // Write any missed validators to disk
+        store
+            .do_atomically_with_block_and_blobs_cache(pubkey_store_ops)
+            .map_err(|e| format!("Unable to write pubkeys to disk {:?}", e))?;
 
         self.genesis_block_root = Some(chain.genesis_block_root);
         self.genesis_state_root = Some(genesis_block.state_root());

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -855,11 +855,17 @@ where
                 let pubkey_store_ops = validator_pubkey_cache
                     .import_new_pubkeys(&head_snapshot.beacon_state)
                     .map_err(|e| format!("Unable to top-up persisted pubkey cache {:?}", e))?;
-                // Write any missed validators to disk
-                store
-                    .clone()
-                    .do_atomically_with_block_and_blobs_cache(pubkey_store_ops)
-                    .map_err(|e| format!("Unable to write pubkeys to disk {:?}", e))?;
+                if !pubkey_store_ops.is_empty() {
+                    // Write any missed validators to disk
+                    debug!(
+                        store.log,
+                        "Topping up validator pubkey cache";
+                        "missing_validators" => pubkey_store_ops.len()
+                    );
+                    store
+                        .do_atomically_with_block_and_blobs_cache(pubkey_store_ops)
+                        .map_err(|e| format!("Unable to write pubkeys to disk {:?}", e))?;
+                }
                 Ok(validator_pubkey_cache)
             })
             .unwrap_or_else(|| {

--- a/beacon_node/beacon_chain/src/builder.rs
+++ b/beacon_node/beacon_chain/src/builder.rs
@@ -325,19 +325,8 @@ where
                 .unwrap_or_else(OperationPool::new),
         );
 
-        let mut pubkey_cache = ValidatorPubkeyCache::load_from_store(store.clone())
+        let pubkey_cache = ValidatorPubkeyCache::load_from_store(store.clone())
             .map_err(|e| format!("Unable to open persisted pubkey cache: {:?}", e))?;
-
-        // If any validators weren't persisted to disk on previous runs, this will use the genesis_state to
-        // "top-up" the in-memory validator cache and its on-disk representation with any missing validators.
-        let pubkey_store_ops = pubkey_cache
-            .import_new_pubkeys(&genesis_state)
-            .map_err(|e| format!("Unable to top-up persisted pubkey cache {:?}", e))?;
-
-        // Write any missed validators to disk
-        store
-            .do_atomically_with_block_and_blobs_cache(pubkey_store_ops)
-            .map_err(|e| format!("Unable to write pubkeys to disk {:?}", e))?;
 
         self.genesis_block_root = Some(chain.genesis_block_root);
         self.genesis_state_root = Some(genesis_block.state_root());
@@ -858,10 +847,25 @@ where
             ));
         }
 
-        let validator_pubkey_cache = self.validator_pubkey_cache.map(Ok).unwrap_or_else(|| {
-            ValidatorPubkeyCache::new(&head_snapshot.beacon_state, store.clone())
-                .map_err(|e| format!("Unable to init validator pubkey cache: {:?}", e))
-        })?;
+        let validator_pubkey_cache = self
+            .validator_pubkey_cache
+            .map(|mut validator_pubkey_cache| {
+                // If any validators weren't persisted to disk on previous runs, this will use the genesis_state to
+                // "top-up" the in-memory validator cache and its on-disk representation with any missing validators.
+                let pubkey_store_ops = validator_pubkey_cache
+                    .import_new_pubkeys(&head_snapshot.beacon_state)
+                    .map_err(|e| format!("Unable to top-up persisted pubkey cache {:?}", e))?;
+                // Write any missed validators to disk
+                store
+                    .clone()
+                    .do_atomically_with_block_and_blobs_cache(pubkey_store_ops)
+                    .map_err(|e| format!("Unable to write pubkeys to disk {:?}", e))?;
+                Ok(validator_pubkey_cache)
+            })
+            .unwrap_or_else(|| {
+                ValidatorPubkeyCache::new(&head_snapshot.beacon_state, store.clone())
+                    .map_err(|e| format!("Unable to init validator pubkey cache: {:?}", e))
+            })?;
 
         let migrator_config = self.store_migrator_config.unwrap_or_default();
         let store_migrator = BackgroundMigrator::new(


### PR DESCRIPTION
## Issue Addressed

This is a workaround for #7216

## Proposed Changes

In the case of gaps between the in-memory pub key cache and its on-disk representation, use the head state on startup to "top-up" the cache/db w/ any missing validators
