### PR TITLE
Disable LevelDB snappy feature

### DIFF
--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -22,7 +22,7 @@ directory = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
 itertools = { workspace = true }
-leveldb = { version = "0.8.6", optional = true }
+leveldb = { version = "0.8.6", optional = true, default-features = false }
 logging = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true }


### PR DESCRIPTION
## Proposed Changes

Disable the `snappy` feature of LevelDB to prevent compilation issues with CMake 4.0, e.g.

https://github.com/sigp/lighthouse/actions/runs/14182783816/job/39732457274?pr=7231

We do not use Snappy compression in LevelDB, and do not need to compile this. This might also shave a few seconds off compilation!

## Additional Info

I thought maybe we'd need to bump the LevelDB version -- an old change of mine from here:

- https://github.com/skade/leveldb-sys/pull/29

But that PR doesn't actually fix the issue because it doesn't update the real culprit: the bundled version of `snappy`.

In future if we need more changes to LevelDB I think we'll have to release from our own fork, as the upstream Rust crates are essentially unmaintained.

I will merge this to `release-v7.0.0` and then to unstable to unblock CI.
