### PR TITLE
Backmerge apr 2

### DIFF
--- a/beacon_node/store/Cargo.toml
+++ b/beacon_node/store/Cargo.toml
@@ -22,7 +22,7 @@ directory = { workspace = true }
 ethereum_ssz = { workspace = true }
 ethereum_ssz_derive = { workspace = true }
 itertools = { workspace = true }
-leveldb = { version = "0.8.6", optional = true }
+leveldb = { version = "0.8.6", optional = true, default-features = false }
 logging = { workspace = true }
 lru = { workspace = true }
 metrics = { workspace = true }


### PR DESCRIPTION
## Proposed Changes

Backmerge `release-v7.0.0` to `unstable` for the inclusion of:

- https://github.com/sigp/lighthouse/pull/7235

This doesn't seem to be blocking CI for unstable at the moment, but if Github updates to CMake 4.0 it will start causing issues.

This PR needs to be merged manually (NOT squashed).