### PR TITLE
Return eth1_data early post transition

### DIFF
--- a/beacon_node/beacon_chain/src/eth1_chain.rs
+++ b/beacon_node/beacon_chain/src/eth1_chain.rs
@@ -369,6 +369,12 @@ pub struct DummyEth1ChainBackend<E: EthSpec>(PhantomData<E>);
 impl<E: EthSpec> Eth1ChainBackend<E> for DummyEth1ChainBackend<E> {
     /// Produce some deterministic junk based upon the current epoch.
     fn eth1_data(&self, state: &BeaconState<E>, _spec: &ChainSpec) -> Result<Eth1Data, Error> {
+        // [New in Electra:EIP6110]
+        if let Ok(deposit_requests_start_index) = state.deposit_requests_start_index() {
+            if state.eth1_deposit_index() == deposit_requests_start_index {
+                return Ok(state.eth1_data().clone());
+            }
+        }
         let current_epoch = state.current_epoch();
         let slots_per_voting_period = E::slots_per_eth1_voting_period() as u64;
         let current_voting_period: u64 = current_epoch.as_u64() / slots_per_voting_period;
@@ -467,6 +473,12 @@ impl<E: EthSpec> CachingEth1Backend<E> {
 
 impl<E: EthSpec> Eth1ChainBackend<E> for CachingEth1Backend<E> {
     fn eth1_data(&self, state: &BeaconState<E>, spec: &ChainSpec) -> Result<Eth1Data, Error> {
+        // [New in Electra:EIP6110]
+        if let Ok(deposit_requests_start_index) = state.deposit_requests_start_index() {
+            if state.eth1_deposit_index() == deposit_requests_start_index {
+                return Ok(state.eth1_data().clone());
+            }
+        }
         let period = E::SlotsPerEth1VotingPeriod::to_u64();
         let voting_period_start_slot = (state.slot() / period) * period;
         let voting_period_start_seconds = slot_start_seconds(

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -784,7 +784,6 @@ impl Service {
     ) -> Result<Option<RangeInclusive<u64>>, Error> {
         let follow_distance = self.cache_follow_distance();
         let latest_cached_block = self.latest_cached_block();
-        // 3415708
         let next_required_block = match head_type {
             HeadType::Deposit => self
                 .deposits()
@@ -852,7 +851,6 @@ impl Service {
         &self,
         new_block_numbers: Option<Option<RangeInclusive<u64>>>,
     ) -> Result<DepositCacheUpdateOutcome, Error> {
-        // 3415708
         let client = self.client();
         let deposit_contract_address = self.config().deposit_contract_address.clone();
 
@@ -902,12 +900,6 @@ impl Service {
              * Step 1. Download logs.
              */
             let block_range_ref = &block_range;
-            debug!(
-                self.log,
-                "Getting deposit logs in range";
-                "start" => block_range_ref.start,
-                "end" => block_range_ref.end,
-            );
             let logs = client
                 .get_deposit_logs_in_range(
                     deposit_contract_address_ref,
@@ -943,31 +935,12 @@ impl Service {
                 // a block, but not _all_ logs for that block). This scenario can cause the
                 // node to choose an invalid genesis state or propose an invalid block.
                 .try_for_each(|deposit_log| {
-                    match cache
+                    if let DepositCacheInsertOutcome::Inserted = cache
                         .cache
-                        .insert_log(deposit_log.clone())
-                        .map_err(Error::FailedToInsertDeposit) {
-                            Ok(DepositCacheInsertOutcome::Inserted) => {
-                                logs_imported += 1;
-                            }
-                            Ok(DepositCacheInsertOutcome::Duplicate) => {
-                                debug!(
-                                    self.log,
-                                    "Attempted to insert duplicate log";
-                                    "log" => ?deposit_log
-                                );
-                            }
-                            Err(err) => {
-                                debug!(
-                                    self.log,
-                                    "Error while inserting deposit log";
-                                    "deposit_log" => ?deposit_log
-                                );
-                                return Err(err);
-                            }
-
-                        }
+                        .insert_log(deposit_log)
+                        .map_err(Error::FailedToInsertDeposit)?
                     {
+                        logs_imported += 1;
                     }
 
                     Ok::<_, Error>(())
@@ -1178,7 +1151,6 @@ fn relevant_block_range(
     latest_cached_block: Option<&Eth1Block>,
     spec: &ChainSpec,
 ) -> Result<Option<RangeInclusive<u64>>, Error> {
-    // 3415708
     // If the latest cached block is lagging the head block by more than `cache_follow_distance`
     // times the expected block time then the eth1 block time is likely quite different from what we
     // assumed.

--- a/beacon_node/eth1/src/service.rs
+++ b/beacon_node/eth1/src/service.rs
@@ -784,6 +784,7 @@ impl Service {
     ) -> Result<Option<RangeInclusive<u64>>, Error> {
         let follow_distance = self.cache_follow_distance();
         let latest_cached_block = self.latest_cached_block();
+        // 3415708
         let next_required_block = match head_type {
             HeadType::Deposit => self
                 .deposits()
@@ -851,6 +852,7 @@ impl Service {
         &self,
         new_block_numbers: Option<Option<RangeInclusive<u64>>>,
     ) -> Result<DepositCacheUpdateOutcome, Error> {
+        // 3415708
         let client = self.client();
         let deposit_contract_address = self.config().deposit_contract_address.clone();
 
@@ -900,6 +902,12 @@ impl Service {
              * Step 1. Download logs.
              */
             let block_range_ref = &block_range;
+            debug!(
+                self.log,
+                "Getting deposit logs in range";
+                "start" => block_range_ref.start,
+                "end" => block_range_ref.end,
+            );
             let logs = client
                 .get_deposit_logs_in_range(
                     deposit_contract_address_ref,
@@ -935,12 +943,31 @@ impl Service {
                 // a block, but not _all_ logs for that block). This scenario can cause the
                 // node to choose an invalid genesis state or propose an invalid block.
                 .try_for_each(|deposit_log| {
-                    if let DepositCacheInsertOutcome::Inserted = cache
+                    match cache
                         .cache
-                        .insert_log(deposit_log)
-                        .map_err(Error::FailedToInsertDeposit)?
+                        .insert_log(deposit_log.clone())
+                        .map_err(Error::FailedToInsertDeposit) {
+                            Ok(DepositCacheInsertOutcome::Inserted) => {
+                                logs_imported += 1;
+                            }
+                            Ok(DepositCacheInsertOutcome::Duplicate) => {
+                                debug!(
+                                    self.log,
+                                    "Attempted to insert duplicate log";
+                                    "log" => ?deposit_log
+                                );
+                            }
+                            Err(err) => {
+                                debug!(
+                                    self.log,
+                                    "Error while inserting deposit log";
+                                    "deposit_log" => ?deposit_log
+                                );
+                                return Err(err);
+                            }
+
+                        }
                     {
-                        logs_imported += 1;
                     }
 
                     Ok::<_, Error>(())
@@ -1151,6 +1178,7 @@ fn relevant_block_range(
     latest_cached_block: Option<&Eth1Block>,
     spec: &ChainSpec,
 ) -> Result<Option<RangeInclusive<u64>>, Error> {
+    // 3415708
     // If the latest cached block is lagging the head block by more than `cache_follow_distance`
     // times the expected block time then the eth1 block time is likely quite different from what we
     // assumed.


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Return state.eth1_data() early if we have passed the transition period post electra. Even if we don't return early, the function would still return state.eth1_data() based on the current conditions. However, doing this explicitly here to match the spec. This covers setting the right eth1_data in our block.

The other thing we need to ensure is that the deposits returned by the eth1_chain is empty post transition.

The only way we get non-empty deposits post the transition is if `state.eth1_deposit_index` in the below code is less than `min(deposit_requests_start_index, state.eth1_data().deposit_count)`. 
https://github.com/sigp/lighthouse/blob/0850bcfb89d1048030c1aced795f3d43d91abeb0/beacon_node/beacon_chain/src/eth1_chain.rs#L543-L579

This can never happen because state.eth1_deposit_index will be equal to state.eth1_data.deposit count and cannot exceed the value.

@michaelsproul @ethDreamer please double check the logic for deposits being empty post transition. Following the logic in the spec makes my head hurt.