### PR TITLE
Fix the `cargo audit` failure by backmerging `release-v7.0.0` into `unstable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6336,9 +6336,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -6377,9 +6377,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Proposed Changes

Backmerge `release-v7.0.0` to `unstable` to fix the `cargo audit` error and unblock CI. 

This shouldn't be merged with `mergify` or squash merged.


