### PR TITLE
Remove CLI conflict for secrets-dir and datadir

### DIFF
--- a/lighthouse/tests/validator_client.rs
+++ b/lighthouse/tests/validator_client.rs
@@ -71,6 +71,22 @@ fn validators_and_secrets_dir_flags() {
 }
 
 #[test]
+fn datadir_and_secrets_dir_flags() {
+    let dir = TempDir::new().expect("Unable to create temporary directory");
+    CommandLineTest::new()
+        .flag("datadir", dir.path().join("data").to_str())
+        .flag("secrets-dir", dir.path().join("secrets").to_str())
+        .run_with_no_datadir()
+        .with_config(|config| {
+            assert_eq!(
+                config.validator_dir,
+                dir.path().join("data").join("validators")
+            );
+            assert_eq!(config.secrets_dir, dir.path().join("secrets"));
+        });
+}
+
+#[test]
 fn validators_dir_alias_flags() {
     let dir = TempDir::new().expect("Unable to create temporary directory");
     CommandLineTest::new()

--- a/validator_client/src/cli.rs
+++ b/validator_client/src/cli.rs
@@ -67,7 +67,6 @@ pub struct ValidatorClient {
     #[clap(
         long,
         value_name = "SECRETS_DIRECTORY",
-        conflicts_with = "datadir",
         help = "The directory which contains the password to unlock the validator \
                 voting keypairs. Each password should be contained in a file where the \
                 name is the 0x-prefixed hex representation of the validators voting public \


### PR DESCRIPTION
## Issue Addressed

Redo this PR:

- https://github.com/sigp/lighthouse/pull/5480

After a regression during the switch to `clap_derive`.

- https://github.com/sigp/lighthouse/pull/6300

## Proposed Changes

- Remove `conflicts_with`
- Add test to prevent future regression