### PR TITLE
Bump version to v7.1.0-beta.0 (not a release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "beacon_node"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "boot_node"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 dependencies = [
  "beacon_node",
  "bytes",
@@ -4704,7 +4704,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcli"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 dependencies = [
  "account_utils",
  "beacon_chain",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "lighthouse"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 dependencies = [
  "account_manager",
  "account_utils",

--- a/beacon_node/Cargo.toml
+++ b/beacon_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "beacon_node"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 authors = [
     "Paul Hauner <paul@paulhauner.com>",
     "Age Manning <Age@AgeManning.com",

--- a/boot_node/Cargo.toml
+++ b/boot_node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boot_node"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 

--- a/common/lighthouse_version/src/lib.rs
+++ b/common/lighthouse_version/src/lib.rs
@@ -17,8 +17,8 @@ pub const VERSION: &str = git_version!(
         // NOTE: using --match instead of --exclude for compatibility with old Git
         "--match=thiswillnevermatchlol"
     ],
-    prefix = "Lighthouse/v7.0.0-beta.5-",
-    fallback = "Lighthouse/v7.0.0-beta.5"
+    prefix = "Lighthouse/v7.1.0-beta.0-",
+    fallback = "Lighthouse/v7.1.0-beta.0"
 );
 
 /// Returns the first eight characters of the latest commit hash for this build.
@@ -54,7 +54,7 @@ pub fn version_with_platform() -> String {
 ///
 /// `1.5.1`
 pub fn version() -> &'static str {
-    "7.0.0-beta.5"
+    "7.1.0-beta.0"
 }
 
 /// Returns the name of the current client running.

--- a/lcli/Cargo.toml
+++ b/lcli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lcli"
 description = "Lighthouse CLI (modeled after zcli)"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 authors = ["Paul Hauner <paul@paulhauner.com>"]
 edition = { workspace = true }
 

--- a/lighthouse/Cargo.toml
+++ b/lighthouse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lighthouse"
-version = "7.0.0-beta.5"
+version = "7.1.0-beta.0"
 authors = ["Sigma Prime <contact@sigmaprime.io>"]
 edition = { workspace = true }
 autotests = false


### PR DESCRIPTION
## Proposed Changes

Having merged the drop-headtracker PR we now have a DB schema change in `unstable` compared to `release-v7.0.0`:

- https://github.com/sigp/lighthouse/pull/6744

There is a DB downgrade available, however this needs to be applied manually and it's usually a bit of a hassle.

This PR bumps the version on `unstable` to `v7.1.0-beta.0` _without_ actually cutting a `v7.1.0-beta.0` release, so that we can tell at a glance which schema version a node is using.

## Additional Info

Our next release with hot tree-states _can_ be v7.1.0 rather than v8.0.0 because we have a schema downgrade for this change as well:

- https://github.com/sigp/lighthouse/pull/6750
